### PR TITLE
AG-9017 Error Bars Options Feedback

### DIFF
--- a/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
@@ -3,6 +3,16 @@ import type { LineDashOptions, StrokeOptions } from '../series/cartesian/commonO
 import type { AgChartCallbackParams } from './callbackOptions';
 import type { PixelSize, Ratio } from './types';
 
+export interface AgErrorBarFormatterParams
+    extends Omit<AgChartCallbackParams<any>, 'itemId'>,
+        SeriesKeyOptions,
+        SeriesNameOptions,
+        ErrorBarKeyOptions,
+        ErrorBarNameOptions {}
+
+export type AgErrorBarFormatter = (params: AgErrorBarFormatterParams) => AgErrorBarOptions | undefined;
+export type AgErrorBarCapFormatter = (params: AgErrorBarFormatterParams) => AgErrorBarOptions['cap'] | undefined;
+
 interface ErrorBarStylingOptions extends StrokeOptions, LineDashOptions {
     /** Whether to display the error bars. */
     visible?: boolean;
@@ -52,7 +62,10 @@ interface ErrorBarNameOptions {
     yUpperName?: string;
 }
 
-interface ErrorBarCapOptions extends ErrorBarCapLengthOptions, ErrorBarStylingOptions {}
+interface ErrorBarCapOptions extends ErrorBarCapLengthOptions, ErrorBarStylingOptions {
+    /** Function used to return formatting for individual caps, based on the given parameters. If the current error bar is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */
+    formatter?: AgErrorBarCapFormatter;
+}
 
 export interface AgErrorBarThemeableOptions extends ErrorBarStylingOptions {
     /** Options to style error bars' caps */
@@ -61,17 +74,13 @@ export interface AgErrorBarThemeableOptions extends ErrorBarStylingOptions {
 
 export const AgErrorBarSupportedSeriesTypes = ['bar', 'line', 'scatter'] as const;
 
-export interface AgErrorBarOptions extends ErrorBarKeyOptions, ErrorBarNameOptions, AgErrorBarThemeableOptions {}
+export interface AgErrorBarOptions extends ErrorBarKeyOptions, ErrorBarNameOptions, AgErrorBarThemeableOptions {
+    /** Function used to return formatting for individual error bars, based on the given parameters. If the current error bar is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */
+    formattter?: AgErrorBarFormatter;
+}
 
 export interface AgErrorBarTooltipParams
     // Note: AgCartesianSeriesTooltipRendererParams includes SeriesKeyOptions & SeriesNameOptions
     extends AgCartesianSeriesTooltipRendererParams<any>,
-        ErrorBarKeyOptions,
-        ErrorBarNameOptions {}
-
-export interface AgErrorBarFormatterParams
-    extends Omit<AgChartCallbackParams<any>, 'itemId'>,
-        SeriesKeyOptions,
-        SeriesNameOptions,
         ErrorBarKeyOptions,
         ErrorBarNameOptions {}

--- a/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
@@ -8,7 +8,9 @@ export interface AgErrorBarFormatterParams
         SeriesKeyOptions,
         SeriesNameOptions,
         ErrorBarKeyOptions,
-        ErrorBarNameOptions {}
+        ErrorBarNameOptions {
+    readonly highlighted: boolean;
+}
 
 export type AgErrorBarFormatter = (params: AgErrorBarFormatterParams) => AgErrorBarOptions | undefined;
 export type AgErrorBarCapFormatter = (params: AgErrorBarFormatterParams) => AgErrorBarOptions['cap'] | undefined;

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.test.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
-import type { AgChartInstance, AgScatterSeriesTooltipRendererParams } from 'ag-charts-community';
+import type {
+    AgChartInstance,
+    AgErrorBarCapFormatter,
+    AgErrorBarFormatter,
+    AgScatterSeriesTooltipRendererParams,
+} from 'ag-charts-community';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
     clickAction,
@@ -14,7 +19,6 @@ import {
 
 import { AgEnterpriseCharts } from '../../main';
 import { prepareEnterpriseTestOptions } from '../../test/utils';
-import type { ErrorBarCapFormatter, ErrorBarFormatter } from './errorBarNode';
 
 expect.extend({ toMatchImageSnapshot });
 
@@ -627,7 +631,7 @@ describe('ErrorBars', () => {
     });
 
     it('should apply formatter as expected', async () => {
-        const whisker_formatter: ErrorBarFormatter = (params) => {
+        const whisker_formatter: AgErrorBarFormatter = (params) => {
             let color = undefined;
             switch (params.datum[params.xKey]) {
                 case 'Jan':
@@ -652,7 +656,7 @@ describe('ErrorBars', () => {
             }
             return { stroke: color };
         };
-        const cap_formatter: ErrorBarCapFormatter = (params) => {
+        const cap_formatter: AgErrorBarCapFormatter = (params) => {
             switch (params.datum[params.xKey]) {
                 case 'Jan':
                 case 'Feb':

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.test.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.test.ts
@@ -5,6 +5,7 @@ import type {
     AgChartInstance,
     AgErrorBarCapFormatter,
     AgErrorBarFormatter,
+    AgErrorBarFormatterParams,
     AgScatterSeriesTooltipRendererParams,
 } from 'ag-charts-community';
 import {
@@ -687,6 +688,57 @@ describe('ErrorBars', () => {
             ],
         });
         await compare();
+    });
+
+    it('should set formatter highlighted param as expected', async () => {
+        const whiskerResult: boolean[] = [];
+        const capResult: boolean[] = [];
+        chart = deproxy(
+            AgEnterpriseCharts.create({
+                ...opts,
+                series: [
+                    {
+                        ...SERIES_CANADA,
+                        errorBar: {
+                            ...SERIES_CANADA.errorBar,
+                            formatter: (param: AgErrorBarFormatterParams) => {
+                                whiskerResult.push(param.highlighted);
+                                return {};
+                            },
+                            cap: {
+                                formatter: (param: AgErrorBarFormatterParams) => {
+                                    capResult.push(param.highlighted);
+                                    return {};
+                                },
+                            },
+                        },
+                    },
+                ],
+            })
+        );
+
+        // Check formatter initialisation
+        await waitForChartStability(chart);
+        const allfalse = [false, false, false, false, false, false, false, false, false, false, false, false];
+        expect(whiskerResult).toStrictEqual(allfalse);
+        expect(capResult).toStrictEqual(allfalse);
+        whiskerResult.length = 0;
+        capResult.length = 0;
+
+        // Hover over an error bar
+        const { x, y } = getItemCoords(4);
+        await hoverAction(x, y - 20)(chart);
+        await waitForChartStability(chart);
+        expect(whiskerResult).toStrictEqual([true]);
+        expect(capResult).toStrictEqual([true]);
+        whiskerResult.length = 0;
+        capResult.length = 0;
+
+        // Hover over nothing
+        await hoverAction(0, 0)(chart);
+        await waitForChartStability(chart);
+        expect(whiskerResult).toStrictEqual([false]);
+        expect(capResult).toStrictEqual([false]);
     });
 
     it('should use correct cursor', async () => {

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -295,7 +295,7 @@ export class ErrorBars
     private updateNode(node: ErrorBarNode, datum: ErrorBarNodeDatum, _index: number) {
         const style = this.getDefaultStyle();
         node.datum = datum;
-        node.update(style, this);
+        node.update(style, this, false);
         node.updateBBoxes();
     }
 
@@ -359,7 +359,11 @@ export class ErrorBars
         return this.makeStyle(this.cartesianSeries.highlightStyle.item);
     }
 
-    private restyleHightlightChange(highlightChange: HighlightNodeDatum, style: AgErrorBarThemeableOptions) {
+    private restyleHightlightChange(
+        highlightChange: HighlightNodeDatum,
+        style: AgErrorBarThemeableOptions,
+        highlighted: boolean
+    ) {
         // Search for the ErrorBarNode that matches this highlight change. This
         // isn't a good solution in terms of performance. However, it's assumed
         // that the typical use case for error bars includes few data points
@@ -368,7 +372,7 @@ export class ErrorBars
         const { nodeData } = this.cartesianSeries.contextNodeData[0];
         for (let i = 0; i < nodeData.length; i++) {
             if (highlightChange === nodeData[i]) {
-                this.selection.nodes()[i].update(style, this);
+                this.selection.nodes()[i].update(style, this, highlighted);
                 break;
             }
         }
@@ -380,12 +384,12 @@ export class ErrorBars
 
         if (currentHighlight?.series === thisSeries) {
             // Highlight this node:
-            this.restyleHightlightChange(currentHighlight, this.getHighlightStyle());
+            this.restyleHightlightChange(currentHighlight, this.getHighlightStyle(), true);
         }
 
         if (previousHighlight?.series === thisSeries) {
             // Unhighlight this node:
-            this.restyleHightlightChange(previousHighlight, this.getDefaultStyle());
+            this.restyleHightlightChange(previousHighlight, this.getDefaultStyle(), false);
         }
 
         this.groupNode.opacity = this.cartesianSeries.getOpacity();

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -63,7 +63,7 @@ class ErrorBarCap implements NonNullable<AgErrorBarOptions['cap']> {
     @Validate(OPT_COLOR_STRING)
     stroke?: string = undefined;
 
-    @Validate(OPT_NUMBER(1))
+    @Validate(OPT_NUMBER(0))
     strokeWidth?: number = undefined;
 
     @Validate(OPT_NUMBER(0, 1))

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -1,12 +1,13 @@
-import type { AgErrorBarOptions, AgErrorBarThemeableOptions, _Scale } from 'ag-charts-community';
+import type {
+    AgErrorBarCapFormatter,
+    AgErrorBarFormatter,
+    AgErrorBarOptions,
+    AgErrorBarThemeableOptions,
+    _Scale,
+} from 'ag-charts-community';
 import { AgErrorBarSupportedSeriesTypes, _ModuleSupport, _Scene } from 'ag-charts-community';
 
-import type {
-    ErrorBarCapFormatter,
-    ErrorBarFormatter,
-    ErrorBarNodeDatum,
-    ErrorBarStylingOptions,
-} from './errorBarNode';
+import type { ErrorBarNodeDatum, ErrorBarStylingOptions } from './errorBarNode';
 import { ErrorBarGroup, ErrorBarNode } from './errorBarNode';
 
 const {
@@ -81,7 +82,7 @@ class ErrorBarCap implements NonNullable<AgErrorBarOptions['cap']> {
     lengthRatio?: number = undefined;
 
     @Validate(OPT_FUNCTION)
-    formatter?: ErrorBarCapFormatter = undefined;
+    formatter?: AgErrorBarCapFormatter = undefined;
 }
 
 export class ErrorBars
@@ -131,7 +132,7 @@ export class ErrorBars
     lineDashOffset?: number;
 
     @Validate(OPT_FUNCTION)
-    formatter?: ErrorBarFormatter = undefined;
+    formatter?: AgErrorBarFormatter = undefined;
 
     cap: ErrorBarCap = new ErrorBarCap();
 

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -94,7 +94,7 @@ export class ErrorBarNode extends _Scene.Group {
         return Math.min(desiredLength, lengthMax);
     }
 
-    private getFormatterParams(formatters: Formatters): AgErrorBarFormatterParams | undefined {
+    private getFormatterParams(formatters: Formatters, highlighted: boolean): AgErrorBarFormatterParams | undefined {
         const { datum } = this;
         if (datum === undefined || (formatters.formatter === undefined && formatters.cap.formatter === undefined)) {
             return undefined;
@@ -114,13 +114,14 @@ export class ErrorBarNode extends _Scene.Group {
             yLowerName,
             yUpperKey,
             yUpperName,
+            highlighted,
         };
     }
 
-    private formatStyles(style: AgErrorBarThemeableOptions, formatters: Formatters) {
+    private formatStyles(style: AgErrorBarThemeableOptions, formatters: Formatters, highlighted: boolean) {
         let { cap: capsStyle, ...whiskerStyle } = style;
 
-        const params = this.getFormatterParams(formatters);
+        const params = this.getFormatterParams(formatters, highlighted);
         if (params !== undefined) {
             if (formatters.formatter !== undefined) {
                 const result = formatters.formatter(params);
@@ -148,13 +149,13 @@ export class ErrorBarNode extends _Scene.Group {
         );
     }
 
-    update(style: AgErrorBarThemeableOptions, formatters: Formatters) {
+    update(style: AgErrorBarThemeableOptions, formatters: Formatters, highlighted: boolean) {
         // Note: The method always uses the RedrawType.MAJOR mode for simplicity.
         // This could be optimised to reduce a amount of unnecessary redraws.
         if (this.datum === undefined) {
             return;
         }
-        const { whiskerStyle, capsStyle } = this.formatStyles(style, formatters);
+        const { whiskerStyle, capsStyle } = this.formatStyles(style, formatters, highlighted);
 
         const { xBar, yBar, capDefaults } = this.datum;
 

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -1,4 +1,10 @@
-import type { AgErrorBarFormatterParams, AgErrorBarOptions, AgErrorBarThemeableOptions } from 'ag-charts-community';
+import type {
+    AgErrorBarCapFormatter,
+    AgErrorBarFormatter,
+    AgErrorBarFormatterParams,
+    AgErrorBarOptions,
+    AgErrorBarThemeableOptions,
+} from 'ag-charts-community';
 import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
 const { partialAssign, mergeDefaults } = _ModuleSupport;
@@ -8,26 +14,17 @@ type Point = _Scene.Point;
 type NearestResult<T> = _Scene.NearestResult<T>;
 
 export type ErrorBarNodeDatum = _ModuleSupport.CartesianSeriesNodeDatum & _ModuleSupport.ErrorBoundSeriesNodeDatum;
-
-interface ErrorBarPoint {
-    readonly lowerPoint: _Scene.Point;
-    readonly upperPoint: _Scene.Point;
-}
-
-export interface ErrorBarPoints {
-    readonly xBar?: ErrorBarPoint;
-    readonly yBar?: ErrorBarPoint;
-}
-
 export type ErrorBarStylingOptions = Omit<AgErrorBarThemeableOptions, 'cap'>;
-export type ErrorBarFormatter = (params: AgErrorBarFormatterParams) => AgErrorBarOptions | undefined;
-export type ErrorBarCapFormatter = (params: AgErrorBarFormatterParams) => AgErrorBarOptions['cap'] | undefined;
-export type ErrorBarDataOptions = Pick<
+
+type ErrorBarDataOptions = Pick<
     AgErrorBarOptions,
     'xLowerKey' | 'xLowerName' | 'xUpperKey' | 'xUpperName' | 'yLowerKey' | 'yLowerName' | 'yUpperKey' | 'yUpperName'
 >;
 
-type Formatters = { formatter?: ErrorBarFormatter; cap: { formatter?: ErrorBarCapFormatter } } & ErrorBarDataOptions;
+type Formatters = {
+    formatter?: AgErrorBarFormatter;
+    cap: { formatter?: AgErrorBarCapFormatter };
+} & ErrorBarDataOptions;
 
 type CapDefaults = NonNullable<ErrorBarNodeDatum['capDefaults']>;
 type CapOptions = NonNullable<AgErrorBarThemeableOptions['cap']>;

--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/main.ts
@@ -1,5 +1,21 @@
-import { AgChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgEnterpriseCharts, AgErrorBarFormatterParams } from 'ag-charts-enterprise';
 import { getData } from './data';
+
+const highlightStyle = {
+    item: {stroke: 'red' },
+    series: { dimOpacity: 0.3 },
+}
+
+const formatter = (param: AgErrorBarFormatterParams) => {
+    const errorBarStyle = { strokeWidth: 3 }
+    if (param.highlighted) {
+        return {...errorBarStyle, ...highlightStyle.item}
+    }
+    else {
+        return errorBarStyle
+    }
+
+}
 
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
@@ -15,7 +31,9 @@ const options: AgChartOptions = {
             errorBar:  {
                 yLowerKey: 'temperatureLower',
                 yUpperKey: 'temperatureUpper',
+                formatter,
             },
+            highlightStyle,
         },
         {
             data: getData2(),
@@ -25,7 +43,9 @@ const options: AgChartOptions = {
             errorBar:  {
                 yLowerKey: 'temperatureLower',
                 yUpperKey: 'temperatureUpper',
+                formatter,
             },
+            highlightStyle,
         },
     ],
 };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9017

- Add formatters to API Reference
- Add `highlighted: boolean` formatter parameter
- Allow `errorBars.cap.strokeWidth` to be set to 0.