### PR TITLE
AG-9655 - Make site url env vars accessible on client side

### DIFF
--- a/packages/ag-charts-website/.env.build
+++ b/packages/ag-charts-website/.env.build
@@ -1,2 +1,2 @@
 # Astro local preview server
-SITE_URL=http://localhost:4601
+PUBLIC_SITE_URL=http://localhost:4601

--- a/packages/ag-charts-website/.env.build.production
+++ b/packages/ag-charts-website/.env.build.production
@@ -1,2 +1,2 @@
 # Production site
-SITE_URL=https://charts.ag-grid.com
+PUBLIC_SITE_URL=https://charts.ag-grid.com

--- a/packages/ag-charts-website/.env.build.staging
+++ b/packages/ag-charts-website/.env.build.staging
@@ -1,2 +1,2 @@
 PUBLIC_SITE_URL=https://testing.ag-grid.com
-SITE_BASE_URL=/ag-charts
+PUBLIC_BASE_URL=/ag-charts

--- a/packages/ag-charts-website/.env.build.staging
+++ b/packages/ag-charts-website/.env.build.staging
@@ -1,2 +1,2 @@
-SITE_URL=https://testing.ag-grid.com
+PUBLIC_SITE_URL=https://testing.ag-grid.com
 SITE_BASE_URL=/ag-charts

--- a/packages/ag-charts-website/.env.dev
+++ b/packages/ag-charts-website/.env.dev
@@ -1,2 +1,2 @@
 # Dev server path
-SITE_URL=http://localhost:4600
+PUBLIC_SITE_URL=http://localhost:4600

--- a/packages/ag-charts-website/.env.preview
+++ b/packages/ag-charts-website/.env.preview
@@ -1,2 +1,2 @@
 # Astro local preview server
-SITE_URL=http://localhost:4601
+PUBLIC_SITE_URL=http://localhost:4601

--- a/packages/ag-charts-website/.env.preview.production
+++ b/packages/ag-charts-website/.env.preview.production
@@ -1,1 +1,1 @@
-SITE_URL=https://charts.ag-grid.com
+PUBLIC_SITE_URL=https://charts.ag-grid.com

--- a/packages/ag-charts-website/.env.preview.staging
+++ b/packages/ag-charts-website/.env.preview.staging
@@ -1,2 +1,2 @@
 PUBLIC_SITE_URL=https://testing.ag-grid.com
-SITE_BASE_URL=/ag-charts
+PUBLIC_BASE_URL=/ag-charts

--- a/packages/ag-charts-website/.env.preview.staging
+++ b/packages/ag-charts-website/.env.preview.staging
@@ -1,2 +1,2 @@
-SITE_URL=https://testing.ag-grid.com
+PUBLIC_SITE_URL=https://testing.ag-grid.com
 SITE_BASE_URL=/ag-charts

--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -1,23 +1,22 @@
 import markdoc from '@astrojs/markdoc';
 import react from '@astrojs/react';
 import { defineConfig } from 'astro/config';
+import { loadEnv } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 import agHotModuleReload from './src/astro/plugins/agHotModuleReload';
 import { getDevFileList } from './src/utils/pages';
 
-const SITE_URL = process?.env?.SITE_URL;
-
 const DEFAULT_SITE_BASE_URL = '/';
-const SITE_BASE_URL = process?.env?.SITE_BASE_URL || DEFAULT_SITE_BASE_URL;
+const { PUBLIC_SITE_URL, SITE_BASE_URL = DEFAULT_SITE_BASE_URL } = loadEnv(process.env.NODE_ENV, process.cwd(), '');
 
 const OUTPUT_DIR = '../../dist/packages/ag-charts-website';
 
