### PR TITLE
AG-5670 Bullet themes and defaults

### DIFF
--- a/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
@@ -1,15 +1,14 @@
 import { hasRegisteredEnterpriseModules } from '../../module-support';
-import type { SeriesConstructor, SeriesOptions, SeriesPaletteFactory } from '../../module/coreModules';
+import type { SeriesConstructor, SeriesPaletteFactory } from '../../module/coreModules';
 import type { ModuleContext } from '../../module/moduleContext';
-import type { AgChartOptions } from '../../options/agChartOptions';
+import type { AgCartesianChartOptions, AgChartOptions } from '../../options/agChartOptions';
 import { jsonMerge } from '../../sparklines-util';
 import type { SeriesOptionsTypes } from '../mapping/types';
 import type { Series } from '../series/series';
 import type { ChartType } from './chartTypes';
 import { registerChartSeriesType } from './chartTypes';
 
-type SeriesOptionsUnion = SeriesOptions<NonNullable<SeriesOptionsTypes['type']>>;
-type SwapperFunction = (opts: unknown) => SeriesOptionsUnion;
+type SwapperFunction = (opts: AgCartesianChartOptions) => AgCartesianChartOptions;
 
 const SERIES_FACTORIES: Record<string, SeriesConstructor> = {};
 const SERIES_DEFAULTS: Record<string, any> = {};
