### PR TITLE
AG-9087 - Add doc internal links

### DIFF
--- a/packages/ag-charts-website/markdoc.config.ts
+++ b/packages/ag-charts-website/markdoc.config.ts
@@ -8,6 +8,10 @@ export default defineMarkdocConfig({
             ...nodes.heading, // Preserve default anchor link generation
             render: component('./src/components/Heading.astro'),
         },
+        link: {
+            ...nodes.link,
+            render: component('./src/components/Link.astro'),
+        },
     },
     functions: {
         isFramework: {

--- a/packages/ag-charts-website/src/components/Link.astro
+++ b/packages/ag-charts-website/src/components/Link.astro
@@ -1,0 +1,10 @@
+---
+import type { Framework } from '@ag-grid-types';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+const { framework } = Astro.params;
+const { href } = Astro.props;
+const url = urlWithPrefix({ url: href, framework: framework as Framework });
+---
+
+<a href={url}><slot /></a>

--- a/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
@@ -28,7 +28,7 @@ to, not a partial configuration. Use `AgChart.updateDelta()` to apply partial up
 `AgChartOptions` are supplied to the AG Charts component, and mutations of the options trigger an update of the chart configuration.
 {% /if %}
 
-See the [Options Reference](/charts-api/) for more detail about the `AgChartOptions` structure.
+See the [Options Reference](./api/) for more detail about the `AgChartOptions` structure.
 
 The following example demonstrates both create and update cases:
 

--- a/packages/ag-charts-website/src/content/docs/axes-domain/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/index.mdoc
@@ -61,4 +61,4 @@ To enforce the axis domain minimum and maximum configurations while also respect
 
 ## Next Up
 
-Continue to the next section to learn about [Axis Labels](/charts-axes-labels/).
+Continue to the next section to learn about [Axis Labels](./axes-labels/).

--- a/packages/ag-charts-website/src/content/docs/axes-grid-lines/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-grid-lines/index.mdoc
@@ -7,7 +7,7 @@ reference for interpreting data.
 
 ## Customising Grid Lines
 
-Grid lines are shown by default and their display is controlled by the [Axis Ticks](/charts-axes-ticks/).
+Grid lines are shown by default and their display is controlled by the [Axis Ticks](./axes-ticks/).
 
 Grid lines of each axis can be styled individually via the `gridStyle` config. The config takes an array of objects with two properties:
 
@@ -36,4 +36,4 @@ The following example demonstrates different grid line customisations:
 
 ## Next Up
 
-Continue to the next section to learn about [Secondary Axes](/charts-axes-secondary/).
+Continue to the next section to learn about [Secondary Axes](./axes-secondary/).

--- a/packages/ag-charts-website/src/content/docs/axes-labels/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-labels/index.mdoc
@@ -208,4 +208,4 @@ Please see the [Axis Ticks](#axis-ticks) section to learn more about tick interv
 
 ## Next Up
 
-Continue to the next section to learn about [Grid Lines](/charts-axes-grid-lines/).
+Continue to the next section to learn about [Grid Lines](./axes-grid-lines/).

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/index.mdoc
@@ -20,7 +20,7 @@ Tick placement can be customised by using one of the following strategies:
 
 The `tick.interval` defines the exact step value between ticks, expressed in the units of the respective axis.
 
-For [Number Axes](/charts-axes-types/#number), the interval property should be a number. Ticks will be displayed at every interval
+For [Number Axes](./axes-types/#number), the interval property should be a number. Ticks will be displayed at every interval
 value within the axis range. For instance, with an interval of `5`, the ticks will appear at `0`, `5`, `10`, and so on.
 
 ```js
@@ -33,11 +33,11 @@ The following example demonstrates how to specify the tick interval on a number 
 
 {% chartExampleRunner title="Number Axis Tick Interval" name="axis-tick-interval" type="generated" /%}
 
-For [Log Axes](/charts-axes-types/#log) the interval attribute should be assigned a numerical value. This number increments
+For [Log Axes](./axes-types/#log) the interval attribute should be assigned a numerical value. This number increments
 the exponent to which the base of the logarithm is elevated. For instance, an interval of `2` will display values like
 `10^0`, `10^2`, `10^4`, and so on.
 
-For [Time Axes](/charts-axes-types/#time) the interval property should represent a time interval, such as `time.month`, which
+For [Time Axes](./axes-types/#time) the interval property should represent a time interval, such as `time.month`, which
 displays a tick every month. You can also utilise an interval based on predefined time intervals, like `time.month.every(3)`,
 to customise the frequency of the ticks.
 
@@ -116,4 +116,4 @@ When `minSpacing` and `maxSpacing` are very close in value, the actual spacing b
 
 ## Next Up
 
-Continue to the next section to learn about [Axis Domain](/charts-axes-domain/).
+Continue to the next section to learn about [Axis Domain](./axes-domain/).

--- a/packages/ag-charts-website/src/content/docs/axes-types/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-types/index.mdoc
@@ -9,8 +9,8 @@ the relationships between data points on the graph. This section discusses the d
 
 A category axis is used to display distinct categories or groups of data in a chart.
 
-The category axis shows discrete categories or groups of data, unlike the [Number](/charts-axes-types/#number) or
-[Time](/charts-axes-types/#time) axes which use a continuous scale. For instance, in a bar chart of sales per product, the
+The category axis shows discrete categories or groups of data, unlike the [Number](./axes-types/#number) or
+[Time](./axes-types/#time) axes which use a continuous scale. For instance, in a bar chart of sales per product, the
 category axis shows the products as different groups, and the number axis displays the corresponding sale value for each group.
 
 If no `axes` are supplied, a category axis will be used as the x-axis by default. However, it can also
@@ -25,8 +25,8 @@ axes: [
 ];
 ```
 
-The category axis will attempt to render an [Axis Tick](/charts-axes-ticks/), [Axis Label](/charts-axis-labels/) and
-[Grid Line](/charts-axis-grid-lines/) for each category with even spacing.
+The category axis will attempt to render an [Axis Tick](./axes-ticks/), [Axis Label](./axis-labels/) and
+[Grid Line](./axis-grid-lines/) for each category with even spacing.
 
 For a full list of configuration options see [Category Axis Options](#category-axis-options).
 
@@ -34,11 +34,11 @@ For a full list of configuration options see [Category Axis Options](#category-a
 
 A number axis is used to display continuous numerical values in a chart.
 
-The number axis displays continuous numerical values, unlike the [Category](/charts-axes-types/#category) axis which displays
+The number axis displays continuous numerical values, unlike the [Category](./axes-types/#category) axis which displays
 discrete categories or groups of data. This means that while categories are spaced out evenly, the distance between values
 in a number axis will depend on their magnitude.
 
-Instead of using one [Axis Tick](/charts-axes-ticks/) per value, the number axis will determine the range of all values,
+Instead of using one [Axis Tick](./axes-ticks/) per value, the number axis will determine the range of all values,
 round it up and try to segment the rounded range with evenly spaced ticks.
 
 If no `axes` are supplied, a number axis will be used as the y-axis by default. However, it can also be explicitly
@@ -148,4 +148,4 @@ The domain of a log axis should be strictly positive or strictly negative (becau
 
 ## Next Up
 
-Continue to the next section to learn about the [Axis Ticks](/charts-axes-ticks/).
+Continue to the next section to learn about the [Axis Ticks](./axes-ticks/).

--- a/packages/ag-charts-website/src/content/docs/axes/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes/index.mdoc
@@ -8,12 +8,12 @@ This section provides an overview of the different chart axes elements.
 
 Follow the links below to learn more about chart axes:
 
--   **[Axis Types](/charts-axes-types/)**: The horizontal (X) and vertical (Y) lines in cartesian charts are referred to as chart axes, and they serve to illustrate the relationships between data points on the graph.
--   **[Axis Ticks](/charts-axes-ticks/)**: Axis ticks are markers placed at regular intervals along each axis, and are also used to determine where and how often to show the axis labels and grid lines.
--   **[Axis Labels](/charts-axes-labels/)**: Axis labels, positioned on the X and Y axes of a chart, supply context for the depicted data, making it easier for users to comprehend.
--   **[Grid Lines](/charts-axes-grid-lines/)**: Grid lines are the horizontal and vertical lines that divide a chart or graph into smaller sections, providing a visual reference for interpreting data.
--   **[Secondary Axis](/charts-axes-secondary/)**: Secondary axes are typically used to compare data sets with different scales, where extra y-axes are usually located on the opposite side of the chart.
+-   **[Axis Types](./axes-types/)**: The horizontal (X) and vertical (Y) lines in cartesian charts are referred to as chart axes, and they serve to illustrate the relationships between data points on the graph.
+-   **[Axis Ticks](./axes-ticks/)**: Axis ticks are markers placed at regular intervals along each axis, and are also used to determine where and how often to show the axis labels and grid lines.
+-   **[Axis Labels](./axes-labels/)**: Axis labels, positioned on the X and Y axes of a chart, supply context for the depicted data, making it easier for users to comprehend.
+-   **[Grid Lines](./axes-grid-lines/)**: Grid lines are the horizontal and vertical lines that divide a chart or graph into smaller sections, providing a visual reference for interpreting data.
+-   **[Secondary Axis](./axes-secondary/)**: Secondary axes are typically used to compare data sets with different scales, where extra y-axes are usually located on the opposite side of the chart.
 
 ## Next Up
 
-Continue to the next section to learn about [Axis Types](/charts-axes-types/).
+Continue to the next section to learn about [Axis Types](./axes-types/).

--- a/packages/ag-charts-website/src/content/docs/bar-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/bar-series/index.mdoc
@@ -27,7 +27,7 @@ In this configuration:
 
 -   `xKey` defines the categories, and is mapped to the [Category Axis](./axes-types/#category).
 -   `yKey` provides the numerical values, corresponding to the [Number Axis](./axes-types/#number).
--   `yName` configures display names, reflected in [Tooltip Headers](/tooltips) and [Legend Items](/legend).
+-   `yName` configures display names, reflected in [Tooltip Headers](./tooltips) and [Legend Items](./legend).
 
 ## Horizontal Bar
 

--- a/packages/ag-charts-website/src/content/docs/bar-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/bar-series/index.mdoc
@@ -25,8 +25,8 @@ series: [
 
 In this configuration:
 
--   `xKey` defines the categories, and is mapped to the [Category Axis](/charts-axes-types/#category).
--   `yKey` provides the numerical values, corresponding to the [Number Axis](/charts-axes-types/#number).
+-   `xKey` defines the categories, and is mapped to the [Category Axis](./axes-types/#category).
+-   `yKey` provides the numerical values, corresponding to the [Number Axis](./axes-types/#number).
 -   `yName` configures display names, reflected in [Tooltip Headers](/tooltips) and [Legend Items](/legend).
 
 ## Horizontal Bar

--- a/packages/ag-charts-website/src/content/docs/charts-overview/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/charts-overview/index.mdoc
@@ -3,6 +3,6 @@ title: 'AG Charts'
 sideMenu: false
 ---
 
-Our standalone charting library - explore the gallery below or see [Getting Started](/charts-getting-started/).
+Our standalone charting library - explore the gallery below or see [Getting Started](./getting-started/).
 
 <chart-gallery></chart-gallery>

--- a/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
@@ -4,7 +4,7 @@ title: 'Formatters'
 
 Formatters allow individual item customisation based on the data they represent.
 
-Please use the [API reference](/charts-api/) to learn more about the formatters, the inputs they receive and the attributes they allow to customize.
+Please use the [API reference](./api/) to learn more about the formatters, the inputs they receive and the attributes they allow to customize.
 
 ## Marker Formatter
 

--- a/packages/ag-charts-website/src/content/docs/getting-started/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/getting-started/index.mdoc
@@ -1436,7 +1436,7 @@ agCharts.AgChart.create(options);
 The table below gives the ranges of compatible versions of AG Charts with Angular versions.
 
 {% note %}
-AG Charts Legacy is only required for apps on Angular v8-11 that wish to use AG Charts v6-7. See [AG Grid Legacy](/angular-compatibility/#ag-grid-legacy) for more details about our legacy packages.
+AG Charts Legacy is only required for apps on Angular v8-11 that wish to use AG Charts v6-7. See [AG Grid Legacy](./angular-compatibility/#ag-grid-legacy) for more details about our legacy packages.
 {% /note %}
 
 Angular AG Charts AG Charts Package

--- a/packages/ag-charts-website/src/content/docs/layout/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/layout/index.mdoc
@@ -48,14 +48,14 @@ height of the title and its additional `subtitle.spacing`.
 ### Legend
 
 `legend` configuration is applied to the remaining space. The exact space consumed depends on how the
-[legend](/charts-legend/) is configured.
+[legend](./legend/) is configured.
 
 `legend.spacing` can be used to adjust the space between the legend and later components.
 
 ### Navigator
 
 `navigator` configuration is applied next. The exact space consumed depends on how the
-[navigator](/charts-navigator/) is configured.
+[navigator](./navigator/) is configured.
 
 `navigator.margin` can be used to adjust the space between the navigator and later components.
 
@@ -65,7 +65,7 @@ height of the title and its additional `subtitle.spacing`.
 
 ### Axes
 
-`axes` layout is then calculated based upon the remaining space and how the [axes](/charts-axes/) are
+`axes` layout is then calculated based upon the remaining space and how the [axes](./axes/) are
 configured.
 
 ### Series Area

--- a/packages/ag-charts-website/src/content/docs/legend/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/legend/index.mdoc
@@ -212,9 +212,9 @@ legend: {
 }
 ```
 
-If a callback function is configured via [`legend.listeners.legendItemClick`](/charts-events/#legend-events---legenditemclick-and-legenditemdoubleclick), it will still be invoked when the legend click event is fired.
+If a callback function is configured via [`legend.listeners.legendItemClick`](./events/#legend-events---legenditemclick-and-legenditemdoubleclick), it will still be invoked when the legend click event is fired.
 
-The `legendItemClick` and `legendItemDoubleClick` events can be used to listen to legend item clicks and double clicks, respectively. For more information see [Legend Events](/charts-events/#legend-events---legenditemclick-and-legenditemdoubleclick).
+The `legendItemClick` and `legendItemDoubleClick` events can be used to listen to legend item clicks and double clicks, respectively. For more information see [Legend Events](./events/#legend-events---legenditemclick-and-legenditemdoubleclick).
 
 {% note %}
 NOTE: Pie series sectors do not toggle when a legend item is double clicked.

--- a/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
@@ -117,7 +117,7 @@ We'll get a result like this:
 
 {% chartExampleRunner title="Line and Marker Colours" name="line-marker-colors" type="generated" /%}
 
-There are many other customisations you can make to the markers; see the [markers section](/charts-markers/) for more information.
+There are many other customisations you can make to the markers; see the [markers section](./markers/) for more information.
 
 ## Missing Data
 
@@ -131,7 +131,7 @@ If the bottom axis is also continuous (for example, if it's a `'number'` axis to
 
 ## Continuous Data
 
-By default, the bottom axis is a `'category'` axis, but this can be changed if you have continuous data that you would like to plot. See the [axes section](/charts-axes/) for more information on configuring axes.
+By default, the bottom axis is a `'category'` axis, but this can be changed if you have continuous data that you would like to plot. See the [axes section](./axes/) for more information on configuring axes.
 
 {% chartExampleRunner title="Continuous Data: Spiral Curve" name="two-number-axes" type="generated" options="{ \"exampleHeight\": 600 }" /%}
 

--- a/packages/ag-charts-website/src/content/docs/overview/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/overview/index.mdoc
@@ -2,6 +2,6 @@
 title: 'Overview'
 ---
 
-Our standalone charting library - explore the gallery below or see [Getting Started](/getting-started/).
+Our standalone charting library - explore the gallery below or see [Getting Started](./getting-started/).
 
 TODO: Gallery

--- a/packages/ag-charts-website/src/content/docs/pie-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/pie-series/index.mdoc
@@ -21,7 +21,7 @@ series: [
 ];
 ```
 
-This results in the chart shown below. Note that [tooltips](/charts-tooltips/) show the absolute value of each pie sector.
+This results in the chart shown below. Note that [tooltips](./tooltips/) show the absolute value of each pie sector.
 
 {% chartExampleRunner title="Basic Pie Chart" name="basic-pie" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/series/index.mdoc
@@ -3,7 +3,7 @@ title: 'Series'
 ---
 
 Chart series represent data sets to be plotted on a chart. Each series type
-([Line](/charts-line-series/), [Bar](/charts-bar-series/), [Pie](/charts-pie-series/) etc.) have
+([Line](./line-series/), [Bar](./bar-series/), [Pie](./pie-series/) etc.) have
 series-specific options, but there are some common options between them.
 
 ## Type
@@ -21,8 +21,8 @@ series: [
 If unspecified, we default to the optional `type` specified for the chart. Failing that we
 default to `'line'`.
 
-Cartesian series types can be [combined on the same chart](/charts-combination-series/).
-See the [Options Reference](/charts-api/) for the complete list of available series types.
+Cartesian series types can be [combined on the same chart](./combination-series/).
+See the [Options Reference](./api/) for the complete list of available series types.
 
 ## Data
 
@@ -51,4 +51,4 @@ See other available options in the [API reference](#api-reference).
 
 ## Next Up
 
-Continue to the next section to learn about the [Line Series](/charts-line-series/).
+Continue to the next section to learn about the [Line Series](./line-series/).

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/index.mdoc
@@ -22,8 +22,8 @@ series: [
 ],
 ```
 
-The `xKey` defines categories for the [Category Axis](/charts-axes-types/#category), and the `yKey` supplies numerical
-values for the [Number Axis](/charts-axes-types/#number).
+The `xKey` defines categories for the [Category Axis](./axes-types/#category), and the `yKey` supplies numerical
+values for the [Number Axis](./axes-types/#number).
 
 {% note %}
 Legend toggling is disabled in Waterfall Series to avoid misleading or incorrect data representation.
@@ -60,7 +60,7 @@ In this configuration:
 
 -   `totalType` specifies whether the value is a Total or Subtotal.
 -   `index` determines the position in the data after which the Total or Subtotal will appear.
--   `axisLabel` is used to provide a unique label, used as a category on the [Category Axis](/charts-axes-types/#category).
+-   `axisLabel` is used to provide a unique label, used as a category on the [Category Axis](./axes-types/#category).
 
 ## Customisation
 

--- a/packages/ag-charts-website/src/utils/pages.ts
+++ b/packages/ag-charts-website/src/utils/pages.ts
@@ -1,7 +1,7 @@
 import type { CollectionEntry } from 'astro:content';
 import glob from 'glob';
 import { TYPESCRIPT_INTERNAL_FRAMEWORKS, SITE_BASE_URL, DEV_FILE_BASE_PATH } from '../constants';
-import type { InternalFramework, Library } from '@ag-grid-types';
+import type { Framework, InternalFramework, Library } from '@ag-grid-types';
 import { getIsDev } from './env';
 import { pathJoin } from './pathJoin';
 

--- a/packages/ag-charts-website/src/utils/urlWithPrefix.test.ts
+++ b/packages/ag-charts-website/src/utils/urlWithPrefix.test.ts
@@ -1,0 +1,18 @@
+import { urlWithPrefix } from './urlWithPrefix';
+
+describe('urlWithPrefix', () => {
+    test.each`
+        url                      | framework       | expected
+        ${'./docs'}              | ${'javascript'} | ${'/ag-charts/javascript/docs'}
+        ${'./docs'}              | ${'react'}      | ${'/ag-charts/react/docs'}
+        ${'./docs/path'}         | ${'react'}      | ${'/ag-charts/react/docs/path'}
+        ${'/gallery'}            | ${'react'}      | ${'/ag-charts/gallery'}
+        ${'https://youtube.com'} | ${'react'}      | ${'https://youtube.com'}
+    `(
+        'returns "$expected" for url $url, framework $framework siteBaseUrl /ag-charts',
+        ({ url, framework, expected }) => {
+            const siteBaseUrl = '/ag-charts';
+            expect(urlWithPrefix({ url, framework, siteBaseUrl })).toBe(expected);
+        }
+    );
+});

--- a/packages/ag-charts-website/src/utils/urlWithPrefix.ts
+++ b/packages/ag-charts-website/src/utils/urlWithPrefix.ts
@@ -1,0 +1,25 @@
+import { SITE_BASE_URL } from '@constants';
+import { pathJoin } from './pathJoin';
+import type { Framework } from '@ag-grid-types';
+
+export const urlWithPrefix = ({
+    url = '',
+    framework,
+    siteBaseUrl = SITE_BASE_URL,
+}: {
+    url: string;
+    framework: Framework;
+    siteBaseUrl?: string;
+}): string => {
+    const hasRelativePathRegex = /(^\.\/)(.*)/;
+    const substitution = '$2';
+
+    let path = url;
+    if (url.match(hasRelativePathRegex)) {
+        path = pathJoin('/', siteBaseUrl, framework, url.replace(hasRelativePathRegex, substitution));
+    } else if (url.startsWith('/')) {
+        path = pathJoin('/', siteBaseUrl, url);
+    }
+
+    return path;
+};


### PR DESCRIPTION
## Changes

* Remove all `charts-` prefix in links
* Replace absolute link urls (`/`) with relative path (`./`)
* Add link markdoc replacement to include base url and framework

## Notes

The following rules are used for markdoc links:

1. For internal docs links, use `./` prefix only eg, `[Axis Label](./axis-labels/)` -> `/ag-charts/vue/axes-labels/`
1. For website links use `/` eg, `[Gallery](/gallery)` -> `/ag-charts/gallery/`
1. For external links use `http/s` eg, `[Getting started](https://www.youtube.com/watch?v=KS-wg5zfCXc)` -> `https://www.youtube.com/watch?v=KS-wg5zfCXc`