### PR TITLE
Enable Typescript plunkr example

### DIFF
--- a/packages/ag-charts-website/jest.config.ts
+++ b/packages/ag-charts-website/jest.config.ts
@@ -10,5 +10,6 @@ export default {
         'examples-generator/transformation-scripts',
         'snippet/snippetTransformer',
         'utils/framework',
+        'examples-generator/utils/fileUtils',
     ],
 };

--- a/packages/ag-charts-website/src/constants.ts
+++ b/packages/ag-charts-website/src/constants.ts
@@ -44,7 +44,7 @@ export const SITE_BASE_URL = import.meta.env.BASE_URL;
 /**
  * URL prefix to serve files for dev server
  */
-export const localPrefix = `${SITE_BASE_URL}dev`;
+export const DEV_FILE_BASE_PATH = '/dev';
 
 const siteBaseUrlSegments = SITE_BASE_URL.split('/').filter(Boolean).length;
 export const FRAMEWORK_PATH_INDEX = 1 + siteBaseUrlSegments;

--- a/packages/ag-charts-website/src/features/example-runner/components/ExampleRunner.tsx
+++ b/packages/ag-charts-website/src/features/example-runner/components/ExampleRunner.tsx
@@ -52,6 +52,7 @@ const ExampleRunnerInner: FunctionComponent<Props> = ({ name, title, exampleType
     const [initialSelectedFile, setInitialSelectedFile] = useState();
     const [exampleUrl, setExampleUrl] = useState<string>();
     const [exampleFiles, setExampleFiles] = useState();
+    const [exampleBoilerPlateFiles, setExampleBoilerPlateFiles] = useState();
 
     const exampleId = `example-${name}`;
     const exampleHeight = options?.exampleHeight || DEFAULT_HEIGHT;
@@ -60,8 +61,8 @@ const ExampleRunnerInner: FunctionComponent<Props> = ({ name, title, exampleType
     const id = `example-${name}`;
     const minHeight = `${exampleHeight + FRAME_WRAPPER_HEIGHT}px`;
 
-    // NOTE: Plunkr only works for vanilla examples for now
-    const supportsPlunkr = internalFramework === 'vanilla';
+    // NOTE: Plunkr only works for these internal frameworks for now
+    const supportsPlunkr = ['vanilla', 'typescript'].includes(internalFramework);
 
     const {
         isLoading: exampleFilesIsLoading,
@@ -116,6 +117,7 @@ const ExampleRunnerInner: FunctionComponent<Props> = ({ name, title, exampleType
         };
 
         setExampleFiles(files);
+        setExampleBoilerPlateFiles(data.boilerPlateFiles);
     }, [data, exampleFilesIsLoading, exampleFilesIsError, exampleFileHtml]);
 
     useUpdateInternalFrameworkFromFramework(framework);
@@ -170,6 +172,7 @@ const ExampleRunnerInner: FunctionComponent<Props> = ({ name, title, exampleType
                                 <OpenInPlunkr
                                     title={title}
                                     files={exampleFiles}
+                                    boilerPlateFiles={exampleBoilerPlateFiles}
                                     fileToOpen={initialSelectedFile!}
                                     internalFramework={internalFramework}
                                     pageName={pageName}

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
@@ -4,6 +4,7 @@ import { MetaData } from './lib/MetaData';
 import { ExampleStyle } from './lib/ExampleStyle';
 import { Styles } from './lib/Styles';
 import { SystemJs } from './lib/SystemJs';
+import { pathJoin } from '../../../utils/pathJoin';
 
 interface Props {
     isDev: boolean;
@@ -37,7 +38,7 @@ const {
     boilerplatePath,
 } = Astro.props as Props;
 
-const startFile = appLocation + '/' + entryFileName;
+const startFile = pathJoin(appLocation, entryFileName);
 ---
 
 <html lang="en">

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
@@ -3,7 +3,6 @@ import { getCacheBustingUrl } from '../../../utils/pages';
 import { MetaData } from './lib/MetaData';
 import { ExampleStyle } from './lib/ExampleStyle';
 import { Styles } from './lib/Styles';
-import { Scripts } from './lib/Scripts';
 import { SystemJs } from './lib/SystemJs';
 
 interface Props {
@@ -15,10 +14,7 @@ interface Props {
     isExecuting: boolean;
     options: any;
     entryFileName: string;
-    /**
-     * All script file names
-     */
-    scriptFiles?: string[];
+
     styleFiles?: string[];
     indexFragment: string;
     appLocation: string;
@@ -35,7 +31,6 @@ const {
     options,
     appLocation,
     entryFileName,
-    scriptFiles,
     styleFiles,
     indexFragment,
     library,
@@ -43,8 +38,6 @@ const {
 } = Astro.props as Props;
 
 const startFile = appLocation + '/' + entryFileName;
-// The entry file is loaded through SystemJS, but other scripts need to be included directly on the page
-const extraScriptFiles = scriptFiles?.filter((scriptFile) => scriptFile !== entryFileName);
 ---
 
 <html lang="en">
@@ -78,7 +71,6 @@ const extraScriptFiles = scriptFiles?.filter((scriptFile) => scriptFile !== entr
             window.__basePath = appLocation;
         </script>
 
-        <Scripts baseUrl={appLocation} files={extraScriptFiles} />
         <SystemJs
             isDev={isDev}
             library={library}

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/Scripts.jsx
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/Scripts.jsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { pathJoin } from '../../../../utils/pathJoin';
 
 export const Scripts = ({ baseUrl, files = [] }) => {
-    if (!baseUrl) {
-        throw new Error('No baseUrl');
-    }
-
     return files.map((file) => {
         const srcFile = pathJoin(baseUrl, file);
         return <script key={file} src={srcFile} />;

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/SystemJs.jsx
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/SystemJs.jsx
@@ -10,10 +10,14 @@ import {
     agGridVue3Version,
     agGridVueVersion,
     agGridEnterpriseVersion,
-    localPrefix,
+    SITE_BASE_URL,
+    DEV_FILE_BASE_PATH,
 } from '../../../../constants';
+import { pathJoin } from '../../../../utils/pathJoin';
 
 import { isUsingPublishedPackages, isBuildServerBuild, isPreProductionBuild } from '../../../../utils/pages';
+
+const localPrefix = pathJoin(import.meta.env.SITE_URL, SITE_BASE_URL, DEV_FILE_BASE_PATH);
 
 const localConfiguration = {
     gridMap: {
@@ -268,7 +272,7 @@ function getRelevantConfig(configuration, framework) {
  */
 export const SystemJs = ({ library, boilerplatePath, appLocation, startFile, options, framework, isDev }) => {
     const { enterprise: isEnterprise } = options;
-    const systemJsPath = `${boilerplatePath}systemjs.config${isDev ? '.dev' : ''}.js`;
+    const systemJsPath = pathJoin(boilerplatePath, `systemjs.config${isDev ? '.dev' : ''}.js`);
     let configuration = isUsingPublishedPackages()
         ? publishedConfiguration
         : isBuildServerBuild() || isPreProductionBuild()

--- a/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
@@ -4,6 +4,7 @@ import {
     getFrameworkFromInternalFramework,
     getIsEnterprise,
     getSourceFolderUrl,
+    getBoilerPlateFiles,
 } from './utils/fileUtils';
 import chartVanillaSrcParser from './transformation-scripts/chart-vanilla-src-parser';
 import fs from 'node:fs/promises';
@@ -128,7 +129,7 @@ export const getGeneratedContents = async ({
         throw new Error(`No entry file config generator for '${internalFramework}'`);
     }
 
-    const { files, scriptFiles, entryFileName } = getFrameworkFiles({
+    const { files, boilerPlateFiles, scriptFiles, entryFileName } = await getFrameworkFiles({
         entryFile,
         indexHtml,
         isEnterprise,
@@ -141,6 +142,7 @@ export const getGeneratedContents = async ({
         styleFiles: Object.keys(styleFiles),
         sourceFileList,
         files: Object.assign(otherScriptFiles, styleFiles, files),
+        boilerPlateFiles,
         entryFileName,
     } as GeneratedContents;
 

--- a/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.test.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.test.ts
@@ -1,0 +1,19 @@
+import { getBoilerPlateName } from './fileUtils';
+
+describe('getBoilerPlateName', () => {
+    test.each`
+        internalFramework      | expected
+        ${undefined}           | ${undefined}
+        ${'other'}             | ${undefined}
+        ${'vanilla'}           | ${undefined}
+        ${'typescript'}        | ${'charts-typescript-boilerplate'}
+        ${'react'}             | ${'charts-react-boilerplate'}
+        ${'reactFunctional'}   | ${'charts-react-boilerplate'}
+        ${'reactFunctionalTs'} | ${'charts-react-ts-boilerplate'}
+        ${'angular'}           | ${'charts-angular-boilerplate'}
+        ${'vue'}               | ${'charts-vue-boilerplate'}
+        ${'vue3'}              | ${'charts-vue3-boilerplate'}
+    `('$internalFramework is $expected', ({ internalFramework, expected }) => {
+        expect(getBoilerPlateName(internalFramework)).toEqual(expected);
+    });
+});

--- a/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
@@ -1,8 +1,10 @@
 import type { InternalFramework } from '../../../types/ag-grid';
 import { readAsJsFile } from '../transformation-scripts/parser-utils';
+import { getBoilerPlateFiles } from './fileUtils';
 
 interface FrameworkFiles {
     files: Record<string, string>;
+    boilerPlateFiles?: Record<string, string>;
     scriptFiles: string[];
     entryFileName: string;
 }
@@ -19,7 +21,8 @@ type ConfigGenerator = ({
     isEnterprise: boolean;
     bindings: any;
     typedBindings: any;
-}) => FrameworkFiles;
+}) => FrameworkFiles | Promise<FrameworkFiles>;
+
 export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator> = {
     vanilla: ({ entryFile, indexHtml, typedBindings, isEnterprise }) => {
         let mainJs = readAsJsFile(entryFile);
@@ -48,12 +51,14 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
             entryFileName: 'main.js',
         };
     },
-    typescript: ({ entryFile, indexHtml }) => {
+    typescript: async ({ entryFile, indexHtml }) => {
+        const boilerPlateFiles = await getBoilerPlateFiles('typescript');
         return {
             files: {
                 'main.ts': entryFile,
                 'index.html': indexHtml,
             },
+            boilerPlateFiles,
             scriptFiles: ['main.ts'],
             entryFileName: 'main.ts',
         };

--- a/packages/ag-charts-website/src/features/plunkr/components/OpenInPlunkr.tsx
+++ b/packages/ag-charts-website/src/features/plunkr/components/OpenInPlunkr.tsx
@@ -1,6 +1,7 @@
 import { OpenInCTA } from '../../../components/open-in-cta/OpenInCTA';
 import { useCallback, type FunctionComponent } from 'react';
 import { openPlunker } from '../utils/plunkr';
+import { fetchTextFile } from '../utils/fetchTextFile';
 import type { FileContents } from '../../examples-generator/types';
 import { getExampleUrlWithRelativePath } from '../../../utils/pages';
 import type { InternalFramework } from 'packages/ag-charts-website/src/types/ag-grid';
@@ -26,13 +27,13 @@ export const OpenInPlunkr: FunctionComponent<Props> = ({
      * Get Plunkr HTML files, which requires relative paths
      */
     const getPlunkrHtml = useCallback(async () => {
-        const plunkrHtml = await fetch(
+        const plunkrHtml = await fetchTextFile(
             getExampleUrlWithRelativePath({
                 internalFramework,
                 pageName,
                 exampleName,
             })
-        ).then((res) => res.text());
+        );
 
         return plunkrHtml;
     }, [internalFramework, pageName, exampleName]);

--- a/packages/ag-charts-website/src/features/plunkr/components/OpenInPlunkr.tsx
+++ b/packages/ag-charts-website/src/features/plunkr/components/OpenInPlunkr.tsx
@@ -9,6 +9,7 @@ import type { InternalFramework } from 'packages/ag-charts-website/src/types/ag-
 interface Props {
     title: string;
     files: FileContents;
+    boilerPlateFiles?: FileContents;
     fileToOpen: string;
     internalFramework: InternalFramework;
     pageName: string;
@@ -18,6 +19,7 @@ interface Props {
 export const OpenInPlunkr: FunctionComponent<Props> = ({
     title,
     files,
+    boilerPlateFiles,
     fileToOpen,
     internalFramework,
     pageName,
@@ -45,6 +47,7 @@ export const OpenInPlunkr: FunctionComponent<Props> = ({
                 const plunkrHtml = await getPlunkrHtml();
                 const plunkrExampleFiles = {
                     ...files,
+                    ...boilerPlateFiles,
                     'index.html': plunkrHtml,
                 };
                 openPlunker({

--- a/packages/ag-charts-website/src/features/plunkr/utils/fetchTextFile.ts
+++ b/packages/ag-charts-website/src/features/plunkr/utils/fetchTextFile.ts
@@ -1,0 +1,3 @@
+export const fetchTextFile = (url: string) => {
+    return fetch(url).then((res) => res.text());
+};

--- a/packages/ag-charts-website/src/features/plunkr/utils/plunkr.ts
+++ b/packages/ag-charts-website/src/features/plunkr/utils/plunkr.ts
@@ -15,7 +15,7 @@ export const openPlunker = ({
     form.action = `//plnkr.co/edit/?preview&open=${fileToOpen}`;
     form.target = '_blank';
 
-    const addHiddenInput = (name, value) => {
+    const addHiddenInput = (name: string, value: any) => {
         const input = document.createElement('input');
         input.type = 'hidden';
         input.name = name;

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
@@ -84,7 +84,6 @@ const supportedInternalFrameworks: InternalFramework[] = ['vanilla', 'typescript
                 enterprise: isEnterprise,
             }}
             entryFileName={entryFileName!}
-            scriptFiles={scriptFiles}
             styleFiles={styleFiles}
             indexFragment={indexFragment!}
             appLocation={appLocation}

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
@@ -6,6 +6,7 @@ import JavascriptTemplate from '../../../../features/example-runner/framework-te
 import TypescriptTemplate from '../../../../features/example-runner/framework-templates/TypescriptTemplate.astro';
 import { getGeneratedContents } from '../../../../features/examples-generator/examplesGenerator';
 import { getIsDev } from '../../../../utils/env';
+import { pathJoin } from '../../../../utils/pathJoin';
 
 interface Props {
     /**
@@ -42,12 +43,13 @@ const exampleUrl = getExampleUrl({
     pageName,
     exampleName,
 });
-const appLocation = relativePath ? './' : exampleUrl;
-
-const boilerPlateUrl = getBoilerPlateUrl({
-    library,
-    internalFramework,
-});
+const appLocation = relativePath ? '' : exampleUrl;
+const boilerPlateUrl = relativePath
+    ? ''
+    : getBoilerPlateUrl({
+          library,
+          internalFramework,
+      });
 
 // TODO: Can remove, once we support all frameworks
 const supportedInternalFrameworks: InternalFramework[] = ['vanilla', 'typescript'];
@@ -88,7 +90,7 @@ const supportedInternalFrameworks: InternalFramework[] = ['vanilla', 'typescript
             indexFragment={indexFragment!}
             appLocation={appLocation}
             library={library}
-            boilerplatePath={boilerPlateUrl + '/'}
+            boilerplatePath={boilerPlateUrl}
         />
     )
 }

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/files.ts
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/files.ts
@@ -21,7 +21,7 @@ export async function getStaticPaths() {
 export async function get({ params }: { params: Params }) {
     const { internalFramework, pageName, exampleName } = params;
 
-    const { entryFileName, files } =
+    const { entryFileName, files, boilerPlateFiles } =
         (await getGeneratedContents({
             internalFramework,
             pageName,
@@ -29,6 +29,7 @@ export async function get({ params }: { params: Params }) {
         })) || {};
     const response = {
         files,
+        boilerPlateFiles,
         entryFileName,
     };
     const body = JSON.stringify(response);

--- a/packages/ag-charts-website/src/utils/fs.ts
+++ b/packages/ag-charts-website/src/utils/fs.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
  * Get folders on a root path (1 level deep)
  */
 export const getFolders = async (rootPath: string) => {
-    const folders = [];
+    const folders: string[] = [];
     const exists = fsOriginal.existsSync(rootPath);
     if (exists) {
         const files = await fs.readdir(rootPath);

--- a/packages/ag-charts-website/src/utils/pages.ts
+++ b/packages/ag-charts-website/src/utils/pages.ts
@@ -5,7 +5,7 @@ import {
     TYPESCRIPT_INTERNAL_FRAMEWORKS,
     SITE_BASE_URL,
     FRAMEWORK_PATH_INDEX,
-    localPrefix,
+    DEV_FILE_BASE_PATH,
 } from '../constants';
 import { getSourceExamplesPathUrl } from '../features/examples-generator/utils/fileUtils';
 import type { InternalFramework, Library } from '../types/ag-grid';
@@ -62,15 +62,15 @@ export const getChartEnterpriseScriptPath = (sitePrefix?: string) => {
 };
 
 /**
- * The dist url where packages are generated
+ * The root url where the monorepo exists
  */
 const getRootUrl = (): URL => {
-    const distRoot = getIsDev()
+    const root = getIsDev()
         ? // Relative to the folder of this file
           '../../../../'
         : // Relative to `/dist/packages/ag-charts-website/chunks/pages` folder (Nx specific)
           '../../../../../';
-    return new URL(distRoot, import.meta.url);
+    return new URL(root, import.meta.url);
 };
 
 export const urlWithBaseUrl = (url: string = '') => {
@@ -218,7 +218,7 @@ export const getExampleFileUrl = ({
 };
 
 export const getDevFileUrl = ({ filePath }: { filePath: string }) => {
-    return pathJoin(localPrefix, filePath);
+    return pathJoin(DEV_FILE_BASE_PATH, filePath);
 };
 
 export const getDevFileList = () => {
@@ -228,6 +228,9 @@ export const getDevFileList = () => {
     });
 };
 
+/**
+ * Get url of example boiler plate files
+ */
 export const getBoilerPlateUrl = ({
     library,
     internalFramework,

--- a/packages/ag-charts-website/src/utils/pathJoin.test.ts
+++ b/packages/ag-charts-website/src/utils/pathJoin.test.ts
@@ -8,7 +8,9 @@ describe('pathJoin', () => {
     test.each`
         segments                                              | expected
         ${[]}                                                 | ${''}
+        ${[undefined]}                                        | ${''}
         ${['/']}                                              | ${'/'}
+        ${['/', undefined]}                                   | ${'/'}
         ${['/ag-charts']}                                     | ${'/ag-charts'}
         ${['/', 'ag-charts']}                                 | ${'/ag-charts'}
         ${['/', 'ag-charts', 'page']}                         | ${'/ag-charts/page'}

--- a/packages/ag-charts-website/src/utils/pathJoin.ts
+++ b/packages/ag-charts-website/src/utils/pathJoin.ts
@@ -3,7 +3,7 @@
  *
  * Works on server and client side
  */
-export function pathJoin(...segments: (string | URL)[]): string {
+export function pathJoin(...segments: (string | URL | undefined)[]): string {
     if (!segments || !segments.length) {
         return '';
     } else if (segments[0] === '/' && segments.length === 1) {
@@ -13,7 +13,7 @@ export function pathJoin(...segments: (string | URL)[]): string {
     const removedSlashes = segments
         .filter(Boolean)
         // Convert segments to string, in case it's a URL
-        .map((segment) => segment.toString())
+        .map((segment) => segment!.toString())
         // Remove initial /
         .map((segment) => {
             return segment !== '/' && segment[0] === '/' ? segment.slice(1) : segment;


### PR DESCRIPTION
## Changes

* Allow typescript examples to be viewed in plunkr
* Add `boilerPlateFiles` to generated content
* Pass through boilerplate files to plunkr
* Use empty string for base url for relative path to simplify path calculations
* Allow empty `baseUrl` in `Scripts` component
* Clean up `/dev` base url constant
* Generate `localPrefix` in `SystemJs` component

## Known issues

* There is a `[exampleName]/relative-path` url that is purely used for generating plunkr examples, however this does not render at the endpoint anymore for typescript examples. This is because the relative paths for boilerplate files don't reference a valid file. However when we open it in plunkr it, it sends the boilerplate files across. We don't really need it to render at the endpoint, so I didn't bother fixing it. If we ever need to, we can add astro endpoints to serve the files (it will also mean the build will take a little longer to duplicate all the boilerplate files)