### PR TITLE
Improve bar series legend handling

### DIFF
--- a/packages/ag-charts-community/src/chart/data/dataModel.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.ts
@@ -1,5 +1,6 @@
 import { Debug } from '../../util/debug';
 import { Logger } from '../../util/logger';
+import { isNegative } from '../../util/number';
 import { isNumber } from '../../util/value';
 import type { ChartAxis } from '../chartAxis';
 import { DataDomain } from './dataDomain';
@@ -195,6 +196,7 @@ export type DatumPropertyDefinition<K> = PropertyIdentifiers & {
     type: 'key' | 'value';
     valueType: DatumPropertyType;
     property: K;
+    forceValue?: any;
     invalidValue?: any;
     missing?: number;
     missingValue?: any;
@@ -929,6 +931,14 @@ export class DataModel<
             } else {
                 valueInDatum = def.property in datum;
                 value = valueInDatum ? datum[def.property] : def.missingValue;
+            }
+
+            if (def.forceValue != null) {
+                // Maintain sign of forceValue from actual value, this maybe significant later when
+                // we account fo the value falling into positive/negative buckets.
+                const valueNegative = valueInDatum && isNegative(value);
+                value = valueNegative ? -1 * def.forceValue : def.forceValue;
+                valueInDatum = true;
             }
 
             const missingValueDef = 'missingValue' in def;

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -1,5 +1,6 @@
 import { arraysEqual } from '../../util/array';
 import { memo } from '../../util/memo';
