### PR TITLE
Enforce and cleanup mutually exclusive chart updates.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -346,8 +346,6 @@ abstract class AgChartInternal {
             };
         }
 
-        await chart.awaitUpdateCompletion();
-
         if (chart.destroyed) return;
 
         debug('AgChartV2.updateDelta() - applying delta', processedOptions);

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -26,7 +26,6 @@ import type {
 import { debouncedAnimationFrame, debouncedCallback } from '../util/render';
 import type { Point } from '../scene/point';
 import { BOOLEAN, OPT_BOOLEAN, STRING_UNION, Validate } from '../util/validation';
-import { sleep } from '../util/async';
 import type { TooltipMeta as PointerMeta } from './tooltip/tooltip';
 import { Tooltip } from './tooltip/tooltip';
 import { ChartOverlays } from './overlay/chartOverlays';
@@ -59,6 +58,8 @@ import type { Module } from '../module/module';
 import type { ModuleContext } from '../module/moduleContext';
 import type { LegendModule, RootModule } from '../module/coreModules';
 import type { ModuleInstance } from '../module/baseModule';
+import { Mutex } from '../util/mutex';
+import { sleep } from '../util/async';
 
 type OptionalHTMLElement = HTMLElement | undefined | null;
 
@@ -307,7 +308,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.seriesLayerManager = new SeriesLayerManager(this.seriesRoot);
         this.callbackCache = new CallbackCache();
 
-        this.animationManager = new AnimationManager(this.interactionManager);
+        this.animationManager = new AnimationManager(this.interactionManager, this.updateMutex);
         this.animationManager.skip();
         this.animationManager.play();
 
@@ -462,7 +463,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
         let result: TransferableResources | undefined = undefined;
 
         this._performUpdateType = ChartUpdateType.NONE;
-        this._pendingFactoryUpdates.splice(0);
 
         this.tooltipManager.destroy();
         this.tooltip.destroy();
@@ -511,46 +511,19 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
     }
 
-    private _pendingFactoryUpdates: (() => Promise<void>)[] = [];
-
     requestFactoryUpdate(cb: () => Promise<void>) {
-        const callbacks = this._pendingFactoryUpdates;
-        const count = callbacks.length;
-        if (count === 0) {
-            callbacks.push(cb);
-            this._processCallbacks().catch((e) => Logger.errorOnce(e));
-        } else {
-            // Factory callback process already running, the callback will be invoked asynchronously.
-            // Clear the queue after the first callback to prevent unnecessary re-renderings.
-            callbacks.splice(1, count - 1, cb);
-        }
+        this._pendingFactoryUpdatesCount++;
+        this.updateMutex.acquire(async () => {
+            await cb();
+            this._pendingFactoryUpdatesCount--;
+        });
     }
 
