### PR TITLE
More AreaSeries fixes.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -283,6 +283,7 @@ export class AreaSeries extends CartesianSeries<
             nodeData: markerData,
             scales: super.calculateScaling(),
             animationValid: true,
+            visible: this.visible,
         };
 
         const fillPoints = context.fillData.points;

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
@@ -1,3 +1,4 @@
+import type { NodeUpdateState } from '../../../motion/fromToMotion';
 import type { FontStyle, FontWeight } from '../../../options/agChartOptions';
 import type { Point } from '../../../scene/point';
 import type { ProcessedOutputDiff } from '../../data/dataModel';
@@ -69,6 +70,7 @@ function prepPoints(key: 'top' | 'bottom', ctx: AreaSeriesNodeDataContext, point
     return {
         scales: ctx.scales,
         nodeData: points[key],
+        visible: ctx.visible,
     };
 }
 
@@ -106,6 +108,12 @@ export function prepareAreaPathAnimation(
     diff?: ProcessedOutputDiff
 ) {
     const isCategoryBased = newData.scales.x?.type === 'category';
+    let status: NodeUpdateState = 'updated';
+    if (oldData.visible && !newData.visible) {
+        status = 'removed';
+    } else if (!oldData.visible && newData.visible) {
+        status = 'added';
+    }
 
     const prepareMarkerPairs = () => {
         if (isCategoryBased && diff) {
@@ -130,6 +138,6 @@ export function prepareAreaPathAnimation(
 
     const pairData = [...top.result, ...bottom.result.reverse()];
     const fill = prepareLinePathAnimationFns(newData, oldData, pairData, renderPartialPath);
-    const marker = prepareMarkerAnimation(markerPairMap);
+    const marker = prepareMarkerAnimation(markerPairMap, status);
     return { fill, marker };
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -346,6 +346,7 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
             nodeData: [],
             labelData: [],
             scales: super.calculateScaling(),
+            visible: this.visible,
         };
         processedData?.data.forEach(({ keys, datum: seriesDatum, values }) => {
             const xValue = keys[xIndex];

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -276,7 +276,15 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
             });
         }
 
-        return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData, scales: super.calculateScaling() }];
+        return [
+            {
+                itemId: this.yKey ?? this.id,
+                nodeData,
+                labelData: nodeData,
+                scales: super.calculateScaling(),
+                visible: this.visible,
+            },
+        ];
     }
 
     protected override isPathOrSelectionDirty(): boolean {

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -131,6 +131,7 @@ export interface CartesianSeriesNodeDataContext<
 > extends SeriesNodeDataContext<TDatum, TLabel> {
     scales: { [key in ChartAxisDirection]?: Scaling };
     animationValid?: boolean;
+    visible: boolean;
 }
 
 export abstract class CartesianSeries<

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -267,6 +267,7 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
                 labelData: nodeData,
                 scales: super.calculateScaling(),
                 animationValid: isXUniqueAndOrdered,
+                visible: this.visible,
             },
         ];
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -282,23 +282,33 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
         return new MarkerShape();
     }
 
-    protected override async updatePathNodes(opts: { seriesHighlighted?: boolean; paths: Path[] }) {
+    protected override async updatePathNodes(opts: {
+        seriesHighlighted?: boolean;
+        paths: Path[];
+        opacity: number;
+        visible: boolean;
+        animationEnabled: boolean;
+    }) {
         const {
             paths: [lineNode],
+            opacity,
+            visible,
+            animationEnabled,
         } = opts;
         const { seriesRectHeight: height, seriesRectWidth: width } = this.nodeDataDependencies;
 
-        lineNode.fill = undefined;
-        lineNode.lineJoin = 'round';
-        lineNode.pointerEvents = PointerEvents.None;
-        lineNode.opacity = 1;
-
-        lineNode.stroke = this.stroke;
-        lineNode.strokeWidth = this.getStrokeWidth(this.strokeWidth);
-        lineNode.strokeOpacity = this.strokeOpacity;
-
-        lineNode.lineDash = this.lineDash;
-        lineNode.lineDashOffset = this.lineDashOffset;
+        lineNode.setProperties({
+            fill: undefined,
+            lineJoin: 'round',
+            pointerEvents: PointerEvents.None,
+            opacity,
+            stroke: this.stroke,
+            strokeWidth: this.getStrokeWidth(this.strokeWidth),
+            strokeOpacity: this.strokeOpacity,
+            lineDash: this.lineDash,
+            lineDashOffset: this.lineDashOffset,
+            visible: visible || animationEnabled,
+        });
 
         if (lineNode.clipPath == null) {
             lineNode.clipPath = new Path2D();

--- a/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
@@ -72,7 +72,7 @@ export function resetMarkerPositionFn<T extends CartesianSeriesNodeDatum>(_node:
     };
 }
 
-export function prepareMarkerAnimation(pairMap: PathPointMap) {
+export function prepareMarkerAnimation(pairMap: PathPointMap, parentStatus: NodeUpdateState) {
     const markerStatus = (datum: PathNodeDatumLike): { point?: PathPoint; status: NodeUpdateState } => {
         const { xValue } = datum;
 
@@ -97,7 +97,7 @@ export function prepareMarkerAnimation(pairMap: PathPointMap) {
             ...FROM_TO_MIXINS[status],
         };
 
-        if (status === 'added') {
+        if (status === 'added' || parentStatus === 'added') {
             return { ...defaults, opacity: 0 };
         }
 
@@ -110,7 +110,7 @@ export function prepareMarkerAnimation(pairMap: PathPointMap) {
 
         const defaults = { translationX: datum.point.x, translationY: datum.point.y, opacity: 1 };
 
-        if (status === 'removed') {
+        if (status === 'removed' || parentStatus === 'removed') {
             return { ...defaults, translationX: point?.to?.x, translationY: point?.to?.y, opacity: 0 };
         }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -210,7 +210,15 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
             });
         }
 
-        return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData, scales: super.calculateScaling() }];
+        return [
+            {
+                itemId: this.yKey ?? this.id,
+                nodeData,
+                labelData: nodeData,
+                scales: super.calculateScaling(),
+                visible: this.visible,
+            },
+        ];
     }
 
     protected override isPathOrSelectionDirty(): boolean {

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -320,7 +320,7 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
             });
         });
 
