### PR TITLE
AG-9202 Fix area animation resize interruption reset

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -823,6 +823,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
         if (this.scene.resize(width, height)) {
             this.disablePointer();
+            this.animationManager.reset();
             this.update(ChartUpdateType.PERFORM_LAYOUT, { forceNodeDataRefresh: true });
         }
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -51,6 +51,7 @@ import {
     AreaSeriesTag,
     areaAnimateEmptyUpdateReady,
     areaAnimateReadyUpdate,
+    areaResetMarkersAndPaths,
 } from './areaUtil';
 import { getMarkerConfig, updateMarker } from './markerUtil';
 
@@ -704,6 +705,43 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
     }
 
     animateEmptyUpdateReady({ markerSelections, labelSelections, contextData, paths, seriesRect }: AreaAnimationData) {
+        const { seriesId, styles, ctx, formatter, getFormatterParams } = this.getAnimationOptions();
+        areaAnimateEmptyUpdateReady({
+            markerSelections,
+            labelSelections,
+            contextData,
+            paths,
+            seriesRect,
+            styles,
+            seriesId,
+            ctx,
+            formatter,
+            getFormatterParams,
+        });
+    }
+
+    animateReadyUpdate({ contextData, paths }: AreaAnimationData) {
+        const { styles } = this.getAnimationOptions();
+        areaAnimateReadyUpdate({ contextData, paths, styles });
+    }
+
+    animateReadyResize({ contextData, markerSelections, labelSelections, paths }: AreaAnimationData) {
+        this.ctx.animationManager?.reset();
+        const { styles, ctx, formatter, getFormatterParams } = this.getAnimationOptions();
+
+        areaResetMarkersAndPaths({
+            contextData,
+            markerSelections,
+            labelSelections,
+            paths,
+            styles,
+            ctx,
+            formatter,
+            getFormatterParams,
+        });
+    }
+
+    getAnimationOptions() {
         const { id: seriesId, ctx, xKey = '', yKey = '', marker } = this;
         const styles = {
             stroke: this.stroke,
@@ -713,7 +751,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             lineDashOffset: this.lineDashOffset,
             strokeOpacity: this.strokeOpacity,
             shadow: this.shadow,
-            strokeWidth: () => this.getStrokeWidth(this.strokeWidth),
+            strokeWidth: this.getStrokeWidth(this.strokeWidth),
         };
 
         const { size, formatter } = marker;
@@ -736,33 +774,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
             };
         };
 
