### PR TITLE
AG-9272 Fix errorbar tooltip docs/example

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesEvents.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesEvents.ts
@@ -30,9 +30,7 @@ export interface SeriesDataGetDomainEvent extends BaseSeriesEvent<'data-getDomai
     readonly direction: ChartAxisDirection;
 }
 
-export interface SeriesTooltipGetParamsEvent extends BaseSeriesEvent<'tooltip-getParams'> {
-    readonly datum: object;
-}
+export interface SeriesTooltipGetParamsEvent extends BaseSeriesEvent<'tooltip-getParams'> {}
 
 export interface SeriesVisibilityEvent extends BaseSeriesEvent<'visibility-changed'> {
     readonly itemId: any;

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -264,7 +264,7 @@ export class ErrorBars
         }
     }
 
-    private onTooltipGetParams(event: SeriesTooltipGetParamsEvent) {
+    private onTooltipGetParams(_event: SeriesTooltipGetParamsEvent) {
         const { xLowerKey, xUpperKey, yLowerKey, yUpperKey } = this;
         let { xLowerName, xUpperName, yLowerName, yUpperName } = this;
         xLowerName ??= xLowerKey;
@@ -272,29 +272,14 @@ export class ErrorBars
         yLowerName ??= yLowerKey;
         yUpperName ??= yUpperKey;
 
-        const datum: { [key: string]: any } = event.datum;
-        const getValue = (key?: string) => {
-            if (key !== undefined && key in datum) {
-                return datum[key];
-            }
-        };
-        const xLowerValue = getValue(xLowerKey);
-        const xUpperValue = getValue(xUpperKey);
-        const yLowerValue = getValue(yLowerKey);
-        const yUpperValue = getValue(yUpperKey);
-
         return {
             xLowerKey,
-            xLowerValue,
             xLowerName,
             xUpperKey,
-            xUpperValue,
             xUpperName,
             yLowerKey,
-            yLowerValue,
             yLowerName,
             yUpperKey,
-            yUpperValue,
             yUpperName,
         };
     }

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/main.ts
@@ -2,22 +2,29 @@ import { AgChartOptions, AgEnterpriseCharts, AgScatterSeriesTooltipRendererParam
 import { getData } from './data';
 
 function verbose_renderer(params: AgScatterSeriesTooltipRendererParams) {
+    const datum = params.datum;
     return {
-        title: `${params.xValue}m³ / ${params.yValue}kPa`,
-        content: '<ul>'+
-            `<li>${params.xUpperName}: ${params.xUpperValue}m³</li>`+
-            `<li>${params.xLowerName}: ${params.xLowerValue}m³</li>`+
-            `<li>${params.yUpperName}: ${params.yUpperValue}kPa</li>`+
-            `<li>${params.yLowerName}: ${params.yLowerValue}kPa</li>`+
+        title: `${datum[params.xKey]}m³ / ${datum[params.yKey]}kPa`,
+        content:
+            '<ul>' +
+            `<li>${params.xUpperName}: ${params.xUpperKey ? datum[params.xUpperKey] : undefined}m³</li>` +
+            `<li>${params.xLowerName}: ${params.xLowerKey ? datum[params.xLowerKey] : undefined}m³</li>` +
+            `<li>${params.yUpperName}: ${params.yUpperKey ? datum[params.yUpperKey] : undefined}kPa</li>` +
+            `<li>${params.yLowerName}: ${params.yLowerKey ? datum[params.yLowerKey] : undefined}kPa</li>` +
             '</ul>',
-    }
+    };
 }
 
 function brief_renderer(params: AgScatterSeriesTooltipRendererParams) {
+    const datum = params.datum;
     return {
         content:
-            `<strong>${params.xKey}:</strong> ${params.xValue} [${params.xLowerValue}, ${params.xUpperValue}] m³<br/>`+
-            `<strong>${params.yKey}:</strong> ${params.yValue} [${params.yLowerValue}, ${params.yUpperValue}] kPa`,
+          `<strong>${params.xKey}:</strong> ${datum[params.xKey]} `+
+            `[${params.xLowerKey ? datum[params.xLowerKey] : undefined},`+
+            ` ${params.xUpperKey ? datum[params.xUpperKey] : undefined}] m³<br/>`+
+            `<strong>${params.yKey}:</strong> ${datum[params.yKey]} `+
+              `[${params.yLowerKey ? datum[params.yLowerKey] : undefined},`+
+              ` ${params.yUpperKey ? datum[params.yUpperKey] : undefined}] kPa`
     }
 }
 

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -80,14 +80,15 @@ provided the `renderer` for customization.
 
 ```js
 function verbose_renderer(params) {
+    const datum = params.datum;
     return {
-        title: `${params.xValue}m³ / ${params.yValue}kPa`,
+        title: `${datum[params.xKey]}m³ / ${datum[params.yKey]}kPa`,
         content:
             '<ul>' +
-            `<li>${params.xUpperName}: ${params.xUpperValue}m³</li>` +
-            `<li>${params.xLowerName}: ${params.xLowerValue}m³</li>` +
-            `<li>${params.yUpperName}: ${params.yUpperValue}kPa</li>` +
-            `<li>${params.yLowerName}: ${params.yLowerValue}kPa</li>` +
+            `<li>${params.xUpperName}: ${params.xUpperKey ? datum[params.xUpperKey] : undefined}m³</li>` +
+            `<li>${params.xLowerName}: ${params.xLowerKey ? datum[params.xLowerKey] : undefined}m³</li>` +
+            `<li>${params.yUpperName}: ${params.yUpperKey ? datum[params.yUpperKey] : undefined}kPa</li>` +
+            `<li>${params.yLowerName}: ${params.yLowerKey ? datum[params.yLowerKey] : undefined}kPa</li>` +
             '</ul>',
     };
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -98,16 +98,12 @@ The `renderer` has access to the keys, names, and values for the error data for
 both axes:
 
 -   `xLowerKey`
--   `xLowerValue`
 -   `xLowerName`
 -   `xUpperKey`
--   `xUpperValue`
 -   `xUpperName`
 -   `yLowerKey`
--   `yLowerValue`
 -   `yLowerName`
 -   `yUpperKey`
--   `yUpperValue`
 -   `yUpperName`
 
 The optional names will default to keys if unset.


### PR DESCRIPTION
The xValue / yValue tooltip parameters are no longer provided to the formatter. Use datum[params.xKey] / datum[params.yKey] instead.

Also update errorBar.ts to reflect this (no longer provides the values for error data).

For more info see:
https://github.com/ag-grid/ag-charts/pull/307