### PR TITLE
AG-9206 - Options reference round 5 - Add full screen view

### DIFF
--- a/packages/ag-charts-website/src/components/site-header/HeaderNav.tsx
+++ b/packages/ag-charts-website/src/components/site-header/HeaderNav.tsx
@@ -13,6 +13,10 @@ const SITE_HEADER_SMALL_WIDTH = parseInt(breakpoints['site-header-small'], 10);
 
 const links = [
     {
+        name: 'API',
+        url: pathJoin(SITE_BASE_URL, 'options'),
+    },
+    {
         name: 'Gallery',
         url: pathJoin(SITE_BASE_URL, 'gallery'),
     },

--- a/packages/ag-charts-website/src/components/site-header/HeaderNav.tsx
+++ b/packages/ag-charts-website/src/components/site-header/HeaderNav.tsx
@@ -13,16 +13,16 @@ const SITE_HEADER_SMALL_WIDTH = parseInt(breakpoints['site-header-small'], 10);
 
 const links = [
     {
-        name: 'API',
-        url: pathJoin(SITE_BASE_URL, 'options'),
-    },
-    {
         name: 'Gallery',
         url: pathJoin(SITE_BASE_URL, 'gallery'),
     },
     {
         name: 'Documentation',
         url: pathJoin(SITE_BASE_URL, 'documentation'),
+    },
+    {
+        name: 'API',
+        url: pathJoin(SITE_BASE_URL, 'options'),
     },
     {
         name: 'Pricing',

--- a/packages/ag-charts-website/src/features/api-documentation/components/ApiDocumentation.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/ApiDocumentation.module.scss
@@ -92,6 +92,10 @@
         font-size: var(--font-size-medium);
     }
 
+    :hover :global(a.docs-header-icon) {
+        opacity: 0.5;
+    }
+
     :global(a.docs-header-icon) {
         position: absolute;
         bottom: -0.125em;

--- a/packages/ag-charts-website/src/features/api-documentation/components/HeadingPath.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/HeadingPath.tsx
@@ -1,0 +1,32 @@
+import { createUnionNestedObjectPathItemRegex } from '../utils/modelPath';
+import styles from './ApiDocumentation.module.scss';
+
+export function HeadingPath({ path }: { path: string[] }) {
+    const regex = createUnionNestedObjectPathItemRegex();
+    return (
+        path.length > 0 && (
+            <span className={styles.parentProperties}>
+                {path.map((pathItem, index) => {
+                    const arrayDiscriminatorMatches = regex.exec(pathItem);
+                    const [_, preValue, value, postValue] = arrayDiscriminatorMatches || [];
+                    // Only show separator `.` at the front, when not the first and not an array discriminator afterwards
+                    const separator = index !== 0 && !arrayDiscriminatorMatches ? '.' : '';
+
+                    return (
+                        <span className={styles.noWrap} key={`${pathItem}-${index}`}>
+                            {separator}
+                            {!arrayDiscriminatorMatches && <>{pathItem}</>}
+                            {arrayDiscriminatorMatches && (
+                                <>
+                                    {preValue}
+                                    <span className={styles.unionDiscriminator}>{value}</span>
+                                    {postValue}
+                                </>
+                            )}
+                        </span>
+                    );
+                })}
+            </span>
+        )
+    );
+}

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectProperties.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectProperties.module.scss
@@ -2,20 +2,58 @@
 
 .container {
     display: flex;
-    gap: $size-4;
+    width: 100%;
+    gap: $size-6;
+    padding-right: max(var(--horizontal-margin), 50vw - var(--max-page-width) / 2);
 
     > div:first-child {
-        $sticky-offset: $site-header-height + $size-4;
+        $sticky-offset: 41px;
 
+        border-right: 1px solid var(--border-color);
         position: sticky;
         top: $sticky-offset;
-        max-height: calc(100vh - #{$sticky-offset + $size-4});
-        width: min(50%, 540px);
-        flex-shrink: 0;
+        max-height: calc(100vh - #{$sticky-offset});
         overflow-y: auto;
-
-        pre {
-            max-height: 100%;
-        }
+        min-width: 380px;
     }
+
+    pre {
+        border: 0;
+        border-radius: 0;
+        width: 380px;
+        min-height: 100vh;
+    }
+
+    pre code {
+        min-height: 100vh;
+        padding-top: calc(26.25px * 2) !important;
+    }
+
+    > div:nth-child(2) {
+        width: 100%;
+    }
+
+    header {
+        margin-top: $size-4;
+        margin-bottom: $size-4;
+    }
+
+    svg {
+        display: none;
+    }
+
+    // > div:first-child {
+    //     $sticky-offset: $site-header-height + $size-4;
+
+    //     position: sticky;
+    //     top: $sticky-offset;
+    //     max-height: calc(100vh - #{$sticky-offset + $size-4});
+    //     width: min(50%, 540px);
+    //     flex-shrink: 0;
+    //     overflow-y: auto;
+
+    //     pre {
+    //         max-height: 100%;
+    //     }
+    // }
 }

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectProperties.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectProperties.module.scss
@@ -5,55 +5,18 @@
     width: 100%;
     gap: $size-6;
     padding-right: max(var(--horizontal-margin), 50vw - var(--max-page-width) / 2);
+}
 
-    > div:first-child {
-        $sticky-offset: 41px;
+.objectViewOuter {
+    border-right: 1px solid var(--border-color);
+}
 
-        border-right: 1px solid var(--border-color);
-        position: sticky;
-        top: $sticky-offset;
-        max-height: calc(100vh - #{$sticky-offset});
-        overflow-y: auto;
-        min-width: 380px;
-    }
-
-    pre {
-        border: 0;
-        border-radius: 0;
-        width: 380px;
-        min-height: 100vh;
-    }
-
-    pre code {
-        min-height: 100vh;
-        padding-top: calc(26.25px * 2) !important;
-    }
-
-    > div:nth-child(2) {
-        width: 100%;
-    }
+.referenceOuter {
+    width: 100%;
+    margin-bottom: $size-9;
 
     header {
         margin-top: $size-4;
         margin-bottom: $size-4;
     }
-
-    svg {
-        display: none;
-    }
-
-    // > div:first-child {
-    //     $sticky-offset: $site-header-height + $size-4;
-
-    //     position: sticky;
-    //     top: $sticky-offset;
-    //     max-height: calc(100vh - #{$sticky-offset + $size-4});
-    //     width: min(50%, 540px);
-    //     flex-shrink: 0;
-    //     overflow-y: auto;
-
-    //     pre {
-    //         max-height: 100%;
-    //     }
-    // }
 }

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectProperties.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectProperties.module.scss
@@ -1,14 +1,19 @@
 @use '../../../design-system' as *;
 
 .container {
+    --jsObjectWidth: 420px;
+
     display: flex;
     width: 100%;
-    gap: $size-6;
     padding-right: max(var(--horizontal-margin), 50vw - var(--max-page-width) / 2);
 }
 
 .objectViewOuter {
+    --right-margin: max(#{$size-6}, calc(50vw - var(--max-page-width) / 2 - var(--jsObjectWidth)));
+
     border-right: 1px solid var(--border-color);
+    min-width: var(--jsObjectWidth);
+    margin-right: var(--right-margin);
 }
 
 .referenceOuter {

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -2,16 +2,48 @@ import classNames from 'classnames';
 import type { FunctionComponent } from 'react';
 import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
-import type { JsObjectPropertiesViewConfig, JsObjectPropertiesViewProps } from '../types';
+import type {
+    JsObjectPropertiesViewConfig,
+    JsObjectPropertiesViewProps,
+    JsObjectSelection,
+    TopLevelHeaderData,
+} from '../types';
 import { JsObjectDetails } from './JsObjectDetails';
 import { buildModel } from '../utils/model';
 import { useJsObjectSelection } from '../utils/useJsObjectSelection';
 import { OptionsDataContext } from '../utils/optionsDataContext';
 import { JsObjectPropertiesViewConfigContext } from '../utils/jsObjectPropertiesViewConfigContext';
 import { FrameworkContext } from '../utils/frameworkContext';
+import { HeadingPath } from './HeadingPath';
+import { MetaList } from './MetaList';
+
+function TopLevelHeader({
+    topLevelHeader,
+    topLevelSelection,
+}: {
+    topLevelHeader?: TopLevelHeaderData;
+    topLevelSelection: JsObjectSelection;
+}) {
+    if (!topLevelHeader) {
+        return null;
+    }
+    return (
+        <header>
+            <h1 className="font-size-gigantic">
+                <HeadingPath path={topLevelHeader.path} />
+                {topLevelHeader.heading}
+            </h1>
+            <p>{topLevelHeader.descriptionWithoutDefault}</p>
+            <MetaList
+                propertyType={topLevelHeader.propertyType}
+                model={topLevelSelection.model}
+                description={topLevelHeader.description}
+            />
+        </header>
+    );
+}
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
-    heading,
     interfaceName,
     breadcrumbs = [],
     codeLookup,
@@ -21,7 +53,7 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
     framework,
 }) => {
     const model = buildModel(interfaceName, interfaceLookup, codeLookup);
-    const { topLevelSelection, handleSelection } = useJsObjectSelection({ model });
+    const { topLevelSelection, topLevelHeader, handleSelection } = useJsObjectSelection({ model });
 
     return (
         <div className={styles.container}>
@@ -33,11 +65,7 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
                 <FrameworkContext.Provider value={framework}>
                     <OptionsDataContext.Provider value={optionsData}>
                         <div className={classNames(styles.referenceOuter, 'font-size-responsive')}>
-                            {heading && (
-                                <header>
-                                    <h1 className="font-size-gigantic">{heading}</h1>
-                                </header>
-                            )}
+                            <TopLevelHeader topLevelHeader={topLevelHeader} topLevelSelection={topLevelSelection} />
                             <JsObjectDetails selection={topLevelSelection} />
                         </div>
                     </OptionsDataContext.Provider>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { FunctionComponent } from 'react';
 import { JsObjectView } from './JsObjectView';
 import styles from './JsObjectProperties.module.scss';
@@ -25,11 +26,13 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
     return (
         <div className={styles.container}>
             <JsObjectPropertiesViewConfigContext.Provider value={config}>
-                <JsObjectView breadcrumbs={breadcrumbs} handleSelection={handleSelection} model={model} />
+                <div className={styles.objectViewOuter}>
+                    <JsObjectView breadcrumbs={breadcrumbs} handleSelection={handleSelection} model={model} />
+                </div>
 
                 <FrameworkContext.Provider value={framework}>
                     <OptionsDataContext.Provider value={optionsData}>
-                        <div className="font-size-responsive">
+                        <div className={classNames(styles.referenceOuter, 'font-size-responsive')}>
                             {heading && (
                                 <header>
                                     <h1 className="font-size-gigantic">{heading}</h1>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -28,7 +28,20 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
 
                 <FrameworkContext.Provider value={framework}>
                     <OptionsDataContext.Provider value={optionsData}>
-                        <JsObjectDetails selection={selection} />
+                        <div className="font-size-responsive">
+                            <header>
+                                <h1 className="font-size-gigantic">Options Reference</h1>
+                                <p className="font-size-extra-large">
+                                    A comprehensive interactive explorer for the <code>AgChartOptions</code> structure.
+                                </p>
+                            </header>
+
+                            <p className="font-size-large">
+                                Read more about how to use this structure in the <a href="#">Create/Update</a> section.
+                            </p>
+
+                            <JsObjectDetails selection={selection} />
+                        </div>
                     </OptionsDataContext.Provider>
                 </FrameworkContext.Provider>
             </JsObjectPropertiesViewConfigContext.Provider>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -21,7 +21,7 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
     framework,
 }) => {
     const model = buildModel(interfaceName, interfaceLookup, codeLookup);
-    const { selection, handleSelection } = useJsObjectSelection({ model });
+    const { topLevelSelection, handleSelection } = useJsObjectSelection({ model });
 
     return (
         <div className={styles.container}>
@@ -38,7 +38,7 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
                                     <h1 className="font-size-gigantic">{heading}</h1>
                                 </header>
                             )}
-                            <JsObjectDetails selection={selection} />
+                            <JsObjectDetails selection={topLevelSelection} />
                         </div>
                     </OptionsDataContext.Provider>
                 </FrameworkContext.Provider>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertiesView.tsx
@@ -10,6 +10,7 @@ import { JsObjectPropertiesViewConfigContext } from '../utils/jsObjectProperties
 import { FrameworkContext } from '../utils/frameworkContext';
 
 export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewProps> = ({
+    heading,
     interfaceName,
     breadcrumbs = [],
     codeLookup,
@@ -29,17 +30,11 @@ export const JsObjectPropertiesView: FunctionComponent<JsObjectPropertiesViewPro
                 <FrameworkContext.Provider value={framework}>
                     <OptionsDataContext.Provider value={optionsData}>
                         <div className="font-size-responsive">
-                            <header>
-                                <h1 className="font-size-gigantic">Options Reference</h1>
-                                <p className="font-size-extra-large">
-                                    A comprehensive interactive explorer for the <code>AgChartOptions</code> structure.
-                                </p>
-                            </header>
-
-                            <p className="font-size-large">
-                                Read more about how to use this structure in the <a href="#">Create/Update</a> section.
-                            </p>
-
+                            {heading && (
+                                <header>
+                                    <h1 className="font-size-gigantic">{heading}</h1>
+                                </header>
+                            )}
                             <JsObjectDetails selection={selection} />
                         </div>
                     </OptionsDataContext.Provider>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -1,17 +1,15 @@
 import classnames from 'classnames';
 import styles from './ApiDocumentation.module.scss';
-import { Icon } from '@components/icon/Icon';
 import {
     convertMarkdown,
-    formatJsDocString,
-    getFormattedDefaultValue,
+    formatPropertyDocumentation,
     removeDefaultValue,
     splitName,
 } from '../utils/documentationHelpers';
 import type { JsObjectSelection, JsObjectSelectionProperty, JsObjectSelectionUnionNestedObject } from '../types';
 import type { JsonArray, JsonModel, JsonModelProperty, JsonObjectProperty, JsonUnionType } from '../utils/model';
 import { getPropertyType } from '../utils/getPropertyType';
-import { createUnionNestedObjectPathItemRegex, getUnionPathInfo } from '../utils/modelPath';
+import { getUnionPathInfo } from '../utils/modelPath';
 import { getSelectionReferenceId } from '../utils/getObjectReferenceId';
 import { useContext } from 'react';
 import { OptionsDataContext } from '../utils/optionsDataContext';
@@ -19,40 +17,12 @@ import { JsObjectPropertiesViewConfigContext } from '../utils/jsObjectProperties
 import { FrameworkContext } from '../utils/frameworkContext';
 import { getExamplePageUrl } from '@features/docs/utils/urlPaths';
 import { LinkIcon } from '@components/link-icon/LinkIcon';
+import { HeadingPath } from './HeadingPath';
+import { MetaList } from './MetaList';
 
 interface Props {
     selection: JsObjectSelection;
     parentName?: string;
-}
-
-function HeadingPath({ path }: { path: string[] }) {
-    const regex = createUnionNestedObjectPathItemRegex();
-    return (
-        path.length > 0 && (
-            <span className={styles.parentProperties}>
-                {path.map((pathItem, index) => {
-                    const arrayDiscriminatorMatches = regex.exec(pathItem);
-                    const [_, preValue, value, postValue] = arrayDiscriminatorMatches || [];
-                    // Only show separator `.` at the front, when not the first and not an array discriminator afterwards
-                    const separator = index !== 0 && !arrayDiscriminatorMatches ? '.' : '';
-
-                    return (
-                        <span className={styles.noWrap} key={`${pathItem}-${index}`}>
-                            {separator}
-                            {!arrayDiscriminatorMatches && <>{pathItem}</>}
-                            {arrayDiscriminatorMatches && (
-                                <>
-                                    {preValue}
-                                    <span className={styles.unionDiscriminator}>{value}</span>
-                                    {postValue}
-                                </>
-                            )}
-                        </span>
-                    );
-                })}
-            </span>
-        )
-    );
 }
 
 function NameHeading({ id, name, path }: { id: string; name?: string; path: string[] }) {
@@ -100,47 +70,6 @@ function Actions({ propName }: { propName?: string }) {
             )}
         </div>
     );
-}
-
-function MetaList({
-    propertyType,
-    description,
-    model,
-}: {
-    propertyType: string;
-    description: string;
-    model: JsonModelProperty;
-}) {
-    const formattedDefaultValue = getFormattedDefaultValue({
-        model,
-        description,
-    });
-    return (
-        <div className={styles.metaList}>
-            <div title={propertyType} className={styles.metaItem}>
-                <span className={styles.metaLabel}>Type</span>
-                <span className={styles.metaValue}>{propertyType}</span>
-            </div>
-            {formattedDefaultValue != null && (
-                <div className={styles.metaItem}>
-                    <span className={styles.metaLabel}>Default</span>
-                    <span className={styles.metaValue}>{formattedDefaultValue}</span>
-                </div>
-            )}
-        </div>
-    );
-}
-
-function formatPropertyDocumentation(model: Omit<JsonModelProperty, 'desc'>): string[] {
-    const { documentation } = model;
-    const defaultValue = model.default;
-    const result: string[] = documentation?.trim() ? [formatJsDocString(documentation.trim())] : [];
-
-    if (Object.hasOwn(model, 'default')) {
-        result.push('Default: `' + JSON.stringify(defaultValue) + '`');
-    }
-
-    return result.filter((v) => !!v?.trim());
 }
 
 function PrimitivePropertyView({

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectPropertyView.tsx
@@ -18,6 +18,7 @@ import { OptionsDataContext } from '../utils/optionsDataContext';
 import { JsObjectPropertiesViewConfigContext } from '../utils/jsObjectPropertiesViewConfigContext';
 import { FrameworkContext } from '../utils/frameworkContext';
 import { getExamplePageUrl } from '@features/docs/utils/urlPaths';
+import { LinkIcon } from '@components/link-icon/LinkIcon';
 
 interface Props {
     selection: JsObjectSelection;
@@ -65,9 +66,7 @@ function NameHeading({ id, name, path }: { id: string; name?: string; path: stri
                 {pathSeparator}
                 {displayNameSplit && <span dangerouslySetInnerHTML={{ __html: displayNameSplit }}></span>}
             </span>
-            <a href={`#${id}`} className="docs-header-icon">
-                <Icon name="link" />
-            </a>
+            <LinkIcon href={`#${id}`} />
         </h6>
     );
 }

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
@@ -13,9 +13,33 @@ $indent: 24px;
     cursor: pointer;
 }
 
+.expandableSnippet,
+.expandableSnippet pre,
+.expandableSnippet pre > code {
+    --sticky-offset: 56px; // top bar height
+
+    min-height: calc(100vh - var(--sticky-offset));
+}
+
+.expandableSnippet {
+    position: sticky;
+    top: var(--sticky-offset);
+    width: 420px;
+    height: calc(100vh - var(--sticky-offset));
+    overflow-y: auto;
+}
+
+.expandableSnippet pre {
+    margin-bottom: 0;
+    border-radius: 0;
+    border: none;
+}
+
 .expandableSnippet pre > code {
     --code-line-height: calc(28 / 16);
 
+    padding-top: calc(var(--code-line-height) * 2 * 1em);
+    padding-bottom: calc(var(--code-line-height) * 4 * 1em);
     line-height: var(--code-line-height);
     background-size: 1px calc(1em * var(--code-line-height) * 2);
 }

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
@@ -13,6 +13,47 @@ $indent: 24px;
     cursor: pointer;
 }
 
+.expandableSnippet header {
+    position: sticky;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: $size-2;
+    background-color: var(--white);
+    z-index: 2;
+    border-bottom: 1px solid var(--platinum-gray);
+
+    h3 {
+        margin-bottom: 0;
+    }
+
+    p {
+        line-height: var(--line-height-tight);
+    }
+}
+
+.searchOuter {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+input[type='search'].searchInput {
+    padding-left: 2em;
+}
+
+.searchIcon {
+    --icon-size: 1.25em;
+    --text-color: var(--secondary-text-color);
+
+    position: absolute;
+    left: 0.625em;
+}
+
+.expandableSnippet input[type='search'] {
+    width: 100%;
+}
+
 .expandableSnippet,
 .expandableSnippet pre,
 .expandableSnippet pre > code {
@@ -38,7 +79,6 @@ $indent: 24px;
 .expandableSnippet pre > code {
     --code-line-height: calc(28 / 16);
 
-    padding-top: calc(var(--code-line-height) * 2 * 1em);
     padding-bottom: calc(var(--code-line-height) * 4 * 1em);
     line-height: var(--code-line-height);
     background-size: 1px calc(1em * var(--code-line-height) * 2);

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.module.scss
@@ -65,7 +65,7 @@ input[type='search'].searchInput {
 .expandableSnippet {
     position: sticky;
     top: var(--sticky-offset);
-    width: 420px;
+    width: 100%;
     height: calc(100vh - var(--sticky-offset));
     overflow-y: auto;
 }

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -15,7 +15,6 @@ import { Icon } from '@components/icon/Icon';
 import { getTopSelection, getUnionPathInfo } from '../utils/modelPath';
 import { TOP_LEVEL_OPTIONS_TO_HIDE_CHILDREN, UNION_DISCRIMINATOR_PROP } from '../constants';
 import { JsObjectPropertiesViewConfigContext } from '../utils/jsObjectPropertiesViewConfigContext';
-import { Icon } from '@components/icon/Icon';
 
 const SelectionContext = createContext<{ handleSelection?: JsObjectViewProps['handleSelection'] }>({});
 

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -15,6 +15,7 @@ import { Icon } from '@components/icon/Icon';
 import { getTopSelection, getUnionPathInfo } from '../utils/modelPath';
 import { TOP_LEVEL_OPTIONS_TO_HIDE_CHILDREN, UNION_DISCRIMINATOR_PROP } from '../constants';
 import { JsObjectPropertiesViewConfigContext } from '../utils/jsObjectPropertiesViewConfigContext';
+import { Icon } from '@components/icon/Icon';
 
 const SelectionContext = createContext<{ handleSelection?: JsObjectViewProps['handleSelection'] }>({});
 
@@ -46,6 +47,18 @@ export const JsObjectView: FunctionComponent<JsObjectViewProps> = ({ model, brea
     };
     return (
         <div className={styles.expandableSnippet} role="presentation">
+            <header>
+                <h3>Options Reference</h3>
+                <p className="text-secondary font-size-small">
+                    A comprehensive interactive explorer for the <b>AgChartOptions</b> structure.
+                </p>
+
+                <div className={styles.searchOuter}>
+                    <input className={styles.searchInput} type="search" placeholder="Search properties..." />
+                    <Icon svgClasses={styles.searchIcon} name={'search'} />
+                </div>
+            </header>
+
             <pre className={classnames('code', 'language-ts')}>
                 <code className={'language-ts'}>
                     <SelectionContext.Provider value={{ handleSelection }}>

--- a/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/JsObjectView.tsx
@@ -261,8 +261,11 @@ function UnionNestedObject({
                                 toggleExpand={toggleExpand}
                                 onSelection={handleUnionNestedObjectSelection}
                                 style="unionTypeProperty"
-                            />{' '}
-                            = <DiscriminatorType discriminatorType={discriminatorType} />
+                            />
+                            <span onClick={handleUnionNestedObjectSelection}>
+                                {' '}
+                                = <DiscriminatorType discriminatorType={discriminatorType} />
+                            </span>
                         </>
                     )}
                     {!isExpanded && <span className={classnames('token', 'punctuation')}>{closeWith}</span>}

--- a/packages/ag-charts-website/src/features/api-documentation/components/MetaList.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/MetaList.tsx
@@ -1,0 +1,32 @@
+import { getFormattedDefaultValue } from '../utils/documentationHelpers';
+import type { JsonModelProperty } from '../utils/model';
+import styles from './ApiDocumentation.module.scss';
+
+export function MetaList({
+    propertyType,
+    description,
+    model,
+}: {
+    propertyType: string;
+    description: string;
+    model: JsonModelProperty;
+}) {
+    const formattedDefaultValue = getFormattedDefaultValue({
+        model,
+        description,
+    });
+    return (
+        <div className={styles.metaList}>
+            <div title={propertyType} className={styles.metaItem}>
+                <span className={styles.metaLabel}>Type</span>
+                <span className={styles.metaValue}>{propertyType}</span>
+            </div>
+            {formattedDefaultValue != null && (
+                <div className={styles.metaItem}>
+                    <span className={styles.metaLabel}>Default</span>
+                    <span className={styles.metaValue}>{formattedDefaultValue}</span>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -243,6 +243,7 @@ interface JsSelectionBase {
     path: string[];
     model: JsonModelProperty;
     onlyShowToDepth?: number;
+    isRoot?: boolean;
 }
 
 export type JsModelSelectionProperty = JsSelectionBase & {

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -264,6 +264,14 @@ export type JsObjectSelection =
     | JsObjectSelectionProperty
     | JsObjectSelectionUnionNestedObject;
 
+export interface TopLevelHeaderData {
+    path: string[];
+    heading: string;
+    propertyType: string;
+    description: string;
+    descriptionWithoutDefault: string;
+}
+
 export interface JsObjectViewProps {
     model: JsonModel;
     breadcrumbs?: string[];
@@ -272,7 +280,6 @@ export interface JsObjectViewProps {
 }
 
 export interface JsObjectPropertiesViewProps {
-    heading: string;
     interfaceName: string;
     framework: Framework;
     breadcrumbs?: string[];

--- a/packages/ag-charts-website/src/features/api-documentation/types.d.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/types.d.ts
@@ -272,6 +272,7 @@ export interface JsObjectViewProps {
 }
 
 export interface JsObjectPropertiesViewProps {
+    heading: string;
     interfaceName: string;
     framework: Framework;
     breadcrumbs?: string[];

--- a/packages/ag-charts-website/src/features/api-documentation/utils/documentationHelpers.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/documentationHelpers.ts
@@ -468,3 +468,15 @@ export function splitName(name?: string) {
             return `${cv}<wbr />` + acc;
         });
 }
+
+export function formatPropertyDocumentation(model: Omit<JsonModelProperty, 'desc'>): string[] {
+    const { documentation } = model;
+    const defaultValue = model.default;
+    const result: string[] = documentation?.trim() ? [formatJsDocString(documentation.trim())] : [];
+
+    if (Object.hasOwn(model, 'default')) {
+        result.push('Default: `' + JSON.stringify(defaultValue) + '`');
+    }
+
+    return result.filter((v) => !!v?.trim());
+}

--- a/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/modelPath.ts
@@ -125,5 +125,6 @@ export function getTopSelection({
         path: [],
         model,
         onlyShowToDepth: hideChildren ? 0 : undefined,
+        isRoot: true,
     };
 }

--- a/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
@@ -17,7 +17,9 @@ function selectionHasChanged({
 }
 
 export function useJsObjectSelection({ model }: { model: JsonModel }) {
-    const [selection, setSelection] = useState<JsObjectSelection>(getTopSelection({ model, hideChildren: true }));
+    const [topLevelSelection, setTopLevelSelection] = useState<JsObjectSelection>(
+        getTopSelection({ model, hideChildren: true })
+    );
 
     const handleSelection = useCallback(
         (newSelection: JsObjectSelection) => {
@@ -39,15 +41,15 @@ export function useJsObjectSelection({ model }: { model: JsonModel }) {
                     newSelection.onlyShowToDepth === undefined
                         ? shouldLimitChildrenDepth
                         : newSelection.onlyShowToDepth;
-                setSelection({ ...newSelection, onlyShowToDepth });
+                setTopLevelSelection({ ...newSelection, onlyShowToDepth });
                 smoothScrollIntoView('#top');
             } else {
                 try {
                     const [newTopLevelPathItem] = newSelection.path;
-                    if (selectionHasChanged({ selection, newSelection })) {
+                    if (selectionHasChanged({ selection: topLevelSelection, newSelection })) {
                         const newTopLevelSelection = getTopLevelSelection({ selection: newSelection, model });
                         if (newTopLevelSelection) {
-                            setSelection(newTopLevelSelection);
+                            setTopLevelSelection(newTopLevelSelection);
                         } else {
                             // eslint-disable-next-line no-console
                             console.warn('No top level selection found:', {
@@ -66,15 +68,15 @@ export function useJsObjectSelection({ model }: { model: JsonModel }) {
                     }, 0);
                 } catch (error) {
                     // eslint-disable-next-line no-console
-                    console.warn(error, { selection, newSelection });
+                    console.warn(error, { topLevelSelection, newSelection });
                 }
             }
         },
-        [selection]
+        [topLevelSelection]
     );
 
     return {
-        selection,
+        topLevelSelection,
         handleSelection,
     };
 }

--- a/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
+++ b/packages/ag-charts-website/src/features/api-documentation/utils/useJsObjectSelection.ts
@@ -33,7 +33,6 @@ function scrollToId(id?: string) {
 const ROOT_HEADING = 'AgChartOptions'; // TODO: Get this from the data;
 function getTopLevelHeader(selection: JsObjectSelection): TopLevelHeaderData | undefined {
     const { type, path, model } = selection;
-    const isRoot = type === 'model' && path.length === 0;
     const description = formatPropertyDocumentation(model).join('\n');
     const descriptionWithoutDefault = removeDefaultValue(description);
     const output = {
@@ -42,7 +41,7 @@ function getTopLevelHeader(selection: JsObjectSelection): TopLevelHeaderData | u
         descriptionWithoutDefault,
     };
 
-    if (isRoot) {
+    if (selection.isRoot) {
         return Object.assign({}, output, {
             heading: ROOT_HEADING,
             propertyType: getPropertyType(model.tsType),

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -12,9 +12,6 @@ const codeLookup = getJsonFromDevFile('ag-charts-community/doc-interfaces.AUTO.j
 const optionsData = (await getEntry('options-reference', 'data')).data;
 
 const framework = Astro.params.framework as Framework;
-const { config: configString, breadcrumbs: breadcrumbsString, ...props } = Astro.props;
-const breadcrumbs = breadcrumbsString ? JSON.parse(breadcrumbsString) : undefined;
-const config = configString ? JSON.parse(configString) : undefined;
 
 const menuItems = [
     {
@@ -58,8 +55,7 @@ const interfaceName = 'AgCartesianChartOptions';
             interfaceName={interfaceName}
             interfaceLookup={interfaceLookup}
             codeLookup={codeLookup}
-            breadcrumbs={breadcrumbs}
-            config={config}
+            breadcrumbs={['options']}
             framework={framework}
             optionsData={optionsData}
         />

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -54,6 +54,7 @@ const interfaceName = 'AgCartesianChartOptions';
     <div class="container">
         <JsObjectPropertiesView
             client:load
+            heading="Options Reference"
             interfaceName={interfaceName}
             interfaceLookup={interfaceLookup}
             codeLookup={codeLookup}

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -1,0 +1,109 @@
+---
+import type { Framework } from '@ag-grid-types';
+import { JsObjectPropertiesView } from '@features/api-documentation/components/JsObjectPropertiesView';
+import Layout from '@layouts/Layout.astro';
+import { getJsonFromDevFile } from '@utils/getJsonFromDevFile';
+import { urlWithBaseUrl } from '@utils/pages';
+import { getEntry } from 'astro:content';
+
+const interfaceLookup = getJsonFromDevFile('ag-charts-community/interfaces.AUTO.json');
+const codeLookup = getJsonFromDevFile('ag-charts-community/doc-interfaces.AUTO.json');
+
+const optionsData = (await getEntry('options-reference', 'data')).data;
+
+const framework = Astro.params.framework as Framework;
+const { config: configString, breadcrumbs: breadcrumbsString, ...props } = Astro.props;
+const breadcrumbs = breadcrumbsString ? JSON.parse(breadcrumbsString) : undefined;
+const config = configString ? JSON.parse(configString) : undefined;
+
+const menuItems = [
+    {
+        name: 'Options API',
+        url: '/options',
+    },
+    {
+        name: 'Themes API',
+        url: '/theme',
+    },
+    {
+        name: 'API Explorer',
+        url: '/explorer',
+    },
+];
+
+// TODO: Use `AgChartOptions`
+const interfaceName = 'AgCartesianChartOptions';
+---
+
+<Layout>
+    <div class="topBar">
+        <div class="page-margin">
+            <ul class="topBarInner list-style-none">
+                {
+                    menuItems.map(({ name, url }) => {
+                        return (
+                            <li>
+                                <a href={urlWithBaseUrl(url)}>{name}</a>
+                            </li>
+                        );
+                    })
+                }
+            </ul>
+        </div>
+    </div>
+    <div class="container">
+        <!-- TODO: Remove `client:only` -->
+        <JsObjectPropertiesView
+            client:only
+            interfaceName={interfaceName}
+            interfaceLookup={interfaceLookup}
+            codeLookup={codeLookup}
+            breadcrumbs={breadcrumbs}
+            config={config}
+            framework={framework}
+            optionsData={optionsData}
+        />
+    </div>
+</Layout>
+
+<style lang="scss">
+    @use '../design-system' as *;
+
+    .container {
+        --horizontal-padding: max(calc((100vw - var(--max-page-width)) / 2), var(--horizontal-margin));
+        --menu-width: 14rem;
+        --gallery-list-gap: #{$size-3};
+
+        display: flex;
+        flex-direction: row;
+        position: relative;
+    }
+
+    .topBar {
+        background-color: var(--toolbar-background);
+        border-bottom: 1px solid var(--border-color);
+
+        @media screen and (min-width: $breakpoint-docs-nav-medium) {
+            position: sticky;
+            top: 0;
+            z-index: 3;
+        }
+    }
+
+    .topBarInner {
+        position: relative;
+        display: flex;
+        flex-wrap: wrap;
+        gap: $size-1;
+        padding-top: $size-1;
+        padding-bottom: $size-1;
+
+        gap: $size-3;
+    }
+
+    .menu {
+    }
+
+    .content {
+    }
+</style>

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -91,7 +91,7 @@ const interfaceName = 'AgCartesianChartOptions';
             </label>
         </div>
     </div>
-    <div class="container">
+    <div id="top" class="container">
         <JsObjectPropertiesView
             client:load
             heading="AgChartOptions"

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -52,9 +52,8 @@ const interfaceName = 'AgCartesianChartOptions';
         </div>
     </div>
     <div class="container">
-        <!-- TODO: Remove `client:only` -->
         <JsObjectPropertiesView
-            client:only
+            client:load
             interfaceName={interfaceName}
             interfaceLookup={interfaceLookup}
             codeLookup={codeLookup}

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -92,7 +92,7 @@ const interfaceName = 'AgCartesianChartOptions';
     <div class="container">
         <JsObjectPropertiesView
             client:load
-            heading="Options Reference"
+            heading="AgChartOptions"
             interfaceName={interfaceName}
             interfaceLookup={interfaceLookup}
             codeLookup={codeLookup}

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -94,7 +94,6 @@ const interfaceName = 'AgCartesianChartOptions';
     <div id="top" class="container">
         <JsObjectPropertiesView
             client:load
-            heading="AgChartOptions"
             interfaceName={interfaceName}
             interfaceLookup={interfaceLookup}
             codeLookup={codeLookup}

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -17,6 +17,7 @@ const menuItems = [
     {
         name: 'Options API',
         url: '/options',
+        active: true,
     },
     {
         name: 'Themes API',
@@ -67,9 +68,9 @@ const interfaceName = 'AgCartesianChartOptions';
             <nav>
                 <ul class="list-style-none">
                     {
-                        menuItems.map(({ name, url }) => {
+                        menuItems.map(({ name, url, active }) => {
                             return (
-                                <li>
+                                <li class={active ? 'active' : ''}>
                                     <a href={urlWithBaseUrl(url)}>{name}</a>
                                 </li>
                             );
@@ -77,8 +78,9 @@ const interfaceName = 'AgCartesianChartOptions';
                     }
                 </ul>
             </nav>
-            <label
-                >Series:
+            <label>
+                <span class="text-secondary">Series:</span>
+
                 <select>
                     {
                         dummySeries.map((series) => {
@@ -137,6 +139,43 @@ const interfaceName = 'AgCartesianChartOptions';
 
     nav ul {
         display: flex;
-        gap: $size-3;
+        gap: $size-4;
+    }
+
+    nav li {
+        position: relative;
+
+        &::before {
+            content: '';
+            position: absolute;
+            width: 100%;
+            height: 2px;
+            left: 0;
+            bottom: -2px;
+            border-radius: 1px;
+            background-color: var(--link-color);
+            opacity: 0;
+            transform: scaleX(0);
+            transition: transform 0.33s ease-in-out, opacity 0.33s ease-in-out;
+        }
+
+        &:hover::before {
+            opacity: 0.4;
+            transform: scaleX(1);
+        }
+
+        &.active::before {
+            opacity: 1;
+            transform: scaleX(1);
+        }
+    }
+
+    nav a {
+        display: block;
+        font-weight: 500;
+
+        &:hover {
+            color: var(--link-color);
+        }
     }
 </style>

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -28,24 +28,65 @@ const menuItems = [
     },
 ];
 
+const dummySeries = [
+    'All',
+    'Bar',
+    'Column',
+    'Line',
+    'Area',
+    'Scatter',
+    'Bubble',
+    'Pie',
+    'Donut',
+    'Combination',
+    'Histogram',
+    'Heatmap',
+    'Range',
+    'Box Plot',
+    'Error Bar',
+    'Waterfall',
+    'Radar',
+    'Nightingale',
+    'Radial Column',
+    'Radial Bar',
+    'Treemap',
+    'Sunburst',
+    'Icicle',
+    'Funnel',
+    'Pyramid',
+    'Bullet',
+];
+
 // TODO: Use `AgChartOptions`
 const interfaceName = 'AgCartesianChartOptions';
 ---
 
 <Layout>
     <div class="topBar">
-        <div class="page-margin">
-            <ul class="topBarInner list-style-none">
-                {
-                    menuItems.map(({ name, url }) => {
-                        return (
-                            <li>
-                                <a href={urlWithBaseUrl(url)}>{name}</a>
-                            </li>
-                        );
-                    })
-                }
-            </ul>
+        <div class="topBarInner page-margin">
+            <nav>
+                <ul class="list-style-none">
+                    {
+                        menuItems.map(({ name, url }) => {
+                            return (
+                                <li>
+                                    <a href={urlWithBaseUrl(url)}>{name}</a>
+                                </li>
+                            );
+                        })
+                    }
+                </ul>
+            </nav>
+            <label
+                >Series:
+                <select>
+                    {
+                        dummySeries.map((series) => {
+                            return <option>{series}</option>;
+                        })
+                    };
+                </select>
+            </label>
         </div>
     </div>
     <div class="container">
@@ -87,19 +128,15 @@ const interfaceName = 'AgCartesianChartOptions';
     }
 
     .topBarInner {
-        position: relative;
         display: flex;
-        flex-wrap: wrap;
-        gap: $size-1;
+        justify-content: space-between;
+        align-items: center;
         padding-top: $size-1;
         padding-bottom: $size-1;
+    }
 
+    nav ul {
+        display: flex;
         gap: $size-3;
-    }
-
-    .menu {
-    }
-
-    .content {
     }
 </style>


### PR DESCRIPTION
## Changes

* Add options reference page (`/options`) with full screen view
  * Add dummy secondary nav
  * Add dummy search box
  * Add series selection box
  * Add header section that shows the top property
* Allow discriminator value to be clicked on, to expand

## Screenshot

![Screenshot 2023-09-13 at 12 23 02 pm](https://github.com/ag-grid/ag-charts/assets/79451/c5da7181-0eb0-414c-8742-10ce50ca0ad0)
