### PR TITLE
Fix PieSeries toggling of only visible segment.

### DIFF
--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -113,10 +113,12 @@ export function normaliseGroupTo(
 
 function normalisePropertyFnBuilder({
     normaliseTo,
+    zeroDomain,
     rangeMin,
     rangeMax,
 }: {
     normaliseTo: [number, number];
+    zeroDomain: number;
     rangeMin?: number;
     rangeMax?: number;
 }) {
@@ -124,7 +126,7 @@ function normalisePropertyFnBuilder({
     const normalise = (val: number, start: number, span: number) => {
         const result = normaliseTo[0] + ((val - start) / span) * normaliseSpan;
 
-        if (span === 0) return normaliseTo[1];
+        if (span === 0) return zeroDomain;
         if (result >= normaliseTo[1]) return normaliseTo[1];
         if (result < normaliseTo[0]) return normaliseTo[0];
         return result;
@@ -154,6 +156,7 @@ export function normalisePropertyTo(
     scope: ScopeProvider,
     property: PropertyId<any>,
     normaliseTo: [number, number],
+    zeroDomain: number,
     rangeMin?: number,
     rangeMax?: number
 ): PropertyValueProcessorDefinition<any> {
@@ -161,7 +164,7 @@ export function normalisePropertyTo(
         scopes: [scope.id],
         type: 'property-value-processor',
         property,
-        adjust: memo({ normaliseTo, rangeMin, rangeMax }, normalisePropertyFnBuilder),
+        adjust: memo({ normaliseTo, rangeMin, rangeMax, zeroDomain }, normalisePropertyFnBuilder),
     };
 }
 

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -379,7 +379,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
                     max: this.radiusMax,
                 }),
                 valueProperty(this, radiusKey, true, { id: `radiusRaw` }), // Raw value pass-through.
-                normalisePropertyTo(this, { id: 'radiusValue' }, [0, 1], this.radiusMin ?? 0, this.radiusMax)
+                normalisePropertyTo(this, { id: 'radiusValue' }, [0, 1], 1, this.radiusMin ?? 0, this.radiusMax)
             );
         }
         if (calloutLabelKey) {
@@ -424,7 +424,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
                 ...extraKeyProps,
                 accumulativeValueProperty(this, angleKey, true, { id: `angleValue` }),
                 valueProperty(this, angleKey, true, { id: `angleRaw` }), // Raw value pass-through.
-                normalisePropertyTo(this, { id: 'angleValue' }, [0, 1], 0),
+                normalisePropertyTo(this, { id: 'angleValue' }, [0, 1], 0, 0),
                 ...extraProps,
             ],
         });

--- a/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
@@ -12,13 +12,12 @@ type AnimatableSectorDatum = {
 
 export function preparePieSeriesAnimationFunctions(rotationDegrees: number) {
     const rotation = Math.PI / -2 + toRadians(rotationDegrees);
-    const fullRotation = Math.PI / -2 + toRadians(rotationDegrees + 360);
 
     const fromFn = (
         sect: Sector,
         datum: AnimatableSectorDatum,
         status: NodeUpdateState,
-        { prevFromProps, last }: FromToMotionPropFnContext<Sector>
+        { prevFromProps }: FromToMotionPropFnContext<Sector>
     ) => {
         // Default to starting from current state.
         let { startAngle, endAngle, innerRadius, outerRadius } = sect;
@@ -34,8 +33,6 @@ export function preparePieSeriesAnimationFunctions(rotationDegrees: number) {
             endAngle = prevFromProps.endAngle ?? rotation;
             innerRadius = prevFromProps.innerRadius ?? datum.innerRadius;
             outerRadius = prevFromProps.outerRadius ?? datum.outerRadius;
-        } else if (last) {
-            endAngle = fullRotation;
         }
 
         return { startAngle, endAngle, innerRadius, outerRadius };


### PR DESCRIPTION
Fixes legend toggling on of PieSeries when zero segments are enabled.

https://github.com/ag-grid/ag-charts/assets/17544187/169ced2b-98ff-47d4-8618-4e6afb15f07a

