### PR TITLE
AG-9702 Fix area series zoom reset on double click

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1294,12 +1294,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
             pixelRange = nodeClickRange;
         }
 
-        const pickedNode = this.pickSeriesNode(
-            { x: event.offsetX, y: event.offsetY },
-            nodeClickRange === 'exact',
-            pixelRange
-        );
-
+        // Find the node if exactly matched and update the highlight picked node
+        let pickedNode = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY }, true);
         if (pickedNode) {
             this.highlightManager.updatePicked(this.id, pickedNode.datum);
         } else {
@@ -1310,6 +1306,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
         if (datum && nodeClickRange === 'nearest') {
             callback(datum.series, datum);
             return true;
+        }
+
+        if (nodeClickRange !== 'exact') {
+            pickedNode = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY }, false, pixelRange);
         }
 
         if (!pickedNode) return false;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9702

For the purposes of checking if clicking a node should block the double click zoom reset, this changes it to only check if the node is exactly matched. Since area series by default use `'nearest'` matching and would thus always block double click otherwise.