### PR TITLE
AG-8524 Fix zoom with animation

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -514,7 +514,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
     private seriesToUpdate: Set<ISeries<any>> = new Set();
     private updateMutex = new Mutex();
     private updateRequestors: Record<string, ChartUpdateType> = {};
-    private updateAnimationIsSkipping?: boolean;
     private performUpdateTrigger = debouncedCallback(async ({ count }) => {
         if (this._destroyed) return;
 
@@ -547,8 +546,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
 
         if (skipAnimations) {
-            this.updateAnimationIsSkipping ??= this.animationManager.isSkipped();
-            this.animationManager.skip();
+            this.animationManager.skipCurrentBatch();
         }
 
         if (Debug.check(true)) {
@@ -624,11 +622,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
 
         this.updateService.dispatchUpdateComplete(this.getMinRect());
-
-        if (this.updateAnimationIsSkipping !== undefined) {
-            this.animationManager.skip(this.updateAnimationIsSkipping);
-            this.updateAnimationIsSkipping = undefined;
-        }
 
         const end = performance.now();
         this.debug('Chart.performUpdate() - end', {

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -301,8 +301,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.zoomManager = new ZoomManager();
         this.dataService = new DataService<Series<any>>(() => this.series);
         this.layoutService = new LayoutService();
-        this.updateService = new UpdateService((type = ChartUpdateType.FULL, { forceNodeDataRefresh }) =>
-            this.update(type, { forceNodeDataRefresh })
+        this.updateService = new UpdateService(
+            (type = ChartUpdateType.FULL, { forceNodeDataRefresh, skipAnimations }) =>
+                this.update(type, { forceNodeDataRefresh, skipAnimations })
         );
         this.seriesStateManager = new SeriesStateManager();
         this.seriesLayerManager = new SeriesLayerManager(this.seriesRoot);
@@ -340,7 +341,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             }),
             this.highlightManager.addListener('highlight-change', (event) => this.changeHighlightDatum(event)),
             this.zoomManager.addListener('zoom-change', (_) =>
-                this.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true })
+                this.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true, skipAnimations: true })
             )
         );
 
@@ -513,6 +514,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     private seriesToUpdate: Set<ISeries<any>> = new Set();
     private updateMutex = new Mutex();
     private updateRequestors: Record<string, ChartUpdateType> = {};
+    private updateAnimationIsSkipping?: boolean;
     private performUpdateTrigger = debouncedCallback(async ({ count }) => {
         if (this._destroyed) return;
 
@@ -527,9 +529,14 @@ export abstract class Chart extends Observable implements AgChartInstance {
     });
     public update(
         type = ChartUpdateType.FULL,
-        opts?: { forceNodeDataRefresh?: boolean; seriesToUpdate?: Iterable<ISeries<any>>; backOffMs?: number }
+        opts?: {
+            forceNodeDataRefresh?: boolean;
+            skipAnimations?: boolean;
+            seriesToUpdate?: Iterable<ISeries<any>>;
+            backOffMs?: number;
+        }
     ) {
-        const { forceNodeDataRefresh = false, seriesToUpdate = this.series } = opts ?? {};
+        const { forceNodeDataRefresh = false, skipAnimations, seriesToUpdate = this.series } = opts ?? {};
 
         if (forceNodeDataRefresh) {
             this.series.forEach((series) => series.markNodeDataDirty());
@@ -537,6 +544,11 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
         for (const series of seriesToUpdate) {
             this.seriesToUpdate.add(series);
+        }
+
+        if (skipAnimations) {
+            this.updateAnimationIsSkipping ??= this.animationManager.isSkipped();
+            this.animationManager.skip();
         }
 
         if (Debug.check(true)) {
@@ -612,6 +624,11 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
 
         this.updateService.dispatchUpdateComplete(this.getMinRect());
+
+        if (this.updateAnimationIsSkipping !== undefined) {
+            this.animationManager.skip(this.updateAnimationIsSkipping);
+            this.updateAnimationIsSkipping = undefined;
+        }
 
         const end = performance.now();
         this.debug('Chart.performUpdate() - end', {

--- a/packages/ag-charts-community/src/chart/updateService.ts
+++ b/packages/ag-charts-community/src/chart/updateService.ts
@@ -2,7 +2,10 @@ import type { BBox } from '../scene/bbox';
 import { Listeners } from '../util/listeners';
 import { ChartUpdateType } from './chartUpdateType';
 
-type UpdateCallback = (type: ChartUpdateType, options: { forceNodeDataRefresh?: boolean }) => void;
+type UpdateCallback = (
+    type: ChartUpdateType,
+    options: { forceNodeDataRefresh?: boolean; skipAnimations?: boolean }
+) => void;
 
 export interface UpdateCompleteEvent {
     type: 'update-complete';
@@ -17,8 +20,8 @@ export class UpdateService extends Listeners<'update-complete', (event: UpdateCo
         this.updateCallback = updateCallback;
     }
 
-    public update(type = ChartUpdateType.FULL, { forceNodeDataRefresh = false } = {}) {
-        this.updateCallback(type, { forceNodeDataRefresh });
+    public update(type = ChartUpdateType.FULL, { forceNodeDataRefresh = false, skipAnimations = false } = {}) {
+        this.updateCallback(type, { forceNodeDataRefresh, skipAnimations });
     }
 
     public dispatchUpdateComplete(minRect?: BBox) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -222,7 +222,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
             zoom
         );
 
-        this.updateService.update(ChartUpdateType.PERFORM_LAYOUT);
+        this.updateService.update(ChartUpdateType.PERFORM_LAYOUT, { skipAnimations: true });
     }
 
     private onDragEnd() {


### PR DESCRIPTION
Adds animation batches that contain the controllers. These can be skipped as a batch together.

So the chart update can just call `this.animationManager.skipCurrentBatch()` and the state of that will be handled internally.