### PR TITLE
AG-8395 Fix node highlight outside chart pending crosshair hover option

### DIFF
--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -42,15 +42,12 @@ export class CartesianChart extends Chart {
             left: seriesAreaPadding.left,
         });
 
-        const hoverRectPadding = 20;
-        const hoverRect = seriesPaddedRect.clone().grow(hoverRectPadding);
-
-        this.hoverRect = hoverRect;
+        this.hoverRect = seriesPaddedRect;
 
         this.layoutService.dispatchLayoutComplete({
             type: 'layout-complete',
             chart: { width: this.scene.width, height: this.scene.height },
-            series: { rect: seriesRect, paddedRect: seriesPaddedRect, hoverRect, visible: visibility.series },
+            series: { rect: seriesRect, paddedRect: seriesPaddedRect, visible: visibility.series },
             axes: this.axes.map((axis) => ({ id: axis.id, ...axis.getLayoutState() })),
         });
 

--- a/packages/ag-charts-community/src/chart/hierarchyChart.ts
+++ b/packages/ag-charts-community/src/chart/hierarchyChart.ts
@@ -24,10 +24,7 @@ export class HierarchyChart extends Chart {
         shrinkRect.shrink(seriesAreaPadding.bottom, 'bottom');
 
         this.seriesRect = shrinkRect;
-
-        const hoverRectPadding = 20;
-        const hoverRect = shrinkRect.clone().grow(hoverRectPadding);
-        this.hoverRect = hoverRect;
+        this.hoverRect = shrinkRect;
 
         this.seriesRoot.translationX = Math.floor(shrinkRect.x);
         this.seriesRoot.translationY = Math.floor(shrinkRect.y);
@@ -45,7 +42,7 @@ export class HierarchyChart extends Chart {
         this.layoutService.dispatchLayoutComplete({
             type: 'layout-complete',
             chart: { width: this.scene.width, height: this.scene.height },
-            series: { rect: fullSeriesRect, paddedRect: shrinkRect, hoverRect, visible: true },
+            series: { rect: fullSeriesRect, paddedRect: shrinkRect, visible: true },
             axes: [],
         });
 

--- a/packages/ag-charts-community/src/chart/layout/layoutService.ts
+++ b/packages/ag-charts-community/src/chart/layout/layoutService.ts
@@ -20,7 +20,7 @@ export interface AxisLayout {
 export interface LayoutCompleteEvent {
     type: 'layout-complete';
     chart: { width: number; height: number };
-    series: { rect: BBox; paddedRect: BBox; hoverRect: BBox; visible: boolean };
+    series: { rect: BBox; paddedRect: BBox; visible: boolean };
     axes?: (AxisLayout & {
         id: string;
     })[];

--- a/packages/ag-charts-community/src/chart/polarChart.ts
+++ b/packages/ag-charts-community/src/chart/polarChart.ts
@@ -27,14 +27,12 @@ export class PolarChart extends Chart {
         this.computeCircle(shrinkRect);
         this.axes.forEach((axis) => axis.update());
 
-        const hoverRectPadding = 20;
-        const hoverRect = shrinkRect.clone().grow(hoverRectPadding);
-        this.hoverRect = hoverRect;
+        this.hoverRect = shrinkRect;
 
         this.layoutService.dispatchLayoutComplete({
             type: 'layout-complete',
             chart: { width: this.scene.width, height: this.scene.height },
-            series: { rect: fullSeriesRect, paddedRect: shrinkRect, hoverRect, visible: true },
+            series: { rect: fullSeriesRect, paddedRect: shrinkRect, visible: true },
             axes: [],
         });
 

--- a/packages/ag-charts-enterprise/src/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/crosshair/crosshair.ts
@@ -71,7 +71,7 @@ export class Crosshair extends _ModuleSupport.BaseModuleInstance implements _Mod
         this.destroyFns.push(() => this.label.destroy());
     }
 
-    private layout({ series: { rect, hoverRect, visible }, axes }: _ModuleSupport.LayoutCompleteEvent) {
+    private layout({ series: { rect, paddedRect, visible }, axes }: _ModuleSupport.LayoutCompleteEvent) {
         this.hideCrosshair();
 
         if (!(visible && axes && this.enabled)) {
@@ -81,7 +81,7 @@ export class Crosshair extends _ModuleSupport.BaseModuleInstance implements _Mod
 
         this.visible = true;
         this.seriesRect = rect;
-        this.hoverRect = hoverRect;
+        this.hoverRect = paddedRect;
 
         const { position: axisPosition = 'left', axisId } = this.axisCtx;
 


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8395

This was added for https://ag-grid.atlassian.net/browse/AG-4371 to enable the crosshair to be triggered when hovering slightly outside the chart series area.

A safer solution would be to have it as an option specific to hovering with crosshairs. Though perhaps still generic such that different features can trigger at different paddings? (Ticket added https://ag-grid.atlassian.net/browse/AG-8983)