-        areaAnimateEmptyUpdateReady({
-            markerSelections,
-            labelSelections,
-            contextData,
-            paths,
-            seriesRect,
-            styles,
-            seriesId,
-            ctx,
-            formatter,
-            getFormatterParams,
-        });
-    }
-
-    animateReadyUpdate({ contextData, paths }: AreaAnimationData) {
-        const styles = {
-            stroke: this.stroke,
-            fill: this.fill,
-            fillOpacity: this.fillOpacity,
-            lineDash: this.lineDash,
-            lineDashOffset: this.lineDashOffset,
-            strokeOpacity: this.strokeOpacity,
-            shadow: this.shadow,
-            strokeWidth: () => this.getStrokeWidth(this.strokeWidth),
-        };
-
-        areaAnimateReadyUpdate({ contextData, paths, styles });
+        return { seriesId, styles, ctx, formatter, getFormatterParams };
     }
 
     protected isLabelEnabled() {

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -726,7 +726,6 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
     }
 
     animateReadyResize({ contextData, markerSelections, labelSelections, paths }: AreaAnimationData) {
-        this.ctx.animationManager?.reset();
         const { styles, ctx, formatter, getFormatterParams } = this.getAnimationOptions();
 
         areaResetMarkersAndPaths({

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -723,7 +723,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
     }
 
     animateReadyResize({ datumSelections }: BarAnimationData) {
-        this.ctx.animationManager?.reset();
         datumSelections.forEach((datumSelection) => {
             this.resetSelectionRects(datumSelection);
         });

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -266,23 +266,22 @@ export abstract class CartesianSeries<
         await this.updateSelections(seriesHighlighted, visible);
         await this.updateNodes(seriesHighlighted, visible);
 
-        if (resize) {
-            this.animationState.transition('resize', {
-                datumSelections: this.subGroups.map(({ datumSelection }) => datumSelection),
-                markerSelections: this.subGroups.map(({ markerSelection }) => markerSelection),
-                contextData: this._contextNodeData,
-                paths: this.subGroups.map(({ paths }) => paths),
-            });
-        }
-
-        this.animationState.transition('update', {
+        const animationData: CartesianAnimationData<C, N> = {
             datumSelections: this.subGroups.map(({ datumSelection }) => datumSelection),
-            markerSelections: this.subGroups.map(({ markerSelection }) => markerSelection),
+            markerSelections: this.subGroups
+                .filter(({ markerSelection }) => markerSelection !== undefined)
+                .map(({ markerSelection }) => markerSelection!),
             labelSelections: this.subGroups.map(({ labelSelection }) => labelSelection),
             contextData: this._contextNodeData,
             paths: this.subGroups.map(({ paths }) => paths),
             seriesRect,
-        });
+        };
+
+        if (resize) {
+            this.animationState.transition('resize', animationData);
+        }
+
+        this.animationState.transition('update', animationData);
     }
 
     protected async updateSelections(seriesHighlighted: boolean | undefined, anySeriesItemEnabled: boolean) {
@@ -815,12 +814,7 @@ export abstract class CartesianSeries<
         // Override point for sub-classes.
     }
 
-    protected animateReadyResize(_data: {
-        datumSelections: Array<NodeDataSelection<N, C>>;
-        markerSelections: Array<NodeDataSelection<Marker, C>>;
-        contextData: Array<C>;
-        paths: Array<Array<Path>>;
-    }) {
+    protected animateReadyResize(_data: CartesianAnimationData<C, N>) {
         // Override point for sub-classes.
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -638,9 +638,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     }
 
     animateReadyUpdate({ datumSelections }: HistogramAnimationData) {
-        datumSelections.forEach((datumSelection) => {
-            this.resetSelectionRects(datumSelection);
-        });
+        this.resetSelections(datumSelections);
     }
 
     animateReadyHighlight(highlightSelection: Selection<Rect, HistogramNodeDatum>) {
@@ -648,9 +646,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     }
 
     animateReadyResize({ datumSelections }: HistogramAnimationData) {
-        datumSelections.forEach((datumSelection) => {
-            this.resetSelectionRects(datumSelection);
-        });
+        this.resetSelections(datumSelections);
     }
 
     animateWaitingUpdateReady({
@@ -664,9 +660,7 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
         const diff = processedData?.reduced?.diff;
 
         if (!diff?.changed) {
-            datumSelections.forEach((datumSelection) => {
-                this.resetSelectionRects(datumSelection);
-            });
+            this.resetSelections(datumSelections);
             return;
         }
 
@@ -759,6 +753,12 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
                     },
                 });
             });
+        });
+    }
+
+    resetSelections(datumSelections: HistogramAnimationData['datumSelections']) {
+        datumSelections.forEach((datumSelection) => {
+            this.resetSelectionRects(datumSelection);
         });
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -648,7 +648,6 @@ export class HistogramSeries extends CartesianSeries<SeriesNodeDataContext<Histo
     }
 
     animateReadyResize({ datumSelections }: HistogramAnimationData) {
-        this.ctx.animationManager?.reset();
         datumSelections.forEach((datumSelection) => {
             this.resetSelectionRects(datumSelection);
         });

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -639,7 +639,6 @@ export class LineSeries extends CartesianSeries<LineContext> {
         contextData: Array<LineContext>;
         paths: Array<Array<Path>>;
     }) {
-        this.ctx.animationManager?.reset();
         this.resetMarkersAndPaths(data);
     }
 

