### PR TITLE
AG-8489 Change pie animation method and clear on complex animations

### DIFF
--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1932,6 +1932,18 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
                 sector.startAngle = datum.startAngle;
                 sector.endAngle = datum.endAngle;
             });
+
+        this.calloutLabelSelection.each((label, _, index) => {
+            label.visible = this.seriesItemEnabled[index];
+        });
+
+        this.sectorLabelSelection.each((label, _, index) => {
+            label.visible = this.seriesItemEnabled[index];
+        });
+
+        this.innerLabelsSelection.each((label, _, index) => {
+            label.visible = this.seriesItemEnabled[index];
+        });
     }
 
     getDatumId(datum: PieNodeDatum) {

--- a/packages/ag-charts-website/src/content/docs/charts-animation/_examples/pie/main.ts
+++ b/packages/ag-charts-website/src/content/docs/charts-animation/_examples/pie/main.ts
@@ -25,6 +25,7 @@ const options: AgChartOptions = {
       sectorLabel: {
         color: "white",
         fontWeight: "bold",
+        formatter: ({ sectorLabelValue }) => sectorLabelValue ? `${Math.round(parseFloat(sectorLabelValue) * 100) / 100}` : '',
       },
     },
   ],


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8489
https://ag-grid.atlassian.net/browse/AG-9236

- Removed pie sectors are taken from the end and others are replaced by the updated sectors
- If an animation includes added and removed sectors, it fades out the whole pie and redraws the initial animation


https://github.com/ag-grid/ag-charts/assets/3817697/13bf86e2-9c09-41e2-8c94-9c4a60457c11

