### PR TITLE
Add ErrorBar styling options

### DIFF
--- a/packages/ag-charts-community/src/util/optionModules.ts
+++ b/packages/ag-charts-community/src/util/optionModules.ts
@@ -16,4 +16,5 @@ export interface SeriesOptionModule<M extends ModuleInstance = ModuleInstance> e
 
     identifier: string;
     instanceConstructor: new (ctx: SeriesContext) => M;
+    themeTemplate: {};
 }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -1,5 +1,6 @@
 import type { _Scale } from 'ag-charts-community';
 import { _Scene, _Util, _ModuleSupport } from 'ag-charts-community';
+import { ErrorBarPoints, ErrorBarNode } from './errorBarNode';
 
 const { ChartAxisDirection, Validate, OPT_STRING } = _ModuleSupport;
 
@@ -7,32 +8,6 @@ type CartesianSeries<
     C extends _ModuleSupport.SeriesNodeDataContext<any, any>,
     N extends _Scene.Node
 > = _ModuleSupport.CartesianSeries<C, N>;
-
-export interface ErrorBarPoints {
-    readonly yLowerPoint: _Scene.Point;
-    readonly yUpperPoint: _Scene.Point;
-}
-
-export class ErrorBarNode extends _Scene.Path {
-    public points: ErrorBarPoints = { yLowerPoint: { x: 0, y: 0 }, yUpperPoint: { x: 0, y: 0 } };
-
-    updatePath() {
-        // TODO(olegat) implement, this is just placeholder draw code
-        const { path } = this;
-        this.fill = 'black';
-        this.stroke = 'black';
-        this.strokeWidth = 1;
-        this.fillOpacity = 1;
-        this.strokeOpacity = 1;
-
-        const { yLowerPoint, yUpperPoint } = this.points;
-
-        path.clear();
-        path.moveTo(yLowerPoint.x, yLowerPoint.y);
-        path.lineTo(yUpperPoint.x, yUpperPoint.y);
-        path.closePath();
-    }
-}
 
 export class ErrorBars extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     @Validate(OPT_STRING)

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -145,15 +145,11 @@ export class ErrorBars
         src: OptionalErrorBarNodeProperties,
         parent: ErrorBarNodeProperties
     ): ErrorBarNodeProperties {
-        const fallback = (src: any, fallback: any) => {
-            return src !== undefined ? src : fallback;
-        };
-
         return {
-            visible: fallback(src.visible, parent.visible),
-            stroke: fallback(src.stroke, parent.stroke),
-            strokeWidth: fallback(src.strokeWidth, parent.strokeWidth),
-            strokeOpacity: fallback(src.strokeOpacity, parent.strokeOpacity),
+            visible: src.visible ?? parent.visible,
+            stroke: src.stroke ?? parent.stroke,
+            strokeWidth: src.strokeWidth ?? parent.strokeWidth,
+            strokeOpacity: src.strokeOpacity ?? parent.strokeOpacity,
         };
     }
 

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -152,8 +152,8 @@ export class ErrorBars
         const points = nodeData[index];
         if (points) {
             const whiskerProps = this.inheritProperties(this, ERROR_BARS_THEME.errorBar);
-            node.updateData(points, whiskerProps);
-            node.updatePath();
+            const capProps = this.inheritProperties(this.cap, whiskerProps);
+            node.update(points, whiskerProps, capProps);
         }
     }
 

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -4,7 +4,7 @@ import type { ErrorBarPoints, ErrorBarNodeProperties } from './errorBarNode';
 import { ErrorBarNode } from './errorBarNode';
 import { ERROR_BARS_THEME } from './errorBarTheme';
 
-const { ChartAxisDirection, Validate, BOOLEAN, OPT_STRING, NUMBER } = _ModuleSupport;
+const { mergeDefaults, ChartAxisDirection, Validate, BOOLEAN, OPT_STRING, NUMBER } = _ModuleSupport;
 
 type CartesianSeries<
     C extends _ModuleSupport.SeriesNodeDataContext<any, any>,
@@ -135,24 +135,13 @@ export class ErrorBars
         this.selection.each((node, datum, i) => this.updateNode(node, datum, i));
     }
 
