### PR TITLE
Remove animation state machine actions

### DIFF
--- a/packages/ag-charts-community/src/axis.ts
+++ b/packages/ag-charts-community/src/axis.ts
@@ -234,27 +234,21 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         this.animationManager = moduleCtx.animationManager;
         this.animationState = new AxisStateMachine('empty', {
             empty: {
-                on: {
-                    update: {
-                        target: 'align',
-                        action: () => this.resetSelectionNodes(),
-                    },
+                update: {
+                    target: 'align',
+                    action: () => this.resetSelectionNodes(),
                 },
             },
             align: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.resetSelectionNodes(),
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.resetSelectionNodes(),
                 },
             },
             ready: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: (data: AxisUpdateDiff) => this.animateReadyUpdate(data),
-                    },
+                update: {
+                    target: 'ready',
+                    action: (data: AxisUpdateDiff) => this.animateReadyUpdate(data),
                 },
             },
         });

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -157,43 +157,36 @@ export abstract class CartesianSeries<
 
         this.animationState = new CartesianStateMachine('empty', {
             empty: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: (data) => this.animateEmptyUpdateReady(data),
-                    },
+                update: {
+                    target: 'ready',
+                    action: (data) => this.animateEmptyUpdateReady(data),
                 },
             },
             ready: {
-                on: {
-                    updateData: {
-                        target: 'waiting',
-                        action: () => {},
-                    },
-                    update: {
-                        target: 'ready',
-                        action: (data) => this.animateReadyUpdate(data),
-                    },
-                    highlight: {
-                        target: 'ready',
-                        action: (data) => this.animateReadyHighlight(data),
-                    },
-                    highlightMarkers: {
-                        target: 'ready',
-                        action: (data) => this.animateReadyHighlightMarkers(data),
-                    },
-                    resize: {
-                        target: 'ready',
-                        action: (data) => this.animateReadyResize(data),
-                    },
+                updateData: {
+                    target: 'waiting',
+                },
+                update: {
+                    target: 'ready',
+                    action: (data) => this.animateReadyUpdate(data),
+                },
+                highlight: {
+                    target: 'ready',
+                    action: (data) => this.animateReadyHighlight(data),
+                },
+                highlightMarkers: {
+                    target: 'ready',
+                    action: (data) => this.animateReadyHighlightMarkers(data),
+                },
+                resize: {
+                    target: 'ready',
+                    action: (data) => this.animateReadyResize(data),
                 },
             },
             waiting: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: (data) => this.animateWaitingUpdateReady(data),
-                    },
+                update: {
+                    target: 'ready',
+                    action: (data) => this.animateWaitingUpdateReady(data),
                 },
             },
         });

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -361,31 +361,24 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
 
         this.animationState = new PieStateMachine('empty', {
             empty: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.animateEmptyUpdateReady(),
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.animateEmptyUpdateReady(),
                 },
             },
             ready: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.animateReadyUpdateReady(),
-                    },
-                    updateData: {
-                        target: 'waiting',
-                        action: () => {},
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.animateReadyUpdateReady(),
+                },
+                updateData: {
+                    target: 'waiting',
                 },
             },
             waiting: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.animateWaitingUpdateReady(),
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.animateWaitingUpdateReady(),
                 },
             },
         });

