### PR TITLE
AG-8826 - Improve high series count performance

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -611,7 +611,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         const end = performance.now();
         this.log('Chart.performUpdate() - end', {
             chart: this,
-            durationMs: Math.round((end - splits[0]) * 100) / 100,
+            durationMs: Math.round((end - splits['start']) * 100) / 100,
             count,
             performUpdateType: ChartUpdateType[performUpdateType],
         });
@@ -643,7 +643,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             const count = this._performUpdateNoRenderCount++;
             const backOffMs = (count ^ 2) * 10;
 
-            if (count < 5) {
+            if (count < 8) {
                 // Reschedule if canvas size hasn't been set yet to avoid a race.
                 this.update(ChartUpdateType.PERFORM_LAYOUT, { seriesToUpdate, backOffMs });
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -559,14 +559,14 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.seriesToUpdate.clear();
 
         this.log('Chart.performUpdate() - start', ChartUpdateType[performUpdateType]);
-        const splits = [performance.now()];
+        const splits: Record<string, number> = { start: performance.now() };
 
         switch (performUpdateType) {
             case ChartUpdateType.FULL:
             case ChartUpdateType.PROCESS_DATA:
                 await this.processData();
                 this.disablePointer(true);
-                splits.push(performance.now());
+                splits['🏭'] = performance.now();
             // eslint-disable-next-line no-fallthrough
             case ChartUpdateType.PERFORM_LAYOUT:
                 if (this.checkUpdateShortcut(ChartUpdateType.PERFORM_LAYOUT)) break;
@@ -575,7 +575,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 await this.performLayout();
                 this.handleOverlays();
                 this.log('Chart.performUpdate() - seriesRect', this.seriesRect);
-                splits.push(performance.now());
+                splits['⌖'] = performance.now();
 
             // eslint-disable-next-line no-fallthrough
             case ChartUpdateType.SERIES_UPDATE:
@@ -585,7 +585,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 const seriesUpdates = [...seriesToUpdate].map((series) => series.update({ seriesRect }));
                 await Promise.all(seriesUpdates);
 
-                splits.push(performance.now());
+                splits['🤔'] = performance.now();
             // eslint-disable-next-line no-fallthrough
             case ChartUpdateType.TOOLTIP_RECALCULATION:
                 if (this.checkUpdateShortcut(ChartUpdateType.TOOLTIP_RECALCULATION)) break;
@@ -594,6 +594,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 if (performUpdateType < ChartUpdateType.SERIES_UPDATE && tooltipMeta?.event?.type === 'hover') {
                     this.handlePointer(tooltipMeta.event as InteractionEvent<'hover'>);
                 }
+                splits['↖'] = performance.now();
 
             // eslint-disable-next-line no-fallthrough
             case ChartUpdateType.SCENE_RENDER:

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -687,6 +687,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     protected _series: Series[] = [];
     set series(values: Series[]) {
         this.removeAllSeries();
+        this.seriesLayerManager.setSeriesCount(values.length);
         values.forEach((series) => this.addSeries(series));
     }
     get series(): Series[] {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -364,7 +364,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
     seriesGrouping?: SeriesGrouping = undefined;
 
     private onSeriesGroupingChange(prev?: SeriesGrouping, next?: SeriesGrouping) {
-        const { id, type, visible, rootGroup } = this;
+        const { id, type, visible, rootGroup, highlightGroup } = this;
 
         if (prev) {
             this.ctx.seriesStateManager.deregisterSeries({ id, type });
@@ -376,6 +376,7 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
             id,
             type,
             rootGroup,
+            highlightGroup,
             getGroupZIndexSubOrder: (type) => this.getGroupZIndexSubOrder(type),
             seriesGrouping: next,
             oldGrouping: prev,
@@ -426,14 +427,13 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
             })
         );
 
-        this.highlightGroup = rootGroup.appendChild(
-            new Group({
-                name: `${this.id}-highlight`,
-                layer: true,
-                zIndex: Layers.SERIES_LAYER_ZINDEX,
-                zIndexSubOrder: this.getGroupZIndexSubOrder('highlight'),
-            })
-        );
+        this.highlightGroup = new Group({
+            name: `${this.id}-highlight`,
+            layer: !contentGroupVirtual,
+            isVirtual: contentGroupVirtual,
+            zIndex: Layers.SERIES_LAYER_ZINDEX,
+            zIndexSubOrder: this.getGroupZIndexSubOrder('highlight'),
+        });
         this.highlightNode = this.highlightGroup.appendChild(new Group({ name: 'highlightNode' }));
         this.highlightLabel = this.highlightGroup.appendChild(new Group({ name: 'highlightLabel' }));
         this.highlightNode.zIndex = 0;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -372,6 +372,10 @@ export abstract class Series<C extends SeriesNodeDataContext = SeriesNodeDataCon
         if (next) {
             this.ctx.seriesStateManager.registerSeries({ id, type, visible, seriesGrouping: next });
         }
+
+        // Short-circuit if series isn't already attached to the scene-graph yet.
+        if (this.rootGroup.parent == null) return;
+
         this.ctx.seriesLayerManager.changeGroup({
             id,
             type,

--- a/packages/ag-charts-community/src/chart/series/seriesLayerManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesLayerManager.ts
@@ -68,7 +68,7 @@ export class SeriesLayerManager {
 
         this.groups[type] ??= {};
 
-        const lookupIndex = this.mode === 'normal' ? groupIndex : 0;
+        const lookupIndex = this.lookupIdx(groupIndex);
         let groupInfo = this.groups[type][lookupIndex];
         if (!groupInfo) {
             groupInfo = this.groups[type][lookupIndex] ??= {
@@ -129,7 +129,7 @@ export class SeriesLayerManager {
             throw new Error(`AG Charts - series doesn't have an allocated layer: ${id}`);
         }
 
-        const lookupIndex = this.mode === 'normal' ? groupIndex : 0;
+        const lookupIndex = this.lookupIdx(groupIndex);
         const groupInfo = this.groups[type]?.[lookupIndex] ?? this.series[id]?.layerState;
         if (groupInfo) {
             groupInfo.seriesIds = groupInfo.seriesIds.filter((v) => v !== id);
@@ -152,6 +152,22 @@ export class SeriesLayerManager {
         }
 
         delete this.series[id];
+    }
+
+    private lookupIdx(groupIndex: number | string) {
+        if (this.mode === 'normal') {
+            return groupIndex;
+        }
+
+        if (typeof groupIndex === 'string') {
+            groupIndex = Number(groupIndex.split('-').slice(-1)[0]);
+            if (!groupIndex) return 0;
+        }
+
+        return Math.floor(
+            Math.max(Math.min(groupIndex / this.expectedSeriesCount, 1), 0) *
+                SERIES_THRESHOLD_FOR_AGGRESSIVE_LAYER_REDUCTION
+        );
     }
 
     public destroy() {

--- a/packages/ag-charts-community/src/chart/series/seriesLayerManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesLayerManager.ts
@@ -7,6 +7,7 @@ export type SeriesConfig = {
     id: string;
     seriesGrouping?: SeriesGrouping;
     rootGroup: Group;
+    highlightGroup: Group;
     type: string;
     getGroupZIndexSubOrder(
         type: 'data' | 'labels' | 'highlight' | 'path' | 'marker' | 'paths',
@@ -17,7 +18,10 @@ export type SeriesConfig = {
 type LayerState = {
     seriesIds: string[];
     group: Group;
+    highlight: Group;
 };
+
+const SERIES_THRESHOLD_FOR_AGGRESSIVE_LAYER_REDUCTION = 30;
 
 export class SeriesLayerManager {
     private readonly rootGroup: Group;
@@ -29,22 +33,45 @@ export class SeriesLayerManager {
     } = {};
     private readonly series: { [id: string]: { layerState: LayerState; seriesConfig: SeriesConfig } } = {};
 
+    private expectedSeriesCount = 1;
+    private mode: 'normal' | 'aggressive-grouping' = 'normal';
+
     constructor(rootGroup: Group) {
         this.rootGroup = rootGroup;
     }
 
+    public setSeriesCount(count: number) {
+        this.expectedSeriesCount = count;
+    }
+
     public requestGroup(seriesConfig: SeriesConfig) {
-        const { id, type, rootGroup: seriesRootGroup, seriesGrouping } = seriesConfig;
+        const {
+            id,
+            type,
+            rootGroup: seriesRootGroup,
+            highlightGroup: seriesHighlightGroup,
+            seriesGrouping,
+        } = seriesConfig;
         const { groupIndex = id } = seriesGrouping ?? {};
 
         if (this.series[id] != null) {
             throw new Error(`AG Charts - series already has an allocated layer: ${this.series[id]}`);
         }
 
+        // Re-evaluate mode only on first series addition - we can't swap strategy mid-setup.
+        if (Object.keys(this.series).length === 0) {
+            this.mode =
+                this.expectedSeriesCount >= SERIES_THRESHOLD_FOR_AGGRESSIVE_LAYER_REDUCTION
+                    ? 'aggressive-grouping'
+                    : 'normal';
+        }
+
         this.groups[type] ??= {};
-        let groupInfo = this.groups[type][groupIndex];
+
+        const lookupIndex = this.mode === 'normal' ? groupIndex : 0;
+        let groupInfo = this.groups[type][lookupIndex];
         if (!groupInfo) {
-            groupInfo = this.groups[type][groupIndex] ??= {
+            groupInfo = this.groups[type][lookupIndex] ??= {
                 seriesIds: [],
                 group: this.rootGroup.appendChild(
                     new Group({
@@ -54,6 +81,14 @@ export class SeriesLayerManager {
                         zIndexSubOrder: seriesConfig.getGroupZIndexSubOrder('data'),
                     })
                 ),
+                highlight: this.rootGroup.appendChild(
+                    new Group({
+                        name: `${type}-highlight`,
+                        layer: true,
+                        zIndex: Layers.SERIES_LAYER_ZINDEX,
+                        zIndexSubOrder: seriesConfig.getGroupZIndexSubOrder('highlight'),
+                    })
+                ),
             };
         }
 
@@ -61,11 +96,12 @@ export class SeriesLayerManager {
 
         groupInfo.seriesIds.push(id);
         groupInfo.group.appendChild(seriesRootGroup);
+        groupInfo.highlight.appendChild(seriesHighlightGroup);
         return groupInfo.group;
     }
 
     public changeGroup(seriesConfig: SeriesConfig & { oldGrouping?: SeriesGrouping }) {
-        const { id, seriesGrouping, type, rootGroup, oldGrouping } = seriesConfig;
+        const { id, seriesGrouping, type, rootGroup, highlightGroup, oldGrouping } = seriesConfig;
         const { groupIndex = id } = seriesGrouping ?? {};
 
         if (this.groups[type]?.[groupIndex]?.seriesIds.includes(id)) {
@@ -74,35 +110,45 @@ export class SeriesLayerManager {
         }
 
         if (this.series[id] != null) {
-            this.releaseGroup({ id, seriesGrouping: oldGrouping, type, rootGroup });
+            this.releaseGroup({ id, seriesGrouping: oldGrouping, type, rootGroup, highlightGroup });
         }
         this.requestGroup(seriesConfig);
     }
 
-    public releaseGroup(seriesConfig: { id: string; seriesGrouping?: SeriesGrouping; rootGroup: Group; type: string }) {
-        const { id, seriesGrouping, rootGroup, type } = seriesConfig;
+    public releaseGroup(seriesConfig: {
+        id: string;
+        seriesGrouping?: SeriesGrouping;
+        highlightGroup: Group;
+        rootGroup: Group;
+        type: string;
+    }) {
+        const { id, seriesGrouping, rootGroup, highlightGroup, type } = seriesConfig;
         const { groupIndex = id } = seriesGrouping ?? {};
 
         if (this.series[id] == null) {
             throw new Error(`AG Charts - series doesn't have an allocated layer: ${id}`);
         }
 
-        const groupInfo = this.groups[type]?.[groupIndex] ?? this.series[id]?.layerState;
+        const lookupIndex = this.mode === 'normal' ? groupIndex : 0;
+        const groupInfo = this.groups[type]?.[lookupIndex] ?? this.series[id]?.layerState;
         if (groupInfo) {
             groupInfo.seriesIds = groupInfo.seriesIds.filter((v) => v !== id);
             groupInfo.group.removeChild(rootGroup);
+            groupInfo.highlight.removeChild(highlightGroup);
         }
 
         if (groupInfo?.seriesIds.length === 0) {
             // Last member of the layer, cleanup.
             this.rootGroup.removeChild(groupInfo.group);
-            delete this.groups[type][groupIndex];
+            this.rootGroup.removeChild(groupInfo.highlight);
+            delete this.groups[type][lookupIndex];
             delete this.groups[type][id];
         } else if (groupInfo?.seriesIds.length > 0) {
             // Update zIndexSubOrder to avoid it becoming stale as series are removed and re-added
             // with the same groupIndex, but are otherwise unrelated.
             const leadSeriesConfig = this.series[groupInfo?.seriesIds?.[0]]?.seriesConfig;
             groupInfo.group.zIndexSubOrder = leadSeriesConfig?.getGroupZIndexSubOrder('data');
+            groupInfo.highlight.zIndexSubOrder = leadSeriesConfig?.getGroupZIndexSubOrder('highlight');
         }
 
         delete this.series[id];
@@ -112,6 +158,7 @@ export class SeriesLayerManager {
         for (const groups of Object.values(this.groups)) {
             for (const groupInfo of Object.values(groups)) {
                 this.rootGroup.removeChild(groupInfo.group);
+                this.rootGroup.removeChild(groupInfo.highlight);
             }
         }
         (this as any).groups = {};


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8826

Significantly improves performance for high series-count charts by counter-intuitively reducing the number of layers. This effectively batches up more canvas operations per layer rasterisation, which is why it is faster for low per-series data sizes.

Concrete changes:
- Reduces the 1:1 mapping for series<->layer if the series count is >= 30
- Also now collapses highlight groups into shared layers to reduce layer count overhead at minimal performance change.
- Fixes double render on initial load due to later resize (I increase the back-off count, which seems to have fixed the issue although I'm not sure why).

Bonus:
- Adds emojis to `window.agChartsSceneRenderCharts` outputs to better distinguish timing measurements.