### PR TITLE
AG-9212 - Add missing theme override common options.

### DIFF
--- a/packages/ag-charts-community/src/chart/themes/chartTheme.test.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.test.ts
@@ -66,6 +66,8 @@ describe('ChartTheme', () => {
                         //     height: 20,
                         // },
                     },
+                    // Special cases, as they are in 'common' but only apply to cartesian charts.
+                    navigator: {},
                 },
                 bar: {
                     series: {
@@ -227,6 +229,10 @@ describe('ChartTheme', () => {
                 strokes: ['cyan'],
             },
             overrides: {
+                common: {
+                    // Special cases, as they are in 'common' but only apply to cartesian charts.
+                    navigator: {},
+                },
                 pie: {
                     title: {
                         fontSize: 24,
@@ -318,6 +324,8 @@ describe('ChartTheme', () => {
                     background: {
                         fill: 'red',
                     },
+                    // Special cases, as they are in 'common' but only apply to cartesian charts.
+                    navigator: {},
                 },
                 bar: {
                     series: {

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -10,6 +10,7 @@ import type {
     InteractionRange,
     AgTooltipPositionType,
     AgChartTheme,
+    AgCommonThemeableChartOptions,
 } from '../../options/agChartOptions';
 import { AXIS_TYPES, getAxisThemeTemplate } from '../factory/axisTypes';
 import { CHART_TYPES, type ChartType, getChartDefaults } from '../factory/chartTypes';
@@ -37,6 +38,21 @@ export const DEFAULT_TREEMAP_TILE_BORDER_COLOUR = Symbol('default-treemap-tile-b
 const BOLD: FontWeight = 'bold';
 const INSIDE: AgBarSeriesLabelOptions['placement'] = 'inside';
 const BOTTOM: AgChartLegendPosition = 'bottom';
+
+type ChartTypeConfig = {
+    seriesTypes: string[];
+    commonOptions: (keyof AgCommonThemeableChartOptions)[];
+};
+const CHART_TYPE_CONFIG: { [k in ChartType]: ChartTypeConfig } = {
+    cartesian: { seriesTypes: CHART_TYPES.cartesianTypes, commonOptions: ['zoom', 'navigator'] },
+    polar: { seriesTypes: CHART_TYPES.polarTypes, commonOptions: [] },
+    hierarchy: { seriesTypes: CHART_TYPES.hierarchyTypes, commonOptions: [] },
+};
+const CHART_TYPE_SPECIFIC_COMMON_OPTIONS = Object.values(CHART_TYPE_CONFIG).reduce(
+    (r, { commonOptions }) => [...r, ...commonOptions],
+    [] as (keyof AgCommonThemeableChartOptions)[]
+);
+
 export class ChartTheme {
     readonly palette: AgChartThemePalette;
 
@@ -628,7 +644,15 @@ export class ChartTheme {
                     defaults[seriesType] = deepMerge(defaults[seriesType], overrideOpts);
                 }
             };
-            applyOverrides(CHART_TYPES.seriesTypes, common);
+            for (const [, { seriesTypes, commonOptions }] of Object.entries(CHART_TYPE_CONFIG)) {
+                const cleanedCommon = { ...common };
+                for (const commonKey of CHART_TYPE_SPECIFIC_COMMON_OPTIONS) {
+                    if (!commonOptions.includes(commonKey)) {
+                        delete cleanedCommon[commonKey];
+                    }
+                }
+                applyOverrides(seriesTypes, cleanedCommon);
+            }
 
             CHART_TYPES.seriesTypes.forEach((s) => {
                 const seriesType = s as keyof AgChartThemeOverrides;
@@ -643,17 +667,10 @@ export class ChartTheme {
     }
 
     private createChartConfigPerChartType(config: AgChartThemeOverrides) {
-        const typeToAliases = {
-            cartesian: CHART_TYPES.cartesianTypes,
-            polar: CHART_TYPES.polarTypes,
-            hierarchy: CHART_TYPES.hierarchyTypes,
-            groupedCategory: [],
-        };
-        Object.entries(typeToAliases).forEach(([nextType, aliases]) => {
-            const type = nextType as ChartType;
-            const typeDefaults = getChartDefaults(type) as any;
+        Object.entries(CHART_TYPE_CONFIG).forEach(([nextType, { seriesTypes }]) => {
+            const typeDefaults = getChartDefaults(nextType as ChartType) as any;
 
-            aliases.forEach((next) => {
+            seriesTypes.forEach((next) => {
                 const alias = next as keyof AgChartThemeOverrides;
                 if (!config[alias]) {
                     config[alias] = {};

--- a/packages/ag-charts-community/src/options/options/chartOptions.ts
+++ b/packages/ag-charts-community/src/options/options/chartOptions.ts
@@ -3,8 +3,10 @@ import type { AgAnimationOptions } from '../interaction/animationOptions';
 import type { AgContextMenuOptions } from './contextOptions';
 import type { AgBaseChartListeners } from './eventOptions';
 import type { AgChartLegendOptions } from './legendOptions';
+import type { AgNavigatorOptions } from './navigatorOptions';
 import type { AgChartTooltipOptions } from './tooltipOptions';
 import type { CssColor, FontFamily, FontSize, FontStyle, FontWeight, PixelSize, TextWrap } from './types';
+import type { AgZoomOptions } from './zoomOptions';
 
 export interface AgChartPaddingOptions {
     /** The number of pixels of padding at the top of the chart area. */
@@ -119,6 +121,10 @@ export interface AgBaseThemeableChartOptions {
     legend?: AgChartLegendOptions;
     animation?: AgAnimationOptions;
     contextMenu?: AgContextMenuOptions;
+
+    // Cartesian-specific options - special care required.
+    zoom?: AgZoomOptions;
+    navigator?: AgNavigatorOptions;
 }
 
 /** Configuration common to all charts.  */

--- a/packages/ag-charts-community/src/options/series/cartesian/cartesianOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/cartesianOptions.ts
@@ -10,9 +10,7 @@ import type {
     AgCrossLineLabelPosition,
     AgCrossLineThemeOptions,
 } from '../../options/crossLineOptions';
-import type { AgNavigatorOptions } from '../../options/navigatorOptions';
 import type { PixelSize, Ratio } from '../../options/types';
-import type { AgZoomOptions } from '../../options/zoomOptions';
 import type { AgCrosshairOptions } from '../../options/crosshairOptions';
 import type { AgCartesianSeriesOptions } from './cartesianSeriesTypes';
 import type { AgBaseThemeableChartOptions } from '../../options/chartOptions';
@@ -43,9 +41,6 @@ export interface AgBaseCartesianChartOptions {
     axes?: AgCartesianAxisOptions[];
     /** Series configurations. */
     series?: AgCartesianSeriesOptions[];
-
-    /** Configuration for zoom. */
-    zoom?: AgZoomOptions;
 }
 
 export interface AgNumberAxisOptions extends AgBaseCartesianAxisOptions {
@@ -137,8 +132,6 @@ export interface AgCartesianAxisThemeOptions<T> {
 export interface AgBaseCartesianThemeOptions extends AgBaseThemeableChartOptions {
     /** Axis configurations. */
     axes?: AgCartesianAxesTheme;
-    /** Configuration for the chart navigator. */
-    navigator?: AgNavigatorOptions;
 }
 
 export interface AgCartesianAxesCrossLineThemeOptions {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9212

Adds missing cartesian-specific chart-level options to the theme overrides `common` config structure.

These require special handling, as polar + hierarchy charts should never have these configured (they current console.warn() in the latest `8.1.0` release too).