### PR TITLE
AG-9212 - Fix missing theme option items.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartOptions.ts
+++ b/packages/ag-charts-community/src/chart/agChartOptions.ts
@@ -1,5 +1,5 @@
 import type { AgBaseChartOptions } from './options/chartOptions';
-import type { AgBaseChartThemeOptions, AgChartTheme } from './options/themeOptions';
+import type { AgBaseChartThemeOptions, AgChartTheme, AgChartThemeName } from './options/themeOptions';
 import type { AgBaseCartesianChartOptions } from './series/cartesian/cartesianOptions';
 import type { AgBaseHierarchyChartOptions } from './series/hierarchy/hierarchyOptions';
 import type { AgBasePolarChartOptions } from './series/polar/polarOptions';
@@ -49,13 +49,13 @@ export interface AgChartThemeOptions extends AgBaseChartThemeOptions {}
 export type AgChartThemeOverrides = NonNullable<AgChartThemeOptions['overrides']>;
 
 export interface AgCartesianChartOptions extends AgBaseCartesianChartOptions, AgBaseChartOptions {
-    theme?: AgChartTheme;
+    theme?: AgChartTheme | AgChartThemeName;
 }
 export interface AgPolarChartOptions extends AgBasePolarChartOptions, AgBaseChartOptions {
-    theme?: AgChartTheme;
+    theme?: AgChartTheme | AgChartThemeName;
 }
 export interface AgHierarchyChartOptions extends AgBaseHierarchyChartOptions, AgBaseChartOptions<any> {
-    theme?: AgChartTheme;
+    theme?: AgChartTheme | AgChartThemeName;
 }
 export type AgChartOptions = AgCartesianChartOptions | AgPolarChartOptions | AgHierarchyChartOptions;
 

--- a/packages/ag-charts-community/src/chart/options/chartOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/chartOptions.ts
@@ -1,5 +1,8 @@
 import type { AgChartBackgroundImage } from '../background/backgroundOptions';
+import type { AgAnimationOptions } from '../interaction/animationOptions';
+import type { AgContextMenuOptions } from './contextOptions';
 import type { AgBaseChartListeners } from './eventOptions';
+import type { AgChartLegendOptions } from './legendOptions';
 import type { AgChartTooltipOptions } from './tooltipOptions';
 import type { CssColor, FontFamily, FontSize, FontStyle, FontWeight, PixelSize, TextWrap } from './types';
 
@@ -103,6 +106,10 @@ export interface AgBaseThemeableChartOptions {
     highlight?: AgChartHighlightOptions;
     /** HTML overlays */
     overlays?: AgChartOverlaysOptions;
+    /** Configuration for the chart legend. */
+    legend?: AgChartLegendOptions;
+    animation?: AgAnimationOptions;
+    contextMenu?: AgContextMenuOptions;
 }
 
 /** Configuration common to all charts.  */

--- a/packages/ag-charts-community/src/chart/options/legendOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/legendOptions.ts
@@ -82,7 +82,9 @@ export interface AgChartLegendListeners {
     legendItemDoubleClick?: (event: AgChartLegendDoubleClickEvent) => void;
 }
 
