### PR TITLE
Apply fromToMotion to more series types.

### DIFF
--- a/packages/ag-charts-community/src/integrated-charts-scene.ts
+++ b/packages/ag-charts-community/src/integrated-charts-scene.ts
@@ -1,3 +1,6 @@
+import * as fromToMotion from './motion/fromToMotion';
+import * as resetMotion from './motion/resetMotion';
+
 export { Caption } from './chart/caption';
 export { DropShadow } from './scene/dropShadow';
 export { Group } from './scene/group';
@@ -33,4 +36,6 @@ export { HdpiCanvas } from './scene/canvas/hdpiCanvas';
 export { Image } from './scene/image';
 export { Path2D } from './scene/path2D';
 export * as easing from './motion/easing';
-export * as motion from './motion/fromToMotion';
+
+const motion = { ...fromToMotion, ...resetMotion };
+export { motion };

--- a/packages/ag-charts-community/src/motion/fromToMotion.ts
+++ b/packages/ag-charts-community/src/motion/fromToMotion.ts
@@ -1,7 +1,7 @@
 import type { ProcessedOutputDiff } from '../chart/data/processors';
 import type { AnimationManager } from '../chart/interaction/animationManager';
+import type { Node } from '../scene/node';
 import type { Selection } from '../scene/selection';
-import type { Shape } from '../scene/shape/shape';
 import { zipObject } from '../util/zip';
 import type { AdditionalAnimationOptions, AnimationOptions, AnimationValue } from './animation';
 import * as easing from './easing';
@@ -22,7 +22,7 @@ export type NodeUpdateState = 'added' | 'removed' | 'updated' | 'moved';
  *                   specified iff diff is specified
  * @param diff optional diff from a DataModel to use to detect added/moved/removed cases
  */
-export function fromToMotion<N extends Shape, T extends AnimationValue & Partial<N>, D>(
+export function fromToMotion<N extends Node, T extends AnimationValue & Partial<N>, D>(
     id: string,
     animationManager: AnimationManager,
     selections: Selection<N, D>[],
@@ -93,7 +93,7 @@ export function fromToMotion<N extends Shape, T extends AnimationValue & Partial
  * @param to node final properties
  * @param extraOpts optional additional animation properties to pass to AnimationManager#animate.
  */
-export function staticFromToMotion<N extends Shape, T extends AnimationValue & Partial<N>, D>(
+export function staticFromToMotion<N extends Node, T extends AnimationValue & Partial<N>, D>(
     id: string,
     animationManager: AnimationManager,
     selections: Selection<N, D>[],
@@ -118,7 +118,7 @@ export function staticFromToMotion<N extends Shape, T extends AnimationValue & P
     });
 }
 
-function calculateStatus<N extends Shape, D>(
+function calculateStatus<N extends Node, D>(
     node: N,
     datum: D,
     getDatumId: (node: N, datum: D) => string,

--- a/packages/ag-charts-community/src/motion/fromToMotion.ts
+++ b/packages/ag-charts-community/src/motion/fromToMotion.ts
@@ -62,6 +62,9 @@ export function fromToMotion<N extends Node, T extends AnimationValue & Partial<
                 onUpdate(props) {
                     node.setProperties(props);
                 },
+                onStop() {
+                    node.setProperties(to);
+                },
                 ...extraOpts,
             });
         }
@@ -111,6 +114,13 @@ export function staticFromToMotion<N extends Node, T extends AnimationValue & Pa
             for (const selection of selections) {
                 for (const node of selection.nodes()) {
                     node.setProperties(props);
+                }
+            }
+        },
+        onStop() {
+            for (const selection of selections) {
+                for (const node of selection.nodes()) {
+                    node.setProperties(to);
                 }
             }
         },

--- a/packages/ag-charts-community/src/motion/resetMotion.ts
+++ b/packages/ag-charts-community/src/motion/resetMotion.ts
@@ -1,0 +1,24 @@
+import type { Selection } from '../scene/selection';
+import type { Shape } from '../scene/shape/shape';
+import type { AnimationValue } from './animation';
+
+/**
+ * Implements a per-node reset.
+ *
+ * @param selections contains nodes to be reset
+ * @param propsFn callback to determine per-node properties
+ */
+export function resetMotion<N extends Shape, T extends AnimationValue & Partial<N>, D>(
+    selections: Selection<N, D>[],
+    propsFn: (node: N, datum: D) => T
+) {
+    for (const selection of selections) {
+        for (const node of selection.nodes()) {
+            const from = propsFn(node, node.datum);
+
+            node.setProperties(from);
+        }
+
+        selection.cleanup();
+    }
+}

