### PR TITLE
AG-9022 ErrorBar Styling & Cap Length Documentation

### DIFF
--- a/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
@@ -1,10 +1,46 @@
-export interface AgErrorBarOptions {
+import type { StrokeOptions } from '../series/cartesian/commonOptions';
+import type { PixelSize, Ratio } from './types';
+
+interface ErrorBarStylingOptions extends StrokeOptions {
+    /** Whether to display the error bars. */
+    visible?: boolean;
+}
+
+interface ErrorBarCapLengthOptions {
+    /** Absolute length of caps in pixels. */
+    length?: PixelSize;
+    /** Length of caps relative to the shape used by the series. */
+    lengthRatio?: Ratio;
+}
+
+interface ErrorBarDataOptions {
+    /** The key to use to retrieve lower bound error values from the x axis data. */
+    xLowerKey?: string;
+    /** Human-readable description of the lower bound error value for the x axis. This is the value to use in tooltips or labels. */
+    xLowerName?: string;
+    /** The key to use to retrieve upper bound error values from the x axis data. */
+    xUpperKey?: string;
+    /** Human-readable description of the upper bound error value for the x axis. This is the value to use in tooltips or labels. */
+    xUpperName?: string;
+
     /** The key to use to retrieve lower bound error values from the y axis data. */
-    yLowerKey: string;
+    yLowerKey?: string;
     /** Human-readable description of the lower bound error value for the y axis. This is the value to use in tooltips or labels. */
     yLowerName?: string;
     /** The key to use to retrieve upper bound error values from the y axis data. */
-    yUpperKey: string;
+    yUpperKey?: string;
     /** Human-readable description of the upper bound error value for the y axis. This is the value to use in tooltips or labels. */
     yUpperName?: string;
+}
+
+export interface AgErrorBarCapOptions extends ErrorBarCapLengthOptions, ErrorBarStylingOptions {}
+
+export interface AgErrorBarOptions extends ErrorBarDataOptions, ErrorBarStylingOptions {
+    /** Options to style error bars' caps */
+    cap?: AgErrorBarCapOptions;
+}
+
+export interface AgErrorBarSeriesOptions {
+    /** Configuration for the Error Bars. */
+    errorBar?: AgErrorBarOptions;
 }

--- a/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
@@ -13,7 +13,7 @@ interface ErrorBarCapLengthOptions {
     lengthRatio?: Ratio;
 }
 
-interface ErrorBarDataOptions {
+export interface AgErrorBarDataOptions {
     /** The key to use to retrieve lower bound error values from the x axis data. */
     xLowerKey?: string;
     /** Human-readable description of the lower bound error value for the x axis. This is the value to use in tooltips or labels. */
@@ -35,7 +35,7 @@ interface ErrorBarDataOptions {
 
 export interface AgErrorBarCapOptions extends ErrorBarCapLengthOptions, ErrorBarStylingOptions {}
 
-export interface AgErrorBarOptions extends ErrorBarDataOptions, ErrorBarStylingOptions {
+export interface AgErrorBarOptions extends AgErrorBarDataOptions, ErrorBarStylingOptions {
     /** Options to style error bars' caps */
     cap?: AgErrorBarCapOptions;
 }

--- a/packages/ag-charts-community/src/options/series/cartesian/barOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/barOptions.ts
@@ -1,6 +1,6 @@
 import type { AgChartCallbackParams } from '../../chart/callbackOptions';
 import type { AgDropShadowOptions } from '../../chart/dropShadowOptions';
-import type { AgErrorBarOptions } from '../../chart/errorBarOptions';
+import type { AgErrorBarSeriesOptions } from '../../chart/errorBarOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip, AgSeriesTooltipRendererParams } from '../../chart/tooltipOptions';
 import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../seriesOptions';
@@ -68,7 +68,8 @@ export interface AgBarSeriesOptions<TDatum = any>
     extends AgBaseSeriesOptions<TDatum>,
         AgBarSeriesOptionsKeys,
         AgBarSeriesOptionsNames,
-        AgBarSeriesThemeableOptions<TDatum> {
+        AgBarSeriesThemeableOptions<TDatum>,
+        AgErrorBarSeriesOptions {
     type: 'bar';
     /** Whether to group together (adjacently) separate bars. */
     grouped?: boolean;
@@ -80,6 +81,4 @@ export interface AgBarSeriesOptions<TDatum = any>
     normalizedTo?: number;
     /** Human-readable description of the y-values. If supplied, matching items with the same value will be toggled together. */
     legendItemName?: string;
-    /** Configuration for the series error bars. */
-    errorBar?: AgErrorBarOptions;
 }

--- a/packages/ag-charts-community/src/options/series/cartesian/lineOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/lineOptions.ts
@@ -1,4 +1,4 @@
-import type { AgErrorBarOptions } from '../../chart/errorBarOptions';
+import type { AgErrorBarSeriesOptions } from '../../chart/errorBarOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip } from '../../chart/tooltipOptions';
 import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../seriesOptions';
@@ -46,8 +46,7 @@ export interface AgLineSeriesOptions<TDatum = any>
     extends AgBaseSeriesOptions<TDatum>,
         AgLineSeriesOptionsKeys,
         AgLineSeriesOptionsNames,
-        AgLineSeriesThemeableOptions<TDatum> {
+        AgLineSeriesThemeableOptions<TDatum>,
+        AgErrorBarSeriesOptions {
     type?: 'line';
-    /** Configuration for the series error bars. */
-    errorBar?: AgErrorBarOptions;
 }

--- a/packages/ag-charts-community/src/options/series/cartesian/scatterOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/scatterOptions.ts
@@ -1,4 +1,4 @@
-import type { AgErrorBarOptions } from '../../chart/errorBarOptions';
+import type { AgErrorBarSeriesOptions } from '../../chart/errorBarOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip, AgSeriesTooltipRendererParams } from '../../chart/tooltipOptions';
 import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../seriesOptions';
@@ -52,9 +52,8 @@ export interface AgScatterSeriesOptions<TDatum = any>
     extends AgBaseSeriesOptions<TDatum>,
         AgScatterSeriesOptionsKeys,
         AgScatterSeriesOptionsNames,
-        AgScatterSeriesThemeableOptions<TDatum> {
+        AgScatterSeriesThemeableOptions<TDatum>,
+        AgErrorBarSeriesOptions {
     /** Configuration for the scatter series.  */
     type: 'scatter';
-    /** Configuration for the series error bars. */
-    errorBar?: AgErrorBarOptions;
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-length/data.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-length/data.ts
@@ -1,0 +1,68 @@
+export function getData() {
+    return [
+        {
+            volume: 0.5,
+            volumeLower: 0.45,
+            volumeUpper: 0.55,
+            pressure: 9.5,
+            pressureLower: 8.7,
+            pressureUpper: 10.3,
+        },
+        {
+            volume: 1.0,
+            volumeLower: 0.9,
+            volumeUpper: 1.1,
+            pressure: 8.1,
+            pressureLower: 7.4,
+            pressureUpper: 8.9,
+        },
+        {
+            volume: 1.5,
+            volumeLower: 1.35,
+            volumeUpper: 1.65,
+            pressure: 6.8,
+            pressureLower: 6.2,
+            pressureUpper: 7.5,
+        },
+        {
+            volume: 2.0,
+            volumeLower: 1.8,
+            volumeUpper: 2.2,
+            pressure: 5.5,
+            pressureLower: 5.0,
+            pressureUpper: 5.9,
+        },
+        {
+            volume: 2.5,
+            volumeLower: 2.25,
+            volumeUpper: 2.75,
+            pressure: 4.2,
+            pressureLower: 3.8,
+            pressureUpper: 4.7,
+        },
+        {
+            volume: 3.0,
+            volumeLower: 2.7,
+            volumeUpper: 3.3,
+            pressure: 3.1,
+            pressureLower: 2.8,
+            pressureUpper: 3.5,
+        },
+        {
+            volume: 3.5,
+            volumeLower: 3.15,
+            volumeUpper: 3.85,
+            pressure: 2.0,
+            pressureLower: 1.8,
+            pressureUpper: 2.3,
+        },
+        {
+            volume: 4.0,
+            volumeLower: 3.6,
+            volumeUpper: 4.4,
+            pressure: 1.2,
+            pressureLower: 1.1,
+            pressureUpper: 1.4,
+        }
+    ];
+}

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-length/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-length/index.html
@@ -1,0 +1,1 @@
+<div id="myChart" style="height: 100%;"></div>

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-length/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-length/main.ts
@@ -1,0 +1,26 @@
+import { AgChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+import { getData } from './data';
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    title: {
+        text: 'Volume-Pressure Relationship with Confidence Intervals',
+    },
+    series: [
+        {
+            type: 'scatter',
+            xKey: 'volume',
+            yKey: 'pressure',
+            errorBar:  {
+                xLowerKey: 'volumeLower',
+                xUpperKey: 'volumeUpper',
+                yLowerKey: 'pressureLower',
+                yUpperKey: 'pressureUpper',
+                cap: { length: 25 },
+            },
+        },
+    ],
+};
+
+AgEnterpriseCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-lengthRatio/data.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-lengthRatio/data.ts
@@ -1,0 +1,76 @@
+export function getData() {
+    return [
+        {
+            month: 'Jan',
+            temperature: 12.5,
+            temperatureLower: 10.0,
+            temperatureUpper: 15.0
+        },
+        {
+            month: 'Feb',
+            temperature: 13.0,
+            temperatureLower: 11.5,
+            temperatureUpper: 15.5
+        },
+        {
+            month: 'Mar',
+            temperature: 15.5,
+            temperatureLower: 13.0,
+            temperatureUpper: 18.0
+        },
+        {
+            month: 'Apr',
+            temperature: 18.0,
+            temperatureLower: 16.5,
+            temperatureUpper: 19.5
+        },
+        {
+            month: 'May',
+            temperature: 21.5,
+            temperatureLower: 19.0,
+            temperatureUpper: 24.0
+        },
+        {
+            month: 'Jun',
+            temperature: 24.0,
+            temperatureLower: 22.5,
+            temperatureUpper: 26.0
+        },
+        {
+            month: 'Jul',
+            temperature: 26.5,
+            temperatureLower: 24.0,
+            temperatureUpper: 29.0
+        },
+        {
+            month: 'Aug',
+            temperature: 25.0,
+            temperatureLower: 22.5,
+            temperatureUpper: 28.0
+        },
+        {
+            month: 'Sep',
+            temperature: 23.5,
+            temperatureLower: 21.0,
+            temperatureUpper: 27.0
+        },
+        {
+            month: 'Oct',
+            temperature: 20.0,
+            temperatureLower: 17.5,
+            temperatureUpper: 22.5
+        },
+        {
+            month: 'Nov',
+            temperature: 16.5,
+            temperatureLower: 14.0,
+            temperatureUpper: 19.0
+        },
+        {
+            month: 'Dec',
+            temperature: 13.0,
+            temperatureLower: 11.5,
+            temperatureUpper: 15.5
+        },
+    ] ;
+}

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-lengthRatio/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-lengthRatio/index.html
@@ -1,0 +1,1 @@
+<div id="myChart" style="height: 100%;"></div>

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-lengthRatio/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-lengthRatio/main.ts
@@ -1,0 +1,25 @@
+import { AgChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+import { getData } from './data';
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Monthly Average Temperatures with Error Bars (Celsius)',
+    },
+    series: [
+        {
+            type: 'bar',
+            data: getData(),
+            xKey: 'month',
+            yKey: 'temperature',
+            yName: 'Canada',
+            errorBar:  {
+                yLowerKey: 'temperatureLower',
+                yUpperKey: 'temperatureUpper',
+                cap: { lengthRatio: 1.0 },
+            },
+        },
+    ],
+};
+
+const chart = AgEnterpriseCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/double/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/double/index.html
@@ -1,1 +1,8 @@
-<div id="myChart" style="height: 100%;"></div>
+<!-- TODO: style buttons using CSS -->
+<div style="display: flex; flex-direction: column; height: 100%">
+    <div>
+        <button onclick="scatter()">Scatter</button>
+        <button onclick="line()">Line</button>
+    </div>
+    <div id="myChart" style="flex: 1"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/double/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/double/main.ts
@@ -7,6 +7,12 @@ const options: AgChartOptions = {
     title: {
         text: 'Volume-Pressure Relationship with Confidence Intervals',
     },
+    axes: [
+        // Note: axis configuration is required only for line series.
+        // The bottom axis defaults to 'number' for scatter series.
+        { type: 'number', position: 'left' },
+        { type: 'number', position: 'bottom' },
+    ],
     series: [
         {
             type: 'scatter',
@@ -22,4 +28,18 @@ const options: AgChartOptions = {
     ],
 };
 
-AgEnterpriseCharts.create(options);
+const chart = AgEnterpriseCharts.create(options);
+
+function scatter() {
+    if (options.series !== undefined) {
+        options.series[0].type = 'scatter';
+    }
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function line() {
+    if (options.series !== undefined) {
+        options.series[0].type = 'line';
+    }
+    AgEnterpriseCharts.update(chart, options);
+}

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/single/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/single/main.ts
@@ -33,15 +33,19 @@ const options: AgChartOptions = {
 const chart = AgEnterpriseCharts.create(options);
 
 function line() {
-    for (const opt of options.series ?? []) {
-        opt.type = 'line';
+    if (options.series !== undefined) {
+        for (const opt of options.series) {
+            opt.type = 'line';
+        }
     }
     AgEnterpriseCharts.update(chart, options);
 }
 
 function bar() {
-    for (const opt of options.series ?? []) {
-        opt.type = 'bar';
+    if (options.series !== undefined) {
+        for (const opt of options.series) {
+            opt.type = 'bar';
+        }
     }
     AgEnterpriseCharts.update(chart, options);
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/data.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/data.ts
@@ -1,0 +1,76 @@
+export function getData() {
+    return [
+        {
+            month: 'Jan',
+            temperature: 12.5,
+            temperatureLower: 10.0,
+            temperatureUpper: 15.0
+        },
+        {
+            month: 'Feb',
+            temperature: 13.0,
+            temperatureLower: 11.5,
+            temperatureUpper: 15.5
+        },
+        {
+            month: 'Mar',
+            temperature: 15.5,
+            temperatureLower: 13.0,
+            temperatureUpper: 18.0
+        },
+        {
+            month: 'Apr',
+            temperature: 18.0,
+            temperatureLower: 16.5,
+            temperatureUpper: 19.5
+        },
+        {
+            month: 'May',
+            temperature: 21.5,
+            temperatureLower: 19.0,
+            temperatureUpper: 24.0
+        },
+        {
+            month: 'Jun',
+            temperature: 24.0,
+            temperatureLower: 22.5,
+            temperatureUpper: 26.0
+        },
+        {
+            month: 'Jul',
+            temperature: 26.5,
+            temperatureLower: 24.0,
+            temperatureUpper: 29.0
+        },
+        {
+            month: 'Aug',
+            temperature: 25.0,
+            temperatureLower: 22.5,
+            temperatureUpper: 28.0
+        },
+        {
+            month: 'Sep',
+            temperature: 23.5,
+            temperatureLower: 21.0,
+            temperatureUpper: 27.0
+        },
+        {
+            month: 'Oct',
+            temperature: 20.0,
+            temperatureLower: 17.5,
+            temperatureUpper: 22.5
+        },
+        {
+            month: 'Nov',
+            temperature: 16.5,
+            temperatureLower: 14.0,
+            temperatureUpper: 19.0
+        },
+        {
+            month: 'Dec',
+            temperature: 13.0,
+            temperatureLower: 11.5,
+            temperatureUpper: 15.5
+        },
+    ] ;
+}

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/index.html
@@ -1,0 +1,8 @@
+<!-- TODO: style buttons using CSS -->
+<div style="display: flex; flex-direction: column; height: 100%">
+    <div>
+        <button onclick="line()">Line</button>
+        <button onclick="bar()">Bar</button>
+    </div>
+    <div id="myChart" style="flex: 1"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/main.ts
@@ -1,0 +1,40 @@
+import { AgChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+import { getData } from './data';
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Monthly Average Temperatures with Error Bars (Celsius)',
+    },
+    series: [
+        {
+            data: getData(),
+            xKey: 'month',
+            yKey: 'temperature',
+            errorBar:  {
+                yLowerKey: 'temperatureLower',
+                yUpperKey: 'temperatureUpper',
+                stroke: 'orange',
+                cap: {
+                     strokeWidth: 4,
+                },
+            },
+        },
+    ],
+};
+
+const chart = AgEnterpriseCharts.create(options);
+
+function line() {
+    for (const opt of options.series ?? []) {
+        opt.type = 'line';
+    }
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function bar() {
+    for (const opt of options.series ?? []) {
+        opt.type = 'bar';
+    }
+    AgEnterpriseCharts.update(chart, options);
+}

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/main.ts
@@ -26,15 +26,19 @@ const options: AgChartOptions = {
 const chart = AgEnterpriseCharts.create(options);
 
 function line() {
-    for (const opt of options.series ?? []) {
-        opt.type = 'line';
+    if (options.series !== undefined) {
+        for (const opt of options.series) {
+            opt.type = 'line';
+        }
     }
     AgEnterpriseCharts.update(chart, options);
 }
 
 function bar() {
-    for (const opt of options.series ?? []) {
-        opt.type = 'bar';
+    if (options.series !== undefined) {
+        for (const opt of options.series) {
+            opt.type = 'bar';
+        }
     }
     AgEnterpriseCharts.update(chart, options);
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/index.html
@@ -1,10 +1,1 @@
-<!-- TODO: style buttons using CSS -->
-<div style="display: flex; flex-direction: column; height: 100%">
-    <div>
-      Tooltip:
-        <button onclick="defaults()">Default</button>
-        <button onclick="verbose()">Verbose</button>
-        <button onclick="brief()">Brief</button>
-    </div>
-    <div id="myChart" style="flex: 1"></div>
-</div>
+<div id="myChart" style="height: 100%;"></div>

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/main.ts
@@ -4,7 +4,6 @@ import { getData } from './data';
 function verbose_renderer(params: AgScatterSeriesTooltipRendererParams) {
     const datum = params.datum;
     return {
-        title: `${datum[params.xKey]}m³ / ${datum[params.yKey]}kPa`,
         content:
             '<ul>' +
             `<li>${params.xUpperName}: ${params.xUpperKey ? datum[params.xUpperKey] : undefined}m³</li>` +

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/tooltips-error-bars/main.ts
@@ -1,7 +1,7 @@
 import { AgChartOptions, AgEnterpriseCharts, AgScatterSeriesTooltipRendererParams } from 'ag-charts-enterprise';
 import { getData } from './data';
 
-function verbose_renderer(params: AgScatterSeriesTooltipRendererParams) {
+function myRenderer(params: AgScatterSeriesTooltipRendererParams) {
     const datum = params.datum;
     return {
         content:
@@ -14,24 +14,11 @@ function verbose_renderer(params: AgScatterSeriesTooltipRendererParams) {
     };
 }
 
-function brief_renderer(params: AgScatterSeriesTooltipRendererParams) {
-    const datum = params.datum;
-    return {
-        content:
-          `<strong>${params.xKey}:</strong> ${datum[params.xKey]} `+
-            `[${params.xLowerKey ? datum[params.xLowerKey] : undefined},`+
-            ` ${params.xUpperKey ? datum[params.xUpperKey] : undefined}] m³<br/>`+
-            `<strong>${params.yKey}:</strong> ${datum[params.yKey]} `+
-              `[${params.yLowerKey ? datum[params.yLowerKey] : undefined},`+
-              ` ${params.yUpperKey ? datum[params.yUpperKey] : undefined}] kPa`
-    }
-}
-
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: {
-        text: 'Volume-Pressure Relationship with Confidence Intervals',
+        text: 'Hover over markers to view tooltip example',
     },
     series: [
         {
@@ -45,32 +32,12 @@ const options: AgChartOptions = {
                 yUpperKey: 'pressureUpper',
                 xLowerName: 'Volume (lower bound)',
                 xUpperName: 'Volume (upper bound)',
+                /* yLowerName implicitly defaults to 'pressureLower' */
+                /* yUpperName implicitly defaults to 'pressureUpper' */
             },
-            tooltip: { renderer: verbose_renderer },
+            tooltip: { renderer: myRenderer },
         },
     ],
 };
 
-const chart = AgEnterpriseCharts.create(options);
-
-function defaults() {
-  if (options.series) {
-    options.series[0].tooltip = undefined;
-    AgEnterpriseCharts.update(chart, options);
-  }
-}
-
-
-function verbose() {
-  if (options.series) {
-    options.series[0].tooltip = { renderer: verbose_renderer };
-    AgEnterpriseCharts.update(chart, options);
-  }
-}
-
-function brief() {
-  if (options.series) {
-    options.series[0].tooltip = { renderer: brief_renderer };
-    AgEnterpriseCharts.update(chart, options);
-  }
-}
+AgEnterpriseCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -121,3 +121,25 @@ errorBar: {
     /* yUpperName implicitly set to 'pressureUpper' */
 },
 ```
+
+## Customisation
+
+### Styling
+
+{% chartExampleRunner title="Styling Example" name="styling" type="generated" options="{ \"enterprise\": true }" /%}
+
+The Error Bar's can be customised by setting styling options in the `errorBar`
+properties. Styling options in `errorBar` property will apply to both the
+Whiskers and Cap.
+
+Styling options for the Caps can be overriden using the `errorBar.cap` property.
+
+```js
+errorBar: {
+    stroke: 'orange',
+    cap: {
+        /* stroke implicitly set to 'orange' */
+        strokeWidth: 4,
+    },
+},
+```

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -190,3 +190,7 @@ errorBar: {
 In this configuration:
 
 -   `length` sets the length of all Caps to 25 pixels.
+
+## API Reference
+
+{% interfaceDocumentation interfaceName="AgErrorBarOptions" config="{ \"showSnippets\": false }" /%}

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -10,10 +10,12 @@ on Line, Bar and Scatter Series.
 
 {% chartExampleRunner title="Line Series Error Bars" name="single" type="generated" options="{ \"enterprise\": true }" /%}
 
-Error Bars can be enabled on Line and Bar Series using the `errorBars` key.
+Error Bars can be enabled on supported series types using the `errorBars` key.
 
-The required `yLowerKey` and `yUpperKey` defines the keys used to retrieve the
-error values from the data.
+Line and Bar only support Error Bars on the Y axis.
+
+The required `yLowerKey` and `yUpperKey` properties defines the keys used to
+retrieve the error values from the data.
 
 ```js
 data: [
@@ -40,10 +42,10 @@ series: [
 
 {% chartExampleRunner title="Scatter Series Error Bars" name="double" type="generated" options="{ \"enterprise\": true }" /%}
 
-Error Bars can be enabled on Scatter Series using the `errorBars` key.
+Scatter plots support error bars on the X axis, the Y axis, or both axes.
 
-The required properties `xLowerKey`, `xUpperKey`, `yLowerKey` and `yUpperKey`
-define the keys used to retrieve the X and Y error values from the data.
+The properties `xLowerKey`, `xUpperKey`, `yLowerKey` and `yUpperKey` define the
+keys used to retrieve the X and Y error values from the data.
 
 ```js
 data: [
@@ -75,27 +77,25 @@ series: [
 
 {% chartExampleRunner title="Error Bars Tooltips" name="tooltips-error-bars" type="generated" options="{ \"enterprise\": true }" /%}
 
-[Tooltips](./tooltips) are not shown by default, but error bar parameters are
-provided the `renderer` for customization.
+[Tooltips](./tooltips) are not shown by default, but Error Bar parameters are
+provided to the `renderer` for customisation.
 
 ```js
 function verbose_renderer(params) {
     const datum = params.datum;
     return {
-        title: `${datum[params.xKey]}m³ / ${datum[params.yKey]}kPa`,
         content:
             '<ul>' +
-            `<li>${params.xUpperName}: ${params.xUpperKey ? datum[params.xUpperKey] : undefined}m³</li>` +
-            `<li>${params.xLowerName}: ${params.xLowerKey ? datum[params.xLowerKey] : undefined}m³</li>` +
-            `<li>${params.yUpperName}: ${params.yUpperKey ? datum[params.yUpperKey] : undefined}kPa</li>` +
-            `<li>${params.yLowerName}: ${params.yLowerKey ? datum[params.yLowerKey] : undefined}kPa</li>` +
+            `<li>${params.xUpperName}: ${datum[params.xUpperKey]}m³</li>` +
+            `<li>${params.xLowerName}: ${datum[params.xLowerKey]}m³</li>` +
+            `<li>${params.yUpperName}: ${datum[params.yUpperKey]}kPa</li>` +
+            `<li>${params.yLowerName}: ${datum[params.yLowerKey]}kPa</li>` +
             '</ul>',
     };
 }
 ```
 
-The `renderer` has access to the keys, names, and values for the error data for
-both axes:
+The `renderer` has access to all the key and names for the error data:
 
 -   `xLowerKey`
 -   `xLowerName`
@@ -106,4 +106,18 @@ both axes:
 -   `yUpperKey`
 -   `yUpperName`
 
-The optional names will default to keys if unset.
+The names can be specified as part of the `errorBar` property, but they are
+optional and will default to keys if unset.
+
+```js
+errorBar: {
+    xLowerKey: 'volumeLower',
+    xUpperKey: 'volumeUpper',
+    yLowerKey: 'pressureLower',
+    yUpperKey: 'pressureUpper',
+    xLowerName: 'Volume (lower bound)',
+    xUpperName: 'Volume (upper bound)',
+    /* yLowerName implicitly set to 'pressureLower' */
+    /* yUpperName implicitly set to 'pressureUpper' */
+},
+```

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -101,34 +101,34 @@ function verbose_renderer(params) {
             '</ul>',
     };
 }
+
+const options = {
+    series: [
+        {
+            errorBar:  {
+                xLowerKey: 'volumeLower',
+                xUpperKey: 'volumeUpper',
+                yLowerKey: 'pressureLower',
+                yUpperKey: 'pressureUpper',
+                xLowerName: 'Volume (lower bound)',
+                xUpperName: 'Volume (upper bound)',
+                /* yLowerName implicitly defaults to 'pressureLower' */
+                /* yUpperName implicitly defaults to 'pressureUpper' */
+            },
+            tooltip: { renderer: verbose_renderer },
+        },
+        ...
+    ],
+    ...
+};
 ```
 
 The `renderer` has access to all the key and names for the error data:
 
--   `xLowerKey`
--   `xLowerName`
--   `xUpperKey`
--   `xUpperName`
--   `yLowerKey`
--   `yLowerName`
--   `yUpperKey`
--   `yUpperName`
+{% interfaceDocumentation interfaceName="AgErrorBarDataOptions" config="{\"description\":\"\", \"showSnippets\": false }" /%}
 
-The names can be specified as part of the `errorBar` property, but they are
-optional and will default to keys if unset.
+{% note %}All names are optional and will default to keys if unset.{% /note %}
 
-```js
-errorBar: {
-    xLowerKey: 'volumeLower',
-    xUpperKey: 'volumeUpper',
-    yLowerKey: 'pressureLower',
-    yUpperKey: 'pressureUpper',
-    xLowerName: 'Volume (lower bound)',
-    xUpperName: 'Volume (upper bound)',
-    /* yLowerName implicitly set to 'pressureLower' */
-    /* yUpperName implicitly set to 'pressureUpper' */
-},
-```
 
 ## Customisation
 

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -143,3 +143,50 @@ errorBar: {
     },
 },
 ```
+
+### Cap Length
+
+The default length of Cap is determined relative the shape representing the data
+point. This varies depending the type of series used:
+
+-   **Line and Scatter Series:** Cap length defaults to the Marker size.
+-   **Vertical Bar Series:** Cap length defaults to half of Bar width.
+-   **Horizontal Bar Series:** Cap length defaults to half of Bar height.
+
+The Cap length can be customised as a ratio relative to series' shape or using
+an absolute value.
+
+#### Length Ratio
+
+{% chartExampleRunner title="Length Ratio Example" name="cap-lengthRatio" type="generated" options="{ \"enterprise\": true }" /%}
+
+The `cap.lengthRatio` property must be number between 0 and 1. If set, the Cap
+length will be calculated by multiplying this ratio with the length of the shape
+used by the series (Marker size, or Bar width/height).
+
+```
+errorBar: {
+    cap: { lengthRatio: 1.0 },
+},
+```
+
+In this configuration:
+
+-   `lengthRatio` sets the Cap length 100% of the Bar widths.
+
+#### Absolute Length
+
+{% chartExampleRunner title="Absolute Length Example" name="cap-length" type="generated" options="{ \"enterprise\": true }" /%}
+
+The `cap.length` property sets the absolute length of the Cap in pixels. If
+defined, this propertiy takes priority over the `cap.lengthRatio` property.
+
+```
+errorBar: {
+    cap: { length: 25 },
+},
+```
+
+In this configuration:
+
+-   `length` sets the length of all Caps to 25 pixels.

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -80,7 +80,6 @@ Data](./line-series#continuous-data) for more information on how to configure
 this series.
 {% /note %}
 
-
 ## Tooltip Parameters
 
 {% chartExampleRunner title="Error Bars Tooltips" name="tooltips-error-bars" type="generated" options="{ \"enterprise\": true }" /%}
@@ -89,7 +88,7 @@ this series.
 provided to the `renderer` for customisation.
 
 ```js
-function verbose_renderer(params) {
+function myRenderer(params) {
     const datum = params.datum;
     return {
         content:
@@ -115,7 +114,7 @@ const options = {
                 /* yLowerName implicitly defaults to 'pressureLower' */
                 /* yUpperName implicitly defaults to 'pressureUpper' */
             },
-            tooltip: { renderer: verbose_renderer },
+            tooltip: { renderer: myRenderer },
         },
         ...
     ],
@@ -128,7 +127,6 @@ The `renderer` has access to all the key and names for the error data:
 {% interfaceDocumentation interfaceName="AgErrorBarDataOptions" config="{\"description\":\"\", \"showSnippets\": false }" /%}
 
 {% note %}All names are optional and will default to keys if unset.{% /note %}
-
 
 ## Customisation
 

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -12,7 +12,7 @@ on Line, Bar and Scatter Series.
 
 Error Bars can be enabled on supported series types using the `errorBars` key.
 
-Line and Bar only support Error Bars on the Y axis.
+Categoric Line Series and Bar Series only support Error Bars on the Y axis.
 
 The required `yLowerKey` and `yUpperKey` properties defines the keys used to
 retrieve the error values from the data.
@@ -24,7 +24,7 @@ data: [
         temperature: 35,
         temperatureLower: 32,
         temperatureUpper: 37,
-    },
+    }, ...
 ],
 series: [
     {
@@ -38,11 +38,12 @@ series: [
 ],
 ```
 
-## Scatter Series Error Bars
+## Double Error Bars
 
-{% chartExampleRunner title="Scatter Series Error Bars" name="double" type="generated" options="{ \"enterprise\": true }" /%}
+{% chartExampleRunner title="Double Error Bars" name="double" type="generated" options="{ \"enterprise\": true }" /%}
 
-Scatter plots support error bars on the X axis, the Y axis, or both axes.
+Scatter Plots and Continuous Line Series support error bars on the X axis, the Y
+axis, or both axes.
 
 The properties `xLowerKey`, `xUpperKey`, `yLowerKey` and `yUpperKey` define the
 keys used to retrieve the X and Y error values from the data.
@@ -56,7 +57,7 @@ data: [
         pressure: 1.2,
         pressureLower: 1.1,
         pressureUpper: 1.4
-    },
+    }, ...
 ],
 series: [
     {
@@ -72,6 +73,13 @@ series: [
     },
 ],
 ```
+
+{% note %}
+The X axis of Line Series is categoric by default. See the [Continuous
+Data](./line-series#continuous-data) for more information on how to configure
+this series.
+{% /note %}
+
 
 ## Tooltip Parameters
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9022

Add sections to error-bars/index.mdoc:
- Customisation.Styling
- Customisation.CapLength
- Customisation.CapLength.LengthRatio
- Customisation.CapLength.AbsoluteLength

Add examples:
-   packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-length
-   packages/ag-charts-website/src/content/docs/error-bars/_examples/cap-lengthRatio
-   packages/ag-charts-website/src/content/docs/error-bars/_examples/styling/

Also make minor tweaks to the existing documentation.