### PR TITLE
Enforce Typescript override modifier.

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -54,12 +54,12 @@ export abstract class CartesianAxis<
         }
     }
 
-    update(primaryTickCount?: number): number | undefined {
+    override update(primaryTickCount?: number): number | undefined {
         this.updateDirection();
         return super.update(primaryTickCount);
     }
 
-    protected createAxisContext(): AxisContext {
+    protected override createAxisContext(): AxisContext {
         return {
             ...super.createAxisContext(),
             position: this.position,
@@ -70,7 +70,7 @@ export abstract class CartesianAxis<
         assignJsonApplyConstructedArray(crossLines, CartesianCrossLine);
     }
 
-    protected createLabel() {
+    protected override createLabel() {
         return new CartesianAxisLabel();
     }
 }

--- a/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
@@ -34,7 +34,7 @@ export class CategoryAxis extends CartesianAxis<BandScale<string | object>> {
         return this.scale.paddingOuter;
     }
 
-    normaliseDataDomain(d: (string | object)[]) {
+    override normaliseDataDomain(d: (string | object)[]) {
         const domain = [];
         const uniqueValues = new Set();
         for (const v of d) {
@@ -48,7 +48,7 @@ export class CategoryAxis extends CartesianAxis<BandScale<string | object>> {
         return { domain, clipped: false };
     }
 
-    protected calculateDomain() {
+    protected override calculateDomain() {
         if (!this._paddingOverrideEnabled) {
             const { boundSeries } = this;
             const paddings = boundSeries.map((s) => s.getBandScalePadding?.()).filter((p) => p != null);

--- a/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -56,7 +56,7 @@ export class GroupedCategoryAxis extends CartesianAxis<BandScale<string | number
         this.labelSelection = Selection.select(tickLabelGroup, Text);
     }
 
-    protected updateRange() {
+    protected override updateRange() {
         const { range: rr, visibleRange: vr, scale } = this;
         const span = (rr[1] - rr[0]) / (vr[1] - vr[0]);
         const shift = span * vr[0];
@@ -83,14 +83,14 @@ export class GroupedCategoryAxis extends CartesianAxis<BandScale<string | number
         }
     }
 
-    readonly translation: Point = {
+    override readonly translation: Point = {
         x: 0,
         y: 0,
     };
 
-    readonly line = new AxisLine();
+    override readonly line = new AxisLine();
 
-    readonly label = new GroupedCategoryAxisLabel();
+    override readonly label = new GroupedCategoryAxisLabel();
 
     private get lineHeight() {
         return this.label.fontSize * 1.5;
@@ -106,7 +106,7 @@ export class GroupedCategoryAxis extends CartesianAxis<BandScale<string | number
     /**
      * The length of the grid. The grid is only visible in case of a non-zero value.
      */
-    set gridLength(value: number) {
+    override set gridLength(value: number) {
         // Was visible and now invisible, or was invisible and now visible.
         if ((this._gridLength && !value) || (!this._gridLength && value)) {
             this.gridLineSelection.clear();
@@ -114,11 +114,11 @@ export class GroupedCategoryAxis extends CartesianAxis<BandScale<string | number
         }
         this._gridLength = value;
     }
-    get gridLength(): number {
+    override get gridLength(): number {
         return this._gridLength;
     }
 
-    protected calculateDomain() {
+    protected override calculateDomain() {
         const { direction, boundSeries } = this;
         const domains: any[][] = [];
         let isNumericX: boolean | undefined = undefined;
@@ -148,7 +148,7 @@ export class GroupedCategoryAxis extends CartesianAxis<BandScale<string | number
         this.scale.domain = this.dataDomain.domain;
     }
 
-    normaliseDataDomain(d: any[]) {
+    override normaliseDataDomain(d: any[]) {
         // Prevent duplicate categories.
         const values = d.filter((s, i, arr) => arr.indexOf(s) === i);
 
@@ -177,7 +177,7 @@ export class GroupedCategoryAxis extends CartesianAxis<BandScale<string | number
      * but this extra level of async indirection will not just introduce an unwanted delay,
      * it will also make it harder to reason about the program.
      */
-    update(primaryTickCount?: number): number | undefined {
+    override update(primaryTickCount?: number): number | undefined {
         this.updateDirection();
         this.calculateDomain();
         this.updateRange();

--- a/packages/ag-charts-community/src/chart/axis/logAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/logAxis.ts
@@ -14,10 +14,10 @@ function NON_ZERO_NUMBER() {
 }
 
 export class LogAxis extends NumberAxis {
-    static className = 'LogAxis';
-    static type = 'log' as const;
+    static override className = 'LogAxis';
+    static override type = 'log' as const;
 
-    normaliseDataDomain(d: number[]) {
+    override normaliseDataDomain(d: number[]) {
         const { min, max } = this;
 
         const { extent, clipped } = normalisedExtentWithMetadata(d, min, max);
@@ -49,11 +49,11 @@ export class LogAxis extends NumberAxis {
 
     @Validate(AND(NUMBER_OR_NAN(), LESS_THAN('max'), NON_ZERO_NUMBER()))
     @Default(NaN)
-    min: number = NaN;
+    override min: number = NaN;
 
     @Validate(AND(NUMBER_OR_NAN(), GREATER_THAN('min'), NON_ZERO_NUMBER()))
     @Default(NaN)
-    max: number = NaN;
+    override max: number = NaN;
 
     set base(value: number) {
         (this.scale as LogScale).base = value;

--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -12,7 +12,7 @@ import { CartesianAxis } from './cartesianAxis';
 class NumberAxisTick extends AxisTick<LinearScale | LogScale, number> {
     @Validate(AND(NUMBER_OR_NAN(1), GREATER_THAN('minSpacing')))
     @Default(NaN)
-    maxSpacing: number = NaN;
+    override maxSpacing: number = NaN;
 }
 
 export class NumberAxis extends CartesianAxis<LinearScale | LogScale, number> {
@@ -23,7 +23,7 @@ export class NumberAxis extends CartesianAxis<LinearScale | LogScale, number> {
         super(moduleCtx, scale);
     }
 
-    normaliseDataDomain(d: number[]) {
+    override normaliseDataDomain(d: number[]) {
         const { min, max } = this;
         const { extent, clipped } = normalisedExtentWithMetadata(d, min, max);
 
@@ -38,7 +38,7 @@ export class NumberAxis extends CartesianAxis<LinearScale | LogScale, number> {
     @Default(NaN)
     max: number = NaN;
 
-    formatDatum(datum: number): string {
+    override formatDatum(datum: number): string {
         if (typeof datum === 'number') {
             return datum.toFixed(2);
         } else {
@@ -49,11 +49,11 @@ export class NumberAxis extends CartesianAxis<LinearScale | LogScale, number> {
         }
     }
 
-    protected createTick() {
+    protected override createTick() {
         return new NumberAxisTick();
     }
 
-    updateSecondaryAxisTicks(primaryTickCount: number | undefined): any[] {
+    override updateSecondaryAxisTicks(primaryTickCount: number | undefined): any[] {
         if (this.dataDomain == null) {
             throw new Error('AG Charts - dataDomain not calculated, cannot perform tick calculation.');
         }

--- a/packages/ag-charts-community/src/chart/axis/polarAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/polarAxis.ts
@@ -11,7 +11,7 @@ export abstract class PolarAxis<S extends Scale<any, any, any> = Scale<any, any,
     @Validate(NUMBER(0, 1))
     innerRadiusRatio: number = 0;
 
-    protected defaultTickMinSpacing = 20;
+    protected override defaultTickMinSpacing = 20;
 
     computeLabelsBBox(_options: { hideWhenNecessary: boolean }, _seriesRect: BBox): BBox | null {
         return null;

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -9,7 +9,7 @@ import { CartesianAxis } from './cartesianAxis';
 class TimeAxisTick extends AxisTick<TimeScale, number | Date> {
     @Validate(AND(NUMBER_OR_NAN(1), GREATER_THAN('minSpacing')))
     @Default(NaN)
-    maxSpacing: number = NaN;
+    override maxSpacing: number = NaN;
 }
 
 export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
@@ -36,7 +36,7 @@ export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
     @Validate(AND(OPT_DATE_OR_DATETIME_MS, GREATER_THAN('min')))
     max?: Date | number = undefined;
 
-    normaliseDataDomain(d: Date[]) {
+    override normaliseDataDomain(d: Date[]) {
         let { min, max } = this;
         let clipped = false;
 
@@ -65,11 +65,11 @@ export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
         return { domain: d, clipped };
     }
 
-    protected createTick() {
+    protected override createTick() {
         return new TimeAxisTick();
     }
 
-    protected onLabelFormatChange(ticks: any[], format?: string) {
+    protected override onLabelFormatChange(ticks: any[], format?: string) {
         if (format) {
             super.onLabelFormatChange(ticks, format);
         } else {
@@ -78,11 +78,11 @@ export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
         }
     }
 
-    formatDatum(datum: Date): string {
+    override formatDatum(datum: Date): string {
         return this.moduleCtx.callbackCache.call(this.datumFormatter, datum) ?? String(datum);
     }
 
-    calculatePadding(_min: number, _max: number): [number, number] {
+    override calculatePadding(_min: number, _max: number): [number, number] {
         // numbers in domain correspond to Unix timestamps
         // automatically expand domain by 1 in forward direction
         return [0, 1];

--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -23,7 +23,7 @@ export class CartesianChart extends Chart {
         super(specialOverrides, resources);
     }
 
-    async performLayout() {
+    override async performLayout() {
         const shrinkRect = await super.performLayout();
 
         const { seriesRect, visibility, clipSeries } = this.updateAxes(shrinkRect);

--- a/packages/ag-charts-community/src/chart/hierarchyChart.ts
+++ b/packages/ag-charts-community/src/chart/hierarchyChart.ts
@@ -12,7 +12,7 @@ export class HierarchyChart extends Chart {
 
     protected _data: any = {};
 
-    async performLayout() {
+    override async performLayout() {
         const shrinkRect = await super.performLayout();
 
         const {

--- a/packages/ag-charts-community/src/chart/layout/layoutService.ts
+++ b/packages/ag-charts-community/src/chart/layout/layoutService.ts
@@ -38,7 +38,7 @@ type Handler<T extends EventTypes> = T extends LayoutStage ? LayoutProcessor : L
 export class LayoutService extends Listeners<EventTypes, Handler<EventTypes>> {
     private readonly layoutComplete = 'layout-complete';
 
-    public addListener<T extends EventTypes>(eventType: T, handler: Handler<T>) {
+    public override addListener<T extends EventTypes>(eventType: T, handler: Handler<T>) {
         if (this.isLayoutStage(eventType) || this.isLayoutComplete(eventType)) {
             return super.addListener(eventType, handler);
         }

--- a/packages/ag-charts-community/src/chart/marker/circle.ts
+++ b/packages/ag-charts-community/src/chart/marker/circle.ts
@@ -1,9 +1,9 @@
 import { Marker } from './marker';
 
 export class Circle extends Marker {
-    static className = 'Circle';
+    static override className = 'Circle';
 
-    updatePath() {
+    override updatePath() {
         const { x, y, path, size } = this;
         const r = size / 2;
 

--- a/packages/ag-charts-community/src/chart/marker/cross.ts
+++ b/packages/ag-charts-community/src/chart/marker/cross.ts
@@ -2,7 +2,7 @@ import type { MarkerPathMove } from './marker';
 import { Marker } from './marker';
 
 export class Cross extends Marker {
-    static className = 'Cross';
+    static override className = 'Cross';
     static moves: MarkerPathMove[] = [
         { x: -1, y: 0, t: 'move' },
         { x: -1, y: -1 },
@@ -18,7 +18,7 @@ export class Cross extends Marker {
         { x: -1, y: -1 },
     ];
 
-    updatePath() {
+    override updatePath() {
         const s = this.size / 4.2;
 
         super.applyPath(s, Cross.moves);

--- a/packages/ag-charts-community/src/chart/marker/diamond.ts
+++ b/packages/ag-charts-community/src/chart/marker/diamond.ts
@@ -2,7 +2,7 @@ import type { MarkerPathMove } from './marker';
 import { Marker } from './marker';
 
 export class Diamond extends Marker {
-    static className = 'Diamond';
+    static override className = 'Diamond';
 
     static moves: MarkerPathMove[] = [
         { x: 0, y: -1, t: 'move' },
@@ -12,7 +12,7 @@ export class Diamond extends Marker {
         { x: +1, y: -1 },
     ];
 
-    updatePath() {
+    override updatePath() {
         const s = this.size / 2;
 
         super.applyPath(s, Diamond.moves);

--- a/packages/ag-charts-community/src/chart/marker/heart.ts
+++ b/packages/ag-charts-community/src/chart/marker/heart.ts
@@ -1,13 +1,13 @@
 import { Marker } from './marker';
 
 export class Heart extends Marker {
-    static className = 'Heart';
+    static override className = 'Heart';
 
     rad(degree: number) {
         return (degree / 180) * Math.PI;
     }
 
-    updatePath() {
+    override updatePath() {
         const { x, path, size, rad } = this;
         const r = size / 4;
         const y = this.y + r / 2;

--- a/packages/ag-charts-community/src/chart/marker/marker.ts
+++ b/packages/ag-charts-community/src/chart/marker/marker.ts
@@ -13,7 +13,7 @@ export abstract class Marker extends Path {
     @ScenePathChangeDetection({ convertor: Math.abs })
     size: number = 12;
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         const { x, y, size } = this;
         const half = size / 2;
 

--- a/packages/ag-charts-community/src/chart/marker/plus.ts
+++ b/packages/ag-charts-community/src/chart/marker/plus.ts
@@ -2,7 +2,7 @@ import type { MarkerPathMove } from './marker';
 import { Marker } from './marker';
 
 export class Plus extends Marker {
-    static className = 'Plus';
+    static override className = 'Plus';
 
     static moves: MarkerPathMove[] = [
         { x: -0.5, y: -0.5, t: 'move' },
@@ -19,7 +19,7 @@ export class Plus extends Marker {
         { x: 0, y: -1 },
     ];
 
-    updatePath() {
+    override updatePath() {
         const s = this.size / 3;
 
         super.applyPath(s, Plus.moves);

--- a/packages/ag-charts-community/src/chart/marker/square.ts
+++ b/packages/ag-charts-community/src/chart/marker/square.ts
@@ -1,9 +1,9 @@
 import { Marker } from './marker';
 
 export class Square extends Marker {
-    static className = 'Square';
+    static override className = 'Square';
 
-    updatePath() {
+    override updatePath() {
         const { path, x, y } = this;
         const hs = this.size / 2;
 

--- a/packages/ag-charts-community/src/chart/marker/triangle.ts
+++ b/packages/ag-charts-community/src/chart/marker/triangle.ts
@@ -2,7 +2,7 @@ import type { MarkerPathMove } from './marker';
 import { Marker } from './marker';
 
 export class Triangle extends Marker {
-    static className = 'Triangle';
+    static override className = 'Triangle';
 
     static moves: MarkerPathMove[] = [
         { x: 0, y: -0.48, t: 'move' },
@@ -10,7 +10,7 @@ export class Triangle extends Marker {
         { x: -1, y: 0 },
     ];
 
-    updatePath() {
+    override updatePath() {
         const s = this.size * 1.1;
 
         super.applyPath(s, Triangle.moves);

--- a/packages/ag-charts-community/src/chart/markerLabel.ts
+++ b/packages/ag-charts-community/src/chart/markerLabel.ts
@@ -8,7 +8,7 @@ import type { Marker } from './marker/marker';
 import { Square } from './marker/square';
 
 export class MarkerLabel extends Group {
-    static className = 'MarkerLabel';
+    static override className = 'MarkerLabel';
 
     private label = new Text();
 
@@ -104,7 +104,7 @@ export class MarkerLabel extends Group {
         this.label.x = markerSize / 2 + this.spacing;
     }
 
-    render(renderCtx: RenderContext): void {
+    override render(renderCtx: RenderContext): void {
         // Cannot override field Group.opacity with get/set pair, so
         // propagate opacity changes here.
         this.marker.opacity = this.opacity;

--- a/packages/ag-charts-community/src/chart/polarChart.ts
+++ b/packages/ag-charts-community/src/chart/polarChart.ts
@@ -14,14 +14,14 @@ export class PolarChart extends Chart {
     static className = 'PolarChart';
     static type = 'polar' as const;
 
-    padding = new Padding(40);
+    override padding = new Padding(40);
 
     constructor(specialOverrides: SpecialOverrides, resources?: TransferableResources) {
         super(specialOverrides, resources);
         this.axisGroup.zIndex = Layers.AXIS_FOREGROUND_ZINDEX;
     }
 
-    async performLayout() {
+    override async performLayout() {
         const shrinkRect = await super.performLayout();
 
         const fullSeriesRect = shrinkRect.clone();

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -556,7 +556,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         });
     }
 
-    protected override getNodeClickEvent(event: MouseEvent, datum: MarkerSelectionDatum): CartesianSeriesNodeClickEvent<any> {
+    protected override getNodeClickEvent(
+        event: MouseEvent,
+        datum: MarkerSelectionDatum
+    ): CartesianSeriesNodeClickEvent<any> {
         return new CartesianSeriesNodeClickEvent(this.xKey ?? '', datum.yKey, event, datum, this);
     }
 
@@ -673,7 +676,13 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         ];
     }
 
-    override animateEmptyUpdateReady({ markerSelections, labelSelections, contextData, paths, seriesRect }: AreaAnimationData) {
+    override animateEmptyUpdateReady({
+        markerSelections,
+        labelSelections,
+        contextData,
+        paths,
+        seriesRect,
+    }: AreaAnimationData) {
         const { seriesId, styles, ctx, formatter, getFormatterParams } = this.getAnimationOptions();
         areaAnimateEmptyUpdateReady({
             markerSelections,

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -445,17 +445,17 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         return [context];
     }
 
-    protected isPathOrSelectionDirty(): boolean {
+    protected override isPathOrSelectionDirty(): boolean {
         return this.marker.isDirty();
     }
 
-    protected markerFactory() {
+    protected override markerFactory() {
         const { shape } = this.marker;
         const MarkerShape = getMarker(shape);
         return new MarkerShape();
     }
 
-    protected async updateMarkerSelection(opts: {
+    protected override async updateMarkerSelection(opts: {
         nodeData: MarkerSelectionDatum[];
         markerSelection: Selection<Marker, MarkerSelectionDatum>;
     }) {
@@ -474,7 +474,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         });
     }
 
-    protected async updateMarkerNodes(opts: {
+    protected override async updateMarkerNodes(opts: {
         markerSelection: Selection<Marker, MarkerSelectionDatum>;
         isHighlight: boolean;
     }) {
@@ -556,11 +556,11 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         });
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: MarkerSelectionDatum): CartesianSeriesNodeClickEvent<any> {
+    protected override getNodeClickEvent(event: MouseEvent, datum: MarkerSelectionDatum): CartesianSeriesNodeClickEvent<any> {
         return new CartesianSeriesNodeClickEvent(this.xKey ?? '', datum.yKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: MarkerSelectionDatum
     ): CartesianSeriesNodeDoubleClickEvent<any> {
@@ -673,7 +673,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         ];
     }
 
-    animateEmptyUpdateReady({ markerSelections, labelSelections, contextData, paths, seriesRect }: AreaAnimationData) {
+    override animateEmptyUpdateReady({ markerSelections, labelSelections, contextData, paths, seriesRect }: AreaAnimationData) {
         const { seriesId, styles, ctx, formatter, getFormatterParams } = this.getAnimationOptions();
         areaAnimateEmptyUpdateReady({
             markerSelections,
@@ -689,12 +689,12 @@ export class AreaSeries extends CartesianSeries<AreaSeriesNodeDataContext> {
         });
     }
 
-    animateReadyUpdate({ contextData, paths }: AreaAnimationData) {
+    override animateReadyUpdate({ contextData, paths }: AreaAnimationData) {
         const { styles } = this.getAnimationOptions();
         areaAnimateReadyUpdate({ contextData, paths, styles });
     }
 
-    animateReadyResize({ contextData, markerSelections, labelSelections, paths }: AreaAnimationData) {
+    override animateReadyResize({ contextData, markerSelections, labelSelections, paths }: AreaAnimationData) {
         const { styles, ctx, formatter, getFormatterParams } = this.getAnimationOptions();
 
         areaResetMarkersAndPaths({

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -452,7 +452,10 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return datumSelection.update(nodeData, (rect) => (rect.tag = BarSeriesNodeTag.Bar), getDatumId);
     }
 
-    protected override async updateDatumNodes(opts: { datumSelection: Selection<Rect, BarNodeDatum>; isHighlight: boolean }) {
+    protected override async updateDatumNodes(opts: {
+        datumSelection: Selection<Rect, BarNodeDatum>;
+        isHighlight: boolean;
+    }) {
         const { datumSelection, isHighlight } = opts;
         const {
             yKey = '',

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -154,7 +154,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
      */
     private groupScale = new BandScale<string>();
 
-    protected resolveKeyDirection(direction: ChartAxisDirection) {
+    protected override resolveKeyDirection(direction: ChartAxisDirection) {
         if (this.getBarDirection() === ChartAxisDirection.X) {
             if (direction === ChartAxisDirection.X) {
                 return ChartAxisDirection.Y;
@@ -262,11 +262,11 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         }
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: BarNodeDatum): CartesianSeriesNodeClickEvent<any> {
+    protected override getNodeClickEvent(event: MouseEvent, datum: BarNodeDatum): CartesianSeriesNodeClickEvent<any> {
         return new CartesianSeriesNodeClickEvent(this.xKey ?? '', datum.yKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: BarNodeDatum
     ): CartesianSeriesNodeDoubleClickEvent<any> {
@@ -435,13 +435,13 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return [context];
     }
 
-    protected nodeFactory() {
+    protected override nodeFactory() {
         return new Rect();
     }
 
-    datumSelectionGarbageCollection = false;
+    override datumSelectionGarbageCollection = false;
 
-    protected async updateDatumSelection(opts: {
+    protected override async updateDatumSelection(opts: {
         nodeData: BarNodeDatum[];
         datumSelection: Selection<Rect, BarNodeDatum>;
     }) {
@@ -452,7 +452,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return datumSelection.update(nodeData, (rect) => (rect.tag = BarSeriesNodeTag.Bar), getDatumId);
     }
 
-    protected async updateDatumNodes(opts: { datumSelection: Selection<Rect, BarNodeDatum>; isHighlight: boolean }) {
+    protected override async updateDatumNodes(opts: { datumSelection: Selection<Rect, BarNodeDatum>; isHighlight: boolean }) {
         const { datumSelection, isHighlight } = opts;
         const {
             yKey = '',
@@ -632,7 +632,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         ];
     }
 
-    animateEmptyUpdateReady({ datumSelections, labelSelections }: BarAnimationData) {
+    override animateEmptyUpdateReady({ datumSelections, labelSelections }: BarAnimationData) {
         const duration = this.ctx.animationManager.defaultDuration;
         const isVertical = this.getBarDirection() === ChartAxisDirection.Y;
         const { startingX, startingY } = this.getDirectionStartingValues(datumSelections);
@@ -673,17 +673,17 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         });
     }
 
-    animateReadyHighlight(highlightSelection: Selection<Rect, BarNodeDatum>) {
+    override animateReadyHighlight(highlightSelection: Selection<Rect, BarNodeDatum>) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize({ datumSelections }: BarAnimationData) {
+    override animateReadyResize({ datumSelections }: BarAnimationData) {
         datumSelections.forEach((datumSelection) => {
             this.resetSelectionRects(datumSelection);
         });
     }
 
-    animateWaitingUpdateReady({ datumSelections, labelSelections }: BarAnimationData) {
+    override animateWaitingUpdateReady({ datumSelections, labelSelections }: BarAnimationData) {
         const { processedData } = this;
         const diff = processedData?.reduced?.diff;
 
@@ -815,7 +815,7 @@ export class BarSeries extends CartesianSeries<SeriesNodeDataContext<BarNodeDatu
         return this.label.enabled;
     }
 
-    getBandScalePadding() {
+    override getBandScalePadding() {
         return { inner: 0.2, outer: 0.1 };
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -228,7 +228,10 @@ export class BubbleSeries extends CartesianSeries<SeriesNodeDataContext<BubbleNo
         return new BubbleSeriesNodeClickEvent(this.sizeKey, this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 
-    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: BubbleNodeDatum): BubbleSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(
+        event: MouseEvent,
+        datum: BubbleNodeDatum
+    ): BubbleSeriesNodeDoubleClickEvent {
         return new BubbleSeriesNodeDoubleClickEvent(this.sizeKey, this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -67,11 +67,11 @@ class BubbleSeriesNodeBaseClickEvent extends CartesianSeriesNodeBaseClickEvent<a
 }
 
 class BubbleSeriesNodeClickEvent extends BubbleSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 class BubbleSeriesNodeDoubleClickEvent extends BubbleSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 class BubbleSeriesMarker extends CartesianSeriesMarker {
@@ -224,11 +224,11 @@ export class BubbleSeries extends CartesianSeries<SeriesNodeDataContext<BubbleNo
         return this.fixNumericExtent(extent(domain), axis);
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: BubbleNodeDatum): BubbleSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: BubbleNodeDatum): BubbleSeriesNodeClickEvent {
         return new BubbleSeriesNodeClickEvent(this.sizeKey, this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(event: MouseEvent, datum: BubbleNodeDatum): BubbleSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: BubbleNodeDatum): BubbleSeriesNodeDoubleClickEvent {
         return new BubbleSeriesNodeDoubleClickEvent(this.sizeKey, this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 
@@ -308,23 +308,23 @@ export class BubbleSeries extends CartesianSeries<SeriesNodeDataContext<BubbleNo
         return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData }];
     }
 
-    protected isPathOrSelectionDirty(): boolean {
+    protected override isPathOrSelectionDirty(): boolean {
         return this.marker.isDirty();
     }
 
-    getLabelData(): PointLabelDatum[] {
+    override getLabelData(): PointLabelDatum[] {
         return this.contextNodeData?.reduce<PointLabelDatum[]>((r, n) => r.concat(n.labelData), []);
     }
 
-    protected markerFactory() {
+    protected override markerFactory() {
         const { shape } = this.marker;
         const MarkerShape = getMarker(shape);
         return new MarkerShape();
     }
 
-    markerSelectionGarbageCollection = false;
+    override markerSelectionGarbageCollection = false;
 
-    protected async updateMarkerSelection(opts: {
+    protected override async updateMarkerSelection(opts: {
         nodeData: BubbleNodeDatum[];
         markerSelection: Selection<Marker, BubbleNodeDatum>;
     }) {
@@ -341,7 +341,7 @@ export class BubbleSeries extends CartesianSeries<SeriesNodeDataContext<BubbleNo
         return markerSelection.update(data, undefined, (datum) => this.getDatumId(datum));
     }
 
-    protected async updateMarkerNodes(opts: {
+    protected override async updateMarkerNodes(opts: {
         markerSelection: Selection<Marker, BubbleNodeDatum>;
         isHighlight: boolean;
     }) {
@@ -547,7 +547,7 @@ export class BubbleSeries extends CartesianSeries<SeriesNodeDataContext<BubbleNo
         ];
     }
 
-    animateEmptyUpdateReady(animationData: BubbleAnimationData) {
+    override animateEmptyUpdateReady(animationData: BubbleAnimationData) {
         const { markerSelections, labelSelections } = animationData;
         const duration = animationData.duration ?? this.ctx.animationManager.defaultDuration;
         const labelDuration = 200;
@@ -588,7 +588,7 @@ export class BubbleSeries extends CartesianSeries<SeriesNodeDataContext<BubbleNo
         });
     }
 
-    animateReadyResize({ markerSelections }: BubbleAnimationData) {
+    override animateReadyResize({ markerSelections }: BubbleAnimationData) {
         this.ctx.animationManager.reset();
         markerSelections.forEach((markerSelection) => {
             this.resetMarkers(markerSelection);
@@ -689,7 +689,7 @@ export class BubbleSeries extends CartesianSeries<SeriesNodeDataContext<BubbleNo
     }
     */
 
-    animateClearingUpdateEmpty(animationData: BubbleAnimationData) {
+    override animateClearingUpdateEmpty(animationData: BubbleAnimationData) {
         const { markerSelections } = animationData;
 
         const updateDuration = this.ctx.animationManager.defaultDuration / 2;

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -86,13 +86,13 @@ export class CartesianSeriesNodeBaseClickEvent<Datum extends { datum: any }> ext
 export class CartesianSeriesNodeClickEvent<
     Datum extends { datum: any },
 > extends CartesianSeriesNodeBaseClickEvent<Datum> {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 export class CartesianSeriesNodeDoubleClickEvent<
     Datum extends { datum: any },
 > extends CartesianSeriesNodeBaseClickEvent<Datum> {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 type CartesianAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
@@ -218,14 +218,14 @@ export abstract class CartesianSeries<
         });
     }
 
-    addChartEventListeners(): void {
+    override addChartEventListeners(): void {
         this.ctx.chartEventManager?.addListener('legend-item-click', (event) => this.onLegendItemClick(event));
         this.ctx.chartEventManager?.addListener('legend-item-double-click', (event) =>
             this.onLegendItemDoubleClick(event)
         );
     }
 
-    destroy() {
+    override destroy() {
         super.destroy();
 
         this._contextNodeData.splice(0, this._contextNodeData.length);
@@ -387,7 +387,7 @@ export abstract class CartesianSeries<
         }
     }
 
-    getGroupZIndexSubOrder(type: SeriesGroupZIndexSubOrderType, subIndex = 0): ZIndexSubOrder {
+    override getGroupZIndexSubOrder(type: SeriesGroupZIndexSubOrderType, subIndex = 0): ZIndexSubOrder {
         const result = super.getGroupZIndexSubOrder(type, subIndex);
         if (type === 'paths') {
             const pathOffset = this.opts.pathsZIndexSubOrderOffset[subIndex] ?? 0;
@@ -537,7 +537,7 @@ export abstract class CartesianSeries<
         return highlightItems;
     }
 
-    protected pickNodeExactShape(point: Point): SeriesNodePickMatch | undefined {
+    protected override pickNodeExactShape(point: Point): SeriesNodePickMatch | undefined {
         const result = super.pickNodeExactShape(point);
 
         if (result) {
@@ -562,7 +562,7 @@ export abstract class CartesianSeries<
         }
     }
 
-    protected pickNodeClosestDatum(point: Point): SeriesNodePickMatch | undefined {
+    protected override pickNodeClosestDatum(point: Point): SeriesNodePickMatch | undefined {
         const { x, y } = point;
         const { axes, rootGroup, _contextNodeData: contextNodeData } = this;
 
@@ -602,7 +602,7 @@ export abstract class CartesianSeries<
         }
     }
 
-    protected pickNodeMainAxisFirst(
+    protected override pickNodeMainAxisFirst(
         point: Point,
         requireCategoryAxis: boolean
     ): { datum: CartesianSeriesNodeDatum; distance: number } | undefined {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -283,19 +283,19 @@ export class LineSeries extends CartesianSeries<LineContext> {
         return [{ itemId: yKey, nodeData, labelData: nodeData }];
     }
 
-    protected isPathOrSelectionDirty(): boolean {
+    protected override isPathOrSelectionDirty(): boolean {
         return this.marker.isDirty();
     }
 
-    protected markerFactory() {
+    protected override markerFactory() {
         const { shape } = this.marker;
         const MarkerShape = getMarker(shape);
         return new MarkerShape();
     }
 
-    markerSelectionGarbageCollection = false;
+    override markerSelectionGarbageCollection = false;
 
-    protected async updateMarkerSelection(opts: {
+    protected override async updateMarkerSelection(opts: {
         nodeData: LineNodeDatum[];
         markerSelection: Selection<Marker, LineNodeDatum>;
     }) {
@@ -315,7 +315,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         );
     }
 
-    protected async updateMarkerNodes(opts: {
+    protected override async updateMarkerNodes(opts: {
         markerSelection: Selection<Marker, LineNodeDatum>;
         isHighlight: boolean;
     }) {
@@ -397,11 +397,11 @@ export class LineSeries extends CartesianSeries<LineContext> {
         });
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: LineNodeDatum): CartesianSeriesNodeClickEvent<any> {
+    protected override getNodeClickEvent(event: MouseEvent, datum: LineNodeDatum): CartesianSeriesNodeClickEvent<any> {
         return new CartesianSeriesNodeClickEvent(this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: LineNodeDatum
     ): CartesianSeriesNodeDoubleClickEvent<any> {
@@ -494,7 +494,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         ];
     }
 
-    animateEmptyUpdateReady(animationData: LineAnimationData) {
+    override animateEmptyUpdateReady(animationData: LineAnimationData) {
         const { markerSelections, labelSelections, contextData, paths } = animationData;
 
         contextData.forEach(({ nodeData }, contextDataIndex) => {
@@ -606,15 +606,15 @@ export class LineSeries extends CartesianSeries<LineContext> {
         });
     }
 
-    animateReadyUpdate(animationData: LineAnimationData) {
+    override animateReadyUpdate(animationData: LineAnimationData) {
         this.resetMarkersAndPaths(animationData);
     }
 
-    animateReadyResize(animationData: LineAnimationData) {
+    override animateReadyResize(animationData: LineAnimationData) {
         this.resetMarkersAndPaths(animationData);
     }
 
-    animateWaitingUpdateReady(animationData: LineAnimationData) {
+    override animateWaitingUpdateReady(animationData: LineAnimationData) {
         const { markerSelections, labelSelections, contextData, paths } = animationData;
         const { processedData, extendLine, findPointOnLine } = this;
         const diff = processedData?.reduced?.diff;
@@ -969,7 +969,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         });
     }
 
-    protected animateClearingUpdateEmpty(animationData: LineAnimationData) {
+    protected override animateClearingUpdateEmpty(animationData: LineAnimationData) {
         const { markerSelections, labelSelections, contextData, paths } = animationData;
 
         const updateDuration = this.ctx.animationManager.defaultDuration / 2;
@@ -1103,7 +1103,7 @@ export class LineSeries extends CartesianSeries<LineContext> {
         return this.label.enabled;
     }
 
-    getBandScalePadding() {
+    override getBandScalePadding() {
         return { inner: 1, outer: 0.1 };
     }
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -238,23 +238,23 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData }];
     }
 
-    protected isPathOrSelectionDirty(): boolean {
+    protected override isPathOrSelectionDirty(): boolean {
         return this.marker.isDirty();
     }
 
-    getLabelData(): PointLabelDatum[] {
+    override getLabelData(): PointLabelDatum[] {
         return this.contextNodeData?.reduce<PointLabelDatum[]>((r, n) => r.concat(n.labelData), []);
     }
 
-    protected markerFactory() {
+    protected override markerFactory() {
         const { shape } = this.marker;
         const MarkerShape = getMarker(shape);
         return new MarkerShape();
     }
 
-    markerSelectionGarbageCollection = false;
+    override markerSelectionGarbageCollection = false;
 
-    protected async updateMarkerSelection(opts: {
+    protected override async updateMarkerSelection(opts: {
         nodeData: ScatterNodeDatum[];
         markerSelection: Selection<Marker, ScatterNodeDatum>;
     }) {
@@ -271,7 +271,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         return markerSelection.update(data);
     }
 
-    protected async updateMarkerNodes(opts: {
+    protected override async updateMarkerNodes(opts: {
         markerSelection: Selection<Marker, ScatterNodeDatum>;
         isHighlight: boolean;
     }) {
@@ -468,7 +468,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         ];
     }
 
-    animateEmptyUpdateReady(animationData: ScatterAnimationData) {
+    override animateEmptyUpdateReady(animationData: ScatterAnimationData) {
         const { markerSelections, labelSelections } = animationData;
         const duration = animationData.duration ?? this.ctx.animationManager.defaultDuration;
         const labelDuration = 200;
@@ -509,7 +509,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
         });
     }
 
-    animateReadyResize({ markerSelections }: ScatterAnimationData) {
+    override animateReadyResize({ markerSelections }: ScatterAnimationData) {
         this.ctx.animationManager.reset();
         markerSelections.forEach((markerSelection) => {
             this.resetMarkers(markerSelection);
@@ -610,7 +610,7 @@ export class ScatterSeries extends CartesianSeries<SeriesNodeDataContext<Scatter
     }
     */
 
-    animateClearingUpdateEmpty(animationData: ScatterAnimationData) {
+    override animateClearingUpdateEmpty(animationData: ScatterAnimationData) {
         const { markerSelections } = animationData;
 
         const updateDuration = this.ctx.animationManager.defaultDuration / 2;

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -5,7 +5,7 @@ import type { SeriesNodeDataContext, SeriesNodeDatum } from '../series';
 import { Series, SeriesNodePickMode } from '../series';
 
 export abstract class HierarchySeries<S extends SeriesNodeDatum> extends Series<SeriesNodeDataContext<S>> {
-    chart?: HierarchyChart;
+    override chart?: HierarchyChart;
 
     constructor(moduleCtx: ModuleContext) {
         super({ moduleCtx, pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH] });

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -81,11 +81,11 @@ class PieSeriesNodeBaseClickEvent extends SeriesNodeBaseClickEvent<any> {
 }
 
 class PieSeriesNodeClickEvent extends PieSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 class PieSeriesNodeDoubleClickEvent extends PieSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 interface PieNodeDatum extends SeriesNodeDatum {
@@ -313,7 +313,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
 
     shadow?: DropShadow = undefined;
 
-    readonly highlightStyle = new HighlightStyle();
+    override readonly highlightStyle = new HighlightStyle();
 
     surroundingRadius?: number = undefined;
 
@@ -378,11 +378,11 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    addChartEventListeners(): void {
+    override addChartEventListeners(): void {
         this.ctx.chartEventManager?.addListener('legend-item-click', (event) => this.onLegendItemClick(event));
     }
 
-    visibleChanged() {
+    override visibleChanged() {
         this.processSeriesItemEnabled();
     }
 
@@ -1258,7 +1258,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    async computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: BBox) {
+    override async computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: BBox) {
         const { radiusScale, calloutLabel, calloutLine } = this;
         const calloutLength = calloutLine.length;
         const { offset, maxCollisionOffset, minSpacing } = calloutLabel;
@@ -1462,7 +1462,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         });
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: PieNodeDatum): PieSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: PieNodeDatum): PieSeriesNodeClickEvent {
         return new PieSeriesNodeClickEvent(
             this.angleKey,
             this.calloutLabelKey,
@@ -1474,7 +1474,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         );
     }
 
-    protected getNodeDoubleClickEvent(event: MouseEvent, datum: PieNodeDatum): PieSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: PieNodeDatum): PieSeriesNodeDoubleClickEvent {
         return new PieSeriesNodeDoubleClickEvent(
             this.angleKey,
             this.calloutLabelKey,
@@ -1613,7 +1613,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         }
     }
 
-    protected toggleSeriesItem(itemId: number, enabled: boolean): void {
+    protected override toggleSeriesItem(itemId: number, enabled: boolean): void {
         this.seriesItemEnabled[itemId] = enabled;
         this.nodeDataRefresh = true;
     }
@@ -1940,7 +1940,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum> {
         return sectors;
     }
 
-    protected onDataChange() {
+    protected override onDataChange() {
         this.processSeriesItemEnabled();
     }
 }

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -217,7 +217,7 @@ export class SeriesNodeBaseClickEvent<Datum extends { datum: any }> implements T
 export class SeriesNodeClickEvent<Datum extends { datum: any }> extends SeriesNodeBaseClickEvent<Datum> {}
 
 export class SeriesNodeDoubleClickEvent<Datum extends { datum: any }> extends SeriesNodeBaseClickEvent<Datum> {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 export class SeriesItemHighlightStyle {

--- a/packages/ag-charts-community/src/chart/themes/darkTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/darkTheme.ts
@@ -36,7 +36,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class DarkTheme extends ChartTheme {
-    protected getTemplateParameters() {
+    protected override getTemplateParameters() {
         const result = super.getTemplateParameters();
 
         result.properties.set(DEFAULT_LABEL_COLOUR, 'rgb(200, 200, 200)');
@@ -48,7 +48,7 @@ export class DarkTheme extends ChartTheme {
         return result;
     }
 
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 

--- a/packages/ag-charts-community/src/chart/themes/materialDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/materialDark.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class MaterialDark extends DarkTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/chart/themes/materialLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/materialLight.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class MaterialLight extends ChartTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/chart/themes/pastelDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/pastelDark.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class PastelDark extends DarkTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/chart/themes/pastelLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/pastelLight.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class PastelLight extends ChartTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/chart/themes/solarDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/solarDark.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class SolarDark extends DarkTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/chart/themes/solarLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/solarLight.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class SolarLight extends ChartTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/chart/themes/vividDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/vividDark.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class VividDark extends DarkTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/chart/themes/vividLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/vividLight.ts
@@ -29,7 +29,7 @@ const palette: AgChartThemePalette = {
 };
 
 export class VividLight extends ChartTheme {
-    protected getPalette(): AgChartThemePalette {
+    protected override getPalette(): AgChartThemePalette {
         return palette;
     }
 }

--- a/packages/ag-charts-community/src/scale/linearScale.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.ts
@@ -8,7 +8,7 @@ import { ContinuousScale } from './continuousScale';
 export class LinearScale extends ContinuousScale<number> {
     readonly type = 'linear';
 
-    interval?: number;
+    override interval?: number;
 
     public constructor() {
         super([0, 1], [0, 1]);

--- a/packages/ag-charts-community/src/scale/logScale.ts
+++ b/packages/ag-charts-community/src/scale/logScale.ts
@@ -22,14 +22,14 @@ export class LogScale extends ContinuousScale<number> {
     @Validate(NUMBER(0))
     base = 10;
 
-    protected transform(x: any) {
+    protected override transform(x: any) {
         return this.domain[0] >= 0 ? Math.log(x) : -Math.log(-x);
     }
-    protected transformInvert(x: any) {
+    protected override transformInvert(x: any) {
         return this.domain[0] >= 0 ? Math.exp(x) : -Math.exp(-x);
     }
 
-    protected cacheProps: Array<keyof this> = ['domain', 'range', 'nice', 'tickCount', 'base'];
+    protected override cacheProps: Array<keyof this> = ['domain', 'range', 'nice', 'tickCount', 'base'];
 
     update() {
         if (!this.domain || this.domain.length < 2) {

--- a/packages/ag-charts-community/src/scale/timeScale.ts
+++ b/packages/ag-charts-community/src/scale/timeScale.ts
@@ -52,7 +52,7 @@ function toNumber(x: any) {
 export class TimeScale extends ContinuousScale<Date, TimeInterval | number> {
     readonly type = 'time';
 
-    protected cacheProps: Array<keyof this> = [
+    protected override cacheProps: Array<keyof this> = [
         'domain',
         'range',
         'nice',
@@ -281,7 +281,7 @@ export class TimeScale extends ContinuousScale<Date, TimeInterval | number> {
         return countableTimeInterval.every(step);
     }
 
-    invert(y: number): Date {
+    override invert(y: number): Date {
         return new Date(super.invert(y));
     }
 

--- a/packages/ag-charts-community/src/scene/group.ts
+++ b/packages/ag-charts-community/src/scene/group.ts
@@ -20,7 +20,7 @@ export class Group extends Node {
     })
     opacity: number = 1;
 
-    protected zIndexChanged() {
+    protected override zIndexChanged() {
         if (this.layer) {
             this._layerManager?.moveLayer(this.layer, this.zIndex, this.zIndexSubOrder);
         }
@@ -53,7 +53,7 @@ export class Group extends Node {
         this.name = this.opts?.name;
     }
 
-    _setLayerManager(scene?: LayerManager) {
+    override _setLayerManager(scene?: LayerManager) {
         if (this._layerManager && this.layer) {
             this._layerManager.removeLayer(this.layer);
             this.layer = undefined;
@@ -96,13 +96,13 @@ export class Group extends Node {
         return visible;
     }
 
-    protected visibilityChanged() {
+    protected override visibilityChanged() {
         if (this.layer) {
             this.layer.enabled = this.visible;
         }
     }
 
-    markDirty(source: Node, type = RedrawType.TRIVIAL) {
+    override markDirty(source: Node, type = RedrawType.TRIVIAL) {
         if (this.isVirtual) {
             // Always percolate directly for virtual nodes - they don't exist for rendering purposes.
             super.markDirty(source, type);
@@ -119,23 +119,23 @@ export class Group extends Node {
     }
 
     // We consider a group to be boundless, thus any point belongs to it.
-    containsPoint(_x: number, _y: number): boolean {
+    override containsPoint(_x: number, _y: number): boolean {
         return true;
     }
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         this.computeTransformMatrix();
 
         return Group.computeBBox(this.children);
     }
 
-    computeTransformedBBox(): BBox | undefined {
+    override computeTransformedBBox(): BBox | undefined {
         return this.computeBBox();
     }
 
     private lastBBox?: BBox = undefined;
 
-    render(renderCtx: RenderContext) {
+    override render(renderCtx: RenderContext) {
         const { opts: { name = undefined } = {}, _debug: debug = () => {} } = this;
         const { dirty, dirtyZIndex, layer, children, clipRect, dirtyTransform } = this;
         let { ctx, forceRender, clipBBox } = renderCtx;

--- a/packages/ag-charts-community/src/scene/image.ts
+++ b/packages/ag-charts-community/src/scene/image.ts
@@ -24,7 +24,7 @@ export class Image extends Node {
     @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     opacity: number = 1;
 
-    render(renderCtx: RenderContext): void {
+    override render(renderCtx: RenderContext): void {
         const { ctx, forceRender, stats } = renderCtx;
 
         if (this.dirty === RedrawType.NONE && !forceRender) {

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -452,7 +452,7 @@ export abstract class Node extends ChangeDetectable {
         ctx.clearRect(topLeft.x, topLeft.y, bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
     }
 
-    markDirty(_source: Node, type = RedrawType.TRIVIAL, parentType = type) {
+    override markDirty(_source: Node, type = RedrawType.TRIVIAL, parentType = type) {
         if (this._dirty > type) {
             return;
         }
@@ -472,7 +472,7 @@ export abstract class Node extends ChangeDetectable {
         return this._dirty;
     }
 
-    markClean(opts?: { force?: boolean; recursive?: boolean | 'virtual' }) {
+    override markClean(opts?: { force?: boolean; recursive?: boolean | 'virtual' }) {
         const { force = false, recursive = true } = opts ?? {};
 
         if (this._dirty === RedrawType.NONE && !force) {

--- a/packages/ag-charts-community/src/scene/shape/arc.ts
+++ b/packages/ag-charts-community/src/scene/shape/arc.ts
@@ -14,9 +14,9 @@ enum ArcType {
  * Elliptical arc node.
  */
 export class Arc extends Path {
-    static className = 'Arc';
+    static override className = 'Arc';
 
-    protected static defaultStyles = Object.assign({}, Shape.defaultStyles, {
+    protected static override defaultStyles = Object.assign({}, Shape.defaultStyles, {
         lineWidth: 1,
         fillStyle: null,
     });
@@ -63,7 +63,7 @@ export class Arc extends Path {
     @ScenePathChangeDetection()
     type: ArcType = ArcType.Open;
 
-    updatePath(): void {
+    override updatePath(): void {
         const path = this.path;
 
         path.clear(); // No need to recreate the Path, can simply clear the existing one.
@@ -77,12 +77,12 @@ export class Arc extends Path {
         }
     }
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         // Only works with full arcs (circles) and untransformed ellipses.
         return new BBox(this.centerX - this.radius, this.centerY - this.radius, this.radius * 2, this.radius * 2);
     }
 
-    isPointInPath(x: number, y: number): boolean {
+    override isPointInPath(x: number, y: number): boolean {
         const point = this.transformPoint(x, y);
         const bbox = this.computeBBox();
 

--- a/packages/ag-charts-community/src/scene/shape/line.ts
+++ b/packages/ag-charts-community/src/scene/shape/line.ts
@@ -6,7 +6,7 @@ import { Shape } from './shape';
 export class Line extends Shape {
     static className = 'Line';
 
-    protected static defaultStyles = Object.assign({}, Shape.defaultStyles, {
+    protected static override defaultStyles = Object.assign({}, Shape.defaultStyles, {
         fill: undefined,
         strokeWidth: 1,
     });
@@ -38,7 +38,7 @@ export class Line extends Shape {
         this.y2 = value;
     }
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         return new BBox(
             Math.min(this.x1, this.x2),
             Math.min(this.y1, this.y2),
@@ -57,7 +57,7 @@ export class Line extends Shape {
         return false;
     }
 
-    render(renderCtx: RenderContext) {
+    override render(renderCtx: RenderContext) {
         const { ctx, forceRender, stats } = renderCtx;
 
         if (this.dirty === RedrawType.NONE && !forceRender) {

--- a/packages/ag-charts-community/src/scene/shape/path.ts
+++ b/packages/ag-charts-community/src/scene/shape/path.ts
@@ -70,7 +70,7 @@ export class Path extends Shape {
         // Override point for subclasses.
     }
 
-    render(renderCtx: RenderContext) {
+    override render(renderCtx: RenderContext) {
         const { ctx, forceRender, stats } = renderCtx;
 
         if (this.dirty === RedrawType.NONE && !forceRender) {

--- a/packages/ag-charts-community/src/scene/shape/range.ts
+++ b/packages/ag-charts-community/src/scene/shape/range.ts
@@ -6,7 +6,7 @@ import { Shape } from './shape';
 export class Range extends Shape {
     static className = 'Range';
 
-    protected static defaultStyles = {
+    protected static override defaultStyles = {
         ...Shape.defaultStyles,
         strokeWidth: 1,
     };
@@ -37,7 +37,7 @@ export class Range extends Shape {
     @SceneChangeDetection({ redraw: RedrawType.MINOR })
     isRange: boolean = false;
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         return new BBox(this.x1, this.y1, this.x2 - this.x1, this.y2 - this.y1);
     }
 
@@ -45,7 +45,7 @@ export class Range extends Shape {
         return false;
     }
 
-    render(renderCtx: RenderContext) {
+    override render(renderCtx: RenderContext) {
         const { ctx, forceRender, stats } = renderCtx;
 
         if (this.dirty === RedrawType.NONE && !forceRender) {

--- a/packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.ts
@@ -4,7 +4,7 @@ import { Path, ScenePathChangeDetection } from './path';
 import { Shape } from './shape';
 
 export class Rect extends Path {
-    static className = 'Rect';
+    static override className = 'Rect';
 
     readonly borderPath = new Path2D();
 
@@ -35,7 +35,7 @@ export class Rect extends Path {
 
     private lastUpdatePathStrokeWidth: number = Shape.defaultStyles.strokeWidth;
 
-    protected isDirtyPath() {
+    protected override isDirtyPath() {
         if (this.lastUpdatePathStrokeWidth !== this.strokeWidth) {
             return true;
         }
@@ -52,7 +52,7 @@ export class Rect extends Path {
      */
     protected microPixelEffectOpacity: number = 1;
 
-    updatePath() {
+    override updatePath() {
         const { path, borderPath, crisp } = this;
         let { x, y, width: w, height: h, strokeWidth } = this;
         const pixelRatio = this.layerManager?.canvas.pixelRatio ?? 1;
@@ -120,25 +120,25 @@ export class Rect extends Path {
         this.microPixelEffectOpacity = microPixelEffectOpacity;
     }
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         const { x, y, width, height } = this;
         return new BBox(x, y, width, height);
     }
 
-    isPointInPath(x: number, y: number): boolean {
+    override isPointInPath(x: number, y: number): boolean {
         const point = this.transformPoint(x, y);
         const bbox = this.computeBBox();
 
         return bbox.containsPoint(point.x, point.y);
     }
 
-    protected applyFillAlpha(ctx: CanvasRenderingContext2D) {
+    protected override applyFillAlpha(ctx: CanvasRenderingContext2D) {
         const { fillOpacity, microPixelEffectOpacity, opacity } = this;
         const { globalAlpha } = ctx;
         ctx.globalAlpha = globalAlpha * opacity * fillOpacity * microPixelEffectOpacity;
     }
 
-    protected renderStroke(ctx: CanvasRenderingContext2D) {
+    protected override renderStroke(ctx: CanvasRenderingContext2D) {
         const { stroke, effectiveStrokeWidth, borderPath, borderClipPath, opacity, microPixelEffectOpacity } = this;
 
         const borderActive = !!stroke && !!effectiveStrokeWidth;

--- a/packages/ag-charts-community/src/scene/shape/sector.ts
+++ b/packages/ag-charts-community/src/scene/shape/sector.ts
@@ -5,7 +5,7 @@ import { BBox } from '../bbox';
 import { Path, ScenePathChangeDetection } from './path';
 
 export class Sector extends Path {
-    static className = 'Sector';
+    static override className = 'Sector';
 
     @ScenePathChangeDetection()
     centerX: number = 0;
@@ -28,12 +28,12 @@ export class Sector extends Path {
     @ScenePathChangeDetection()
     angleOffset: number = 0;
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         const radius = this.outerRadius;
         return new BBox(this.centerX - radius, this.centerY - radius, radius * 2, radius * 2);
     }
 
-    updatePath(): void {
+    override updatePath(): void {
         const path = this.path;
 
         const angleOffset = this.angleOffset;
@@ -69,7 +69,7 @@ export class Sector extends Path {
         this.dirtyPath = false;
     }
 
-    isPointInPath(x: number, y: number): boolean {
+    override isPointInPath(x: number, y: number): boolean {
         const { angleOffset } = this;
         const startAngle = this.startAngle + angleOffset;
         const endAngle = this.endAngle + angleOffset;

--- a/packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/packages/ag-charts-community/src/scene/shape/shape.ts
@@ -231,7 +231,7 @@ export abstract class Shape extends Node {
         }
     }
 
-    containsPoint(x: number, y: number): boolean {
+    override containsPoint(x: number, y: number): boolean {
         return this.isPointInPath(x, y);
     }
 

--- a/packages/ag-charts-community/src/scene/shape/text.ts
+++ b/packages/ag-charts-community/src/scene/shape/text.ts
@@ -29,7 +29,7 @@ export class Text extends Shape {
     // The default line spacing for document editors is usually 1.15
     static defaultLineHeightRatio = 1.15;
 
-    static defaultStyles = Object.assign({}, Shape.defaultStyles, {
+    static override defaultStyles = Object.assign({}, Shape.defaultStyles, {
         textAlign: 'start' as CanvasTextAlign,
         fontStyle: undefined,
         fontWeight: undefined,
@@ -85,7 +85,7 @@ export class Text extends Shape {
     @SceneChangeDetection({ redraw: RedrawType.MAJOR })
     lineHeight?: number = undefined;
 
-    computeBBox(): BBox {
+    override computeBBox(): BBox {
         return HdpiCanvas.has.textMetrics
             ? getPreciseBBox(this.lines, this.x, this.y, this)
             : getApproximateBBox(this.lines, this.x, this.y, this);
@@ -112,7 +112,7 @@ export class Text extends Shape {
         return bbox ? bbox.containsPoint(point.x, point.y) : false;
     }
 
-    render(renderCtx: RenderContext): void {
+    override render(renderCtx: RenderContext): void {
         const { ctx, forceRender, stats } = renderCtx;
 
         if (this.dirty === RedrawType.NONE && !forceRender) {

--- a/packages/ag-charts-community/tsconfig.json
+++ b/packages/ag-charts-community/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "forceConsistentCasingInFileNames": false,
-    "noImplicitOverride": false,
+    "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": false,

--- a/packages/ag-charts-enterprise/src/axes/angle-number/angleNumberAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/angleNumberAxis.ts
@@ -10,7 +10,7 @@ export class AngleNumberAxis extends AngleAxis {
     static className = 'AngleNumberAxis';
     static type = 'angle-number' as const;
 
-    shape = 'circle' as const;
+    override shape = 'circle' as const;
 
     @Validate(AND(NUMBER_OR_NAN(), LESS_THAN('max')))
     @Default(NaN)
@@ -24,7 +24,7 @@ export class AngleNumberAxis extends AngleAxis {
         super(moduleCtx, new LinearAngleScale());
     }
 
-    normaliseDataDomain(d: number[]) {
+    override normaliseDataDomain(d: number[]) {
         const { min, max } = this;
         const { extent, clipped } = normalisedExtentWithMetadata(d, min, max);
 

--- a/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
@@ -4,7 +4,7 @@ const { LinearScale } = _Scale;
 const { range } = _Util;
 
 export class LinearAngleScale extends LinearScale {
-    ticks() {
+    override ticks() {
         const count = 8;
         if (!this.domain || this.domain.length < 2 || this.domain.some((d) => !isFinite(d))) {
             return [];

--- a/packages/ag-charts-enterprise/src/axes/angle/angleAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle/angleAxis.ts
@@ -74,11 +74,11 @@ export abstract class AngleAxis extends _ModuleSupport.PolarAxis<_Scale.Scale<an
         assignJsonApplyConstructedArray(crossLines, AngleCrossLine);
     }
 
-    protected createLabel() {
+    protected override createLabel() {
         return new AngleAxisLabel();
     }
 
-    update() {
+    override update() {
         this.updateScale();
         this.updatePosition();
         this.updateGridLines();
@@ -89,7 +89,7 @@ export abstract class AngleAxis extends _ModuleSupport.PolarAxis<_Scale.Scale<an
         return this.scale.ticks?.().length ?? 0;
     }
 
-    updatePosition() {
+    override updatePosition() {
         const { translation, axisGroup, gridGroup, crossLineGroup } = this;
         const translationX = Math.floor(translation.x);
         const translationY = Math.floor(translation.y);
@@ -180,7 +180,7 @@ export abstract class AngleAxis extends _ModuleSupport.PolarAxis<_Scale.Scale<an
         return this.tickData.filter((tick) => tick.visible).map(({ value }) => value);
     }
 
-    protected updateGridLines() {
+    protected override updateGridLines() {
         const { scale, gridLength: radius, gridStyle, tick, innerRadiusRatio } = this;
         if (!(gridStyle && radius > 0)) {
             return;
@@ -202,7 +202,7 @@ export abstract class AngleAxis extends _ModuleSupport.PolarAxis<_Scale.Scale<an
         });
     }
 
-    protected updateLabels() {
+    protected override updateLabels() {
         const { label, tickLabelGroupSelection } = this;
 
         const ticks = this.getVisibleTicks();
@@ -231,7 +231,7 @@ export abstract class AngleAxis extends _ModuleSupport.PolarAxis<_Scale.Scale<an
         });
     }
 
-    protected updateTickLines() {
+    protected override updateTickLines() {
         const { scale, gridLength: radius, tick, tickLineGroupSelection } = this;
 
         const ticks = this.getVisibleTicks();
@@ -373,7 +373,7 @@ export abstract class AngleAxis extends _ModuleSupport.PolarAxis<_Scale.Scale<an
         });
     }
 
-    computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: _Scene.BBox) {
+    override computeLabelsBBox(options: { hideWhenNecessary: boolean }, seriesRect: _Scene.BBox) {
         this.tickData = this.createTickVisibilityData();
         this.labelData = this.createLabelNodeData(options, seriesRect);
 
@@ -442,7 +442,7 @@ export abstract class AngleAxis extends _ModuleSupport.PolarAxis<_Scale.Scale<an
         return { textAlign, textBaseline };
     }
 
-    protected updateCrossLines() {
+    protected override updateCrossLines() {
         this.crossLines?.forEach((crossLine) => {
             if (crossLine instanceof AngleCrossLine) {
                 crossLine.shape = this.shape;

--- a/packages/ag-charts-enterprise/src/axes/polar-crosslines/angleCrossLine.ts
+++ b/packages/ag-charts-enterprise/src/axes/polar-crosslines/angleCrossLine.ts
@@ -8,7 +8,7 @@ const { normalizeAngle360, isNumberEqual } = _Util;
 export class AngleCrossLine extends PolarCrossLine {
     static className = 'AngleCrossLine';
 
-    direction: _ModuleSupport.ChartAxisDirection = ChartAxisDirection.X;
+    override direction: _ModuleSupport.ChartAxisDirection = ChartAxisDirection.X;
 
     private polygonNode = new Path();
     private sectorNode = new Sector();

--- a/packages/ag-charts-enterprise/src/axes/polar-crosslines/radiusCrossLine.ts
+++ b/packages/ag-charts-enterprise/src/axes/polar-crosslines/radiusCrossLine.ts
@@ -14,10 +14,10 @@ class RadiusCrossLineLabel extends PolarCrossLineLabel {
 export class RadiusCrossLine extends PolarCrossLine {
     static className = 'RadiusCrossLine';
 
-    direction: _ModuleSupport.ChartAxisDirection = ChartAxisDirection.Y;
+    override direction: _ModuleSupport.ChartAxisDirection = ChartAxisDirection.Y;
     gridAngles?: number[];
 
-    label = new RadiusCrossLineLabel();
+    override label = new RadiusCrossLineLabel();
 
     private polygonNode = new Path();
     private sectorNode = new Sector();

--- a/packages/ag-charts-enterprise/src/axes/radius-category/radiusCategoryAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius-category/radiusCategoryAxis.ts
@@ -10,7 +10,7 @@ export class RadiusCategoryAxis extends RadiusAxis {
     static className = 'RadiusCategoryAxis';
     static type = 'radius-category' as const;
 
-    shape = 'circle' as const;
+    override shape = 'circle' as const;
 
     @Validate(NUMBER(0, 1))
     groupPaddingInner: number = 0;

--- a/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
@@ -18,7 +18,7 @@ export class RadiusNumberAxis extends RadiusAxis {
     static className = 'RadiusNumberAxis';
     static type = 'radius-number' as const;
 
-    shape: 'polygon' | 'circle' = 'polygon';
+    override shape: 'polygon' | 'circle' = 'polygon';
 
     @Validate(AND(NUMBER_OR_NAN(), LESS_THAN('max')))
     @Default(NaN)
@@ -47,7 +47,7 @@ export class RadiusNumberAxis extends RadiusAxis {
         return maxRadius - tickDatum.translationY + minRadius;
     }
 
-    normaliseDataDomain(d: number[]) {
+    override normaliseDataDomain(d: number[]) {
         const { min, max } = this;
         const { extent, clipped } = normalisedExtentWithMetadata(d, min, max);
 

--- a/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
@@ -21,7 +21,7 @@ const { toRadians } = _Util;
 class RadiusAxisTick extends _ModuleSupport.AxisTick<_Scale.LinearScale, number> {
     @Validate(AND(NUMBER_OR_NAN(1), GREATER_THAN('minSpacing')))
     @Default(NaN)
-    maxSpacing: number = NaN;
+    override maxSpacing: number = NaN;
 }
 
 class RadiusAxisLabel extends _ModuleSupport.AxisLabel {
@@ -72,7 +72,7 @@ export abstract class RadiusAxis extends _ModuleSupport.PolarAxis {
         assignJsonApplyConstructedArray(crossLines, RadiusCrossLine);
     }
 
-    protected getAxisTransform() {
+    protected override getAxisTransform() {
         const maxRadius = this.scale.range[0];
         const { translation, positionAngle, innerRadiusRatio } = this;
         const innerRadius = maxRadius * innerRadiusRatio;
@@ -89,7 +89,7 @@ export abstract class RadiusAxis extends _ModuleSupport.PolarAxis {
     protected abstract prepareTickData(tickData: RadiusTickDatum[]): RadiusTickDatum[];
     protected abstract getTickRadius(tickDatum: RadiusTickDatum): number;
 
-    protected updateSelections(data: RadiusTickDatum[]) {
+    protected override updateSelections(data: RadiusTickDatum[]) {
         super.updateSelections(data);
 
         const { gridStyle, tick, shape } = this;
@@ -141,7 +141,7 @@ export abstract class RadiusAxis extends _ModuleSupport.PolarAxis {
         });
     }
 
-    protected updateTitle() {
+    protected override updateTitle() {
         const identityFormatter = (params: AgAxisCaptionFormatterParams) => params.defaultValue;
         const {
             title,
@@ -182,11 +182,11 @@ export abstract class RadiusAxis extends _ModuleSupport.PolarAxis {
         titleNode.visible = titleVisible;
     }
 
-    protected createTick() {
+    protected override createTick() {
         return new RadiusAxisTick();
     }
 
-    protected updateCrossLines() {
+    protected override updateCrossLines() {
         this.crossLines?.forEach((crossLine) => {
             if (crossLine instanceof RadiusCrossLine) {
                 crossLine.shape = this.shape;
@@ -196,7 +196,7 @@ export abstract class RadiusAxis extends _ModuleSupport.PolarAxis {
         super.updateCrossLines({ rotation: 0, parallelFlipRotation: 0, regularFlipRotation: 0, sideFlag: -1 });
     }
 
-    protected createLabel() {
+    protected override createLabel() {
         return new RadiusAxisLabel();
     }
 }

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -311,7 +311,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         }
     }
 
-    public destroy() {
+    public override destroy() {
         super.destroy();
 
         this.intersectionObserver?.unobserve(this.canvasElement);

--- a/packages/ag-charts-enterprise/src/features/navigator/shapes/rangeHandle.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/shapes/rangeHandle.ts
@@ -4,7 +4,7 @@ const { BBox } = _Scene;
 const { LINE_CAP, NUMBER, COLOR_STRING, Validate } = _ModuleSupport;
 
 export class RangeHandle extends _Scene.Path {
-    static className = 'RangeHandle';
+    static override className = 'RangeHandle';
 
     @Validate(COLOR_STRING)
     protected _fill = '#f2f2f2';
@@ -91,7 +91,7 @@ export class RangeHandle extends _Scene.Path {
         return this._height;
     }
 
-    computeBBox() {
+    override computeBBox() {
         const { centerX, centerY, width, height } = this;
         const x = centerX - width / 2;
         const y = centerY - height / 2;
@@ -99,14 +99,14 @@ export class RangeHandle extends _Scene.Path {
         return new BBox(x, y, width, height);
     }
 
-    isPointInPath(x: number, y: number): boolean {
+    override isPointInPath(x: number, y: number): boolean {
         const point = this.transformPoint(x, y);
         const bbox = this.computeBBox();
 
         return bbox.containsPoint(point.x, point.y);
     }
 
-    updatePath() {
+    override updatePath() {
         const { path, centerX, centerY, width, height } = this;
 
         path.clear();

--- a/packages/ag-charts-enterprise/src/features/navigator/shapes/rangeMask.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/shapes/rangeMask.ts
@@ -10,7 +10,7 @@ function markDirtyOnChange(this: RangeMask, newValue: unknown, oldValue: unknown
 }
 
 export class RangeMask extends _Scene.Path {
-    static className = 'RangeMask';
+    static override className = 'RangeMask';
 
     @ActionOnSet<RangeMask>({ changeValue: markDirtyOnChange })
     @Validate(NUMBER(0))
@@ -60,7 +60,7 @@ export class RangeMask extends _Scene.Path {
 
     onRangeChange?: () => any;
 
-    computeBBox() {
+    override computeBBox() {
         const { x, y, width, height } = this;
         return new BBox(x, y, width, height);
     }
@@ -72,7 +72,7 @@ export class RangeMask extends _Scene.Path {
         return new BBox(minX, y, maxX - minX, height);
     }
 
-    updatePath() {
+    override updatePath() {
         const { path, x, y, width, height, min, max } = this;
 
         path.clear();

--- a/packages/ag-charts-enterprise/src/features/navigator/shapes/rangeSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/shapes/rangeSelector.ts
@@ -6,7 +6,7 @@ import { RangeMask } from './rangeMask';
 const { RedrawType } = _Scene;
 
 export class RangeSelector extends _Scene.Group {
-    static className = 'Range';
+    static override className = 'Range';
 
     private static defaults = {
         x: 0,
@@ -112,7 +112,7 @@ export class RangeSelector extends _Scene.Group {
         minHandle.centerY = maxHandle.centerY = y + height / 2;
     }
 
-    computeBBox() {
+    override computeBBox() {
         return this.mask.computeBBox();
     }
 
@@ -120,7 +120,7 @@ export class RangeSelector extends _Scene.Group {
         return this.mask.computeVisibleRangeBBox();
     }
 
-    render(renderCtx: _Scene.RenderContext) {
+    override render(renderCtx: _Scene.RenderContext) {
         const { ctx, forceRender, stats } = renderCtx;
 
         if (this.dirty === RedrawType.NONE && !forceRender) {

--- a/packages/ag-charts-enterprise/src/features/zoom/scenes/zoomRect.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/scenes/zoomRect.ts
@@ -3,11 +3,11 @@ import { _ModuleSupport, _Scene } from 'ag-charts-community';
 const { COLOR_STRING, NUMBER, Validate } = _ModuleSupport;
 
 export class ZoomRect extends _Scene.Rect {
-    static className = 'ZoomRect';
+    static override className = 'ZoomRect';
 
     @Validate(COLOR_STRING)
-    public fill = 'rgb(33, 150, 243)';
+    public override fill = 'rgb(33, 150, 243)';
 
     @Validate(NUMBER(0, 1))
-    public fillOpacity = 0.2;
+    public override fillOpacity = 0.2;
 }

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -51,13 +51,13 @@ export class BoxPlotSeriesNodeBaseClickEvent<
 }
 
 export class BoxPlotSeriesNodeClickEvent<Datum extends { datum: any }> extends BoxPlotSeriesNodeBaseClickEvent<Datum> {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 export class BoxPlotSeriesNodeDoubleClickEvent<
     Datum extends { datum: any },
 > extends BoxPlotSeriesNodeBaseClickEvent<Datum> {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 class BoxPlotSeriesCap {
@@ -374,11 +374,11 @@ export class BoxPlotSeries extends CartesianSeries<
         ];
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: BoxPlotNodeDatum): BoxPlotSeriesNodeClickEvent<any> {
+    protected override getNodeClickEvent(event: MouseEvent, datum: BoxPlotNodeDatum): BoxPlotSeriesNodeClickEvent<any> {
         return new BoxPlotSeriesNodeClickEvent(event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: BoxPlotNodeDatum
     ): BoxPlotSeriesNodeDoubleClickEvent<any> {
@@ -446,7 +446,7 @@ export class BoxPlotSeries extends CartesianSeries<
         );
     }
 
-    protected animateEmptyUpdateReady({
+    protected override animateEmptyUpdateReady({
         datumSelections,
     }: _ModuleSupport.CartesianAnimationData<_ModuleSupport.SeriesNodeDataContext<BoxPlotNodeDatum>, BoxPlotGroup>) {
         const isVertical = this.direction === 'vertical';
@@ -486,7 +486,7 @@ export class BoxPlotSeries extends CartesianSeries<
         return false;
     }
 
-    protected async updateDatumSelection(opts: {
+    protected override async updateDatumSelection(opts: {
         nodeData: BoxPlotNodeDatum[];
         datumSelection: _Scene.Selection<BoxPlotGroup, BoxPlotNodeDatum>;
         seriesIdx: number;
@@ -495,7 +495,7 @@ export class BoxPlotSeries extends CartesianSeries<
         return opts.datumSelection.update(data);
     }
 
-    protected async updateDatumNodes({
+    protected override async updateDatumNodes({
         datumSelection,
         highlightedItems,
         isHighlight: highlighted,
@@ -548,7 +548,7 @@ export class BoxPlotSeries extends CartesianSeries<
         return labelSelection.update(labelData);
     }
 
-    protected nodeFactory() {
+    protected override nodeFactory() {
         return new BoxPlotGroup();
     }
 
@@ -597,7 +597,7 @@ export class BoxPlotSeries extends CartesianSeries<
         return activeStyles;
     }
 
-    getBandScalePadding() {
+    override getBandScalePadding() {
         return { inner: 0.2, outer: 0.1 };
     }
 

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -47,11 +47,11 @@ class HeatmapSeriesNodeBaseClickEvent extends _ModuleSupport.CartesianSeriesNode
 }
 
 export class HeatmapSeriesNodeClickEvent extends HeatmapSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 export class HeatmapSeriesNodeDoubleClickEvent extends HeatmapSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
@@ -171,11 +171,11 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         }
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: HeatmapNodeDatum): HeatmapSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: HeatmapNodeDatum): HeatmapSeriesNodeClickEvent {
         return new HeatmapSeriesNodeClickEvent(this.labelKey, this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(event: MouseEvent, datum: HeatmapNodeDatum): HeatmapSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: HeatmapNodeDatum): HeatmapSeriesNodeDoubleClickEvent {
         return new HeatmapSeriesNodeDoubleClickEvent(
             this.labelKey,
             this.xKey ?? '',
@@ -258,15 +258,15 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData }];
     }
 
-    getLabelData(): _Util.PointLabelDatum[] {
+    override getLabelData(): _Util.PointLabelDatum[] {
         return this.contextNodeData?.reduce<_Util.PointLabelDatum[]>((r, n) => r.concat(n.labelData), []);
     }
 
-    protected nodeFactory() {
+    protected override nodeFactory() {
         return new Rect();
     }
 
-    protected async updateDatumSelection(opts: {
+    protected override async updateDatumSelection(opts: {
         nodeData: HeatmapNodeDatum[];
         datumSelection: _Scene.Selection<_Scene.Rect, HeatmapNodeDatum>;
     }) {
@@ -275,7 +275,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         return datumSelection.update(data);
     }
 
-    protected async updateDatumNodes(opts: {
+    protected override async updateDatumNodes(opts: {
         datumSelection: _Scene.Selection<_Scene.Rect, HeatmapNodeDatum>;
         isHighlight: boolean;
     }) {
@@ -496,7 +496,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         return this.label.enabled;
     }
 
-    getBandScalePadding() {
+    override getBandScalePadding() {
         return { inner: 0, outer: 0 };
     }
 }

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -175,7 +175,10 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         return new HeatmapSeriesNodeClickEvent(this.labelKey, this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 
-    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: HeatmapNodeDatum): HeatmapSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(
+        event: MouseEvent,
+        datum: HeatmapNodeDatum
+    ): HeatmapSeriesNodeDoubleClickEvent {
         return new HeatmapSeriesNodeDoubleClickEvent(
             this.labelKey,
             this.xKey ?? '',

--- a/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
@@ -297,14 +297,14 @@ export class HistogramSeries extends CartesianSeries<
         return fixNumericExtent(yDomain);
     }
 
-    protected getNodeClickEvent(
+    protected override getNodeClickEvent(
         event: MouseEvent,
         datum: HistogramNodeDatum
     ): _ModuleSupport.CartesianSeriesNodeClickEvent<any> {
         return new CartesianSeriesNodeClickEvent(this.xKey ?? '', this.yKey ?? '', event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: HistogramNodeDatum
     ): _ModuleSupport.CartesianSeriesNodeDoubleClickEvent<any> {
@@ -407,13 +407,13 @@ export class HistogramSeries extends CartesianSeries<
         return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData }];
     }
 
-    protected nodeFactory() {
+    protected override nodeFactory() {
         return new Rect();
     }
 
-    datumSelectionGarbageCollection = false;
+    override datumSelectionGarbageCollection = false;
 
-    protected async updateDatumSelection(opts: {
+    protected override async updateDatumSelection(opts: {
         nodeData: HistogramNodeDatum[];
         datumSelection: _Scene.Selection<_Scene.Rect, HistogramNodeDatum>;
     }) {
@@ -429,7 +429,7 @@ export class HistogramSeries extends CartesianSeries<
         );
     }
 
-    protected async updateDatumNodes(opts: {
+    protected override async updateDatumNodes(opts: {
         datumSelection: _Scene.Selection<_Scene.Rect, HistogramNodeDatum>;
         isHighlight: boolean;
     }) {
@@ -582,7 +582,7 @@ export class HistogramSeries extends CartesianSeries<
         ];
     }
 
-    animateEmptyUpdateReady({ datumSelections, labelSelections }: HistogramAnimationData) {
+    override animateEmptyUpdateReady({ datumSelections, labelSelections }: HistogramAnimationData) {
         const duration = this.ctx.animationManager.defaultDuration;
         const labelDuration = 200;
 
@@ -624,19 +624,19 @@ export class HistogramSeries extends CartesianSeries<
         });
     }
 
-    animateReadyUpdate({ datumSelections }: HistogramAnimationData) {
+    override animateReadyUpdate({ datumSelections }: HistogramAnimationData) {
         this.resetSelections(datumSelections);
     }
 
-    animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, HistogramNodeDatum>) {
+    override animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, HistogramNodeDatum>) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize({ datumSelections }: HistogramAnimationData) {
+    override animateReadyResize({ datumSelections }: HistogramAnimationData) {
         this.resetSelections(datumSelections);
     }
 
-    animateWaitingUpdateReady({
+    override animateWaitingUpdateReady({
         datumSelections,
         labelSelections,
     }: {

--- a/packages/ag-charts-enterprise/src/series/polar-series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/polar-series/radial-column/radialColumnSeriesBase.ts
@@ -556,7 +556,10 @@ export abstract class RadialColumnSeriesBase<
         });
     }
 
-    protected override getNodeClickEvent(event: MouseEvent, datum: RadialColumnNodeDatum): RadialColumnSeriesNodeClickEvent {
+    protected override getNodeClickEvent(
+        event: MouseEvent,
+        datum: RadialColumnNodeDatum
+    ): RadialColumnSeriesNodeClickEvent {
         return new RadialColumnSeriesNodeClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/polar-series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/polar-series/radial-column/radialColumnSeriesBase.ts
@@ -50,11 +50,11 @@ class RadialColumnSeriesNodeBaseClickEvent extends _ModuleSupport.SeriesNodeBase
 }
 
 class RadialColumnSeriesNodeClickEvent extends RadialColumnSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 class RadialColumnSeriesNodeDoubleClickEvent extends RadialColumnSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 interface RadialColumnLabelNodeDatum {
@@ -144,7 +144,7 @@ export abstract class RadialColumnSeriesBase<
     @Validate(OPT_NUMBER())
     normalizedTo?: number;
 
-    readonly highlightStyle = new HighlightStyle();
+    override readonly highlightStyle = new HighlightStyle();
 
     private groupScale = new BandScale<string>();
 
@@ -186,7 +186,7 @@ export abstract class RadialColumnSeriesBase<
 
     protected abstract createPathSelection(parent: _Scene.Group): _Scene.Selection<ItemPathType, RadialColumnNodeDatum>;
 
-    addChartEventListeners(): void {
+    override addChartEventListeners(): void {
         this.ctx.chartEventManager?.addListener('legend-item-click', (event) => this.onLegendItemClick(event));
         this.ctx.chartEventManager?.addListener('legend-item-double-click', (event) =>
             this.onLegendItemDoubleClick(event)
@@ -556,11 +556,11 @@ export abstract class RadialColumnSeriesBase<
         });
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: RadialColumnNodeDatum): RadialColumnSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: RadialColumnNodeDatum): RadialColumnSeriesNodeClickEvent {
         return new RadialColumnSeriesNodeClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: RadialColumnNodeDatum
     ): RadialColumnSeriesNodeDoubleClickEvent {
@@ -689,7 +689,7 @@ export abstract class RadialColumnSeriesBase<
         this.toggleSeriesItem(itemId, newEnabled);
     }
 
-    computeLabelsBBox() {
+    override computeLabelsBBox() {
         return null;
     }
 }

--- a/packages/ag-charts-enterprise/src/series/radar-area/radarAreaSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-area/radarAreaSeries.ts
@@ -7,7 +7,7 @@ const { NUMBER, OPT_COLOR_STRING, Validate } = _ModuleSupport;
 const { Group, Path, PointerEvents, Selection } = _Scene;
 
 export class RadarAreaSeries extends RadarSeries {
-    static className = 'RadarAreaSeries';
+    static override className = 'RadarAreaSeries';
     static type = 'radar-area' as const;
 
     protected areaSelection: _Scene.Selection<_Scene.Path, boolean>;
@@ -26,7 +26,7 @@ export class RadarAreaSeries extends RadarSeries {
         this.areaSelection = Selection.select(areaGroup, Path);
     }
 
-    protected updatePathSelections() {
+    protected override updatePathSelections() {
         const pathData = this.visible ? [true] : [];
         this.areaSelection.update(pathData);
         super.updatePathSelections();
@@ -36,11 +36,11 @@ export class RadarAreaSeries extends RadarSeries {
         return this.areaSelection.nodes()[0];
     }
 
-    protected getMarkerFill(highlightedStyle?: _ModuleSupport.SeriesItemHighlightStyle) {
+    protected override getMarkerFill(highlightedStyle?: _ModuleSupport.SeriesItemHighlightStyle) {
         return highlightedStyle?.fill ?? this.marker.fill ?? this.fill;
     }
 
-    protected beforePathAnimation() {
+    protected override beforePathAnimation() {
         super.beforePathAnimation();
 
         const areaNode = this.getAreaNode();
@@ -50,13 +50,13 @@ export class RadarAreaSeries extends RadarSeries {
         areaNode.stroke = undefined;
     }
 
-    protected animatePaths(totalDuration: number, timePassed: number) {
+    protected override animatePaths(totalDuration: number, timePassed: number) {
         super.animatePaths(totalDuration, timePassed);
         const areaPoints = this.getLinePoints({ breakMissingPoints: false });
         this.animateSinglePath(this.getAreaNode(), areaPoints, totalDuration, timePassed);
     }
 
-    protected resetMarkersAndPaths() {
+    protected override resetMarkersAndPaths() {
         super.resetMarkersAndPaths();
         const areaNode = this.getAreaNode();
 

--- a/packages/ag-charts-enterprise/src/series/radar-line/radarLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-line/radarLineSeries.ts
@@ -1,10 +1,10 @@
 import { RadarSeries } from '../radar/radarSeries';
 
 export class RadarLineSeries extends RadarSeries {
-    static className = 'RadarLineSeries';
+    static override className = 'RadarLineSeries';
     static type = 'radar-line' as const;
 
-    protected updatePathSelections() {
+    protected override updatePathSelections() {
         this.lineSelection.update(this.visible ? [true] : []);
     }
 }

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -437,7 +437,10 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         return new RadarSeriesNodeClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 
-    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: RadarNodeDatum): RadarSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(
+        event: MouseEvent,
+        datum: RadarNodeDatum
+    ): RadarSeriesNodeDoubleClickEvent {
         return new RadarSeriesNodeDoubleClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -52,11 +52,11 @@ class RadarSeriesNodeBaseClickEvent extends _ModuleSupport.SeriesNodeBaseClickEv
 }
 
 class RadarSeriesNodeClickEvent extends RadarSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 class RadarSeriesNodeDoubleClickEvent extends RadarSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 interface RadarNodeDatum extends _ModuleSupport.SeriesNodeDatum {
@@ -148,7 +148,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
     @Validate(NUMBER(0))
     strokeWidth = 1;
 
-    readonly highlightStyle = new HighlightStyle();
+    override readonly highlightStyle = new HighlightStyle();
 
     constructor(moduleCtx: _ModuleSupport.ModuleContext) {
         super({
@@ -197,7 +197,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         });
     }
 
-    addChartEventListeners(): void {
+    override addChartEventListeners(): void {
         this.ctx.chartEventManager?.addListener('legend-item-click', (event) => this.onLegendItemClick(event));
         this.ctx.chartEventManager?.addListener('legend-item-double-click', (event) =>
             this.onLegendItemDoubleClick(event)
@@ -433,11 +433,11 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         });
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: RadarNodeDatum): RadarSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: RadarNodeDatum): RadarSeriesNodeClickEvent {
         return new RadarSeriesNodeClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(event: MouseEvent, datum: RadarNodeDatum): RadarSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: RadarNodeDatum): RadarSeriesNodeDoubleClickEvent {
         return new RadarSeriesNodeDoubleClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 
@@ -543,7 +543,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         this.toggleSeriesItem(itemId, newEnabled);
     }
 
-    protected pickNodeClosestDatum(point: _Scene.Point): _ModuleSupport.SeriesNodePickMatch | undefined {
+    protected override pickNodeClosestDatum(point: _Scene.Point): _ModuleSupport.SeriesNodePickMatch | undefined {
         const { x, y } = point;
         const { rootGroup, nodeData, centerX: cx, centerY: cy, marker } = this;
         const hitPoint = rootGroup.transformPoint(x, y);
@@ -576,7 +576,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         }
     }
 
-    async computeLabelsBBox() {
+    override async computeLabelsBBox() {
         const { label } = this;
 
         await this.maybeRefreshNodeData();

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -50,7 +50,7 @@ class RadialBarSeriesNodeClickEvent extends _ModuleSupport.SeriesNodeBaseClickEv
 }
 
 class RadialBarSeriesNodeDoubleClickEvent extends RadialBarSeriesNodeClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 interface RadialBarLabelNodeDatum {
@@ -140,7 +140,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDat
     @Validate(OPT_NUMBER())
     normalizedTo?: number;
 
-    readonly highlightStyle = new HighlightStyle();
+    override readonly highlightStyle = new HighlightStyle();
 
     private groupScale = new BandScale<string>();
 
@@ -180,7 +180,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDat
         });
     }
 
-    addChartEventListeners(): void {
+    override addChartEventListeners(): void {
         this.ctx.chartEventManager?.addListener('legend-item-click', (event) => this.onLegendItemClick(event));
         this.ctx.chartEventManager?.addListener('legend-item-double-click', (event) =>
             this.onLegendItemDoubleClick(event)
@@ -535,11 +535,11 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDat
         });
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: RadialBarNodeDatum): RadialBarSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: RadialBarNodeDatum): RadialBarSeriesNodeClickEvent {
         return new RadialBarSeriesNodeClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: RadialBarNodeDatum
     ): RadialBarSeriesNodeDoubleClickEvent {
@@ -656,7 +656,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDat
         this.toggleSeriesItem(itemId, newEnabled);
     }
 
-    computeLabelsBBox() {
+    override computeLabelsBBox() {
         return null;
     }
 

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -50,11 +50,11 @@ class RadialColumnSeriesNodeBaseClickEvent extends _ModuleSupport.SeriesNodeBase
 }
 
 class RadialColumnSeriesNodeClickEvent extends RadialColumnSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 class RadialColumnSeriesNodeDoubleClickEvent extends RadialColumnSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 interface RadialColumnLabelNodeDatum {
@@ -144,7 +144,7 @@ export abstract class RadialColumnSeriesBase<
     @Validate(OPT_NUMBER())
     normalizedTo?: number;
 
-    readonly highlightStyle = new HighlightStyle();
+    override readonly highlightStyle = new HighlightStyle();
 
     private groupScale = new BandScale<string>();
 
@@ -186,7 +186,7 @@ export abstract class RadialColumnSeriesBase<
 
     protected abstract createPathSelection(parent: _Scene.Group): _Scene.Selection<ItemPathType, RadialColumnNodeDatum>;
 
-    addChartEventListeners(): void {
+    override addChartEventListeners(): void {
         this.ctx.chartEventManager?.addListener('legend-item-click', (event) => this.onLegendItemClick(event));
         this.ctx.chartEventManager?.addListener('legend-item-double-click', (event) =>
             this.onLegendItemDoubleClick(event)
@@ -554,11 +554,11 @@ export abstract class RadialColumnSeriesBase<
         });
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: RadialColumnNodeDatum): RadialColumnSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: RadialColumnNodeDatum): RadialColumnSeriesNodeClickEvent {
         return new RadialColumnSeriesNodeClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: RadialColumnNodeDatum
     ): RadialColumnSeriesNodeDoubleClickEvent {
@@ -675,7 +675,7 @@ export abstract class RadialColumnSeriesBase<
         this.toggleSeriesItem(itemId, newEnabled);
     }
 
-    computeLabelsBBox() {
+    override computeLabelsBBox() {
         return null;
     }
 }

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -554,7 +554,10 @@ export abstract class RadialColumnSeriesBase<
         });
     }
 
-    protected override getNodeClickEvent(event: MouseEvent, datum: RadialColumnNodeDatum): RadialColumnSeriesNodeClickEvent {
+    protected override getNodeClickEvent(
+        event: MouseEvent,
+        datum: RadialColumnNodeDatum
+    ): RadialColumnSeriesNodeClickEvent {
         return new RadialColumnSeriesNodeClickEvent(this.angleKey, this.radiusKey, event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -238,7 +238,10 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         }
     }
 
-    protected override getNodeClickEvent(event: MouseEvent, datum: RangeAreaMarkerDatum): RangeAreaSeriesNodeClickEvent {
+    protected override getNodeClickEvent(
+        event: MouseEvent,
+        datum: RangeAreaMarkerDatum
+    ): RangeAreaSeriesNodeClickEvent {
         return new RangeAreaSeriesNodeClickEvent(datum.xKey, datum.yLowKey, datum.yHighKey, event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -87,11 +87,11 @@ class RangeAreaSeriesNodeBaseClickEvent extends _ModuleSupport.SeriesNodeBaseCli
 }
 
 export class RangeAreaSeriesNodeClickEvent extends RangeAreaSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 export class RangeAreaSeriesNodeDoubleClickEvent extends RangeAreaSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 class RangeAreaSeriesLabel extends _Scene.Label {
@@ -238,11 +238,11 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         }
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: RangeAreaMarkerDatum): RangeAreaSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: RangeAreaMarkerDatum): RangeAreaSeriesNodeClickEvent {
         return new RangeAreaSeriesNodeClickEvent(datum.xKey, datum.yLowKey, datum.yHighKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: RangeAreaMarkerDatum
     ): RangeAreaSeriesNodeDoubleClickEvent {
@@ -475,17 +475,17 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         return labelText ?? (isNumber(value) ? value.toFixed(2) : String(value));
     }
 
-    protected isPathOrSelectionDirty(): boolean {
+    protected override isPathOrSelectionDirty(): boolean {
         return this.marker.isDirty();
     }
 
-    protected markerFactory() {
+    protected override markerFactory() {
         const { shape } = this.marker;
         const MarkerShape = getMarker(shape);
         return new MarkerShape();
     }
 
-    protected async updateMarkerSelection(opts: {
+    protected override async updateMarkerSelection(opts: {
         nodeData: RangeAreaMarkerDatum[];
         markerSelection: _Scene.Selection<_Scene.Marker, RangeAreaMarkerDatum>;
     }) {
@@ -504,7 +504,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         });
     }
 
-    protected async updateMarkerNodes(opts: {
+    protected override async updateMarkerNodes(opts: {
         markerSelection: _Scene.Selection<_Scene.Marker, RangeAreaMarkerDatum>;
         isHighlight: boolean;
     }) {
@@ -576,7 +576,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         });
     }
 
-    protected getHighlightLabelData(
+    protected override getHighlightLabelData(
         labelData: RangeAreaLabelDatum[],
         highlightedItem: RangeAreaMarkerDatum
     ): RangeAreaLabelDatum[] | undefined {
@@ -584,7 +584,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         return labelItems.length > 0 ? labelItems : undefined;
     }
 
-    protected getHighlightData(
+    protected override getHighlightData(
         nodeData: RangeAreaMarkerDatum[],
         highlightedItem: RangeAreaMarkerDatum
     ): RangeAreaMarkerDatum[] | undefined {
@@ -680,7 +680,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         ];
     }
 
-    animateEmptyUpdateReady({
+    override animateEmptyUpdateReady({
         markerSelections,
         labelSelections,
         contextData,
@@ -751,7 +751,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         });
     }
 
-    animateReadyUpdate({
+    override animateReadyUpdate({
         contextData,
         paths,
     }: {
@@ -776,5 +776,5 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaCon
         return this.label.enabled;
     }
 
-    onDataChange() {}
+    override onDataChange() {}
 }

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -287,7 +287,10 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         return new RangeBarSeriesNodeClickEvent(datum.xKey, datum.yLowKey, datum.yHighKey, event, datum, this);
     }
 
-    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: RangeBarNodeDatum): RangeBarSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(
+        event: MouseEvent,
+        datum: RangeBarNodeDatum
+    ): RangeBarSeriesNodeDoubleClickEvent {
         return new RangeBarSeriesNodeDoubleClickEvent(datum.xKey, datum.yLowKey, datum.yHighKey, event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -105,11 +105,11 @@ class RangeBarSeriesNodeBaseClickEvent extends _ModuleSupport.SeriesNodeBaseClic
 }
 
 export class RangeBarSeriesNodeClickEvent extends RangeBarSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 export class RangeBarSeriesNodeDoubleClickEvent extends RangeBarSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 class RangeBarSeriesLabel extends _Scene.Label {
@@ -172,7 +172,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
      */
     private groupScale = new BandScale<string>();
 
-    protected resolveKeyDirection(direction: _ModuleSupport.ChartAxisDirection) {
+    protected override resolveKeyDirection(direction: _ModuleSupport.ChartAxisDirection) {
         if (this.getBarDirection() === ChartAxisDirection.X) {
             if (direction === ChartAxisDirection.X) {
                 return ChartAxisDirection.Y;
@@ -283,11 +283,11 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         }
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: RangeBarNodeDatum): RangeBarSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: RangeBarNodeDatum): RangeBarSeriesNodeClickEvent {
         return new RangeBarSeriesNodeClickEvent(datum.xKey, datum.yLowKey, datum.yHighKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(event: MouseEvent, datum: RangeBarNodeDatum): RangeBarSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: RangeBarNodeDatum): RangeBarSeriesNodeDoubleClickEvent {
         return new RangeBarSeriesNodeDoubleClickEvent(datum.xKey, datum.yLowKey, datum.yHighKey, event, datum, this);
     }
 
@@ -515,13 +515,13 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         return labelText ?? (isNumber(value) ? value.toFixed(2) : '');
     }
 
-    protected nodeFactory() {
+    protected override nodeFactory() {
         return new Rect();
     }
 
-    datumSelectionGarbageCollection = false;
+    override datumSelectionGarbageCollection = false;
 
-    protected async updateDatumSelection(opts: {
+    protected override async updateDatumSelection(opts: {
         nodeData: RangeBarNodeDatum[];
         datumSelection: _Scene.Selection<_Scene.Rect, RangeBarNodeDatum>;
     }) {
@@ -530,7 +530,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         return datumSelection.update(data, undefined, (datum) => this.getDatumId(datum));
     }
 
-    protected async updateDatumNodes(opts: {
+    protected override async updateDatumNodes(opts: {
         datumSelection: _Scene.Selection<_Scene.Rect, RangeBarNodeDatum>;
         isHighlight: boolean;
     }) {
@@ -590,7 +590,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         });
     }
 
-    protected getHighlightLabelData(
+    protected override getHighlightLabelData(
         labelData: RangeBarNodeLabelDatum[],
         highlightedItem: RangeBarNodeDatum
     ): RangeBarNodeLabelDatum[] | undefined {
@@ -738,7 +738,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         ];
     }
 
-    animateEmptyUpdateReady({ datumSelections, labelSelections, contextData }: RangeBarAnimationData) {
+    override animateEmptyUpdateReady({ datumSelections, labelSelections, contextData }: RangeBarAnimationData) {
         contextData.forEach((_, contextDataIndex) => {
             this.animateRects(datumSelections[contextDataIndex]);
             this.animateLabels(labelSelections[contextDataIndex]);
@@ -764,7 +764,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         });
     }
 
-    animateWaitingUpdateReady({ datumSelections, labelSelections }: RangeBarAnimationData) {
+    override animateWaitingUpdateReady({ datumSelections, labelSelections }: RangeBarAnimationData) {
         const { processedData } = this;
         const diff = processedData?.reduced?.diff;
 
@@ -866,15 +866,15 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         });
     }
 
-    animateReadyUpdate({ datumSelections }: RangeBarAnimationData) {
+    override animateReadyUpdate({ datumSelections }: RangeBarAnimationData) {
         this.resetSelections(datumSelections);
     }
 
-    animateReadyHighlight(highlightSelection: RangeBarAnimationData['datumSelections'][number]) {
+    override animateReadyHighlight(highlightSelection: RangeBarAnimationData['datumSelections'][number]) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize({ datumSelections }: RangeBarAnimationData) {
+    override animateReadyResize({ datumSelections }: RangeBarAnimationData) {
         this.resetSelections(datumSelections);
     }
 
@@ -916,9 +916,9 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         return ChartAxisDirection.X;
     }
 
-    getBandScalePadding() {
+    override getBandScalePadding() {
         return { inner: 0.2, outer: 0.1 };
     }
 
-    protected onDataChange() {}
+    protected override onDataChange() {}
 }

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -71,11 +71,11 @@ class TreemapSeriesNodeBaseClickEvent extends SeriesNodeBaseClickEvent<any> {
 }
 
 class TreemapSeriesNodeClickEvent extends TreemapSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 class TreemapSeriesNodeDoubleClickEvent extends TreemapSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 class TreemapSeriesLabel extends Label {
@@ -145,7 +145,7 @@ class TreemapTextHighlightStyle {
 }
 
 class TreemapHighlightStyle extends HighlightStyle {
-    readonly text = new TreemapTextHighlightStyle();
+    override readonly text = new TreemapTextHighlightStyle();
 }
 
 export class TreemapSeries extends _ModuleSupport.HierarchySeries<TreemapNodeDatum> {
@@ -265,7 +265,7 @@ export class TreemapSeries extends _ModuleSupport.HierarchySeries<TreemapNodeDat
 
     readonly tooltip = new SeriesTooltip<AgTreemapSeriesTooltipRendererParams<any>>();
 
-    readonly highlightStyle = new TreemapHighlightStyle();
+    override readonly highlightStyle = new TreemapHighlightStyle();
 
     private getNodePaddingTop(nodeDatum: TreemapNodeDatum, bbox: _Scene.BBox) {
         const { title, subtitle, nodePadding } = this;
@@ -879,11 +879,11 @@ export class TreemapSeries extends _ModuleSupport.HierarchySeries<TreemapNodeDat
         return [0, 1];
     }
 
-    protected getNodeClickEvent(event: MouseEvent, datum: TreemapNodeDatum): TreemapSeriesNodeClickEvent {
+    protected override getNodeClickEvent(event: MouseEvent, datum: TreemapNodeDatum): TreemapSeriesNodeClickEvent {
         return new TreemapSeriesNodeClickEvent(this.labelKey, this.sizeKey, this.colorKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(event: MouseEvent, datum: TreemapNodeDatum): TreemapSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: TreemapNodeDatum): TreemapSeriesNodeDoubleClickEvent {
         return new TreemapSeriesNodeDoubleClickEvent(this.labelKey, this.sizeKey, this.colorKey, event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -883,7 +883,10 @@ export class TreemapSeries extends _ModuleSupport.HierarchySeries<TreemapNodeDat
         return new TreemapSeriesNodeClickEvent(this.labelKey, this.sizeKey, this.colorKey, event, datum, this);
     }
 
-    protected override getNodeDoubleClickEvent(event: MouseEvent, datum: TreemapNodeDatum): TreemapSeriesNodeDoubleClickEvent {
+    protected override getNodeDoubleClickEvent(
+        event: MouseEvent,
+        datum: TreemapNodeDatum
+    ): TreemapSeriesNodeDoubleClickEvent {
         return new TreemapSeriesNodeDoubleClickEvent(this.labelKey, this.sizeKey, this.colorKey, event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -86,11 +86,11 @@ class WaterfallSeriesNodeBaseClickEvent extends _ModuleSupport.CartesianSeriesNo
 }
 
 export class WaterfallSeriesNodeClickEvent extends WaterfallSeriesNodeBaseClickEvent {
-    readonly type = 'nodeClick';
+    override readonly type = 'nodeClick';
 }
 
 export class WaterfallSeriesNodeDoubleClickEvent extends WaterfallSeriesNodeBaseClickEvent {
-    readonly type = 'nodeDoubleClick';
+    override readonly type = 'nodeDoubleClick';
 }
 
 class WaterfallSeriesItemTooltip {
@@ -198,7 +198,7 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         });
     }
 
-    protected resolveKeyDirection(direction: _ModuleSupport.ChartAxisDirection) {
+    protected override resolveKeyDirection(direction: _ModuleSupport.ChartAxisDirection) {
         if (this.getBarDirection() === ChartAxisDirection.X) {
             if (direction === ChartAxisDirection.X) {
                 return ChartAxisDirection.Y;
@@ -339,14 +339,14 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         }
     }
 
-    protected getNodeClickEvent(
+    protected override getNodeClickEvent(
         event: MouseEvent,
         datum: WaterfallNodeDatum
     ): _ModuleSupport.CartesianSeriesNodeClickEvent<any> {
         return new CartesianSeriesNodeClickEvent(this.xKey ?? '', datum.yKey, event, datum, this);
     }
 
-    protected getNodeDoubleClickEvent(
+    protected override getNodeDoubleClickEvent(
         event: MouseEvent,
         datum: WaterfallNodeDatum
     ): _ModuleSupport.CartesianSeriesNodeDoubleClickEvent<any> {
@@ -591,7 +591,7 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         return datumType === 'total';
     }
 
-    protected nodeFactory() {
+    protected override nodeFactory() {
         return new Rect();
     }
 
@@ -614,7 +614,7 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         }
     }
 
-    protected async updateDatumSelection(opts: {
+    protected override async updateDatumSelection(opts: {
         nodeData: WaterfallNodeDatum[];
         datumSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>;
     }) {
@@ -623,7 +623,7 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         return datumSelection.update(data);
     }
 
-    protected async updateDatumNodes(opts: {
+    protected override async updateDatumNodes(opts: {
         datumSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>;
         isHighlight: boolean;
     }) {
@@ -816,9 +816,9 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         return legendData;
     }
 
-    protected toggleSeriesItem(): void {}
+    protected override toggleSeriesItem(): void {}
 
-    animateEmptyUpdateReady({ datumSelections, labelSelections, contextData, paths }: WaterfallAnimationData) {
+    override animateEmptyUpdateReady({ datumSelections, labelSelections, contextData, paths }: WaterfallAnimationData) {
         contextData.forEach(({ pointData }, contextDataIndex) => {
             this.animateRects(datumSelections[contextDataIndex]);
             this.animateLabels(labelSelections[contextDataIndex]);
@@ -952,15 +952,15 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         });
     }
 
-    animateReadyUpdate(data: WaterfallAnimationData) {
+    override animateReadyUpdate(data: WaterfallAnimationData) {
         this.resetSelectionRectsAndPaths(data);
     }
 
-    animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>) {
+    override animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>) {
         this.resetSelectionRects(highlightSelection);
     }
 
-    animateReadyResize(data: WaterfallAnimationData) {
+    override animateReadyResize(data: WaterfallAnimationData) {
         this.resetSelectionRectsAndPaths(data);
     }
 
@@ -1044,9 +1044,9 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
         return ChartAxisDirection.X;
     }
 
-    getBandScalePadding() {
+    override getBandScalePadding() {
         return { inner: 0.2, outer: 0.1 };
     }
 
-    protected onDataChange() {}
+    protected override onDataChange() {}
 }

--- a/packages/ag-charts-enterprise/tsconfig.json
+++ b/packages/ag-charts-enterprise/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "strict": true,
     "forceConsistentCasingInFileNames": false,
-    "noImplicitOverride": false,
+    "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": false,


### PR DESCRIPTION
Tighten up our our overrides so that renames on parents trigger compile failures on children.

Interestingly, also highlights a bunch of places we're overriding but probably shouldn't....