### PR TITLE
Add Rollup config for UMD bundles.

### DIFF
--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -11,16 +11,22 @@
         "outputPath": "packages/ag-charts-community/dist",
         "main": "packages/ag-charts-community/src/main.ts",
         "tsConfig": "packages/ag-charts-community/tsconfig.lib.json",
+        "rollupConfig": "packages/ag-charts-community/rollup.config.js",
         "assets": [],
         "project": "packages/ag-charts-community/package.json",
         "compiler": "tsc",
         "updateBuildableProjectDepsInPackageJson": true,
-        "buildableProjectDepsInPackageJsonType": "dependencies"
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "format": ["cjs"],
+        "generateExportsField": true
       },
       "configurations": {
         "watch": {
           "watch": true,
           "compiler": "swc"
+        },
+        "production": {
+          "format": ["cjs", "esm"]
         }
       }
     },

--- a/packages/ag-charts-community/rollup.config.js
+++ b/packages/ag-charts-community/rollup.config.js
@@ -1,0 +1,22 @@
+module.exports = ({ output, ...config }) => {
+    if (!Array.isArray(output)) {
+        output = [output];
+    }
+
+    return {
+        ...config,
+        output: [
+            ...output.map((o) => ({
+                ...o,
+                name: 'agCharts',
+            })),
+            ...output.map(({ entryFileNames, chunkFileNames, ...opts }) => ({
+                ...opts,
+                name: 'agCharts',
+                entryFileNames: entryFileNames.replace('[name]', '[name].umd'),
+                chunkFileNames: chunkFileNames.replace('[name]', '[name].umd'),
+                format: 'umd',
+            })),
+        ],
+    };
+};

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -11,16 +11,22 @@
         "outputPath": "packages/ag-charts-enterprise/dist",
         "main": "packages/ag-charts-enterprise/src/main.ts",
         "tsConfig": "packages/ag-charts-enterprise/tsconfig.lib.json",
+        "rollupConfig": "packages/ag-charts-community/rollup.config.js",
         "assets": [],
         "project": "packages/ag-charts-enterprise/package.json",
         "compiler": "tsc",
         "updateBuildableProjectDepsInPackageJson": true,
-        "buildableProjectDepsInPackageJsonType": "dependencies"
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "format": ["cjs"],
+        "generateExportsField": true
       },
       "configurations": {
         "watch": {
           "watch": true,
           "compiler": "swc"
+        },
+        "production": {
+          "format": ["cjs", "esm"]
         }
       }
     },

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -11,7 +11,7 @@
         "outputPath": "packages/ag-charts-enterprise/dist",
         "main": "packages/ag-charts-enterprise/src/main.ts",
         "tsConfig": "packages/ag-charts-enterprise/tsconfig.lib.json",
-        "rollupConfig": "packages/ag-charts-community/rollup.config.js",
+        "rollupConfig": "packages/ag-charts-enterprise/rollup.config.js",
         "assets": [],
         "project": "packages/ag-charts-enterprise/package.json",
         "compiler": "tsc",

--- a/packages/ag-charts-enterprise/rollup.config.js
+++ b/packages/ag-charts-enterprise/rollup.config.js
@@ -1,0 +1,22 @@
+module.exports = ({ output, ...config }) => {
+    if (!Array.isArray(output)) {
+        output = [output];
+    }
+
+    return {
+        ...config,
+        output: [
+            ...output.map((o) => ({
+                ...o,
+                name: 'agChartsEnterprise',
+            })),
+            ...output.map(({ entryFileNames, chunkFileNames, ...opts }) => ({
+                ...opts,
+                name: 'agChartsEnterprise',
+                entryFileNames: entryFileNames.replace('[name]', '[name].umd'),
+                chunkFileNames: chunkFileNames.replace('[name]', '[name].umd'),
+                format: 'umd',
+            })),
+        ],
+    };
+};

--- a/packages/ag-charts-website/src/utils/pages.ts
+++ b/packages/ag-charts-website/src/utils/pages.ts
@@ -38,6 +38,8 @@ export interface DevFileRoute {
 export const DEV_FILE_PATH_MAP: Record<string, string> = {
     'ag-charts-community/dist/ag-charts-community.cjs.js': 'packages/ag-charts-community/dist/main.cjs',
     'ag-charts-enterprise/dist/ag-charts-enterprise.cjs.js': 'packages/ag-charts-enterprise/dist/main.cjs',
+    'ag-charts-community/dist/ag-charts-community.umd.js': 'packages/ag-charts-community/dist/main.umd.cjs',
+    'ag-charts-enterprise/dist/ag-charts-enterprise.umd.js': 'packages/ag-charts-enterprise/dist/main.umd.cjs',
 };
 
 /**


### PR DESCRIPTION
Adds `.umd.js` bundle variants, allowing direct use via a `<script>` tag in a browser.