### PR TITLE
AG-8826 - Remove redundant resize callback

### DIFF
--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -23,9 +23,6 @@
         "generateExportsField": true
       },
       "configurations": {
-        "watch": {
-          "compiler": "swc"
-        },
         "production": {
           "format": ["cjs", "esm"]
         }

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -818,7 +818,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     private resize(width?: number, height?: number, source?: string) {
         width ??= this.width ?? (this.autoSize ? this._lastAutoSize?.[0] : this.scene.canvas.width);
         height ??= this.height ?? (this.autoSize ? this._lastAutoSize?.[1] : this.scene.canvas.height);
-        this.log(`Chart.resize() from ${source}`, { width, height });
+        this.log(`Chart.resize() from ${source}`, { width, height, stack: new Error().stack });
         if (!width || !height || !Number.isFinite(width) || !Number.isFinite(height)) return;
 
         if (this.scene.resize(width, height)) {

--- a/packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -101,9 +101,6 @@ export class SizeMonitor {
         }
 
         this.elements.set(element, { cb });
-
-        // Ensure first size callback happens synchronously.
-        this.checkClientSize(element, { cb });
     }
 
     static unobserve(element: HTMLElement, cleanup = true) {

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -20,9 +20,6 @@
         "generateExportsField": true
       },
       "configurations": {
-        "watch": {
-          "compiler": "swc"
-        },
         "production": {
           "format": ["cjs", "esm"]
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8826

Removes a redundant and incorrect resize callback on first resize callback setup. This additional callback may have been necessary prior to https://github.com/ag-grid/ag-charts/pull/113 being merged due to the resize event not firing consistently before that.

Bonus:
- Cleanup redundant `Nx` watch configurations.