### PR TITLE
AG-9212 - Remove root `type` options field.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -29,7 +29,7 @@ import { getJsonApplyOptions } from './chartOptions';
 import { REGISTERED_MODULES } from '../module-support';
 import { setupModules } from './factory/setupModules';
 
-type ProcessedOptions = Partial<AgChartOptions> & { type?: string };
+type ProcessedOptions = Partial<AgChartOptions> & { type?: SeriesOptionsTypes['type'] };
 
 export interface DownloadOptions extends ImageDataUrlOptions {
     /** Name of downloaded image file. Defaults to `image`.  */

--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -29,6 +29,8 @@ import { getJsonApplyOptions } from './chartOptions';
 import { REGISTERED_MODULES } from '../module-support';
 import { setupModules } from './factory/setupModules';
 
+type ProcessedOptions = Partial<AgChartOptions> & { type?: string };
+
 export interface DownloadOptions extends ImageDataUrlOptions {
     /** Name of downloaded image file. Defaults to `image`.  */
     fileName?: string;
@@ -332,16 +334,12 @@ abstract class AgChartInternal {
         throw new Error(`AG Charts - couldn't apply configuration, check type of options: ${options['type']}`);
     }
 
-    private static async updateDelta(
-        chart: Chart,
-        processedOptions: Partial<AgChartOptions>,
-        userOptions: AgChartOptions
-    ) {
+    private static async updateDelta(chart: Chart, processedOptions: ProcessedOptions, userOptions: AgChartOptions) {
         if (processedOptions.type == null) {
             processedOptions = {
                 ...processedOptions,
                 type: chart.processedOptions.type ?? optionsType(processedOptions),
-            } as Partial<AgChartOptions>;
+            };
         }
 
         await chart.awaitUpdateCompletion();
@@ -359,7 +357,7 @@ function debug(message?: any, ...optionalParams: any[]): void {
     }
 }
 
-function applyChartOptions(chart: Chart, processedOptions: Partial<AgChartOptions>, userOptions: AgChartOptions): void {
+function applyChartOptions(chart: Chart, processedOptions: ProcessedOptions, userOptions: AgChartOptions): void {
     const completeOptions = jsonMerge([chart.processedOptions ?? {}, processedOptions], noDataCloneMergeOptions);
     const modulesChanged = applyModules(chart, completeOptions);
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -96,7 +96,7 @@ function initialiseSpecialOverrides(opts: Partial<SpecialOverrides>): SpecialOve
 export abstract class Chart extends Observable implements AgChartInstance {
     readonly id = createId(this);
 
-    processedOptions: AgChartOptions = {};
+    processedOptions: AgChartOptions & { type?: string } = {};
     userOptions: AgChartOptions = {};
     queuedUserOptions: AgChartOptions[] = [];
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -49,6 +49,7 @@ import type { ModuleContext } from '../util/moduleContext';
 import { DataController } from './data/dataController';
 import { SeriesStateManager } from './series/seriesStateManager';
 import { SeriesLayerManager } from './series/seriesLayerManager';
+import type { SeriesOptionsTypes } from './mapping/defaults';
 
 type OptionalHTMLElement = HTMLElement | undefined | null;
 
@@ -96,7 +97,7 @@ function initialiseSpecialOverrides(opts: Partial<SpecialOverrides>): SpecialOve
 export abstract class Chart extends Observable implements AgChartInstance {
     readonly id = createId(this);
 
-    processedOptions: AgChartOptions & { type?: string } = {};
+    processedOptions: AgChartOptions & { type?: SeriesOptionsTypes['type'] } = {};
     userOptions: AgChartOptions = {};
     queuedUserOptions: AgChartOptions[] = [];
 

--- a/packages/ag-charts-community/src/chart/mapping/prepare.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepare.ts
@@ -27,9 +27,9 @@ import { addSeriesPaletteFactory, getSeriesDefaults, getSeriesPaletteFactory } f
 type AxesOptionsTypes = NonNullable<AgCartesianChartOptions['axes']>[number];
 
 export function optionsType(input: {
-    type?: AgChartOptions['type'];
+    type?: SeriesOptions['type'];
     series?: { type?: SeriesOptionsTypes['type'] }[];
-}): NonNullable<AgChartOptions['type']> {
+}): NonNullable<SeriesOptions['type']> {
     return input.type ?? input.series?.[0]?.type ?? 'line';
 }
 
@@ -126,7 +126,6 @@ export function prepareOptions<T extends AgChartOptions>(newOptions: T, fallback
     sanityCheckOptions(options);
 
     // Determine type and ensure it's explicit in the options config.
-    const userSuppliedOptionsType = options.type;
     const type = optionsType(options);
 
     const globalTooltipPositionOptions = options.tooltip?.position ?? {};
@@ -179,8 +178,6 @@ export function prepareOptions<T extends AgChartOptions>(newOptions: T, fallback
             let type = defaultSeriesType;
             if (s.type) {
                 type = s.type;
-            } else if (isSeriesOptionType(userSuppliedOptionsType)) {
-                type = userSuppliedOptionsType;
             }
 
             const mergedSeries = mergeSeriesOptions(s, type, seriesThemes, globalTooltipPositionOptions);

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianOptions.ts
@@ -62,19 +62,6 @@ export interface AgCartesianAxisLabelOptions extends AgBaseAxisLabelOptions {
 }
 
 export interface AgCartesianChartOptions extends AgBaseChartOptions {
-    /** If specified overrides the default series type. */
-    type?:
-        | 'line'
-        | 'bar'
-        | 'column'
-        | 'area'
-        | 'scatter'
-        | 'histogram'
-        | 'heatmap'
-        | 'waterfall-bar'
-        | 'waterfall-column'
-        | 'range-bar'
-        | 'range-column';
     /** Axis configurations. */
     axes?: AgCartesianAxisOptions[];
     /** Series configurations. */

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchyOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchyOptions.ts
@@ -6,8 +6,6 @@ import type { AgTreemapSeriesOptions } from './treemapOptions';
 export type AgHierarchySeriesOptions = AgTreemapSeriesOptions;
 
 export interface AgHierarchyChartOptions extends AgBaseChartOptions {
-    /** If specified overrides the default series type. */
-    type?: 'treemap';
     data?: any;
     /** Series configurations. */
     series?: AgHierarchySeriesOptions[];

--- a/packages/ag-charts-community/src/chart/series/polar/polarOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarOptions.ts
@@ -20,8 +20,6 @@ export type AgPolarSeriesOptions =
 export type AgPolarAxisOptions = AgAngleCategoryAxisOptions | AgRadiusNumberAxisOptions;
 
 export interface AgPolarChartOptions extends AgBaseChartOptions {
-    /** If specified overrides the default series type. */
-    type?: 'pie' | 'radar-line' | 'radar-area' | 'radial-column' | 'nightingale';
     /** Series configurations. */
     series?: AgPolarSeriesOptions[];
     /** Configuration for the chart legend. */

--- a/packages/ag-charts-community/src/chart/test/examples-axes.ts
+++ b/packages/ag-charts-community/src/chart/test/examples-axes.ts
@@ -10,7 +10,6 @@ import * as data from './data-axes';
 import * as examples from './examples';
 
 export const CATEGORY_AXIS_BASIC_EXAMPLE: AgChartOptions = {
-    type: 'column',
     data: data.DATA_COUNTRY_DIETARY_STATS,
     axes: [
         { type: 'category', position: 'bottom' },
@@ -45,7 +44,6 @@ export const CATEGORY_AXIS_BASIC_EXAMPLE: AgChartOptions = {
 };
 
 export const CATEGORY_AXIS_UNIFORM_BASIC_EXAMPLE: AgChartOptions = {
-    type: 'column',
     data: data.DATA_YOUTUBE_VIDEOS_STATS_BY_DAY_OF_YEAR,
     axes: [
         { type: 'category', position: 'bottom' },
@@ -108,7 +106,6 @@ export const TIME_AXIS_MIN_MAX_NUMBER_EXAMPLE: AgCartesianChartOptions = {
 };
 
 export const NUMBER_AXIS_UNIFORM_BASIC_EXAMPLE: AgChartOptions = {
-    type: 'line',
     data: data.DATA_YOUTUBE_VIDEOS_STATS_BY_DAY_OF_YEAR,
     axes: [
         { type: 'number', position: 'bottom' },

--- a/rollup.base.cjs
+++ b/rollup.base.cjs
@@ -5,6 +5,7 @@ module.exports = function buildConfig(name, { output, ...config }, { umd = {} } 
 
     const result = {
         ...config,
+        cache: false,
         output: [
             ...output.map(({ entryFileNames, chunkFileNames, format, ...opts }) => ({
                 ...opts,
@@ -21,6 +22,7 @@ module.exports = function buildConfig(name, { output, ...config }, { umd = {} } 
     if (format === 'cjs') {
         result.output.push({
             ...opts,
+            cache: false,
             name,
             entryFileNames: entryFileNames.replace('cjs', 'umd'),
             chunkFileNames: chunkFileNames.replace('cjs', 'umd'),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9212

Remove the redundant `type` option.