-export interface AgChartBaseLegendOptions {
+export interface AgChartLegendOptions {
+    /** Whether or not to show the legend. By default, the chart displays a legend when there is more than one series present. */
+    enabled?: boolean;
     /** Where the legend should show in relation to the chart. */
     position?: AgChartLegendPosition;
     /** How the legend items should be arranged. */

--- a/packages/ag-charts-community/src/chart/options/themeOptions.ts
+++ b/packages/ag-charts-community/src/chart/options/themeOptions.ts
@@ -1,5 +1,5 @@
 import type { AgBaseChartOptions, AgBaseThemeableChartOptions } from './chartOptions';
-import type { AgBaseCartesianThemeOptions } from '../series/cartesian/cartesianOptions';
+import type { AgBaseCartesianThemeOptions, AgCartesianAxesTheme } from '../series/cartesian/cartesianOptions';
 import type { AgCartesianSeriesOptions } from '../series/cartesian/cartesianSeriesTypes';
 import type { AgBarSeriesThemeableOptions } from '../series/cartesian/barOptions';
 import type { AgBoxPlotSeriesThemeableOptions } from '../series/cartesian/boxPlotOptions';
@@ -8,7 +8,7 @@ import type { AgLineSeriesThemeableOptions } from '../series/cartesian/lineOptio
 import type { AgRangeBarSeriesThemeableOptions } from '../series/cartesian/rangeBarOptions';
 import type { AgWaterfallSeriesThemeableOptions } from '../series/cartesian/waterfallOptions';
 import type { AgBaseHierarchyThemeOptions, AgHierarchySeriesOptions } from '../series/hierarchy/hierarchyOptions';
-import type { AgBasePolarThemeOptions, AgPolarSeriesOptions } from '../series/polar/polarOptions';
+import type { AgBasePolarThemeOptions, AgPolarAxesTheme, AgPolarSeriesOptions } from '../series/polar/polarOptions';
 import type { AgRadarAreaSeriesThemeableOptions } from '../series/polar/radarAreaOptions';
 import type { AgRadialColumnSeriesThemeableOptions } from '../series/polar/radialColumnOptions';
 import type { AgNightingaleSeriesThemeableOptions } from '../series/polar/nightingaleOptions';
@@ -102,8 +102,14 @@ export interface AgTreemapSeriesThemeOverrides extends AgBaseHierarchyThemeOptio
     series?: AgTreemapSeriesThemeableOptions;
 }
 
+export interface AgCommonThemeableAxisOptions extends AgCartesianAxesTheme, AgPolarAxesTheme {}
+
+export interface AgCommonThemeableChartOptions extends AgBaseThemeableChartOptions {
+    axes?: AgCommonThemeableAxisOptions;
+}
+
 export interface AgBaseChartThemeOverrides {
-    common?: AgBaseThemeableChartOptions;
+    common?: AgCommonThemeableChartOptions;
 
     line?: AgLineSeriesThemeOverrides;
     scatter?: AgScatterSeriesThemeOverrides;

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianOptions.ts
@@ -1,18 +1,15 @@
-import type { AgAnimationOptions } from '../../interaction/animationOptions';
 import type {
     AgAxisBaseTickOptions,
     AgAxisCaptionOptions,
     AgBaseAxisOptions,
     AgBaseAxisLabelOptions,
 } from '../../options/axisOptions';
-import type { AgContextMenuOptions } from '../../options/contextOptions';
 import type {
     AgBaseCrossLineLabelOptions,
     AgBaseCrossLineOptions,
     AgCrossLineLabelPosition,
     AgCrossLineThemeOptions,
 } from '../../options/crossLineOptions';
-import type { AgChartBaseLegendOptions } from '../../options/legendOptions';
 import type { AgNavigatorOptions } from '../../options/navigatorOptions';
 import type { PixelSize, Ratio } from '../../options/types';
 import type { AgZoomOptions } from '../../options/zoomOptions';
@@ -46,13 +43,7 @@ export interface AgBaseCartesianChartOptions {
     axes?: AgCartesianAxisOptions[];
     /** Series configurations. */
     series?: AgCartesianSeriesOptions[];
-    /** Configuration for the chart legend. */
-    legend?: AgCartesianChartLegendOptions;
-    /** Configuration for the chart navigator. */
-    navigator?: AgNavigatorOptions;
 
-    animation?: AgAnimationOptions;
-    contextMenu?: AgContextMenuOptions;
     /** Configuration for zoom. */
     zoom?: AgZoomOptions;
 }
@@ -146,8 +137,6 @@ export interface AgCartesianAxisThemeOptions<T> {
 export interface AgBaseCartesianThemeOptions extends AgBaseThemeableChartOptions {
     /** Axis configurations. */
     axes?: AgCartesianAxesTheme;
-    /** Configuration for the chart legend. */
-    legend?: AgCartesianChartLegendOptions;
     /** Configuration for the chart navigator. */
     navigator?: AgNavigatorOptions;
 }
@@ -188,11 +177,6 @@ export interface AgTimeAxisThemeOptions
         AgCartesianAxisThemeOptions<AgTimeAxisOptions>,
         AgCartesianAxesCrossLineThemeOptions {}
 
-export interface AgCartesianChartLegendOptions extends AgChartBaseLegendOptions {
-    /** Whether or not to show the legend. By default, the chart displays a legend when there is more than one series present. */
-    enabled?: boolean;
-}
-
 export interface AgCartesianCrossLineOptions extends AgBaseCrossLineOptions<AgCartesianCrossLineLabelOptions> {}
 
 export interface AgCartesianCrossLineLabelOptions extends AgBaseCrossLineLabelOptions {
@@ -200,11 +184,6 @@ export interface AgCartesianCrossLineLabelOptions extends AgBaseCrossLineLabelOp
     position?: AgCrossLineLabelPosition;
     /** The rotation of the crossLine label in degrees. */
     rotation?: number;
-}
-
-export interface AgCartesianChartLegendOptions extends AgChartBaseLegendOptions {
-    /** Whether or not to show the legend. By default, the chart displays a legend when there is more than one series present. */
-    enabled?: boolean;
 }
 
 export interface AgAxisCategoryTickOptions extends AgAxisBaseTickOptions {}

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchyOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchyOptions.ts
@@ -1,6 +1,4 @@
 import type { AgBaseThemeableChartOptions } from '../../options/chartOptions';
-import type { AgContextMenuOptions } from '../../options/contextOptions';
-import type { AgChartBaseLegendOptions } from '../../options/legendOptions';
 import type { AgTreemapSeriesOptions } from './treemapOptions';
 
 export type AgHierarchySeriesOptions = AgTreemapSeriesOptions;
@@ -9,17 +7,6 @@ export interface AgBaseHierarchyChartOptions {
     data?: any;
     /** Series configurations. */
     series?: AgHierarchySeriesOptions[];
-    /** Configuration for the chart legend. */
-    legend?: AgHierarchyChartLegendOptions;
-    contextMenu?: AgContextMenuOptions;
 }
 
-export interface AgBaseHierarchyThemeOptions extends AgBaseThemeableChartOptions {
-    /** Configuration for the chart legend. */
-    legend?: AgHierarchyChartLegendOptions;
-}
-
-export interface AgHierarchyChartLegendOptions extends AgChartBaseLegendOptions {
-    /** Whether or not to show the legend. By default, the chart displays a legend when there is more than one series present. */
-    enabled?: boolean;
-}
+export interface AgBaseHierarchyThemeOptions extends AgBaseThemeableChartOptions {}

--- a/packages/ag-charts-community/src/chart/series/polar/polarOptions.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarOptions.ts
@@ -1,6 +1,3 @@
-import type { AgAnimationOptions } from '../../interaction/animationOptions';
-import type { AgContextMenuOptions } from '../../options/contextOptions';
-import type { AgChartBaseLegendOptions } from '../../options/legendOptions';
 import type { AgPieSeriesOptions } from './pieOptions';
 import type { AgAngleCategoryAxisOptions } from '../../options/polarAxisOptions';
 import type { AgRadiusNumberAxisOptions } from '../../options/radiusAxisOptions';
@@ -21,21 +18,17 @@ export type AgPolarAxisOptions = AgAngleCategoryAxisOptions | AgRadiusNumberAxis
 export interface AgBasePolarChartOptions {
     /** Series configurations. */
     series?: AgPolarSeriesOptions[];
-    /** Configuration for the chart legend. */
-    legend?: AgPolarChartLegendOptions;
 
-    animation?: AgAnimationOptions;
-    contextMenu?: AgContextMenuOptions;
     /** Axis configurations. */
     axes?: AgPolarAxisOptions[];
 }
 
-export interface AgBasePolarThemeOptions extends AgBaseThemeableChartOptions {
-    /** Configuration for the chart legend. */
-    legend?: AgPolarChartLegendOptions;
+export interface AgPolarAxesTheme {
+    'angle-category': AgAngleCategoryAxisOptions;
+    'radius-number': AgRadiusNumberAxisOptions;
 }
 
-export interface AgPolarChartLegendOptions extends AgChartBaseLegendOptions {
-    /** Whether or not to show the legend. The legend is shown by default. */
-    enabled?: boolean;
+export interface AgBasePolarThemeOptions extends AgBaseThemeableChartOptions {
+    /** Axis configurations. */
+    axes?: AgPolarAxesTheme;
 }

--- a/packages/ag-charts-website/src/content/docs/legend/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/legend/index.mdoc
@@ -228,14 +228,6 @@ This example demonstrates toggling the visiblity of series via clicks and double
 
 ## API Reference
 
-### Cartesian Chart Legend Options
+### Chart Legend Options
 
-{% interfaceDocumentation interfaceName="AgCartesianChartLegendOptions" config="{ \"showSnippets\": false }" /%}
-
-### Polar Chart Legend Options
-
-{% interfaceDocumentation interfaceName="AgPolarChartLegendOptions" config="{ \"showSnippets\": false }" /%}
-
-### Hierarchy Chart Legend Options
-
-{% interfaceDocumentation interfaceName="AgHierarchyChartLegendOptions" config="{ \"showSnippets\": false }" /%}
+{% interfaceDocumentation interfaceName="AgChartLegendOptions" config="{ \"showSnippets\": false }" /%}

--- a/plugins/ag-charts-build-tools/src/executors/generate-code-reference-files/generate-code-reference-files.mjs
+++ b/plugins/ag-charts-build-tools/src/executors/generate-code-reference-files/generate-code-reference-files.mjs
@@ -45,8 +45,8 @@ function extractTypesFromNode(node, srcFile, includeQuestionMark) {
     let nodeMembers = {};
     const kind = ts.SyntaxKind[node.kind];
 
-    let name = node && node.name && node.name.escapedText;
-    let returnType = node && node.type && node.type.getFullText().trim();
+    let name = node?.name?.escapedText ?? node?.getText()?.split(':')[0];
+    let returnType = node?.type?.getFullText().trim();
     let optional = includeQuestionMark ? node && !!node.questionToken : undefined;
 
     if (kind == 'PropertySignature') {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9212

Fixes some additional gaps after #180:
- Fixes `undefined` properties keys in `docs-interfaces.AUTO.json` processing.
- Fixes missing series types that were being collapsed to `undefined` ^
- Adds `common.axes`, `common.legend`, `common.animation` and `common.contextMenu`.
- Fixes missing polar series `axes` config.
- Fixes support for string-based theme selection at root `theme` property.