@@ -34,7 +33,7 @@ export function registerSeries(
     groupable: boolean | undefined,
     stackedByDefault: boolean | undefined,
     swapDefaultAxesCondition: ((opts: any) => boolean) | undefined,
-    customDefaultAxesSwapper: ((opts: any) => SeriesOptionsUnion) | undefined
+    customDefaultAxesSwapper: SwapperFunction | undefined
 ) {
     SERIES_FACTORIES[seriesType] = cstr;
     SERIES_DEFAULTS[seriesType] = defaults;

--- a/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
@@ -1,14 +1,14 @@
 import { hasRegisteredEnterpriseModules } from '../../module-support';
 import type { SeriesConstructor, SeriesPaletteFactory } from '../../module/coreModules';
 import type { ModuleContext } from '../../module/moduleContext';
-import type { AgCartesianChartOptions, AgChartOptions } from '../../options/agChartOptions';
+import type { AgChartOptions } from '../../options/agChartOptions';
 import { jsonMerge } from '../../sparklines-util';
 import type { SeriesOptionsTypes } from '../mapping/types';
 import type { Series } from '../series/series';
 import type { ChartType } from './chartTypes';
 import { registerChartSeriesType } from './chartTypes';
 
-type SwapperFunction = (opts: AgCartesianChartOptions) => AgCartesianChartOptions;
+type DefaultsFunction = (opts: unknown) => AgChartOptions;
 
 const SERIES_FACTORIES: Record<string, SeriesConstructor> = {};
 const SERIES_DEFAULTS: Record<string, any> = {};
@@ -19,7 +19,7 @@ const STACKABLE_SERIES_TYPES = new Set<SeriesOptionsTypes['type']>();
 const GROUPABLE_SERIES_TYPES = new Set<SeriesOptionsTypes['type']>();
 const STACKED_BY_DEFAULT_SERIES_TYPES = new Set<string>();
 const SWAP_DEFAULT_AXES_CONDITIONS: Record<string, (opts: unknown) => boolean> = {};
-const CUSTOM_DEFAULT_AXES_SWAPPERS: Record<string, SwapperFunction> = {};
+const CUSTOM_DEFAULTS_FUNCTIONS: Record<string, DefaultsFunction> = {};
 
 export function registerSeries(
     seriesType: NonNullable<SeriesOptionsTypes['type']>,
@@ -33,7 +33,7 @@ export function registerSeries(
     groupable: boolean | undefined,
     stackedByDefault: boolean | undefined,
     swapDefaultAxesCondition: ((opts: any) => boolean) | undefined,
-    customDefaultAxesSwapper: SwapperFunction | undefined
+    customDefaultsFunction: ((opts: any) => AgChartOptions) | undefined
 ) {
     SERIES_FACTORIES[seriesType] = cstr;
     SERIES_DEFAULTS[seriesType] = defaults;
@@ -55,8 +55,8 @@ export function registerSeries(
     if (swapDefaultAxesCondition) {
         addSwapDefaultAxesCondition(seriesType, swapDefaultAxesCondition);
     }
-    if (customDefaultAxesSwapper) {
-        addCustomDefaultAxesSwapper(seriesType, customDefaultAxesSwapper);
+    if (customDefaultsFunction) {
+        addCustomDefaultsFunctions(seriesType, customDefaultsFunction);
     }
 
     registerChartSeriesType(seriesType, chartType);
@@ -132,8 +132,8 @@ export function addSwapDefaultAxesCondition(seriesType: string, predicate: (opts
     SWAP_DEFAULT_AXES_CONDITIONS[seriesType] = predicate;
 }
 
-export function addCustomDefaultAxesSwapper(seriesType: string, predicate: SwapperFunction) {
-    CUSTOM_DEFAULT_AXES_SWAPPERS[seriesType] = predicate;
+export function addCustomDefaultsFunctions(seriesType: string, predicate: DefaultsFunction) {
+    CUSTOM_DEFAULTS_FUNCTIONS[seriesType] = predicate;
 }
 
 export function isDefaultAxisSwapNeeded(opts: AgChartOptions) {
@@ -154,13 +154,16 @@ export function isDefaultAxisSwapNeeded(opts: AgChartOptions) {
     return result ?? false;
 }
 
-export function getDefaultAxisSwapper(opts: AgChartOptions): SwapperFunction | undefined {
-    let result: SwapperFunction | undefined;
+export function executeCustomDefaultsFunctions(opts: AgChartOptions, initialDefaults: {}): {} {
+    let result = initialDefaults;
 
     for (const series of opts.series ?? []) {
         const { type } = series;
 
-        result = type != null ? CUSTOM_DEFAULT_AXES_SWAPPERS[type] : undefined;
+        const fn = type != null ? CUSTOM_DEFAULTS_FUNCTIONS[type] : undefined;
+        if (fn !== undefined) {
+            result = { ...result, ...fn(series) };
+        }
     }
 
     return result;

--- a/packages/ag-charts-community/src/chart/factory/setupModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/setupModules.ts
@@ -43,7 +43,7 @@ export function setupModules() {
                 m.groupable,
                 m.stackedByDefault,
                 m.swapDefaultAxesCondition,
-                m.customDefaultAxesSwapper
+                m.customDefaultsFunction
             );
         }
 

--- a/packages/ag-charts-community/src/chart/mapping/prepare.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepare.ts
@@ -12,7 +12,7 @@ import type { DeepPartial } from '../../util/types';
 import { AXIS_TYPES } from '../factory/axisTypes';
 import { CHART_TYPES } from '../factory/chartTypes';
 import {
-    getDefaultAxisSwapper,
+    executeCustomDefaultsFunctions,
     getSeriesDefaults,
     getSeriesPaletteFactory,
     isDefaultAxisSwapNeeded,
@@ -86,9 +86,10 @@ export function prepareOptions<T extends AgChartOptions>(options: T): T {
 
     let defaultOverrides = getSeriesDefaults(type);
     if (isDefaultAxisSwapNeeded(options)) {
-        const swapper = getDefaultAxisSwapper(options) ?? swapAxes;
-        defaultOverrides = swapper(defaultOverrides);
+        defaultOverrides = swapAxes(defaultOverrides);
     }
+    defaultOverrides = executeCustomDefaultsFunctions(options, defaultOverrides);
+
     const conflictOverrides = resolveModuleConflicts(options);
 
     removeDisabledOptions<T>(options);

--- a/packages/ag-charts-community/src/module/coreModules.ts
+++ b/packages/ag-charts-community/src/module/coreModules.ts
@@ -1,12 +1,7 @@
 import type { ChartAxis } from '../chart/chartAxis';
 import type { ChartLegend, ChartLegendType } from '../chart/legendDatum';
 import type { Series } from '../chart/series/series';
-import type {
-    AgBaseChartThemeOverrides,
-    AgCartesianChartOptions,
-    AgChartOptions,
-    AgChartThemePalette,
-} from '../options/agChartOptions';
+import type { AgBaseChartThemeOverrides, AgChartOptions, AgChartThemePalette } from '../options/agChartOptions';
 import type { BaseModule, ModuleInstance } from './baseModule';
 import type { ModuleContext } from './moduleContext';
 
@@ -98,5 +93,5 @@ export interface SeriesModule<SeriesType extends RequiredSeriesType = RequiredSe
     groupable?: boolean;
     stackedByDefault?: boolean;
     swapDefaultAxesCondition?: (opts: SeriesOptions<SeriesType>) => boolean;
-    customDefaultAxesSwapper?: (opts: AgCartesianChartOptions) => AgCartesianChartOptions;
+    customDefaultsFunction?: (opts: SeriesOptions<SeriesType>) => AgChartOptions;
 }

--- a/packages/ag-charts-community/src/module/coreModules.ts
+++ b/packages/ag-charts-community/src/module/coreModules.ts
@@ -1,7 +1,12 @@
 import type { ChartAxis } from '../chart/chartAxis';
 import type { ChartLegend, ChartLegendType } from '../chart/legendDatum';
 import type { Series } from '../chart/series/series';
-import type { AgBaseChartThemeOverrides, AgChartOptions, AgChartThemePalette } from '../options/agChartOptions';
+import type {
+    AgBaseChartThemeOverrides,
+    AgCartesianChartOptions,
+    AgChartOptions,
+    AgChartThemePalette,
+} from '../options/agChartOptions';
 import type { BaseModule, ModuleInstance } from './baseModule';
 import type { ModuleContext } from './moduleContext';
 
@@ -93,5 +98,5 @@ export interface SeriesModule<SeriesType extends RequiredSeriesType = RequiredSe
     groupable?: boolean;
     stackedByDefault?: boolean;
     swapDefaultAxesCondition?: (opts: SeriesOptions<SeriesType>) => boolean;
-    customDefaultAxesSwapper?: (opts: SeriesOptions<SeriesType>) => SeriesOptions<SeriesType>;
+    customDefaultAxesSwapper?: (opts: AgCartesianChartOptions) => AgCartesianChartOptions;
 }

--- a/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
@@ -1,5 +1,6 @@
 import type { AgSeriesTooltip, AgSeriesTooltipRendererParams } from '../../chart/tooltipOptions';
 import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../seriesOptions';
+import type { AgBarSeriesStyle } from './barOptions';
 
 interface BulletSeriesKeysAndNames {
     /** The key to use to retrieve the gauge value from the data. */
@@ -16,7 +17,10 @@ export interface AgBulletSeriesTooltipRendererParams<TDatum = any>
     extends AgSeriesTooltipRendererParams<TDatum>,
         BulletSeriesKeysAndNames {}
 
-export interface AgBulletSeriesThemeableOptions extends AgBaseSeriesThemeableOptions {}
+export interface AgBulletSeriesThemeableOptions extends AgBarSeriesStyle, AgBaseSeriesThemeableOptions {
+    /** Styling options for the target node. */
+    target?: AgBarSeriesStyle;
+}
 
 export interface AgBulletColorRange {
     /** Color of this category. */

--- a/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
@@ -17,9 +17,16 @@ export interface AgBulletSeriesTooltipRendererParams<TDatum = any>
     extends AgSeriesTooltipRendererParams<TDatum>,
         BulletSeriesKeysAndNames {}
 
-export interface AgBulletSeriesThemeableOptions extends AgBarSeriesStyle, AgBaseSeriesThemeableOptions {
+export interface AgBulletSeriesStyle extends AgBarSeriesStyle {}
+
+export interface AgBulletScaleOptions {
+    /** Maximum value of the scale. Any values exceeding this number will be clipped to this maximum */
+    max?: number;
+}
+
+export interface AgBulletSeriesThemeableOptions extends AgBulletSeriesStyle, AgBaseSeriesThemeableOptions {
     /** Styling options for the target node. */
-    target?: AgBarSeriesStyle;
+    target?: AgBulletSeriesStyle;
 }
 
 export interface AgBulletColorRange {
@@ -29,7 +36,10 @@ export interface AgBulletColorRange {
     stop?: number;
 }
 
-export interface AgBulletSeriesOptions<TDatum = any> extends AgBaseSeriesOptions<TDatum>, BulletSeriesKeysAndNames {
+export interface AgBulletSeriesOptions<TDatum = any>
+    extends AgBaseSeriesOptions<TDatum>,
+        AgBulletSeriesThemeableOptions,
+        BulletSeriesKeysAndNames {
     /** Configuration for the Bullet series. */
     type: 'bullet';
     /** Bar rendering direction. NOTE: This option affects the layout direction of X and Y data values. */
@@ -38,4 +48,6 @@ export interface AgBulletSeriesOptions<TDatum = any> extends AgBaseSeriesOptions
     tooltip?: AgSeriesTooltip<AgBulletSeriesTooltipRendererParams>;
     /** Categoric ranges of the chart */
     colorRanges?: AgBulletColorRange[];
+    /** Scale options for the graph. */
+    scale?: AgBulletScaleOptions;
 }

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletDefaults.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletDefaults.ts
@@ -6,12 +6,13 @@ export const BULLET_DEFAULTS = {
     axes: [
         {
             type: CARTESIAN_AXIS_TYPES.NUMBER,
-            position: CARTESIAN_AXIS_POSITIONS.BOTTOM,
+            position: CARTESIAN_AXIS_POSITIONS.BOTTOM as 'bottom' | 'left',
             nice: false,
+            max: undefined as number | undefined,
         },
         {
             type: CARTESIAN_AXIS_TYPES.CATEGORY,
-            position: CARTESIAN_AXIS_POSITIONS.LEFT,
+            position: CARTESIAN_AXIS_POSITIONS.LEFT as 'left' | 'top',
         },
     ],
 };

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletDefaults.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletDefaults.ts
@@ -1,0 +1,17 @@
+import { _Theme } from 'ag-charts-community';
+
+const { CARTESIAN_AXIS_TYPES, CARTESIAN_AXIS_POSITIONS } = _Theme;
+
+export const BULLET_DEFAULTS = {
+    axes: [
+        {
+            type: CARTESIAN_AXIS_TYPES.NUMBER,
+            position: CARTESIAN_AXIS_POSITIONS.BOTTOM,
+            nice: false,
+        },
+        {
+            type: CARTESIAN_AXIS_TYPES.CATEGORY,
+            position: CARTESIAN_AXIS_POSITIONS.LEFT,
+        },
+    ],
+};

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
@@ -1,9 +1,11 @@
 import type { _ModuleSupport } from 'ag-charts-community';
 import { _Theme } from 'ag-charts-community';
 
+import { BULLET_DEFAULTS } from './bulletDefaults';
 import { BulletSeries } from './bulletSeries';
+import { BULLET_SERIES_THEME } from './bulletThemes';
 
-const { CARTESIAN_AXIS_TYPES, CARTESIAN_AXIS_POSITIONS } = _Theme;
+const { CARTESIAN_AXIS_POSITIONS } = _Theme;
 
 export const BulletModule: _ModuleSupport.SeriesModule<'bullet'> = {
     type: 'series',
@@ -12,18 +14,8 @@ export const BulletModule: _ModuleSupport.SeriesModule<'bullet'> = {
     chartTypes: ['cartesian'],
     identifier: 'bullet',
     instanceConstructor: BulletSeries,
-    seriesDefaults: {
-        axes: [
-            {
-                type: CARTESIAN_AXIS_TYPES.NUMBER,
-                position: CARTESIAN_AXIS_POSITIONS.BOTTOM,
-            },
-            {
-                type: CARTESIAN_AXIS_TYPES.CATEGORY,
-                position: CARTESIAN_AXIS_POSITIONS.LEFT,
-            },
-        ],
-    },
+    seriesDefaults: BULLET_DEFAULTS,
+    themeTemplate: BULLET_SERIES_THEME,
     swapDefaultAxesCondition: (opts) => opts?.direction !== 'horizontal',
     customDefaultAxesSwapper: (opts) => {
         const [axis0, axis1] = opts.axes ?? [];
@@ -35,5 +27,4 @@ export const BulletModule: _ModuleSupport.SeriesModule<'bullet'> = {
             ],
         };
     },
-    themeTemplate: {},
 };

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
@@ -26,17 +26,12 @@ export const BulletModule: _ModuleSupport.SeriesModule<'bullet'> = {
     },
     swapDefaultAxesCondition: (opts) => opts?.direction !== 'horizontal',
     customDefaultAxesSwapper: (opts) => {
+        const [axis0, axis1] = opts.axes ?? [];
         return {
             ...opts,
             axes: [
-                {
-                    type: CARTESIAN_AXIS_TYPES.CATEGORY,
-                    position: CARTESIAN_AXIS_POSITIONS.TOP,
-                },
-                {
-                    type: CARTESIAN_AXIS_TYPES.NUMBER,
-                    position: CARTESIAN_AXIS_POSITIONS.LEFT,
-                },
+                { ...axis0, position: CARTESIAN_AXIS_POSITIONS.LEFT },
+                { ...axis1, position: CARTESIAN_AXIS_POSITIONS.TOP },
             ],
         };
     },

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
@@ -16,15 +16,16 @@ export const BulletModule: _ModuleSupport.SeriesModule<'bullet'> = {
     instanceConstructor: BulletSeries,
     seriesDefaults: BULLET_DEFAULTS,
     themeTemplate: BULLET_SERIES_THEME,
-    swapDefaultAxesCondition: (opts) => opts?.direction !== 'horizontal',
-    customDefaultAxesSwapper: (opts) => {
-        const [axis0, axis1] = opts.axes ?? [];
-        return {
-            ...opts,
-            axes: [
-                { ...axis0, position: CARTESIAN_AXIS_POSITIONS.LEFT },
-                { ...axis1, position: CARTESIAN_AXIS_POSITIONS.TOP },
-            ],
-        };
+    customDefaultsFunction: (series) => {
+        const axis0 = { ...BULLET_DEFAULTS.axes[0] };
+        const axis1 = { ...BULLET_DEFAULTS.axes[1] };
+        if (series.direction !== 'horizontal') {
+            axis0.position = CARTESIAN_AXIS_POSITIONS.LEFT;
+            axis1.position = CARTESIAN_AXIS_POSITIONS.TOP;
+        }
+        if (series.scale?.max !== undefined) {
+            axis0.max = series.scale.max;
+        }
+        return { ...BULLET_DEFAULTS, axes: [axis0, axis1] };
     },
 };

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -173,7 +173,9 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<BulletNode, B
             props.push(valueProperty(this, targetKey, isContinuousY, { id: 'target' }));
         }
 
-        await this.requestDataModel<any, any, true>(dataController, data, {
+        // Bullet graphs only need 1 datum, but we keep that `data` option as array for consistency with other series
+        // types and future compatibility (we may decide to support multiple datums at some point).
+        await this.requestDataModel<any, any, true>(dataController, data.slice(0, 1), {
             props,
             groupByKeys: true,
             dataVisible: this.visible,

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -1,8 +1,19 @@
-import type { AgBulletSeriesTooltipRendererParams } from 'ag-charts-community';
+import type { AgBarSeriesStyle, AgBulletSeriesTooltipRendererParams } from 'ag-charts-community';
 import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 
-const { keyProperty, partialAssign, valueProperty, Validate, COLOR_STRING, STRING, OPT_ARRAY, OPT_NUMBER, OPT_STRING } =
-    _ModuleSupport;
+const {
+    keyProperty,
+    partialAssign,
+    valueProperty,
+    Validate,
+    COLOR_STRING,
+    STRING,
+    LINE_DASH,
+    NUMBER,
+    OPT_ARRAY,
+    OPT_NUMBER,
+    OPT_STRING,
+} = _ModuleSupport;
 const { sanitizeHtml } = _Util;
 
 interface BulletNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum {
@@ -34,6 +45,16 @@ interface NormalizedColorRange {
     stop: number;
 }
 
+const STYLING_KEYS: (keyof _Scene.Shape)[] = [
+    'fill',
+    'fillOpacity',
+    'stroke',
+    'strokeWidth',
+    'strokeOpacity',
+    'lineDash',
+    'lineDashOffset',
+];
+
 class BulletNode extends _Scene.Group {
     private valueRect: _Scene.Rect = new _Scene.Rect();
     private targetLine: _Scene.Line = new _Scene.Line();
@@ -44,18 +65,62 @@ class BulletNode extends _Scene.Group {
         this.append(this.targetLine);
     }
 
-    public update(datum: BulletNodeDatum) {
+    public update(datum: BulletNodeDatum, valueStyle: AgBarSeriesStyle, targetStyle: AgBarSeriesStyle) {
         partialAssign(['x', 'y', 'height', 'width'], this.valueRect, datum);
-        this.valueRect.visible = true;
+        partialAssign(STYLING_KEYS, this.valueRect, valueStyle);
 
         partialAssign(['x1', 'x2', 'y1', 'y2'], this.targetLine, datum.target);
-        this.targetLine.stroke = 'black';
-        this.targetLine.strokeWidth = 3;
-        this.targetLine.visible = datum.target !== undefined;
+        partialAssign(STYLING_KEYS, this.targetLine, targetStyle);
     }
 }
 
+class TargetStyle {
+    @Validate(COLOR_STRING)
+    fill: string = 'black';
+
+    @Validate(NUMBER(0, 1))
+    fillOpacity = 1;
+
+    @Validate(COLOR_STRING)
+    stroke: string = 'black';
+
+    @Validate(NUMBER(0))
+    strokeWidth = 1;
+
+    @Validate(NUMBER(0, 1))
+    strokeOpacity = 1;
+
+    @Validate(LINE_DASH)
+    lineDash: number[] = [0];
+
+    @Validate(NUMBER(0))
+    lineDashOffset: number = 0;
+}
+
 export class BulletSeries extends _ModuleSupport.AbstractBarSeries<BulletNode, BulletNodeDatum> {
+    @Validate(COLOR_STRING)
+    fill: string = 'black';
+
+    @Validate(NUMBER(0, 1))
+    fillOpacity = 1;
+
+    @Validate(COLOR_STRING)
+    stroke: string = 'black';
+
+    @Validate(NUMBER(0))
+    strokeWidth = 1;
+
+    @Validate(NUMBER(0, 1))
+    strokeOpacity = 1;
+
+    @Validate(LINE_DASH)
+    lineDash: number[] = [0];
+
+    @Validate(NUMBER(0))
+    lineDashOffset: number = 0;
+
+    target: TargetStyle = new TargetStyle();
+
     @Validate(STRING)
     valueKey: string = '';
 
@@ -270,7 +335,7 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<BulletNode, B
         isHighlight: boolean;
     }) {
         for (const { node, datum } of opts.datumSelection) {
-            node.update(datum);
+            node.update(datum, this, this.target);
         }
     }
 

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -99,7 +99,7 @@ class TargetStyle {
 
 class BulletScale {
     @Validate(OPT_NUMBER(0))
-    max?: number = undefined;
+    max?: number = undefined; // alias for AgChartOptions.axes[0].max
 }
 
 export class BulletSeries extends _ModuleSupport.AbstractBarSeries<BulletNode, BulletNodeDatum> {
@@ -190,25 +190,20 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<BulletNode, B
     }
 
     private getMaxValue(): number {
-        const { dataModel, processedData, targetKey, scale } = this;
-        if (scale.max !== undefined) {
-            return scale.max;
-        }
-        if (!dataModel || !processedData) {
-            return NaN;
-        }
-
-        const valueDomain = dataModel.getDomain(this, 'value', 'value', processedData);
-        const targetDomain = targetKey === undefined ? [] : dataModel.getDomain(this, 'target', 'value', processedData);
-
-        return Math.max(...valueDomain, ...targetDomain);
+        return Math.max(...(this.getValueAxis()?.dataDomain.domain ?? [0]));
     }
 
     override getSeriesDomain(direction: _ModuleSupport.ChartAxisDirection) {
+        const { dataModel, processedData, targetKey } = this;
+        if (!dataModel || !processedData) return [];
+
         if (direction === this.getCategoryDirection()) {
             return [this.valueName ?? this.valueKey];
         } else if (direction == this.getValueAxis()?.direction) {
-            return [0, this.getMaxValue()];
+            const valueDomain = dataModel.getDomain(this, 'value', 'value', processedData);
+            const targetDomain =
+                targetKey === undefined ? [] : dataModel.getDomain(this, 'target', 'value', processedData);
+            return [0, Math.max(...valueDomain, ...targetDomain)];
         } else {
             throw new Error(`unknown direction ${direction}`);
         }

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletThemes.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletThemes.ts
@@ -1,0 +1,14 @@
+import { _Theme } from 'ag-charts-community';
+
+export const BULLET_SERIES_THEME = {
+    stroke: 'black',
+    strokeWidth: 0,
+    strokeOpacity: 1,
+    fill: 'black',
+    fillOpacity: 1,
+    target: {
+        stroke: 'black',
+        strokeWidth: 3,
+        strokeOpacity: 1,
+    },
+};


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9301
https://ag-grid.atlassian.net/browse/AG-9321
https://ag-grid.atlassian.net/browse/AG-9323

- Fixes incorrect param&return types for `customDefaultAxesSwapper` https://github.com/ag-grid/ag-charts/blob/83422ce66b91c212454f6d89f25410fc8a25ff07/packages/ag-charts-community/src/module/coreModules.ts#L101
- Adds files _bulletDefaults.ts_ and _bulletThemes.ts_.
- Adds styling options to `BulletSeries`
- Adds `scale.max` property to `BulletSeries`. Clip the colour ranges to not exceed `scale.max`

Test file:
https://plnkr.co/edit/BqtSjxH0R7fgHi6g?open=main.js