### PR TITLE
AG-8492 Add prettier formatting middleware and on generated contents.json

### DIFF
--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/index.html
@@ -1,4 +1,3 @@
-<!-- TODO: style buttons using CSS -->
 <div style="display: flex; flex-direction: column; height: 100%">
     <div>
         <button onclick="scatter()">Scatter</button>

--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/index.html
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/index.html
@@ -1,4 +1,3 @@
-<!-- TODO: style buttons using CSS -->
 <div style="display: flex; flex-direction: column; height: 100%">
     <div>
         <button onclick="line()">Line</button>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="addValue()">Add New Data</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="addValue()">Add New Data</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="removeValue()">Remove Data</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="removeValue()">Remove Data</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="shuffleValues()">Shuffle Data</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="shuffleValues()">Shuffle Data</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="updateValues()">Update Low and High</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="updateValues()">Update Low and High</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/index.html
@@ -1,3 +1,5 @@
-<button onclick="startUpdates()">Start</button>
-<button onclick="stopUpdates()">Stop</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="startUpdates()">Start</button>
+    <button onclick="stopUpdates()">Stop</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="addValue()">Add New Data</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="addValue()">Add New Data</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="removeValue()">Remove Data</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="removeValue()">Remove Data</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="shuffleValues()">Shuffle Data</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="shuffleValues()">Shuffle Data</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/index.html
@@ -1,2 +1,4 @@
-<button onclick="updateValues()">Update Low and High</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="updateValues()">Update Low and High</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/index.html
@@ -1,3 +1,5 @@
-<button onclick="startUpdates()">Start</button>
-<button onclick="stopUpdates()">Stop</button>
-<div id="myChart" style="height: 100%"></div>
+<div>
+    <button onclick="startUpdates()">Start</button>
+    <button onclick="stopUpdates()">Stop</button>
+    <div id="myChart" style="height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/middleware/index.ts
+++ b/packages/ag-charts-website/src/middleware/index.ts
@@ -1,0 +1,41 @@
+import { defineMiddleware } from 'astro/middleware';
+
+import { format } from '../utils/format';
+
+// We only need to format `.html` files in middleware. The example `index.html` files are fetched in
+// the example runner components since the generated content only includes the example fragment
+// and not the wrapping framework.
+const extensionsToFormat = ['html'];
+
+export const onRequest = defineMiddleware(async (context, next) => {
+    const response = await next();
+
+    if (response.text === undefined) {
+        return wrapResponse(response);
+    }
+
+    const isExample = context.url.pathname.includes('/examples/');
+
+    if (!isExample) {
+        return wrapResponse(response);
+    }
+
+    let body = await response.text();
+
+    try {
+        body = await format(context.url.pathname, body, extensionsToFormat);
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(`Failed to format [${context.url.pathname}] with the error "${(e as Error).message}"`);
+    }
+
+    return new Response(body, {
+        status: 200,
+        headers: response.headers,
+    });
+});
+
+function wrapResponse(response: Response) {
+    // If the response is returned directly, Astro complains with a `MiddlewareNotAResponse` error.
+    return new Response(response.body, { status: response.status, headers: response.headers });
+}

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/contents.json.ts
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/contents.json.ts
@@ -1,13 +1,10 @@
 import type { InternalFramework } from '@ag-grid-types';
 import { getGeneratedDocsContents } from '@features/docs/utils/examplesGenerator';
 import { getDocsExamplePages } from '@features/docs/utils/pageData';
+import type { APIContext } from 'astro';
 import { getCollection } from 'astro:content';
 
