### PR TITLE
AG-5670 Join duplicate bar-like series code into AbstractBarSeries

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
@@ -1,0 +1,44 @@
+import type { Direction } from '../../../options/chart/types';
+import type { Node } from '../../../scene/node';
+import { DIRECTION, Validate } from '../../../util/validation';
+import type { ChartAxis } from '../../chartAxis';
+import { ChartAxisDirection } from '../../chartAxisDirection';
+import type { SeriesNodeDatum } from '../seriesTypes';
+import { CartesianSeries } from './cartesianSeries';
+import type { CartesianSeriesNodeDataContext, CartesianSeriesNodeDatum } from './cartesianSeries';
+
+export abstract class AbstractBarSeries<
+    TNode extends Node,
+    TDatum extends CartesianSeriesNodeDatum,
+    TLabel extends SeriesNodeDatum = TDatum,
+    TContext extends CartesianSeriesNodeDataContext<TDatum, TLabel> = CartesianSeriesNodeDataContext<TDatum, TLabel>,
+> extends CartesianSeries<TNode, TDatum, TLabel, TContext> {
+    @Validate(DIRECTION)
+    direction: Direction = 'vertical';
+
+    override getBandScalePadding() {
+        return { inner: 0.2, outer: 0.1 };
+    }
+
+    override shouldFlipXY(): boolean {
+        return this.direction === 'horizontal';
+    }
+
+    protected getBarDirection() {
+        return this.shouldFlipXY() ? ChartAxisDirection.X : ChartAxisDirection.Y;
+    }
+
+    protected getCategoryDirection() {
+        return this.shouldFlipXY() ? ChartAxisDirection.Y : ChartAxisDirection.X;
+    }
+
+    protected getValueAxis(): ChartAxis | undefined {
+        const direction = this.getBarDirection();
+        return this.axes[direction];
+    }
+
+    protected getCategoryAxis(): ChartAxis | undefined {
+        const direction = this.getCategoryDirection();
+        return this.axes[direction];
+    }
+}

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -6,7 +6,6 @@ import type {
     AgBarSeriesLabelPlacement,
     AgBarSeriesStyle,
     AgBarSeriesTooltipRendererParams,
-    Direction,
     FontStyle,
     FontWeight,
 } from '../../../options/agChartOptions';
