### PR TITLE
AG-9206 - Options reference round 3 - Add scroll to property

### DIFF
--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -13,20 +13,24 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
     config = {} as Config,
     framework,
 }) => {
-    const [selection, setSelection] = useState<JsObjectSelection>();
+    const model = buildModel(interfaceName, interfaceLookup, codeLookup);
+    const completeModelSelection = {
+        type: model.type,
+        path: [],
+        model,
+    };
+    const [selection, setSelection] = useState<JsObjectSelection>(completeModelSelection);
     const onSelection = useCallback(
         (data: JsObjectSelection) => {
             setSelection(data);
         },
         [selection]
     );
-    const model = buildModel(interfaceName, interfaceLookup, codeLookup);
 
     return (
         <div className={styles.container}>
             <JsObjectView breadcrumbs={breadcrumbs} config={config} onSelection={onSelection} model={model} />
-
-            {selection ? <JsObjectDetails selection={selection} framework={framework} /> : 'TODO: No selection'}
+            <JsObjectDetails selection={selection} framework={framework} />
         </div>
     );
 };

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -3,6 +3,7 @@ import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
 import type { Config, JsObjectPropertiesViewProps, JsObjectSelection } from '../types';
 import { JsObjectDetails } from './JsObjectDetails';
+import { buildModel } from '../utils/model';
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
     interfaceName,
@@ -19,16 +20,11 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
         },
         [selection]
     );
+    const model = buildModel(interfaceName, interfaceLookup, codeLookup);
+
     return (
         <div className={styles.container}>
-            <JsObjectView
-                interfaceName={interfaceName}
-                interfaceLookup={interfaceLookup}
-                codeLookup={codeLookup}
-                breadcrumbs={breadcrumbs}
-                config={config}
-                onSelection={onSelection}
-            />
+            <JsObjectView breadcrumbs={breadcrumbs} config={config} onSelection={onSelection} model={model} />
 
             {selection ? <JsObjectDetails selection={selection} framework={framework} /> : 'TODO: No selection'}
         </div>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type FunctionComponent } from 'react';
+import { useCallback, type FunctionComponent, useState } from 'react';
 import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
 import type { Config, JsObjectPropertiesViewProps, JsObjectSelection } from '../types';
@@ -6,6 +6,7 @@ import { JsObjectDetails } from './JsObjectDetails';
 import { buildModel } from '../utils/model';
 import { getSelectionReferenceId } from '../utils/getObjectReferenceId';
 import { smoothScrollIntoView } from '@utils/smoothScrollIntoView';
+import { getTopLevelSelection, getTopSelection } from '../utils/modelPath';
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
     interfaceName,
@@ -16,21 +17,48 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
     framework,
 }) => {
     const model = buildModel(interfaceName, interfaceLookup, codeLookup);
-    const completeModelSelection: JsObjectSelection = {
-        type: model.type,
-        path: [],
-        model,
-        hideChildren: true,
-    };
-    const onSelection = useCallback((selection: JsObjectSelection) => {
-        const id = getSelectionReferenceId(selection);
-        smoothScrollIntoView(`#${id}`);
-    }, []);
+    const [selection, setSelection] = useState<JsObjectSelection>(getTopSelection({ model, hideChildren: true }));
+    const handleSelection = useCallback(
+        (newSelection: JsObjectSelection) => {
+            const { path } = newSelection;
+            const isTopLevelSelection = path.length === 0;
+
+            if (isTopLevelSelection) {
+                setSelection(newSelection);
+                smoothScrollIntoView('#top');
+            } else {
+                const [currentTopLevelPathItem] = selection.path;
+                const [newTopLevelPathItem] = newSelection.path;
+                const isCurrentTopLevelSelection = currentTopLevelPathItem === newTopLevelPathItem;
+                if (!isCurrentTopLevelSelection) {
+                    const newTopLevelSelection = getTopLevelSelection({ pathItem: newTopLevelPathItem, model });
+                    if (newTopLevelSelection) {
+                        setSelection(newTopLevelSelection);
+                    } else {
+                        // eslint-disable-next-line no-console
+                        console.warn('No top level selection found:', {
+                            newTopLevelPathItem,
+                            newSelection,
+                        });
+                    }
+                }
+
+                const id = getSelectionReferenceId(newSelection);
+                // Scroll to top to reset scroll position
+                smoothScrollIntoView('#top');
+                // Wait for one render cycle before scrolling to position
+                setTimeout(() => {
+                    smoothScrollIntoView(`#${id}`);
+                }, 0);
+            }
+        },
+        [selection]
+    );
 
     return (
         <div className={styles.container}>
-            <JsObjectView breadcrumbs={breadcrumbs} config={config} onSelection={onSelection} model={model} />
-            <JsObjectDetails selection={completeModelSelection} framework={framework} />
+            <JsObjectView breadcrumbs={breadcrumbs} config={config} handleSelection={handleSelection} model={model} />
+            <JsObjectDetails selection={selection} framework={framework} />
         </div>
     );
 };

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -1,12 +1,13 @@
 import { useCallback, type FunctionComponent, useState } from 'react';
 import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
-import type { Config, JsObjectPropertiesViewProps, JsObjectSelection } from '../types';
+import type { Config, JsObjectPropertiesViewProps, JsObjectSelection, JsObjectSelectionProperty } from '../types';
 import { JsObjectDetails } from './JsObjectDetails';
 import { buildModel } from '../utils/model';
 import { getSelectionReferenceId } from '../utils/getObjectReferenceId';
 import { smoothScrollIntoView } from '@utils/smoothScrollIntoView';
 import { getTopLevelSelection, getTopSelection } from '../utils/modelPath';
+import { TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN } from '../constants';
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
     interfaceName,