-    private inheritProperties(
-        src: OptionalErrorBarNodeProperties,
-        parent: ErrorBarNodeProperties
-    ): ErrorBarNodeProperties {
-        return {
-            visible: src.visible ?? parent.visible,
-            stroke: src.stroke ?? parent.stroke,
-            strokeWidth: src.strokeWidth ?? parent.strokeWidth,
-            strokeOpacity: src.strokeOpacity ?? parent.strokeOpacity,
-        };
-    }
-
     private updateNode(node: ErrorBarNode, _datum: any, index: number) {
         const { nodeData } = this;
         const points = nodeData[index];
         if (points) {
-            const whiskerProps = this.inheritProperties(this, ERROR_BARS_THEME.errorBar);
-            const capProps = this.inheritProperties(this.cap, whiskerProps);
+            const defaults: ErrorBarNodeProperties = ERROR_BARS_THEME.errorBar;
+            const whiskerProps = mergeDefaults(this, defaults);
+            const capProps = mergeDefaults(this.cap, whiskerProps);
             node.update(points, whiskerProps, capProps);
         }
     }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -2,6 +2,7 @@ import type { _Scale } from 'ag-charts-community';
 import { _Scene, _Util, _ModuleSupport } from 'ag-charts-community';
 import type { ErrorBarPoints, ErrorBarNodeProperties } from './errorBarNode';
 import { ErrorBarNode } from './errorBarNode';
+import { ERROR_BARS_THEME } from './errorBarTheme';
 
 const { ChartAxisDirection, Validate, BOOLEAN, OPT_STRING, NUMBER } = _ModuleSupport;
 
@@ -9,13 +10,6 @@ type CartesianSeries<
     C extends _ModuleSupport.SeriesNodeDataContext<any, any>,
     N extends _Scene.Node
 > = _ModuleSupport.CartesianSeries<C, N>;
-
-const ERRORBAR_DEFAULTS = {
-    visible: true,
-    stroke: 'black',
-    strokeWidth: 1,
-    strokeOpacity: 1,
-};
 
 type OptionalErrorBarNodeProperties = { [K in keyof ErrorBarNodeProperties]?: ErrorBarNodeProperties[K] };
 
@@ -157,7 +151,7 @@ export class ErrorBars
         const { nodeData, inheritProperties } = this;
         const points = nodeData[index];
         if (points) {
-            const whiskerProps = inheritProperties(this, ERRORBAR_DEFAULTS);
+            const whiskerProps = inheritProperties(this, ERROR_BARS_THEME.errorBar);
             node.updateData(points, whiskerProps);
             node.updatePath();
         }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -154,12 +154,11 @@ export class ErrorBars
     }
 
     private updateNode(node: ErrorBarNode, _datum: any, index: number) {
-        const { cap, nodeData, inheritProperties } = this;
+        const { nodeData, inheritProperties } = this;
         const points = nodeData[index];
         if (points) {
             const whiskerProps = inheritProperties(this, ERRORBAR_DEFAULTS);
-            const capProps = inheritProperties(cap, whiskerProps);
-            node.updateData(points, whiskerProps, capProps, cap);
+            node.updateData(points, whiskerProps);
             node.updatePath();
         }
     }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -159,7 +159,7 @@ export class ErrorBars
         if (points) {
             const whiskerProps = inheritProperties(this, ERRORBAR_DEFAULTS);
             const capProps = inheritProperties(cap, whiskerProps);
-            node.updateData(points, cap, capProps, whiskerProps);
+            node.updateData(points, whiskerProps, capProps, cap);
             node.updatePath();
         }
     }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBar.ts
