### PR TITLE
AG-9744 - Fix pathUtil rendering of missing points on their return.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
@@ -139,7 +139,7 @@ export function renderPartialPath(pairData: PathPoint[], ratios: Partial<Record<
             linePath.lineTo(midPointX, midPointY);
             linePath.moveTo(x, y);
         }
-        previousTo = to;
+        previousTo = { x, y };
     }
 }
 


### PR DESCRIPTION
Fixes animation of line-series data with missing Y values which become a number value.