### PR TITLE
AG-9206 - Options reference round 4 - Adding theme link

### DIFF
--- a/packages/ag-charts-website/src/content/docs/api-themes/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-themes/index.mdoc
@@ -5,3 +5,5 @@ title: 'Themes Reference'
 A comprehensive interactive explorer for the `AgChartOptions.theme.overrides` structure.
 
 Read more about how to use this structure in the [Themes](/charts-themes/) section.
+
+{% jsObjectPropertiesView interfaceName="AgChartTheme" breadcrumbs="[\"options\", \"theme\"]" /%}

--- a/packages/ag-charts-website/src/content/menu/data.json
+++ b/packages/ag-charts-website/src/content/menu/data.json
@@ -22,6 +22,7 @@
                 "title": "API",
                 "items": [
                     { "title": "Options Reference", "path": "options" },
+                    { "title": "Themes Reference", "path": "api-themes" },
                     { "title": "Create/Update", "path": "api-create-update" },
                     { "title": "Download", "path": "api-download" },
                     { "title": "Events", "path": "events" }

--- a/packages/ag-charts-website/src/content/options-reference/data.json
+++ b/packages/ag-charts-website/src/content/options-reference/data.json
@@ -1,0 +1,8 @@
+{
+    "theme": {
+        "more": {
+            "name": "Themes Reference",
+            "url": "./api-themes"
+        }
+    }
+}

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectDetails.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectDetails.tsx
@@ -3,11 +3,9 @@ import styles from './ApiDocumentation.module.scss';
 import type { FunctionComponent, ReactNode } from 'react';
 import type { JsObjectSelection } from '../types';
 import { JsObjectPropertyView } from './JsObjectPropertyView';
-import type { Framework } from '@ag-grid-types';
 
 interface Props {
     selection: JsObjectSelection;
-    framework: Framework;
 }
 
 function JsObjectDetailsContainer({ children }: { children: ReactNode }) {
@@ -20,10 +18,10 @@ function JsObjectDetailsContainer({ children }: { children: ReactNode }) {
     );
 }
 
-export const JsObjectDetails: FunctionComponent<Props> = ({ selection, framework }) => {
+export const JsObjectDetails: FunctionComponent<Props> = ({ selection }) => {
     return (
         <JsObjectDetailsContainer>
-            <JsObjectPropertyView selection={selection} framework={framework} />
+            <JsObjectPropertyView selection={selection} />
             {/* For debugging
             <tr>
                 <td colSpan={2}>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.astro
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.astro
@@ -1,10 +1,13 @@
 ---
+import { getEntry } from 'astro:content';
 import type { Framework } from '@ag-grid-types';
 import { JsObjectPropertiesView } from './JsObjectPropertiesView';
 import { getJsonFromDevFile } from '@utils/getJsonFromDevFile';
 
 const interfaceLookup = getJsonFromDevFile('ag-charts-community/interfaces.AUTO.json');
 const codeLookup = getJsonFromDevFile('ag-charts-community/doc-interfaces.AUTO.json');
+
+const optionsData = (await getEntry('options-reference', 'data')).data;
 
 const framework = Astro.params.framework as Framework;
 const { config: configString, breadcrumbs: breadcrumbsString, ...props } = Astro.props;
@@ -19,5 +22,6 @@ const config = configString ? JSON.parse(configString) : undefined;
     breadcrumbs={breadcrumbs}
     config={config}
     framework={framework}
+    optionsData={optionsData}
     {...props}
 />

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -1,17 +1,21 @@
 import type { FunctionComponent } from 'react';
 import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
-import type { Config, JsObjectPropertiesViewProps } from '../types';
+import type { JsObjectPropertiesViewConfig, JsObjectPropertiesViewProps } from '../types';
 import { JsObjectDetails } from './JsObjectDetails';
 import { buildModel } from '../utils/model';
 import { useJsObjectSelection } from '../utils/useJsObjectSelection';
+import { OptionsDataContext } from '../utils/optionsDataContext';
+import { JsObjectPropertiesViewConfigContext } from '../utils/jsObjectPropertiesViewConfigContext';
+import { FrameworkContext } from '../utils/frameworkContext';
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
     interfaceName,
     breadcrumbs = [],
     codeLookup,
     interfaceLookup,
-    config = {} as Config,
+    config = {} as JsObjectPropertiesViewConfig,
+    optionsData,
     framework,
 }) => {
     const model = buildModel(interfaceName, interfaceLookup, codeLookup);
@@ -19,8 +23,15 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
 
     return (
         <div className={styles.container}>
-            <JsObjectView breadcrumbs={breadcrumbs} config={config} handleSelection={handleSelection} model={model} />
-            <JsObjectDetails selection={selection} framework={framework} />
+            <JsObjectPropertiesViewConfigContext.Provider value={config}>
+                <JsObjectView breadcrumbs={breadcrumbs} handleSelection={handleSelection} model={model} />
+
+                <FrameworkContext.Provider value={framework}>
+                    <OptionsDataContext.Provider value={optionsData}>
+                        <JsObjectDetails selection={selection} />
+                    </OptionsDataContext.Provider>
+                </FrameworkContext.Provider>
+            </JsObjectPropertiesViewConfigContext.Provider>
         </div>
     );
 };

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -537,7 +537,7 @@ function PropertyDeclaration({
             {showTypeAsDiscriminatorValue && (
                 <>
                     {` = `}
-                    <DiscriminatorType discriminatorType={tsType} />
+                    <DiscriminatorType discriminatorType={tsType!} />
                 </>
             )}
         </>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -13,7 +13,7 @@ import type {
 } from '../utils/model';
 import { Icon } from '@components/icon/Icon';
 import { getTopSelection, getUnionPathInfo } from '../utils/modelPath';
-import { UNION_DISCRIMINATOR_PROP } from '../constants';
+import { TOP_LEVEL_OPTIONS_TO_HIDE_CHILDREN, UNION_DISCRIMINATOR_PROP } from '../constants';
 
 const SelectionContext = createContext<{ handleSelection?: JsObjectViewProps['handleSelection'] }>({});
 
@@ -451,7 +451,22 @@ const PropertySnippet: React.FC<PropertySnippetParams> = ({
             console.warn(`AG Docs - unhandled sub-type: ${desc['type']}`);
     }
 
-    const expandable = !!collapsePropertyRendering;
+    const shouldHideChildren = TOP_LEVEL_OPTIONS_TO_HIDE_CHILDREN.includes(propName);
+    const expandable = !shouldHideChildren && !!collapsePropertyRendering;
+
+    let propertyValue;
+    if (shouldHideChildren) {
+        propertyValue = null;
+    } else if (!isJSONNodeExpanded && collapsePropertyRendering) {
+        propertyValue = collapsePropertyRendering;
+    } else {
+        propertyValue = (
+            <span className={classnames(styles['unexpandable'])} onClick={(e) => e.stopPropagation()}>
+                {propertyRendering}
+            </span>
+        );
+    }
+
     return (
         <div
             className={classnames(
@@ -474,13 +489,7 @@ const PropertySnippet: React.FC<PropertySnippetParams> = ({
                     showTypeAsDiscriminatorValue={showTypeAsDiscriminatorValue && propName === UNION_DISCRIMINATOR_PROP}
                 />
             }
-            {!isJSONNodeExpanded && collapsePropertyRendering ? (
-                collapsePropertyRendering
-            ) : (
-                <span className={classnames(styles['unexpandable'])} onClick={(e) => e.stopPropagation()}>
-                    {propertyRendering}
-                </span>
-            )}
+            {propertyValue}
             {(!isJSONNodeExpanded || needsClosingSemi) && (
                 <span className={classnames('token', 'punctuation')}>{closeWith}</span>
             )}

--- a/packages/ag-charts-website/src/features/api-documentation/constants.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/constants.ts
@@ -7,3 +7,8 @@ export const UNION_DISCRIMINATOR_PROP = 'type';
  * Top level options reference items to limit the number of children shown
  */
 export const TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN = ['axes', 'series'];
+
+/**
+ * Top level options reference items to limit the number of children shown
+ */
+export const TOP_LEVEL_OPTIONS_TO_HIDE_CHILDREN = ['theme'];

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -237,6 +237,8 @@ export interface ApiDocumentationProps {
     config?: Config;
 }
 
+type OptionsData = CollectionEntry<'options-reference'>['data'];
+
 interface JsSelectionBase {
     path: string[];
     model: JsonModelProperty;
@@ -275,8 +277,19 @@ export interface JsObjectPropertiesViewProps {
     breadcrumbs?: string[];
     interfaceLookup: InterfaceLookup;
     codeLookup: CodeLookup;
-    config?: Config;
+    config?: JsObjectPropertiesViewConfig;
     framework: Framework;
+    optionsData: OptionsData;
+}
+
+export interface JsObjectPropertiesViewConfig {
+    includeDeprecated?: boolean;
+    excludeProperties?: string[];
+    expandedProperties?: string[];
+    expandedPaths?: string[];
+    expandAll?: boolean;
+    lookupRoot?: string;
+    hideMore?: boolean;
 }
 
 export interface InterfaceDocumentationProps {

--- a/packages/ag-charts-website/src/features/api-documentation/utils/frameworkContext.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/frameworkContext.ts
@@ -1,0 +1,4 @@
+import type { Framework } from '@ag-grid-types';
+import { createContext } from 'react';
+
+export const FrameworkContext = createContext<Framework>('javascript');

--- a/packages/ag-charts-website/src/features/api-documentation/utils/jsObjectPropertiesViewConfigContext.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/jsObjectPropertiesViewConfigContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import type { JsObjectPropertiesViewConfig } from '../types';
+
+export const JsObjectPropertiesViewConfigContext = createContext<JsObjectPropertiesViewConfig>(
+    {} as JsObjectPropertiesViewConfig
+);

--- a/packages/ag-charts-website/src/features/api-documentation/utils/optionsDataContext.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/optionsDataContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { OptionsData } from '../types';
+
+export const OptionsDataContext = createContext<OptionsData>({});

--- a/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
@@ -4,7 +4,7 @@ import type { JsonModel } from './model';
 import { getSelectionReferenceId } from './getObjectReferenceId';
 import { smoothScrollIntoView } from '@utils/smoothScrollIntoView';
 import { getTopLevelSelection, getTopSelection } from './modelPath';
-import { TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN } from '../constants';
+import { TOP_LEVEL_OPTIONS_TO_HIDE_CHILDREN, TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN } from '../constants';
 
 function selectionHasChanged({
     selection,
@@ -26,8 +26,15 @@ export function useJsObjectSelection({ model }: { model: JsonModel }) {
 
             if (isTopLevelSelection) {
                 const { propName } = newSelection as JsObjectSelectionProperty;
+                const shouldHideChildren = TOP_LEVEL_OPTIONS_TO_HIDE_CHILDREN.includes(propName);
                 const shouldLimitChildren = TOP_LEVEL_OPTIONS_TO_LIMIT_CHILDREN.includes(propName);
-                const shouldLimitChildrenDepth = shouldLimitChildren ? 1 : undefined;
+
+                let shouldLimitChildrenDepth;
+                if (shouldHideChildren) {
+                    shouldLimitChildrenDepth = 0;
+                } else if (shouldLimitChildren) {
+                    shouldLimitChildrenDepth = 1;
+                }
                 const onlyShowToDepth =
                     newSelection.onlyShowToDepth === undefined
                         ? shouldLimitChildrenDepth


### PR DESCRIPTION
## Changes

* Add themes reference page
* Remove `theme` object from options reference replace with a top level link to the themes reference page
* Extract `framework`, `config` and `optionsData` as context that can get passed into react components