### PR TITLE
AG-8826 - Ignore incorrect resize event before DOMContentLoaded.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -146,14 +146,14 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     @ActionOnSet<Chart>({
         newValue(value) {
-            this.resize(value);
+            this.resize(value, undefined, 'width option');
         },
     })
     width?: number;
 
     @ActionOnSet<Chart>({
         newValue(value) {
-            this.resize(undefined, value);
+            this.resize(undefined, value, 'height option');
         },
     })
     height?: number;
@@ -177,7 +177,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             if (!this._lastAutoSize) {
                 return;
             }
-            this.resize();
+            this.resize(undefined, undefined, 'autoSize option');
         } else {
             style.display = 'inline-block';
             style.width = 'auto';
@@ -305,7 +305,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.debug = false;
 
         SizeMonitor.observe(this.element, (size) => {
-            const { width, height } = size;
+            let { width, height } = size;
+            width = Math.floor(width);
+            height = Math.floor(height);
 
             if (!this.autoSize) {
                 return;
@@ -321,7 +323,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             }
 
             this._lastAutoSize = [width, height];
-            this.resize();
+            this.resize(undefined, undefined, 'SizeMonitor');
         });
         // eslint-disable-next-line sonarjs/no-duplicate-string
         this.layoutService.addListener('start-layout', (e) => this.positionPadding(e.shrinkRect));
@@ -813,10 +815,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
     }
 
-    private resize(width?: number, height?: number) {
+    private resize(width?: number, height?: number, source?: string) {
         width ??= this.width ?? (this.autoSize ? this._lastAutoSize?.[0] : this.scene.canvas.width);
         height ??= this.height ?? (this.autoSize ? this._lastAutoSize?.[1] : this.scene.canvas.height);
-        this.log('Chart.resize()', { width, height });
+        this.log(`Chart.resize() from ${source}`, { width, height });
         if (!width || !height || !Number.isFinite(width) || !Number.isFinite(height)) return;
 
         if (this.scene.resize(width, height)) {

--- a/packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -12,10 +12,13 @@ export class SizeMonitor {
     private static elements = new Map<HTMLElement, Entry>();
     private static resizeObserver: any;
     private static ready = false;
+    private static documentReady = false;
+    private static readyEventFn?: EventListener;
+    private static queuedObserveRequests: [HTMLElement, OnSizeChange][] = [];
 
     private static pollerHandler?: number;
 
-    static init() {
+    static init(document: Document) {
         if (typeof ResizeObserver !== 'undefined') {
             this.resizeObserver = new ResizeObserver((entries: any) => {
                 for (const entry of entries) {
@@ -34,12 +37,32 @@ export class SizeMonitor {
         }
 
         this.ready = true;
+
+        this.documentReady = document.readyState !== 'loading';
+        if (!this.documentReady) {
+            this.readyEventFn = () => {
+                const newState = document.readyState !== 'loading';
+                const oldState = this.documentReady;
+                this.documentReady = newState;
+                if (newState !== oldState && newState) {
+                    for (const [el, cb] of this.queuedObserveRequests) {
+                        this.observe(el, cb);
+                    }
+                    this.queuedObserveRequests.length = 0;
+                }
+            };
+            document.addEventListener('DOMContentLoaded', this.readyEventFn);
+        }
     }
 
     private static destroy() {
         if (this.pollerHandler != null) {
             clearInterval(this.pollerHandler);
             this.pollerHandler = undefined;
+        }
+        if (this.readyEventFn) {
+            document.removeEventListener('DOMContentLoaded', this.readyEventFn);
+            this.readyEventFn = undefined;
         }
         this.resizeObserver?.disconnect();
         this.resizeObserver = undefined;
@@ -58,12 +81,18 @@ export class SizeMonitor {
     // Only a single callback is supported.
     static observe(element: HTMLElement, cb: OnSizeChange) {
         if (!this.ready) {
-            this.init();
+            this.init(element.ownerDocument);
         }
+        if (!this.documentReady) {
+            this.queuedObserveRequests.push([element, cb]);
+            return;
+        }
+
         this.unobserve(element, false);
         if (this.resizeObserver) {
             this.resizeObserver.observe(element);
         }
+
         this.elements.set(element, { cb });
 
         // Ensure first size callback happens synchronously.
@@ -75,6 +104,8 @@ export class SizeMonitor {
             this.resizeObserver.unobserve(element);
         }
         this.elements.delete(element);
+
+        this.queuedObserveRequests = this.queuedObserveRequests.filter(([el]) => el === element);
 
         if (cleanup && this.elements.size === 0) {
             this.destroy();


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8826

Attempt to fix render-resize-render glitch on initial load.

From observation, this Plnkr had the following behaviour before this change:
- ResizeObserver is setup and monitors the chart element.
- Resize event fires with non-stable sizes.
- Chart.update() processing runs and renders a chart.
- DOMContentLoaded event fires.
- Resize event fires with stable sizes.
- Chart.update() processing runs and renders a chart at a different size.

This change attempt to prevent the first resize event from triggering a resize by waiting for `DOMContentLoaded` to fire if the DOM is still being loaded at chart setup.