@@ -21,7 +20,6 @@ import type { Text } from '../../../scene/shape/text';
 import { extent } from '../../../util/array';
 import { sanitizeHtml } from '../../../util/sanitize';
 import {
-    DIRECTION,
     NUMBER,
     OPT_COLOR_STRING,
     OPT_FUNCTION,
@@ -35,7 +33,6 @@ import { isNumber } from '../../../util/value';
 import { CategoryAxis } from '../../axis/categoryAxis';
 import { GroupedCategoryAxis } from '../../axis/groupedCategoryAxis';
 import { LogAxis } from '../../axis/logAxis';
-import type { ChartAxis } from '../../chartAxis';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
@@ -46,6 +43,7 @@ import { SeriesNodePickMode, groupAccumulativeValueProperty, keyProperty, valueP
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { SeriesTooltip } from '../seriesTooltip';
 import type { ErrorBoundSeriesNodeDatum } from '../seriesTypes';
+import { AbstractBarSeries } from './abstractBarSeries';
 import type { RectConfig } from './barUtil';
 import {
     checkCrisp,
@@ -60,7 +58,6 @@ import type {
     CartesianSeriesNodeDataContext,
     CartesianSeriesNodeDatum,
 } from './cartesianSeries';
-import { CartesianSeries } from './cartesianSeries';
 import { adjustLabelPlacement, updateLabelNode } from './labelUtil';
 
 interface BarNodeLabelDatum extends Readonly<Point> {
@@ -98,7 +95,7 @@ class BarSeriesLabel extends Label<AgBarSeriesLabelFormatterParams> {
     placement: AgBarSeriesLabelPlacement = 'inside';
 }
 
-export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
+export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
     static className = 'BarSeries';
     static type = 'bar' as const;
 
@@ -138,9 +135,6 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
 
     @Validate(OPT_STRING)
     yName?: string = undefined;
-
-    @Validate(DIRECTION)
-    direction: Direction = 'vertical';
 
     @Validate(OPT_STRING)
     stackGroup?: string = undefined;
@@ -270,16 +264,6 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
             const fixedYExtent = [yExtent[0] > 0 ? 0 : yExtent[0], yExtent[1] < 0 ? 0 : yExtent[1]];
             return fixNumericExtent(fixedYExtent as any, valueAxis);
         }
-    }
-
-    private getCategoryAxis(): ChartAxis | undefined {
-        const direction = this.getCategoryDirection();
-        return this.axes[direction];
-    }
-
-    private getValueAxis(): ChartAxis | undefined {
-        const direction = this.getBarDirection();
-        return this.axes[direction];
     }
 
     async createNodeData() {
@@ -661,27 +645,5 @@ export class BarSeries extends CartesianSeries<Rect, BarNodeDatum> {
 
     protected isLabelEnabled() {
         return this.label.enabled;
-    }
-
-    override getBandScalePadding() {
-        return { inner: 0.2, outer: 0.1 };
-    }
-
-    override shouldFlipXY(): boolean {
-        return this.direction === 'horizontal';
-    }
-
-    protected getBarDirection() {
-        if (this.direction === 'vertical') {
-            return ChartAxisDirection.Y;
-        }
-        return ChartAxisDirection.X;
-    }
-
-    protected getCategoryDirection() {
-        if (this.direction === 'vertical') {
-            return ChartAxisDirection.X;
-        }
-        return ChartAxisDirection.Y;
     }
 }

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -36,6 +36,7 @@ export * from './chart/series/seriesLabelUtil';
 export * from './chart/series/seriesMarker';
 export * from './chart/series/seriesTooltip';
 export * from './chart/series/seriesTypes';
+export * from './chart/series/cartesian/abstractBarSeries';
 export * from './chart/series/cartesian/cartesianSeries';
 export * from './chart/series/cartesian/lineUtil';
 export * from './chart/series/cartesian/barUtil';

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotDefaults.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotDefaults.ts
@@ -5,18 +5,18 @@ const { CARTESIAN_AXIS_TYPES, CARTESIAN_AXIS_POSITIONS } = _Theme;
 export const BOX_PLOT_SERIES_DEFAULTS = {
     axes: [
         {
+            type: CARTESIAN_AXIS_TYPES.NUMBER,
+            position: CARTESIAN_AXIS_POSITIONS.LEFT,
+            crosshair: {
+                snap: false,
+            },
+        },
+        {
             type: CARTESIAN_AXIS_TYPES.CATEGORY,
             position: CARTESIAN_AXIS_POSITIONS.BOTTOM,
             groupPaddingInner: 0.2,
             crosshair: {
                 enabled: false,
-                snap: false,
-            },
-        },
-        {
-            type: CARTESIAN_AXIS_TYPES.NUMBER,
-            position: CARTESIAN_AXIS_POSITIONS.LEFT,
-            crosshair: {
                 snap: false,
             },
         },

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -2,7 +2,6 @@ import {
     type AgBoxPlotSeriesFormatterParams,
     type AgBoxPlotSeriesStyles,
     type AgBoxPlotSeriesTooltipRendererParams,
-    type Direction,
     _ModuleSupport,
     _Scale,
     _Scene,
@@ -14,8 +13,6 @@ import { BoxPlotGroup } from './boxPlotGroup';
 import type { BoxPlotNodeDatum } from './boxPlotTypes';
 
 const {
-    CartesianSeries,
-    ChartAxisDirection,
     extent,
     extractDecoratedProperties,
     fixNumericExtent,
@@ -29,7 +26,6 @@ const {
     SeriesNodePickMode,
     SeriesTooltip,
     SMALLEST_KEY_INTERVAL,
-    DIRECTION,
     Validate,
     valueProperty,
 } = _ModuleSupport;
@@ -78,7 +74,7 @@ class BoxPlotSeriesWhisker {
     lineDashOffset?: number;
 }
 
-export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatum> {
+export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup, BoxPlotNodeDatum> {
     @Validate(OPT_STRING)
     xKey?: string = undefined;
 
@@ -139,9 +135,6 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
     @Validate(NUMBER(0))
     lineDashOffset: number = 0;
 
-    @Validate(DIRECTION)
-    direction: Direction = 'vertical';
-
     @Validate(OPT_FUNCTION)
     formatter?: (params: AgBoxPlotSeriesFormatterParams<unknown>) => AgBoxPlotSeriesStyles = undefined;
 
@@ -198,11 +191,11 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
         const { processedData, dataModel, smallestDataInterval } = this;
         if (!(processedData && dataModel)) return [];
 
-        if (direction === this.getValuesDirection()) {
+        if (direction === this.getBarDirection()) {
             const minValues = dataModel.getDomain(this, `minValue`, 'value', processedData);
             const maxValues = dataModel.getDomain(this, `maxValue`, 'value', processedData);
 
-            return fixNumericExtent([Math.min(...minValues), Math.max(...maxValues)], this.getValuesAxis());
+            return fixNumericExtent([Math.min(...minValues), Math.max(...maxValues)], this.getValueAxis());
         }
 
         const { index, def } = dataModel.resolveProcessedDataIndexById(this, `xValue`);
@@ -220,7 +213,7 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
         const { visible, dataModel } = this;
 
         const xAxis = this.getCategoryAxis();
-        const yAxis = this.getValuesAxis();
+        const yAxis = this.getValueAxis();
 
         if (!(dataModel && visible && xAxis && yAxis)) {
             return [];
@@ -380,7 +373,7 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
         const { datum } = nodeDatum as { datum: any };
 
         const xAxis = this.getCategoryAxis();
-        const yAxis = this.getValuesAxis();
+        const yAxis = this.getValueAxis();
 
         if (!xAxis || !yAxis || !xKey || !minKey || !q1Key || !medianKey || !q3Key || !maxKey) return '';
 
@@ -548,36 +541,12 @@ export class BoxPlotSeries extends CartesianSeries<BoxPlotGroup, BoxPlotNodeDatu
         return activeStyles;
     }
 
-    override getBandScalePadding() {
-        return { inner: 0.2, outer: 0.1 };
-    }
-
-    override shouldFlipXY() {
-        return this.direction === 'vertical';
-    }
-
-    protected getValuesDirection() {
-        return this.shouldFlipXY() ? ChartAxisDirection.Y : ChartAxisDirection.X;
-    }
-
-    protected getCategoryDirection() {
-        return this.shouldFlipXY() ? ChartAxisDirection.X : ChartAxisDirection.Y;
-    }
-
-    protected getCategoryAxis(): _ModuleSupport.ChartAxis | undefined {
-        return this.axes[this.getCategoryDirection()];
-    }
-
-    protected getValuesAxis(): _ModuleSupport.ChartAxis | undefined {
-        return this.axes[this.getValuesDirection()];
-    }
-
     convertValuesToScaleByDefs<T extends string>(
         defs: [string, _ModuleSupport.ProcessedDataDef[]][],
         values: Record<T, unknown>
     ): Record<T, number> {
         const xAxis = this.getCategoryAxis();
-        const yAxis = this.getValuesAxis();
+        const yAxis = this.getValueAxis();
         if (!(xAxis && yAxis)) {
             throw new Error('Axes must be defined');
         }

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -447,7 +447,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup
         // highlightedItems?: BoxPlotNodeDatum[];
         isHighlight: boolean;
     }) {
-        const invertAxes = this.shouldFlipXY();
+        const isVertical = this.direction === 'vertical';
         datumSelection.each((boxPlotGroup, nodeDatum) => {
             let activeStyles = this.getFormattedStyles(nodeDatum, highlighted);
 
@@ -472,7 +472,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup
             boxPlotGroup.updateDatumStyles(
                 nodeDatum,
                 activeStyles as _ModuleSupport.DeepRequired<AgBoxPlotSeriesStyles>,
-                invertAxes
+                isVertical
             );
         });
     }

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -1,18 +1,8 @@
-import type { AgBulletSeriesTooltipRendererParams, Direction } from 'ag-charts-community';
+import type { AgBulletSeriesTooltipRendererParams } from 'ag-charts-community';
 import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 
-const {
-    keyProperty,
-    partialAssign,
-    valueProperty,
-    Validate,
-    COLOR_STRING,
-    DIRECTION,
-    STRING,
-    OPT_ARRAY,
-    OPT_NUMBER,
-    OPT_STRING,
-} = _ModuleSupport;
+const { keyProperty, partialAssign, valueProperty, Validate, COLOR_STRING, STRING, OPT_ARRAY, OPT_NUMBER, OPT_STRING } =
+    _ModuleSupport;
 const { sanitizeHtml } = _Util;
 
 interface BulletNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum {
@@ -65,7 +55,7 @@ class BulletNode extends _Scene.Group {
     }
 }
 
-export class BulletSeries extends _ModuleSupport.CartesianSeries<BulletNode, BulletNodeDatum> {
+export class BulletSeries extends _ModuleSupport.AbstractBarSeries<BulletNode, BulletNodeDatum> {
     @Validate(STRING)
     valueKey: string = '';
 
@@ -77,9 +67,6 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<BulletNode, Bul
 
     @Validate(OPT_STRING)
     targetName?: string = undefined;
-
-    @Validate(DIRECTION)
-    direction: Direction = 'vertical';
 
     @Validate(OPT_ARRAY())
     colorRanges?: BulletColorRange[] = undefined;
@@ -332,29 +319,4 @@ export class BulletSeries extends _ModuleSupport.CartesianSeries<BulletNode, Bul
     protected override async updateLabelNodes(_opts: {
         labelSelection: _Scene.Selection<_Scene.Text, BulletNodeDatum>;
     }) {}
-
-    // barSeries.ts copy/pasta
-    private getCategoryAxis(): _ModuleSupport.ChartAxis | undefined {
-        const direction = this.getCategoryDirection();
-        return this.axes[direction];
-    }
-
-    private getValueAxis(): _ModuleSupport.ChartAxis | undefined {
-        const direction = this.getBarDirection();
-        return this.axes[direction];
-    }
-
-    private getBarDirection() {
-        if (this.direction === 'vertical') {
-            return _ModuleSupport.ChartAxisDirection.Y;
-        }
-        return _ModuleSupport.ChartAxisDirection.X;
-    }
-
-    private getCategoryDirection() {
-        if (this.direction === 'vertical') {
-            return _ModuleSupport.ChartAxisDirection.X;
-        }
-        return _ModuleSupport.ChartAxisDirection.Y;
-    }
 }

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -5,7 +5,6 @@ import type {
     AgRangeBarSeriesLabelPlacement,
     AgRangeBarSeriesTooltipRendererParams,
     AgTooltipRendererResult,
-    Direction,
 } from 'ag-charts-community';
 import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
@@ -28,7 +27,6 @@ const {
     CategoryAxis,
     SMALLEST_KEY_INTERVAL,
     STRING_UNION,
-    DIRECTION,
     diff,
     prepareBarAnimationFunctions,
     midpointStartingBarPosition,
@@ -113,7 +111,7 @@ class RangeBarSeriesLabel extends _Scene.Label<AgRangeBarSeriesLabelFormatterPar
     padding: number = 6;
 }
 
-export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
+export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
     _Scene.Rect,
     RangeBarNodeDatum,
     RangeBarNodeLabelDatum
@@ -204,9 +202,6 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
     @Validate(OPT_STRING)
     yName?: string = undefined;
 
-    @Validate(DIRECTION)
-    direction: Direction = 'vertical';
-
     protected smallestDataInterval?: { x: number; y: number } = undefined;
 
     override async processData(dataController: _ModuleSupport.DataController) {
@@ -280,14 +275,6 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
             ];
             return fixNumericExtent(fixedYExtent);
         }
-    }
-
-    private getCategoryAxis(): _ModuleSupport.ChartAxis | undefined {
-        return this.axes[this.getCategoryDirection()];
-    }
-
-    protected getValueAxis(): _ModuleSupport.ChartAxis | undefined {
-        return this.axes[this.getBarDirection()];
     }
 
     async createNodeData() {
@@ -718,28 +705,6 @@ export class RangeBarSeries extends _ModuleSupport.CartesianSeries<
 
     protected isLabelEnabled() {
         return this.label.enabled;
-    }
-
-    protected getBarDirection() {
-        if (this.direction === 'horizontal') {
-            return ChartAxisDirection.X;
-        }
-        return ChartAxisDirection.Y;
-    }
-
-    protected getCategoryDirection() {
-        if (this.direction === 'horizontal') {
-            return ChartAxisDirection.Y;
-        }
-        return ChartAxisDirection.X;
-    }
-
-    override getBandScalePadding() {
-        return { inner: 0.2, outer: 0.1 };
-    }
-
-    override shouldFlipXY() {
-        return this.direction === 'horizontal';
     }
 
     protected override onDataChange() {}

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -6,7 +6,6 @@ import type {
     AgWaterfallSeriesLabelFormatterParams,
     AgWaterfallSeriesLabelPlacement,
     AgWaterfallSeriesTooltipRendererParams,
-    Direction,
 } from 'ag-charts-community';
 import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
@@ -28,7 +27,6 @@ const {
     OPT_FUNCTION,
     OPT_COLOR_STRING,
     OPT_LINE_DASH,
-    DIRECTION,
     getRectConfig,
     updateRect,
     checkCrisp,
@@ -160,7 +158,7 @@ interface TotalMeta {
     axisLabel: any;
 }
 
-export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
+export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
     _Scene.Rect,
     WaterfallNodeDatum,
     WaterfallNodeDatum,
@@ -209,9 +207,6 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
 
     @Validate(OPT_STRING)
     yName?: string = undefined;
-
-    @Validate(DIRECTION)
-    direction: Direction = 'vertical';
 
     private seriesItemTypes: Set<AgWaterfallSeriesItemType> = new Set(['positive', 'negative', 'total']);
 
@@ -324,14 +319,6 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
             const fixedYExtent = [yExtent[0] > 0 ? 0 : yExtent[0], yExtent[1] < 0 ? 0 : yExtent[1]];
             return fixNumericExtent(fixedYExtent as any);
         }
-    }
-
-    private getCategoryAxis(): _ModuleSupport.ChartAxis | undefined {
-        return this.axes[this.getCategoryDirection()];
-    }
-
-    protected getValueAxis(): _ModuleSupport.ChartAxis | undefined {
-        return this.axes[this.getBarDirection()];
     }
 
     async createNodeData() {
@@ -929,28 +916,6 @@ export class WaterfallSeries extends _ModuleSupport.CartesianSeries<
 
     protected isLabelEnabled() {
         return this.item.positive.label.enabled || this.item.negative.label.enabled || this.item.total.label.enabled;
-    }
-
-    protected getBarDirection() {
-        if (this.direction === 'horizontal') {
-            return ChartAxisDirection.X;
-        }
-        return ChartAxisDirection.Y;
-    }
-
-    protected getCategoryDirection() {
-        if (this.direction === 'horizontal') {
-            return ChartAxisDirection.Y;
-        }
-        return ChartAxisDirection.X;
-    }
-
-    override getBandScalePadding() {
-        return { inner: 0.2, outer: 0.1 };
-    }
-
-    override shouldFlipXY() {
-        return this.direction === 'horizontal';
     }
 
     protected override onDataChange() {}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-5670

Cut down duplicate code in the follow series classes:
- `BarSeries`
- `BoxPlotSeries`
- `BullerSeries`
- `RangeBar`
- `WaterfallSeries`

This merges common features into a new `AbstractBarSeries`. Right now, this class just contains a `direction` property and methods to help with category/number axes management.