### PR TITLE
AG0-9016 Add Error Bars to Scatter series

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -305,6 +305,11 @@ export abstract class CartesianSeries<
 
             this._contextNodeData = await this.createNodeData();
             await this.updateSeriesGroups();
+
+            const { dataModel, processedData } = this;
+            if (dataModel !== undefined && processedData !== undefined) {
+                this.fireDataProcessed(dataModel, processedData);
+            }
         }
 
         await Promise.all(this.subGroups.map((g, i) => this.updateSeriesGroupSelections(g, i)));

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -272,7 +272,6 @@ export class LineSeries extends CartesianSeries<LineContext> {
             }
         }
         nodeData.length = actualLength;
-        this.fireDataProcessed(dataModel, processedData);
 
         return [{ itemId: yKey, nodeData, labelData: nodeData }];
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -225,6 +225,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         }
 
         nodeData.length = actualLength;
+        this.fireDataProcessed(dataModel, processedData);
 
         return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData }];
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -225,7 +225,6 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         }
 
         nodeData.length = actualLength;
-        this.fireDataProcessed(dataModel, processedData);
 
         return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData }];
     }

--- a/packages/ag-charts-community/src/options/series/cartesian/scatterOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/scatterOptions.ts
@@ -5,6 +5,7 @@ import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../serie
 import type { AgCartesianSeriesMarker } from './cartesianSeriesMarkerOptions';
 import type { AgCartesianSeriesTooltipRendererParams } from './cartesianSeriesTooltipOptions';
 import type { AgCartesianSeriesLabelFormatterParams } from './cartesianLabelOptions';
+import type { AgErrorBarOptions } from '../../chart/errorBarOptions';
 
 export interface AgScatterSeriesTooltipRendererParams extends AgCartesianSeriesTooltipRendererParams {
     /** labelKey as specified on series options. */
@@ -54,4 +55,6 @@ export interface AgScatterSeriesOptions<DatumType = any>
     labelName?: string;
     /** A map of event names to event listeners. */
     listeners?: AgSeriesListeners<DatumType>;
+    /** Configuration for the series error bars. */
+    errorBar?: AgErrorBarOptions;
 }

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -5,6 +5,7 @@ import { ErrorBarNode } from './errorBarNode';
 import { ERROR_BARS_THEME } from './errorBarTheme';
 
 const { mergeDefaults, ChartAxisDirection, Validate, BOOLEAN, OPT_STRING, NUMBER } = _ModuleSupport;
+const { Logger } = _Util;
 type AnyScale = _Scale.Scale<any, any, any>;
 
 type OptionalErrorBarNodeProperties = { [K in keyof ErrorBarNodeProperties]?: ErrorBarNodeProperties[K] };
