### PR TITLE
AG-8932 - Move enterprise typings into community.

### DIFF
--- a/packages/ag-charts-community-examples/src/charts-overview/examples/pie-in-a-doughnut/main.ts
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/pie-in-a-doughnut/main.ts
@@ -1,4 +1,5 @@
 import type {
+  AgPieSeriesOptions,
   AgPolarChartOptions,
   AgPolarSeriesOptions} from "ag-charts-community";
 import {
@@ -11,7 +12,7 @@ const numFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 0,
 })
 
-const sharedSeriesOptions: AgPolarSeriesOptions = {
+const sharedSeriesOptions: AgPieSeriesOptions = {
   sectorLabelKey: "share",
   angleKey: "share",
   sectorLabel: {

--- a/packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -1,185 +1,39 @@
-import type { AgBaseChartListeners } from './options/eventOptions';
-import type { AgChartTheme } from './options/themeOptions';
-import type { AgChartTooltipOptions } from './options/tooltipOptions';
-import type { CssColor, FontFamily, FontSize, FontStyle, FontWeight, PixelSize, TextWrap } from './options/types';
 import type { AgCartesianChartOptions } from './series/cartesian/cartesianOptions';
 import type { AgHierarchyChartOptions } from './series/hierarchy/hierarchyOptions';
 import type { AgPolarChartOptions } from './series/polar/polarOptions';
 
 export * from './options/axisOptions';
+export * from './options/crosshairOptions';
+export * from './options/chartOptions';
 export * from './options/crossLineOptions';
 export * from './options/eventOptions';
 export * from './options/legendOptions';
+export * from './options/polarAxisOptions';
 export * from './options/tooltipOptions';
 export * from './options/themeOptions';
 export * from './options/types';
+export * from './options/zoomOptions';
 export * from './series/seriesOptions';
 export * from './series/cartesian/cartesianOptions';
 export * from './series/cartesian/areaOptions';
 export * from './series/cartesian/barOptions';
 export * from './series/cartesian/lineOptions';
+export * from './series/cartesian/heatmapOptions';
 export * from './series/cartesian/histogramOptions';
+export * from './series/cartesian/rangeBarOptions';
 export * from './series/cartesian/scatterOptions';
+export * from './series/cartesian/waterfallOptions';
 export * from './series/hierarchy/hierarchyOptions';
 export * from './series/hierarchy/treemapOptions';
+export * from './series/polar/nightingaleOptions';
 export * from './series/polar/pieOptions';
 export * from './series/polar/polarOptions';
+export * from './series/polar/radarOptions';
+export * from './series/polar/radarLineOptions';
+export * from './series/polar/radarAreaOptions';
+export * from './series/polar/radialColumnOptions';
 
-export interface AgChartPaddingOptions {
-    /** The number of pixels of padding at the top of the chart area. */
-    top?: PixelSize;
-    /** The number of pixels of padding at the right of the chart area. */
-    right?: PixelSize;
-    /** The number of pixels of padding at the bottom of the chart area. */
-    bottom?: PixelSize;
-    /** The number of pixels of padding at the left of the chart area. */
-    left?: PixelSize;
-}
-
-export interface AgSeriesAreaPaddingOptions {
-    /** The number of pixels of padding at the top of the series area. */
-    top?: PixelSize;
-    /** The number of pixels of padding at the right of the series area. */
-    right?: PixelSize;
-    /** The number of pixels of padding at the bottom of the series area. */
-    bottom?: PixelSize;
-    /** The number of pixels of padding at the left of the series area. */
-    left?: PixelSize;
-}
-
-export interface AgChartOverlayOptions {
-    /** Text to render in the overlay. */
-    text?: string;
-    /** A function for generating HTML string for overlay content. */
-    renderer?: () => string;
-}
-
-export interface AgChartOverlaysOptions {
-    /** An overlay to be displayed when there is no data. */
-    noData?: AgChartOverlayOptions;
-}
-
-export interface AgChartLabelOptions {
-    /** Whether or not the labels should be shown. */
-    enabled?: boolean;
-    /** The font style to use for the labels. */
-    fontStyle?: FontStyle;
-    /** The font weight to use for the labels. */
-    fontWeight?: FontWeight;
-    /** The font size in pixels to use for the labels. */
-    fontSize?: FontSize;
-    /** The font family to use for the labels. */
-    fontFamily?: FontFamily;
-    /** The colour to use for the labels. */
-    color?: CssColor;
-}
-
-export interface AgDropShadowOptions {
-    /** Whether or not the shadow is visible. */
-    enabled?: boolean;
-    /** The colour of the shadow. */
-    color?: CssColor;
-    /** The horizontal offset in pixels for the shadow. */
-    xOffset?: PixelSize;
-    /** The vertical offset in pixels for the shadow. */
-    yOffset?: PixelSize;
-    /** The radius of the shadow's blur, given in pixels. */
-    blur?: PixelSize;
-}
-
-export interface AgChartCaptionOptions {
-    /** Whether or not the text should be shown. */
-    enabled?: boolean;
-    /** The text to display. */
-    text?: string;
-    /** The font style to use for the text. */
-    fontStyle?: FontStyle;
-    /** The font weight to use for the text. */
-    fontWeight?: FontWeight;
-    /** The font size in pixels to use for the text. */
-    fontSize?: FontSize;
-    /** The font family to use for the text. */
-    fontFamily?: FontFamily;
-    /** The colour to use for the text. */
-    color?: CssColor;
-    /** Spacing added to help position the text. */
-    spacing?: number;
-    /** Used to constrain the width of the title. */
-    maxWidth?: PixelSize;
-    /** Used to constrain the height of the title. */
-    maxHeight?: PixelSize;
-    /**
-     * Text wrapping strategy for long text.
-     * `'always'` will always wrap text to fit within the `maxWidth`.
-     * `'hyphenate'` is similar to `'always'`, but inserts a hyphen (`-`) if forced to wrap in the middle of a word.
-     * `'on-space'` will only wrap on white space. If there is no possibility to wrap a line on space and satisfy `maxWidth`, the text will be truncated.
-     * `'never'` disables text wrapping.
-     */
-    wrapping?: TextWrap;
-}
-export interface AgChartSubtitleOptions extends AgChartCaptionOptions {}
-export interface AgChartFooterOptions extends AgChartCaptionOptions {}
-
-export interface AgChartBackground {
-    /** Whether or not the background should be visible. */
-    visible?: boolean;
-    /** Colour of the chart background. */
-    fill?: CssColor;
-}
-
-type AgChartHighlightRange = 'tooltip' | 'node';
-
-export interface AgChartHighlightOptions {
-    /** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */
-    range?: AgChartHighlightRange;
-}
-
-/** Configuration common to all charts.  */
-export interface AgBaseChartOptions {
-    /** The data to render the chart from. If this is not specified, it must be set on individual series instead. */
-    data?: any[];
-    /** The element to place the rendered chart into.<br/><strong>Important:</strong> make sure to read the `autoSize` config description for information on how the container element affects the chart size (by default). */
-    container?: HTMLElement | null;
-    /** The width of the chart in pixels. */
-    width?: PixelSize;
-    /** The height of the chart in pixels. */
-    height?: PixelSize;
-    /** By default, the chart will resize automatically to fill the container element. Set this to `false` to disable this behaviour. If `width` or `height` are specified, auto-sizing will be active for the other unspecified dimension.<br/><strong>Important:</strong> if this config is set to `true`, make sure to give the chart's `container` element an explicit size, otherwise you will run into a chicken and egg situation where the container expects to size itself according to the content and the chart expects to size itself according to the container. */
-    autoSize?: boolean;
-    /** Configuration for the padding shown around the chart. */
-    padding?: AgChartPaddingOptions;
-    /** Configuration for the padding around the series area. */
-    seriesAreaPadding?: AgSeriesAreaPaddingOptions;
-    /** Configuration for the background shown behind the chart. */
-    background?: AgChartBackground;
-    /** Configuration for the title shown at the top of the chart. */
-    title?: AgChartCaptionOptions;
-    /** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */
-    subtitle?: AgChartSubtitleOptions;
-    /** Configuration for the footnote shown at the bottom of the chart. */
-    footnote?: AgChartFooterOptions;
-    /** Global configuration that applies to all tooltips in the chart. */
-    tooltip?: AgChartTooltipOptions;
-    /** A map of event names to event listeners. */
-    listeners?: AgBaseChartListeners;
-    /** Configuration for the chart highlighting. */
-    highlight?: AgChartHighlightOptions;
-    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */
-    theme?: string | AgChartTheme;
-    /** HTML overlays */
-    overlays?: AgChartOverlaysOptions;
-}
-
-export type AgChartOptions<
-    CartesianAddonType = never,
-    CartesianAddonSeries = never,
-    PolarAddonType = never,
-    PolarAddonSeries = never
-> =
-    | AgCartesianChartOptions<CartesianAddonType, CartesianAddonSeries>
-    | AgPolarChartOptions<PolarAddonType, PolarAddonSeries>
-    | AgHierarchyChartOptions;
-
+export type AgChartOptions = AgCartesianChartOptions | AgPolarChartOptions | AgHierarchyChartOptions;
 export interface AgChartInstance {
     /** Get the `AgChartOptions` representing the current chart configuration. */
     getOptions(): AgChartOptions;

--- a/packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -21,6 +21,7 @@ export * from './series/cartesian/lineOptions';
 export * from './series/cartesian/heatmapOptions';
 export * from './series/cartesian/histogramOptions';
 export * from './series/cartesian/rangeBarOptions';
+export * from './series/cartesian/rangeAreaOptions';
 export * from './series/cartesian/scatterOptions';
 export * from './series/cartesian/waterfallOptions';
 export * from './series/hierarchy/hierarchyOptions';

--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -1,30 +1,11 @@
-import type {
-    AgChartOptions,
-    AgLineSeriesOptions,
-    AgBarSeriesOptions,
-    AgAreaSeriesOptions,
-    AgScatterSeriesOptions,
-    AgHistogramSeriesOptions,
-    AgPieSeriesOptions,
-    AgTreemapSeriesOptions,
-    AgChartInstance,
-    AgBaseAxisOptions,
-    AgColumnSeriesOptions,
-} from './agChartOptions';
+import type { AgChartOptions, AgChartInstance, AgBaseAxisOptions, AgBaseSeriesOptions } from './agChartOptions';
 import { CartesianChart } from './cartesianChart';
 import { PolarChart } from './polarChart';
 import { HierarchyChart } from './hierarchyChart';
 import type { Series } from './series/series';
 import { getAxis } from './factory/axisTypes';
 import { getSeries } from './factory/seriesTypes';
-import type { AreaSeries } from './series/cartesian/areaSeries';
-import type { BarSeries, ColumnSeries } from './series/cartesian/barSeries';
-import type { HistogramSeries } from './series/cartesian/histogramSeries';
-import type { LineSeries } from './series/cartesian/lineSeries';
-import type { ScatterSeries } from './series/cartesian/scatterSeries';
-import type { PieSeries } from './series/polar/pieSeries';
 import { PieTitle } from './series/polar/pieSeries';
-import type { TreemapSeries } from './series/hierarchy/treemapSeries';
 import type { ChartAxis } from './chartAxis';
 import type { Chart, SpecialOverrides } from './chart';
 import { ChartUpdateType } from './chartUpdateType';
@@ -47,24 +28,6 @@ import { getJsonApplyOptions } from './chartOptions';
 // Deliberately imported via `module-support` so that internal module registration happens.
 import { REGISTERED_MODULES } from '../module-support';
 import { setupModules } from './factory/setupModules';
-
-type SeriesOptionType<T extends Series> = T extends LineSeries
-    ? AgLineSeriesOptions
-    : T extends BarSeries
-    ? AgBarSeriesOptions
-    : T extends ColumnSeries
-    ? AgColumnSeriesOptions
-    : T extends AreaSeries
-    ? AgAreaSeriesOptions
-    : T extends ScatterSeries
-    ? AgScatterSeriesOptions
-    : T extends HistogramSeries
-    ? AgHistogramSeriesOptions
-    : T extends PieSeries
-    ? AgPieSeriesOptions
-    : T extends TreemapSeries
-    ? AgTreemapSeriesOptions
-    : never;
 
 export interface DownloadOptions extends ImageDataUrlOptions {
     /** Name of downloaded image file. Defaults to `image`.  */
@@ -228,8 +191,8 @@ abstract class AgChartInternal {
 
         const { overrideDevicePixelRatio, document, window } = userOptions;
         delete userOptions['overrideDevicePixelRatio'];
-        delete userOptions['document'];
-        delete userOptions['window'];
+        delete (userOptions as any)['document'];
+        delete (userOptions as any)['window'];
         const specialOverrides = { overrideDevicePixelRatio, document, window };
 
         const processedOptions = prepareOptions(userOptions, mixinOpts);
@@ -636,7 +599,7 @@ function applyOptionValues<T extends object, S>(
 
 function applySeriesValues(
     target: Series<any>,
-    options?: SeriesOptionType<any>,
+    options?: AgBaseSeriesOptions<any>,
     { path, index }: { path?: string; index?: number } = {}
 ): Series<any> {
     const skip: string[] = ['series[].listeners', 'series[].seriesGrouping'];

--- a/packages/ag-charts-community/src/chart/background/backgroundOptions.ts
+++ b/packages/ag-charts-community/src/chart/background/backgroundOptions.ts
@@ -1,0 +1,30 @@
+import type { Opacity, PixelSize } from '../options/types';
+
+export interface AgChartBackgroundImage {
+    /** URL of the image */
+    url: string;
+
+    /** Distance from the left border of the chart to the left border of the image. If neither left nor right specified, the image is centred horizontally. */
+    left?: PixelSize;
+    /** Distance from the top border of the chart to the top border of the image. If neither top nor bottom specified, the image is centred vertically. */
+    top?: PixelSize;
+    /** Distance from the right border of the chart to the right border of the image. If neither left nor right specified, the image is centred horizontally. */
+    right?: PixelSize;
+    /** Distance from the bottom border of the chart to the bottom border of the image. If neither top nor bottom specified, the image is centred vertically. */
+    bottom?: PixelSize;
+
+    /**
+     * Width of the image. If both left and width are specified, right is ignored. If only height is provided,
+     * width will be computed to preserve the original width/height ratio. If neither is provided, the original width is used.
+     */
+    width?: PixelSize;
+
+    /**
+     * Height of the image. If both top and height are specified, bottom is ignored. If only width is provided,
+     * height will be computed to preserve the original width/height ratio.  If neither is provided, the original height is used.
+     */
+    height?: PixelSize;
+
+    /** Opacity of the image. */
+    opacity?: Opacity;
+}

--- a/packages/ag-charts-community/src/chart/interaction/animationOptions.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationOptions.ts
@@ -1,0 +1,6 @@
+export interface AgAnimationOptions {
+    /** Set to true to enable the animation module. */
+    enabled?: boolean;
+    /** The total duration of the animation for each series on initial load and updates */
+    duration?: number;
+}

--- a/packages/ag-charts-community/src/chart/options/chartOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/chartOptions.ts
@@ -1,0 +1,152 @@
+import type { AgChartBackgroundImage } from '../background/backgroundOptions';
+import type { AgBaseChartListeners } from './eventOptions';
+import type { AgChartTheme } from './themeOptions';
+import type { AgChartTooltipOptions } from './tooltipOptions';
+import type { CssColor, FontFamily, FontSize, FontStyle, FontWeight, PixelSize, TextWrap } from './types';
+
+export interface AgChartPaddingOptions {
+    /** The number of pixels of padding at the top of the chart area. */
+    top?: PixelSize;
+    /** The number of pixels of padding at the right of the chart area. */
+    right?: PixelSize;
+    /** The number of pixels of padding at the bottom of the chart area. */
+    bottom?: PixelSize;
+    /** The number of pixels of padding at the left of the chart area. */
+    left?: PixelSize;
+}
+
+export interface AgSeriesAreaPaddingOptions {
+    /** The number of pixels of padding at the top of the series area. */
+    top?: PixelSize;
+    /** The number of pixels of padding at the right of the series area. */
+    right?: PixelSize;
+    /** The number of pixels of padding at the bottom of the series area. */
+    bottom?: PixelSize;
+    /** The number of pixels of padding at the left of the series area. */
+    left?: PixelSize;
+}
+
+export interface AgChartOverlayOptions {
+    /** Text to render in the overlay. */
+    text?: string;
+    /** A function for generating HTML string for overlay content. */
+    renderer?: () => string;
+}
+
+export interface AgChartOverlaysOptions {
+    /** An overlay to be displayed when there is no data. */
+    noData?: AgChartOverlayOptions;
+}
+
+export interface AgChartCaptionOptions {
+    /** Whether or not the text should be shown. */
+    enabled?: boolean;
+    /** The text to display. */
+    text?: string;
+    /** The font style to use for the text. */
+    fontStyle?: FontStyle;
+    /** The font weight to use for the text. */
+    fontWeight?: FontWeight;
+    /** The font size in pixels to use for the text. */
+    fontSize?: FontSize;
+    /** The font family to use for the text. */
+    fontFamily?: FontFamily;
+    /** The colour to use for the text. */
+    color?: CssColor;
+    /** Spacing added to help position the text. */
+    spacing?: number;
+    /** Used to constrain the width of the title. */
+    maxWidth?: PixelSize;
+    /** Used to constrain the height of the title. */
+    maxHeight?: PixelSize;
+    /**
+     * Text wrapping strategy for long text.
+     * `'always'` will always wrap text to fit within the `maxWidth`.
+     * `'hyphenate'` is similar to `'always'`, but inserts a hyphen (`-`) if forced to wrap in the middle of a word.
+     * `'on-space'` will only wrap on white space. If there is no possibility to wrap a line on space and satisfy `maxWidth`, the text will be truncated.
+     * `'never'` disables text wrapping.
+     */
+    wrapping?: TextWrap;
+}
+export interface AgChartSubtitleOptions extends AgChartCaptionOptions {}
+export interface AgChartFooterOptions extends AgChartCaptionOptions {}
+
+export interface AgChartBackground {
+    /** Whether or not the background should be visible. */
+    visible?: boolean;
+    /** Colour of the chart background. */
+    fill?: CssColor;
+    /** Background image. May be combined with fill colour. */
+    image?: AgChartBackgroundImage;
+}
+
+type AgChartHighlightRange = 'tooltip' | 'node';
+
+export interface AgChartHighlightOptions {
+    /** By default, nodes will be highlighted when the cursor is within the `tooltip.range`. Set this to `'node'` to highlight nodes when within the `series[].nodeClickRange`. */
+    range?: AgChartHighlightRange;
+}
+
+/** Configuration common to all charts.  */
+export interface AgBaseChartOptions {
+    /** The data to render the chart from. If this is not specified, it must be set on individual series instead. */
+    data?: any[];
+    /** The element to place the rendered chart into.<br/><strong>Important:</strong> make sure to read the `autoSize` config description for information on how the container element affects the chart size (by default). */
+    container?: HTMLElement | null;
+    /** The width of the chart in pixels. */
+    width?: PixelSize;
+    /** The height of the chart in pixels. */
+    height?: PixelSize;
+    /** By default, the chart will resize automatically to fill the container element. Set this to `false` to disable this behaviour. If `width` or `height` are specified, auto-sizing will be active for the other unspecified dimension.<br/><strong>Important:</strong> if this config is set to `true`, make sure to give the chart's `container` element an explicit size, otherwise you will run into a chicken and egg situation where the container expects to size itself according to the content and the chart expects to size itself according to the container. */
+    autoSize?: boolean;
+    /** Configuration for the padding shown around the chart. */
+    padding?: AgChartPaddingOptions;
+    /** Configuration for the padding around the series area. */
+    seriesAreaPadding?: AgSeriesAreaPaddingOptions;
+    /** Configuration for the background shown behind the chart. */
+    background?: AgChartBackground;
+    /** Configuration for the title shown at the top of the chart. */
+    title?: AgChartCaptionOptions;
+    /** Configuration for the subtitle shown beneath the chart title. Note: a subtitle will only be shown if a title is also present. */
+    subtitle?: AgChartSubtitleOptions;
+    /** Configuration for the footnote shown at the bottom of the chart. */
+    footnote?: AgChartFooterOptions;
+    /** Global configuration that applies to all tooltips in the chart. */
+    tooltip?: AgChartTooltipOptions;
+    /** A map of event names to event listeners. */
+    listeners?: AgBaseChartListeners;
+    /** Configuration for the chart highlighting. */
+    highlight?: AgChartHighlightOptions;
+    /** Theme to use for rendering of the chart. Specify an inbuilt theme name, or provide an `AgChartTheme` instance to customise. */
+    theme?: string | AgChartTheme;
+    /** HTML overlays */
+    overlays?: AgChartOverlaysOptions;
+}
+
+export interface AgChartLabelOptions {
+    /** Whether or not the labels should be shown. */
+    enabled?: boolean;
+    /** The font style to use for the labels. */
+    fontStyle?: FontStyle;
+    /** The font weight to use for the labels. */
+    fontWeight?: FontWeight;
+    /** The font size in pixels to use for the labels. */
+    fontSize?: FontSize;
+    /** The font family to use for the labels. */
+    fontFamily?: FontFamily;
+    /** The colour to use for the labels. */
+    color?: CssColor;
+}
+
+export interface AgDropShadowOptions {
+    /** Whether or not the shadow is visible. */
+    enabled?: boolean;
+    /** The colour of the shadow. */
+    color?: CssColor;
+    /** The horizontal offset in pixels for the shadow. */
+    xOffset?: PixelSize;
+    /** The vertical offset in pixels for the shadow. */
+    yOffset?: PixelSize;
+    /** The radius of the shadow's blur, given in pixels. */
+    blur?: PixelSize;
+}

--- a/packages/ag-charts-community/src/chart/options/contextOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/contextOptions.ts
@@ -1,0 +1,14 @@
+export interface AgContextMenuOptions {
+    enabled?: boolean;
+    extraActions?: Array<AgContextMenuAction>;
+}
+
+export type AgContextMenuAction = {
+    label: string;
+    action: (params: AgContextMenuActionParams) => void;
+};
+
+export type AgContextMenuActionParams = {
+    datum?: any;
+    event: MouseEvent;
+};

--- a/packages/ag-charts-community/src/chart/options/crosshairOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/crosshairOptions.ts
@@ -1,0 +1,53 @@
+import type { CssColor, Opacity, PixelSize } from './types';
+
+export interface AgCrosshairOptions {
+    /** Whether or not to show the crosshair. */
+    enabled?: boolean;
+    /** When true, the crosshair snaps to the highlighted data point. By default this property is false and the crosshair is rendered at the mouse pointer position. */
+    snap?: boolean;
+    /** The colour of the stroke for the lines. */
+    stroke?: CssColor;
+    /** The width in pixels of the stroke for the lines. */
+    strokeWidth?: PixelSize;
+    /** The opacity of the stroke for the lines. */
+    strokeOpacity?: Opacity;
+    /** Defines how the line stroke is rendered. Every number in the array specifies the length in pixels of alternating dashes and gaps. For example, `[6, 3]` means dashes with a length of `6` pixels with gaps between of `3` pixels. */
+    lineDash?: PixelSize[];
+    /** The initial offset of the dashed line in pixels. */
+    lineDashOffset?: PixelSize;
+    /** The crosshair label configuration */
+    label?: AgCrosshairLabel;
+}
+
+export interface AgCrosshairLabel {
+    /** Whether or not to show label when the crosshair is visible. */
+    enabled?: boolean;
+    /** A class name to be added to the crosshair label element. */
+    className?: string;
+    /** The horizontal offset in pixels for the label. */
+    xOffset?: PixelSize;
+    /** The vertical offset in pixels for the label. */
+    yOffset?: PixelSize;
+    /** Format string used when rendering the crosshair label. */
+    format?: string;
+    /** Function used to create the content for the label. */
+    renderer?: (params: AgCrosshairLabelRendererParams) => string | AgCrosshairLabelRendererResult;
+}
+
+export interface AgCrosshairLabelRendererParams {
+    /** Axis value that the label is being rendered for. */
+    readonly value: any;
+    /** If the axis value is a number, the fractional digits used to format the value. */
+    readonly fractionDigits?: number;
+}
+
+export interface AgCrosshairLabelRendererResult {
+    /** Text for the label. */
+    text?: string;
+    /** Label text colour. */
+    color?: CssColor;
+    /** Label background colour. */
+    backgroundColor?: CssColor;
+    /** Opacity of the label. */
+    opacity?: Opacity;
+}

--- a/packages/ag-charts-community/src/chart/options/polarAxisOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/polarAxisOptions.ts
@@ -1,9 +1,6 @@
-import type {
-    AgBaseAxisOptions,
-    AgAxisCategoryTickOptions,
-    AgBaseCrossLineOptions,
-    AgBaseAxisLabelOptions,
-} from 'ag-charts-community';
+import type { AgAxisCategoryTickOptions } from '../series/cartesian/cartesianOptions';
+import type { AgBaseAxisLabelOptions, AgBaseAxisOptions } from './axisOptions';
+import type { AgBaseCrossLineOptions } from './crossLineOptions';
 
 export interface AgAngleCategoryAxisOptions extends AgBaseAxisOptions<AgAngleCategoryAxisLabelOptions> {
     type: 'angle-category';

--- a/packages/ag-charts-community/src/chart/options/radiusAxisOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/radiusAxisOptions.ts
@@ -1,11 +1,7 @@
-import type {
-    AgBaseAxisOptions,
-    AgAxisCaptionOptions,
-    AgAxisNumberTickOptions,
-    AgBaseCrossLineOptions,
-    AgBaseCrossLineLabelOptions,
-    Ratio,
-} from 'ag-charts-community';
+import type { AgAxisNumberTickOptions } from '../series/cartesian/cartesianOptions';
+import type { AgAxisCaptionOptions, AgBaseAxisOptions } from './axisOptions';
+import type { AgBaseCrossLineLabelOptions, AgBaseCrossLineOptions } from './crossLineOptions';
+import type { Ratio } from './types';
 
 export interface AgRadiusNumberAxisOptions extends AgBaseAxisOptions {
     type: 'radius-number';

--- a/packages/ag-charts-community/src/chart/options/zoomOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/zoomOptions.ts
@@ -1,0 +1,28 @@
+export type AgZoomAxes = 'x' | 'y' | 'xy';
+export type AgZoomPanKey = 'alt' | 'ctrl' | 'meta' | 'shift';
+export type AgZoomScrollingPivot = 'pointer' | 'start' | 'end';
+
+export interface AgZoomOptions {
+    /** The axes on which to zoom, one of 'xy', 'x', or 'y'. */
+    axes?: AgZoomAxes;
+    /** Set to true to enable the zoom module. */
+    enabled?: boolean;
+    /** Set to true to enable dragging an axis to zoom series attached to that axis, defaults to true. */
+    enableAxisDragging?: boolean;
+    /** Set to true to enable panning while zoomed, defaults to true. */
+    enablePanning?: boolean;
+    /** Set to true to enable zooming with the mouse wheel, defaults to true. */
+    enableScrolling?: boolean;
+    /** Set to true to enable selecting an area of the chart to zoom into, defaults to false. */
+    enableSelecting?: boolean;
+    /** The minimum amount of the chart to show in the x-axis as a ratio of the full chart, defaults to `0.2`. */
+    minXRatio?: number;
+    /** The minimum amount of the chart to show in the y-axis as a ratio of the full chart, defaults to `0.2`. */
+    minYRatio?: number;
+    /** The key that should be pressed to allow dragging to pan around while zoomed, one of `alt`, `ctrl`, `meta` or `shift, defaults to `alt`. */
+    panKey?: AgZoomPanKey;
+    /** The amount to zoom when scrolling with the mouse wheel, as a ratio of the full chart, defaults to `0.1`. */
+    scrollingStep?: number;
+    /** The pivot about which to zoom into when scrolling, defaults to `end`. */
+    scrollingPivot?: AgZoomScrollingPivot;
+}

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaOptions.ts
@@ -1,4 +1,4 @@
-import type { AgDropShadowOptions } from '../../agChartOptions';
+import type { AgDropShadowOptions } from '../../options/chartOptions';
 import type { AgSeriesTooltip, AgTooltipRendererResult } from '../../options/tooltipOptions';
 import type { CssColor, Opacity, PixelSize } from '../../options/types';
 import type { AgBaseSeriesOptions } from '../seriesOptions';

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianOptions.ts
@@ -1,10 +1,12 @@
 import type { AgBaseChartOptions, AgChartLabelOptions } from '../../agChartOptions';
+import type { AgAnimationOptions } from '../../interaction/animationOptions';
 import type {
     AgAxisBaseTickOptions,
     AgAxisCaptionOptions,
     AgBaseAxisOptions,
     AgBaseAxisLabelOptions,
 } from '../../options/axisOptions';
+import type { AgContextMenuOptions } from '../../options/contextOptions';
 import type {
     AgBaseCrossLineLabelOptions,
     AgBaseCrossLineOptions,
@@ -21,15 +23,22 @@ import type { AgBarSeriesOptions, AgColumnSeriesOptions } from './barOptions';
 import type { AgHistogramSeriesOptions } from './histogramOptions';
 import type { AgLineSeriesOptions } from './lineOptions';
 import type { AgScatterSeriesOptions } from './scatterOptions';
+import type { AgZoomOptions } from '../../options/zoomOptions';
+import type { AgCrosshairOptions } from '../../options/crosshairOptions';
+import type { AgHeatmapSeriesOptions } from './heatmapOptions';
+import type { AgWaterfallSeriesOptions } from './waterfallOptions';
+import type { AgRangeBarSeriesOptions } from './rangeBarOptions';
 
-export type AgCartesianSeriesOptions<TAddon = never> =
+export type AgCartesianSeriesOptions =
     | AgLineSeriesOptions
     | AgScatterSeriesOptions
     | AgAreaSeriesOptions
     | AgBarSeriesOptions
     | AgColumnSeriesOptions
     | AgHistogramSeriesOptions
-    | TAddon;
+    | AgHeatmapSeriesOptions
+    | AgWaterfallSeriesOptions
+    | AgRangeBarSeriesOptions;
 
 /** Configuration for axes in cartesian charts. */
 export interface AgBaseCartesianAxisOptions extends AgBaseAxisOptions<AgCartesianAxisLabelOptions> {
@@ -41,6 +50,8 @@ export interface AgBaseCartesianAxisOptions extends AgBaseAxisOptions<AgCartesia
     thickness?: PixelSize;
     /** Configuration for the title shown next to the axis. */
     title?: AgAxisCaptionOptions;
+    /** Configuration for the axis crosshair. */
+    crosshair?: AgCrosshairOptions;
 }
 
 export interface AgCartesianAxisLabelOptions extends AgBaseAxisLabelOptions {
@@ -50,17 +61,33 @@ export interface AgCartesianAxisLabelOptions extends AgBaseAxisLabelOptions {
     autoRotateAngle?: number;
 }
 
-export interface AgCartesianChartOptions<TAddonType = never, TAddonSeries = never> extends AgBaseChartOptions {
+export interface AgCartesianChartOptions extends AgBaseChartOptions {
     /** If specified overrides the default series type. */
-    type?: 'line' | 'bar' | 'column' | 'area' | 'scatter' | 'histogram' | TAddonType;
+    type?:
+        | 'line'
+        | 'bar'
+        | 'column'
+        | 'area'
+        | 'scatter'
+        | 'histogram'
+        | 'heatmap'
+        | 'waterfall-bar'
+        | 'waterfall-column'
+        | 'range-bar'
+        | 'range-column';
     /** Axis configurations. */
     axes?: AgCartesianAxisOptions[];
     /** Series configurations. */
-    series?: AgCartesianSeriesOptions<TAddonSeries>[];
+    series?: AgCartesianSeriesOptions[];
     /** Configuration for the chart legend. */
     legend?: AgCartesianChartLegendOptions;
     /** Configuration for the chart navigator. */
     navigator?: AgNavigatorOptions;
+
+    animation?: AgAnimationOptions;
+    contextMenu?: AgContextMenuOptions;
+    /** Configuration for zoom. */
+    zoom?: AgZoomOptions;
 }
 
 export interface AgNumberAxisOptions extends AgBaseCartesianAxisOptions {

--- a/packages/ag-charts-community/src/chart/series/cartesian/heatmapOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/heatmapOptions.ts
@@ -1,12 +1,8 @@
-import type {
-    AgBaseSeriesOptions,
-    AgSeriesListeners,
-    AgSeriesTooltip,
-    AgCartesianSeriesTooltipRendererParams,
-    AgTooltipRendererResult,
-    CssColor,
-    PixelSize,
-} from 'ag-charts-community';
+import type { AgSeriesListeners } from '../../options/eventOptions';
+import type { AgSeriesTooltip, AgTooltipRendererResult } from '../../options/tooltipOptions';
+import type { CssColor, PixelSize } from '../../options/types';
+import type { AgBaseSeriesOptions } from '../seriesOptions';
+import type { AgCartesianSeriesTooltipRendererParams } from './cartesianOptions';
 
 export interface AgHeatmapSeriesFormatterParams<DatumType> {
     readonly datum: DatumType;

--- a/packages/ag-charts-community/src/chart/series/cartesian/rangeAreaOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/rangeAreaOptions.ts
@@ -1,17 +1,9 @@
-import type {
-    AgBaseSeriesOptions,
-    AgSeriesListeners,
-    AgSeriesHighlightStyle,
-    AgSeriesTooltip,
-    AgCartesianSeriesTooltipRendererParams,
-    AgTooltipRendererResult,
-    AgCartesianSeriesLabelOptions,
-    AgSeriesMarker,
-    CssColor,
-    PixelSize,
-    Opacity,
-    AgDropShadowOptions,
-} from 'ag-charts-community';
+import type { AgDropShadowOptions } from '../../options/chartOptions';
+import type { AgSeriesListeners } from '../../options/eventOptions';
+import type { AgSeriesTooltip, AgTooltipRendererResult } from '../../options/tooltipOptions';
+import type { CssColor, Opacity, PixelSize } from '../../options/types';
+import type { AgBaseSeriesOptions, AgSeriesHighlightStyle, AgSeriesMarker } from '../seriesOptions';
+import type { AgCartesianSeriesLabelOptions, AgCartesianSeriesTooltipRendererParams } from './cartesianOptions';
 
 export interface AgRangeAreaSeriesMarkerFormatterParams<DatumType> {
     readonly datum: DatumType;

--- a/packages/ag-charts-community/src/chart/series/cartesian/rangeBarOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/rangeBarOptions.ts
@@ -1,16 +1,9 @@
-import type {
-    AgBaseSeriesOptions,
-    AgSeriesListeners,
-    AgSeriesHighlightStyle,
-    AgSeriesTooltip,
-    AgCartesianSeriesTooltipRendererParams,
-    AgTooltipRendererResult,
-    AgCartesianSeriesLabelOptions,
-    CssColor,
-    PixelSize,
-    Opacity,
-    AgDropShadowOptions,
-} from 'ag-charts-community';
+import type { AgDropShadowOptions } from '../../options/chartOptions';
+import type { AgSeriesListeners } from '../../options/eventOptions';
+import type { AgSeriesTooltip, AgTooltipRendererResult } from '../../options/tooltipOptions';
+import type { CssColor, Opacity, PixelSize } from '../../options/types';
+import type { AgBaseSeriesOptions, AgSeriesHighlightStyle } from '../seriesOptions';
+import type { AgCartesianSeriesLabelOptions, AgCartesianSeriesTooltipRendererParams } from './cartesianOptions';
 
 export interface AgRangeBarSeriesFormatterParams<DatumType> {
     readonly datum: DatumType;

--- a/packages/ag-charts-community/src/chart/series/cartesian/waterfallOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/waterfallOptions.ts
@@ -1,16 +1,9 @@
-import type {
-    AgBaseSeriesOptions,
-    AgSeriesListeners,
-    AgSeriesHighlightStyle,
-    AgSeriesTooltip,
-    AgCartesianSeriesTooltipRendererParams,
-    AgTooltipRendererResult,
-    AgCartesianSeriesLabelOptions,
-    CssColor,
-    PixelSize,
-    Opacity,
-    AgDropShadowOptions,
-} from 'ag-charts-community';
+import type { AgDropShadowOptions } from '../../options/chartOptions';
+import type { AgSeriesListeners } from '../../options/eventOptions';
+import type { AgSeriesTooltip, AgTooltipRendererResult } from '../../options/tooltipOptions';
+import type { CssColor, Opacity, PixelSize } from '../../options/types';
+import type { AgBaseSeriesOptions, AgSeriesHighlightStyle } from '../seriesOptions';
+import type { AgCartesianSeriesLabelOptions, AgCartesianSeriesTooltipRendererParams } from './cartesianOptions';
 
 export interface AgWaterfallSeriesFormatterParams<DatumType> {
     readonly datum: DatumType;

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchyOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchyOptions.ts
@@ -1,4 +1,5 @@
 import type { AgBaseChartOptions } from '../../agChartOptions';
+import type { AgContextMenuOptions } from '../../options/contextOptions';
 import type { AgChartBaseLegendOptions } from '../../options/legendOptions';
 import type { AgTreemapSeriesOptions } from './treemapOptions';
 
@@ -12,6 +13,7 @@ export interface AgHierarchyChartOptions extends AgBaseChartOptions {
     series?: AgHierarchySeriesOptions[];
     /** Configuration for the chart legend. */
     legend?: AgHierarchyChartLegendOptions;
+    contextMenu?: AgContextMenuOptions;
 }
 
 export interface AgHierarchyThemeOptions<S = AgHierarchySeriesTheme> extends AgBaseChartOptions {

--- a/packages/ag-charts-community/src/chart/series/polar/nightingaleOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/nightingaleOptions.ts
@@ -1,11 +1,12 @@
-import type { AgChartLabelOptions, AgSeriesTooltip, AgTooltipRendererResult } from 'ag-charts-community';
+import type { AgChartLabelOptions } from '../../options/chartOptions';
+import type { AgSeriesTooltip, AgTooltipRendererResult } from '../../options/tooltipOptions';
 import type {
     AgBaseRadialColumnSeriesOptions,
     AgRadialColumnSeriesFormat,
     AgRadialColumnSeriesFormatterParams,
     AgRadialColumnSeriesLabelFormatterParams,
     AgRadialColumnSeriesTooltipRendererParams,
-} from '../radial-column/typings';
+} from './radialColumnOptions';
 
 /** Configuration for Nightingale series. */
 export interface AgNightingaleSeriesOptions<DatumType = any> extends AgBaseRadialColumnSeriesOptions<DatumType> {

--- a/packages/ag-charts-community/src/chart/series/polar/polarOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarOptions.ts
@@ -1,17 +1,36 @@
 import type { AgBaseChartOptions } from '../../agChartOptions';
+import type { AgAnimationOptions } from '../../interaction/animationOptions';
+import type { AgContextMenuOptions } from '../../options/contextOptions';
 import type { AgChartBaseLegendOptions } from '../../options/legendOptions';
 import type { AgSeriesTooltipRendererParams } from '../../options/tooltipOptions';
 import type { AgPieSeriesOptions, AgPieSeriesTheme } from './pieOptions';
+import type { AgAngleCategoryAxisOptions } from '../../options/polarAxisOptions';
+import type { AgRadiusNumberAxisOptions } from '../../options/radiusAxisOptions';
+import type { AgRadarLineSeriesOptions } from './radarLineOptions';
+import type { AgRadarAreaSeriesOptions } from './radarAreaOptions';
+import type { AgRadialColumnSeriesOptions } from './radialColumnOptions';
+import type { AgNightingaleSeriesOptions } from './nightingaleOptions';
 
-export type AgPolarSeriesOptions<TAddon = never> = AgPieSeriesOptions | TAddon;
+export type AgPolarSeriesOptions =
+    | AgPieSeriesOptions
+    | AgRadarLineSeriesOptions
+    | AgRadarAreaSeriesOptions
+    | AgRadialColumnSeriesOptions
+    | AgNightingaleSeriesOptions;
+export type AgPolarAxisOptions = AgAngleCategoryAxisOptions | AgRadiusNumberAxisOptions;
 
-export interface AgPolarChartOptions<TAddonType = never, TAddonSeries = never> extends AgBaseChartOptions {
+export interface AgPolarChartOptions extends AgBaseChartOptions {
     /** If specified overrides the default series type. */
-    type?: 'pie' | TAddonType;
+    type?: 'pie' | 'radar-line' | 'radar-area' | 'radial-column' | 'nightingale';
     /** Series configurations. */
-    series?: AgPolarSeriesOptions<TAddonSeries>[];
+    series?: AgPolarSeriesOptions[];
     /** Configuration for the chart legend. */
     legend?: AgPolarChartLegendOptions;
+
+    animation?: AgAnimationOptions;
+    contextMenu?: AgContextMenuOptions;
+    /** Axis configurations. */
+    axes?: AgPolarAxisOptions[];
 }
 
 export interface AgPolarThemeOptions<S = AgPolarSeriesTheme> extends AgBaseChartOptions {

--- a/packages/ag-charts-community/src/chart/series/polar/radarAreaOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/radarAreaOptions.ts
@@ -1,5 +1,5 @@
-import type { CssColor, Opacity } from 'ag-charts-community';
-import type { AgBaseRadarSeriesOptions } from '../radar/typings';
+import type { CssColor, Opacity } from '../../options/types';
+import type { AgBaseRadarSeriesOptions } from './radarOptions';
 
 export interface AgRadarAreaSeriesOptions<DatumType = any> extends AgBaseRadarSeriesOptions<DatumType> {
     type?: 'radar-area';

--- a/packages/ag-charts-community/src/chart/series/polar/radarLineOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/radarLineOptions.ts
@@ -1,4 +1,4 @@
-import type { AgBaseRadarSeriesOptions } from '../radar/typings';
+import type { AgBaseRadarSeriesOptions } from './radarOptions';
 
 export interface AgRadarLineSeriesOptions<DatumType = any> extends AgBaseRadarSeriesOptions<DatumType> {
     type?: 'radar-line';

--- a/packages/ag-charts-community/src/chart/series/polar/radarOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/radarOptions.ts
@@ -1,16 +1,12 @@
+import type { AgChartLabelOptions } from '../../options/chartOptions';
+import type { AgSeriesListeners } from '../../options/eventOptions';
 import type {
-    AgBaseSeriesOptions,
-    AgChartLabelOptions,
-    AgSeriesListeners,
-    AgSeriesMarker,
-    AgSeriesMarkerFormatterParams,
     AgSeriesTooltip,
     AgSeriesTooltipRendererParams,
     AgTooltipRendererResult,
-    CssColor,
-    Opacity,
-    PixelSize,
-} from 'ag-charts-community';
+} from '../../options/tooltipOptions';
+import type { CssColor, Opacity, PixelSize } from '../../options/types';
+import type { AgBaseSeriesOptions, AgSeriesMarker, AgSeriesMarkerFormatterParams } from '../seriesOptions';
 
 export interface AgBaseRadarSeriesOptions<DatumType = any> extends AgBaseSeriesOptions<DatumType> {
     type?: 'radar-line' | 'radar-area';

--- a/packages/ag-charts-community/src/chart/series/polar/radialColumnOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/radialColumnOptions.ts
@@ -1,14 +1,12 @@
+import type { AgChartLabelOptions } from '../../options/chartOptions';
+import type { AgSeriesListeners } from '../../options/eventOptions';
 import type {
-    AgBaseSeriesOptions,
-    AgChartLabelOptions,
-    AgSeriesListeners,
     AgSeriesTooltip,
     AgSeriesTooltipRendererParams,
     AgTooltipRendererResult,
-    CssColor,
-    Opacity,
-    PixelSize,
-} from 'ag-charts-community';
+} from '../../options/tooltipOptions';
+import type { CssColor, Opacity, PixelSize } from '../../options/types';
+import type { AgBaseSeriesOptions } from '../seriesOptions';
 
 /** Base configuration for Radial Column series. */
 export interface AgBaseRadialColumnSeriesOptions<DatumType = any> extends AgBaseSeriesOptions<DatumType> {

--- a/packages/ag-charts-community/src/chart/series/test/examples.ts
+++ b/packages/ag-charts-community/src/chart/series/test/examples.ts
@@ -1,4 +1,12 @@
-import type { AgCartesianChartOptions, AgHierarchyChartOptions, AgPolarChartOptions } from '../../agChartOptions';
+import type {
+    AgAreaSeriesOptions,
+    AgCartesianChartOptions,
+    AgHierarchyChartOptions,
+    AgHistogramSeriesOptions,
+    AgLineSeriesOptions,
+    AgPolarChartOptions,
+    AgScatterSeriesOptions,
+} from '../../agChartOptions';
 import { DATA_APPLE_REVENUE_BY_PRODUCT, DATA_BROWSER_MARKET_SHARE } from '../../test/data';
 import {
     DATA_MALE_HEIGHT_WEIGHT,
@@ -9,7 +17,8 @@ import {
 } from './data';
 import { loadExampleOptions } from '../../test/load-example';
 
-const GROUPED_AREA_EXAMPLE: AgCartesianChartOptions = loadExampleOptions('area-with-negative-values');
+const GROUPED_AREA_EXAMPLE: AgCartesianChartOptions & { series: AgAreaSeriesOptions[] } =
+    loadExampleOptions('area-with-negative-values');
 const { axes, ...LINE_WITH_GAPS_EXAMPLE }: AgCartesianChartOptions = loadExampleOptions('line-with-gaps');
 const HISTOGRAM_EXAMPLE: AgCartesianChartOptions = loadExampleOptions('simple-histogram');
 const SCATTER_EXAMPLE: AgCartesianChartOptions = loadExampleOptions('simple-scatter');
@@ -319,13 +328,13 @@ export const STACKED_AREA_SERIES_LABELS: AgCartesianChartOptions = {
 export const GROUPED_AREA_SERIES_LABELS: AgCartesianChartOptions = {
     ...GROUPED_AREA_EXAMPLE,
     series: [
-        ...(GROUPED_AREA_EXAMPLE.series?.slice(0, 3).map((s) => {
+        ...(GROUPED_AREA_EXAMPLE.series?.slice(0, 3).map((s: any) => {
             return {
                 ...s,
                 label: {
                     enabled: true,
                 },
-            };
+            } as AgAreaSeriesOptions;
         }) ?? []),
     ],
 };
@@ -333,13 +342,13 @@ export const GROUPED_AREA_SERIES_LABELS: AgCartesianChartOptions = {
 export const LINE_SERIES_LABELS: AgCartesianChartOptions = {
     ...LINE_WITH_GAPS_EXAMPLE,
     series: [
-        ...(LINE_WITH_GAPS_EXAMPLE.series?.slice(0, 3).map((s) => {
+        ...(LINE_WITH_GAPS_EXAMPLE.series?.slice(0, 3).map((s: any) => {
             return {
                 ...s,
                 label: {
                     enabled: true,
                 },
-            };
+            } as AgLineSeriesOptions;
         }) ?? []),
     ],
 };
@@ -347,13 +356,13 @@ export const LINE_SERIES_LABELS: AgCartesianChartOptions = {
 export const HISTOGRAM_SERIES_LABELS: AgCartesianChartOptions = {
     ...HISTOGRAM_EXAMPLE,
     series: [
-        ...(HISTOGRAM_EXAMPLE.series?.map((s) => {
+        ...(HISTOGRAM_EXAMPLE.series?.map((s: any) => {
             return {
                 ...s,
                 label: {
                     enabled: true,
                 },
-            };
+            } as AgHistogramSeriesOptions;
         }) ?? []),
     ],
 };
@@ -361,14 +370,14 @@ export const HISTOGRAM_SERIES_LABELS: AgCartesianChartOptions = {
 export const SCATTER_SERIES_LABELS: AgCartesianChartOptions = {
     ...SCATTER_EXAMPLE,
     series: [
-        ...(SCATTER_EXAMPLE.series?.map((s) => {
+        ...(SCATTER_EXAMPLE.series?.map((s: any) => {
             return {
                 ...s,
                 labelKey: 'team',
                 label: {
                     enabled: true,
                 },
-            };
+            } as AgScatterSeriesOptions;
         }) ?? []),
     ],
 };
@@ -376,7 +385,7 @@ export const SCATTER_SERIES_LABELS: AgCartesianChartOptions = {
 export const GROUPED_SCATTER_SERIES_LABELS: AgCartesianChartOptions = {
     ...GROUPED_LINE_EXAMPLE,
     series: [
-        ...(GROUPED_LINE_EXAMPLE.series?.map((s) => {
+        ...(GROUPED_LINE_EXAMPLE.series?.map((s: any) => {
             return {
                 ...s,
                 type: 'scatter' as const,
@@ -384,7 +393,7 @@ export const GROUPED_SCATTER_SERIES_LABELS: AgCartesianChartOptions = {
                 label: {
                     enabled: true,
                 },
-            };
+            } as AgScatterSeriesOptions;
         }) ?? []),
     ],
 };
@@ -392,14 +401,14 @@ export const GROUPED_SCATTER_SERIES_LABELS: AgCartesianChartOptions = {
 export const BUBBLE_SERIES_LABELS: AgCartesianChartOptions = {
     ...BUBBLE_EXAMPLE,
     series: [
-        ...(BUBBLE_EXAMPLE.series?.map((s) => {
+        ...(BUBBLE_EXAMPLE.series?.map((s: any) => {
             return {
                 ...s,
                 labelKey: 'city',
                 label: {
                     enabled: true,
                 },
-            };
+            } as AgScatterSeriesOptions;
         }) ?? []),
     ],
     axes: [

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -35,7 +35,7 @@ export const CANVAS_TO_BUFFER_DEFAULTS: PngConfig = { compressionLevel: 6, filte
 const CANVAS_WIDTH = 800;
 const CANVAS_HEIGHT = 600;
 
-export function prepareTestOptions<T extends AgChartOptions<any, any>>(options: T, container = document.body) {
+export function prepareTestOptions<T extends AgChartOptions>(options: T, container = document.body) {
     options.autoSize = false;
     options.width = CANVAS_WIDTH;
     options.height = CANVAS_HEIGHT;

--- a/packages/ag-charts-enterprise/src/animation/animationModule.ts
+++ b/packages/ag-charts-enterprise/src/animation/animationModule.ts
@@ -8,10 +8,3 @@ export const AnimationModule: _ModuleSupport.Module = {
     chartTypes: ['cartesian', 'polar'],
     instanceConstructor: Animation,
 };
-
-export interface AgAnimationOptions {
-    /** Set to true to enable the animation module. */
-    enabled?: boolean;
-    /** The total duration of the animation for each series on initial load and updates */
-    duration?: number;
-}

--- a/packages/ag-charts-enterprise/src/background/backgroundModule.ts
+++ b/packages/ag-charts-enterprise/src/background/backgroundModule.ts
@@ -1,4 +1,4 @@
-import type { _ModuleSupport, PixelSize, Opacity } from 'ag-charts-community';
+import type { _ModuleSupport } from 'ag-charts-community';
 import { Background } from './background';
 import { BackgroundImage } from './backgroundImage';
 
@@ -12,32 +12,3 @@ export const BackgroundModule: _ModuleSupport.RootModule = {
     },
     instanceConstructor: Background,
 };
-
-export interface AgChartBackgroundImage {
-    /** URL of the image */
-    url: string;
-
-    /** Distance from the left border of the chart to the left border of the image. If neither left nor right specified, the image is centred horizontally. */
-    left?: PixelSize;
-    /** Distance from the top border of the chart to the top border of the image. If neither top nor bottom specified, the image is centred vertically. */
-    top?: PixelSize;
-    /** Distance from the right border of the chart to the right border of the image. If neither left nor right specified, the image is centred horizontally. */
-    right?: PixelSize;
-    /** Distance from the bottom border of the chart to the bottom border of the image. If neither top nor bottom specified, the image is centred vertically. */
-    bottom?: PixelSize;
-
-    /**
-     * Width of the image. If both left and width are specified, right is ignored. If only height is provided,
-     * width will be computed to preserve the original width/height ratio. If neither is provided, the original width is used.
-     */
-    width?: PixelSize;
-
-    /**
-     * Height of the image. If both top and height are specified, bottom is ignored. If only width is provided,
-     * height will be computed to preserve the original width/height ratio.  If neither is provided, the original height is used.
-     */
-    height?: PixelSize;
-
-    /** Opacity of the image. */
-    opacity?: Opacity;
-}

--- a/packages/ag-charts-enterprise/src/context-menu/contextMenuModule.ts
+++ b/packages/ag-charts-enterprise/src/context-menu/contextMenuModule.ts
@@ -35,18 +35,3 @@ export function _disableAction(actionId: string) {
 export function _enableAction(actionId: string) {
     ContextMenu.enableAction(actionId);
 }
-
-export interface AgContextMenuOptions {
-    enabled?: boolean;
-    extraActions?: Array<AgContextMenuAction>;
-}
-
-export type AgContextMenuAction = {
-    label: string;
-    action: (params: AgContextMenuActionParams) => void;
-};
-
-export type AgContextMenuActionParams = {
-    datum?: any;
-    event: MouseEvent;
-};

--- a/packages/ag-charts-enterprise/src/crosshair/crosshairModule.ts
+++ b/packages/ag-charts-enterprise/src/crosshair/crosshairModule.ts
@@ -1,4 +1,4 @@
-import type { _ModuleSupport, CssColor, PixelSize, Opacity } from 'ag-charts-community';
+import type { _ModuleSupport } from 'ag-charts-community';
 import { Crosshair } from './crosshair';
 import { AXIS_CROSSHAIR_THEME } from './crosshairTheme';
 
@@ -11,55 +11,3 @@ export const CrosshairModule: _ModuleSupport.AxisOptionModule = {
     instanceConstructor: Crosshair,
     themeTemplate: AXIS_CROSSHAIR_THEME,
 };
-
-export interface AgCrosshairOptions {
-    /** Whether or not to show the crosshair. */
-    enabled?: boolean;
-    /** When true, the crosshair snaps to the highlighted data point. By default this property is false and the crosshair is rendered at the mouse pointer position. */
-    snap?: boolean;
-    /** The colour of the stroke for the lines. */
-    stroke?: CssColor;
-    /** The width in pixels of the stroke for the lines. */
-    strokeWidth?: PixelSize;
-    /** The opacity of the stroke for the lines. */
-    strokeOpacity?: Opacity;
-    /** Defines how the line stroke is rendered. Every number in the array specifies the length in pixels of alternating dashes and gaps. For example, `[6, 3]` means dashes with a length of `6` pixels with gaps between of `3` pixels. */
-    lineDash?: PixelSize[];
-    /** The initial offset of the dashed line in pixels. */
-    lineDashOffset?: PixelSize;
-    /** The crosshair label configuration */
-    label?: AgCrosshairLabel;
-}
-
-export interface AgCrosshairLabel {
-    /** Whether or not to show label when the crosshair is visible. */
-    enabled?: boolean;
-    /** A class name to be added to the crosshair label element. */
-    className?: string;
-    /** The horizontal offset in pixels for the label. */
-    xOffset?: PixelSize;
-    /** The vertical offset in pixels for the label. */
-    yOffset?: PixelSize;
-    /** Format string used when rendering the crosshair label. */
-    format?: string;
-    /** Function used to create the content for the label. */
-    renderer?: (params: AgCrosshairLabelRendererParams) => string | AgCrosshairLabelRendererResult;
-}
-
-export interface AgCrosshairLabelRendererParams {
-    /** Axis value that the label is being rendered for. */
-    readonly value: any;
-    /** If the axis value is a number, the fractional digits used to format the value. */
-    readonly fractionDigits?: number;
-}
-
-export interface AgCrosshairLabelRendererResult {
-    /** Text for the label. */
-    text?: string;
-    /** Label text colour. */
-    color?: CssColor;
-    /** Label background colour. */
-    backgroundColor?: CssColor;
-    /** Opacity of the label. */
-    opacity?: Opacity;
-}

--- a/packages/ag-charts-enterprise/src/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/heatmap/heatmapSeries.ts
@@ -1,11 +1,11 @@
-import type { AgTooltipRendererResult } from 'ag-charts-community';
-import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
-import type { GradientLegendDatum } from '../gradient-legend/gradientLegendDatum';
 import type {
     AgHeatmapSeriesFormat,
-    AgHeatmapSeriesTooltipRendererParams,
     AgHeatmapSeriesFormatterParams,
-} from './typings';
+    AgHeatmapSeriesTooltipRendererParams,
+    AgTooltipRendererResult,
+} from 'ag-charts-community';
+import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
+import type { GradientLegendDatum } from '../gradient-legend/gradientLegendDatum';
 
 const {
     Validate,

--- a/packages/ag-charts-enterprise/src/heatmap/main.ts
+++ b/packages/ag-charts-enterprise/src/heatmap/main.ts
@@ -1,2 +1,1 @@
 export { HeatmapModule } from './heatmapModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/main.ts
+++ b/packages/ag-charts-enterprise/src/main.ts
@@ -16,8 +16,8 @@ import { RadarLineModule } from './polar-series/radar-line/main';
 import { RadarAreaModule } from './polar-series/radar-area/main';
 import { ZoomModule } from './zoom/main';
 import { WaterfallBarModule, WaterfallColumnModule } from './waterfall/main';
-
 import { RangeBarModule, RangeColumnModule } from './rangeBar/main';
+import { RangeAreaModule } from './rangeArea/rangeAreaModule';
 
 export * from 'ag-charts-community';
 

--- a/packages/ag-charts-enterprise/src/main.ts
+++ b/packages/ag-charts-enterprise/src/main.ts
@@ -1,95 +1,23 @@
-import type { AgChartOptions as AgCommunityChartOptions, AgChartInstance } from 'ag-charts-community';
+import type { AgChartInstance, AgChartOptions } from 'ag-charts-community';
 import { AgChart, _ModuleSupport } from 'ag-charts-community';
 
-import type { AgAnimationOptions } from './animation/main';
 import { AnimationModule } from './animation/main';
-import type { AgChartBackgroundImage } from './background/main';
 import { BackgroundModule } from './background/main';
-import type { AgContextMenuOptions } from './context-menu/main';
 import { ContextMenuModule } from './context-menu/main';
-import {
-    AgCrosshairOptions,
-    CrosshairModule,
-    AgCrosshairLabel,
-    AgCrosshairLabelRendererParams,
-    AgCrosshairLabelRendererResult,
-} from './crosshair/main';
+import { CrosshairModule } from './crosshair/main';
 import { GradientLegendModule } from './gradient-legend/main';
-import {
-    AgHeatmapSeriesFormat,
-    AgHeatmapSeriesFormatterParams,
-    AgHeatmapSeriesLabelOptions,
-    AgHeatmapSeriesOptions,
-    AgHeatmapSeriesTooltip,
-    AgHeatmapSeriesTooltipRendererParams,
-    HeatmapModule,
-} from './heatmap/main';
-import type { AgNavigatorOptions } from './navigator/main';
-import { AngleCategoryAxisModule, AgAngleCategoryAxisOptions } from './polar-axes/angle-category/main';
-import { RadiusNumberAxisModule, AgRadiusNumberAxisOptions } from './polar-axes/radius-number/main';
+import { HeatmapModule } from './heatmap/main';
+import { AngleCategoryAxisModule } from './polar-axes/angle-category/main';
+import { RadiusNumberAxisModule } from './polar-axes/radius-number/main';
 export { RadiusNumberAxisModule } from './polar-axes/radius-number/radiusNumberAxisModule';
-import type {
-    AgBaseRadarSeriesOptions,
-    AgRadarSeriesLabelFormatterParams,
-    AgRadarSeriesLabelOptions,
-    AgRadarSeriesMarker,
-    AgRadarSeriesMarkerFormat,
-    AgRadarSeriesMarkerFormatter,
-    AgRadarSeriesMarkerFormatterParams,
-    AgRadarSeriesTooltip,
-    AgRadarSeriesTooltipRendererParams,
-} from './polar-series/radar/typings';
-import {
-    NightingaleModule,
-    AgNightingaleSeriesOptions,
-    AgNightingaleSeriesFormat,
-    AgNightingaleSeriesFormatterParams,
-    AgNightingaleSeriesLabelFormatterParams,
-    AgNightingaleSeriesLabelOptions,
-    AgNightingaleSeriesTooltip,
-    AgNightingaleSeriesTooltipRendererParams,
-} from './polar-series/nightingale/main';
-import {
-    RadialColumnModule,
-    AgRadialColumnSeriesOptions,
-    AgRadialColumnSeriesFormat,
-    AgBaseRadialColumnSeriesOptions,
-    AgRadialColumnSeriesFormatterParams,
-    AgRadialColumnSeriesLabelFormatterParams,
-    AgRadialColumnSeriesLabelOptions,
-    AgRadialColumnSeriesTooltip,
-    AgRadialColumnSeriesTooltipRendererParams,
-} from './polar-series/radial-column/main';
-import { RadarLineModule, AgRadarLineSeriesOptions } from './polar-series/radar-line/main';
-import { RadarAreaModule, AgRadarAreaSeriesOptions } from './polar-series/radar-area/main';
-import { AgZoomAxes, AgZoomOptions, AgZoomPanKey, AgZoomScrollingPivot, ZoomModule } from './zoom/main';
-import {
-    WaterfallBarModule,
-    WaterfallColumnModule,
-    AgWaterfallSeriesOptions,
-    AgWaterfallSeriesTooltip,
-    AgWaterfallSeriesLabelOptions,
-    AgWaterfallSeriesLabelPlacement,
-    AgWaterfallSeriesItemOptions,
-    AgWaterfallSeriesTooltipRendererParams,
-} from './waterfall/main';
+import { NightingaleModule } from './polar-series/nightingale/main';
+import { RadialColumnModule } from './polar-series/radial-column/main';
+import { RadarLineModule } from './polar-series/radar-line/main';
+import { RadarAreaModule } from './polar-series/radar-area/main';
+import { ZoomModule } from './zoom/main';
+import { WaterfallBarModule, WaterfallColumnModule } from './waterfall/main';
 
-import {
-    RangeBarModule,
-    RangeColumnModule,
-    AgRangeBarSeriesOptions,
-    AgRangeBarSeriesTooltip,
-    AgRangeBarSeriesLabelOptions,
-    AgRangeBarSeriesTooltipRendererParams,
-} from './rangeBar/main';
-
-import {
-    RangeAreaModule,
-    AgRangeAreaSeriesOptions,
-    AgRangeAreaSeriesTooltip,
-    AgRangeAreaSeriesLabelOptions,
-    AgRangeAreaSeriesTooltipRendererParams,
-} from './rangeArea/main';
+import { RangeBarModule, RangeColumnModule } from './rangeBar/main';
 
 export * from 'ag-charts-community';
 
@@ -112,134 +40,8 @@ _ModuleSupport.registerModule(RangeColumnModule);
 _ModuleSupport.registerModule(RangeAreaModule);
 _ModuleSupport.registerModule(ZoomModule);
 
-export { AgCrosshairOptions, AgCrosshairLabel, AgCrosshairLabelRendererParams, AgCrosshairLabelRendererResult };
-export {
-    AgHeatmapSeriesFormat,
-    AgHeatmapSeriesFormatterParams,
-    AgHeatmapSeriesLabelOptions,
-    AgHeatmapSeriesOptions,
-    AgHeatmapSeriesTooltip,
-    AgHeatmapSeriesTooltipRendererParams,
-};
-export { AgAngleCategoryAxisOptions, AgRadiusNumberAxisOptions };
-export {
-    AgBaseRadarSeriesOptions,
-    AgRadarLineSeriesOptions,
-    AgRadarAreaSeriesOptions,
-    AgRadarSeriesLabelFormatterParams,
-    AgRadarSeriesLabelOptions,
-    AgRadarSeriesMarker,
-    AgRadarSeriesMarkerFormat,
-    AgRadarSeriesMarkerFormatter,
-    AgRadarSeriesMarkerFormatterParams,
-    AgRadarSeriesTooltip,
-    AgRadarSeriesTooltipRendererParams,
-};
-export {
-    AgRadialColumnSeriesOptions,
-    AgRadialColumnSeriesFormat,
-    AgBaseRadialColumnSeriesOptions,
-    AgRadialColumnSeriesFormatterParams,
-    AgRadialColumnSeriesLabelFormatterParams,
-    AgRadialColumnSeriesLabelOptions,
-    AgRadialColumnSeriesTooltip,
-    AgRadialColumnSeriesTooltipRendererParams,
-};
-export {
-    AgNightingaleSeriesOptions,
-    AgNightingaleSeriesFormat,
-    AgNightingaleSeriesFormatterParams,
-    AgNightingaleSeriesLabelFormatterParams,
-    AgNightingaleSeriesLabelOptions,
-    AgNightingaleSeriesTooltip,
-    AgNightingaleSeriesTooltipRendererParams,
-};
-export { AgZoomAxes, AgZoomOptions, AgZoomPanKey, AgZoomScrollingPivot };
-export {
-    AgWaterfallSeriesOptions,
-    AgWaterfallSeriesTooltip,
-    AgWaterfallSeriesLabelOptions,
-    AgWaterfallSeriesLabelPlacement,
-    AgWaterfallSeriesItemOptions,
-    AgWaterfallSeriesTooltipRendererParams,
-};
-
-export {
-    AgRangeBarSeriesOptions,
-    AgRangeBarSeriesTooltip,
-    AgRangeBarSeriesLabelOptions,
-    AgRangeBarSeriesTooltipRendererParams,
-};
-
-export {
-    AgRangeAreaSeriesOptions,
-    AgRangeAreaSeriesTooltip,
-    AgRangeAreaSeriesLabelOptions,
-    AgRangeAreaSeriesTooltipRendererParams,
-};
-
-declare module 'ag-charts-community' {
-    export interface AgCartesianChartOptions {
-        animation?: AgAnimationOptions;
-        contextMenu?: AgContextMenuOptions;
-        /** Configuration for the chart navigator. */
-        navigator?: AgNavigatorOptions;
-        /** Configuration for zoom. */
-        zoom?: AgZoomOptions;
-    }
-
-    export interface AgBaseCartesianAxisOptions {
-        /** Configuration for the axis crosshair. */
-        crosshair?: AgCrosshairOptions;
-    }
-
-    export type AgPolarAxisOptions = AgAngleCategoryAxisOptions | AgRadiusNumberAxisOptions;
-
-    export interface AgPolarChartOptions {
-        animation?: AgAnimationOptions;
-        contextMenu?: AgContextMenuOptions;
-        /** Axis configurations. */
-        axes?: AgPolarAxisOptions[];
-    }
-
-    export interface AgHierarchyChartOptions {
-        contextMenu?: AgContextMenuOptions;
-    }
-
-    export interface AgChartBackground {
-        /** Background image. May be combined with fill colour. */
-        image?: AgChartBackgroundImage;
-    }
-}
-
 import { LicenseManager } from './license/licenseManager';
 
-type CartesianAddonType =
-    | 'heatmap'
-    | 'waterfall-bar'
-    | 'waterfall-column'
-    | 'range-bar'
-    | 'range-column'
-    | 'range-area';
-type CartesianAddonSeries =
-    | AgHeatmapSeriesOptions
-    | AgWaterfallSeriesOptions
-    | AgRangeBarSeriesOptions
-    | AgRangeAreaSeriesOptions;
-
-type PolarAddonType = 'radar-line' | 'radar-area' | 'radial-column' | 'nightingale';
-type PolarAddonSeries =
-    | AgRadarLineSeriesOptions
-    | AgRadarAreaSeriesOptions
-    | AgRadialColumnSeriesOptions
-    | AgNightingaleSeriesOptions;
-
-export type AgChartOptions = AgCommunityChartOptions<
-    CartesianAddonType,
-    CartesianAddonSeries,
-    PolarAddonType,
-    PolarAddonSeries
->;
 export class AgEnterpriseCharts {
     public static create(options: AgChartOptions): AgChartInstance {
         new LicenseManager(options.container?.ownerDocument ?? document).validateLicense();

--- a/packages/ag-charts-enterprise/src/polar-axes/angle-category/angleCategoryAxis.ts
+++ b/packages/ag-charts-enterprise/src/polar-axes/angle-category/angleCategoryAxis.ts
@@ -1,6 +1,6 @@
+import type { AgAngleCategoryAxisLabelOrientation } from 'ag-charts-community';
 import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 import { AngleCrossLine } from './angleCrossLine';
-import type { AgAngleCategoryAxisLabelOrientation } from './typings';
 
 const { assignJsonApplyConstructedArray, ChartAxisDirection, NUMBER, ProxyOnWrite, Validate, predicateWithMessage } =
     _ModuleSupport;

--- a/packages/ag-charts-enterprise/src/polar-axes/angle-category/main.ts
+++ b/packages/ag-charts-enterprise/src/polar-axes/angle-category/main.ts
@@ -1,2 +1,1 @@
 export { AngleCategoryAxisModule } from './angleCategoryAxisModule';
-export { AgAngleCategoryAxisOptions } from './typings';

--- a/packages/ag-charts-enterprise/src/polar-axes/radius-number/main.ts
+++ b/packages/ag-charts-enterprise/src/polar-axes/radius-number/main.ts
@@ -1,2 +1,1 @@
 export { RadiusNumberAxisModule } from './radiusNumberAxisModule';
-export { AgRadiusNumberAxisOptions } from './typings';

--- a/packages/ag-charts-enterprise/src/polar-series/nightingale/main.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/nightingale/main.ts
@@ -1,2 +1,1 @@
 export { NightingaleModule } from './nightingaleModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/polar-series/radar-area/main.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radar-area/main.ts
@@ -1,2 +1,1 @@
 export { RadarAreaModule } from './radarAreaModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/polar-series/radar-line/main.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radar-line/main.ts
@@ -1,2 +1,1 @@
 export { RadarLineModule } from './radarLineModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/polar-series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radar/radarSeries.ts
@@ -3,14 +3,11 @@ import type {
     AgPieSeriesTooltipRendererParams,
     AgPieSeriesFormat,
     AgTooltipRendererResult,
-} from 'ag-charts-community';
-import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
-
-import type {
     AgRadarSeriesLabelFormatterParams,
     AgRadarSeriesMarkerFormat,
     AgRadarSeriesMarkerFormatterParams,
-} from './typings';
+} from 'ag-charts-community';
+import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 
 const {
     ChartAxisDirection,

--- a/packages/ag-charts-enterprise/src/polar-series/radial-column/main.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radial-column/main.ts
@@ -1,2 +1,1 @@
 export { RadialColumnModule } from './radialColumnModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnSeriesBase.ts
@@ -1,13 +1,12 @@
-import type { AgTooltipRendererResult } from 'ag-charts-community';
-import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
-import { AngleCategoryAxis } from '../../polar-axes/angle-category/angleCategoryAxis';
-
 import type {
-    AgRadialColumnSeriesLabelFormatterParams,
     AgRadialColumnSeriesFormat,
     AgRadialColumnSeriesFormatterParams,
+    AgRadialColumnSeriesLabelFormatterParams,
     AgRadialColumnSeriesTooltipRendererParams,
-} from './typings';
+    AgTooltipRendererResult,
+} from 'ag-charts-community';
+import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
+import { AngleCategoryAxis } from '../../polar-axes/angle-category/angleCategoryAxis';
 
 const {
     ChartAxisDirection,

--- a/packages/ag-charts-enterprise/src/rangeArea/main.ts
+++ b/packages/ag-charts-enterprise/src/rangeArea/main.ts
@@ -1,2 +1,1 @@
 export { RangeAreaModule } from './rangeAreaModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/rangeArea/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/rangeArea/rangeArea.ts
@@ -2,13 +2,11 @@ import type {
     AgCartesianSeriesLabelFormatterParams,
     AgTooltipRendererResult,
     AgCartesianSeriesMarkerFormat,
-} from 'ag-charts-community';
-import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
-import type {
-    AgRangeAreaSeriesTooltipRendererParams,
     AgRangeAreaSeriesLabelPlacement,
     AgRangeAreaSeriesMarkerFormatterParams,
-} from './typings';
+    AgRangeAreaSeriesTooltipRendererParams,
+} from 'ag-charts-community';
+import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 
 const {
     Validate,

--- a/packages/ag-charts-enterprise/src/rangeBar/main.ts
+++ b/packages/ag-charts-enterprise/src/rangeBar/main.ts
@@ -1,2 +1,1 @@
 export { RangeBarModule, RangeColumnModule } from './rangeBarModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/rangeBar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/rangeBar/rangeBar.ts
@@ -1,11 +1,12 @@
-import type { AgCartesianSeriesLabelFormatterParams, AgTooltipRendererResult } from 'ag-charts-community';
-import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 import type {
+    AgCartesianSeriesLabelFormatterParams,
     AgRangeBarSeriesFormat,
     AgRangeBarSeriesFormatterParams,
-    AgRangeBarSeriesTooltipRendererParams,
     AgRangeBarSeriesLabelPlacement,
-} from './typings';
+    AgRangeBarSeriesTooltipRendererParams,
+    AgTooltipRendererResult,
+} from 'ag-charts-community';
+import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 
 const {
     Validate,

--- a/packages/ag-charts-enterprise/src/waterfall/main.ts
+++ b/packages/ag-charts-enterprise/src/waterfall/main.ts
@@ -1,2 +1,1 @@
 export { WaterfallBarModule, WaterfallColumnModule } from './waterfallModule';
-export * from './typings';

--- a/packages/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
@@ -1,11 +1,12 @@
-import type { AgCartesianSeriesLabelFormatterParams, AgTooltipRendererResult } from 'ag-charts-community';
-import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 import type {
+    AgCartesianSeriesLabelFormatterParams,
+    AgTooltipRendererResult,
     AgWaterfallSeriesFormat,
-    AgWaterfallSeriesLabelPlacement,
     AgWaterfallSeriesFormatterParams,
+    AgWaterfallSeriesLabelPlacement,
     AgWaterfallSeriesTooltipRendererParams,
-} from './typings';
+} from 'ag-charts-community';
+import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 
 const {
     Validate,

--- a/packages/ag-charts-enterprise/src/zoom/zoomModule.ts
+++ b/packages/ag-charts-enterprise/src/zoom/zoomModule.ts
@@ -8,32 +8,3 @@ export const ZoomModule: _ModuleSupport.Module = {
     chartTypes: ['cartesian'],
     instanceConstructor: Zoom,
 };
-
-export type AgZoomAxes = 'x' | 'y' | 'xy';
-export type AgZoomPanKey = 'alt' | 'ctrl' | 'meta' | 'shift';
-export type AgZoomScrollingPivot = 'pointer' | 'start' | 'end';
-
-export interface AgZoomOptions {
-    /** The axes on which to zoom, one of 'xy', 'x', or 'y'. */
-    axes?: AgZoomAxes;
-    /** Set to true to enable the zoom module. */
-    enabled?: boolean;
-    /** Set to true to enable dragging an axis to zoom series attached to that axis, defaults to true. */
-    enableAxisDragging?: boolean;
-    /** Set to true to enable panning while zoomed, defaults to true. */
-    enablePanning?: boolean;
-    /** Set to true to enable zooming with the mouse wheel, defaults to true. */
-    enableScrolling?: boolean;
-    /** Set to true to enable selecting an area of the chart to zoom into, defaults to false. */
-    enableSelecting?: boolean;
-    /** The minimum amount of the chart to show in the x-axis as a ratio of the full chart, defaults to `0.2`. */
-    minXRatio?: number;
-    /** The minimum amount of the chart to show in the y-axis as a ratio of the full chart, defaults to `0.2`. */
-    minYRatio?: number;
-    /** The key that should be pressed to allow dragging to pan around while zoomed, one of `alt`, `ctrl`, `meta` or `shift, defaults to `alt`. */
-    panKey?: AgZoomPanKey;
-    /** The amount to zoom when scrolling with the mouse wheel, as a ratio of the full chart, defaults to `0.1`. */
-    scrollingStep?: number;
-    /** The pivot about which to zoom into when scrolling, defaults to `end`. */
-    scrollingPivot?: AgZoomScrollingPivot;
-}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8932

Moves us towards the desired end-state of all typings being part of `ag-charts-community`. with runtime messages to highlight use of enterprise features outside the scope of `ag-charts-community`.

This change attempts to move typings wholesale, with the minimal changes to enable `nx build`/`nx lint` and `nx test` to pass.