### PR TITLE
AG-9098 - Add enterprise module metadata and verification.

### DIFF
--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -1,0 +1,52 @@
+import type { Module } from '../../module-support';
+
+type EnterpriseModuleStub = Pick<Module<any>, 'type' | 'identifier' | 'optionsKey' | 'chartTypes'>;
+
+const EXPECTED_ENTERPRISE_MODULES: EnterpriseModuleStub[] = [
+    { type: 'axis', optionsKey: 'axes[]', chartTypes: ['polar'], identifier: 'angle-category' },
+    { type: 'axis', optionsKey: 'axes[]', chartTypes: ['polar'], identifier: 'angle-number' },
+    { type: 'root', optionsKey: 'animation', chartTypes: ['cartesian', 'polar', 'hierarchy'] },
+    { type: 'root', optionsKey: 'background', chartTypes: ['cartesian', 'polar', 'hierarchy'] },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['cartesian'], identifier: 'box-plot' },
+    { type: 'root', optionsKey: 'contextMenu', chartTypes: ['cartesian', 'polar', 'hierarchy'] },
+    { type: 'axis-option', optionsKey: 'crosshair', chartTypes: ['cartesian'] },
+    { type: 'series-option', optionsKey: 'errorBar', chartTypes: ['cartesian'], identifier: 'error-bars' },
+    {
+        type: 'legend',
+        optionsKey: 'gradientLegend',
+        chartTypes: ['cartesian', 'polar', 'hierarchy'],
+        identifier: 'gradient',
+    },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['cartesian'], identifier: 'heatmap' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['cartesian'], identifier: 'histogram' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['polar'], identifier: 'nightingale' },
+    { type: 'root', optionsKey: 'navigator', chartTypes: ['cartesian'] },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['polar'], identifier: 'radar-area' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['polar'], identifier: 'radar-line' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['polar'], identifier: 'radial-bar' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['polar'], identifier: 'radial-column' },
+    { type: 'axis', optionsKey: 'axes[]', chartTypes: ['polar'], identifier: 'radius-category' },
+    { type: 'axis', optionsKey: 'axes[]', chartTypes: ['polar'], identifier: 'radius-number' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['cartesian'], identifier: 'range-bar' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['cartesian'], identifier: 'range-area' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['hierarchy'], identifier: 'treemap' },
+    { type: 'series', optionsKey: 'series[]', chartTypes: ['cartesian'], identifier: 'waterfall' },
+    { type: 'root', optionsKey: 'zoom', chartTypes: ['cartesian'] },
+];
+
+export function verifyIfModuleExpected(module: Module<any>) {
+    if (module.packageType !== 'enterprise') {
+        throw new Error('AG Charts - internal configuration error, only enterprise modules need verification.');
+    }
+
+    const stub = EXPECTED_ENTERPRISE_MODULES.find((s) => {
+        return (
+            s.type === module.type &&
+            s.optionsKey === module.optionsKey &&
+            s.identifier === module.identifier &&
+            module.chartTypes.every((t) => s.chartTypes.includes(t))
+        );
+    });
+
+    return stub != null;
+}

--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -1,6 +1,8 @@
 import type { Module } from '../../module-support';
 
-type EnterpriseModuleStub = Pick<Module<any>, 'type' | 'identifier' | 'optionsKey' | 'chartTypes'>;
+type EnterpriseModuleStub = Pick<Module<any>, 'type' | 'identifier' | 'optionsKey' | 'chartTypes'> & {
+    useCount?: number;
+};
 
 const EXPECTED_ENTERPRISE_MODULES: EnterpriseModuleStub[] = [
     { type: 'axis', optionsKey: 'axes[]', chartTypes: ['polar'], identifier: 'angle-category' },
@@ -48,5 +50,14 @@ export function verifyIfModuleExpected(module: Module<any>) {
         );
     });
 
+    if (stub) {
+        stub.useCount ??= 0;
+        stub.useCount++;
+    }
+
     return stub != null;
+}
+
+export function getUnusedExpectedModules() {
+    return EXPECTED_ENTERPRISE_MODULES.filter(({ useCount }) => useCount == null || useCount === 0);
 }

--- a/packages/ag-charts-community/src/chart/factory/setupModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/setupModules.ts
@@ -4,9 +4,14 @@ import { JSON_APPLY_PLUGINS } from '../chartOptions';
 import { registerChartDefaults } from './chartTypes';
 import { registerLegend } from './legendTypes';
 import { registerSeries } from './seriesTypes';
+import { verifyIfModuleExpected } from './expectedEnterpriseModules';
 
 export function setupModules() {
     for (const m of REGISTERED_MODULES) {
+        if (m.packageType === 'enterprise' && !verifyIfModuleExpected(m)) {
+            throw new Error('AG Charts - Unexpected enterprise module registered: ' + m.identifier);
+        }
+
         if (JSON_APPLY_PLUGINS.constructors != null && m.optionConstructors != null) {
             Object.assign(JSON_APPLY_PLUGINS.constructors, m.optionConstructors);
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9098

Adds metadata about enterprise modules, and a verification step so we can't forget to add new modules.

The intent is that we can use this metadata to provide console warnings to users about enterprise features they are trying to use when only importing `ag-charts-community`.