### PR TITLE
AG-8564 Remove delay from axis and bar animations

### DIFF
--- a/packages/ag-charts-community/src/axis.ts
+++ b/packages/ag-charts-community/src/axis.ts
@@ -1449,8 +1449,6 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         }
 
         const { gridLineGroupSelection, tickLineGroupSelection, tickLabelGroupSelection } = this;
-
-        const addedCount = Object.keys(diff.added).length;
         const removedCount = Object.keys(diff.removed).length;
 
         if (removedCount === diff.tickCount) {
@@ -1458,35 +1456,22 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             return;
         }
 
-        const totalDuration = this.animationManager.defaultDuration();
-        let sectionDuration = Math.floor(totalDuration / 2);
-        if (addedCount > 0 && removedCount > 0) {
-            sectionDuration = Math.floor(totalDuration / 3);
-        }
-        const options = {
-            delay: removedCount > 0 ? sectionDuration : 0,
-            duration: sectionDuration,
-        };
-
         const animationGroup = `${this.id}_${Math.random()}`;
 
         tickLabelGroupSelection.each((node, datum) => {
-            this.animateSelectionNode(tickLabelGroupSelection, diff, options, node, datum, animationGroup);
+            this.animateSelectionNode(tickLabelGroupSelection, diff, node, datum, animationGroup);
         });
-
         gridLineGroupSelection.each((node, datum) => {
-            this.animateSelectionNode(gridLineGroupSelection, diff, options, node, datum, animationGroup);
+            this.animateSelectionNode(gridLineGroupSelection, diff, node, datum, animationGroup);
         });
-
         tickLineGroupSelection.each((node, datum) => {
-            this.animateSelectionNode(tickLineGroupSelection, diff, options, node, datum, animationGroup);
+            this.animateSelectionNode(tickLineGroupSelection, diff, node, datum, animationGroup);
         });
     }
 
     private animateSelectionNode(
         selection: Selection<Text | Line, any>,
         diff: AxisUpdateDiff,
-        options: { delay: number; duration: number },
         node: Text | Line,
         datum: TickDatum,
         animationGroup: string
@@ -1495,24 +1480,19 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         let translate = { from: node.translationY, to: roundedTranslationY };
         let opacity = { from: 1, to: 1 };
 
-        const { duration } = options;
-        let { delay } = options;
-
         const datumId = datum.tickLabel;
         if (diff.added[datumId]) {
             translate = { from: roundedTranslationY, to: roundedTranslationY };
             opacity = { from: 0, to: 1 };
-            delay += duration;
         } else if (diff.removed[datumId]) {
             opacity = { from: 1, to: 0 };
-            delay = 0;
         }
 
+        const duration = this.animationManager.defaultDuration();
         const props = [translate, opacity];
 
         this.animationManager.animateManyWithThrottle(`${this.id}_ready-update_${node.id}`, props, {
             disableInteractions: false,
-            delay,
             duration,
             ease: easing.easeOut,
             throttleId: this.id,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -716,13 +716,8 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
             return;
         }
 
-        const totalDuration = this.ctx.animationManager.defaultDuration();
+        const duration = this.ctx.animationManager.defaultDuration();
         const labelDuration = 200;
-
-        let sectionDuration = totalDuration;
-        if (diff.added.length > 0 || diff.removed.length > 0) {
-            sectionDuration = Math.floor(totalDuration / 2);
-        }
 
         const { startingX, startingY } = this.getDirectionStartingValues(datumSelections);
 
@@ -740,8 +735,6 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                     { from: rect.y, to: datum.y },
                     { from: rect.height, to: datum.height },
                 ];
-                let delay = diff.removed.length > 0 ? sectionDuration : 0;
-                const duration = sectionDuration;
                 let cleanup = false;
 
                 let contextX = startingX;
@@ -773,12 +766,10 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                         { from: datum.y, to: contextY },
                         { from: datum.height, to: contextHeight },
                     ];
-                    delay = 0;
                     cleanup = true;
                 }
 
                 this.ctx.animationManager.animateManyWithThrottle(`${this.id}_waiting-update-ready_${rect.id}`, props, {
-                    delay,
                     duration,
                     ease: easing.easeOut,
                     throttleId: `${this.id}_rects`,
@@ -803,7 +794,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
                 this.ctx.animationManager.animateWithThrottle(`${this.id}_waiting-update-ready_${label.id}`, {
                     from: 0,
                     to: 1,
-                    delay: totalDuration,
+                    delay: duration,
                     duration: labelDuration,
                     throttleId: `${this.id}_labels`,
                     throttleGroup: labelThrottleGroup,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8564

This makes bar series consistent with the other series and prevents any complications around axis being different for each series.

https://github.com/ag-grid/ag-charts/assets/3817697/ad2980df-214c-472a-a04c-ace8334bbd0d

