### PR TITLE
AG-9075 - Add prism syntax highlighting

### DIFF
--- a/packages/ag-charts-website/markdoc.config.ts
+++ b/packages/ag-charts-website/markdoc.config.ts
@@ -1,6 +1,8 @@
 import { defineMarkdocConfig, component } from '@astrojs/markdoc/config';
+import prism from './src/astro/plugins/prism';
 
 export default defineMarkdocConfig({
+    extends: [prism()],
     tags: {
         chartExampleRunner: {
             render: component('./src/features/docs/components/DocsExampleRunner.astro'),

--- a/packages/ag-charts-website/src/astro/plugins/prism.ts
+++ b/packages/ag-charts-website/src/astro/plugins/prism.ts
@@ -1,0 +1,28 @@
+// @ts-expect-error Cannot find module 'astro/runtime/server/index.js' or its corresponding type declarations.
+import { unescapeHTML } from 'astro/runtime/server/index.js';
+
+import { runHighlighterWithAstro } from '@astrojs/prism/dist/highlighter';
+import { Markdoc, type AstroMarkdocConfig } from '@astrojs/markdoc/config';
+
+/**
+ * Extend default markdoc prism highlighter to include AG Charts `code` styles
+ *
+ * @see https://github.com/withastro/astro/blob/fa3e83984343d3b9c37af7af876ad03ac95bf1c6/packages/integrations/markdoc/src/extensions/prism.ts
+ */
+export default function prism(): AstroMarkdocConfig {
+    return {
+        nodes: {
+            fence: {
+                attributes: Markdoc.nodes.fence.attributes!,
+                transform({ attributes: { language, content } }) {
+                    const { html, classLanguage } = runHighlighterWithAstro(language, content);
+
+                    // Use `unescapeHTML` to return `HTMLString` for Astro renderer to inline as HTML
+                    return unescapeHTML(
+                        `<pre class="${classLanguage} code"><code class="${classLanguage}">${html}</code></pre>`
+                    );
+                },
+            },
+        },
+    };
+}


### PR DESCRIPTION
## Changes

* Add prism syntax highlighting
* Extend default astro prism plugin to add the `code` class for design system styles to come through