@@ -24,11 +25,13 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
             const isTopLevelSelection = path.length === 0;
 
             if (isTopLevelSelection) {
-                setSelection(newSelection);
+                const { propName } = newSelection as JsObjectSelectionProperty;
+                const onlyShowToDepth = TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN.includes(propName) ? 1 : undefined;
+                setSelection({ ...newSelection, onlyShowToDepth });
                 smoothScrollIntoView('#top');
             } else {
-                const [currentTopLevelPathItem] = selection.path;
                 const [newTopLevelPathItem] = newSelection.path;
+                const [currentTopLevelPathItem] = selection.path;
                 const isCurrentTopLevelSelection = currentTopLevelPathItem === newTopLevelPathItem;
                 if (!isCurrentTopLevelSelection) {
                     const newTopLevelSelection = getTopLevelSelection({ pathItem: newTopLevelPathItem, model });

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -1,13 +1,10 @@
-import { useCallback, type FunctionComponent, useState } from 'react';
+import type { FunctionComponent } from 'react';
 import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
-import type { Config, JsObjectPropertiesViewProps, JsObjectSelection, JsObjectSelectionProperty } from '../types';
+import type { Config, JsObjectPropertiesViewProps } from '../types';
 import { JsObjectDetails } from './JsObjectDetails';
 import { buildModel } from '../utils/model';
-import { getSelectionReferenceId } from '../utils/getObjectReferenceId';
-import { smoothScrollIntoView } from '@utils/smoothScrollIntoView';
-import { getTopLevelSelection, getTopSelection } from '../utils/modelPath';
-import { TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN } from '../constants';
+import { useJsObjectSelection } from '../utils/useJsObjectSelection';
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
     interfaceName,
@@ -18,45 +15,7 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
     framework,
 }) => {
     const model = buildModel(interfaceName, interfaceLookup, codeLookup);
-    const [selection, setSelection] = useState<JsObjectSelection>(getTopSelection({ model, hideChildren: true }));
-    const handleSelection = useCallback(
-        (newSelection: JsObjectSelection) => {
-            const { path } = newSelection;
-            const isTopLevelSelection = path.length === 0;
-
-            if (isTopLevelSelection) {
-                const { propName } = newSelection as JsObjectSelectionProperty;
-                const onlyShowToDepth = TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN.includes(propName) ? 1 : undefined;
-                setSelection({ ...newSelection, onlyShowToDepth });
-                smoothScrollIntoView('#top');
-            } else {
-                const [newTopLevelPathItem] = newSelection.path;
-                const [currentTopLevelPathItem] = selection.path;
-                const isCurrentTopLevelSelection = currentTopLevelPathItem === newTopLevelPathItem;
-                if (!isCurrentTopLevelSelection) {
-                    const newTopLevelSelection = getTopLevelSelection({ pathItem: newTopLevelPathItem, model });
-                    if (newTopLevelSelection) {
-                        setSelection(newTopLevelSelection);
-                    } else {
-                        // eslint-disable-next-line no-console
-                        console.warn('No top level selection found:', {
-                            newTopLevelPathItem,
-                            newSelection,
-                        });
-                    }
-                }
-
-                const id = getSelectionReferenceId(newSelection);
-                // Scroll to top to reset scroll position
-                smoothScrollIntoView('#top');
-                // Wait for one render cycle before scrolling to position
-                setTimeout(() => {
-                    smoothScrollIntoView(`#${id}`);
-                }, 0);
-            }
-        },
-        [selection]
-    );
+    const { selection, handleSelection } = useJsObjectSelection({ model });
 
     return (
         <div className={styles.container}>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -4,6 +4,8 @@ import styles from './JsObjectProperties.module.scss';
 import type { Config, JsObjectPropertiesViewProps, JsObjectSelection } from '../types';
 import { JsObjectDetails } from './JsObjectDetails';
 import { buildModel } from '../utils/model';
+import { getSelectionReferenceId } from '../utils/getObjectReferenceId';
+import { smoothScrollIntoView } from '@utils/smoothScrollIntoView';
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
     interfaceName,
@@ -19,18 +21,15 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
         path: [],
         model,
     };
-    const [selection, setSelection] = useState<JsObjectSelection>(completeModelSelection);
-    const onSelection = useCallback(
-        (data: JsObjectSelection) => {
-            setSelection(data);
-        },
-        [selection]
-    );
+    const onSelection = useCallback((selection: JsObjectSelection) => {
+        const id = getSelectionReferenceId(selection);
+        smoothScrollIntoView(`#${id}`);
+    }, []);
 
     return (
         <div className={styles.container}>
             <JsObjectView breadcrumbs={breadcrumbs} config={config} onSelection={onSelection} model={model} />
-            <JsObjectDetails selection={selection} framework={framework} />
+            <JsObjectDetails selection={completeModelSelection} framework={framework} />
         </div>
     );
 };

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type FunctionComponent, useState } from 'react';
+import { useCallback, type FunctionComponent } from 'react';
 import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
 import type { Config, JsObjectPropertiesViewProps, JsObjectSelection } from '../types';