+import { isNegative } from '../../util/number';
 import type {
     GroupValueProcessorDefinition,
     ProcessedData,
@@ -170,7 +171,7 @@ function buildGroupAccFn({ mode, separateNegative }: { mode: 'normal' | 'trailin
         const acc = [0, 0];
         for (const valueIdx of valueIndexes) {
             const currentVal = values[valueIdx];
-            const accIndex = currentVal < 0 && separateNegative ? 0 : 1;
+            const accIndex = isNegative(currentVal) && separateNegative ? 0 : 1;
             if (typeof currentVal !== 'number' || isNaN(currentVal)) continue;
 
             if (mode === 'normal') acc[accIndex] += currentVal;

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -183,6 +183,7 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
 
     override async processData(dataController: DataController) {
         const { xKey, yKey, normalizedTo, seriesGrouping: { groupIndex = this.id } = {}, data = [] } = this;
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const normalizedToAbs = Math.abs(normalizedTo ?? NaN);
 
         const isContinuousX = this.getCategoryAxis()?.scale instanceof ContinuousScale;
@@ -196,31 +197,34 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
             extraProps.push(normaliseGroupTo(this, [stackGroupName, stackGroupTrailingName], normaliseTo, 'range'));
         }
 
-        if (!this.ctx.animationManager.isSkipped() && this.processedData) {
+        if (animationEnabled && this.processedData) {
             extraProps.push(diff(this.processedData));
         }
 
+        const visibleProps = this.visible || !animationEnabled ? {} : { forceValue: 0 };
         const { processedData } = await this.requestDataModel<any, any, true>(dataController, data, {
             props: [
                 keyProperty(this, xKey, isContinuousX, { id: 'xValue' }),
-                valueProperty(this, yKey, isContinuousY, { id: `yValue-raw`, invalidValue: null }),
+                valueProperty(this, yKey, isContinuousY, { id: `yValue-raw`, invalidValue: null, ...visibleProps }),
                 ...groupAccumulativeValueProperty(this, yKey, isContinuousY, 'normal', 'current', {
                     id: `yValue-end`,
                     invalidValue: null,
                     groupId: stackGroupName,
                     separateNegative: true,
+                    ...visibleProps,
                 }),
                 ...groupAccumulativeValueProperty(this, yKey, isContinuousY, 'trailing', 'current', {
                     id: `yValue-start`,
                     invalidValue: null,
                     groupId: stackGroupTrailingName,
                     separateNegative: true,
+                    ...visibleProps,
                 }),
                 ...(isContinuousX ? [SMALLEST_KEY_INTERVAL] : []),
                 ...extraProps,
             ],
             groupByKeys: true,
-            dataVisible: this.visible,
+            dataVisible: this.visible || animationEnabled,
         });
 
         this.smallestDataInterval = {
@@ -288,11 +292,11 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
     }
 
     async createNodeData() {
-        const { visible, dataModel } = this;
+        const { dataModel } = this;
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!(dataModel && visible && xAxis && yAxis)) {
+        if (!(dataModel && xAxis && yAxis)) {
             return [];
         }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -156,6 +156,7 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
             pathsPerSeries: 0,
             hasHighlightedLabels: true,
+            datumSelectionGarbageCollection: false,
             animationResetFns: {
                 datum: resetBarSelectionsFn,
                 label: resetLabelFn,
@@ -454,8 +455,6 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
     protected nodeFactory() {
         return new Rect();
     }
-
-    override datumSelectionGarbageCollection = false;
 
     protected override async updateDatumSelection(opts: {
         nodeData: BarNodeDatum[];

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -131,6 +131,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
             ],
             pathsPerSeries: 0,
             hasMarkers: true,
+            markerSelectionGarbageCollection: false,
             animationResetFns: {
                 label: resetLabelFn,
                 marker: resetMarkerFn,
@@ -295,8 +296,6 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
         const MarkerShape = getMarker(shape);
         return new MarkerShape();
     }
-
-    override markerSelectionGarbageCollection = false;
 
     protected override async updateMarkerSelection(opts: {
         nodeData: BubbleNodeDatum[];

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -58,6 +58,8 @@ interface SeriesOpts<TNode extends Node, TDatum extends CartesianSeriesNodeDatum
     hasHighlightedLabels: boolean;
     directionKeys: { [key in ChartAxisDirection]?: string[] };
     directionNames: { [key in ChartAxisDirection]?: string[] };
+    datumSelectionGarbageCollection: boolean;
+    markerSelectionGarbageCollection: boolean;
     animationResetFns?: {
         datum?: (node: TNode, datum: TDatum) => AnimationValue & Partial<TNode>;
         label?: (node: Text, datum: TLabel) => AnimationValue & Partial<Text>;
@@ -136,8 +138,6 @@ export abstract class CartesianSeries<
     private readonly debug = Debug.create();
 
     protected animationState: StateMachine<CartesianAnimationState, CartesianAnimationEvent>;
-    protected datumSelectionGarbageCollection = true;
-    protected markerSelectionGarbageCollection = true;
 
     protected constructor({
         pathsPerSeries = 1,
@@ -146,6 +146,8 @@ export abstract class CartesianSeries<
         pathsZIndexSubOrderOffset = [],
         directionKeys = DEFAULT_DIRECTION_KEYS,
         directionNames = DEFAULT_DIRECTION_NAMES,
+        datumSelectionGarbageCollection = true,
+        markerSelectionGarbageCollection = true,
         animationResetFns,
         ...otherOpts
     }: Partial<SeriesOpts<TNode, TDatum, TLabel>> & ConstructorParameters<typeof Series>[0]) {
@@ -165,6 +167,8 @@ export abstract class CartesianSeries<
             directionKeys,
             directionNames,
             animationResetFns,
+            datumSelectionGarbageCollection,
+            markerSelectionGarbageCollection,
         };
 
         this.animationState = new StateMachine('empty', {
@@ -306,7 +310,7 @@ export abstract class CartesianSeries<
             _contextNodeData: contextNodeData,
             contentGroup,
             subGroups,
-            opts: { pathsPerSeries, hasMarkers },
+            opts: { pathsPerSeries, hasMarkers, datumSelectionGarbageCollection, markerSelectionGarbageCollection },
         } = this;
         if (contextNodeData.length === subGroups.length) {
             return;
@@ -375,10 +379,10 @@ export abstract class CartesianSeries<
                 datumSelection: Selection.select(
                     dataNodeGroup,
                     () => this.nodeFactory(),
-                    this.datumSelectionGarbageCollection
+                    datumSelectionGarbageCollection
                 ),
                 markerSelection: markerGroup
-                    ? Selection.select(markerGroup, () => this.markerFactory(), this.markerSelectionGarbageCollection)
+                    ? Selection.select(markerGroup, () => this.markerFactory(), markerSelectionGarbageCollection)
                     : undefined,
             });
         }

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -259,7 +259,7 @@ export abstract class CartesianSeries<
     }
 
     protected async updateSelections(anySeriesItemEnabled: boolean) {
-        if (!anySeriesItemEnabled) {
+        if (!anySeriesItemEnabled && this.ctx.animationManager.isSkipped()) {
             return;
         }
         if (!this.nodeDataRefresh && !this.isPathOrSelectionDirty()) {
@@ -413,6 +413,7 @@ export abstract class CartesianSeries<
             opts: { hasMarkers, hasHighlightedLabels },
         } = this;
 
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const visible = this.visible && this._contextNodeData?.length > 0 && anySeriesItemEnabled;
         this.rootGroup.visible = visible;
         this.contentGroup.visible = visible;
@@ -458,7 +459,7 @@ export abstract class CartesianSeries<
                 const subGroupOpacity = subGroupOpacities[seriesIdx];
 
                 dataNodeGroup.opacity = subGroupOpacity;
-                dataNodeGroup.visible = subGroupVisible;
+                dataNodeGroup.visible = animationEnabled || subGroupVisible;
                 labelGroup.visible = subGroupVisible;
 
                 if (markerGroup) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -90,6 +90,7 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
             ],
             pathsPerSeries: 0,
             hasMarkers: true,
+            markerSelectionGarbageCollection: false,
             animationResetFns: {
                 marker: resetMarkerFn,
                 label: resetLabelFn,
@@ -227,8 +228,6 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
         const MarkerShape = getMarker(shape);
         return new MarkerShape();
     }
-
-    override markerSelectionGarbageCollection = false;
 
     protected override async updateMarkerSelection(opts: {
         nodeData: ScatterNodeDatum[];

--- a/packages/ag-charts-community/src/util/number.ts
+++ b/packages/ag-charts-community/src/util/number.ts
@@ -6,6 +6,10 @@ export function isEqual(a: number, b: number, epsilon: number = 1e-10) {
     return Math.abs(a - b) < epsilon;
 }
 
+export function isNegative(a: number) {
+    return Math.sign(a) < 0 || Object.is(a, -0);
+}
+
 /**
  * `Number.toFixed(n)` always formats a number so that it has `n` digits after the decimal point.
  * For example, `Number(0.00003427).toFixed(2)` returns `0.00`.

--- a/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
@@ -114,6 +114,7 @@ export class HistogramSeries extends CartesianSeries<_Scene.Rect, HistogramNodeD
         super({
             moduleCtx,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
+            datumSelectionGarbageCollection: false,
             animationResetFns: {
                 datum: resetBarSelectionsFn,
                 label: resetLabelFn,
@@ -407,8 +408,6 @@ export class HistogramSeries extends CartesianSeries<_Scene.Rect, HistogramNodeD
     protected override nodeFactory() {
         return new Rect();
     }
-
-    override datumSelectionGarbageCollection = false;
 
     protected override async updateDatumSelection(opts: {
         nodeData: HistogramNodeDatum[];

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -156,6 +156,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
             hasHighlightedLabels: true,
             directionKeys: DEFAULT_DIRECTION_KEYS,
             directionNames: DEFAULT_DIRECTION_NAMES,
+            datumSelectionGarbageCollection: false,
             animationResetFns: {
                 datum: resetBarSelectionsFn,
                 label: resetLabelFn,
@@ -506,8 +507,6 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
     protected override nodeFactory() {
         return new Rect();
     }
-
-    override datumSelectionGarbageCollection = false;
 
     protected override async updateDatumSelection(opts: {
         nodeData: RangeBarNodeDatum[];


### PR DESCRIPTION
Changes `BarSeries` so that legend hidden series are still processed and rendered when animation is enabled - this gives us the opportunity to shrink items in a stack rather than just immediately removing them:

https://github.com/ag-grid/ag-charts/assets/17544187/8650ff17-57f4-460f-be0a-ded98d0506ab

