### PR TITLE
AG-9234 - Add devFiles wildcard support.

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,7 +24,7 @@
       "tsDeclarations",
       "sharedGlobals"
     ],
-    "sharedGlobals": ["{workspaceRoot}/rollup.*.js", "{workspaceRoot}/tsconfig.*.json"]
+    "sharedGlobals": ["{workspaceRoot}/rollup.*.cjs", "{workspaceRoot}/tsconfig.*.json"]
   },
   "targetDefaults": {
     "build": {

--- a/packages/ag-charts-react/project.json
+++ b/packages/ag-charts-react/project.json
@@ -28,6 +28,7 @@
             "output": "."
           }
         ],
+        "format": ["cjs", "esm"],
         "updateBuildableProjectDepsInPackageJson": true
       }
     },

--- a/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
@@ -93,11 +93,11 @@
                 defaultExtension: 'js',
             },
             'ag-charts-community': {
-                main: './dist/ag-charts-community.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
             'ag-charts-enterprise': {
-                main: './dist/ag-charts-enterprise.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
             rxjs: {

--- a/packages/ag-charts-website/public/example-runner/charts-react-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-react-boilerplate/systemjs.config.dev.js
@@ -43,11 +43,11 @@
                 defaultExtension: 'js',
             },
             'ag-charts-community': {
-                main: './dist/ag-charts-community.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
             'ag-charts-enterprise': {
-                main: './dist/ag-charts-enterprise.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
         },

--- a/packages/ag-charts-website/public/example-runner/charts-react-ts-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-react-ts-boilerplate/systemjs.config.dev.js
@@ -56,11 +56,11 @@
                 defaultExtension: 'js',
             },
             'ag-charts-community': {
-                main: './dist/ag-charts-community.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
             'ag-charts-enterprise': {
-                main: './dist/ag-charts-enterprise.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
         },

--- a/packages/ag-charts-website/public/example-runner/charts-typescript-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-typescript-boilerplate/systemjs.config.dev.js
@@ -43,11 +43,11 @@
                 defaultExtension: 'ts',
             },
             'ag-charts-community': {
-                main: './dist/ag-charts-community.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
             'ag-charts-enterprise': {
-                main: './dist/ag-charts-enterprise.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
         },

--- a/packages/ag-charts-website/public/example-runner/charts-vue-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-vue-boilerplate/systemjs.config.dev.js
@@ -41,11 +41,11 @@
                 defaultExtension: 'js',
             },
             'ag-charts-community': {
-                main: './dist/ag-charts-community.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
             'ag-charts-enterprise': {
-                main: './dist/ag-charts-enterprise.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
         },

--- a/packages/ag-charts-website/public/example-runner/charts-vue3-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-vue3-boilerplate/systemjs.config.dev.js
@@ -41,11 +41,11 @@
                 defaultExtension: 'js',
             },
             'ag-charts-community': {
-                main: './dist/ag-charts-community.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
             'ag-charts-enterprise': {
-                main: './dist/ag-charts-enterprise.cjs.js',
+                main: './dist/main.cjs.js',
                 defaultExtension: 'js',
             },
         },

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/SystemJs.jsx
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/SystemJs.jsx
@@ -44,7 +44,7 @@ const localConfiguration = {
         '@ag-grid-community/csv-export': `${localPrefix}/@ag-grid-community/csv-export/dist/csv-export.cjs.js`,
         '@ag-grid-community/infinite-row-model': `${localPrefix}/@ag-grid-community/infinite-row-model/dist/infinite-row-model.cjs.js`,
         /* END OF GRID COMMUNITY MODULES PATHS DEV - DO NOT DELETE */
-        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/ag-charts-community.cjs.js`,
+        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/main.cjs.js`,
     },
     gridEnterprisePaths: {
         /* START OF GRID ENTERPRISE MODULES PATHS DEV - DO NOT DELETE */
@@ -71,8 +71,8 @@ const localConfiguration = {
         '@ag-grid-enterprise/status-bar': `${localPrefix}/@ag-grid-enterprise/status-bar/dist/status-bar.cjs.js`,
         '@ag-grid-enterprise/viewport-row-model': `${localPrefix}/@ag-grid-enterprise/viewport-row-model/dist/viewport-row-model.cjs.js`,
         /* END OF GRID ENTERPRISE MODULES PATHS DEV - DO NOT DELETE */
-        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/ag-charts-community.cjs.js`,
-        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/ag-charts-enterprise.cjs.js`,
+        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/main.cjs.js`,
+        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/main.cjs.js`,
     },
     chartMap: {
         'ag-charts-react': `${localPrefix}/ag-charts-react`,
@@ -81,8 +81,8 @@ const localConfiguration = {
         'ag-charts-vue3': `${localPrefix}/ag-charts-vue3`,
     },
     chartPaths: {
-        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/ag-charts-community.cjs.js`,
-        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/ag-charts-enterprise.cjs.js`,
+        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/main.cjs.js`,
+        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/main.cjs.js`,
     },
 };
 
@@ -111,7 +111,7 @@ const buildAndArchivesConfiguration = {
         '@ag-grid-community/csv-export': `${localPrefix}/@ag-grid-community/csv-export/dist/csv-export.cjs.js`,
         '@ag-grid-community/infinite-row-model': `${localPrefix}/@ag-grid-community/infinite-row-model/dist/infinite-row-model.cjs.js`,
         /* END OF GRID COMMUNITY MODULES PATHS DEV - DO NOT DELETE */
-        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/ag-charts-community.cjs.js`,
+        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/main.cjs.js`,
     },
     gridEnterprisePaths: {
         /* START OF GRID ENTERPRISE MODULES PATHS DEV - DO NOT DELETE */
@@ -138,8 +138,8 @@ const buildAndArchivesConfiguration = {
         '@ag-grid-enterprise/status-bar': `${localPrefix}/@ag-grid-enterprise/status-bar/dist/status-bar.cjs.js`,
         '@ag-grid-enterprise/viewport-row-model': `${localPrefix}/@ag-grid-enterprise/viewport-row-model/dist/viewport-row-model.cjs.js`,
         /* END OF GRID ENTERPRISE MODULES PATHS DEV - DO NOT DELETE */
-        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/ag-charts-community.cjs.js`,
-        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/ag-charts-enterprise.cjs.js`,
+        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/main.cjs.js`,
+        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/main.cjs.js`,
     },
     chartMap: {
         'ag-charts-react': `${localPrefix}/ag-charts-react`,
@@ -148,8 +148,8 @@ const buildAndArchivesConfiguration = {
         'ag-charts-vue3': `${localPrefix}/ag-charts-vue3`,
     },
     chartPaths: {
-        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/ag-charts-community.cjs.js`,
-        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/ag-charts-enterprise.cjs.js`,
+        'ag-charts-community': `${localPrefix}/ag-charts-community/dist/main.cjs.js`,
+        'ag-charts-enterprise': `${localPrefix}/ag-charts-enterprise/dist/main.cjs.js`,
     },
 };
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9234

Adds `DEV_FILE_PATH_MAP` support for wildcards, which opens the door to chunked bundles for `ag-charts-community` and `ag-charts-enterprise` in the future if we decide to make that change.