### PR TITLE
AG-8838 - Loosen nx dev tsc compile strictness.

### DIFF
--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -23,6 +23,9 @@
         "generateExportsField": true
       },
       "configurations": {
+        "watch": {
+          "tsConfig": "packages/ag-charts-community/tsconfig.watch.json"
+        },
         "production": {
           "format": ["cjs", "esm"]
         }

--- a/packages/ag-charts-community/tsconfig.watch.json
+++ b/packages/ag-charts-community/tsconfig.watch.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "strict": false,
+        "noUnusedParameters": false,
+        "noUnusedLocals": false
+    }
+}

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -20,6 +20,9 @@
         "generateExportsField": true
       },
       "configurations": {
+        "watch": {
+          "tsConfig": "packages/ag-charts-enterprise/tsconfig.watch.json"
+        },
         "production": {
           "format": ["cjs", "esm"]
         }

--- a/packages/ag-charts-enterprise/tsconfig.watch.json
+++ b/packages/ag-charts-enterprise/tsconfig.watch.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "strict": false,
+        "noUnusedParameters": false,
+        "noUnusedLocals": false
+    }
+}

--- a/packages/ag-charts-website/project.json
+++ b/packages/ag-charts-website/project.json
@@ -20,7 +20,10 @@
         "port": 4600,
         "host": true
       },
-      "dependsOn": ["^build", "^interface-metadata", "^interface-docs"]
+      "dependsOn": ["^build", "^interface-metadata", "^interface-docs"],
+      "configurations": {
+        "watch": {}
+      }
     },
     "preview": {
       "dependsOn": [

--- a/packages/all/project.json
+++ b/packages/all/project.json
@@ -32,10 +32,10 @@
         "parallel": true,
         "commands": [
           {
-            "command": "while true ; do nx watch -d -p ag-charts-community,ag-charts-enterprise -- nx run ag-charts-enterprise:build ; done"
+            "command": "while true ; do nx watch -d -p ag-charts-community,ag-charts-enterprise -- nx run ag-charts-enterprise:build --configuration watch ; done"
           },
           {
-            "command": "nx run ag-charts-website:dev"
+            "command": "nx run ag-charts-website:dev --configuration watch"
           }
         ]
       }

--- a/rollup.base.cjs
+++ b/rollup.base.cjs
@@ -22,7 +22,6 @@ module.exports = function buildConfig(name, { output, ...config }, { umd = {} } 
     if (format === 'cjs') {
         result.output.push({
             ...opts,
-            cache: false,
             name,
             entryFileNames: entryFileNames.replace('cjs', 'umd'),
             chunkFileNames: chunkFileNames.replace('cjs', 'umd'),


### PR DESCRIPTION
Reduced `nx dev` Typescript strictness to allow tinkering without needing to meet 'production grade' requirements (i.e. no unused variables or imports).

This doesn't affect `nx build`, `nx lint` or `nx test`, so it should still be easy to identify build failures locally still.