### PR TITLE
Add Vue/Vue3 example runner

### DIFF
--- a/packages/ag-charts-website/src/features/example-runner/components/ExampleRunner.tsx
+++ b/packages/ag-charts-website/src/features/example-runner/components/ExampleRunner.tsx
@@ -69,9 +69,15 @@ const ExampleRunnerInner: FunctionComponent<Props> = ({ name, title, exampleType
     const minHeight = `${exampleHeight + FRAME_WRAPPER_HEIGHT}px`;
 
     // NOTE: Plunkr only works for these internal frameworks for now
-    const supportsPlunkr = ['vanilla', 'typescript', 'react', 'reactFunctional', 'reactFunctionalTs'].includes(
-        internalFramework
-    );
+    const supportsPlunkr = [
+        'vanilla',
+        'typescript',
+        'react',
+        'reactFunctional',
+        'reactFunctionalTs',
+        'vue',
+        'vue3',
+    ].includes(internalFramework);
 
     const {
         isLoading: exampleFilesIsLoading,

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/VueTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/VueTemplate.astro
@@ -1,0 +1,76 @@
+---
+import { ExampleStyle } from './lib/ExampleStyle';
+import { MetaData } from './lib/MetaData';
+import { Scripts } from './lib/Scripts';
+import { Styles } from './lib/Styles';
+import { SystemJs } from './lib/SystemJs';
+import { pathJoin } from '../../../utils/pathJoin';
+
+interface Props {
+    isDev: boolean;
+    pageName: string;
+    exampleName: string;
+
+    modifiedTimeMs: number;
+    isExecuting: boolean;
+    options: any;
+    entryFileName: string;
+    /**
+     * Extra script file names (not including entry file)
+     */
+    scriptFiles?: string[];
+    styleFiles?: string[];
+    appLocation: string;
+    library: string;
+    boilerplatePath: string;
+
+    vueFramework: 'vue' | 'vue3';
+}
+
+const {
+    isDev,
+    pageName,
+    exampleName,
+    isExecuting,
+    modifiedTimeMs,
+    library,
+    boilerplatePath,
+    appLocation,
+    options,
+    entryFileName,
+    scriptFiles,
+    styleFiles,
+    vueFramework,
+} = Astro.props as Props;
+
+const startFile = pathJoin(appLocation, entryFileName);
+const vueFrameworkTitle = vueFramework === 'vue3' ? 'Vue 3' : 'Vue';
+---
+
+<html lang="en">
+    <head>
+        <MetaData
+            isDev={isDev}
+            title={`${vueFrameworkTitle} example - ${pageName} - ${exampleName}`}
+            modifiedTimeMs={modifiedTimeMs}
+            isExecuting={isExecuting}
+            options={options}
+        />
+        <ExampleStyle rootId="app" />
+        <Styles baseUrl={appLocation} files={styleFiles} />
+    </head>
+    <body>
+        <div id="app"><my-component></my-component></div>
+
+        <Scripts baseUrl={appLocation} files={scriptFiles} />
+        <SystemJs
+            isDev={isDev}
+            library={library}
+            boilerplatePath={boilerplatePath}
+            appLocation={appLocation}
+            startFile={startFile}
+            framework={vueFramework}
+            options={options}
+        />
+    </body>
+</html>

--- a/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
@@ -4,7 +4,6 @@ import {
     getFrameworkFromInternalFramework,
     getIsEnterprise,
     getSourceFolderUrl,
-    getBoilerPlateFiles,
     getTransformTsFileExt,
 } from './utils/fileUtils';
 import chartVanillaSrcParser from './transformation-scripts/chart-vanilla-src-parser';
@@ -13,7 +12,6 @@ import { getOtherScriptFiles } from './utils/getOtherScriptFiles';
 import { getStyleFiles } from './utils/getStyleFiles';
 import type { InternalFramework } from '../../types/ag-grid';
 import { frameworkFilesGenerator } from './utils/frameworkFilesGenerator';
-import { isTypescriptInternalFramework } from '../../utils/pages';
 import type { GeneratedContents } from './types.d';
 
 /**
@@ -102,7 +100,6 @@ export const getGeneratedContents = async ({
     }
 
     const isEnterprise = getIsEnterprise({
-        framework,
         internalFramework,
         entryFile,
     });
@@ -115,7 +112,7 @@ export const getGeneratedContents = async ({
         },
     });
 
-    const rawOtherScriptFiles = await getOtherScriptFiles({
+    const otherScriptFiles = await getOtherScriptFiles({
         sourceEntryFileName,
         sourceFileList,
         pageName,
@@ -133,13 +130,13 @@ export const getGeneratedContents = async ({
         throw new Error(`No entry file config generator for '${internalFramework}'`);
     }
 
-    const { files, boilerPlateFiles, scriptFiles, entryFileName, otherScriptFiles } = await getFrameworkFiles({
+    const { files, boilerPlateFiles, scriptFiles, entryFileName } = await getFrameworkFiles({
         entryFile,
         indexHtml,
         isEnterprise,
         bindings,
         typedBindings,
-        otherScriptFiles: rawOtherScriptFiles,
+        otherScriptFiles,
     });
     const contents: GeneratedContents = {
         isEnterprise,

--- a/packages/ag-charts-website/src/features/examples-generator/types.d.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/types.d.ts
@@ -1,5 +1,7 @@
 export type ExampleType = 'generated' | 'mixed' | 'typescript' | 'multi';
 
+export type TransformTsFileExt = undefined | '.js' | '.tsx';
+
 export interface ExampleSettings {
     enterprise?: boolean;
 }

--- a/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.ts
@@ -2,9 +2,10 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import { getIsDev } from '../../../utils/env';
 import { getFolders } from '../../../utils/fs';
-import type { InternalFramework } from '../../../types/ag-grid.d';
+import type { Framework, InternalFramework } from '../../../types/ag-grid.d';
 import { pathJoin } from '../../../utils/pathJoin';
 import { isTypescriptInternalFramework } from '../../../utils/pages';
+import type { TransformTsFileExt } from '../types';
 
 export const getContentRootFileUrl = (): URL => {
     const contentRoot = getIsDev()
@@ -46,7 +47,7 @@ export const getBoilerPlateName = (internalFramework: InternalFramework) => {
     }
 };
 
-export const getTransformTsFileExt = (internalFramework: InternalFramework) => {
+export const getTransformTsFileExt = (internalFramework: InternalFramework): TransformTsFileExt => {
     let transformTsFileExt;
     if (internalFramework === 'reactFunctionalTs') {
         transformTsFileExt = '.tsx';
@@ -121,7 +122,7 @@ export const getSourceExamplesPathUrl = ({ pageName }: { pageName: string }) => 
     return new URL(sourceExamplesPath, import.meta.url);
 };
 
-export const getFrameworkFromInternalFramework = (internalFramework: string) => {
+export const getFrameworkFromInternalFramework = (internalFramework: InternalFramework) => {
     switch (internalFramework) {
         case 'typescript':
         case 'vanilla':
@@ -138,7 +139,7 @@ export const getFrameworkFromInternalFramework = (internalFramework: string) => 
     }
 };
 
-export const getEntryFileName = (internalFramework: string) => {
+export const getEntryFileName = (internalFramework: InternalFramework) => {
     switch (internalFramework) {
         case 'typescript':
             return 'main.ts';
@@ -205,15 +206,13 @@ export const getSourceFileContents = ({
 
 // TODO: Find a better way to determine if an example is enterprise or not
 export const getIsEnterprise = ({
-    framework,
     internalFramework,
     entryFile,
 }: {
-    framework: string;
-    internalFramework: string;
+    internalFramework: InternalFramework;
     entryFile: string;
 }) => {
-    const entryFileName = getEntryFileName({ framework, internalFramework });
+    const entryFileName = getEntryFileName(internalFramework);
 
     return entryFileName === 'main.js'
         ? entryFile?.includes('AgEnterpriseCharts')

--- a/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.ts
@@ -69,7 +69,12 @@ export const getBoilerPlateFiles = async (internalFramework: InternalFramework) 
     const fileNames = await fs.readdir(boilerPlatePath);
 
     const files: Record<string, string> = {};
+    const isDev = getIsDev();
     const fileContentPromises = fileNames.map(async (fileName) => {
+        if (!isDev && fileName === 'systemjs.config.dev.js') {
+            // Ignore systemjs dev file if on production
+            return;
+        }
         const filePath = pathJoin(boilerPlatePath, fileName);
         const contents = await fs.readFile(filePath, 'utf-8').catch(() => {
             return undefined;

--- a/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
@@ -3,13 +3,13 @@ import { readAsJsFile } from '../transformation-scripts/parser-utils';
 import { vanillaToReact } from '../transformation-scripts/chart-vanilla-to-react';
 import { vanillaToReactFunctional } from '../transformation-scripts/chart-vanilla-to-react-functional';
 import { vanillaToReactFunctionalTs } from '../transformation-scripts/chart-vanilla-to-react-functional-ts';
-import { getBoilerPlateFiles } from './fileUtils';
+import { getBoilerPlateFiles, getEntryFileName } from './fileUtils';
 import { deepCloneObject } from './deepCloneObject';
 
 interface FrameworkFiles {
     files: Record<string, string>;
     boilerPlateFiles?: Record<string, string>;
-    scriptFiles: string[];
+    scriptFiles?: string[];
     entryFileName: string;
 }
 
@@ -37,7 +37,8 @@ const createReactFilesGenerator =
         sourceGenerator: (bindings: any, componentFilenames: string[]) => () => string;
         internalFramework: InternalFramework;
     }): ConfigGenerator =>
-    async ({ entryFile, bindings, indexHtml, otherScriptFiles }) => {
+    async ({ bindings, indexHtml, otherScriptFiles }) => {
+        const entryFileName = getEntryFileName(internalFramework)!;
         const boilerPlateFiles = await getBoilerPlateFiles(internalFramework);
 
         const getSource = sourceGenerator(deepCloneObject(bindings), []);
@@ -46,18 +47,19 @@ const createReactFilesGenerator =
         return {
             files: {
                 ...otherScriptFiles,
-                'index.jsx': indexJsx,
+                [entryFileName]: indexJsx,
                 'index.html': indexHtml,
             },
             boilerPlateFiles,
             // Other files, not including entry file
             scriptFiles: Object.keys(otherScriptFiles),
-            entryFileName: 'index.jsx',
+            entryFileName,
         };
     };
 
 export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator> = {
     vanilla: ({ entryFile, indexHtml, typedBindings, isEnterprise, otherScriptFiles }) => {
+        const entryFileName = getEntryFileName('vanilla')!;
         let mainJs = readAsJsFile(entryFile);
 
         // replace Typescript new Grid( with Javascript new agGrid.Grid(
@@ -78,16 +80,19 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         return {
             files: {
                 ...otherScriptFiles,
-                'main.js': mainJs,
+                [entryFileName]: mainJs,
                 'index.html': indexHtml,
             },
-            scriptFiles: Object.keys(otherScriptFiles).concat('main.js'),
-            entryFileName: 'main.js',
+            scriptFiles: Object.keys(otherScriptFiles).concat(entryFileName),
+            entryFileName,
         };
     },
     typescript: async ({ entryFile, indexHtml, otherScriptFiles, bindings }) => {
+        const internalFramework: InternalFramework = 'typescript';
+        const entryFileName = getEntryFileName(internalFramework)!;
+
         const { externalEventHandlers } = bindings;
-        const boilerPlateFiles = await getBoilerPlateFiles('typescript');
+        const boilerPlateFiles = await getBoilerPlateFiles(internalFramework);
 
         // Attach external event handlers
         let externalEventHandlersCode;
@@ -107,12 +112,12 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         return {
             files: {
                 ...otherScriptFiles,
-                'main.ts': mainTsx,
+                [entryFileName]: mainTsx,
                 'index.html': indexHtml,
             },
             boilerPlateFiles,
             // NOTE: `scriptFiles` not required, as system js handles import
-            entryFileName: 'main.ts',
+            entryFileName,
         };
     },
     react: createReactFilesGenerator({
@@ -123,8 +128,10 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         sourceGenerator: vanillaToReactFunctional,
         internalFramework: 'reactFunctional',
     }),
-    reactFunctionalTs: async ({ entryFile, typedBindings, indexHtml, otherScriptFiles }) => {
-        const boilerPlateFiles = await getBoilerPlateFiles('reactFunctionalTs');
+    reactFunctionalTs: async ({ typedBindings, indexHtml, otherScriptFiles }) => {
+        const internalFramework: InternalFramework = 'reactFunctionalTs';
+        const entryFileName = getEntryFileName(internalFramework)!;
+        const boilerPlateFiles = await getBoilerPlateFiles(internalFramework);
 
         const getSource = vanillaToReactFunctionalTs(deepCloneObject(typedBindings), []);
         const indexTsx = getSource();
@@ -132,12 +139,12 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         return {
             files: {
                 ...otherScriptFiles,
-                'index.tsx': indexTsx,
+                [entryFileName]: indexTsx,
                 'index.html': indexHtml,
             },
             boilerPlateFiles,
             // NOTE: `scriptFiles` not required, as system js handles import
-            entryFileName: 'index.tsx',
+            entryFileName,
         };
     },
     angular: () => ({ files: {}, scriptFiles: [], entryFileName: '' }),

--- a/packages/ag-charts-website/src/features/examples-generator/utils/getOtherScriptFiles.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/getOtherScriptFiles.ts
@@ -1,8 +1,6 @@
 import { readAsJsFile } from '../transformation-scripts/parser-utils';
 import { getContentsOfFileList } from './fileUtils';
-import type { FileContents } from '../types.d';
-
-type TransformTsFileExt = undefined | '.js' | '.tsx';
+import type { FileContents, TransformTsFileExt } from '../types.d';
 
 const getOtherTsGeneratedFiles = async ({
     sourceEntryFileName,
@@ -76,7 +74,7 @@ export const getOtherScriptFiles = async ({
     sourceFileList: string[];
     pageName: string;
     exampleName: string;
-    transformTsFileExt: TransformTsFileExt;
+    transformTsFileExt?: TransformTsFileExt;
 }) => {
     const otherTsGeneratedFileContents = await getOtherTsGeneratedFiles({
         sourceEntryFileName,

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
@@ -7,6 +7,7 @@ import TypescriptTemplate from '../../../../features/example-runner/framework-te
 import { getGeneratedContents } from '../../../../features/examples-generator/examplesGenerator';
 import { getIsDev } from '../../../../utils/env';
 import ReactTemplate from '../../../../features/example-runner/framework-templates/ReactTemplate.astro';
+import VueTemplate from '../../../../features/example-runner/framework-templates/VueTemplate.astro';
 
 interface Props {
     /**
@@ -58,7 +59,11 @@ const supportedInternalFrameworks: InternalFramework[] = [
     'react',
     'reactFunctional',
     'reactFunctionalTs',
+    'vue',
+    'vue3',
 ];
+
+const timeNow = Date.now();
 ---
 
 {
@@ -67,7 +72,7 @@ const supportedInternalFrameworks: InternalFramework[] = [
             isDev={isDev}
             pageName={pageName}
             exampleName={exampleName}
-            modifiedTimeMs={Date.now()}
+            modifiedTimeMs={timeNow}
             isExecuting={true}
             options={{
                 enterprise: isEnterprise,
@@ -86,7 +91,7 @@ const supportedInternalFrameworks: InternalFramework[] = [
             isDev={isDev}
             pageName={pageName}
             exampleName={exampleName}
-            modifiedTimeMs={Date.now()}
+            modifiedTimeMs={timeNow}
             isExecuting={true}
             options={{
                 enterprise: isEnterprise,
@@ -107,7 +112,7 @@ const supportedInternalFrameworks: InternalFramework[] = [
             isDev={isDev}
             pageName={pageName}
             exampleName={exampleName}
-            modifiedTimeMs={Date.now()}
+            modifiedTimeMs={timeNow}
             isExecuting={true}
             options={{
                 enterprise: isEnterprise,
@@ -118,6 +123,28 @@ const supportedInternalFrameworks: InternalFramework[] = [
             appLocation={appLocation}
             library={library}
             boilerplatePath={boilerPlateUrl}
+        />
+    )
+}
+
+{
+    (internalFramework === 'vue' || internalFramework === 'vue3') && (
+        <VueTemplate
+            isDev={isDev}
+            pageName={pageName}
+            exampleName={exampleName}
+            modifiedTimeMs={timeNow}
+            isExecuting={true}
+            options={{
+                enterprise: isEnterprise,
+            }}
+            entryFileName={entryFileName!}
+            scriptFiles={scriptFiles}
+            styleFiles={styleFiles}
+            appLocation={appLocation}
+            library={library}
+            boilerplatePath={boilerPlateUrl}
+            vueFramework={internalFramework}
         />
     )
 }

--- a/packages/ag-charts-website/src/utils/pages.ts
+++ b/packages/ag-charts-website/src/utils/pages.ts
@@ -50,6 +50,11 @@ export const DEV_FILE_PATH_MAP: Record<string, string> = {
     'ag-charts-community/dist/main.umd.cjs.map': 'packages/ag-charts-community/dist/main.umd.cjs.map',
     'ag-charts-enterprise/dist/main.umd.cjs.map': 'packages/ag-charts-enterprise/dist/main.umd.cjs.map',
     'ag-charts-react/main.js': 'packages/ag-charts-react/dist/index.js',
+
+    'ag-charts-vue/main.js': 'packages/ag-charts-vue/main.js',
+    'ag-charts-vue/lib/AgChartsVue.js': 'packages/ag-charts-vue/lib/AgChartsVue.js',
+    'ag-charts-vue3/main.js': 'packages/ag-charts-vue3/main.js',
+    'ag-charts-vue3/lib/AgChartsVue.js': 'packages/ag-charts-vue3/lib/AgChartsVue.js',
 };
 
 export const getChartScriptPath = (sitePrefix?: string) => {


### PR DESCRIPTION
## Changes

* Add Vue/Vue3 example runner
* Only show show systemjs dev file on local dev
* Cleaned up files

## Known issues

* It currently uses the source files of the Vue framework wrapper instead of built files. This is how the grid production site works. This is because the built files didn't work as is. Needs more investigation as to why the built files don't work.