### PR TITLE
AG-8556 Update zoom to flip xy in accordance with the series

### DIFF
--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -8,6 +8,7 @@ import type { SpecialOverrides, TransferableResources } from './chart';
 import { Chart } from './chart';
 import type { ChartAxis } from './chartAxis';
 import { ChartAxisDirection } from './chartAxisDirection';
+import { CartesianSeries } from './series/cartesian/cartesianSeries';
 
 type VisibilityMap = { crossLines: boolean; series: boolean };
 const directions: AgCartesianAxisPosition[] = ['top', 'right', 'bottom', 'left'];
@@ -50,7 +51,12 @@ export class CartesianChart extends Chart {
             type: 'layout-complete',
             chart: { width: this.scene.width, height: this.scene.height },
             clipSeries,
-            series: { rect: seriesRect, paddedRect: seriesPaddedRect, visible: visibility.series },
+            series: {
+                rect: seriesRect,
+                paddedRect: seriesPaddedRect,
+                visible: visibility.series,
+                shouldFlipXY: this.shouldFlipXY(),
+            },
             axes: this.axes.map((axis) => ({ id: axis.id, ...axis.getLayoutState() })),
         });
 
@@ -454,5 +460,10 @@ export class CartesianChart extends Chart {
         }
 
         axis.updatePosition({ rotation: toRadians(axis.rotation), sideFlag: axis.label.getSideFlag() });
+    }
+
+    private shouldFlipXY() {
+        // Only flip the xy axes if all the series agree on flipping
+        return !this.series.map((series) => series instanceof CartesianSeries && series.shouldFlipXY()).includes(false);
     }
 }

--- a/packages/ag-charts-community/src/chart/layout/layoutService.ts
+++ b/packages/ag-charts-community/src/chart/layout/layoutService.ts
@@ -20,7 +20,7 @@ export interface AxisLayout {
 export interface LayoutCompleteEvent {
     type: 'layout-complete';
     chart: { width: number; height: number };
-    series: { rect: BBox; paddedRect: BBox; visible: boolean };
+    series: { rect: BBox; paddedRect: BBox; visible: boolean; shouldFlipXY?: boolean };
     clipSeries: boolean;
     axes?: Array<AxisLayout & { id: string }>;
 }

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -125,9 +125,14 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private onDoubleClick(event: _ModuleSupport.InteractionEvent<'dblclick'>) {
-        if (!this.enabled || this.highlightManager.getActivePicked() !== undefined) return;
+        if (!this.enabled) return;
 
-        if (!this.seriesRect?.containsPoint(event.offsetX, event.offsetY) && !this.hoveredAxis) {
+        // Check if the pointer is over a valid area, either the series area or an axis, but not also over a node.
+        if (
+            !this.seriesRect?.containsPoint(event.offsetX, event.offsetY) &&
+            !this.hoveredAxis &&
+            this.highlightManager.getActivePicked() === undefined
+        ) {
             return;
         }
 

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -457,7 +457,7 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
         // highlightedItems?: BoxPlotNodeDatum[];
         isHighlight: boolean;
     }) {
-        const invertAxes = this.isVertical();
+        const invertAxes = this.shouldFlipXY();
         datumSelection.each((boxPlotGroup, nodeDatum) => {
             let activeStyles = this.getFormattedStyles(nodeDatum, highlighted);
 
@@ -555,16 +555,16 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
         return { inner: 0.2, outer: 0.1 };
     }
 
-    protected isVertical() {
+    override shouldFlipXY() {
         return this.direction === 'vertical';
     }
 
     protected getValuesDirection() {
-        return this.isVertical() ? ChartAxisDirection.Y : ChartAxisDirection.X;
+        return this.shouldFlipXY() ? ChartAxisDirection.Y : ChartAxisDirection.X;
     }
 
     protected getCategoryDirection() {
-        return this.isVertical() ? ChartAxisDirection.X : ChartAxisDirection.Y;
+        return this.shouldFlipXY() ? ChartAxisDirection.X : ChartAxisDirection.Y;
     }
 
     protected getCategoryAxis(): _ModuleSupport.ChartAxis | undefined {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -738,5 +738,9 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
         return { inner: 0.2, outer: 0.1 };
     }
 
+    override shouldFlipXY() {
+        return this.direction === 'horizontal';
+    }
+
     protected override onDataChange() {}
 }

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -944,5 +944,9 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
         return { inner: 0.2, outer: 0.1 };
     }
 
+    override shouldFlipXY() {
+        return this.direction === 'horizontal';
+    }
+
     protected override onDataChange() {}
 }

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-min-ratio/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-min-ratio/main.ts
@@ -17,7 +17,8 @@ const options: AgCartesianChartOptions = {
     axes: "xy",
     minXRatio: 0.4,
     minYRatio: 0.4,
-    scrollingPivot: "pointer",
+    anchorPointX: "pointer",
+    anchorPointY: "pointer"
   },
   tooltip: {
     enabled: false,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8556

A better approach than https://github.com/ag-grid/ag-charts/pull/364.

This adds a `shouldFlipXY?: boolean` prop to the `layout-complete` event, which is then populated by `CartesianChart` and set to `true` if all the series in the chart agree.