--- a/packages/ag-charts-enterprise/src/polar-series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radar/radarSeries.ts
@@ -736,7 +736,6 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
     }
 
     animateReadyResize() {
-        this.ctx.animationManager?.reset();
         this.resetMarkersAndPaths();
     }
 

--- a/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnSeriesBase.ts
@@ -563,7 +563,6 @@ export abstract class RadialColumnSeriesBase<
     }
 
     protected animateReadyResize() {
-        this.ctx.animationManager?.reset();
         this.resetSectors();
     }
 

--- a/packages/ag-charts-enterprise/src/rangeArea/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/rangeArea/rangeArea.ts
@@ -665,7 +665,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
             lineDashOffset: this.lineDashOffset,
             strokeOpacity: this.strokeOpacity,
             shadow: this.shadow,
-            strokeWidth: () => this.getStrokeWidth(this.strokeWidth),
+            strokeWidth: this.getStrokeWidth(this.strokeWidth),
         };
 
         const { size, formatter } = marker;
@@ -729,7 +729,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
             lineDashOffset: this.lineDashOffset,
             strokeOpacity: this.strokeOpacity,
             shadow: this.shadow,
-            strokeWidth: () => this.getStrokeWidth(this.strokeWidth),
+            strokeWidth: this.getStrokeWidth(this.strokeWidth),
         };
 
         areaAnimateReadyUpdate({ contextData, paths, styles });

--- a/packages/ag-charts-enterprise/src/rangeBar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/rangeBar/rangeBar.ts
@@ -805,30 +805,19 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
         });
     }
 