--- a/packages/ag-charts-community/src/motion/resetMotion.ts
+++ b/packages/ag-charts-community/src/motion/resetMotion.ts
@@ -1,5 +1,5 @@
+import type { Node } from '../scene/node';
 import type { Selection } from '../scene/selection';
-import type { Shape } from '../scene/shape/shape';
 import type { AnimationValue } from './animation';
 
 /**
@@ -8,7 +8,7 @@ import type { AnimationValue } from './animation';
  * @param selections contains nodes to be reset
  * @param propsFn callback to determine per-node properties
  */
-export function resetMotion<N extends Shape, T extends AnimationValue & Partial<N>, D>(
+export function resetMotion<N extends Node, T extends AnimationValue & Partial<N>, D>(
     selections: Selection<N, D>[],
     propsFn: (node: N, datum: D) => T
 ) {

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -155,6 +155,14 @@ export abstract class Node extends ChangeDetectable {
     // Used to check for duplicate nodes.
     private childSet: { [id: string]: boolean } = {}; // new Set<Node>()
 
+    setProperties<T>(this: T, styles: { [K in keyof T]?: T[K] }, pickKeys?: (keyof T)[]) {
+        const keys = pickKeys ?? (Object.keys(styles) as (keyof T)[]);
+        for (const key of keys) {
+            (this as any)[key] = styles[key];
+        }
+        return this;
+    }
+
     /**
      * Appends one or more new node instances to this parent.
      * If one needs to:

--- a/packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/packages/ag-charts-community/src/scene/shape/shape.ts
@@ -37,14 +37,6 @@ export abstract class Shape extends Node {
         }
     );
 
-    setProperties<T>(this: T, styles: { [K in keyof T]?: T[K] }, pickKeys?: (keyof T)[]) {
-        const keys = pickKeys ?? (Object.keys(styles) as (keyof T)[]);
-        for (const key of keys) {
-            (this as any)[key] = styles[key];
-        }
-        return this;
-    }
-
     /**
      * Restores the default styles introduced by this subclass.
      */

--- a/packages/ag-charts-enterprise/src/series/box-plot/blotPlotUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/blotPlotUtil.ts
@@ -1,0 +1,20 @@
+import type { BoxPlotGroup } from './boxPlotGroup';
+import type { BoxPlotNodeDatum } from './boxPlotTypes';
+
+export function prepareBoxPlotFromTo(isVertical: boolean) {
+    const from = isVertical ? { scalingX: 1, scalingY: 0 } : { scalingX: 0, scalingY: 1 };
+    const to = { scalingX: 1, scalingY: 1 };
+
+    return { from, to };
+}
+
+export function resetBoxPlotSelectionsScalingCenterFn(
+    isVertical: boolean
+): (node: BoxPlotGroup, datum: BoxPlotNodeDatum) => { scalingCenterY: number } | { scalingCenterX: number } {
+    return (_node, datum) => {
+        if (isVertical) {
+            return { scalingCenterY: datum.scaledValues.medianValue };
+        }
+        return { scalingCenterX: datum.scaledValues.medianValue };
+    };
+}

--- a/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
@@ -40,6 +40,8 @@ const {
     valueProperty,
     getBarDirectionStartingValues,
     prepareBarAnimationFunctions,
+    collapsedStartingBarPosition,
+    resetBarSelectionsFn,
 } = _ModuleSupport;
 const { Rect, Label, PointerEvents, motion } = _Scene;
 const { ticks, sanitizeHtml, tickStep } = _Util;
@@ -589,7 +591,7 @@ export class HistogramSeries extends CartesianSeries<
         const labelDuration = 200;
 
         const { startingX, startingY } = getBarDirectionStartingValues(ChartAxisDirection.Y, this.axes);
-        const { toFn, fromFn } = prepareBarAnimationFunctions<HistogramNodeDatum>(true, startingX, startingY);
+        const { toFn, fromFn } = prepareBarAnimationFunctions(collapsedStartingBarPosition(true, startingX, startingY));
 
         motion.fromToMotion(`${this.id}_empty-update-ready`, this.ctx.animationManager, datumSelections, fromFn, toFn);
 
@@ -604,15 +606,15 @@ export class HistogramSeries extends CartesianSeries<
     }
 
     override animateReadyUpdate({ datumSelections }: HistogramAnimationData) {
-        this.resetSelections(datumSelections);
+        motion.resetMotion(datumSelections, resetBarSelectionsFn);
     }
 
     override animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, HistogramNodeDatum>) {
-        this.resetSelectionRects(highlightSelection);
+        motion.resetMotion([highlightSelection], resetBarSelectionsFn);
     }
 
     override animateReadyResize({ datumSelections }: HistogramAnimationData) {
-        this.resetSelections(datumSelections);
+        motion.resetMotion(datumSelections, resetBarSelectionsFn);
     }
 
     override animateWaitingUpdateReady({
@@ -630,12 +632,12 @@ export class HistogramSeries extends CartesianSeries<
         const diff = processedData?.reduced?.diff;
 
         if (!diff?.changed) {
-            this.resetSelections(datumSelections);
+            motion.resetMotion(datumSelections, resetBarSelectionsFn);
             return;
         }
 
         const { startingX, startingY } = getBarDirectionStartingValues(ChartAxisDirection.Y, this.axes);
-        const { toFn, fromFn } = prepareBarAnimationFunctions<HistogramNodeDatum>(true, startingX, startingY);
+        const { toFn, fromFn } = prepareBarAnimationFunctions(collapsedStartingBarPosition(true, startingX, startingY));
         motion.fromToMotion(
             `${this.id}_waiting-update-ready`,
             animationManager,
@@ -657,21 +659,6 @@ export class HistogramSeries extends CartesianSeries<
             { opacity: 1 },
             { delay: duration, duration: labelDuration }
         );
-    }
-
-    resetSelections(datumSelections: HistogramAnimationData['datumSelections']) {
-        datumSelections.forEach((datumSelection) => {
-            this.resetSelectionRects(datumSelection);
-        });
-    }
-
-    resetSelectionRects(selection: _Scene.Selection<_Scene.Rect, HistogramNodeDatum>) {
-        selection.each((rect, datum) => {
-            rect.x = datum.x;
-            rect.y = datum.y;
-            rect.width = datum.width;
-            rect.height = datum.height;
-        });
     }
 
     getDatumId(datum: HistogramNodeDatum) {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -28,11 +28,13 @@ const {
     CategoryAxis,
     SMALLEST_KEY_INTERVAL,
     STRING_UNION,
-    Motion,
     diff,
+    prepareBarAnimationFunctions,
+    midpointStartingBarPosition,
+    resetBarSelectionsFn,
 } = _ModuleSupport;
-const { ContinuousScale, BandScale, Rect, PointerEvents } = _Scene;
-const { sanitizeHtml, isNumber, extent, zipObject } = _Util;
+const { ContinuousScale, BandScale, Rect, PointerEvents, motion } = _Scene;
+const { sanitizeHtml, isNumber, extent } = _Util;
 
 const RANGE_BAR_LABEL_PLACEMENTS: AgRangeBarSeriesLabelPlacement[] = ['inside', 'outside'];
 const OPT_RANGE_BAR_LABEL_PLACEMENT: _ModuleSupport.ValidatePredicate = (v: any, ctx) =>
@@ -741,30 +743,21 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         ];
     }
 
-    override animateEmptyUpdateReady({ datumSelections, labelSelections, contextData }: RangeBarAnimationData) {
-        contextData.forEach((_, contextDataIndex) => {
-            this.animateRects(datumSelections[contextDataIndex]);
-            this.animateLabels(labelSelections[contextDataIndex]);
-        });
-    }
+    override animateEmptyUpdateReady({ datumSelections, labelSelections }: RangeBarAnimationData) {
+        const isVertical = this.getBarDirection() === ChartAxisDirection.Y;
 
-    protected animateRects(datumSelection: RangeBarAnimationData['datumSelections'][number]) {
-        const horizontal = this.getBarDirection() === ChartAxisDirection.X;
-        datumSelection.each((rect, datum) => {
-            this.ctx.animationManager.animate({
-                id: `${this.id}_empty-update-ready_${rect.id}`,
-                from: { cord: (horizontal ? datum.nodeMidPoint?.x : datum.nodeMidPoint?.y) ?? 0, dimension: 0 },
-                to: { cord: horizontal ? datum.x : datum.y, dimension: horizontal ? datum.width : datum.height },
-                ease: _ModuleSupport.Motion.easeOut,
-                onUpdate({ cord, dimension }) {
-                    rect.setProperties(
-                        horizontal
-                            ? { x: cord, y: datum.y, width: dimension, height: datum.height }
-                            : { x: datum.x, y: cord, width: datum.width, height: dimension }
-                    );
-                },
-            });
-        });
+        const { toFn, fromFn } = prepareBarAnimationFunctions(midpointStartingBarPosition(isVertical));
+        motion.fromToMotion(`${this.id}_empty-update-ready`, this.ctx.animationManager, datumSelections, fromFn, toFn);
+
+        const duration = this.ctx.animationManager.defaultDuration;
+        motion.staticFromToMotion(
+            `${this.id}_empty-update-ready_labels`,
+            this.ctx.animationManager,
+            labelSelections,
+            { opacity: 0 },
+            { opacity: 1 },
+            { delay: duration, duration: 200 }
+        );
     }
 
     override animateWaitingUpdateReady({ datumSelections, labelSelections }: RangeBarAnimationData) {
@@ -772,129 +765,45 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<RangeBarConte
         const diff = processedData?.reduced?.diff;
 
         if (!diff?.changed) {
-            datumSelections.forEach((datumSelection) => {
-                this.resetSelectionRects(datumSelection);
-            });
+            motion.resetMotion(datumSelections, resetBarSelectionsFn);
             return;
         }
 
-        const totalDuration = this.ctx.animationManager.defaultDuration;
-        const labelDuration = totalDuration / 5;
+        const isVertical = this.getBarDirection() === ChartAxisDirection.Y;
 
-        let sectionDuration = totalDuration;
-        if (diff.added.length > 0 || diff.removed.length > 0) {
-            sectionDuration = Math.floor(totalDuration / 2);
-        }
+        const { toFn, fromFn } = prepareBarAnimationFunctions(midpointStartingBarPosition(isVertical));
+        motion.fromToMotion(
+            `${this.id}_empty-update-ready`,
+            this.ctx.animationManager,
+            datumSelections,
+            fromFn,
+            toFn,
+            {},
+            (_, datum) => String(datum.xValue),
+            diff
+        );
 
-        const addedIds = zipObject(diff.added, true);
-        const removedIds = zipObject(diff.removed, true);
-
-        const horizontal = this.getBarDirection() === ChartAxisDirection.X;
-
-        datumSelections.forEach((datumSelection) => {
-            datumSelection.each((rect, datum, index) => {
-                let from = { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
-                let to = { x: datum.x, y: datum.y, width: datum.width, height: datum.height };
-
-                const start = {
-                    x: horizontal ? datum.nodeMidPoint?.x ?? 0 : datum.x,
-                    y: horizontal ? datum.y : datum.nodeMidPoint?.y ?? 0,
-                    width: horizontal ? 0 : datum.width,
-                    height: horizontal ? datum.height : 0,
-                };
-
-                const isAdded = datum.xValue !== undefined && addedIds[datum.xValue] !== undefined;
-                const isRemoved = datum.xValue !== undefined && removedIds[datum.xValue] !== undefined;
-                const cleanup = index === datumSelection.nodes().length - 1;
-
-                if (isAdded) {
-                    from = start;
-                } else if (isRemoved) {
-                    from = to;
-                    to = start;
-                }
-
-                this.ctx.animationManager.animate({
-                    id: `${this.id}_waiting-update-ready_${rect.id}`,
-                    from,
-                    to,
-                    duration: sectionDuration,
-                    ease: Motion.easeOut,
-                    onUpdate(props) {
-                        rect.setProperties(props);
-                    },
-                    onComplete() {
-                        if (cleanup) {
-                            datumSelection.cleanup();
-                        }
-                    },
-                    onStop() {
-                        if (cleanup) {
-                            datumSelection.cleanup();
-                        }
-                    },
-                });
-            });
-        });
-
-        this.ctx.animationManager.animate({
-            id: `${this.id}_waiting-update-ready_labels`,
-            from: 0,
-            to: 1,
-            delay: totalDuration,
-            duration: labelDuration,
-            onUpdate: (opacity) => {
-                labelSelections.forEach((labelSelection) => {
-                    labelSelection.each((label) => {
-                        label.opacity = opacity;
-                    });
-                });
-            },
-        });
-    }
-
-    protected animateLabels(labelSelection: RangeBarAnimationData['labelSelections'][number]) {
         const duration = this.ctx.animationManager.defaultDuration;
-        this.ctx.animationManager.animate({
-            id: `${this.id}_empty-update-ready_labels`,
-            from: 0,
-            to: 1,
-            delay: duration,
-            duration: duration / 5,
-            onUpdate: (opacity) => {
-                labelSelection.each((label) => {
-                    label.opacity = opacity;
-                });
-            },
-        });
+        motion.staticFromToMotion(
+            `${this.id}_empty-update-ready_labels`,
+            this.ctx.animationManager,
+            labelSelections,
+            { opacity: 0 },
+            { opacity: 1 },
+            { delay: duration, duration: 200 }
+        );
     }
 
     override animateReadyUpdate({ datumSelections }: RangeBarAnimationData) {
-        this.resetSelections(datumSelections);
+        motion.resetMotion(datumSelections, resetBarSelectionsFn);
     }
 
     override animateReadyHighlight(highlightSelection: RangeBarAnimationData['datumSelections'][number]) {
-        this.resetSelectionRects(highlightSelection);
+        motion.resetMotion([highlightSelection], resetBarSelectionsFn);
     }
 
     override animateReadyResize({ datumSelections }: RangeBarAnimationData) {
-        this.resetSelections(datumSelections);
-    }
-
-    resetSelections(datumSelections: RangeBarAnimationData['datumSelections']) {
-        datumSelections.forEach((datumSelection) => {
-            this.resetSelectionRects(datumSelection);
-        });
-    }
-
-    resetSelectionRects(selection: _Scene.Selection<_Scene.Rect, RangeBarNodeDatum>) {
-        selection.each((rect, datum) => {
-            rect.x = datum.x;
-            rect.y = datum.y;
-            rect.width = datum.width;
-            rect.height = datum.height;
-        });
-        selection.cleanup();
+        motion.resetMotion(datumSelections, resetBarSelectionsFn);
     }
 
     private getDatumId(datum: RangeBarNodeDatum) {

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -32,8 +32,12 @@ const {
     updateRect,
     checkCrisp,
     updateLabel,
+    getBarDirectionStartingValues,
+    prepareBarAnimationFunctions,
+    collapsedStartingBarPosition,
+    resetBarSelectionsFn,
 } = _ModuleSupport;
-const { ContinuousScale, Rect } = _Scene;
+const { ContinuousScale, Rect, motion } = _Scene;
 const { sanitizeHtml, isContinuous } = _Util;
 
 const WATERFALL_LABEL_PLACEMENTS: AgWaterfallSeriesLabelPlacement[] = ['start', 'end', 'inside'];
@@ -819,10 +823,27 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
     protected override toggleSeriesItem(): void {}
 
     override animateEmptyUpdateReady({ datumSelections, labelSelections, contextData, paths }: WaterfallAnimationData) {
-        contextData.forEach(({ pointData }, contextDataIndex) => {
-            this.animateRects(datumSelections[contextDataIndex]);
-            this.animateLabels(labelSelections[contextDataIndex]);
+        const { animationManager } = this.ctx;
+        const isVertical = this.getBarDirection() === ChartAxisDirection.Y;
 
+        const { startingX, startingY } = getBarDirectionStartingValues(this.getBarDirection(), this.axes);
+        const { toFn, fromFn } = prepareBarAnimationFunctions(
+            collapsedStartingBarPosition(isVertical, startingX, startingY)
+        );
+        motion.fromToMotion(`${this.id}_empty-update-ready`, this.ctx.animationManager, datumSelections, fromFn, toFn);
+
+        const duration = this.ctx.animationManager.defaultDuration;
+        const labelDuration = 200;
+        motion.staticFromToMotion(
+            `${this.id}empty-update-ready_labels`,
+            animationManager,
+            labelSelections,
+            { opacity: 0 },
+            { opacity: 1 },
+            { delay: duration, duration: labelDuration }
+        );
+
+        contextData.forEach(({ pointData }, contextDataIndex) => {
             if (contextDataIndex !== 0 || !pointData) {
                 return;
             }
@@ -833,42 +854,6 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
             } else {
                 this.animateConnectorLinesHorizontal(lineNode, pointData);
             }
-        });
-    }
-
-    protected animateRects(datumSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>) {
-        const horizontal = this.direction === 'horizontal';
-        const yAxis = this.getValueAxis();
-        datumSelection.each((rect, datum) => {
-            this.ctx.animationManager.animate({
-                id: `${this.id}_empty-update-ready_${rect.id}`,
-                from: { cord: yAxis?.scale.convert(0) ?? 0, dimension: 0 },
-                to: { cord: horizontal ? datum.x : datum.y, dimension: horizontal ? datum.width : datum.height },
-                ease: _ModuleSupport.Motion.easeOut,
-                onUpdate({ cord, dimension }) {
-                    rect.setProperties(
-                        horizontal
-                            ? { x: cord, y: datum.y, width: dimension, height: datum.height }
-                            : { x: datum.x, y: cord, width: datum.width, height: dimension }
-                    );
-                },
-            });
-        });
-    }
-
-    protected animateLabels(labelSelection: _Scene.Selection<_Scene.Text, WaterfallNodeDatum>) {
-        const duration = this.ctx.animationManager.defaultDuration;
-        this.ctx.animationManager.animate({
-            id: `${this.id}_empty-update-ready_labels`,
-            from: 0,
-            to: 1,
-            delay: duration,
-            duration: duration / 5,
-            onUpdate: (opacity) => {
-                labelSelection.each((label) => {
-                    label.opacity = opacity;
-                });
-            },
         });
     }
 
@@ -953,31 +938,22 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<WaterfallCon
     }
 
     override animateReadyUpdate(data: WaterfallAnimationData) {
-        this.resetSelectionRectsAndPaths(data);
+        motion.resetMotion(data.datumSelections, resetBarSelectionsFn);
+        this.resetConnectorLinesPath(data);
     }
 
     override animateReadyHighlight(highlightSelection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>) {
-        this.resetSelectionRects(highlightSelection);
+        motion.resetMotion([highlightSelection], resetBarSelectionsFn);
     }
 
     override animateReadyResize(data: WaterfallAnimationData) {
-        this.resetSelectionRectsAndPaths(data);
+        motion.resetMotion(data.datumSelections, resetBarSelectionsFn);
+        this.resetConnectorLinesPath(data);
     }
 
-    resetSelectionRectsAndPaths({ datumSelections, contextData, paths }: WaterfallAnimationData) {
-        this.resetConnectorLinesPath({ contextData, paths });
-        datumSelections.forEach((datumSelection) => {
-            this.resetSelectionRects(datumSelection);
-        });
-    }
-
-    resetSelectionRects(selection: _Scene.Selection<_Scene.Rect, WaterfallNodeDatum>) {
-        selection.each((rect, datum) => {
-            rect.x = datum.x;
-            rect.y = datum.y;
-            rect.width = datum.width;
-            rect.height = datum.height;
-        });
+    resetSelectionRectsAndPaths(data: WaterfallAnimationData) {
+        motion.resetMotion(data.datumSelections, resetBarSelectionsFn);
+        this.resetConnectorLinesPath(data);
     }
 
     resetConnectorLinesPath({


### PR DESCRIPTION
- Converts `RangeBarSeries` to use `fromToMotion`.
- Partially converts `WaterfallSeries` to use `fromToMotion`.
- Converts `BoxPlotSeries` to use `fromToMotion`.
- Factors out common selection reset handling to a new `resetMotion` function.
- Moves `Shape.setProperties()` up to `Node`.