--- a/packages/ag-charts-community/src/motion/states.test.ts
+++ b/packages/ag-charts-community/src/motion/states.test.ts
@@ -2,32 +2,19 @@ import { describe, expect, it, beforeEach, jest } from '@jest/globals';
 import { StateMachine } from './states';
 
 describe('Animation States', () => {
-    let state;
-    let initialEventNext;
-    let initialOnExit;
-    let nextOnEnter;
+    let state: any;
+    let initialEventNext: any;
 
     beforeEach(() => {
         initialEventNext = jest.fn();
-        initialOnExit = jest.fn();
-        nextOnEnter = jest.fn();
-        state = new StateMachine<'initial' | 'next', 'event'>('initial', {
+        state = new StateMachine('initial', {
             initial: {
-                actions: {
-                    onExit: initialOnExit,
-                },
-                on: {
-                    event: {
-                        target: 'next',
-                        action: initialEventNext,
-                    },
+                event: {
+                    target: 'next',
+                    action: initialEventNext,
                 },
             },
-            next: {
-                actions: {
-                    onEnter: nextOnEnter,
-                },
-            },
+            next: {},
         });
     });
 
@@ -43,15 +30,5 @@ describe('Animation States', () => {
     it('should call the transition action', () => {
         state.transition('event');
         expect(initialEventNext).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call a state's onExit action", () => {
-        state.transition('event');
-        expect(initialOnExit).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call a state's onEnter action", () => {
-        state.transition('event');
-        expect(nextOnEnter).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/ag-charts-community/src/motion/states.ts
+++ b/packages/ag-charts-community/src/motion/states.ts
@@ -1,18 +1,12 @@
 import { Logger } from '../util/logger';
 import { windowValue } from '../util/window';
 
-interface StateDefinition<State extends string, Event extends string> {
-    actions?: {
-        onEnter?: () => void;
-        onExit?: () => void;
+type StateDefinition<State extends string, Event extends string> = {
+    [key in Event]?: {
+        target: State;
+        action?: (data?: any) => void;
     };
-    on?: {
-        [key in Event]?: {
-            target: State;
-            action: (data?: any) => void;
-        };
-    };
-}
+};
 
 export class StateMachine<State extends string, Event extends string> {
     static DEBUG = () => [true, 'animation'].includes(windowValue('agChartsDebug') as string) ?? false;
@@ -29,7 +23,7 @@ export class StateMachine<State extends string, Event extends string> {
 
     transition(event: Event, data?: any) {
         const currentStateConfig = this.states[this.state];
-        const destinationTransition = currentStateConfig?.on?.[event];
+        const destinationTransition = currentStateConfig?.[event];
 
         if (!destinationTransition) {
             if (StateMachine.DEBUG()) {
@@ -39,7 +33,6 @@ export class StateMachine<State extends string, Event extends string> {
         }
 
         const destinationState = destinationTransition.target;
-        const destinationStateConfig = this.states[destinationState];
 
         if (StateMachine.DEBUG()) {
             Logger.debug(
@@ -48,9 +41,7 @@ export class StateMachine<State extends string, Event extends string> {
             );
         }
 
-        destinationTransition.action(data);
-        currentStateConfig?.actions?.onExit?.();
-        destinationStateConfig?.actions?.onEnter?.();
+        destinationTransition.action?.(data);
 
         this.state = destinationState;
 

--- a/packages/ag-charts-enterprise/src/polar-series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radar/radarSeries.ts
@@ -182,23 +182,19 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
 
         this.animationState = new RadarStateMachine('empty', {
             empty: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.animateEmptyUpdateReady(),
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.animateEmptyUpdateReady(),
                 },
             },
             ready: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.animateReadyUpdate(),
-                    },
-                    resize: {
-                        target: 'ready',
-                        action: () => this.animateReadyResize(),
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.animateReadyUpdate(),
+                },
+                resize: {
+                    target: 'ready',
+                    action: () => this.animateReadyResize(),
                 },
             },
         });

--- a/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnSeriesBase.ts
@@ -175,23 +175,19 @@ export abstract class RadialColumnSeriesBase<
 
         this.animationState = new RadialColumnStateMachine('empty', {
             empty: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.animateEmptyUpdateReady(),
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.animateEmptyUpdateReady(),
                 },
             },
             ready: {
-                on: {
-                    update: {
-                        target: 'ready',
-                        action: () => this.animateReadyUpdate(),
-                    },
-                    resize: {
-                        target: 'ready',
-                        action: () => this.animateReadyResize(),
-                    },
+                update: {
+                    target: 'ready',
+                    action: () => this.animateReadyUpdate(),
+                },
+                resize: {
+                    target: 'ready',
+                    action: () => this.animateReadyResize(),
                 },
             },
         });


### PR DESCRIPTION
Removes the animation state machine actions on transitioning between states, since we were not using them and the extra nesting from the `on` property was annoying.