@@ -16,10 +16,11 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
     framework,
 }) => {
     const model = buildModel(interfaceName, interfaceLookup, codeLookup);
-    const completeModelSelection = {
+    const completeModelSelection: JsObjectSelection = {
         type: model.type,
         path: [],
         model,
+        hideChildren: true,
     };
     const onSelection = useCallback((selection: JsObjectSelection) => {
         const id = getSelectionReferenceId(selection);

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -392,7 +392,17 @@ function FunctionPropertyView({
 export function JsObjectPropertyView({ selection, framework, parentName }: Props) {
     const { type, path, model } = selection;
 
-    if (type === 'property') {
+    if (type === 'model') {
+        const { properties } = model;
+        return (
+            <NestedObjectProperties
+                parentName={parentName}
+                parentPath={path}
+                properties={properties}
+                framework={framework}
+            />
+        );
+    } else if (type === 'property') {
         const { propName } = selection as JsObjectSelectionProperty;
         const id = `reference-${path}-${propName}`;
         const propertyType = model.desc.type;

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -13,6 +13,7 @@ import type { JsonArray, JsonModel, JsonModelProperty, JsonObjectProperty, JsonU
 import { getPropertyType } from '../utils/getPropertyType';
 import type { Framework } from '@ag-grid-types';
 import { createUnionNestedObjectPathItemRegex, getUnionPathInfo } from '../utils/modelPath';
+import { getSelectionReferenceId } from '../utils/getObjectReferenceId';
 
 interface Props {
     selection: JsObjectSelection;
@@ -391,6 +392,7 @@ function FunctionPropertyView({
 
 export function JsObjectPropertyView({ selection, framework, parentName }: Props) {
     const { type, path, model } = selection;
+    const id = getSelectionReferenceId(selection);
 
     if (type === 'model') {
         const { properties } = model;
@@ -404,16 +406,36 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
         );
     } else if (type === 'property') {
         const { propName } = selection as JsObjectSelectionProperty;
-        const id = `reference-${path}-${propName}`;
         const propertyType = model.desc.type;
+        const propertyId = id!;
         if (propertyType === 'primitive') {
-            return <PrimitivePropertyView id={id} model={model} name={propName} framework={framework} path={path} />;
+            return (
+                <PrimitivePropertyView
+                    id={propertyId}
+                    model={model}
+                    name={propName}
+                    framework={framework}
+                    path={path}
+                />
+            );
         } else if (propertyType === 'nested-object') {
-            return <NestedObjectPropertyView id={id} name={propName} path={path} model={model} framework={framework} />;
+            return (
+                <NestedObjectPropertyView
+                    id={propertyId}
+                    name={propName}
+                    path={path}
+                    model={model}
+                    framework={framework}
+                />
+            );
         } else if (propertyType === 'array') {
-            return <ArrayPropertyView id={id} name={propName} path={path} model={model} framework={framework} />;
+            return (
+                <ArrayPropertyView id={propertyId} name={propName} path={path} model={model} framework={framework} />
+            );
         } else if (propertyType === 'function') {
-            return <FunctionPropertyView id={id} model={model} name={propName} framework={framework} path={path} />;
+            return (
+                <FunctionPropertyView id={propertyId} model={model} name={propName} framework={framework} path={path} />
+            );
         } else if (propertyType === 'union') {
             const elements = model.desc;
             return (
@@ -422,12 +444,20 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
         }
     } else if (type === 'unionNestedObject') {
         const { index } = selection as JsObjectSelectionUnionNestedObject;
-        const id = `reference-${path}-${index}`;
+        const unionNestedObjectId = id!;
         const propertyType = model.type;
         const name = parentName!;
 
         if (propertyType === 'primitive') {
-            return <PrimitivePropertyView id={id} model={model} name={name} framework={framework} path={path} />;
+            return (
+                <PrimitivePropertyView
+                    id={unionNestedObjectId}
+                    model={model}
+                    name={name}
+                    framework={framework}
+                    path={path}
+                />
+            );
         } else if (propertyType === 'nested-object') {
             const nestedObjectModel = {
                 desc: model,
@@ -440,7 +470,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
             const nestedObjectPath = path.concat(pathItem);
             return (
                 <NestedObjectPropertyView
-                    id={id}
+                    id={unionNestedObjectId}
                     // NOTE: No `name`, as it's a union nested object
                     path={nestedObjectPath}
                     model={nestedObjectModel}
@@ -448,7 +478,15 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                 />
             );
         } else if (propertyType === 'array') {
-            return <ArrayPropertyView id={id} name={name} path={path} model={model} framework={framework} />;
+            return (
+                <ArrayPropertyView
+                    id={unionNestedObjectId}
+                    name={name}
+                    path={path}
+                    model={model}
+                    framework={framework}
+                />
+            );
         }
     }
 

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -151,11 +151,13 @@ function NestedObjectProperties({
     parentPath,
     properties,
     framework,
+    hideChildren,
 }: {
     parentName?: string;
     parentPath: string[];
     properties: JsonModel['properties'];
     framework: Framework;
+    hideChildren?: boolean;
 }) {
     return (
         <>
@@ -165,6 +167,7 @@ function NestedObjectProperties({
                     propName,
                     path: parentPath,
                     model,
+                    hideChildren,
                 };
                 return (
                     <JsObjectPropertyView
@@ -185,12 +188,14 @@ function NestedObjectPropertyView({
     path,
     model,
     framework,
+    hideChildren,
 }: {
     id: string;
     name?: string;
     path: string[];
     model: JsonModelProperty;
     framework: Framework;
+    hideChildren?: boolean;
 }) {
     const formattedDocumentation = formatPropertyDocumentation(model).join('\n');
     const description = convertMarkdown(formattedDocumentation, framework);
@@ -216,12 +221,14 @@ function NestedObjectPropertyView({
                     <div className={styles.actions}></div>
                 </td>
             </tr>
-            <NestedObjectProperties
-                parentName={name}
-                properties={properties}
-                parentPath={nestedObjectPropertiesPath}
-                framework={framework}
-            />
+            {!hideChildren && (
+                <NestedObjectProperties
+                    parentName={name}
+                    properties={properties}
+                    parentPath={nestedObjectPropertiesPath}
+                    framework={framework}
+                />
+            )}
         </>
     );
 }
@@ -231,11 +238,13 @@ function UnionProperties({
     parentPath,
     elements,
     framework,
+    hideChildren,
 }: {
     parentName: string;
     parentPath: string[];
     elements: JsonUnionType;
     framework: Framework;
+    hideChildren?: boolean;
 }) {
     return elements.options.map((model, index) => {
         const selection: JsObjectSelectionUnionNestedObject = {
@@ -243,6 +252,7 @@ function UnionProperties({
             index,
             path: parentPath,
             model,
+            hideChildren,
         };
         return (
             <JsObjectPropertyView
@@ -314,12 +324,14 @@ function ArrayPropertyView({
     path,
     model,
     framework,
+    hideChildren,
 }: {
     id: string;
     name: string;
     path: string[];
     model: JsonModelProperty;
     framework: Framework;
+    hideChildren?: boolean;
 }) {
     const formattedDocumentation = formatPropertyDocumentation(model).join('\n');
     const description = convertMarkdown(formattedDocumentation, framework);
@@ -343,14 +355,16 @@ function ArrayPropertyView({
                     <div className={styles.actions}></div>
                 </td>
             </tr>
-            <NestedArrayProperties
-                parentId={id}
-                parentName={name}
-                parentPath={nestedArrayPropertiesPath}
-                parentModel={model}
-                elements={elements}
-                framework={framework}
-            />
+            {!hideChildren && (
+                <NestedArrayProperties
+                    parentId={id}
+                    parentName={name}
+                    parentPath={nestedArrayPropertiesPath}
+                    parentModel={model}
+                    elements={elements}
+                    framework={framework}
+                />
+            )}
         </>
     );
 }
@@ -391,7 +405,7 @@ function FunctionPropertyView({
 }
 
 export function JsObjectPropertyView({ selection, framework, parentName }: Props) {
-    const { type, path, model } = selection;
+    const { type, path, model, hideChildren } = selection;
     const id = getSelectionReferenceId(selection);
 
     if (type === 'model') {
@@ -402,6 +416,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                 parentPath={path}
                 properties={properties}
                 framework={framework}
+                hideChildren={hideChildren}
             />
         );
     } else if (type === 'property') {
@@ -426,11 +441,19 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     path={path}
                     model={model}
                     framework={framework}
+                    hideChildren={hideChildren}
                 />
             );
         } else if (propertyType === 'array') {
             return (
-                <ArrayPropertyView id={propertyId} name={propName} path={path} model={model} framework={framework} />
+                <ArrayPropertyView
+                    id={propertyId}
+                    name={propName}
+                    path={path}
+                    model={model}
+                    framework={framework}
+                    hideChildren={hideChildren}
+                />
             );
         } else if (propertyType === 'function') {
             return (
@@ -439,7 +462,13 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
         } else if (propertyType === 'union') {
             const elements = model.desc;
             return (
-                <UnionProperties parentName={propName} elements={elements} parentPath={path} framework={framework} />
+                <UnionProperties
+                    parentName={propName}
+                    elements={elements}
+                    parentPath={path}
+                    framework={framework}
+                    hideChildren={hideChildren}
+                />
             );
         }
     } else if (type === 'unionNestedObject') {
@@ -475,6 +504,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     path={nestedObjectPath}
                     model={nestedObjectModel}
                     framework={framework}
+                    hideChildren={hideChildren}
                 />
             );
         } else if (propertyType === 'array') {
@@ -485,6 +515,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     path={path}
                     model={model}
                     framework={framework}
+                    hideChildren={hideChildren}
                 />
             );
         }

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -56,7 +56,7 @@ function NameHeading({ id, name, path }: { id: string; name?: string; path: stri
     const pathSeparator = name && path.length > 0 ? '.' : '';
 
     return (
-        <h6 id={id} className={classnames(styles.name, 'side-menu-exclude')}>
+        <h6 className={classnames(styles.name, 'side-menu-exclude')}>
             <HeadingPath path={path} />
             <span>
                 {pathSeparator}
@@ -129,7 +129,7 @@ function PrimitivePropertyView({
     );
     const description = convertMarkdown(formattedDocumentation, framework);
     return (
-        <tr>
+        <tr id={id}>
             <td role="presentation" className={styles.leftColumn}>
                 <NameHeading id={id} name={name} path={path} />
                 <MetaList propertyType={propertyType} model={model} description={description} />
@@ -207,7 +207,7 @@ function NestedObjectPropertyView({
 
     return (
         <>
-            <tr>
+            <tr id={id}>
                 <td role="presentation" className={styles.leftColumn}>
                     <NameHeading id={id} name={name} path={path} />
                     <MetaList propertyType={propertyType} model={model} description={description} />
@@ -341,7 +341,7 @@ function ArrayPropertyView({
 
     return (
         <>
-            <tr>
+            <tr id={id}>
                 <td role="presentation" className={styles.leftColumn}>
                     <NameHeading id={id} name={name} path={path} />
                     <MetaList propertyType={propertyType} model={model} description={description} />
@@ -387,7 +387,7 @@ function FunctionPropertyView({
     const propertyType = getPropertyType(model.desc.tsType);
 
     return (
-        <tr>
+        <tr id={id}>
             <td role="presentation" className={styles.leftColumn}>
                 <NameHeading id={id} name={name} path={path} />
                 <MetaList propertyType={propertyType} model={model} description={description} />

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -151,13 +151,13 @@ function NestedObjectProperties({
     parentPath,
     properties,
     framework,
-    hideChildren,
+    onlyShowToDepth,
 }: {
     parentName?: string;
     parentPath: string[];
     properties: JsonModel['properties'];
     framework: Framework;
-    hideChildren?: boolean;
+    onlyShowToDepth?: number;
 }) {
     return (
         <>
@@ -167,7 +167,7 @@ function NestedObjectProperties({
                     propName,
                     path: parentPath,
                     model,
-                    hideChildren,
+                    onlyShowToDepth,
                 };
                 return (
                     <JsObjectPropertyView
@@ -188,14 +188,14 @@ function NestedObjectPropertyView({
     path,
     model,
     framework,
-    hideChildren,
+    onlyShowToDepth,
 }: {
     id: string;
     name?: string;
     path: string[];
     model: JsonModelProperty;
     framework: Framework;
-    hideChildren?: boolean;
+    onlyShowToDepth?: number;
 }) {
     const formattedDocumentation = formatPropertyDocumentation(model).join('\n');
     const description = convertMarkdown(formattedDocumentation, framework);
@@ -204,6 +204,7 @@ function NestedObjectPropertyView({
         model: { properties },
     } = model.desc as JsonObjectProperty;
     const nestedObjectPropertiesPath = name ? path.concat(name) : path;
+    const showChildren = onlyShowToDepth === undefined ? true : path.length < onlyShowToDepth;
 
     return (
         <>
@@ -221,12 +222,13 @@ function NestedObjectPropertyView({
                     <div className={styles.actions}></div>
                 </td>
             </tr>
-            {!hideChildren && (
+            {showChildren && (
                 <NestedObjectProperties
                     parentName={name}
                     properties={properties}
                     parentPath={nestedObjectPropertiesPath}
                     framework={framework}
+                    onlyShowToDepth={onlyShowToDepth}
                 />
             )}
         </>
@@ -238,13 +240,13 @@ function UnionProperties({
     parentPath,
     elements,
     framework,
-    hideChildren,
+    onlyShowToDepth,
 }: {
     parentName: string;
     parentPath: string[];
     elements: JsonUnionType;
     framework: Framework;
-    hideChildren?: boolean;
+    onlyShowToDepth?: number;
 }) {
     return elements.options.map((model, index) => {
         const selection: JsObjectSelectionUnionNestedObject = {
@@ -252,7 +254,7 @@ function UnionProperties({
             index,
             path: parentPath,
             model,
-            hideChildren,
+            onlyShowToDepth,
         };
         return (
             <JsObjectPropertyView
@@ -272,6 +274,7 @@ function NestedArrayProperties({
     parentModel,
     elements,
     framework,
+    onlyShowToDepth,
 }: {
     parentId: string;
     parentName: string;
@@ -279,6 +282,7 @@ function NestedArrayProperties({
     parentModel: JsonModelProperty;
     elements: JsonArray['elements'];
     framework: Framework;
+    onlyShowToDepth?: number;
 }) {
     const { type } = elements;
 
@@ -302,6 +306,7 @@ function NestedArrayProperties({
                 properties={properties}
                 parentPath={parentPath}
                 framework={framework}
+                onlyShowToDepth={onlyShowToDepth}
             />
         );
     } else if (type === 'union') {
@@ -311,6 +316,7 @@ function NestedArrayProperties({
                 elements={elements}
                 parentPath={parentPath}
                 framework={framework}
+                onlyShowToDepth={onlyShowToDepth}
             />
         );
     } else {
@@ -324,20 +330,21 @@ function ArrayPropertyView({
     path,
     model,
     framework,
-    hideChildren,
+    onlyShowToDepth,
 }: {
     id: string;
     name: string;
     path: string[];
     model: JsonModelProperty;
     framework: Framework;
-    hideChildren?: boolean;
+    onlyShowToDepth?: number;
 }) {
     const formattedDocumentation = formatPropertyDocumentation(model).join('\n');
     const description = convertMarkdown(formattedDocumentation, framework);
     const propertyType = getPropertyType(model.desc.tsType);
     const { elements } = model.desc as JsonArray;
     const nestedArrayPropertiesPath = name ? path.concat(name) : path;
+    const showChildren = onlyShowToDepth === undefined ? true : path.length < onlyShowToDepth;
 
     return (
         <>
@@ -355,7 +362,7 @@ function ArrayPropertyView({
                     <div className={styles.actions}></div>
                 </td>
             </tr>
-            {!hideChildren && (
+            {showChildren && (
                 <NestedArrayProperties
                     parentId={id}
                     parentName={name}
@@ -363,6 +370,7 @@ function ArrayPropertyView({
                     parentModel={model}
                     elements={elements}
                     framework={framework}
+                    onlyShowToDepth={onlyShowToDepth}
                 />
             )}
         </>
@@ -405,7 +413,7 @@ function FunctionPropertyView({
 }
 
 export function JsObjectPropertyView({ selection, framework, parentName }: Props) {
-    const { type, path, model, hideChildren } = selection;
+    const { type, path, model, onlyShowToDepth } = selection;
     const id = getSelectionReferenceId(selection);
 
     if (type === 'model') {
@@ -416,7 +424,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                 parentPath={path}
                 properties={properties}
                 framework={framework}
-                hideChildren={hideChildren}
+                onlyShowToDepth={onlyShowToDepth}
             />
         );
     } else if (type === 'property') {
@@ -441,7 +449,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     path={path}
                     model={model}
                     framework={framework}
-                    hideChildren={hideChildren}
+                    onlyShowToDepth={onlyShowToDepth}
                 />
             );
         } else if (propertyType === 'array') {
@@ -452,7 +460,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     path={path}
                     model={model}
                     framework={framework}
-                    hideChildren={hideChildren}
+                    onlyShowToDepth={onlyShowToDepth}
                 />
             );
         } else if (propertyType === 'function') {
@@ -467,7 +475,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     elements={elements}
                     parentPath={path}
                     framework={framework}
-                    hideChildren={hideChildren}
+                    onlyShowToDepth={onlyShowToDepth}
                 />
             );
         }
@@ -504,7 +512,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     path={nestedObjectPath}
                     model={nestedObjectModel}
                     framework={framework}
-                    hideChildren={hideChildren}
+                    onlyShowToDepth={onlyShowToDepth}
                 />
             );
         } else if (propertyType === 'array') {
@@ -515,7 +523,7 @@ export function JsObjectPropertyView({ selection, framework, parentName }: Props
                     path={path}
                     model={model}
                     framework={framework}
-                    hideChildren={hideChildren}
+                    onlyShowToDepth={onlyShowToDepth}
                 />
             );
         }

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
@@ -8,6 +8,11 @@ $indent: 24px;
     border: none;
 }
 
+.topBreadcrumb {
+    color: var(--property-color);
+    cursor: pointer;
+}
+
 .expandableSnippet pre > code {
     --code-line-height: calc(28 / 16);
 

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -46,15 +46,11 @@ interface ModelSnippetWithBreadcrumbsParams {
 }
 
 export const JsObjectView: FunctionComponent<JsObjectViewProps> = ({
-    interfaceName,
+    model,
     breadcrumbs = [],
-    codeLookup,
-    interfaceLookup,
     config = {},
     onSelection,
 }) => {
-    const model = buildModel(interfaceName, interfaceLookup, codeLookup);
-
     return (
         <div className={styles.expandableSnippet} role="presentation">
             <pre className={classnames('code', 'language-ts')}>

--- a/packages/ag-charts-website/src/features/api-documentation/constants.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/constants.ts
@@ -1,4 +1,9 @@
 /**
+ * Property key used to differentiate between different union items
+ */
+export const UNION_DISCRIMINATOR_PROP = 'type';
+
+/**
  * Top level options reference items to limit the number of children shown
  */
 export const TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN = ['axes', 'series'];

--- a/packages/ag-charts-website/src/features/api-documentation/constants.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Top level options reference items to limit the number of children shown
+ */
+export const TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN = ['axes', 'series'];

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -237,25 +237,25 @@ export interface ApiDocumentationProps {
     config?: Config;
 }
 
-export interface JsModelSelectionProperty {
-    type: 'model';
+interface JsSelectionBase {
     path: string[];
     model: JsonModelProperty;
+    hideChildren?: boolean;
 }
 
-export interface JsObjectSelectionProperty {
+export type JsModelSelectionProperty = JsSelectionBase & {
+    type: 'model';
+};
+
+export type JsObjectSelectionProperty = JsSelectionBase & {
     type: 'property';
     propName: string;
-    path: string[];
-    model: JsonModelProperty;
-}
+};
 
-export interface JsObjectSelectionUnionNestedObject {
+export type JsObjectSelectionUnionNestedObject = JsSelectionBase & {
     type: 'unionNestedObject';
     index: number;
-    path: string[];
-    model: JsonObjectProperty;
-}
+};
 
 export type JsObjectSelection =
     | JsModelSelectionProperty

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -266,7 +266,7 @@ export interface JsObjectViewProps {
     model: JsonModel;
     breadcrumbs?: string[];
     config?: Config;
-    onSelection?: (value: OnSelectionValue) => void;
+    handleSelection?: (value: OnSelectionValue) => void;
 }
 
 export interface JsObjectPropertiesViewProps {

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -237,6 +237,12 @@ export interface ApiDocumentationProps {
     config?: Config;
 }
 
+export interface JsModelSelectionProperty {
+    type: 'model';
+    path: string[];
+    model: JsonModelProperty;
+}
+
 export interface JsObjectSelectionProperty {
     type: 'property';
     propName: string;
@@ -251,7 +257,10 @@ export interface JsObjectSelectionUnionNestedObject {
     model: JsonObjectProperty;
 }
 
-export type JsObjectSelection = JsObjectSelectionProperty | JsObjectSelectionUnionNestedObject;
+export type JsObjectSelection =
+    | JsModelSelectionProperty
+    | JsObjectSelectionProperty
+    | JsObjectSelectionUnionNestedObject;
 
 export interface JsObjectViewProps {
     model: JsonModel;

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -240,7 +240,7 @@ export interface ApiDocumentationProps {
 interface JsSelectionBase {
     path: string[];
     model: JsonModelProperty;
-    hideChildren?: boolean;
+    onlyShowToDepth?: number;
 }
 
 export type JsModelSelectionProperty = JsSelectionBase & {

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -1,5 +1,5 @@
 import type { Framework } from '@ag-grid-types';
-import type { JsonProperty } from './utils/model';
+import type { JsonModel, JsonProperty } from './utils/model';
 
 interface MetaTag {
     displayName: string;
@@ -254,10 +254,8 @@ export interface JsObjectSelectionUnionNestedObject {
 export type JsObjectSelection = JsObjectSelectionProperty | JsObjectSelectionUnionNestedObject;
 
 export interface JsObjectViewProps {
-    interfaceName: string;
+    model: JsonModel;
     breadcrumbs?: string[];
-    interfaceLookup: InterfaceLookup;
-    codeLookup: CodeLookup;
     config?: Config;
     onSelection?: (value: OnSelectionValue) => void;
 }

--- a/packages/ag-charts-website/src/features/api-documentation/utils/getObjectReferenceId.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/getObjectReferenceId.ts
@@ -1,0 +1,24 @@
+import type { JsObjectSelection } from '../types';
+
+const CHARS_TO_REPLACE = [' ', "'", '"', ',', '=', '[', ']'];
+const CHAR_TO_REPLACE_WITH = '-';
+
+function cleanString(str: string) {
+    let output: string = str;
+    CHARS_TO_REPLACE.forEach((char) => {
+        output = output.replaceAll(char, CHAR_TO_REPLACE_WITH);
+    });
+    return output;
+}
+
+export function getSelectionReferenceId(selection: JsObjectSelection) {
+    const { type, path } = selection;
+
+    if (type === 'property') {
+        const { propName } = selection;
+        return cleanString(`reference-${path}-${propName}`);
+    } else if (type === 'unionNestedObject') {
+        const { index } = selection;
+        return cleanString(`reference-${path}-${index}`);
+    }
+}

--- a/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
@@ -88,6 +88,6 @@ export function getTopSelection({
         type: model.type,
         path: [],
         model,
-        hideChildren,
+        onlyShowToDepth: hideChildren ? 0 : undefined,
     };
 }

--- a/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
@@ -1,4 +1,5 @@
 import type { JsonModel } from '@features/api-documentation/utils/model';
+import type { JsObjectSelection } from '../types';
 
 /**
  * Property key used to differentiate between different union items
@@ -53,5 +54,40 @@ export function getUnionPathInfo({
         discriminatorType,
         discriminatorProp,
         discriminator,
+    };
+}
+
+export function getTopLevelSelection({
+    pathItem,
+    model,
+}: {
+    pathItem: string;
+    model: JsonModel;
+}): JsObjectSelection | undefined {
+    const topLevelModel = model.properties[pathItem];
+    if (!topLevelModel) {
+        return;
+    }
+
+    return {
+        type: 'property',
+        path: [],
+        propName: pathItem,
+        model: topLevelModel,
+    };
+}
+
+export function getTopSelection({
+    model,
+    hideChildren,
+}: {
+    model: JsonModel;
+    hideChildren?: boolean;
+}): JsObjectSelection {
+    return {
+        type: model.type,
+        path: [],
+        model,
+        hideChildren,
     };
 }

--- a/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
@@ -1,10 +1,6 @@
-import type { JsonModel } from '@features/api-documentation/utils/model';
+import type { JsonArray, JsonModel, JsonObjectProperty, JsonUnionType } from '@features/api-documentation/utils/model';
 import type { JsObjectSelection } from '../types';
-
-/**
- * Property key used to differentiate between different union items
- */
-export const UNION_DISCRIMINATOR_PROP = 'type';
+import { TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN, UNION_DISCRIMINATOR_PROP } from '../constants';
 
 /*
  * Get regex to extract the path item regex if it has a discriminator value
@@ -58,21 +54,61 @@ export function getUnionPathInfo({
 }
 
 export function getTopLevelSelection({
-    pathItem,
+    selection,
     model,
 }: {
-    pathItem: string;
+    selection: JsObjectSelection;
     model: JsonModel;
 }): JsObjectSelection | undefined {
-    const topLevelModel = model.properties[pathItem];
+    const [topLevelPathItem] = selection.path;
+    const topLevelModel = model.properties[topLevelPathItem];
     if (!topLevelModel) {
         return;
+    }
+
+    const shouldLimitChildren = TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN.includes(topLevelPathItem);
+    if (shouldLimitChildren) {
+        let innerOption: JsonObjectProperty;
+        let path = selection.path;
+        if (selection.type === 'property') {
+            const topLevelArray = (topLevelModel.desc as JsonArray).elements as JsonUnionType;
+            const pathDiscriminator = selection.path[1];
+
+            const regex = createUnionNestedObjectPathItemRegex();
+            const [_, _preValue, value] = regex.exec(pathDiscriminator) || [];
+
+            innerOption = topLevelArray.options.find((option) => {
+                const jsonObjectOption = option as JsonObjectProperty;
+                return (
+                    (jsonObjectOption.model as JsonModel).properties[UNION_DISCRIMINATOR_PROP].desc.tsType ===
+                    `'${value}'`
+                );
+            }) as JsonObjectProperty;
+        } else if (selection.type === 'unionNestedObject') {
+            const topLevelArray = (topLevelModel.desc as JsonArray).elements as JsonUnionType;
+            const { index } = selection;
+
+            innerOption = topLevelArray.options[index] as JsonObjectProperty;
+
+            const { pathItem } = getUnionPathInfo({ model: innerOption.model, index });
+            path = selection.path.concat(pathItem);
+        }
+
+        if (!innerOption!) {
+            throw new Error('No inner option found');
+        }
+
+        return {
+            type: 'model',
+            path,
+            model: innerOption.model,
+        };
     }
 
     return {
         type: 'property',
         path: [],
-        propName: pathItem,
+        propName: topLevelPathItem,
         model: topLevelModel,
     };
 }

--- a/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+import type { JsObjectSelection, JsObjectSelectionProperty } from '../types';
+import type { JsonModel } from './model';
+import { getSelectionReferenceId } from './getObjectReferenceId';
+import { smoothScrollIntoView } from '@utils/smoothScrollIntoView';
+import { getTopLevelSelection, getTopSelection } from './modelPath';
+import { TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN } from '../constants';
+
+export function useJsObjectSelection({ model }: { model: JsonModel }) {
+    const [selection, setSelection] = useState<JsObjectSelection>(getTopSelection({ model, hideChildren: true }));
+
+    const handleSelection = useCallback(
+        (newSelection: JsObjectSelection) => {
+            const { path } = newSelection;
+            const isTopLevelSelection = path.length === 0;
+
+            if (isTopLevelSelection) {
+                const { propName } = newSelection as JsObjectSelectionProperty;
+                const onlyShowToDepth = TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN.includes(propName) ? 1 : undefined;
+                setSelection({ ...newSelection, onlyShowToDepth });
+                smoothScrollIntoView('#top');
+            } else {
+                const [newTopLevelPathItem] = newSelection.path;
+                const [currentTopLevelPathItem] = selection.path;
+                const isCurrentTopLevelSelection = currentTopLevelPathItem === newTopLevelPathItem;
+                if (!isCurrentTopLevelSelection) {
+                    const newTopLevelSelection = getTopLevelSelection({ pathItem: newTopLevelPathItem, model });
+                    if (newTopLevelSelection) {
+                        setSelection(newTopLevelSelection);
+                    } else {
+                        // eslint-disable-next-line no-console
+                        console.warn('No top level selection found:', {
+                            newTopLevelPathItem,
+                            newSelection,
+                        });
+                    }
+                }
+
+                const id = getSelectionReferenceId(newSelection);
+                // Scroll to top to reset scroll position
+                smoothScrollIntoView('#top');
+                // Wait for one render cycle before scrolling to position
+                setTimeout(() => {
+                    smoothScrollIntoView(`#${id}`);
+                }, 0);
+            }
+        },
+        [selection]
+    );
+
+    return {
+        selection,
+        handleSelection,
+    };
+}

--- a/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
@@ -6,6 +6,16 @@ import { smoothScrollIntoView } from '@utils/smoothScrollIntoView';
 import { getTopLevelSelection, getTopSelection } from './modelPath';
 import { TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN } from '../constants';
 
+function selectionHasChanged({
+    selection,
+    newSelection,
+}: {
+    selection: JsObjectSelection;
+    newSelection: JsObjectSelection;
+}): boolean {
+    return JSON.stringify(newSelection.path) !== JSON.stringify(selection.path);
+}
+
 export function useJsObjectSelection({ model }: { model: JsonModel }) {
     const [selection, setSelection] = useState<JsObjectSelection>(getTopSelection({ model, hideChildren: true }));
 
@@ -16,33 +26,41 @@ export function useJsObjectSelection({ model }: { model: JsonModel }) {
 
             if (isTopLevelSelection) {
                 const { propName } = newSelection as JsObjectSelectionProperty;
-                const onlyShowToDepth = TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN.includes(propName) ? 1 : undefined;
+                const shouldLimitChildren = TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN.includes(propName);
+                const shouldLimitChildrenDepth = shouldLimitChildren ? 1 : undefined;
+                const onlyShowToDepth =
+                    newSelection.onlyShowToDepth === undefined
+                        ? shouldLimitChildrenDepth
+                        : newSelection.onlyShowToDepth;
                 setSelection({ ...newSelection, onlyShowToDepth });
                 smoothScrollIntoView('#top');
             } else {
-                const [newTopLevelPathItem] = newSelection.path;
-                const [currentTopLevelPathItem] = selection.path;
-                const isCurrentTopLevelSelection = currentTopLevelPathItem === newTopLevelPathItem;
-                if (!isCurrentTopLevelSelection) {
-                    const newTopLevelSelection = getTopLevelSelection({ pathItem: newTopLevelPathItem, model });
-                    if (newTopLevelSelection) {
-                        setSelection(newTopLevelSelection);
-                    } else {
-                        // eslint-disable-next-line no-console
-                        console.warn('No top level selection found:', {
-                            newTopLevelPathItem,
-                            newSelection,
-                        });
+                try {
+                    const [newTopLevelPathItem] = newSelection.path;
+                    if (selectionHasChanged({ selection, newSelection })) {
+                        const newTopLevelSelection = getTopLevelSelection({ selection: newSelection, model });
+                        if (newTopLevelSelection) {
+                            setSelection(newTopLevelSelection);
+                        } else {
+                            // eslint-disable-next-line no-console
+                            console.warn('No top level selection found:', {
+                                newTopLevelPathItem,
+                                newSelection,
+                            });
+                        }
                     }
-                }
 
-                const id = getSelectionReferenceId(newSelection);
-                // Scroll to top to reset scroll position
-                smoothScrollIntoView('#top');
-                // Wait for one render cycle before scrolling to position
-                setTimeout(() => {
-                    smoothScrollIntoView(`#${id}`);
-                }, 0);
+                    const id = getSelectionReferenceId(newSelection);
+                    // Scroll to top to reset scroll position
+                    smoothScrollIntoView('#top');
+                    // Wait for one render cycle before scrolling to position
+                    setTimeout(() => {
+                        smoothScrollIntoView(`#${id}`);
+                    }, 0);
+                } catch (error) {
+                    // eslint-disable-next-line no-console
+                    console.warn(error, { selection, newSelection });
+                }
             }
         },
         [selection]


### PR DESCRIPTION
## Changes

* Show top level items on no selection view ie, default when landing on options reference page
  * Make `options` at the top clickable and show the no selection view
  * For `axes` and `series` only show 1 level deep
* Instead of filtering out selection, display all properties and scroll to value
* Show `type` in the navigation when expanded

## TODO

* [ ] Theme heading references don't work - nav uses `#reference-theme--1--baseTheme` and heading id is `reference--1--baseTheme` (missing theme)

## Screenshots

No selection or `options` clicked view shows top level properties

<img width="1280" alt="Screenshot 2023-09-08 at 5 26 53 pm" src="https://github.com/ag-grid/ag-charts/assets/79451/1cf978f6-32e0-43d2-a694-1986a590223a">


Show type in nav
<img width="574" alt="Screenshot 2023-09-08 at 5 24 19 pm" src="https://github.com/ag-grid/ag-charts/assets/79451/753fc776-a278-4d2d-a958-46f878e7b14b">

Only show 1 level deep for `axes` and `series`
<img width="1258" alt="Screenshot 2023-09-08 at 5 24 43 pm" src="https://github.com/ag-grid/ag-charts/assets/79451/0e52a3d4-3dce-4f12-be5c-303f00b080e0">


