### PR TITLE
AG-9272 Error Bar mouse hover implementation

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -52,11 +52,11 @@ import { Legend } from './legend';
 import type { CategoryLegendDatum, ChartLegend, ChartLegendType, GradientLegendDatum } from './legendDatum';
 import type { SeriesOptionsTypes } from './mapping/types';
 import { ChartOverlays } from './overlay/chartOverlays';
-import type { Series, SeriesNodeDatum } from './series/series';
+import type { Series } from './series/series';
 import { SeriesNodePickMode } from './series/series';
 import { SeriesLayerManager } from './series/seriesLayerManager';
 import { SeriesStateManager } from './series/seriesStateManager';
-import type { ISeries } from './series/seriesTypes';
+import type { ISeries, SeriesNodeDatum } from './series/seriesTypes';
 import { Tooltip } from './tooltip/tooltip';
 import { UpdateService } from './updateService';
 

--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -29,6 +29,10 @@ export class TooltipManager {
         this.destroyFns.push(interactionManager.addListener('hover', (e) => this.checkExclusiveRects(e)));
     }
 
+    public getRange() {
+        return this.tooltip.range;
+    }
+
     public updateTooltip(callerId: string, meta?: TooltipMeta, content?: string) {
         if (content == null) {
             content = this.states[callerId]?.content;

--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -1,8 +1,7 @@
 import type { BBox } from '../../scene/bbox';
 import type { HdpiCanvas } from '../../scene/canvas/hdpiCanvas';
 import type { Point } from '../../scene/point';
-import type { ErrorBoundSeriesNodeDatum } from '../series/cartesian/cartesianSeries';
-import type { SeriesNodeDatum } from '../series/series';
+import type { ErrorBoundSeriesNodeDatum, SeriesNodeDatum } from '../series/seriesTypes';
 import type { Tooltip, TooltipMeta } from '../tooltip/tooltip';
 import type { InteractionEvent, InteractionManager } from './interactionManager';
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -27,10 +27,10 @@ import { Label } from '../../label';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import type { Marker } from '../../marker/marker';
 import { getMarker } from '../../marker/util';
-import type { SeriesNodeDatum } from '../series';
 import { groupAccumulativeValueProperty, keyProperty, valueProperty } from '../series';
 import { SeriesMarker } from '../seriesMarker';
 import { SeriesTooltip } from '../seriesTooltip';
+import type { SeriesNodeDatum } from '../seriesTypes';
 import {
     type AreaPathDatum,
     type AreaPathPoint,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -43,6 +43,7 @@ import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import { SeriesNodePickMode, groupAccumulativeValueProperty, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { SeriesTooltip } from '../seriesTooltip';
+import type { ErrorBoundSeriesNodeDatum } from '../seriesTypes';
 import type { RectConfig } from './barUtil';
 import {
     checkCrisp,
@@ -56,7 +57,6 @@ import type {
     CartesianAnimationData,
     CartesianSeriesNodeDataContext,
     CartesianSeriesNodeDatum,
-    ErrorBoundSeriesNodeDatum,
 } from './cartesianSeries';
 import { CartesianSeries } from './cartesianSeries';
 import { adjustLabelPlacement, updateLabelNode } from './labelUtil';

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -42,6 +42,8 @@ export interface ErrorBoundSeriesNodeDatum {
     // by the size of the marker (line, scatter), width of the bar (vertical
     // bars), or height of the bar (horizontal bars).
     readonly capDefaults: { lengthRatioMultiplier: number; lengthMax: number };
+    xBar?: { lowerPoint: Point; upperPoint: Point };
+    yBar?: { lowerPoint: Point; upperPoint: Point };
 }
 
 interface SubGroup<TNode extends Node, TDatum extends SeriesNodeDatum, TLabel = TDatum> {

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -20,30 +20,16 @@ import { Layers } from '../../layers';
 import type { Marker } from '../../marker/marker';
 import { getMarker } from '../../marker/util';
 import { DataModelSeries } from '../dataModelSeries';
-import type {
-    Series,
-    SeriesNodeDataContext,
-    SeriesNodeDatum,
-    SeriesNodeEventTypes,
-    SeriesNodePickMatch,
-} from '../series';
+import type { Series, SeriesNodeDataContext, SeriesNodeEventTypes, SeriesNodePickMatch } from '../series';
 import { SeriesNodeClickEvent } from '../series';
 import type { SeriesGroupZIndexSubOrderType } from '../seriesLayerManager';
+import type { SeriesNodeDatum } from '../seriesTypes';
 
 export interface CartesianSeriesNodeDatum extends SeriesNodeDatum {
     readonly xKey: string;
     readonly yKey?: string;
     readonly xValue?: any;
     readonly yValue?: any;
-}
-
-export interface ErrorBoundSeriesNodeDatum {
-    // Caps can appear on bar, line and scatter series. The length is determined
-    // by the size of the marker (line, scatter), width of the bar (vertical
-    // bars), or height of the bar (horizontal bars).
-    readonly capDefaults: { lengthRatioMultiplier: number; lengthMax: number };
-    xBar?: { lowerPoint: Point; upperPoint: Point };
-    yBar?: { lowerPoint: Point; upperPoint: Point };
 }
 
 interface SubGroup<TNode extends Node, TDatum extends SeriesNodeDatum, TLabel = TDatum> {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -33,11 +33,11 @@ import { SeriesNodePickMode, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { SeriesMarker } from '../seriesMarker';
 import { SeriesTooltip } from '../seriesTooltip';
+import type { ErrorBoundSeriesNodeDatum } from '../seriesTypes';
 import type {
     CartesianAnimationData,
     CartesianSeriesNodeDataContext,
     CartesianSeriesNodeDatum,
-    ErrorBoundSeriesNodeDatum,
 } from './cartesianSeries';
 import { CartesianSeries } from './cartesianSeries';
 import { prepareLinePathAnimation } from './lineUtil';

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -26,7 +26,8 @@ import { SeriesNodePickMode, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { SeriesMarker } from '../seriesMarker';
 import { SeriesTooltip } from '../seriesTooltip';
-import type { CartesianAnimationData, CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDatum } from './cartesianSeries';
+import type { ErrorBoundSeriesNodeDatum } from '../seriesTypes';
+import type { CartesianAnimationData, CartesianSeriesNodeDatum } from './cartesianSeries';
 import { CartesianSeries } from './cartesianSeries';
 import { markerScaleInAnimation, resetMarkerFn } from './markerUtil';
 

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -2,8 +2,9 @@ import { ContinuousScale } from '../../scale/continuousScale';
 import { ChartAxisDirection } from '../chartAxisDirection';
 import type { DataController } from '../data/dataController';
 import type { DataModel, DataModelOptions, ProcessedData } from '../data/dataModel';
-import type { SeriesNodeDataContext, SeriesNodeDatum } from './series';
+import type { SeriesNodeDataContext } from './series';
 import { Series } from './series';
+import type { SeriesNodeDatum } from './seriesTypes';
 
 export abstract class DataModelSeries<
     TDatum extends SeriesNodeDatum,

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -1,7 +1,7 @@
 import type { ModuleContext } from '../../../module/moduleContext';
 import type { PointLabelDatum } from '../../../util/labelPlacement';
-import type { SeriesNodeDatum } from '../series';
 import { Series, SeriesNodePickMode } from '../series';
+import type { SeriesNodeDatum } from '../seriesTypes';
 
 export abstract class HierarchySeries<S extends SeriesNodeDatum> extends Series<S> {
     constructor(moduleCtx: ModuleContext) {

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -44,7 +44,7 @@ import { Label } from '../../label';
 import { Layers } from '../../layers';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import { Circle } from '../../marker/circle';
-import type { SeriesNodeDatum, SeriesNodeEventTypes } from '../series';
+import type { SeriesNodeEventTypes } from '../series';
 import {
     HighlightStyle,
     SeriesNodeClickEvent,
@@ -55,6 +55,7 @@ import {
 } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation, seriesLabelFadeOutAnimation } from '../seriesLabelUtil';
 import { SeriesTooltip } from '../seriesTooltip';
+import type { SeriesNodeDatum } from '../seriesTypes';
 import { preparePieSeriesAnimationFunctions, resetPieSelectionsFn } from './pieUtil';
 import { type PolarAnimationData, PolarSeries } from './polarSeries';
 

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -10,8 +10,8 @@ import { Text } from '../../../scene/shape/text';
 import type { PointLabelDatum } from '../../../util/labelPlacement';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import { DataModelSeries } from '../dataModelSeries';
-import type { SeriesNodeDatum } from '../series';
 import { SeriesNodePickMode } from '../series';
+import type { SeriesNodeDatum } from '../seriesTypes';
 
 export type PolarAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
 export type PolarAnimationEvent = 'update' | 'updateData' | 'highlight' | 'highlightMarkers' | 'resize' | 'clear';

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -46,8 +46,6 @@ import type { SeriesGrouping } from './seriesStateManager';
 import type { SeriesTooltip } from './seriesTooltip';
 import type { ISeries, SeriesNodeDatum } from './seriesTypes';
 
-export type { SeriesNodeDatum } from './seriesTypes';
-
 /** Modes of matching user interactions to rendered nodes (e.g. hover or click) */
 export enum SeriesNodePickMode {
     /** Pick matches based upon pick coordinates being inside a matching shape/marker. */

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -41,3 +41,12 @@ export interface SeriesNodeDatum {
     readonly point?: Readonly<SizedPoint>;
     midPoint?: Readonly<Point>;
 }
+
+export interface ErrorBoundSeriesNodeDatum {
+    // Caps can appear on bar, line and scatter series. The length is determined
+    // by the size of the marker (line, scatter), width of the bar (vertical
+    // bars), or height of the bar (horizontal bars).
+    readonly capDefaults: { lengthRatioMultiplier: number; lengthMax: number };
+    xBar?: { lowerPoint: Point; upperPoint: Point };
+    yBar?: { lowerPoint: Point; upperPoint: Point };
+}

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -35,6 +35,7 @@ export * from './chart/series/seriesEvents';
 export * from './chart/series/seriesLabelUtil';
 export * from './chart/series/seriesMarker';
 export * from './chart/series/seriesTooltip';
+export * from './chart/series/seriesTypes';
 export * from './chart/series/cartesian/cartesianSeries';
 export * from './chart/series/cartesian/barUtil';
 export * from './chart/series/cartesian/areaUtil';

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -286,13 +286,18 @@ export class ErrorBars
     }
 
     private onHoverEvent(event: _ModuleSupport.InteractionEvent<'hover'>) {
-        const { offsetX, offsetY } = event;
-        // TODO(olegat) Add TNode generic type to _Scene.Group to avoid `as ErrorBarNode`
-        const node = this.groupNode.pickNode(offsetX, offsetY) as ErrorBarNode | undefined;
+        const { scene, highlightManager, tooltipManager, window } = this.ctx;
+        const { id } = this.groupNode;
+
+        const node = this.groupNode.pickNode(event.offsetX, event.offsetY);
         if (node?.datum !== undefined) {
-            this.ctx.highlightManager.updateHighlight(this.groupNode.id, node.datum);
+            const meta = _ModuleSupport.TooltipManager.makeTooltipMeta(event, scene.canvas, node.datum, window);
+            const html = this.cartesianSeries.getTooltipHtml(node.datum);
+            highlightManager.updateHighlight(id, node.datum);
+            tooltipManager.updateTooltip(id, meta, html);
         } else {
-            this.ctx.highlightManager.updateHighlight(this.groupNode.id, undefined);
+            highlightManager.updateHighlight(id, undefined);
+            tooltipManager.removeTooltip(id);
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -282,7 +282,7 @@ export class ErrorBars
         const style = this.getDefaultStyle();
         node.datum = datum;
         node.updateStyle(style);
-        node.updateTranslation(this.cap);
+        node.updateTranslation(this.cap, this.ctx.tooltipManager.getRange());
     }
 
     private onHoverEvent(event: _ModuleSupport.InteractionEvent<'hover'>) {

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -1,7 +1,7 @@
 import type { AgErrorBarCapOptions, AgErrorBarOptions, AgErrorBarThemeableOptions, _Scale } from 'ag-charts-community';
 import { AgErrorBarSupportedSeriesTypes, _ModuleSupport, _Scene } from 'ag-charts-community';
 
-import type { ErrorBarPoints } from './errorBarNode';
+import type { ErrorBarNodeDatum } from './errorBarNode';
 import { ErrorBarNode } from './errorBarNode';
 
 const {
@@ -18,10 +18,7 @@ const {
 } = _ModuleSupport;
 
 type ErrorBoundCartesianSeries = Omit<
-    _ModuleSupport.CartesianSeries<
-        _Scene.Node,
-        _ModuleSupport.CartesianSeriesNodeDatum & _ModuleSupport.ErrorBoundSeriesNodeDatum
-    >,
+    _ModuleSupport.CartesianSeries<_Scene.Node, ErrorBarNodeDatum>,
     'highlightSelection'
 >;
 
@@ -127,7 +124,6 @@ export class ErrorBars
     private readonly cartesianSeries: ErrorBoundCartesianSeries;
     private readonly groupNode: _Scene.Group;
     private readonly selection: _Scene.Selection<ErrorBarNode>;
-    private nodeData: (ErrorBarPoints | undefined)[] = [];
 
     private dataModel?: AnyDataModel;
     private processedData?: AnyProcessedData;
@@ -214,14 +210,12 @@ export class ErrorBars
     }
 
     private createNodeData() {
-        const { nodeData } = this;
+        const nodeData = this.cartesianSeries.contextNodeData[0].nodeData;
         const xScale = this.cartesianSeries.axes[ChartAxisDirection.X]?.scale;
         const yScale = this.cartesianSeries.axes[ChartAxisDirection.Y]?.scale;
         if (!xScale || !yScale) {
             return;
         }
-
-        nodeData.length = this.cartesianSeries.contextNodeData[0].nodeData.length;
 
         for (let i = 0; i < nodeData.length; i++) {
             const { midPoint, xLower, xUpper, yLower, yUpper } = this.getDatum(i);
@@ -240,7 +234,8 @@ export class ErrorBars
                         upperPoint: { x: midPoint.x, y: this.convert(yScale, yUpper) },
                     };
                 }
-                nodeData[i] = { xBar, yBar };
+                nodeData[i].xBar = xBar;
+                nodeData[i].yBar = yBar;
             }
         }
     }
@@ -276,19 +271,15 @@ export class ErrorBars
     }
 
     private update() {
-        this.selection.update(this.nodeData, undefined, undefined);
-        this.selection.each((node, _datum, i) => this.updateNode(node, i));
+        this.selection.update(this.cartesianSeries.contextNodeData[0].nodeData, undefined, undefined);
+        this.selection.each((node, datum, i) => this.updateNode(node, datum, i));
     }
 
-    private updateNode(node: ErrorBarNode, index: number) {
-        const { nodeData } = this;
-        const points = nodeData[index];
-        if (points) {
-            const style = this.getDefaultStyle();
-            const capDefaults = this.cartesianSeries.contextNodeData[0].nodeData[index].capDefaults;
-            node.updateStyle(style);
-            node.updateTranslation(points, this.cap, capDefaults);
-        }
+    private updateNode(node: ErrorBarNode, datum: ErrorBarNodeDatum, _index: number) {
+        const style = this.getDefaultStyle();
+        node.datum = datum;
+        node.updateStyle(style);
+        node.updateTranslation(this.cap);
     }
 
     private onTooltipGetParams(_event: SeriesTooltipGetParamsEvent) {
@@ -315,13 +306,13 @@ export class ErrorBars
         this.groupNode.visible = event.enabled;
     }
 
-    private getDefaultStyle() {
+    private getDefaultStyle(): AgErrorBarThemeableOptions {
         const whiskerStyle = this.getWhiskerProperties();
         const capStyle = mergeDefaults(this.cap, whiskerStyle);
         return { ...whiskerStyle, cap: capStyle };
     }
 
-    private getHighlightStyle() {
+    private getHighlightStyle(): AgErrorBarThemeableOptions {
         const style = this.cartesianSeries.highlightStyle.item;
         const { length, lengthRatio } = this.cap;
         return { ...style, cap: { ...style, length, lengthRatio } };
@@ -333,8 +324,9 @@ export class ErrorBars
         // that the typical use case for error bars includes few data points
         // (because the chart will get cluttered very quickly if there are many
         // data points with error bars).
-        for (let i = 0; i < this.nodeData.length; i++) {
-            if (highlightChange === this.cartesianSeries.contextNodeData[0].nodeData[i]) {
+        const { nodeData } = this.cartesianSeries.contextNodeData[0];
+        for (let i = 0; i < nodeData.length; i++) {
+            if (highlightChange === nodeData[i]) {
                 this.selection.nodes()[i].updateStyle(style);
                 break;
             }

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -131,13 +131,16 @@ export class ErrorBarNode extends _Scene.Group {
     }
 
     override containsPoint(x: number, y: number): boolean {
-        if (this.bboxes.union.containsPoint(x, y)) {
-            for (const bbox of this.bboxes.components) {
-                if (bbox.containsPoint(x, y)) {
-                    return true;
-                }
+        if (!this.bboxes.union.containsPoint(x, y)) {
+            return false;
+        }
+
+        for (const bbox of this.bboxes.components) {
+            if (bbox.containsPoint(x, y)) {
+                return true;
             }
         }
+
         return false;
     }
 }

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -1,23 +1,21 @@
 import type { AgErrorBarCapLengthOptions, AgErrorBarThemeableOptions, _ModuleSupport } from 'ag-charts-community';
 import { _Scene } from 'ag-charts-community';
 
-export type ErrorBoundSeriesNodeDatum = _ModuleSupport.ErrorBoundSeriesNodeDatum;
+export type ErrorBarNodeDatum = _ModuleSupport.CartesianSeriesNodeDatum & _ModuleSupport.ErrorBoundSeriesNodeDatum;
 
-interface ErrorBarPoint {
-    readonly lowerPoint: _Scene.Point;
-    readonly upperPoint: _Scene.Point;
-}
-
-export interface ErrorBarPoints {
-    readonly xBar?: ErrorBarPoint;
-    readonly yBar?: ErrorBarPoint;
-}
-
-type CapDefaults = ErrorBoundSeriesNodeDatum['capDefaults'];
+type CapDefaults = NonNullable<ErrorBarNodeDatum['capDefaults']>;
 
 export class ErrorBarNode extends _Scene.Group {
     private whiskerPath: _Scene.Path;
     private capsPath: _Scene.Path;
+
+    protected override _datum?: ErrorBarNodeDatum;
+    public override get datum(): ErrorBarNodeDatum | undefined {
+        return this._datum;
+    }
+    public override set datum(datum: ErrorBarNodeDatum | undefined) {
+        this._datum = datum;
+    }
 
     constructor() {
         super();
@@ -47,10 +45,13 @@ export class ErrorBarNode extends _Scene.Group {
         capsPath.markDirty(capsPath, _Scene.RedrawType.MINOR);
     }
 
-    updateTranslation(points: ErrorBarPoints, cap: AgErrorBarCapLengthOptions, capDefaults: CapDefaults) {
+    updateTranslation(cap: AgErrorBarCapLengthOptions) {
         // Note: The method always uses the RedrawType.MAJOR mode for simplicity.
         // This could be optimised to reduce a amount of unnecessary redraws.
-        const { xBar, yBar } = points;
+        if (this.datum === undefined) {
+            return;
+        }
+        const { xBar, yBar, capDefaults } = this.datum;
 
         const whisker = this.whiskerPath;
         whisker.path.clear();

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -1,5 +1,6 @@
 import type { AgErrorBarCapLengthOptions, AgErrorBarThemeableOptions, _ModuleSupport } from 'ag-charts-community';
 import { _Scene } from 'ag-charts-community';
+import type { InteractionRange } from 'ag-charts-community';
 
 export type ErrorBarNodeDatum = _ModuleSupport.CartesianSeriesNodeDatum & _ModuleSupport.ErrorBoundSeriesNodeDatum;
 
@@ -53,7 +54,7 @@ export class ErrorBarNode extends _Scene.Group {
         capsPath.markDirty(capsPath, _Scene.RedrawType.MINOR);
     }
 
-    updateTranslation(cap: AgErrorBarCapLengthOptions) {
+    updateTranslation(cap: AgErrorBarCapLengthOptions, range: InteractionRange) {
         // Note: The method always uses the RedrawType.MAJOR mode for simplicity.
         // This could be optimised to reduce a amount of unnecessary redraws.
         if (this.datum === undefined) {
@@ -112,6 +113,12 @@ export class ErrorBarNode extends _Scene.Group {
                 new _Scene.BBox(xBar.lowerPoint.x, xBar.lowerPoint.y - capOffset, caps.strokeWidth, capLength),
                 new _Scene.BBox(xBar.upperPoint.x, xBar.upperPoint.y - capOffset, caps.strokeWidth, capLength)
             );
+        }
+        const expansion = typeof range === 'string' ? 0 : range;
+        if (expansion > 0) {
+            for (const bbox of components) {
+                bbox.grow({ top: expansion, bottom: expansion, left: expansion, right: expansion });
+            }
         }
         this.bboxes.union = _Scene.BBox.merge(components);
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9272

This PR:
- Highlights the datum when the mouse hovers over an error bars scene node.
- Shows the tooltip when the mouse hovers over an error bars scene node.
- Renders the tooltip higher up to avoid covering the error bar.

Notes:
- Interaction range `'exact'` and `'nearest'` are treated the same as `range = 0`
- `ErrorBarNode` uses a hierarchical bounding box structure for precise & high-performance hit-testing.
- Tested on https://plnkr.co/edit/p9mib2yv6YYY97uL?open=main.js

**Before:**
<img width="235" alt="Screenshot 2023-10-20 at 14 44 29" src="https://github.com/ag-grid/ag-charts/assets/23700103/24d9e478-56ff-49f4-8c25-21148122473f">

**After:**
<img width="232" alt="Screenshot 2023-10-20 at 14 44 49" src="https://github.com/ag-grid/ag-charts/assets/23700103/473fa0ce-666f-41c9-8054-ce300fa15555">