### PR TITLE
Add basic Error Bars to Bar Series

### DIFF
--- a/packages/ag-charts-community/src/options/series/cartesian/barOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/barOptions.ts
@@ -6,6 +6,7 @@ import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../serie
 import type { AgCartesianSeriesTooltipRendererParams } from './cartesianSeriesTooltipOptions';
 import type { AgCartesianSeriesLabelOptions } from './cartesianLabelOptions';
 import type { FillOptions, LineDashOptions, StrokeOptions } from './commonOptions';
+import type { AgErrorBarOptions } from '../../chart/errorBarOptions';
 
 export type AgBarSeriesLabelPlacement = 'inside' | 'outside';
 
@@ -78,4 +79,6 @@ export interface AgBarSeriesOptions<DatumType = any>
     legendItemName?: string;
     /** A map of event names to event listeners. */
     listeners?: AgSeriesListeners<DatumType>;
+    /** Configuration for the series error bars. */
+    errorBar?: AgErrorBarOptions;
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/bar-series-error-bars/data.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/bar-series-error-bars/data.ts
@@ -1,0 +1,76 @@
+export function getData() {
+    return [
+        {
+            month: 'Jan',
+            temperature: 12.5,
+            temperatureLower: 10.0,
+            temperatureUpper: 15.0
+        },
+        {
+            month: 'Feb',
+            temperature: 13.0,
+            temperatureLower: 11.5,
+            temperatureUpper: 15.5
+        },
+        {
+            month: 'Mar',
+            temperature: 15.5,
+            temperatureLower: 13.0,
+            temperatureUpper: 18.0
+        },
+        {
+            month: 'Apr',
+            temperature: 18.0,
+            temperatureLower: 16.5,
+            temperatureUpper: 19.5
+        },
+        {
+            month: 'May',
+            temperature: 21.5,
+            temperatureLower: 19.0,
+            temperatureUpper: 24.0
+        },
+        {
+            month: 'Jun',
+            temperature: 24.0,
+            temperatureLower: 22.5,
+            temperatureUpper: 26.0
+        },
+        {
+            month: 'Jul',
+            temperature: 26.5,
+            temperatureLower: 24.0,
+            temperatureUpper: 29.0
+        },
+        {
+            month: 'Aug',
+            temperature: 25.0,
+            temperatureLower: 22.5,
+            temperatureUpper: 28.0
+        },
+        {
+            month: 'Sep',
+            temperature: 23.5,
+            temperatureLower: 21.0,
+            temperatureUpper: 27.0
+        },
+        {
+            month: 'Oct',
+            temperature: 20.0,
+            temperatureLower: 17.5,
+            temperatureUpper: 22.5
+        },
+        {
+            month: 'Nov',
+            temperature: 16.5,
+            temperatureLower: 14.0,
+            temperatureUpper: 19.0
+        },
+        {
+            month: 'Dec',
+            temperature: 13.0,
+            temperatureLower: 11.5,
+            temperatureUpper: 15.5
+        },
+    ] ;
+}

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/bar-series-error-bars/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/bar-series-error-bars/index.html
@@ -1,0 +1,1 @@
+<div id="myChart" style="height: 100%;"></div>

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/bar-series-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/bar-series-error-bars/main.ts
@@ -1,0 +1,23 @@
+import { AgChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+import { getData } from './data';
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    title: {
+        text: 'Monthly Average Temperatures with Error Bars (Celsius)',
+    },
+    series: [
+        {
+            type: 'bar',
+            xKey: 'month',
+            yKey: 'temperature',
+            errorBar:  {
+                yLowerKey: 'temperatureLower',
+                yUpperKey: 'temperatureUpper',
+            },
+        },
+    ],
+};
+
+AgEnterpriseCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -36,6 +36,37 @@ series: [
 ],
 ```
 
+## Bar Series Error Bars
+
+{% chartExampleRunner title="Bar Series Error Bars" name="bar-series-error-bars" type="generated" options="{ \"enterprise\": true }" /%}
+
+Error Bars can be enabled on Bar Series using the `errorBars` key.
+
+The `yLowerKey` and `yUpperKey` defines the keys used to retrieve the error
+values from the data.
+
+```js
+data: [
+    {
+        month: 'Jan',
+        temperature: 35,
+        temperatureLower: 32,
+        temperatureUpper: 37,
+    },
+],
+series: [
+    {
+        type: 'bar',
+        xKey: 'month',
+        yKey: 'temperature' ,
+        errorBar: {
+            yLowerKey: 'temperatureLower',
+            yUpperKey: 'temperatureUpper',
+        },
+    },
+],
+```
+
 ## Scatter Series Error Bars
 
 {% chartExampleRunner title="Scatter Series Error Bars" name="scatter-series-error-bars" type="generated" options="{ \"enterprise\": true }" /%}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9014

Add basic error bar implementation for bar series.

Known issues:
- The bars are drawn on top of the lower whiskers/caps.
- The example docs are mostly just a copy/paste of line series (we may want to reword this).
- Untested on stacked bar series (unlikely to work as intended).