### PR TITLE
AG-9022 a11y: Change error bar docs customisation style

### DIFF
--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/customisation/main.ts
@@ -17,11 +17,11 @@ const options: AgChartOptions = {
                 xUpperKey: 'volUpper',
                 yLowerKey: 'presLower',
                 yUpperKey: 'presUpper',
-                stroke: '#4A4A93',
-                strokeWidth: 1,
+                stroke: 'pink',
+                strokeWidth: 2,
                 cap: {
-                    stroke: '#FF9E4A', // otherwise inherits `#4A4A93` from whisker
-                    strokeWidth: 3, // otherwise inherits `1` from whisker
+                    stroke: 'red', // otherwise inherits `pink` from whisker
+                    strokeWidth: 5, // otherwise inherits `2` from whisker
                     length: 25,
                 },
             },

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -78,10 +78,10 @@ This example shows different Error Bar Cap and Whiskers customisations:
 ```js
 errorBar: {
     ...
-    stroke: '#4A4A93', // Whisker stroke color
-    strokeWidth: 3, // Whisker stroke width
+    stroke: 'pink', // Whisker stroke color
+    strokeWidth: 2, // Whisker stroke width
     cap: {
-        stroke: '#FF9E4A', // Cap stroke color (otherwise inherits from whisker)
+        stroke: 'red', // Cap stroke color (otherwise inherits from whisker)
         strokeWidth: 4, // Cap stroke width (otherwise inherits from whisker)
         length: 25, // Cap length as an absolute width
     },


### PR DESCRIPTION
Generally speaking, it's more readable for the docs to have CSS colour names in plain English. The colours should also be accessible on to wide range of colour blindnesses and vision loses. The colours should ideally also be visible on both the light and dark themes.

'pink' and 'red' seem to be the best colours for these requirements.

Tested using the 'A11Y - Color blindness empathy test' Chrome Extension: https://chrome.google.com/webstore/detail/a11y-color-blindness-empa/idphhflanmeibmjgaciaadkmjebljhcc

Other good colours could include:

-   Colour 1: 'blue', 'lightblue', 'cyan'
-   Colour 2: 'red', 'orange', 'gold'

However, many of these colours are not so distinguishable to people with Achromatopsia. Some of these colour like blue and orange don't look great on a dark background either.