-interface Params {
-    internalFramework: InternalFramework;
-    pageName: string;
-    exampleName: string;
-}
+import { format } from '../../../../../utils/format';
 
 export async function getStaticPaths() {
     const pages = await getCollection('docs');
@@ -17,19 +14,24 @@ export async function getStaticPaths() {
     return examples;
 }
 
-export async function get({ params }: { params: Params }) {
-    const { internalFramework, pageName, exampleName } = params;
+export async function get(context: APIContext) {
+    const { internalFramework, pageName, exampleName } = context.params;
 
-    const generatedContents =
-        (await getGeneratedDocsContents({
-            internalFramework,
-            pageName,
-            exampleName,
-        })) || {};
-    const response = generatedContents;
-    const body = JSON.stringify(response);
+    const generatedContents = await getGeneratedDocsContents({
+        internalFramework: internalFramework as InternalFramework,
+        pageName: pageName!,
+        exampleName: exampleName!,
+    });
 
-    return {
-        body,
-    };
+    const files: Record<string, string> = {};
+    for (const [fileName, fileText] of Object.entries(generatedContents?.files ?? {})) {
+        files[fileName] = await format(fileName, fileText);
+    }
+
+    return new Response(JSON.stringify({ ...generatedContents, files }), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
 }

--- a/packages/ag-charts-website/src/utils/format.ts
+++ b/packages/ag-charts-website/src/utils/format.ts
@@ -1,0 +1,55 @@
+import * as prettier from 'prettier';
+
+/**
+ * Format a block of text by the inferred file type.
+ * @param fileName Name of the file, including the extension.
+ * @param text Text to format.
+ * @param extensionsToFormat optional Only format the text if its extension is in this array.
+ * @returns Promise<string>
+ */
+export function format(fileName: string, text: string, extensionsToFormat?: Array<string>) {
+    const parts = fileName.split('.');
+    const maybeExtension = parts[parts.length - 1];
+
+    let extension: PrettierExtension = 'html';
+    if (Object.keys(prettierParsers).includes(maybeExtension)) {
+        extension = maybeExtension as PrettierExtension;
+    }
+
+    if (extensionsToFormat && !extensionsToFormat.includes(extension)) {
+        return text;
+    }
+
+    return prettier.format(text, {
+        parser: prettierParsers[extension],
+        ...prettierConfig,
+        ...(extension === 'jsx' || extension === 'tsx' ? prettierConfigJsx : {}),
+    });
+}
+
+type PrettierExtension = 'html' | 'json' | 'js' | 'jsx' | 'ts' | 'tsx';
+
+const prettierParsers: { [T in PrettierExtension]: string } = {
+    html: 'html',
+    js: 'babel',
+    ts: 'typescript',
+    jsx: 'babel',
+    tsx: 'babel-ts',
+    json: 'json',
+};
+
+// A trimmed copy of `.prettierrc`
+const prettierConfig = {
+    tabWidth: 4,
+    printWidth: 120,
+    singleQuote: true,
+    importOrder: ['^ag-charts-(.*)$', '^[./]'],
+    importOrderParserPlugins: ['typescript', 'decorators-legacy'],
+    importOrderSeparation: true,
+    importOrderSortSpecifiers: true,
+    plugins: ['@trivago/prettier-plugin-sort-imports'],
+};
+
+const prettierConfigJsx = {
+    importOrderParserPlugins: ['typescript', 'decorators-legacy', 'jsx'],
+};

--- a/packages/ag-charts-website/src/utils/format.ts
+++ b/packages/ag-charts-website/src/utils/format.ts
@@ -29,15 +29,16 @@ export async function format(fileName: string, text: string, extensionsToFormat?
     });
 }
 
-type PrettierExtension = 'html' | 'json' | 'js' | 'jsx' | 'ts' | 'tsx';
+type PrettierExtension = 'html' | 'json' | 'css' | 'js' | 'jsx' | 'ts' | 'tsx';
 
 const prettierParsers: { [T in PrettierExtension]: string } = {
     html: 'html',
+    json: 'json',
+    css: 'css',
     js: 'babel',
     ts: 'typescript',
     jsx: 'babel',
     tsx: 'babel-ts',
-    json: 'json',
 };
 
 async function getPrettierConfig(extension: PrettierExtension) {

--- a/packages/ag-charts-website/src/utils/fs.ts
+++ b/packages/ag-charts-website/src/utils/fs.ts
@@ -7,22 +7,22 @@ import { pathJoin } from './pathJoin';
  * Get folders on a root path (1 level deep)
  */
 export const getFolders = async (rootPath: string) => {
-    const folders: string[] = [];
     const exists = fsOriginal.existsSync(rootPath);
-    if (exists) {
-        const files = await fs.readdir(rootPath);
-        await Promise.all(
-            files.map(async (name) => {
-                const filePath = pathJoin(rootPath, name);
-                const isDirectory = (await fs.stat(filePath)).isDirectory();
-                if (isDirectory) {
-                    folders.push(name);
-                }
-            })
-        );
-    }
+    if (!exists) return [];
 
-    return folders;
+    const files = await fs.readdir(rootPath);
+    const directories = files.map(async (name) => {
+        const dirPath = pathJoin(rootPath, name);
+        const isDirectory = (await fs.stat(dirPath)).isDirectory();
+        if (!isDirectory) return undefined;
+
+        const dirContents = await fs.readdir(dirPath);
+        if (dirContents.length === 0) return undefined;
+
+        return name;
+    });
+
+    return (await Promise.all(directories)).filter((d) => d != null);
 };
 
 export async function getFilesRecursively(dir: string, allFiles: string[] = []) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8492

This method works on both dev server and build.

It does not format the generated ts/js files, instead it formats the text in the `contents.json` files. Since that is what is actually displayed in the code blocks.

Then there is a middleware to catch the `index.html` files which work slightly differently due to astro templates.

Trying to push it all through the middleware did not work as you can not call `fetch()` to the localhost in the astro build process. It gives an `ECONNREFUSED` error.