### PR TITLE
AG-9749 - Fix BarSeries(-like) rapid legend toggles.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -342,12 +342,13 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
         const yRawIndex = dataModel.resolveProcessedDataIndexById(this, `yValue-raw`).index;
         const yStartIndex = dataModel.resolveProcessedDataIndexById(this, `yValue-start`).index;
         const yEndIndex = dataModel.resolveProcessedDataIndexById(this, `yValue-end`).index;
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const context: CartesianSeriesNodeDataContext<BarNodeDatum> = {
             itemId: yKey,
             nodeData: [],
             labelData: [],
             scales: super.calculateScaling(),
-            visible: this.visible,
+            visible: this.visible || animationEnabled,
         };
         processedData?.data.forEach(({ keys, datum: seriesDatum, values }) => {
             const xValue = keys[xIndex];
@@ -628,12 +629,16 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
             collapsedStartingBarPosition(this.direction === 'vertical', this.axes)
         );
 
-        fromToMotion(this.id, 'empty-update-ready', this.ctx.animationManager, datumSelections, fns);
+        fromToMotion(this.id, 'nodes', this.ctx.animationManager, datumSelections, fns);
         seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);
         seriesLabelFadeInAnimation(this, 'annotations', this.ctx.animationManager, annotationSelections);
     }
 
-    override animateWaitingUpdateReady({ datumSelections, labelSelections, annotationSelections }: BarAnimationData) {
+    override animateWaitingUpdateReady(data: BarAnimationData) {
+        const { datumSelections, labelSelections, annotationSelections } = data;
+
+        this.ctx.animationManager.stopByAnimationGroupId(this.id);
+
         const diff = this.processedData?.reduced?.diff;
         const fns = prepareBarAnimationFunctions(
             collapsedStartingBarPosition(this.direction === 'vertical', this.axes)
@@ -641,7 +646,7 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
 
         fromToMotion(
             this.id,
-            'waiting-update-ready',
+            'nodes',
             this.ctx.animationManager,
             datumSelections,
             fns,

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1466,6 +1466,8 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
         const { animationManager } = this.ctx;
         const diff = processedData?.reduced?.diff;
 
+        this.ctx.animationManager.stopByAnimationGroupId(this.id);
+
         const fns = preparePieSeriesAnimationFunctions(this.rotation);
         fromToMotion(
             this.id,

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -130,6 +130,9 @@ export abstract class PolarSeries<TDatum extends SeriesNodeDatum, TNode extends 
 
     protected resetAllAnimation() {
         const { item, label } = this.animationResetFns ?? {};
+
+        this.ctx.animationManager.stopByAnimationGroupId(this.id);
+
         if (item) {
             resetMotion([this.itemSelection, this.highlightSelection], item);
         }

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -459,6 +459,8 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDat
         } = this;
         const diff = processedData?.reduced?.diff;
 
+        this.ctx.animationManager.stopByAnimationGroupId(this.id);
+
         const fns = prepareRadialBarSeriesAnimationFunctions(this.axes);
         motion.fromToMotion(
             this.id,

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -493,6 +493,8 @@ export abstract class RadialColumnSeriesBase<
         const { animationManager } = this.ctx;
         const diff = processedData?.reduced?.diff;
 
+        this.ctx.animationManager.stopByAnimationGroupId(this.id);
+
         const fns = this.getColumnTransitionFunctions();
         motion.fromToMotion(
             this.id,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -696,6 +696,8 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
         const { processedData } = this;
         const diff = processedData?.reduced?.diff;
 
+        this.ctx.animationManager.stopByAnimationGroupId(this.id);
+
         const fns = prepareBarAnimationFunctions(midpointStartingBarPosition(this.direction === 'vertical'));
         motion.fromToMotion(
             this.id,


### PR DESCRIPTION
Since the animation for `BarSeries` and similar series somewhat rely on the scene-graph state being in a consistent state when calculating `from` and `to` properties, we need to actively finish any running animations before calculating new animations.

I've added explicit `AnimationManager.stopByAnimationGroupId(this.id)` calls in strategic places to ensure the affected series types all achieve scene-graph node consistency prior to new animation calculations.