-    animateReadyUpdate({
-        datumSelections,
-    }: {
-        datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>>;
-        contextData: Array<RangeBarContext>;
-        paths: Array<Array<_Scene.Path>>;
-    }) {
-        datumSelections.forEach((datumSelection) => {
-            this.resetSelectionRects(datumSelection);
-        });
+    animateReadyUpdate(data: { datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>> }) {
+        this.resetSelections(data);
     }
 
     animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, RangeBarNodeDatum>) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize({
-        datumSelections,
-    }: {
-        datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>>;
-        contextData: Array<RangeBarContext>;
-        paths: Array<Array<_Scene.Path>>;
-    }) {
-        this.ctx.animationManager?.reset();
+    animateReadyResize(data: { datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>> }) {
+        this.resetSelections(data);
+    }
+
+    resetSelections({ datumSelections }: { datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>> }) {
         datumSelections.forEach((datumSelection) => {
             this.resetSelectionRects(datumSelection);
         });

--- a/packages/ag-charts-enterprise/src/rangeBar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/rangeBar/rangeBar.ts
@@ -81,6 +81,8 @@ interface RangeBarNodeDatum
 
 type RangeBarContext = _ModuleSupport.SeriesNodeDataContext<RangeBarNodeDatum, RangeBarNodeLabelDatum>;
 
+type RangeBarAnimationData = _ModuleSupport.CartesianAnimationData<RangeBarContext, _Scene.Rect>;
+
 class RangeBarSeriesNodeBaseClickEvent extends _ModuleSupport.SeriesNodeBaseClickEvent<RangeBarNodeDatum> {
     readonly xKey: string;
     readonly yLowKey: string;
@@ -125,10 +127,7 @@ class RangeBarSeriesLabel extends _Scene.Label {
     padding: number = 6;
 }
 
-export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
-    _ModuleSupport.SeriesNodeDataContext<any>,
-    _Scene.Rect
-> {
+export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarContext, _Scene.Rect> {
     static className = 'RangeBarSeries';
     static type: 'range-bar' | 'range-column' = 'range-bar' as const;
 
@@ -606,8 +605,8 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
     }
 
     protected async updateLabelSelection(opts: {
-        labelData: RangeBarNodeDatum[];
-        labelSelection: _Scene.Selection<_Scene.Text, RangeBarNodeDatum>;
+        labelData: RangeBarNodeLabelDatum[];
+        labelSelection: RangeBarAnimationData['labelSelections'][number];
     }) {
         const { labelData, labelSelection } = opts;
 
@@ -749,17 +748,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
         return legendData;
     }
 
-    animateEmptyUpdateReady({
-        datumSelections,
-        labelSelections,
-        contextData,
-    }: {
-        datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>>;
-        labelSelections: Array<_Scene.Selection<_Scene.Text, RangeBarNodeDatum>>;
-        contextData: Array<RangeBarContext>;
-        paths: Array<Array<_Scene.Path>>;
-        seriesRect?: _Scene.BBox;
-    }) {
+    animateEmptyUpdateReady({ datumSelections, labelSelections, contextData }: RangeBarAnimationData) {
         const duration = this.ctx.animationManager?.defaultOptions.duration ?? 1000;
 
         contextData.forEach((_, contextDataIndex) => {
@@ -768,7 +757,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
         });
     }
 
-    protected animateRects(datumSelection: _Scene.Selection<_Scene.Rect, RangeBarNodeDatum>, duration: number) {
+    protected animateRects(datumSelection: RangeBarAnimationData['datumSelections'][number], duration: number) {
         datumSelection.each((rect, datum) => {
             this.ctx.animationManager?.animateMany(
                 `${this.id}_empty-update-ready_${rect.id}`,
@@ -791,7 +780,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
         });
     }
 
-    protected animateLabels(labelSelection: _Scene.Selection<_Scene.Text, RangeBarNodeDatum>, duration: number) {
+    protected animateLabels(labelSelection: RangeBarAnimationData['labelSelections'][number], duration: number) {
         labelSelection.each((label) => {
             this.ctx.animationManager?.animate(`${this.id}_empty-update-ready_${label.id}`, {
                 from: 0,
@@ -805,19 +794,19 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
         });
     }
 
-    animateReadyUpdate(data: { datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>> }) {
-        this.resetSelections(data);
+    animateReadyUpdate({ datumSelections }: RangeBarAnimationData) {
+        this.resetSelections(datumSelections);
     }
 
-    animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, RangeBarNodeDatum>) {
+    animateReadyHighlight(highlightSelection: RangeBarAnimationData['datumSelections'][number]) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize(data: { datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>> }) {
-        this.resetSelections(data);
+    animateReadyResize({ datumSelections }: RangeBarAnimationData) {
+        this.resetSelections(datumSelections);
     }
 
-    resetSelections({ datumSelections }: { datumSelections: Array<_Scene.Selection<_Scene.Rect, RangeBarNodeDatum>> }) {
+    resetSelections(datumSelections: RangeBarAnimationData['datumSelections']) {
         datumSelections.forEach((datumSelection) => {
             this.resetSelectionRects(datumSelection);
         });

--- a/packages/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
@@ -939,26 +939,27 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
         });
     }
 
-    animateReadyUpdate({
-        datumSelections,
-        contextData,
-        paths,
-    }: {
+    animateReadyUpdate(data: {
         datumSelections: Array<_Scene.Selection<_Scene.Rect, WaterfallNodeDatum>>;
         contextData: Array<WaterfallContext>;
         paths: Array<Array<_Scene.Path>>;
     }) {
-        this.resetConnectorLinesPath({ contextData, paths });
-        datumSelections.forEach((datumSelection) => {
-            this.resetSelectionRects(datumSelection);
-        });
+        this.reset(data);
     }
 
     animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize({
+    animateReadyResize(data: {
+        datumSelections: Array<_Scene.Selection<_Scene.Rect, WaterfallNodeDatum>>;
+        contextData: Array<WaterfallContext>;
+        paths: Array<Array<_Scene.Path>>;
+    }) {
+        this.reset(data);
+    }
+
+    reset({
         datumSelections,
         contextData,
         paths,
@@ -967,7 +968,6 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
         contextData: Array<WaterfallContext>;
         paths: Array<Array<_Scene.Path>>;
     }) {
-        this.ctx.animationManager?.reset();
         this.resetConnectorLinesPath({ contextData, paths });
         datumSelections.forEach((datumSelection) => {
             this.resetSelectionRects(datumSelection);

--- a/packages/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/waterfall/waterfallSeries.ts
@@ -66,6 +66,8 @@ type WaterfallContext = _ModuleSupport.SeriesNodeDataContext<WaterfallNodeDatum>
     pointData?: WaterfallNodePointDatum[];
 };
 
+type WaterfallAnimationData = _ModuleSupport.CartesianAnimationData<WaterfallContext, _Scene.Rect>;
+
 class WaterfallSeriesNodeBaseClickEvent extends _ModuleSupport.CartesianSeriesNodeBaseClickEvent<any> {
     readonly labelKey?: string;
 
@@ -179,10 +181,7 @@ interface TotalMeta {
     axisLabel: any;
 }
 
-export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
-    _ModuleSupport.SeriesNodeDataContext<any>,
-    _Scene.Rect
-> {
+export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<WaterfallContext, _Scene.Rect> {
     static className = 'WaterfallBarSeries';
     static type: 'waterfall-bar' | 'waterfall-column' = 'waterfall-bar' as const;
 
@@ -834,18 +833,7 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
 
     protected toggleSeriesItem(): void {}
 
-    animateEmptyUpdateReady({
-        datumSelections,
-        labelSelections,
-        contextData,
-        paths,
-    }: {
-        datumSelections: Array<_Scene.Selection<_Scene.Rect, WaterfallNodeDatum>>;
-        labelSelections: Array<_Scene.Selection<_Scene.Text, WaterfallNodeDatum>>;
-        contextData: Array<WaterfallContext>;
-        paths: Array<Array<_Scene.Path>>;
-        seriesRect?: _Scene.BBox;
-    }) {
+    animateEmptyUpdateReady({ datumSelections, labelSelections, contextData, paths }: WaterfallAnimationData) {
         const duration = this.ctx.animationManager?.defaultOptions.duration ?? 1000;
 
         contextData.forEach(({ pointData }, contextDataIndex) => {
@@ -939,35 +927,19 @@ export class WaterfallBarSeries extends _ModuleSupport.CartesianSeries<
         });
     }
 
-    animateReadyUpdate(data: {
-        datumSelections: Array<_Scene.Selection<_Scene.Rect, WaterfallNodeDatum>>;
-        contextData: Array<WaterfallContext>;
-        paths: Array<Array<_Scene.Path>>;
-    }) {
-        this.reset(data);
+    animateReadyUpdate(data: WaterfallAnimationData) {
+        this.resetSelectionRectsAndPaths(data);
     }
 
     animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize(data: {
-        datumSelections: Array<_Scene.Selection<_Scene.Rect, WaterfallNodeDatum>>;
-        contextData: Array<WaterfallContext>;
-        paths: Array<Array<_Scene.Path>>;
-    }) {
-        this.reset(data);
+    animateReadyResize(data: WaterfallAnimationData) {
+        this.resetSelectionRectsAndPaths(data);
     }
 
-    reset({
-        datumSelections,
-        contextData,
-        paths,
-    }: {
-        datumSelections: Array<_Scene.Selection<_Scene.Rect, WaterfallNodeDatum>>;
-        contextData: Array<WaterfallContext>;
-        paths: Array<Array<_Scene.Path>>;
-    }) {
+    resetSelectionRectsAndPaths({ datumSelections, contextData, paths }: WaterfallAnimationData) {
         this.resetConnectorLinesPath({ contextData, paths });
         datumSelections.forEach((datumSelection) => {
             this.resetSelectionRects(datumSelection);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9202

There's some duplication between this reset and the `animateReadyUpdate` functions. This'll be sorted out when doing https://ag-grid.atlassian.net/browse/AG-9130