### PR TITLE
AG-9206 - Options reference round 2 - Show array discriminator type value

### DIFF
--- a/packages/ag-charts-website/src/features/api-documentation/components/ApiDocumentation.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/ApiDocumentation.module.scss
@@ -158,3 +158,7 @@
         transition: fill $default-transition-timing;
     }
 }
+
+.noWrap {
+    white-space: nowrap;
+}

--- a/packages/ag-charts-website/src/features/api-documentation/components/ApiDocumentation.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/ApiDocumentation.module.scss
@@ -104,6 +104,10 @@
     line-break: anywhere;
 }
 
+.unionDiscriminator {
+    color: var(--code-text-color);
+}
+
 .metaList {
     display: flex;
     flex-wrap: wrap;

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -52,7 +52,7 @@ function HeadingPath({ path }: { path: string[] }) {
 
 function NameHeading({ id, name, path }: { id: string; name: string; path: string[] }) {
     const displayNameSplit = splitName(name);
-    const pathSeparator = path.length > 0 ? '.' : '';
+    const pathSeparator = name && path.length > 0 ? '.' : '';
 
     return (
         <h6 id={id} className={classnames(styles.name, 'side-menu-exclude')}>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -13,7 +13,6 @@ import type { JsonArray, JsonModel, JsonModelProperty, JsonObjectProperty, JsonU
 import { getPropertyType } from '../utils/getPropertyType';
 import type { Framework } from '@ag-grid-types';
 import { createUnionNestedObjectPathItemRegex, getUnionPathInfo } from '../utils/modelPath';
-import { Fragment } from 'react';
 
 interface Props {
     selection: JsObjectSelection;
@@ -21,8 +20,7 @@ interface Props {
     parentName?: string;
 }
 
-function HeadingPath({ name, path }: { name: string; path: string[] }) {
-    const lastDot = name ? '.' : '';
+function HeadingPath({ path }: { path: string[] }) {
     const regex = createUnionNestedObjectPathItemRegex();
     return (
         path.length > 0 && (
@@ -34,7 +32,7 @@ function HeadingPath({ name, path }: { name: string; path: string[] }) {
                     const separator = index !== 0 && !arrayDiscriminatorMatches ? '.' : '';
 
                     return (
-                        <Fragment key={`${pathItem}-${index}`}>
+                        <span className={styles.noWrap} key={`${pathItem}-${index}`}>
                             {separator}
                             {!arrayDiscriminatorMatches && <>{pathItem}</>}
                             {arrayDiscriminatorMatches && (
@@ -44,10 +42,9 @@ function HeadingPath({ name, path }: { name: string; path: string[] }) {
                                     {postValue}
                                 </>
                             )}
-                        </Fragment>
+                        </span>
                     );
                 })}
-                {lastDot}
             </span>
         )
     );
@@ -55,11 +52,15 @@ function HeadingPath({ name, path }: { name: string; path: string[] }) {
 
 function NameHeading({ id, name, path }: { id: string; name: string; path: string[] }) {
     const displayNameSplit = splitName(name);
+    const pathSeparator = path.length > 0 ? '.' : '';
 
     return (
         <h6 id={id} className={classnames(styles.name, 'side-menu-exclude')}>
-            <HeadingPath name={name} path={path} />
-            <span dangerouslySetInnerHTML={{ __html: displayNameSplit }}></span>
+            <HeadingPath path={path} />
+            <span>
+                {pathSeparator}
+                <span dangerouslySetInnerHTML={{ __html: displayNameSplit }}></span>
+            </span>
             <a href={`#${id}`} className="docs-header-icon">
                 <Icon name="link" />
             </a>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -50,7 +50,7 @@ function HeadingPath({ path }: { path: string[] }) {
     );
 }
 
-function NameHeading({ id, name, path }: { id: string; name: string; path: string[] }) {
+function NameHeading({ id, name, path }: { id: string; name?: string; path: string[] }) {
     const displayNameSplit = splitName(name);
     const pathSeparator = name && path.length > 0 ? '.' : '';
 
@@ -59,7 +59,7 @@ function NameHeading({ id, name, path }: { id: string; name: string; path: strin
             <HeadingPath path={path} />
             <span>
                 {pathSeparator}
-                <span dangerouslySetInnerHTML={{ __html: displayNameSplit }}></span>
+                {displayNameSplit && <span dangerouslySetInnerHTML={{ __html: displayNameSplit }}></span>}
             </span>
             <a href={`#${id}`} className="docs-header-icon">
                 <Icon name="link" />
@@ -151,7 +151,7 @@ function NestedObjectProperties({
     properties,
     framework,
 }: {
-    parentName: string;
+    parentName?: string;
     parentPath: string[];
     properties: JsonModel['properties'];
     framework: Framework;
@@ -186,7 +186,7 @@ function NestedObjectPropertyView({
     framework,
 }: {
     id: string;
-    name: string;
+    name?: string;
     path: string[];
     model: JsonModelProperty;
     framework: Framework;
@@ -431,7 +431,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
             return (
                 <NestedObjectPropertyView
                     id={id}
-                    name={name}
+                    // NOTE: No `name`, as it's a union nested object
                     path={nestedObjectPath}
                     model={nestedObjectModel}
                     framework={framework}

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -93,7 +93,6 @@ function PrimitivePropertyView({
     framework: Framework;
 }) {
     const formattedDocumentation = formatPropertyDocumentation(model).join('\n');
-    // TODO: cater for model.type === 'primitive' case
     const propertyType = getPropertyType(
         (model as any).type === 'primitive' ? (model as any).tsType : model.desc.tsType
     );

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
@@ -112,3 +112,7 @@ $indent: 24px;
     white-space: normal;
     cursor: text;
 }
+
+.unionDiscriminator {
+    color: var(--code-text-color);
+}

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -205,6 +205,22 @@ function Union({
     );
 }
 
+function DiscriminatorType({ discriminatorType }: { discriminatorType: string }) {
+    const quotationMatches = /(["'])(.*)(["'])/.exec(discriminatorType);
+    if (!quotationMatches) {
+        return <>{discriminatorType}</>;
+    }
+
+    const [_, leftQuote, value, rightQuote] = quotationMatches;
+    return (
+        <>
+            {leftQuote}
+            <span className={styles.unionDiscriminator}>{value}</span>
+            {rightQuote}
+        </>
+    );
+}
+
 function UnionNestedObject({
     desc,
     index,
@@ -252,16 +268,19 @@ function UnionNestedObject({
                         {' { '}
                     </span>
                     {!isExpanded && (
-                        <PropertyDeclaration
-                            propName={discriminatorProp}
-                            tsType={discriminatorType}
-                            propDesc={discriminator}
-                            isExpanded={isExpanded}
-                            expandable={true}
-                            toggleExpand={toggleExpand}
-                            toggleSelection={toggleSelection}
-                            style="unionTypeProperty"
-                        />
+                        <>
+                            <PropertyDeclaration
+                                propName={discriminatorProp}
+                                tsType={discriminatorType}
+                                propDesc={discriminator}
+                                isExpanded={isExpanded}
+                                expandable={true}
+                                toggleExpand={toggleExpand}
+                                toggleSelection={toggleSelection}
+                                style="unionTypeProperty"
+                            />{' '}
+                            = <DiscriminatorType discriminatorType={discriminatorType} />
+                        </>
                     )}
                     {!isExpanded && <span className={classnames('token', 'punctuation')}>{closeWith}</span>}
                     {isExpanded ? (

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -288,7 +288,10 @@ function UnionNestedObject({
                             <ModelSnippet model={desc.model} config={config} path={unionPath}></ModelSnippet>
                         </div>
                     ) : (
-                        <span className={classnames('token', 'operator')}> ... </span>
+                        <span onClick={toggleExpand} className={classnames('token', 'operator')}>
+                            {' '}
+                            ...{' '}
+                        </span>
                     )}
                     <span className={classnames('token', 'punctuation')}>{' }'}</span>
                     {!HIDE_TYPES && (

--- a/packages/ag-charts-website/src/features/api-documentation/utils/documentationHelpers.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/documentationHelpers.ts
@@ -457,7 +457,7 @@ export function getLongestNameLength(nameWithBreaks) {
 /**
  * Split display name on capital letter, add <wbr> to improve text splitting across lines
  */
-export function splitName(name: string) {
+export function splitName(name?: string) {
     if (!name) {
         return name;
     }

--- a/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.test.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.test.ts
@@ -1,0 +1,22 @@
+import { createUnionNestedObjectPathItemRegex } from './modelPath';
+
+describe('createUnionNestedObjectPathItemRegex', () => {
+    it('returns null for simple path items', () => {
+        const regex = createUnionNestedObjectPathItemRegex();
+
+        expect(regex.exec('something')).toBeNull();
+    });
+
+    it('returns value breakdown for discriminator paths', () => {
+        const regex = createUnionNestedObjectPathItemRegex();
+
+        expect(regex.exec("[type = 'number']")).toMatchInlineSnapshot(`
+          [
+            "[type = 'number']",
+            "[type = '",
+            "number",
+            "']",
+          ]
+        `);
+    });
+});

--- a/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
@@ -1,0 +1,57 @@
+import type { JsonModel } from '@features/api-documentation/utils/model';
+
+/**
+ * Property key used to differentiate between different union items
+ */
+export const UNION_DISCRIMINATOR_PROP = 'type';
+
+/*
+ * Get regex to extract the path item regex if it has a discriminator value
+ *
+ * Format specified in `getUnionNestedObjectPathItem`.
+ */
+export function createUnionNestedObjectPathItemRegex(
+    { discriminatorProp = UNION_DISCRIMINATOR_PROP }: { discriminatorProp?: string } = {
+        discriminatorProp: UNION_DISCRIMINATOR_PROP,
+    }
+) {
+    return new RegExp(`^(\\[${discriminatorProp} = ')(.*)('\\])$`);
+}
+
+function getUnionNestedObjectPathItem({
+    discriminatorProp,
+    value,
+    fallbackValue,
+}: {
+    discriminatorProp: string;
+    value: string | null;
+    fallbackValue?: string;
+}) {
+    return value ? `[${discriminatorProp} = ${value}]` : `[${fallbackValue === undefined ? '' : fallbackValue}]`;
+}
+
+export function getUnionPathInfo({
+    discriminatorProp = UNION_DISCRIMINATOR_PROP,
+    model,
+    index,
+}: {
+    discriminatorProp?: string;
+    model: JsonModel;
+    index: number;
+}) {
+    const discriminator = model.properties[discriminatorProp];
+    const discriminatorType =
+        discriminator && discriminator.desc.type === 'primitive' ? discriminator.desc.tsType : null;
+    const pathItem = getUnionNestedObjectPathItem({
+        discriminatorProp,
+        value: discriminatorType,
+        fallbackValue: index.toString(),
+    });
+
+    return {
+        pathItem,
+        discriminatorType,
+        discriminatorProp,
+        discriminator,
+    };
+}


### PR DESCRIPTION
## Changes

* Options reference
  * Show array discriminator type in left hand nav
  * Show array discriminator type in right hand details

## TODO

* [x] Fix doubled up values in top level properties eg, `series[type = 'line'].series` 

## Screenshots

Before
<img width="1524" alt="Screenshot 2023-09-06 at 12 39 47 pm" src="https://github.com/ag-grid/ag-charts/assets/79451/bf4e25f8-a948-4cff-a489-9e187baaaf3f">

After


<img width="1302" alt="Screenshot 2023-09-06 at 12 52 54 pm" src="https://github.com/ag-grid/ag-charts/assets/79451/5d2e20c5-efad-4819-a994-7c7f4cad3eef">
