### PR TITLE
AG-9212 - Improve SeriesModule and theme typings

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
@@ -85,7 +85,7 @@ export function processSeriesOptions(_opts: AgChartOptions, seriesOptions: Serie
 
     const preprocessed = seriesOptions.map((series: SeriesOptions & { stacked?: boolean; grouped?: boolean }) => {
         // Change the default for bar/columns when yKey is used to be grouped rather than stacked.
-        const sType = series.type ?? 'line';
+        const sType = series.type ?? '';
         const groupable = isGroupableSeries(sType);
         const stackable = isStackableSeries(sType);
         const stackedByDefault = isSeriesStackedByDefault(sType);

--- a/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
@@ -85,7 +85,7 @@ export function processSeriesOptions(_opts: AgChartOptions, seriesOptions: Serie
 
     const preprocessed = seriesOptions.map((series: SeriesOptions & { stacked?: boolean; grouped?: boolean }) => {
         // Change the default for bar/columns when yKey is used to be grouped rather than stacked.
-        const sType = series.type ?? '';
+        const sType = series.type ?? 'line';
         const groupable = isGroupableSeries(sType);
         const stackable = isStackableSeries(sType);
         const stackedByDefault = isSeriesStackedByDefault(sType);
@@ -171,7 +171,7 @@ export function processSeriesOptions(_opts: AgChartOptions, seriesOptions: Serie
     }
 
     for (const group of grouped) {
-        const seriesType = String(group.opts[0].type);
+        const seriesType = group.opts[0].type ?? 'line';
         if (isGroupableSeries(seriesType) || isStackableSeries(seriesType)) {
             result.push(...addSeriesGroupingMeta(group));
         } else {

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -21,19 +21,19 @@ const palette: AgChartThemePalette = {
     strokes: ['#aa4520', '#b07513', '#3d803d', '#2d768d', '#2e3e8d', '#6c2e8c', '#8c2d46', '#5f5f5f'],
 };
 
-export const EXTENDS_AXES_DEFAULTS = Symbol('extends-axes-defaults');
-export const EXTENDS_AXES_LABEL_DEFAULTS = Symbol('extends-axes-label-defaults');
-export const EXTENDS_AXES_LINE_DEFAULTS = Symbol('extends-axes-line-defaults');
-export const EXTENDS_AXES_TICK_DEFAULTS = Symbol('extends-axes-tick-defaults');
-export const EXTENDS_SERIES_DEFAULTS = Symbol('extends-series-defaults');
-export const OVERRIDE_SERIES_LABEL_DEFAULTS = Symbol('override-series-label-defaults');
-export const DEFAULT_FONT_FAMILY = Symbol('default-font');
-export const DEFAULT_LABEL_COLOUR = Symbol('default-label-colour');
-export const DEFAULT_MUTED_LABEL_COLOUR = Symbol('default-muted-label-colour');
-export const DEFAULT_AXIS_GRID_COLOUR = Symbol('default-axis-grid-colour');
-export const DEFAULT_BACKGROUND_COLOUR = Symbol('default-background-colour');
-export const DEFAULT_SHADOW_COLOUR = Symbol('default-shadow-colour');
-export const DEFAULT_TREEMAP_TILE_BORDER_COLOUR = Symbol('default-treemap-tile-border-colour');
+export const EXTENDS_AXES_DEFAULTS = Symbol('extends-axes-defaults') as unknown as string;
+export const EXTENDS_AXES_LABEL_DEFAULTS = Symbol('extends-axes-label-defaults') as unknown as string;
+export const EXTENDS_AXES_LINE_DEFAULTS = Symbol('extends-axes-line-defaults') as unknown as string;
+export const EXTENDS_AXES_TICK_DEFAULTS = Symbol('extends-axes-tick-defaults') as unknown as string;
+export const EXTENDS_SERIES_DEFAULTS = Symbol('extends-series-defaults') as unknown as string;
+export const OVERRIDE_SERIES_LABEL_DEFAULTS = Symbol('override-series-label-defaults') as unknown as string;
+export const DEFAULT_FONT_FAMILY = Symbol('default-font') as unknown as string;
+export const DEFAULT_LABEL_COLOUR = Symbol('default-label-colour') as unknown as string;
+export const DEFAULT_MUTED_LABEL_COLOUR = Symbol('default-muted-label-colour') as unknown as string;
+export const DEFAULT_AXIS_GRID_COLOUR = Symbol('default-axis-grid-colour') as unknown as string;
+export const DEFAULT_BACKGROUND_COLOUR = Symbol('default-background-colour') as unknown as string;
+export const DEFAULT_SHADOW_COLOUR = Symbol('default-shadow-colour') as unknown as string;
+export const DEFAULT_TREEMAP_TILE_BORDER_COLOUR = Symbol('default-treemap-tile-border-colour') as unknown as string;
 
 const BOLD: FontWeight = 'bold';
 const INSIDE: AgBarSeriesLabelOptions['placement'] = 'inside';
@@ -74,17 +74,17 @@ export class ChartTheme {
                 fontStyle: undefined,
                 fontWeight: BOLD,
                 fontSize: 12,
-                fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                color: DEFAULT_LABEL_COLOUR as unknown as string,
+                fontFamily: DEFAULT_FONT_FAMILY,
+                color: DEFAULT_LABEL_COLOUR,
             },
             label: {
                 fontStyle: undefined,
                 fontWeight: undefined,
                 fontSize: 12,
-                fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
+                fontFamily: DEFAULT_FONT_FAMILY,
                 padding: 5,
                 rotation: undefined,
-                color: DEFAULT_LABEL_COLOUR as unknown as string,
+                color: DEFAULT_LABEL_COLOUR,
                 formatter: undefined,
                 avoidCollisions: true,
             },
@@ -99,7 +99,7 @@ export class ChartTheme {
             },
             gridStyle: [
                 {
-                    stroke: DEFAULT_AXIS_GRID_COLOUR as unknown as string,
+                    stroke: DEFAULT_AXIS_GRID_COLOUR,
                     lineDash: [4, 2],
                 },
             ],
@@ -113,9 +113,9 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
                     padding: 5,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    color: DEFAULT_LABEL_COLOUR,
                 },
             },
         };
@@ -234,7 +234,7 @@ export class ChartTheme {
         return {
             background: {
                 visible: true,
-                fill: DEFAULT_BACKGROUND_COLOUR as unknown as string,
+                fill: DEFAULT_BACKGROUND_COLOUR,
             },
             padding: {
                 top: 20,
@@ -248,8 +248,8 @@ export class ChartTheme {
                 fontStyle: undefined,
                 fontWeight: BOLD,
                 fontSize: 16,
-                fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                color: DEFAULT_LABEL_COLOUR as unknown as string,
+                fontFamily: DEFAULT_FONT_FAMILY,
+                color: DEFAULT_LABEL_COLOUR,
                 wrapping: ChartTheme.getCaptionWrappingDefaults(),
             },
             subtitle: {
@@ -258,8 +258,8 @@ export class ChartTheme {
                 fontStyle: undefined,
                 fontWeight: undefined,
                 fontSize: 12,
-                fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                color: DEFAULT_MUTED_LABEL_COLOUR as unknown as string,
+                fontFamily: DEFAULT_FONT_FAMILY,
+                color: DEFAULT_MUTED_LABEL_COLOUR,
                 wrapping: ChartTheme.getCaptionWrappingDefaults(),
             },
             footnote: {
@@ -268,7 +268,7 @@ export class ChartTheme {
                 fontStyle: undefined,
                 fontWeight: undefined,
                 fontSize: 12,
-                fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
+                fontFamily: DEFAULT_FONT_FAMILY,
                 color: 'rgb(140, 140, 140)',
                 spacing: 30,
                 wrapping: ChartTheme.getCaptionWrappingDefaults(),
@@ -287,11 +287,11 @@ export class ChartTheme {
                         padding: 8,
                     },
                     label: {
-                        color: DEFAULT_LABEL_COLOUR as unknown as string,
+                        color: DEFAULT_LABEL_COLOUR,
                         fontStyle: undefined,
                         fontWeight: undefined,
                         fontSize: 12,
-                        fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
+                        fontFamily: DEFAULT_FONT_FAMILY,
                         formatter: undefined,
                     },
                 },
@@ -301,16 +301,16 @@ export class ChartTheme {
                         size: 12,
                     },
                     activeStyle: {
-                        fill: DEFAULT_LABEL_COLOUR as unknown as string,
+                        fill: DEFAULT_LABEL_COLOUR,
                     },
                     inactiveStyle: {
-                        fill: DEFAULT_MUTED_LABEL_COLOUR as unknown as string,
+                        fill: DEFAULT_MUTED_LABEL_COLOUR,
                     },
                     highlightStyle: {
-                        fill: DEFAULT_LABEL_COLOUR as unknown as string,
+                        fill: DEFAULT_LABEL_COLOUR,
                     },
                     label: {
-                        color: DEFAULT_LABEL_COLOUR as unknown as string,
+                        color: DEFAULT_LABEL_COLOUR,
                     },
                 },
             },
@@ -374,8 +374,8 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                     formatter: undefined,
                 },
             },
@@ -393,8 +393,8 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                 },
             },
         },
@@ -410,7 +410,7 @@ export class ChartTheme {
                 lineDashOffset: 0,
                 shadow: {
                     enabled: false,
-                    color: DEFAULT_SHADOW_COLOUR as unknown as string,
+                    color: DEFAULT_SHADOW_COLOUR,
                     xOffset: 3,
                     yOffset: 3,
                     blur: 5,
@@ -426,8 +426,8 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                     formatter: undefined,
                 },
             },
@@ -447,13 +447,13 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                     formatter: undefined,
                 },
                 shadow: {
                     enabled: true,
-                    color: DEFAULT_SHADOW_COLOUR as unknown as string,
+                    color: DEFAULT_SHADOW_COLOUR,
                     xOffset: 0,
                     yOffset: 0,
                     blur: 5,
@@ -472,8 +472,8 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: BOLD,
                     fontSize: 14,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                     spacing: 0,
                 },
                 calloutLabel: {
@@ -481,8 +481,8 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                     offset: 3,
                     minAngle: 0,
                 },
@@ -491,8 +491,8 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                     positionOffset: 0,
                     positionRatio: 0.5,
                 },
@@ -510,7 +510,7 @@ export class ChartTheme {
                 innerRadiusOffset: 0,
                 shadow: {
                     enabled: false,
-                    color: DEFAULT_SHADOW_COLOUR as unknown as string,
+                    color: DEFAULT_SHADOW_COLOUR,
                     xOffset: 3,
                     yOffset: 3,
                     blur: 5,
@@ -519,8 +519,8 @@ export class ChartTheme {
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
+                    color: DEFAULT_LABEL_COLOUR,
                     margin: 2,
                 },
             },
@@ -536,14 +536,14 @@ export class ChartTheme {
                 colorDomain: [-5, 5],
                 colorRange: ['#cb4b3f', '#6acb64'],
                 groupFill: '#272931',
-                groupStroke: DEFAULT_TREEMAP_TILE_BORDER_COLOUR as unknown as string,
+                groupStroke: DEFAULT_TREEMAP_TILE_BORDER_COLOUR,
                 groupStrokeWidth: 1,
-                tileStroke: DEFAULT_TREEMAP_TILE_BORDER_COLOUR as unknown as string,
+                tileStroke: DEFAULT_TREEMAP_TILE_BORDER_COLOUR,
                 tileStrokeWidth: 1,
                 gradient: true,
                 tileShadow: {
                     enabled: false,
-                    color: DEFAULT_SHADOW_COLOUR as unknown as string,
+                    color: DEFAULT_SHADOW_COLOUR,
                     xOffset: 3,
                     yOffset: 3,
                     blur: 5,
@@ -560,20 +560,20 @@ export class ChartTheme {
                 nodeGap: 0,
                 title: {
                     enabled: true,
-                    color: DEFAULT_LABEL_COLOUR as unknown as string,
+                    color: DEFAULT_LABEL_COLOUR,
                     fontStyle: undefined,
                     fontWeight: BOLD,
                     fontSize: 12,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
                     padding: 2,
                 },
                 subtitle: {
                     enabled: true,
-                    color: DEFAULT_MUTED_LABEL_COLOUR as unknown as string,
+                    color: DEFAULT_MUTED_LABEL_COLOUR,
                     fontStyle: undefined,
                     fontWeight: undefined,
                     fontSize: 9,
-                    fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
+                    fontFamily: DEFAULT_FONT_FAMILY,
                     padding: 2,
                 },
                 labels: {
@@ -582,8 +582,8 @@ export class ChartTheme {
                         fontStyle: undefined,
                         fontWeight: BOLD,
                         fontSize: 18,
-                        fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                        color: DEFAULT_LABEL_COLOUR as unknown as string,
+                        fontFamily: DEFAULT_FONT_FAMILY,
+                        color: DEFAULT_LABEL_COLOUR,
                         wrapping: 'on-space',
                     },
                     medium: {
@@ -591,8 +591,8 @@ export class ChartTheme {
                         fontStyle: undefined,
                         fontWeight: BOLD,
                         fontSize: 14,
-                        fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                        color: DEFAULT_LABEL_COLOUR as unknown as string,
+                        fontFamily: DEFAULT_FONT_FAMILY,
+                        color: DEFAULT_LABEL_COLOUR,
                         wrapping: 'on-space',
                     },
                     small: {
@@ -600,8 +600,8 @@ export class ChartTheme {
                         fontStyle: undefined,
                         fontWeight: BOLD,
                         fontSize: 10,
-                        fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                        color: DEFAULT_LABEL_COLOUR as unknown as string,
+                        fontFamily: DEFAULT_FONT_FAMILY,
+                        color: DEFAULT_LABEL_COLOUR,
                         wrapping: 'on-space',
                     },
                     value: {
@@ -610,8 +610,8 @@ export class ChartTheme {
                             fontStyle: undefined,
                             fontWeight: undefined,
                             fontSize: 12,
-                            fontFamily: DEFAULT_FONT_FAMILY as unknown as string,
-                            color: DEFAULT_LABEL_COLOUR as unknown as string,
+                            fontFamily: DEFAULT_FONT_FAMILY,
+                            color: DEFAULT_LABEL_COLOUR,
                         },
                     },
                 },
@@ -779,7 +779,7 @@ export class ChartTheme {
         extensions.set(OVERRIDE_SERIES_LABEL_DEFAULTS, {});
 
         const properties = new Map();
-        properties.set(DEFAULT_FONT_FAMILY as unknown as string, 'Verdana, sans-serif');
+        properties.set(DEFAULT_FONT_FAMILY, 'Verdana, sans-serif');
         properties.set(DEFAULT_LABEL_COLOUR, 'rgb(70, 70, 70)');
         properties.set(DEFAULT_MUTED_LABEL_COLOUR, 'rgb(140, 140, 140)');
         properties.set(DEFAULT_AXIS_GRID_COLOUR, 'rgb(219, 219, 219)');

--- a/packages/ag-charts-community/src/options/options/themeOptions.ts
+++ b/packages/ag-charts-community/src/options/options/themeOptions.ts
@@ -18,6 +18,7 @@ import type { AgScatterSeriesThemeableOptions } from '../series/cartesian/scatte
 import type { AgAreaSeriesThemeableOptions } from '../series/cartesian/areaOptions';
 import type { AgRadarSeriesThemeableOptions } from '../series/polar/radarOptions';
 import type { AgHeatmapSeriesThemeableOptions } from '../series/cartesian/heatmapOptions';
+import type { AgRangeAreaSeriesThemeableOptions } from '../series/cartesian/rangeAreaOptions';
 
 export type AgChartThemeName =
     | 'ag-default'
@@ -83,6 +84,9 @@ export interface AgWaterfallSeriesThemeOverrides extends AgBaseCartesianThemeOpt
 export interface AgRangeBarSeriesThemeOverrides extends AgBaseCartesianThemeOptions {
     series?: AgRangeBarSeriesThemeableOptions;
 }
+export interface AgRangeAreaSeriesThemeOverrides extends AgBaseCartesianThemeOptions {
+    series?: AgRangeAreaSeriesThemeableOptions;
+}
 export interface AgPieSeriesThemeOverrides extends AgBasePolarThemeOptions {
     series?: AgPieSeriesThemeableOptions;
 }
@@ -120,6 +124,7 @@ export interface AgBaseChartThemeOverrides {
     heatmap?: AgHeatmapSeriesThemeOverrides;
     waterfall?: AgWaterfallSeriesThemeOverrides;
     'range-bar'?: AgRangeBarSeriesThemeOverrides;
+    'range-area'?: AgRangeAreaSeriesThemeOverrides;
 
     pie?: AgPieSeriesThemeOverrides;
     'radar-line'?: AgRadarLineSeriesThemeOverrides;

--- a/packages/ag-charts-community/src/options/series/cartesian/cartesianSeriesTypes.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/cartesianSeriesTypes.ts
@@ -4,6 +4,7 @@ import type { AgBoxPlotSeriesOptions } from './boxPlotOptions';
 import type { AgHeatmapSeriesOptions } from './heatmapOptions';
 import type { AgHistogramSeriesOptions } from './histogramOptions';
 import type { AgLineSeriesOptions } from './lineOptions';
+import type { AgRangeAreaSeriesOptions } from './rangeAreaOptions';
 import type { AgRangeBarSeriesOptions } from './rangeBarOptions';
 import type { AgScatterSeriesOptions } from './scatterOptions';
 import type { AgWaterfallSeriesOptions } from './waterfallOptions';
@@ -17,4 +18,5 @@ export type AgCartesianSeriesOptions =
     | AgHistogramSeriesOptions
     | AgHeatmapSeriesOptions
     | AgWaterfallSeriesOptions
-    | AgRangeBarSeriesOptions;
+    | AgRangeBarSeriesOptions
+    | AgRangeAreaSeriesOptions;

--- a/packages/ag-charts-community/src/options/series/cartesian/rangeAreaOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/rangeAreaOptions.ts
@@ -110,8 +110,6 @@ export interface AgRangeAreaSeriesOptions<DatumType = any>
     yHighName?: string;
     /** A human-readable description of the y-values. If supplied, this will be shown in the default tooltip and passed to the tooltip renderer as one of the parameters. */
     yName?: string;
-    /** The title to use for the series. Defaults to `yName` if it exists, or `yKey` if not. */
-    title?: string;
     /** A map of event names to event listeners. */
     listeners?: AgSeriesListeners<DatumType>;
 }

--- a/packages/ag-charts-community/src/util/module.ts
+++ b/packages/ag-charts-community/src/util/module.ts
@@ -3,7 +3,7 @@ import type { Series } from '../chart/series/series';
 import type { ChartLegend } from '../chart/legendDatum';
 import type { JsonApplyParams } from './json';
 import type { AxisContext, ModuleContext, ModuleContextWithParent } from './moduleContext';
-import type { AgChartOptions } from '../options/agChartOptions';
+import type { AgBaseChartThemeOverrides, AgChartOptions } from '../options/agChartOptions';
 
 export type AxisConstructor = new (moduleContext: ModuleContext) => ChartAxis;
 export type SeriesConstructor = new (moduleContext: ModuleContext) => Series<any>;
@@ -70,14 +70,18 @@ export interface LegendModule extends BaseModule {
     instanceConstructor: LegendConstructor;
 }
 
-export interface SeriesModule extends BaseModule {
+type RequiredSeriesType = NonNullable<NonNullable<AgChartOptions['series']>[number]['type']>;
+type ExtensibleTheme<SeriesType extends RequiredSeriesType> = NonNullable<
+    AgBaseChartThemeOverrides[SeriesType]
+>['series'] & { __extends__?: string };
+export interface SeriesModule<SeriesType extends RequiredSeriesType> extends BaseModule {
     type: 'series';
 
-    identifier: string;
+    identifier: SeriesType;
     instanceConstructor: SeriesConstructor;
 
-    seriesDefaults: {};
-    themeTemplate: {};
+    seriesDefaults: AgChartOptions;
+    themeTemplate: ExtensibleTheme<SeriesType>;
     paletteFactory?: SeriesPaletteFactory;
     stackable?: boolean;
     groupable?: boolean;
@@ -90,7 +94,7 @@ export type Module<M extends ModuleInstance = ModuleInstance> =
     | AxisModule
     | AxisOptionModule
     | LegendModule
-    | SeriesModule;
+    | SeriesModule<any>;
 
 export abstract class BaseModuleInstance {
     protected readonly destroyFns: (() => void)[] = [];

--- a/packages/ag-charts-community/src/util/module.ts
+++ b/packages/ag-charts-community/src/util/module.ts
@@ -94,7 +94,7 @@ export type Module<M extends ModuleInstance = ModuleInstance> =
     | AxisModule
     | AxisOptionModule
     | LegendModule
-    | SeriesModule<any>;
+    | SeriesModule<RequiredSeriesType>;
 
 export abstract class BaseModuleInstance {
     protected readonly destroyFns: (() => void)[] = [];

--- a/packages/ag-charts-enterprise/src/box-plot/boxPlotModule.ts
+++ b/packages/ag-charts-enterprise/src/box-plot/boxPlotModule.ts
@@ -3,7 +3,7 @@ import { BOX_PLOT_SERIES_THEME } from './boxPlotThemes';
 import { BOX_PLOT_SERIES_DEFAULTS } from './boxPlotDefaults';
 import { BoxPlotSeries } from './boxPlotSeries';
 
-export const BoxPlotModule: _ModuleSupport.SeriesModule = {
+export const BoxPlotModule: _ModuleSupport.SeriesModule<'box-plot'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/heatmap/heatmapModule.ts
+++ b/packages/ag-charts-enterprise/src/heatmap/heatmapModule.ts
@@ -4,7 +4,7 @@ import { HeatmapSeries } from './heatmapSeries';
 import { HEATMAP_DEFAULTS } from './heatmapDefaults';
 import { HEATMAP_SERIES_THEME } from './heatmapThemes';
 
-export const HeatmapModule: _ModuleSupport.SeriesModule = {
+export const HeatmapModule: _ModuleSupport.SeriesModule<'heatmap'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/polar-series/nightingale/nightingaleModule.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/nightingale/nightingaleModule.ts
@@ -4,7 +4,7 @@ import { NIGHTINGALE_DEFAULTS } from './nightingaleDefaults';
 import { NightingaleSeries } from './nightingaleSeries';
 import { NIGHTINGALE_SERIES_THEME } from './nightingaleThemes';
 
-export const NightingaleModule: _ModuleSupport.SeriesModule = {
+export const NightingaleModule: _ModuleSupport.SeriesModule<'nightingale'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/polar-series/radar-area/radarAreaModule.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radar-area/radarAreaModule.ts
@@ -4,7 +4,7 @@ import { RadarAreaSeries } from './radarAreaSeries';
 import { POLAR_DEFAULTS } from '../polarDefaults';
 import { RADAR_AREA_SERIES_THEME } from './radarAreaThemes';
 
-export const RadarAreaModule: _ModuleSupport.SeriesModule = {
+export const RadarAreaModule: _ModuleSupport.SeriesModule<'radar-area'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/polar-series/radar-line/radarLineModule.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radar-line/radarLineModule.ts
@@ -4,7 +4,7 @@ import { RadarLineSeries } from './radarLineSeries';
 import { POLAR_DEFAULTS } from '../polarDefaults';
 import { RADAR_LINE_SERIES_THEME } from './radarLineThemes';
 
-export const RadarLineModule: _ModuleSupport.SeriesModule = {
+export const RadarLineModule: _ModuleSupport.SeriesModule<'radar-line'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnModule.ts
+++ b/packages/ag-charts-enterprise/src/polar-series/radial-column/radialColumnModule.ts
@@ -3,7 +3,7 @@ import { RadialColumnSeries } from './radialColumnSeries';
 import { RADIAL_COLUMN_DEFAULTS } from './radialColumnDefaults';
 import { RADIAL_COLUMN_SERIES_THEME } from './radialColumnThemes';
 
-export const RadialColumnModule: _ModuleSupport.SeriesModule = {
+export const RadialColumnModule: _ModuleSupport.SeriesModule<'radial-column'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/range-area/rangeAreaModule.ts
+++ b/packages/ag-charts-enterprise/src/range-area/rangeAreaModule.ts
@@ -4,7 +4,7 @@ import { RangeAreaSeries } from './rangeArea';
 import { RANGE_AREA_DEFAULTS } from './rangeAreaDefaults';
 import { RANGE_AREA_SERIES_THEME } from './rangeAreaThemes';
 
-export const RangeAreaModule: _ModuleSupport.SeriesModule = {
+export const RangeAreaModule: _ModuleSupport.SeriesModule<'range-area'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/range-bar/rangeBarModule.ts
+++ b/packages/ag-charts-enterprise/src/range-bar/rangeBarModule.ts
@@ -4,7 +4,7 @@ import { RangeBarSeries } from './rangeBar';
 import { RANGE_BAR_DEFAULTS } from './rangeBarDefaults';
 import { RANGE_BAR_SERIES_THEME } from './rangeBarThemes';
 
-export const RangeBarModule: _ModuleSupport.SeriesModule = {
+export const RangeBarModule: _ModuleSupport.SeriesModule<'range-bar'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',

--- a/packages/ag-charts-enterprise/src/waterfall/waterfallModule.ts
+++ b/packages/ag-charts-enterprise/src/waterfall/waterfallModule.ts
@@ -4,7 +4,7 @@ import { WaterfallSeries } from './waterfallSeries';
 import { WATERFALL_DEFAULTS } from './waterfallDefaults';
 import { WATERFALL_SERIES_THEME } from './waterfallThemes';
 
-export const WaterfallModule: _ModuleSupport.SeriesModule = {
+export const WaterfallModule: _ModuleSupport.SeriesModule<'waterfall'> = {
     type: 'series',
     optionsKey: 'series[]',
     packageType: 'enterprise',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9212

On the path to aligning enterprise and community series registration I found some cleanup that was required:
- Makes `SeriesModule` theme definitions type-safe.
- Adds missing `range-area` theme options.
- Removes the need to cast template symbols on every use (moves cast to `string` to declaration point).