### PR TITLE
Remove expect.extend from test files (use jest.setup.ts)

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.test.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import type { AgCartesianChartOptions, AgChartInstance, AgChartOptions } from '../options/agChartOptions';
 import { AgChart } from './agChartV2';
 import type { Chart } from './chart';
@@ -11,12 +10,9 @@ import {
     IMAGE_SNAPSHOT_DEFAULTS,
     setupMockCanvas,
     extractImageData,
-    toMatchImage,
     prepareTestOptions,
     repeat,
 } from './test/utils';
-
-expect.extend({ toMatchImageSnapshot, toMatchImage });
 
 const EXAMPLES: Record<string, TestCase> = {
     TRUNCATED_LEGEND_ITEMS: {
@@ -52,7 +48,7 @@ describe('AgChartV2', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     const snapshot = async () => {
@@ -113,7 +109,7 @@ describe('AgChartV2', () => {
 
                     const exampleSnapshot = await snapshot();
                     if (snapshots[index] != null) {
-                        (expect(exampleSnapshot) as any).toMatchImage(snapshots[index], { writeDiff: false });
+                        expect(exampleSnapshot).toMatchImage(snapshots[index], { writeDiff: false });
                     }
 
                     if (previousSnapshot != null) {

--- a/packages/ag-charts-community/src/chart/cartesianChart.test.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import type { AgCartesianChartOptions, AgChartOptions } from '../options/agChartOptions';
 import { AgChart } from './agChartV2';
 import type { CartesianChart } from './cartesianChart';
@@ -10,14 +9,11 @@ import {
     IMAGE_SNAPSHOT_DEFAULTS,
     setupMockCanvas,
     extractImageData,
-    hoverAction,
     deproxy,
     prepareTestOptions,
 } from './test/utils';
 import * as examples from './test/examples';
 import { fail } from 'assert';
-
-expect.extend({ toMatchImageSnapshot });
 
 export function getData(): any[] {
     return [
@@ -206,7 +202,7 @@ describe('CartesianChart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     const seriesHighlightingTestCases = (name: string, tcOptions: AgCartesianChartOptions) => {

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import type { CartesianTestCase } from '../test/utils';
 import {
     cartesianChartAssertions,
@@ -18,8 +17,6 @@ import type {
 import { AgChart } from '../agChartV2';
 import * as examples from './test/examples';
 import type { Chart } from '../chart';
-
-expect.extend({ toMatchImageSnapshot });
 
 const labelPositions: AgCrossLineLabelPosition[] = [
     'top',
@@ -202,7 +199,7 @@ describe('crossLines', () => {
                     await waitForChartStability(chart);
 
                     const imageData = extractImageData(ctx);
-                    (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+                    expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 
                 const options: AgCartesianChartOptions = { ...example.options };

--- a/packages/ag-charts-community/src/chart/galleryExamples.test.ts
+++ b/packages/ag-charts-community/src/chart/galleryExamples.test.ts
@@ -1,20 +1,15 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { AgChartOptions } from '../options/agChartOptions';
 import { AgChart } from './agChartV2';
 import type { Chart } from './chart';
 import { EXAMPLES } from './test/examples-gallery';
 import {
-    waitForChartStability,
-    IMAGE_SNAPSHOT_DEFAULTS,
-    setupMockCanvas,
-    toMatchImage,
     extractImageData,
+    IMAGE_SNAPSHOT_DEFAULTS,
     prepareTestOptions,
+    setupMockCanvas,
+    waitForChartStability,
 } from './test/utils';
-
-expect.extend({ toMatchImageSnapshot, toMatchImage });
 
 describe('Gallery Examples', () => {
     let chart: Chart;
@@ -54,7 +49,7 @@ describe('Gallery Examples', () => {
                     await waitForChartStability(chart);
 
                     const imageData = extractImageData(ctx);
-                    (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+                    expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 
                 const options: AgChartOptions = { ...example.options };
@@ -121,7 +116,7 @@ describe('Gallery Examples', () => {
                     AgChart.update(chart, options);
                     const after = await snapshot();
 
-                    (expect(after) as any).toMatchImage(before);
+                    expect(after).toMatchImage(before);
                 });
             });
         }

--- a/packages/ag-charts-community/src/chart/galleryExamplesUSTimezone.test.ts
+++ b/packages/ag-charts-community/src/chart/galleryExamplesUSTimezone.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
 import type { AgChartOptions } from '../options/agChartOptions';
 import { AgChart } from './agChartV2';
@@ -13,13 +12,10 @@ import {
     waitForChartStability,
     IMAGE_SNAPSHOT_DEFAULTS,
     setupMockCanvas,
-    toMatchImage,
     extractImageData,
     prepareTestOptions,
 } from './test/utils';
 import { EXAMPLES } from './test/examples-gallery';
-
-expect.extend({ toMatchImageSnapshot, toMatchImage });
 
 const TIME_AXIS_EXAMPLES = Object.entries(EXAMPLES)
     .filter(([, { options }]) => {
@@ -68,7 +64,7 @@ describe('Gallery Examples (US TZ)', () => {
                 await waitForChartStability(chart);
 
                 const imageData = extractImageData(ctx);
-                (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+                expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
             };
 
             const options: AgChartOptions = { ...example.options };

--- a/packages/ag-charts-community/src/chart/integratedChartsExamples.test.ts
+++ b/packages/ag-charts-community/src/chart/integratedChartsExamples.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
 import type { AgChartOptions } from '../options/agChartOptions';
 import { AgChart } from './agChartV2';
 import type { Chart } from './chart';
@@ -9,12 +7,9 @@ import {
     waitForChartStability,
     IMAGE_SNAPSHOT_DEFAULTS,
     setupMockCanvas,
-    toMatchImage,
     extractImageData,
     prepareTestOptions,
 } from './test/utils';
-
-expect.extend({ toMatchImageSnapshot, toMatchImage });
 
 describe('Integrated Charts Examples', () => {
     let chart: Chart;
@@ -52,7 +47,7 @@ describe('Integrated Charts Examples', () => {
                     await waitForChartStability(chart);
 
                     const imageData = extractImageData(ctx);
-                    (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+                    expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 
                 const startingOptions: AgChartOptions = EXAMPLES[index - 1]?.options ?? {};

--- a/packages/ag-charts-community/src/chart/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import { AgChart } from './agChartV2';
 import type { CartesianChart } from './cartesianChart';
 import type { Chart } from './chart';
@@ -16,8 +15,6 @@ import {
 import * as examples from './test/examples';
 import type { AgCartesianChartOptions } from '../options/agChartOptions';
 import { seedRandom } from './test/random';
-
-expect.extend({ toMatchImageSnapshot });
 
 function buildSeries(data: { x: number; y: number }) {
     return {
@@ -67,7 +64,7 @@ describe('Legend', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     describe('Large series count chart', () => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
@@ -111,7 +111,7 @@ describe('AreaSeries', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     let chart: Chart;

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -118,7 +118,7 @@ describe('BarSeries', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     describe('#create', () => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -21,7 +21,7 @@ describe('BubbleSeries', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     let chart: Chart;

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
@@ -88,7 +88,7 @@ describe('LineSeries', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     let chart: Chart;

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
@@ -21,7 +21,7 @@ describe('ScatterSeries', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     let chart: Chart;

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
@@ -96,7 +96,7 @@ describe('PolarSeries', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     describe('#create', () => {
@@ -186,7 +186,7 @@ describe('PolarSeries', () => {
             chart.update(ChartUpdateType.FULL);
 
             const afterFinalUpdate = await snapshot();
-            (expect(afterFinalUpdate) as any).toMatchImage(reference);
+            expect(afterFinalUpdate).toMatchImage(reference);
         });
     });
 });

--- a/packages/ag-charts-community/src/chart/series/seriesLabels.test.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesLabels.test.ts
@@ -154,7 +154,7 @@ describe('series labels', () => {
                     await waitForChartStability(chart);
 
                     const imageData = extractImageData(ctx);
-                    (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+                    expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 
                 const options: AgChartOptions = { ...example.options };

--- a/packages/ag-charts-community/src/scene/scene.test.ts
+++ b/packages/ag-charts-community/src/scene/scene.test.ts
@@ -1,11 +1,8 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import { AgChart } from './../chart/agChartV2';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import * as examples from '../chart/test/examples';
-import { extractImageData, waitForChartStability, setupMockCanvas, IMAGE_SNAPSHOT_DEFAULTS } from '../chart/test/utils';
-import type { AgCartesianChartOptions, AgChartLegendOptions, AgChartInstance } from '../options/agChartOptions';
-
-expect.extend({ toMatchImageSnapshot });
+import { extractImageData, IMAGE_SNAPSHOT_DEFAULTS, setupMockCanvas, waitForChartStability } from '../chart/test/utils';
+import type { AgCartesianChartOptions, AgChartInstance, AgChartLegendOptions } from '../options/agChartOptions';
+import { AgChart } from './../chart/agChartV2';
 
 describe('Scene', () => {
     let chart: AgChartInstance;
@@ -28,7 +25,7 @@ describe('Scene', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     describe('on translation only change', () => {

--- a/packages/ag-charts-community/src/scene/shape/range.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/range.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
 import { setupMockCanvas, extractImageData } from '../../chart/test/utils';
 import { Range } from './range';
 
-expect.extend({ toMatchImageSnapshot });
 const CANVAS_WIDTH = 1150;
 
 describe('Range', () => {
@@ -100,7 +97,7 @@ describe('Range', () => {
 
             // Check rendering.
             const imageData = extractImageData(canvasCtx);
-            (expect(imageData) as any).toMatchImageSnapshot();
+            expect(imageData).toMatchImageSnapshot();
         });
     });
 });

--- a/packages/ag-charts-community/src/scene/shape/rect.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
 import { setupMockCanvas, extractImageData } from '../../chart/test/utils';
 import { Rect } from './rect';
 import { DropShadow } from '../dropShadow';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Rect', () => {
     describe('rendering', () => {
@@ -148,7 +144,7 @@ describe('Rect', () => {
 
             // Check rendering.
             const imageData = extractImageData(canvasCtx);
-            (expect(imageData) as any).toMatchImageSnapshot();
+            expect(imageData).toMatchImageSnapshot();
         });
     });
 });

--- a/packages/ag-charts-community/src/scene/shape/sector.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/sector.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
 import { setupMockCanvas, extractImageData } from '../../chart/test/utils';
 import { Sector } from './sector';
 import { DropShadow } from '../dropShadow';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Sector', () => {
     describe('rendering', () => {
@@ -109,7 +105,7 @@ describe('Sector', () => {
 
             // Check rendering.
             const imageData = extractImageData(canvasCtx);
-            (expect(imageData) as any).toMatchImageSnapshot();
+            expect(imageData).toMatchImageSnapshot();
         });
     });
 });

--- a/packages/ag-charts-community/src/scene/shape/text.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/text.test.ts
@@ -1,12 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
+import { extractImageData, setupMockCanvas } from '../../chart/test/utils';
 import type { TextWrap } from '../../options/agChartOptions';
-import { setupMockCanvas, extractImageData } from '../../chart/test/utils';
 import type { LayerManager } from '../node';
 import { Text } from './text';
-
-expect.extend({ toMatchImageSnapshot });
 
 function setUpMockLayerManager(canvasCtx): LayerManager {
     return {
@@ -245,7 +241,7 @@ describe('Text', () => {
             }
 
             const imageData = extractImageData(canvasCtx);
-            (expect(imageData) as any).toMatchImageSnapshot();
+            expect(imageData).toMatchImageSnapshot();
         });
 
         it('should wrap and render as expected', () => {
@@ -293,7 +289,7 @@ describe('Text', () => {
             }
 
             const imageData = extractImageData(canvasCtx);
-            (expect(imageData) as any).toMatchImageSnapshot();
+            expect(imageData).toMatchImageSnapshot();
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/axes/polarAxes.test.ts
+++ b/packages/ag-charts-enterprise/src/axes/polarAxes.test.ts
@@ -1,17 +1,13 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions, _ModuleSupport } from 'ag-charts-community';
-import { AgEnterpriseCharts } from '../main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { AgChartOptions } from 'ag-charts-community';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import { AgEnterpriseCharts } from '../main';
 import { prepareEnterpriseTestOptions } from '../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Polar Axes', () => {
     let chart: any;
@@ -81,7 +77,7 @@ describe('Polar Axes', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render polar axes as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/features/background/backgroundImage.test.ts
+++ b/packages/ag-charts-enterprise/src/features/background/backgroundImage.test.ts
@@ -1,17 +1,14 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgCartesianChartOptions, AgChartInstance, _ModuleSupport } from 'ag-charts-community';
-import { AgEnterpriseCharts } from '../../main';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { AgCartesianChartOptions, AgChartInstance } from 'ag-charts-community';
 import {
-    waitForChartStability,
+    extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
     setupMockCanvas,
-    extractImageData,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 import { BackgroundImage } from './backgroundImage';
-
-expect.extend({ toMatchImageSnapshot });
 
 const SMALL_IMAGE =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAEq2lUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS41LjAiPgogPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iCiAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgIHhtbG5zOnBob3Rvc2hvcD0iaHR0cDovL25zLmFkb2JlLmNvbS9waG90b3Nob3AvMS4wLyIKICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgZXhpZjpQaXhlbFhEaW1lbnNpb249IjMyIgogICBleGlmOlBpeGVsWURpbWVuc2lvbj0iMzIiCiAgIGV4aWY6Q29sb3JTcGFjZT0iMSIKICAgdGlmZjpJbWFnZVdpZHRoPSIzMiIKICAgdGlmZjpJbWFnZUxlbmd0aD0iMzIiCiAgIHRpZmY6UmVzb2x1dGlvblVuaXQ9IjIiCiAgIHRpZmY6WFJlc29sdXRpb249IjcyLjAiCiAgIHRpZmY6WVJlc29sdXRpb249IjcyLjAiCiAgIHBob3Rvc2hvcDpDb2xvck1vZGU9IjMiCiAgIHBob3Rvc2hvcDpJQ0NQcm9maWxlPSJzUkdCIElFQzYxOTY2LTIuMSIKICAgeG1wOk1vZGlmeURhdGU9IjIwMjEtMDItMDJUMTc6NTM6MjhaIgogICB4bXA6TWV0YWRhdGFEYXRlPSIyMDIxLTAyLTAyVDE3OjUzOjI4WiI+CiAgIDx4bXBNTTpIaXN0b3J5PgogICAgPHJkZjpTZXE+CiAgICAgPHJkZjpsaQogICAgICBzdEV2dDphY3Rpb249InByb2R1Y2VkIgogICAgICBzdEV2dDpzb2Z0d2FyZUFnZW50PSJBZmZpbml0eSBEZXNpZ25lciAoTm92IDExIDIwMjApIgogICAgICBzdEV2dDp3aGVuPSIyMDIxLTAyLTAyVDE3OjUzOjI4WiIvPgogICAgPC9yZGY6U2VxPgogICA8L3htcE1NOkhpc3Rvcnk+CiAgPC9yZGY6RGVzY3JpcHRpb24+CiA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgo8P3hwYWNrZXQgZW5kPSJyIj8+XkwPBAAAAYBpQ0NQc1JHQiBJRUM2MTk2Ni0yLjEAACiRdZHPK0RRFMc/3hD5EWJhYfESVkaMmtgoIw0laYwy2Lx580vNm3m9N5Jsla2ixMavBX8BW2WtFJGSnbImNug5z0zNJHNv957P/d5zTueeC0o4rRt2ZR8YmZwVCgbUuci8Wv2MIrOZLro13TZHpqcnKTs+7qhw7Y3XzVXe799RF4vbOlTUCA/rppUTHheeXMmZLm8Lt+opLSZ8KtxjSYHCt64ezfOLy8k8f7lshUOjoDQJq8kSjpawnrIMYXk5nUZ6WS/U476kPp6ZnRHbIasdmxBBAqhMMMYofvoZkt2PFx+9cqJMfN9v/BRZidVlN1nFYokkKXL0iLos2eNiE6LHZaZZdfv/t692YsCXz14fgKonx3nrguot+N50nM9Dx/k+As8jXGSK8dkDGHwXfbOode5D4zqcXRa16A6cb0Dbg6lZ2q/kkaUkEvB6Ag0RaLmG2oV8zwr3HN9DeE2+6gp296Bb/BsXfwBIdWfYViN73wAAAAlwSFlzAAALEwAACxMBAJqcGAAAAddJREFUWIXtkztIW1Ecxn/34dDVQQeXgikpuDgY1NIgDm4GpEVBBxcHdRPUCh26FBEaF62big/UwUUJcQqSgG8i4gMXsWInNV18gFSj93QIgmhy77k317rkB3c453zn/333nPOHHDleGeXxIByJdgDFLtT9XltTnZAR6k/Gn4GPLgQYBBwFcIWlW720PrRaJCHdczuA2E5qy0f32qykPuBmAGMrqa3s3el+O5ueBmgC3th1TgrUhZu83guhfrK7V7GWmFMfWtWASVLh7RLIGCAciTYCVRYF7mI3+txvQyt3YA4wa/YG/ECryfo90Nxf618EFh0GcNyGRuH5Un/Z8bc/IkhNBs2G0s3lSwQQ3pORuOdsugfoMdH5gE2rYqpd83en4xues2mnd/4MsxPoA0YfBqrxVy0/7Pqaf71f55Y5SLahCKIAw0CLjdo+pdv6CvRwJOoBGkw0RuLXl/WCq3iC1KnIciIj0oH3QG+GdQG0F7bFY0DMhrk0Zm9A5O/u/Kjs7NgRUJFBs6/A1UsEEJ6pyU3vxJhVq30A1rIJkK4NRfHM1Lp3YsyXTWFZdFJ/UP0wUfJzoOxtaD74P8zTIqBJgJD8KrP1S/cGDoAhyf2n2QbIkePV+QdZcZGr6u0rEgAAAABJRU5ErkJggg==';
@@ -170,7 +167,7 @@ describe('backgroundImage', () => {
             await waitForChartStability(chart);
 
             const imageData = extractImageData(ctx);
-            (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+            expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
         };
 
         it('Image in the center', async () => {

--- a/packages/ag-charts-enterprise/src/features/context-menu/placeholder.test.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/placeholder.test.ts
@@ -1,16 +1,13 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { AgChartOptions } from 'ag-charts-community';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
-import { prepareEnterpriseTestOptions } from '../../test/utils';
 import { AgEnterpriseCharts } from '../../main';
-
-expect.extend({ toMatchImageSnapshot });
+import { prepareEnterpriseTestOptions } from '../../test/utils';
 
 describe('Chart', () => {
     let chart: any;
@@ -44,7 +41,7 @@ describe('Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render placeholder chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.test.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.test.ts
@@ -1,26 +1,21 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type {
+    AgAreaSeriesOptions,
+    AgBarSeriesOptions,
+    AgCartesianAxisOptions,
     AgCartesianAxisPosition,
     AgCartesianChartOptions,
     AgChartOptions,
-    AgCartesianAxisOptions,
-    AgBarSeriesOptions,
-    AgAreaSeriesOptions,
-    _ModuleSupport,
 } from 'ag-charts-community';
-
-import { AgEnterpriseCharts } from '../../main';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
-    IMAGE_SNAPSHOT_DEFAULTS,
     hoverAction,
+    IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 function applyAxesFlip<T>(opts: T): T {
     const positionFlip = (position: AgCartesianAxisPosition) => {
@@ -276,7 +271,7 @@ describe('Crosshair', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     const CASES = [

--- a/packages/ag-charts-enterprise/src/features/navigator/navigator.test.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigator.test.ts
@@ -1,21 +1,17 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgCartesianChartOptions, _ModuleSupport } from 'ag-charts-community';
-
-import { AgEnterpriseCharts } from '../../main';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { AgCartesianChartOptions } from 'ag-charts-community';
 import {
-    waitForChartStability,
-    setupMockCanvas,
+    cartesianChartAssertions,
+    type CartesianTestCase,
+    CROSSLINE_EXAMPLES,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
-    type CartesianTestCase,
-    cartesianChartAssertions,
-    CROSSLINE_EXAMPLES,
     repeat,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 const { VALID_RANGE_CROSSLINES } = CROSSLINE_EXAMPLES;
 
@@ -139,7 +135,7 @@ describe('navigator', () => {
                     await waitForChartStability(chart);
 
                     const imageData = extractImageData(ctx);
-                    (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+                    expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 
                 const options: AgCartesianChartOptions = { ...example.options };

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
@@ -1,18 +1,15 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../../main';
-import { _ModuleSupport, AgEnterpriseCharts } from '../../main';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-    waitForChartStability,
-    setupMockCanvas,
-    extractImageData,
-    scrollAction,
-    IMAGE_SNAPSHOT_DEFAULTS,
     clickAction,
+    extractImageData,
+    IMAGE_SNAPSHOT_DEFAULTS,
+    scrollAction,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Zoom', () => {
     let chart: any;
@@ -70,7 +67,7 @@ describe('Zoom', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     describe('when a user scrolls the mouse wheel', () => {

--- a/packages/ag-charts-enterprise/src/galleryExamples.test.ts
+++ b/packages/ag-charts-enterprise/src/galleryExamples.test.ts
@@ -1,22 +1,15 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
-import { GALLERY_EXAMPLES } from 'ag-charts-community-test';
-import type { AgChartOptions, _ModuleSupport } from 'ag-charts-community';
-
-import { AgEnterpriseCharts } from './main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { AgChartOptions } from 'ag-charts-community';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
+    GALLERY_EXAMPLES,
     IMAGE_SNAPSHOT_DEFAULTS,
     prepareTestOptions,
-    toMatchImage,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import { AgEnterpriseCharts } from './main';
 import { prepareEnterpriseTestOptions } from './test/utils';
-
-expect.extend({ toMatchImageSnapshot, toMatchImage });
 
 const ENTERPRISE_GALLERY_EXAMPLES = Object.entries(GALLERY_EXAMPLES)
     .filter(([, v]) => v.enterprise)
@@ -62,7 +55,7 @@ describe('Gallery Examples', () => {
                     await waitForChartStability(chart);
 
                     const imageData = extractImageData(ctx);
-                    (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+                    expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
                 };
 
                 const options: AgChartOptions = { ...example.options };
@@ -129,7 +122,7 @@ describe('Gallery Examples', () => {
                     AgEnterpriseCharts.update(chart, options);
                     const after = await snapshot();
 
-                    (expect(after) as any).toMatchImage(before);
+                    expect(after).toMatchImage(before);
                 });
             });
         }

--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
@@ -1,17 +1,13 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts, _ModuleSupport } from '../main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../main';
 import { prepareEnterpriseTestOptions } from '../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Chart', () => {
     let chart: any;
@@ -61,7 +57,7 @@ describe('Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render placeholder chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.test.ts
@@ -1,17 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts } from '../../main';
 import {
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
     setupMockCanvas,
-    waitForChartStability,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 const BOX_PLOT_BAR_OPTIONS: AgChartOptions = {
     data: [
@@ -50,7 +47,7 @@ describe('Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
 
         chart.destroy();
     };

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
@@ -1,17 +1,14 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts, _ModuleSupport } from '../../main';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Chart', () => {
     let chart: any;
@@ -61,7 +58,7 @@ describe('Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render placeholder chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.test.ts
@@ -1,26 +1,21 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-
-import {
-    waitForChartStability,
-    setupMockCanvas,
-    extractImageData,
-    IMAGE_SNAPSHOT_DEFAULTS,
-    deproxy,
-    GALLERY_EXAMPLES,
-    hoverAction,
-    HISTOGRAM_SERIES_LABELS,
-    HISTOGRAM_SCATTER_COMBO_SERIES_LABELS,
-    cartesianChartAssertions,
-    type TestCase,
-    spyOnAnimationManager,
-} from 'ag-charts-community-test';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { _ModuleSupport, AgChartOptions } from 'ag-charts-community';
-
-import { prepareEnterpriseTestOptions } from '../../test/utils';
+import {
+    cartesianChartAssertions,
+    deproxy,
+    extractImageData,
+    GALLERY_EXAMPLES,
+    HISTOGRAM_SCATTER_COMBO_SERIES_LABELS,
+    HISTOGRAM_SERIES_LABELS,
+    hoverAction,
+    IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    spyOnAnimationManager,
+    type TestCase,
+    waitForChartStability,
+} from 'ag-charts-community-test';
 import { AgEnterpriseCharts } from '../../main';
-
-expect.extend({ toMatchImageSnapshot });
+import { prepareEnterpriseTestOptions } from '../../test/utils';
 
 const EXAMPLES: Record<string, TestCase> = {
     SIMPLE_HISTOGRAM: GALLERY_EXAMPLES.SIMPLE_HISTOGRAM_CHART_EXAMPLE,
@@ -49,7 +44,7 @@ describe('HistogramSeries', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     describe('#create', () => {

--- a/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
+++ b/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
@@ -1,18 +1,15 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts } from '../../main';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Nightingale Chart', () => {
     let chart: any;
@@ -72,7 +69,7 @@ describe('Nightingale Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render stacked nightingale chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/radar-area/radarArea.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-area/radarArea.test.ts
@@ -1,18 +1,14 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts, _ModuleSupport } from '../../main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Radar Area Chart', () => {
     let chart: any;
@@ -61,7 +57,7 @@ describe('Radar Area Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render polar chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/radar-line/radarLine.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-line/radarLine.test.ts
@@ -1,18 +1,14 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts, _ModuleSupport } from '../../main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Radar Line Chart', () => {
     let chart: any;
@@ -61,7 +57,7 @@ describe('Radar Line Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render polar chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
@@ -1,18 +1,14 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts } from '../../main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Radial Bar Chart', () => {
     let chart: any;
@@ -72,7 +68,7 @@ describe('Radial Bar Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render radial bar chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
@@ -1,18 +1,14 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts } from '../../main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Radial Column Chart', () => {
     let chart: any;
@@ -72,7 +68,7 @@ describe('Radial Column Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render radial column chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.test.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.test.ts
@@ -1,19 +1,15 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { AgCartesianSeriesLabelFormatterParams } from 'ag-charts-community';
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts, _ModuleSupport } from '../../main';
-
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Chart', () => {
     let chart: any;
@@ -140,7 +136,7 @@ describe('Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     it(`should render a range-area chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.test.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.test.ts
@@ -1,19 +1,15 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { AgCartesianSeriesLabelFormatterParams } from 'ag-charts-community';
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts, _ModuleSupport } from '../../main';
-
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Chart', () => {
     let chart: any;
@@ -171,7 +167,7 @@ describe('Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     function switchSeriesType<T>(opts: T, direction: 'horizontal' | 'vertical'): T {

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.test.ts
@@ -1,28 +1,26 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type {
+    AgCartesianChartOptions,
+    AgChartOptions,
+    AgPolarChartOptions,
+    AgTreemapSeriesOptions,
+    InteractionRange,
+} from 'ag-charts-community';
 import {
-    waitForChartStability,
-    IMAGE_SNAPSHOT_DEFAULTS,
-    setupMockCanvas,
-    extractImageData,
+    clickAction,
     deproxy,
+    extractImageData,
     GALLERY_EXAMPLES,
-    TREEMAP_SERIES_LABELS,
     hierarchyChartAssertions,
     hoverAction,
-    clickAction,
+    IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
+    TREEMAP_SERIES_LABELS,
+    waitForChartStability,
 } from 'ag-charts-community-test';
-import type { AgChartOptions } from 'ag-charts-community';
-
-import type { TreemapSeries } from './treemapSeries';
 import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-import type { InteractionRange } from 'ag-charts-community';
-import type { AgCartesianChartOptions } from 'ag-charts-community';
-import type { AgPolarChartOptions } from 'ag-charts-community';
-import type { AgTreemapSeriesOptions } from 'ag-charts-community';
-
-expect.extend({ toMatchImageSnapshot });
+import type { TreemapSeries } from './treemapSeries';
 
 describe('HierarchyChart', () => {
     let chart: any;
@@ -40,7 +38,7 @@ describe('HierarchyChart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     describe('Series Highlighting', () => {

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -1,18 +1,14 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import type { AgChartOptions } from '../../main';
-import { AgEnterpriseCharts, _ModuleSupport } from '../../main';
-
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-    waitForChartStability,
-    setupMockCanvas,
     extractImageData,
     IMAGE_SNAPSHOT_DEFAULTS,
+    setupMockCanvas,
     spyOnAnimationManager,
+    waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgChartOptions } from '../../main';
+import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-
-expect.extend({ toMatchImageSnapshot });
 
 describe('Chart', () => {
     let chart: any;
@@ -105,7 +101,7 @@ describe('Chart', () => {
         await waitForChartStability(chart);
 
         const imageData = extractImageData(ctx);
-        (expect(imageData) as any).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
+        expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     };
 
     function switchSeriesType<T>(opts: T, direction: 'horizontal' | 'vertical'): T {

--- a/packages/ag-charts-enterprise/tsconfig.spec.json
+++ b/packages/ag-charts-enterprise/tsconfig.spec.json
@@ -8,5 +8,12 @@
       "ag-charts-community": ["../../dist/packages/ag-charts-community/main.cjs"]
     }
   },
-  "include": ["jest.config.ts", "jest.setup.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/test/**", "src/**/*.d.ts"]
+  "include": [
+    "jest.config.ts",
+    "jest.setup.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/test/**",
+    "src/**/*.d.ts"
+  ]
 }

--- a/packages/ag-charts-enterprise/tsconfig.spec.json
+++ b/packages/ag-charts-enterprise/tsconfig.spec.json
@@ -8,5 +8,5 @@
       "ag-charts-community": ["../../dist/packages/ag-charts-community/main.cjs"]
     }
   },
-  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/test/**", "src/**/*.d.ts"]
+  "include": ["jest.config.ts", "jest.setup.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/test/**", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
Minor tests cleanup following the creation of a `jest.setup.ts` file