### PR TITLE
Fix animation short-circuit cases.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -365,7 +365,7 @@ function applyChartOptions(chart: Chart, processedOptions: ProcessedOptions, use
     const majorChange = forceNodeDataRefresh || modulesChanged;
     const updateType = majorChange ? ChartUpdateType.PROCESS_DATA : ChartUpdateType.PERFORM_LAYOUT;
     debug('AgChartV2.applyChartOptions() - update type', ChartUpdateType[updateType]);
-    chart.update(updateType, { forceNodeDataRefresh });
+    chart.update(updateType, { forceNodeDataRefresh, newAnimationBatch: true });
 }
 
 function applyModules(chart: Chart, options: AgChartOptions) {

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1435,7 +1435,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
 
         fromToMotion(
             this.id,
-            'ready-update',
+            'line-paths',
             animationManager,
             [this.gridLineGroupSelection, this.tickLineGroupSelection],
             fns,
@@ -1444,7 +1444,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         );
         fromToMotion(
             this.id,
-            'ready-update',
+            'tick-labels',
             animationManager,
             [this.tickLabelGroupSelection],
             fns,

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -61,18 +61,6 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
         const id = opts.id ?? Math.random().toString();
 
-        if (opts.shortCircuitId) {
-            const shortCircuitTime = this.shortCircuits.get(opts.shortCircuitId);
-            const isShortCircuited = shortCircuitTime && opts.duration && Date.now() - shortCircuitTime < opts.duration;
-
-            if (isShortCircuited) {
-                opts.delay = 0;
-                opts.duration = 1;
-            }
-
-            this.shortCircuits.set(opts.shortCircuitId, Date.now());
-        }
-
         return new Animation({
             ...opts,
             id,

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -22,7 +22,6 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
     private batch = new AnimationBatch();
 
-    private readonly shortCircuits: Map<string, number> = new Map();
     private readonly debug = Debug.create(true, 'animation');
 
     private isPlaying = false;
@@ -53,6 +52,9 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
                     return batch.controllers.get(opts.id)!.reset(opts);
                 }
                 batch.controllers.get(opts.id)!.stop();
+
+                this.debug(`Skipping animation batch due to update of existing animation: ${opts.id}`);
+                this.batch.skip();
             }
         } catch (error: unknown) {
             this.failsafeOnError(error);
@@ -176,7 +178,12 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         return this.skipAnimations || this.batch.isSkipped();
     }
 
+    public isActive() {
+        return this.isPlaying && this.batch.isActive();
+    }
+
     public skipCurrentBatch() {
+        this.debug(`AnimationManager - skipCurrentBatch()`);
         this.batch.skip();
     }
 
@@ -238,7 +245,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         if (this.requestId === null) return;
         cancelAnimationFrame(this.requestId);
         this.requestId = null;
-        this.createBatch();
+        this.startBatch();
     }
 
     private failsafeOnError(error: unknown, cancelAnimation = true) {
@@ -248,9 +255,26 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         }
     }
 
-    private createBatch() {
+    public startBatch(skipAnimations?: boolean) {
+        this.debug(`AnimationManager - startBatch() with skipAnimations=${skipAnimations}.`);
+        this.reset();
         this.batch.destroy();
         this.batch = new AnimationBatch();
+        if (skipAnimations === true) {
+            this.batch.skip();
+        }
+    }
+
+    public endBatch() {
+        this.debug(
+            `AnimationManager - endBatch() with ${
+                this.batch.controllers.size
+            } animations; skipped: ${this.batch.isSkipped()}.`
+        );
+
+        if (this.batch.isSkipped() && !this.batch.isActive()) {
+            this.batch.skip(false);
+        }
     }
 }
 
@@ -268,17 +292,13 @@ class AnimationBatch {
         return this.controllers.size > 0;
     }
 
-    skip() {
-        if (this.isActive()) {
-            this.skipAnimations = true;
-        }
+    skip(skip = true) {
+        this.skipAnimations = skip;
     }
 
     isSkipped() {
         return this.skipAnimations;
     }
 
-    destroy() {
-        //
-    }
+    destroy() {}
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -333,10 +333,7 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
             markerSelection.clear();
         }
 
