### PR TITLE
AG-8868 Fix chart update to mark series as dirty in scheduled update

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -480,9 +480,14 @@ export abstract class Chart extends Observable implements AgChartInstance {
         return this._lastPerformUpdateError;
     }
 
+    private forceNodeDataRefresh: boolean = false;
     private seriesToUpdate: Set<Series> = new Set();
     private performUpdateTrigger = debouncedCallback(async ({ count }) => {
         if (this._destroyed) return;
+
+        if (this.forceNodeDataRefresh) {
+            this.series.forEach((series) => series.markNodeDataDirty());
+        }
 
         try {
             await this.performUpdate(count);
@@ -500,9 +505,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     ) {
         const { forceNodeDataRefresh = false, seriesToUpdate = this.series } = opts ?? {};
 
-        if (forceNodeDataRefresh) {
-            this.series.forEach((series) => series.markNodeDataDirty());
-        }
+        this.forceNodeDataRefresh = forceNodeDataRefresh;
 
         for (const series of seriesToUpdate) {
             this.seriesToUpdate.add(series);


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-8868

Fixes when an update is called during another update with `forceNodeDataRefresh: true`, the series were marked clean by the current update before the new scheduled update was processed.

This may cause performance issues, if the `forceNodeDataRefresh` value lingers. And may also cause bad side effects. Requires further discussion.