@@ -137,7 +138,7 @@ export class ErrorBars
                             yDatum
                         );
                     } else {
-                        throw new Error(
+                        Logger.warnOnce(
                             `AG Charts - series type 'scatter' requires xLowerKey (= ${xLowerKey}) and xUpperKey (= ${xUpperKey}) to exist in all data points`
                         );
                     }

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -8,13 +8,27 @@ export type ErrorBarNodeProperties = {
     strokeOpacity?: number;
 };
 
+interface ErrorBarPoint {
+    readonly lowerPoint: _Scene.Point;
+    readonly upperPoint: _Scene.Point;
+}
+
 export interface ErrorBarPoints {
-    readonly yLowerPoint: _Scene.Point;
-    readonly yUpperPoint: _Scene.Point;
+    readonly xBar?: ErrorBarPoint;
+    readonly yBar: ErrorBarPoint;
 }
 
 export class ErrorBarNode extends _Scene.Group {
-    private points: ErrorBarPoints = { yLowerPoint: { x: 0, y: 0 }, yUpperPoint: { x: 0, y: 0 } };
+    private points: ErrorBarPoints = {
+        xBar: {
+            lowerPoint: { x: 0, y: 0 },
+            upperPoint: { x: 0, y: 0 },
+        },
+        yBar: {
+            lowerPoint: { x: 0, y: 0 },
+            upperPoint: { x: 0, y: 0 },
+        },
+    };
     private whiskerPath: _Scene.Path;
     private capsPath: _Scene.Path;
 
@@ -30,22 +44,32 @@ export class ErrorBarNode extends _Scene.Group {
         Object.assign(this.whiskerPath, whiskerTheme);
         Object.assign(this.capsPath, capsTheme);
 
-        const { yLowerPoint, yUpperPoint } = this.points;
+        const { xBar, yBar } = this.points;
 
         const whisker = this.whiskerPath;
         whisker.path.clear();
-        whisker.path.moveTo(yLowerPoint.x, yLowerPoint.y);
-        whisker.path.lineTo(yUpperPoint.x, yUpperPoint.y);
+        whisker.path.moveTo(yBar.lowerPoint.x, yBar.lowerPoint.y);
+        whisker.path.lineTo(yBar.upperPoint.x, yBar.upperPoint.y);
+        if (xBar !== undefined) {
+            whisker.path.moveTo(xBar.lowerPoint.x, xBar.lowerPoint.y);
+            whisker.path.lineTo(xBar.upperPoint.x, xBar.upperPoint.y);
+        }
         whisker.path.closePath();
         whisker.updatePath();
 
         const capLength = 5;
         const caps = this.capsPath;
         caps.path.clear();
-        caps.path.moveTo(yLowerPoint.x - capLength, yLowerPoint.y);
-        caps.path.lineTo(yLowerPoint.x + capLength, yLowerPoint.y);
-        caps.path.moveTo(yUpperPoint.x - capLength, yUpperPoint.y);
-        caps.path.lineTo(yUpperPoint.x + capLength, yUpperPoint.y);
+        caps.path.moveTo(yBar.lowerPoint.x - capLength, yBar.lowerPoint.y);
+        caps.path.lineTo(yBar.lowerPoint.x + capLength, yBar.lowerPoint.y);
+        caps.path.moveTo(yBar.upperPoint.x - capLength, yBar.upperPoint.y);
+        caps.path.lineTo(yBar.upperPoint.x + capLength, yBar.upperPoint.y);
+        if (xBar !== undefined) {
+            caps.path.moveTo(xBar.lowerPoint.x, xBar.lowerPoint.y - capLength);
+            caps.path.lineTo(xBar.lowerPoint.x, xBar.lowerPoint.y + capLength);
+            caps.path.moveTo(xBar.upperPoint.x, xBar.upperPoint.y - capLength);
+            caps.path.lineTo(xBar.upperPoint.x, xBar.upperPoint.y + capLength);
+        }
         caps.path.closePath();
         caps.updatePath();
     }

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/data.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/data.ts
@@ -1,0 +1,68 @@
+export function getData() {
+    return [
+        {
+            volume: 0.5,
+            volumeLower: 0.45,
+            volumeUpper: 0.55,
+            pressure: 1.2,
+            pressureLower: 1.1,
+            pressureUpper: 1.4
+        },
+        {
+            volume: 1.0,
+            volumeLower: 0.9,
+            volumeUpper: 1.1,
+            pressure: 2.0,
+            pressureLower: 1.8,
+            pressureUpper: 2.3
+        },
+        {
+            volume: 1.5,
+            volumeLower: 1.35,
+            volumeUpper: 1.65,
+            pressure: 3.1,
+            pressureLower: 2.8,
+            pressureUpper: 3.5
+        },
+        {
+            volume: 2.0,
+            volumeLower: 1.8,
+            volumeUpper: 2.2,
+            pressure: 4.2,
+            pressureLower: 3.8,
+            pressureUpper: 4.7
+        },
+        {
+            volume: 2.5,
+            volumeLower: 2.25,
+            volumeUpper: 2.75,
+            pressure: 5.5,
+            pressureLower: 5.0,
+            pressureUpper: 5.9
+        },
+        {
+            volume: 3.0,
+            volumeLower: 2.7,
+            volumeUpper: 3.3,
+            pressure: 6.8,
+            pressureLower: 6.2,
+            pressureUpper: 7.5
+        },
+        {
+            volume: 3.5,
+            volumeLower: 3.15,
+            volumeUpper: 3.85,
+            pressure: 8.1,
+            pressureLower: 7.4,
+            pressureUpper: 8.9
+        },
+        {
+            volume: 4.0,
+            volumeLower: 3.6,
+            volumeUpper: 4.4,
+            pressure: 9.5,
+            pressureLower: 8.7,
+            pressureUpper: 10.3
+        }
+    ];
+}

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/data.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/data.ts
@@ -4,65 +4,65 @@ export function getData() {
             volume: 0.5,
             volumeLower: 0.45,
             volumeUpper: 0.55,
-            pressure: 1.2,
-            pressureLower: 1.1,
-            pressureUpper: 1.4
+            pressure: 9.5,
+            pressureLower: 10.3,
+            pressureUpper: 8.7
         },
         {
             volume: 1.0,
             volumeLower: 0.9,
             volumeUpper: 1.1,
-            pressure: 2.0,
-            pressureLower: 1.8,
-            pressureUpper: 2.3
+            pressure: 8.1,
+            pressureLower: 8.9,
+            pressureUpper: 7.4
         },
         {
             volume: 1.5,
             volumeLower: 1.35,
             volumeUpper: 1.65,
-            pressure: 3.1,
-            pressureLower: 2.8,
-            pressureUpper: 3.5
+            pressure: 6.8,
+            pressureLower: 7.5,
+            pressureUpper: 6.2
         },
         {
             volume: 2.0,
             volumeLower: 1.8,
             volumeUpper: 2.2,
-            pressure: 4.2,
-            pressureLower: 3.8,
-            pressureUpper: 4.7
+            pressure: 5.5,
+            pressureLower: 5.9,
+            pressureUpper: 5.0
         },
         {
             volume: 2.5,
             volumeLower: 2.25,
             volumeUpper: 2.75,
-            pressure: 5.5,
-            pressureLower: 5.0,
-            pressureUpper: 5.9
+            pressure: 4.2,
+            pressureLower: 4.7,
+            pressureUpper: 3.8
         },
         {
             volume: 3.0,
             volumeLower: 2.7,
             volumeUpper: 3.3,
-            pressure: 6.8,
-            pressureLower: 6.2,
-            pressureUpper: 7.5
+            pressure: 3.1,
+            pressureLower: 3.5,
+            pressureUpper: 2.8
         },
         {
             volume: 3.5,
             volumeLower: 3.15,
             volumeUpper: 3.85,
-            pressure: 8.1,
-            pressureLower: 7.4,
-            pressureUpper: 8.9
+            pressure: 2.0,
+            pressureLower: 2.3,
+            pressureUpper: 1.8
         },
         {
             volume: 4.0,
             volumeLower: 3.6,
             volumeUpper: 4.4,
-            pressure: 9.5,
-            pressureLower: 8.7,
-            pressureUpper: 10.3
+            pressure: 1.2,
+            pressureLower: 1.4,
+            pressureUpper: 1.1
         }
     ];
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/index.html
@@ -1,0 +1,1 @@
+<div id="myChart" style="height: 100%;"></div>

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/scatter-series-error-bars/main.ts
@@ -1,0 +1,25 @@
+import { AgChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+import { getData } from './data';
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    title: {
+        text: 'Volume-Pressure Relationship with Confidence Intervals',
+    },
+    series: [
+        {
+            type: 'scatter',
+            xKey: 'volume',
+            yKey: 'pressure',
+            errorBar:  {
+                xLowerKey: 'volumeLower',
+                xUpperKey: 'volumeUpper',
+                yLowerKey: 'pressureLower',
+                yUpperKey: 'pressureUpper',
+            },
+        },
+    ],
+};
+
+AgEnterpriseCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -23,15 +23,50 @@ data: [
         temperatureLower: 32,
         temperatureUpper: 37,
     },
-  ],
-  series: [
+],
+series: [
     {
-      xKey: 'month',
-      yKey: 'temperature' ,
-      errorBar: {
-        yLowerKey: 'temperatureLower',
-        yUpperKey: 'temperatureUpper',
-      },
+        xKey: 'month',
+        yKey: 'temperature' ,
+        errorBar: {
+            yLowerKey: 'temperatureLower',
+            yUpperKey: 'temperatureUpper',
+        },
     },
-  ],
+],
+```
+
+## Scatter Series Error Bars
+
+{% chartExampleRunner title="Scatter Series Error Bars" name="scatter-series-error-bars" type="generated" options="{ \"enterprise\": true }" /%}
+
+Error Bars can be enabled on Scatter Series using the `errorBars` key.
+
+The required properties `xLowerKey`, `xUpperKey`, `yLowerKey` and `yUpperKey`
+define the keys used to retrieve the X and Y error values from the data.
+
+```js
+data: [
+    {
+        volume: 0.5,
+        volumeLower: 0.45,
+        volumeUpper: 0.55,
+        pressure: 1.2,
+        pressureLower: 1.1,
+        pressureUpper: 1.4
+    },
+],
+series: [
+    {
+        type: 'scatter',
+        xKey: 'volume',
+        yKey: 'pressure',
+        errorBar:  {
+            xLowerKey: 'volumeLower',
+            xUpperKey: 'volumeUpper',
+            yLowerKey: 'pressureLower',
+            yUpperKey: 'pressureUpper',
+        },
+    },
+],
 ```


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9016
Key changes

**Documentation:**
- Add volume/pressure scatter example.
- Tidy indentation of line series example (use 4-space indentation like waterfall doc).

**Community Code:**
- Add `errorBar` option for Scatter series.
- Fire data processing event in `ScatterSeries` class.

**Enterprise Code:**
- Generalise the Y-axis error bar logic.
- Implement (optional) X-axis error bar configuration & rendering.