-        const idFn = this.ctx.animationManager.isSkipped()
-            ? undefined
-            : (datum: LineNodeDatum) => this.getDatumId(datum);
-        return markerSelection.update(nodeData, undefined, idFn);
+        return markerSelection.update(nodeData, undefined, (datum) => this.getDatumId(datum));
     }
 
     protected override async updateMarkerNodes(opts: {
@@ -536,7 +533,7 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
             return;
         }
 
-        fromToMotion(this.id, 'marker_update', animationManager, markerSelections as any, fns.marker as any);
+        fromToMotion(this.id, 'marker', animationManager, markerSelections, fns.marker as any);
         fromToMotion(this.id, 'path_properties', animationManager, path, fns.pathProperties);
         pathMotion(this.id, 'path_update', animationManager, path, fns.path);
         seriesLabelFadeInAnimation(this, 'labels', animationManager, labelSelections);
@@ -544,7 +541,6 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
     }
 
     private getDatumId(datum: LineNodeDatum) {
-        if (this.ctx.animationManager.isSkipped()) return '';
         return createDatumId([`${datum.xValue}`]);
     }
 

--- a/packages/ag-charts-community/src/motion/animation.ts
+++ b/packages/ag-charts-community/src/motion/animation.ts
@@ -63,7 +63,6 @@ export interface AdditionalAnimationOptions {
     id?: string;
     disableInteractions?: boolean;
     immutable?: boolean;
-    shortCircuitId?: string;
 }
 
 export type ResetAnimationOptions<T extends AnimationValue> = Pick<

--- a/packages/ag-charts-community/src/motion/fromToMotion.ts
+++ b/packages/ag-charts-community/src/motion/fromToMotion.ts
@@ -166,7 +166,7 @@ export function fromToMotion<N extends Node, T extends Record<string, string | n
             from: 0,
             to: 1,
             ease: easing.easeOut,
-            onComplete() {
+            onStop() {
                 selection.cleanup();
             },
         });

--- a/packages/ag-charts-community/src/scene/selection.ts
+++ b/packages/ag-charts-community/src/scene/selection.ts
@@ -1,3 +1,4 @@
+import { Debug } from '../util/debug';
 import { Node } from './node';
 
 type NodeConstructor<TNode extends Node> = new () => TNode;
@@ -40,6 +41,8 @@ export class Selection<TChild extends Node = Node, TDatum = any> {
     protected _nodes: TChild[] = [];
     protected data: TDatum[] = [];
 
+    private debug = Debug.create(true, 'scene', 'scene:selections');
+
     constructor(
         private readonly parentNode: Node,
         classOrFactory: NodeConstructorOrFactory<TChild, TDatum>,
@@ -69,6 +72,10 @@ export class Selection<TChild extends Node = Node, TDatum = any> {
      * of the array.
      */
     update(data: TDatum[], initializer?: (node: TChild) => void, getDatumId?: (datum: TDatum) => string | number) {
+        if (this.garbageBin.size > 0) {
+            this.debug(`Selection - update() called with pending garbage: ${data}`);
+        }
+
         if (getDatumId) {
             const dataMap = new Map<string | number, [TDatum, number]>(
                 data.map((datum, idx) => [getDatumId(datum), [datum, idx]])

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/index.html
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/index.html
@@ -25,6 +25,7 @@
     </div>
     <div class="toolPanel">
         <button onclick="actionTickStart()">Start ticking</button>
+        <button onclick="actionTickStartFast()">Start fast ticking</button>
         <button onclick="actionTickStop()">Stop ticking</button>
     </div>
     <div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
@@ -1,6 +1,8 @@
 import { AgChart, AgChartOptions, AgEnterpriseCharts, time } from 'ag-charts-enterprise';
 import { getData } from './data';
 
+(window as any).agChartsDebug = 'animation';
+
 const data = getData();
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
@@ -190,7 +192,13 @@ let tick: NodeJS.Timer;
 function actionTickStart() {
     if (tick) clearInterval(tick);
 
-    tick = setInterval(() => actionAddPointsAfter(1), 1000)
+    tick = setInterval(() => actionAddPointsAfter(1), 1500);
+}
+
+function actionTickStartFast() {
+    if (tick) clearInterval(tick);
+
+    tick = setInterval(() => actionAddPointsAfter(1), 900);
 }
 
 function actionTickStop() {


### PR DESCRIPTION
Extends the new `AnimationBatch` concept to:
- Force animation skip on chart resize.
- Force animation skip on `AgChart.update()` if there are live animations playing.
- Force animation skip on zoom (reset case).

Bonus:
- Removes redundant AnimationManager short-circuit id code (this should be redundant for existing cases).
- Fixes LineSeries processing which was faulty, and exposed by these changes.