### PR TITLE
AG-8238 Improve ErrorBars.pickNodeExact

### DIFF
--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -300,10 +300,10 @@ export class ErrorBars
     }
 
     pickNodeExact(point: Point): PickNodeDatumResult {
-        // TODO(olegat) optimise: distanceSquared isn't required, contains() check is sufficient
-        const { datum, distanceSquared } = this.groupNode.nearestSquared(point) ?? {};
-        if (distanceSquared === 0 && datum !== undefined) {
-            return { datum, distanceSquared };
+        const { x, y } = this.groupNode.transformPoint(point.x, point.y);
+        const node = this.groupNode.pickNode(x, y);
+        if (node !== undefined) {
+            return { datum: node.datum, distanceSquared: 0 };
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -231,6 +231,10 @@ export class ErrorBarNode extends _Scene.Group {
         return this.bboxes.containsPoint(x, y);
     }
 
+    override pickNode(x: number, y: number): _Scene.Node | undefined {
+        return this.containsPoint(x, y) ? this : undefined;
+    }
+
     nearestSquared(point: Point, maxDistance: number): NearestResult<_Scene.Node> {
         const { bboxes } = this;
         if (bboxes.union.distanceSquared(point) > maxDistance) {
@@ -243,21 +247,6 @@ export class ErrorBarNode extends _Scene.Group {
 }
 
 export class ErrorBarGroup extends _Scene.Group {
-    override containsPoint(x: number, y: number): boolean {
-        const children = this.children;
-        if (children.length === 0) {
-            return false;
-        } else {
-            const point = this.transformPoint(x, y);
-            for (const child of children) {
-                if (child.containsPoint(point.x, point.y)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     override get children(): ErrorBarNode[] {
         return super.children as ErrorBarNode[];
     }


### PR DESCRIPTION
We don't need to calculate the distance in this pick-mode because it's always 0. Therefore just use the cheaper containsPoint/pickNode.