-        return [{ itemId: xKey, nodeData, labelData: [], scales: super.calculateScaling() }];
+        return [{ itemId: xKey, nodeData, labelData: [], scales: super.calculateScaling(), visible: this.visible }];
     }
 
     getLegendData(legendType: _ModuleSupport.ChartLegendType): _ModuleSupport.CategoryLegendDatum[] {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -231,7 +231,15 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, H
             });
         }
 
-        return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData, scales: super.calculateScaling() }];
+        return [
+            {
+                itemId: this.yKey ?? this.id,
+                nodeData,
+                labelData: nodeData,
+                scales: super.calculateScaling(),
+                visible: this.visible,
+            },
+        ];
     }
 
     override getLabelData(): _Util.PointLabelDatum[] {

--- a/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
@@ -393,7 +393,15 @@ export class HistogramSeries extends CartesianSeries<_Scene.Rect, HistogramNodeD
             });
         });
 
-        return [{ itemId: this.yKey ?? this.id, nodeData, labelData: nodeData, scales: super.calculateScaling() }];
+        return [
+            {
+                itemId: this.yKey ?? this.id,
+                nodeData,
+                labelData: nodeData,
+                scales: super.calculateScaling(),
+                visible: this.visible,
+            },
+        ];
     }
 
     protected override nodeFactory() {

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -283,6 +283,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
             fillData,
             strokeData,
             scales: super.calculateScaling(),
+            visible: this.visible,
         };
 
         const fillHighPoints = fillData.points;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -450,7 +450,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
         return new MarkerShape();
     }
 
-    protected override async updatePathNodes(opts: { paths: _Scene.Path[] }) {
+    protected override async updatePathNodes(opts: { paths: _Scene.Path[]; opacity: number; visible: boolean }) {
+        const { opacity, visible } = opts;
         const [fill, stroke] = opts.paths;
         const { seriesRectHeight: height, seriesRectWidth: width } = this.nodeDataDependencies;
 
@@ -465,6 +466,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
             strokeOpacity: this.strokeOpacity,
             lineDash: this.lineDash,
             lineDashOffset: this.lineDashOffset,
+            opacity,
+            visible,
         });
         fill.setProperties({
             tag: AreaSeriesTag.Fill,
@@ -478,6 +481,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
             strokeOpacity: this.strokeOpacity,
             fillShadow: this.shadow,
             strokeWidth,
+            opacity,
+            visible,
         });
 
         const updateClipPath = (path: _Scene.Path) => {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -321,6 +321,7 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
             nodeData: [],
             labelData: [],
             scales: super.calculateScaling(),
+            visible: this.visible,
         };
 
         const domain = [];

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -446,6 +446,7 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
                 labelData: [],
                 pointData: [],
                 scales: super.calculateScaling(),
+                visible: this.visible,
             };
 
             const rect = {


### PR DESCRIPTION
Fixes:
- AreaSeries now shrinks to/from `0` height on legend toggle.
- LineSeries now fades in/out on legend toggle in all cases.

Non-visible fixes:
- Animations now have the `visible` state as part of the context data to simplify add/remove detection.
- `NaN` is now handled more gracefully for path animation - practically this is the 'all series hidden' case when the to/from points are all `NaN` since the axes + scales don't exist.