### PR TITLE
AG-9206 - Show all `series` and `axes` in options reference

### DIFF
--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -12,8 +12,7 @@ const optionsData = (await getEntry('options-reference', 'data')).data;
 
 const framework = Astro.params.framework as Framework;
 
-// TODO: Use `AgChartOptions`
-const interfaceName = 'AgCartesianChartOptions';
+const interfaceName = 'AgChartOptions';
 const breadcrumbs = ['options'];
 ---
 


### PR DESCRIPTION
## Changes

* Update options reference model generation to merge `series` and `axes` for all chart option types
  * Resolve interface types on the `buildModel` layer, so that it does not affect the library code typescript types and UI layer

## Screenshots

<img width="1251" alt="Screenshot 2023-10-13 at 5 10 00 pm" src="https://github.com/ag-grid/ag-charts/assets/79451/3141c09a-5c25-4ad7-9e27-8cfb768925db">
