### PR TITLE
AG-9435 - Block redundant highlight maintenance.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -327,7 +327,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.layoutService.addListener('start-layout', (e) => this.positionCaptions(e.shrinkRect)),
             this.layoutService.addListener('layout-complete', (e) => this.layoutComplete(e)),
 
-            // Add interaction listeners last so child components are registered first.
             this.interactionManager.addListener('click', (event) => this.onClick(event)),
             this.interactionManager.addListener('dblclick', (event) => this.onDoubleClick(event)),
             this.interactionManager.addListener('hover', (event) => this.onMouseMove(event)),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9435

Follow up to #278 to reduce redundant `Chart.performUpdate()` restarts/interruption from series highlighting.

The failure case in AG-9435 happens during drag-to-pan - it appears that removing the re-highlighting behaviour during this operation resolves the processing conflict that prevents `Chart.performUpdate()` to complete in a single pass.

Bonus:
- Cleanup of the `Chart` constructor & fix for listener destruction on `Chart.destroy()`.