### PR TITLE
Enable madge lint target.

### DIFF
--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -51,7 +51,7 @@
         "output": "dist/packages/ag-charts-community/doc-interfaces.AUTO.json"
       }
     },
-    "lint": {
+    "lint-eslint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
@@ -62,6 +62,19 @@
         "fix": {
           "fix": true
         }
+      }
+    },
+    "lint-circular": {
+      "executor": "nx:run-script",
+      "options": {
+          "script": "lint:circular"
+      }
+    },
+    "lint": {
+      "executor": "nx:noop",
+      "dependsOn": ["lint-eslint", "lint-circular"],
+      "configurations": {
+        "fix": {}
       }
     },
     "test": {

--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -67,7 +67,7 @@
     "lint-circular": {
       "executor": "nx:run-script",
       "options": {
-          "script": "lint:circular"
+        "script": "lint:circular"
       }
     },
     "lint": {

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -28,7 +28,7 @@
         }
       }
     },
-    "lint": {
+    "lint-eslint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
@@ -39,6 +39,19 @@
         "fix": {
           "fix": true
         }
+      }
+    },
+    "lint-circular": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "lint:circular"
+      }
+    },
+    "lint": {
+      "executor": "nx:noop",
+      "dependsOn": ["lint-eslint", "lint-circular"],
+      "configurations": {
+        "fix": {}
       }
     },
     "test": {


### PR DESCRIPTION
Follow up to #153 to ensure we don't accidentally introduce further circular deps.