-    private async _processCallbacks() {
-        const callbacks = this._pendingFactoryUpdates;
-        while (callbacks.length > 0) {
-            if (this.updatePending) {
-                await sleep(1);
-                continue; // Make sure to check queue has an item before continuing.
-            }
-            try {
-                await callbacks[0]();
-                this.callbackCache.invalidateCache();
-            } catch (e) {
-                Logger.error('update error', e);
-            }
-
-            callbacks.shift();
-        }
-    }
-
+    private _pendingFactoryUpdatesCount = 0;
     private _performUpdateNoRenderCount = 0;
     private _performUpdateType: ChartUpdateType = ChartUpdateType.NONE;
     get performUpdateType() {
         return this._performUpdateType;
-    }
-    get updatePending(): boolean {
-        return this._performUpdateType !== ChartUpdateType.NONE || this.lastInteractionEvent != null;
     }
     private _lastPerformUpdateError?: Error;
     get lastPerformUpdateError() {
@@ -559,19 +532,20 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     private updateShortcutCount = 0;
     private seriesToUpdate: Set<Series> = new Set();
+    private updateMutex = new Mutex();
+    private updateRequestors: Record<string, ChartUpdateType> = {};
     private performUpdateTrigger = debouncedCallback(async ({ count }) => {
         if (this._destroyed) return;
 
-        try {
-            await this.performUpdate(count);
-        } catch (error) {
-            this._lastPerformUpdateError = error as Error;
-            Logger.error('update error', error);
-        }
+        this.updateMutex.acquire(async () => {
+            try {
+                await this.performUpdate(count);
+            } catch (error) {
+                this._lastPerformUpdateError = error as Error;
+                Logger.error('update error', error);
+            }
+        });
     });
-    public async awaitUpdateCompletion() {
-        await this.performUpdateTrigger.await();
-    }
     public update(
         type = ChartUpdateType.FULL,
         opts?: { forceNodeDataRefresh?: boolean; seriesToUpdate?: Iterable<Series>; backOffMs?: number }
@@ -584,6 +558,12 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
         for (const series of seriesToUpdate) {
             this.seriesToUpdate.add(series);
+        }
+
+        if (Debug.check(true)) {
+            let stack = new Error().stack ?? '<unknown>';
+            stack = stack.replace(/\([^)]*/g, '');
+            this.updateRequestors[stack] = type;
         }
 
         if (type < this._performUpdateType) {
@@ -647,6 +627,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             case ChartUpdateType.NONE:
                 // Do nothing.
                 this.updateShortcutCount = 0;
+                this.updateRequestors = {};
         }
 
         const end = performance.now();
@@ -665,7 +646,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
             Logger.warn(
                 `exceeded the maximum number of simultaneous updates (${
                     maxShortcuts + 1
-                }), discarding changes and rendering`
+                }), discarding changes and rendering`,
+                this.updateRequestors
             );
             return false;
         }
@@ -1369,13 +1351,20 @@ export abstract class Chart extends Observable implements AgChartInstance {
     async waitForUpdate(timeoutMs = 5000): Promise<void> {
         const start = performance.now();
 
-        while (this._pendingFactoryUpdates.length > 0 || this.updatePending) {
+        if (this._pendingFactoryUpdatesCount > 0) {
+            // Await until any pending updates are flushed through.
+            await this.updateMutex.acquire(async () => undefined);
+        }
+
+        while (this._performUpdateType !== ChartUpdateType.NONE) {
             if (performance.now() - start > timeoutMs) {
                 throw new Error('waitForUpdate() timeout reached.');
             }
             await sleep(5);
         }
-        await this.awaitUpdateCompletion();
+
+        // Await until any remaining updates are flushed through.
+        return this.updateMutex.acquire(async () => undefined);
     }
 
     protected handleOverlays() {

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -621,6 +621,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             case ChartUpdateType.SCENE_RENDER:
                 if (this.checkUpdateShortcut(ChartUpdateType.SCENE_RENDER)) break;
 
+                extraDebugStats['updateShortcutCount'] = this.updateShortcutCount;
                 await this.scene.render({ debugSplitTimes: splits, extraDebugStats });
                 this.extraDebugStats = {};
             // eslint-disable-next-line no-fallthrough
@@ -1353,7 +1354,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
         if (this._pendingFactoryUpdatesCount > 0) {
             // Await until any pending updates are flushed through.
-            await this.updateMutex.acquire(async () => undefined);
+            await this.updateMutex.waitForClearAcquireQueue();
         }
 
         while (this._performUpdateType !== ChartUpdateType.NONE) {
@@ -1364,7 +1365,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
 
         // Await until any remaining updates are flushed through.
-        return this.updateMutex.acquire(async () => undefined);
+        await this.updateMutex.waitForClearAcquireQueue();
     }
 
     protected handleOverlays() {

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -3,6 +3,7 @@ import { BaseManager } from './baseManager';
 import type { InteractionManager } from './interactionManager';
 import type { AnimationOptions, AnimationValue, IAnimation } from '../../motion/animation';
 import { Animation } from '../../motion/animation';
+import type { Mutex } from '../../util/mutex';
 
 type AnimationEventType = 'animation-frame';
 
@@ -33,7 +34,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
     defaultDuration = 1000;
 
-    constructor(private interactionManager: InteractionManager) {
+    constructor(private readonly interactionManager: InteractionManager, private readonly chartUpdateMutex: Mutex) {
         super();
     }
 
@@ -157,17 +158,22 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         const onAnimationFrame = (time: number) => {
             this.requestId = requestAnimationFrame(onAnimationFrame);
 
-            const deltaTime = time - (prevTime ?? time);
+            const executeAnimationFrame = async () => {
+                const deltaTime = time - (prevTime ?? time);
 
-            prevTime = time;
+                prevTime = time;
 
-            this.debug('AnimationManager - onAnimationFrame()', { controllersCount: this.controllers.size });
+                this.debug('AnimationManager - onAnimationFrame()', { controllersCount: this.controllers.size });
 
-            for (const controller of this.controllers.values()) {
-                controller.update(deltaTime);
-            }
+                for (const controller of this.controllers.values()) {
+                    controller.update(deltaTime);
+                }
 
-            this.listeners.dispatch('animation-frame', { type: 'animation-frame', deltaMs: deltaTime });
+                this.listeners.dispatch('animation-frame', { type: 'animation-frame', deltaMs: deltaTime });
+            };
+
+            // Only run the animation frame if we can acquire the chart update mutex immediately.
+            this.chartUpdateMutex.acquireImmediately(executeAnimationFrame);
         };
 
         this.requestId = requestAnimationFrame(onAnimationFrame);

--- a/packages/ag-charts-community/src/util/mutex.ts
+++ b/packages/ag-charts-community/src/util/mutex.ts
@@ -1,0 +1,46 @@
+import { Logger } from './logger';
+
+type MutexCallback = () => Promise<void>;
+
+export class Mutex {
+    private available: boolean = true;
+    private acquireQueue: [MutexCallback, () => void][] = [];
+
+    public acquire(cb: MutexCallback): Promise<void> {
+        return new Promise((resolve) => {
+            this.acquireQueue.push([cb, resolve]);
+
+            if (this.available) {
+                this.dispatchNext();
+            }
+        });
+    }
+
+    public async acquireImmediately(cb: MutexCallback) {
+        if (!this.available) {
+            return false;
+        }
+
+        await this.acquire(cb);
+        return true;
+    }
+
+    private async dispatchNext() {
+        this.available = false;
+
+        let [next, done] = this.acquireQueue.shift() ?? [];
+        while (next) {
+            try {
+                await next();
+                done?.();
+            } catch (error) {
+                Logger.error('mutex callback error', error);
+                done?.();
+            }
+
+            [next, done] = this.acquireQueue.shift() ?? [];
+        }
+
+        this.available = true;
+    }
+}

--- a/packages/ag-charts-community/src/util/mutex.ts
+++ b/packages/ag-charts-community/src/util/mutex.ts
@@ -25,6 +25,10 @@ export class Mutex {
         return true;
     }
 
+    public async waitForClearAcquireQueue() {
+        return this.acquire(async () => undefined);
+    }
+
     private async dispatchNext() {
         this.available = false;
 


### PR DESCRIPTION
Whilst investigating the source of competing chart updates for a specific large-scale heatmap case, I found that `AnimationManager` animation frame updates don't consider whether `Chart.performUpdate()` is mid-execution. These two processes should be mutually exclusive practically, as `Chart.performUpdate()` will likely affect the currently executed animation anyway.

Adds:
- `Mutex` type to isolate mutex-related behaviours.
- Use of a shared `Mutex` for factory options update, `Chart.performUpdate()` and `AnimationManager` animation-frame processing.
- More debug information for repeated/looping `Chart.performUpdate()` cases.