@@ -148,10 +148,10 @@ export class ErrorBars
     }
 
     private updateNode(node: ErrorBarNode, _datum: any, index: number) {
-        const { nodeData, inheritProperties } = this;
+        const { nodeData } = this;
         const points = nodeData[index];
         if (points) {
-            const whiskerProps = inheritProperties(this, ERROR_BARS_THEME.errorBar);
+            const whiskerProps = this.inheritProperties(this, ERROR_BARS_THEME.errorBar);
             node.updateData(points, whiskerProps);
             node.updatePath();
         }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarModule.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarModule.ts
@@ -1,5 +1,6 @@
 import type { _ModuleSupport } from 'ag-charts-community';
 import { ErrorBars } from './errorBar';
+import { ERROR_BARS_THEME } from './errorBarTheme';
 
 export const ErrorBarsModule: _ModuleSupport.SeriesOptionModule = {
     type: 'series-option',
@@ -8,4 +9,5 @@ export const ErrorBarsModule: _ModuleSupport.SeriesOptionModule = {
     packageType: 'enterprise',
     chartTypes: ['cartesian'],
     instanceConstructor: ErrorBars,
+    themeTemplate: ERROR_BARS_THEME,
 };

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
@@ -13,21 +13,40 @@ export interface ErrorBarPoints {
     readonly yUpperPoint: _Scene.Point;
 }
 
-export class ErrorBarNode extends _Scene.Path {
+export class ErrorBarNode extends _Scene.Group {
     private points: ErrorBarPoints = { yLowerPoint: { x: 0, y: 0 }, yUpperPoint: { x: 0, y: 0 } };
+    private whiskerPath: _Scene.Path;
+    private capsPath: _Scene.Path;
 
-    updateData(points: ErrorBarPoints, whiskerTheme: ErrorBarNodeProperties) {
-        this.points = points;
-        Object.assign(this, whiskerTheme);
+    constructor() {
+        super();
+        this.whiskerPath = new _Scene.Path();
+        this.capsPath = new _Scene.Path();
+        this.append([this.whiskerPath, this.capsPath]);
     }
 
-    updatePath() {
-        const { path } = this;
+    update(points: ErrorBarPoints, whiskerTheme: ErrorBarNodeProperties, capsTheme: ErrorBarNodeProperties) {
+        this.points = points;
+        Object.assign(this.whiskerPath, whiskerTheme);
+        Object.assign(this.capsPath, capsTheme);
+
         const { yLowerPoint, yUpperPoint } = this.points;
 
-        path.clear();
-        path.moveTo(yLowerPoint.x, yLowerPoint.y);
-        path.lineTo(yUpperPoint.x, yUpperPoint.y);
-        path.closePath();
+        const whisker = this.whiskerPath;
+        whisker.path.clear();
+        whisker.path.moveTo(yLowerPoint.x, yLowerPoint.y);
+        whisker.path.lineTo(yUpperPoint.x, yUpperPoint.y);
+        whisker.path.closePath();
+        whisker.updatePath();
+
+        const capLength = 5;
+        const caps = this.capsPath;
+        caps.path.clear();
+        caps.path.moveTo(yLowerPoint.x - capLength, yLowerPoint.y);
+        caps.path.lineTo(yLowerPoint.x + capLength, yLowerPoint.y);
+        caps.path.moveTo(yUpperPoint.x - capLength, yUpperPoint.y);
+        caps.path.lineTo(yUpperPoint.x + capLength, yUpperPoint.y);
+        caps.path.closePath();
+        caps.updatePath();
     }
 }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
@@ -1,23 +1,41 @@
 import type { _Scale } from 'ag-charts-community';
 import { _Scene } from 'ag-charts-community';
 
+export type ErrorBarNodeProperties = {
+    visible: boolean;
+    stroke?: string;
+    strokeWidth: number;
+    strokeOpacity: number;
+};
+
+interface ErrorBarCapExclusiveOptions {
+    lengthRatio: number;
+}
+
 export interface ErrorBarPoints {
     readonly yLowerPoint: _Scene.Point;
     readonly yUpperPoint: _Scene.Point;
 }
 
 export class ErrorBarNode extends _Scene.Path {
-    public points: ErrorBarPoints = { yLowerPoint: { x: 0, y: 0 }, yUpperPoint: { x: 0, y: 0 } };
+    private points: ErrorBarPoints = { yLowerPoint: { x: 0, y: 0 }, yUpperPoint: { x: 0, y: 0 } };
+
+    updateData(
+        points: ErrorBarPoints,
+        capOpts: ErrorBarCapExclusiveOptions,
+        capTheme: ErrorBarNodeProperties,
+        whiskerTheme: ErrorBarNodeProperties
+    ) {
+        // Mute unused variables (cap not yet implemented)
+        capOpts as any;
+        capTheme as any;
+
+        this.points = points;
+        Object.assign(this, whiskerTheme);
+    }
 
     updatePath() {
-        // TODO(olegat) implement, this is just placeholder draw code
         const { path } = this;
-        this.fill = 'black';
-        this.stroke = 'black';
-        this.strokeWidth = 1;
-        this.fillOpacity = 1;
-        this.strokeOpacity = 1;
-
         const { yLowerPoint, yUpperPoint } = this.points;
 
         path.clear();

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
@@ -22,14 +22,10 @@ export class ErrorBarNode extends _Scene.Path {
 
     updateData(
         points: ErrorBarPoints,
-        capOpts: ErrorBarCapExclusiveOptions,
-        capTheme: ErrorBarNodeProperties,
         whiskerTheme: ErrorBarNodeProperties
+        capTheme?: ErrorBarNodeProperties,
+        capOpts?: ErrorBarCapExclusiveOptions,
     ) {
-        // Mute unused variables (cap not yet implemented)
-        capOpts as any;
-        capTheme as any;
-
         this.points = points;
         Object.assign(this, whiskerTheme);
     }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
@@ -2,10 +2,10 @@ import type { _Scale } from 'ag-charts-community';
 import { _Scene } from 'ag-charts-community';
 
 export type ErrorBarNodeProperties = {
-    visible: boolean;
+    visible?: boolean;
     stroke?: string;
-    strokeWidth: number;
-    strokeOpacity: number;
+    strokeWidth?: number;
+    strokeOpacity?: number;
 };
 
 export interface ErrorBarPoints {

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
@@ -8,10 +8,6 @@ export type ErrorBarNodeProperties = {
     strokeOpacity: number;
 };
 
-interface ErrorBarCapExclusiveOptions {
-    lengthRatio: number;
-}
-
 export interface ErrorBarPoints {
     readonly yLowerPoint: _Scene.Point;
     readonly yUpperPoint: _Scene.Point;
@@ -20,12 +16,7 @@ export interface ErrorBarPoints {
 export class ErrorBarNode extends _Scene.Path {
     private points: ErrorBarPoints = { yLowerPoint: { x: 0, y: 0 }, yUpperPoint: { x: 0, y: 0 } };
 
-    updateData(
-        points: ErrorBarPoints,
-        whiskerTheme: ErrorBarNodeProperties
-        capTheme?: ErrorBarNodeProperties,
-        capOpts?: ErrorBarCapExclusiveOptions,
-    ) {
+    updateData(points: ErrorBarPoints, whiskerTheme: ErrorBarNodeProperties) {
         this.points = points;
         Object.assign(this, whiskerTheme);
     }

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarNode.ts
@@ -1,0 +1,28 @@
+import type { _Scale } from 'ag-charts-community';
+import { _Scene } from 'ag-charts-community';
+
+export interface ErrorBarPoints {
+    readonly yLowerPoint: _Scene.Point;
+    readonly yUpperPoint: _Scene.Point;
+}
+
+export class ErrorBarNode extends _Scene.Path {
+    public points: ErrorBarPoints = { yLowerPoint: { x: 0, y: 0 }, yUpperPoint: { x: 0, y: 0 } };
+
+    updatePath() {
+        // TODO(olegat) implement, this is just placeholder draw code
+        const { path } = this;
+        this.fill = 'black';
+        this.stroke = 'black';
+        this.strokeWidth = 1;
+        this.fillOpacity = 1;
+        this.strokeOpacity = 1;
+
+        const { yLowerPoint, yUpperPoint } = this.points;
+
+        path.clear();
+        path.moveTo(yLowerPoint.x, yLowerPoint.y);
+        path.lineTo(yUpperPoint.x, yUpperPoint.y);
+        path.closePath();
+    }
+}

--- a/packages/ag-charts-enterprise/src/error-bar/errorBarTheme.ts
+++ b/packages/ag-charts-enterprise/src/error-bar/errorBarTheme.ts
@@ -1,0 +1,13 @@
+import { _Theme } from 'ag-charts-community';
+
+export const ERROR_BARS_THEME = {
+    errorBar: {
+        visible: true,
+        stroke: 'black',
+        strokeWidth: 1,
+        strokeOpacity: 1,
+        cap: {
+            lengthRatio: 1,
+        },
+    },
+};


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9017

This adds the following options:
    
- visible (default: true)
- stroke (default: 'black')
- strokeWidth (default: 1)
- strokeOpacity (default: 1)
    
These options are duplicated for both the whiskers and caps (so that
these components can be customised individually). Cap inherit the
defaults from the whisky (e.g. setting whisker.stroke = 'red' will
also set cap.stroke = 'red')
    
The rendering of caps is not fully implemented yet (`lengthRatio` is ignored)