### PR TITLE
AG-9301, AG-9323 Add bullet target lines and color ranges 

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -6,6 +6,7 @@ import type {
     AgBarSeriesLabelPlacement,
     AgBarSeriesStyle,
     AgBarSeriesTooltipRendererParams,
+    Direction,
     FontStyle,
     FontWeight,
 } from '../../../options/agChartOptions';
@@ -20,6 +21,7 @@ import type { Text } from '../../../scene/shape/text';
 import { extent } from '../../../util/array';
 import { sanitizeHtml } from '../../../util/sanitize';
 import {
+    DIRECTION,
     NUMBER,
     OPT_COLOR_STRING,
     OPT_FUNCTION,
@@ -137,8 +139,8 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
     @Validate(OPT_STRING)
     yName?: string = undefined;
 
-    @Validate(STRING_UNION('vertical', 'horizontal'))
-    direction: 'vertical' | 'horizontal' = 'vertical';
+    @Validate(DIRECTION)
+    direction: Direction = 'vertical';
 
     @Validate(OPT_STRING)
     stackGroup?: string = undefined;

--- a/packages/ag-charts-community/src/options/chart/types.ts
+++ b/packages/ag-charts-community/src/options/chart/types.ts
@@ -41,3 +41,5 @@ export type TextWrap = 'never' | 'always' | 'hyphenate' | 'on-space';
  * - `'nearest'` always tracks the nearest point anywhere on the chart.
  */
 export type InteractionRange = PixelSize | 'exact' | 'nearest';
+
+export type Direction = 'vertical' | 'horizontal';

--- a/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
@@ -7,6 +7,13 @@ export interface AgBulletSeriesTooltipRendererParams<TDatum = any>
 
 export interface AgBulletSeriesThemeableOptions extends AgBaseSeriesThemeableOptions {}
 
+export interface AgBulletColorRange {
+    /** Color of this category. */
+    color: string;
+    /** Stop value of this category. Defaults the maximum value if unset. */
+    stop?: number;
+}
+
 export interface AgBulletSeriesOptions<TDatum = any> extends AgBaseSeriesOptions<TDatum> {
     /** Configuration for the Bullet series. */
     type: 'bullet';
@@ -14,4 +21,6 @@ export interface AgBulletSeriesOptions<TDatum = any> extends AgBaseSeriesOptions
     direction?: 'horizontal' | 'vertical';
     /** Series-specific tooltip configuration. */
     tooltip?: AgSeriesTooltip<AgBulletSeriesTooltipRendererParams>;
+    /** Categoric ranges of the chart */
+    colorRanges?: AgBulletColorRange[];
 }

--- a/packages/ag-charts-community/src/scene/selection.ts
+++ b/packages/ag-charts-community/src/scene/selection.ts
@@ -152,6 +152,14 @@ export class Selection<TChild extends Node = Node, TDatum = any> {
         return this;
     }
 
+    *[Symbol.iterator](): IterableIterator<{ node: TChild; datum: TDatum; index: number }> {
+        for (let index = 0; index < this._nodes.length; index++) {
+            const node = this._nodes[index];
+            const datum = this._nodes[index].datum;
+            yield { node, datum, index };
+        }
+    }
+
     select<TChild extends Node = Node>(predicate: (node: Node) => node is TChild): TChild[] {
         return Selection.selectAll(this.parentNode, predicate);
     }

--- a/packages/ag-charts-community/src/util/validation.ts
+++ b/packages/ag-charts-community/src/util/validation.ts
@@ -285,3 +285,13 @@ export const TEXT_WRAP = predicateWithMessage(
     (v: any) => TEXT_WRAPS.includes(v),
     `expecting a text wrap strategy keyword such as 'never', 'always', 'hyphenate', 'on-space'`
 );
+
+const DIRECTIONS = ['horizontal', 'vertical'];
+export const DIRECTION = predicateWithMessage(
+    (v: any) => DIRECTIONS.includes(v),
+    `expecting a direction keyword such as 'horizontal' or 'vertical'`
+);
+export const OPT_DIRECTION = predicateWithMessage(
+    (v: any, ctx) => OPTIONAL(v, ctx, DIRECTION),
+    `expecting an optional direction keyword such as 'horizontal' or 'vertical'`
+);

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -2,6 +2,7 @@ import {
     type AgBoxPlotSeriesFormatterParams,
     type AgBoxPlotSeriesStyles,
     type AgBoxPlotSeriesTooltipRendererParams,
+    type Direction,
     _ModuleSupport,
     _Scale,
     _Scene,
@@ -28,7 +29,7 @@ const {
     SeriesNodePickMode,
     SeriesTooltip,
     SMALLEST_KEY_INTERVAL,
-    STRING_UNION,
+    DIRECTION,
     Validate,
     valueProperty,
 } = _ModuleSupport;
@@ -138,8 +139,8 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
     @Validate(NUMBER(0))
     lineDashOffset: number = 0;
 
-    @Validate(STRING_UNION('vertical', 'horizontal'))
-    direction: 'vertical' | 'horizontal' = 'vertical';
+    @Validate(DIRECTION)
+    direction: Direction = 'vertical';
 
     @Validate(OPT_FUNCTION)
     formatter?: (params: AgBoxPlotSeriesFormatterParams<unknown>) => AgBoxPlotSeriesStyles = undefined;

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -1,4 +1,4 @@
-import type { AgBulletSeriesTooltipRendererParams } from 'ag-charts-community';
+import type { AgBulletSeriesTooltipRendererParams, Direction } from 'ag-charts-community';
 import { _ModuleSupport, _Scale, _Scene } from 'ag-charts-community';
 
 const { partialAssign, keyProperty, valueProperty, Validate, STRING, OPT_STRING } = _ModuleSupport;
@@ -23,8 +23,8 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, Bu
     @Validate(OPT_STRING)
     targetName?: string = undefined;
 
-    @Validate(OPT_STRING)
-    direction?: string = 'vertical';
+    @Validate(DIRECTION)
+    direction: Direction = 'vertical';
 
     readonly xValue: string = 'xPlaceholderValue';
 

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -1,24 +1,71 @@
 import type { AgBulletSeriesTooltipRendererParams, Direction } from 'ag-charts-community';
 import { _ModuleSupport, _Scale, _Scene } from 'ag-charts-community';
 
-const { partialAssign, keyProperty, valueProperty, Validate, STRING, OPT_STRING } = _ModuleSupport;
+const {
+    partialAssign,
+    keyProperty,
+    valueProperty,
+    Validate,
+    COLOR_STRING,
+    DIRECTION,
+    STRING,
+    OPT_ARRAY,
+    OPT_NUMBER,
+    OPT_STRING,
+} = _ModuleSupport;
 
 interface BulletNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum {
     readonly x: number;
     readonly y: number;
     readonly width: number;
     readonly height: number;
+    readonly target?: {
+        readonly value: number;
+        readonly x1: number;
+        readonly y1: number;
+        readonly x2: number;
+        readonly y2: number;
+    };
 }
 
-export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, BulletNodeDatum> {
+class BulletColorRange {
+    @Validate(COLOR_STRING)
+    color: string = 'white';
+
+    @Validate(OPT_NUMBER())
+    stop?: number = undefined;
+}
+
+class BulletNode extends _Scene.Group {
+    private valueRect: _Scene.Rect = new _Scene.Rect();
+    private targetLine: _Scene.Line = new _Scene.Line();
+
+    public constructor() {
+        super();
+        this.append(this.valueRect);
+        this.append(this.targetLine);
+    }
+
+    public update(datum: BulletNodeDatum) {
+        partialAssign(['x', 'y', 'height', 'width'], this.valueRect, datum);
+        this.valueRect.visible = true;
+
+        partialAssign(['x1', 'x2', 'y1', 'y2'], this.targetLine, datum.target);
+        this.targetLine.stroke = 'black';
+        this.targetLine.strokeWidth = 3;
+        this.targetLine.visible = datum.target !== undefined;
+    }
+}
+
+export class BulletSeries extends _ModuleSupport.CartesianSeries<BulletNode, BulletNodeDatum> {
     @Validate(STRING)
     valueKey: string = '';
 
     @Validate(OPT_STRING)
     valueName?: string = undefined;
 
-    @Validate(STRING)
-    targetKey: string = '';
+    @Validate(OPT_STRING)
+    targetKey?: string = undefined;
 
     @Validate(OPT_STRING)
     targetName?: string = undefined;
@@ -44,7 +91,7 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, Bu
         await this.requestDataModel<any, any, true>(dataController, data, {
             props: [
                 keyProperty(this, valueKey, isContinuousX, { id: 'xValue' }),
-                valueProperty(this, valueKey, isContinuousX, { id: 'value' }),
+                valueProperty(this, valueKey, isContinuousY, { id: 'value' }),
                 valueProperty(this, targetKey, isContinuousY, { id: 'target' }),
             ],
             groupByKeys: true,
@@ -73,7 +120,8 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, Bu
         const yScale = this.getValueAxis()?.scale;
         if (!valueKey || !dataModel || !processedData || !xScale || !yScale) return [];
 
-        const yIndex = dataModel.resolveProcessedDataIndexById(this, 'target').index;
+        const valueIndex = dataModel.resolveProcessedDataIndexById(this, 'value').index;
+        const targetIndex = dataModel.resolveProcessedDataIndexById(this, 'target').index;
         const context: _ModuleSupport.CartesianSeriesNodeDataContext<BulletNodeDatum> = {
             itemId: valueKey,
             nodeData: [],
@@ -83,10 +131,10 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, Bu
         };
         for (const { datum, values } of processedData.data) {
             const xValue = this.xValue;
-            const yValue = values[0][yIndex];
+            const yValue = values[0][valueIndex];
             const x = xScale.convert(xValue);
             const y = yScale.convert(yValue);
-            const barWidth = 5;
+            const barWidth = 8;
             const bottomY = yScale.convert(0);
             const barAlongX = this.getBarDirection() === _ModuleSupport.ChartAxisDirection.X;
             const rect = {
@@ -96,6 +144,23 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, Bu
                 height: barAlongX ? barWidth : Math.abs(bottomY - y),
             };
 
+            let target;
+            if (this.targetKey) {
+                const targetLineLength = 20;
+                const targetValue = values[0][targetIndex];
+                if (!isNaN(targetValue) && targetValue !== undefined) {
+                    const convertedY = yScale.convert(targetValue);
+                    const convertedX = xScale.convert(xValue) + barWidth / 2;
+                    let x1 = convertedX - targetLineLength / 2;
+                    let x2 = convertedX + targetLineLength / 2;
+                    let [y1, y2] = [convertedY, convertedY];
+                    if (barAlongX) {
+                        [x1, x2, y1, y2] = [y1, y2, x1, x2];
+                    }
+                    target = { value: targetValue, x1, x2, y1, y2 };
+                }
+            }
+
             const nodeData: BulletNodeDatum = {
                 series: this,
                 datum,
@@ -103,6 +168,7 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, Bu
                 xValue,
                 yKey: valueKey,
                 yValue,
+                target,
                 ...rect,
                 midPoint: { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 },
             };
@@ -126,24 +192,23 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, Bu
         return false;
     }
     protected override nodeFactory() {
-        // TODO(olegat)
-        return new _Scene.Rect();
+        return new BulletNode();
     }
 
     protected override async updateDatumSelection(opts: {
         nodeData: BulletNodeDatum[];
-        datumSelection: _Scene.Selection<_Scene.Rect, BulletNodeDatum>;
+        datumSelection: _Scene.Selection<BulletNode, BulletNodeDatum>;
     }) {
         return opts.datumSelection.update(opts.nodeData, undefined, undefined);
     }
 
     protected override async updateDatumNodes(opts: {
-        datumSelection: _Scene.Selection<_Scene.Rect, BulletNodeDatum>;
+        datumSelection: _Scene.Selection<BulletNode, BulletNodeDatum>;
         isHighlight: boolean;
     }) {
-        opts.datumSelection.each((rect, datum) => {
-            partialAssign(['x', 'y', 'height', 'width'], rect, datum);
-        });
+        for (const { node, datum } of opts.datumSelection) {
+            node.update(datum);
+        }
     }
 
     protected override async updateLabelSelection(opts: {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -5,6 +5,7 @@ import type {
     AgRangeBarSeriesLabelPlacement,
     AgRangeBarSeriesTooltipRendererParams,
     AgTooltipRendererResult,
+    Direction,
 } from 'ag-charts-community';
 import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
@@ -27,6 +28,7 @@ const {
     CategoryAxis,
     SMALLEST_KEY_INTERVAL,
     STRING_UNION,
+    DIRECTION,
     diff,
     prepareBarAnimationFunctions,
     midpointStartingBarPosition,
@@ -202,8 +204,8 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
     @Validate(OPT_STRING)
     yName?: string = undefined;
 
-    @Validate(STRING_UNION('vertical', 'horizontal'))
-    direction: 'vertical' | 'horizontal' = 'vertical';
+    @Validate(DIRECTION)
+    direction: Direction = 'vertical';
 
     protected smallestDataInterval?: { x: number; y: number } = undefined;
 

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -6,6 +6,7 @@ import type {
     AgWaterfallSeriesLabelFormatterParams,
     AgWaterfallSeriesLabelPlacement,
     AgWaterfallSeriesTooltipRendererParams,
+    Direction,
 } from 'ag-charts-community';
 import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
@@ -27,7 +28,7 @@ const {
     OPT_FUNCTION,
     OPT_COLOR_STRING,
     OPT_LINE_DASH,
-    STRING_UNION,
+    DIRECTION,
     getRectConfig,
     updateRect,
     checkCrisp,
@@ -209,8 +210,8 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
     @Validate(OPT_STRING)
     yName?: string = undefined;
 
-    @Validate(STRING_UNION('vertical', 'horizontal'))
-    direction: 'vertical' | 'horizontal' = 'vertical';
+    @Validate(DIRECTION)
+    direction: Direction = 'vertical';
 
     private seriesItemTypes: Set<AgWaterfallSeriesItemType> = new Set(['positive', 'negative', 'total']);
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9301
https://ag-grid.atlassian.net/browse/AG-9323

Basic implementation of target line and color ranges for bullet charts

### Horizontal
![Screenshot 2023-11-06 at 16 06 12](https://github.com/ag-grid/ag-charts/assets/23700103/ab8cd206-8297-4eb8-bd8f-195b6994261b)

### Vertical
![Screenshot 2023-11-06 at 16 06 49](https://github.com/ag-grid/ag-charts/assets/23700103/b4b9d88d-088b-4677-96c2-96d95ba6e8c6)

Test program:
```typescript
const options = {
    container: document.getElementById('myChart'),
    data: [ {incomeKey: "income", income: 10, objective: 7} ],
    series: [
        {
            type: 'bullet',
            valueKey: 'income',
            valueName: 'Actual income',
            targetKey: 'objective',
            targetName: 'Target income',
            //direction: 'horizontal',
        }
    ],
};

agChartsEnterprise.AgEnterpriseCharts.create(options);
```