-console.log('Astro configuration', JSON.stringify({ SITE_URL, SITE_BASE_URL, OUTPUT_DIR }, null, 2));
+console.log('Astro configuration', JSON.stringify({ PUBLIC_SITE_URL, SITE_BASE_URL, OUTPUT_DIR }, null, 2));
 
 // https://astro.build/config
 export default defineConfig({
-    site: SITE_URL,
+    site: PUBLIC_SITE_URL,
     base: SITE_BASE_URL,
     outDir: OUTPUT_DIR,
     vite: {

--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -7,17 +7,17 @@ import svgr from 'vite-plugin-svgr';
 import agHotModuleReload from './src/astro/plugins/agHotModuleReload';
 import { getDevFileList } from './src/utils/pages';
 
-const DEFAULT_SITE_BASE_URL = '/';
-const { PUBLIC_SITE_URL, SITE_BASE_URL = DEFAULT_SITE_BASE_URL } = loadEnv(process.env.NODE_ENV, process.cwd(), '');
+const DEFAULT_BASE_URL = '/';
+const { PUBLIC_SITE_URL, PUBLIC_BASE_URL = DEFAULT_BASE_URL } = loadEnv(process.env.NODE_ENV, process.cwd(), '');
 
 const OUTPUT_DIR = '../../dist/packages/ag-charts-website';
 
-console.log('Astro configuration', JSON.stringify({ PUBLIC_SITE_URL, SITE_BASE_URL, OUTPUT_DIR }, null, 2));
+console.log('Astro configuration', JSON.stringify({ PUBLIC_SITE_URL, PUBLIC_BASE_URL, OUTPUT_DIR }, null, 2));
 
 // https://astro.build/config
 export default defineConfig({
     site: PUBLIC_SITE_URL,
-    base: SITE_BASE_URL,
+    base: PUBLIC_BASE_URL,
     outDir: OUTPUT_DIR,
     vite: {
         plugins: [svgr(), agHotModuleReload()],

--- a/packages/ag-charts-website/src/constants.ts
+++ b/packages/ag-charts-website/src/constants.ts
@@ -39,7 +39,9 @@ export const agChartsVueVersion = '8.0.0';
  *
  * NOTE: Includes trailing slash (`/`)
  */
-export const SITE_BASE_URL = import.meta.env?.BASE_URL || process.env.SITE_BASE_URL;
+export const SITE_BASE_URL =
+    import.meta.env.BASE_URL || // Astro default env var (for build time)
+    import.meta.env.PUBLIC_BASE_URL.replace(/\/?$/, '/'); // `.env.*` override (for client side)
 
 /**
  * Number of URL segments in `SITE_BASE_URL`

--- a/packages/ag-charts-website/src/features/docs/utils/urlPaths.ts
+++ b/packages/ag-charts-website/src/features/docs/utils/urlPaths.ts
@@ -1,6 +1,6 @@
 import type { InternalFramework } from '@ag-grid-types';
 import type { Framework } from '@ag-grid-types';
-import { SITE_BASE_URL, SITE_BASE_URL_SEGMENTS } from '@constants';
+import { SITE_BASE_URL } from '@constants';
 import { pathJoin } from '@utils/pathJoin';
 
 import { DOCS_FRAMEWORK_PATH_INDEX } from '../constants';

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/SystemJs.tsx
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/SystemJs.tsx
@@ -36,7 +36,7 @@ interface Configuration {
     chartPaths: Paths;
 }
 
-const localPrefix = pathJoin(import.meta.env?.SITE_URL, SITE_BASE_URL, DEV_FILE_BASE_PATH);
+const localPrefix = pathJoin(import.meta.env?.PUBLIC_SITE_URL, SITE_BASE_URL, DEV_FILE_BASE_PATH);
 
 const localConfiguration: Configuration = {
     gridMap: {

--- a/packages/ag-charts-website/src/features/gallery/utils/urlPaths.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/urlPaths.ts
@@ -4,7 +4,7 @@ import { pathJoin } from '@utils/pathJoin';
 
 export const getExampleUrl = ({ exampleName, isFullPath }: { exampleName: string; isFullPath?: boolean }) => {
     const path = pathJoin(SITE_BASE_URL, 'gallery', 'examples', exampleName);
-    const fullPath = pathJoin(import.meta.env?.SITE_URL, path);
+    const fullPath = pathJoin(import.meta.env?.PUBLIC_SITE_URL, path);
     return isFullPath ? fullPath : path;
 };
 
@@ -24,7 +24,7 @@ export const getPlainExampleUrl = ({
 }) => {
     const plainExamplePath = pathJoin('gallery', 'examples', exampleName, 'plain');
     const fullPlainExamplePath = excludeSiteBaseUrl ? plainExamplePath : pathJoin(SITE_BASE_URL, plainExamplePath);
-    const fullPath = pathJoin(import.meta.env?.SITE_URL, fullPlainExamplePath);
+    const fullPath = pathJoin(import.meta.env?.PUBLIC_SITE_URL, fullPlainExamplePath);
     return isFullPath ? fullPath : fullPlainExamplePath;
 };
 

--- a/packages/ag-charts-website/src/pages/documentation.astro
+++ b/packages/ag-charts-website/src/pages/documentation.astro
@@ -1,6 +1,7 @@
 ---
 import { SITE_BASE_URL } from '@constants';
+import { pathJoin } from '@utils/pathJoin';
 ---
 
 <!-- Redirect to overview -->
-<meta http-equiv="refresh" content={`0;url=${SITE_BASE_URL}javascript/overview`} />
+<meta http-equiv="refresh" content={`0;url=${pathJoin(SITE_BASE_URL, 'javascript/overview')}`} />

--- a/packages/ag-charts-website/src/utils/env.ts
+++ b/packages/ag-charts-website/src/utils/env.ts
@@ -1,2 +1,2 @@
 export const getIsDev = () => import.meta.env?.DEV;
-export const getIsStaging = () => import.meta.env?.SITE_URL === 'https://testing.ag-grid.com';
+export const getIsStaging = () => import.meta.env?.PUBLIC_SITE_URL === 'https://testing.ag-grid.com';


### PR DESCRIPTION
## Changes

* Make `SITE_URL` and `SITE_BASE_URL` accessible on the client side by adding a `PUBLIC_` prefix
* Fix up how `Documentation` tab generates the url