### PR TITLE
AG-9649 - Stop animations in unsupported cases

### DIFF
--- a/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -79,6 +79,9 @@ exports[`DataModel empty data set processing should generated the expected resul
       [],
     ],
   },
+  "input": {
+    "count": 0,
+  },
   "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "ungrouped",
@@ -320,6 +323,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         3505,
       ],
     ],
+  },
+  "input": {
+    "count": 20,
   },
   "partialValidDataCount": 0,
   "reduced": {
@@ -603,6 +609,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       ],
     ],
   },
+  "input": {
+    "count": 20,
+  },
   "partialValidDataCount": 0,
   "reduced": {
     "sortedGroupDomain": [
@@ -803,6 +812,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
       ],
     ],
     "values": [],
+  },
+  "input": {
+    "count": 20,
   },
   "partialValidDataCount": 0,
   "reduced": {
@@ -1094,6 +1106,9 @@ exports[`DataModel grouped processing - grouped example should generated the exp
         4.2,
       ],
     ],
+  },
+  "input": {
+    "count": 7,
   },
   "partialValidDataCount": 0,
   "time": Any<Number>,
@@ -1690,6 +1705,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
       ],
     ],
   },
+  "input": {
+    "count": 12,
+  },
   "partialValidDataCount": 0,
   "reduced": {
     "aggValuesExtent": [
@@ -2019,6 +2037,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         3.221457119468387,
       ],
     ],
+  },
+  "input": {
+    "count": 5,
   },
   "partialValidDataCount": 0,
   "reduced": {
@@ -2396,6 +2417,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         919,
       ],
     ],
+  },
+  "input": {
+    "count": 8,
   },
   "partialValidDataCount": 0,
   "reduced": {
@@ -2778,6 +2802,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
       ],
     ],
   },
+  "input": {
+    "count": 8,
+  },
   "partialValidDataCount": 0,
   "reduced": {
     "aggValuesExtent": [
@@ -3105,6 +3132,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
       ],
     ],
   },
+  "input": {
+    "count": 8,
+  },
   "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "grouped",
@@ -3405,6 +3435,9 @@ exports[`DataModel missing and invalid data processing - multiple scopes should 
         15.23,
       ],
     ],
+  },
+  "input": {
+    "count": 11,
   },
   "partialValidDataCount": 4,
   "time": Any<Number>,
@@ -3715,6 +3748,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
       ],
     ],
   },
+  "input": {
+    "count": 11,
+  },
   "partialValidDataCount": 0,
   "time": Any<Number>,
   "type": "ungrouped",
@@ -3829,6 +3865,9 @@ exports[`DataModel repeated property processing should generated the expected re
         0.6869,
       ],
     ],
+  },
+  "input": {
+    "count": 5,
   },
   "partialValidDataCount": 0,
   "time": Any<Number>,
@@ -3999,6 +4038,9 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
         4159000,
       ],
     ],
+  },
+  "input": {
+    "count": 8,
   },
   "partialValidDataCount": 0,
   "time": Any<Number>,
@@ -4794,6 +4836,9 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
         136.45,
       ],
     ],
+  },
+  "input": {
+    "count": 52,
   },
   "partialValidDataCount": 0,
   "time": Any<Number>,

--- a/packages/ag-charts-community/src/chart/data/dataModel.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.ts
@@ -19,6 +19,7 @@ export type UngroupedDataItem<D, V> = {
 
 export interface UngroupedData<D> {
     type: 'ungrouped';
+    input: { count: number };
     data: UngroupedDataItem<D, any[]>[];
     domain: {
         keys: any[][];
@@ -31,6 +32,10 @@ export interface UngroupedData<D> {
         smallestKeyInterval?: number;
         aggValuesExtent?: [number, number];
         sortedGroupDomain?: any[][];
+        animationValidation?: {
+            uniqueKeys: boolean;
+            orderedKeys: boolean;
+        };
     };
     defs: {
         keys: DatumPropertyDefinition<keyof D>[];
@@ -61,6 +66,7 @@ export interface ProcessedDataDef {
 
 export interface GroupedData<D> {
     type: 'grouped';
+    input: UngroupedData<D>['input'];
     data: GroupedDataItem<D>[];
     domain: UngroupedData<D>['domain'];
     reduced?: UngroupedData<D>['reduced'];
@@ -648,6 +654,7 @@ export class DataModel<
 
         return {
             type: 'ungrouped',
+            input: { count: data.length },
             data: resultData,
             domain: {
                 keys: keyDefs.map((def) => propertyDomain(def)),

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -27,7 +27,7 @@ import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import type { DatumPropertyDefinition } from '../../data/dataModel';
 import { fixNumericExtent } from '../../data/dataModel';
-import { normaliseGroupTo } from '../../data/processors';
+import { animationValidation, normaliseGroupTo } from '../../data/processors';
 import { diff } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
@@ -154,6 +154,9 @@ export class AreaSeries extends CartesianSeries<
         // automatically garbage collect the marker selection.
         if (!isContinuousX && animationEnabled && this.processedData) {
             extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
         }
 
         const common: Partial<DatumPropertyDefinition<unknown>> = { invalidValue: null };
@@ -297,7 +300,6 @@ export class AreaSeries extends CartesianSeries<
             labelData,
             nodeData: markerData,
             scales: super.calculateScaling(),
-            animationValid: true,
             visible: this.visible,
         };
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -36,7 +36,7 @@ import { LogAxis } from '../../axis/logAxis';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
-import { SMALLEST_KEY_INTERVAL, diff, normaliseGroupTo } from '../../data/processors';
+import { SMALLEST_KEY_INTERVAL, animationValidation, diff, normaliseGroupTo } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import { SeriesNodePickMode, groupAccumulativeValueProperty, keyProperty, valueProperty } from '../series';
@@ -196,9 +196,11 @@ export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
         if (normaliseTo) {
             extraProps.push(normaliseGroupTo(this, [stackGroupName, stackGroupTrailingName], normaliseTo, 'range'));
         }
-
         if (animationEnabled && this.processedData) {
             extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
         }
 
         const visibleProps = !this.visible && animationEnabled ? { forceValue: 0 } : {};

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -19,7 +19,7 @@ import { COLOR_STRING_ARRAY, NUMBER, OPT_NUMBER_ARRAY, OPT_STRING, Validate } fr
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
-import { createDatumId, diff } from '../../data/processors';
+import { animationValidation, createDatumId, diff } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum } from '../../legendDatum';
 import type { Marker } from '../../marker/marker';
@@ -142,23 +142,20 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
     }
 
     override async processData(dataController: DataController) {
-        const {
-            xKey,
-            yKey,
-            sizeKey,
-            labelKey,
-            colorScale,
-            colorDomain,
-            colorRange,
-            colorKey,
-            marker,
-            data,
-            ctx: { animationManager },
-        } = this;
+        const { xKey, yKey, sizeKey, labelKey, colorScale, colorDomain, colorRange, colorKey, marker, data } = this;
 
         if (xKey == null || yKey == null || sizeKey === null || data == null) return;
 
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const { isContinuousX, isContinuousY } = this.isContinuous();
+
+        const extraProps = [];
+        if (animationEnabled && this.processedData) {
+            extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
+        }
 
         const { dataModel, processedData } = await this.requestDataModel<any, any, true>(dataController, data, {
             props: [
@@ -170,7 +167,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
                 valueProperty(this, sizeKey, true, { id: `sizeValue` }),
                 ...(colorKey ? [valueProperty(this, colorKey, true, { id: `colorValue` })] : []),
                 ...(labelKey ? [valueProperty(this, labelKey, false, { id: `labelValue` })] : []),
-                ...(!animationManager.isSkipped() && this.processedData ? [diff(this.processedData)] : []),
+                ...extraProps,
             ],
             dataVisible: this.visible,
         });

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -24,7 +24,7 @@ import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import type { DataModelOptions, UngroupedDataItem } from '../../data/dataModel';
 import { fixNumericExtent } from '../../data/dataModel';
-import { createDatumId, diff } from '../../data/processors';
+import { animationValidation, createDatumId, diff } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import type { Marker } from '../../marker/marker';
@@ -138,6 +138,9 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
                 props.push(diff(this.processedData));
             }
         }
+        if (animationEnabled) {
+            props.push(animationValidation(this));
+        }
 
         props.push(
             valueProperty(this, xKey, isContinuousX, { id: 'xValue' }),
@@ -193,8 +196,6 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
 
         let moveTo = true;
         let nextPoint: UngroupedDataItem<any, any> | undefined;
-        let lastXValue: number = -Infinity;
-        let isXUniqueAndOrdered = true;
         for (let i = 0; i < processedData.data.length; i++) {
             const { datum, values } = nextPoint ?? processedData.data[i];
             const xDatum = values[xIdx];
@@ -227,9 +228,6 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
                     },
                     (value) => (isNumber(value) ? value.toFixed(2) : String(value))
                 );
-
-                isXUniqueAndOrdered &&= lastXValue < x;
-                lastXValue = x;
 
                 nodeData.push({
                     series: this,
@@ -264,7 +262,6 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
                 nodeData,
                 labelData: nodeData,
                 scales: super.calculateScaling(),
-                animationValid: isXUniqueAndOrdered,
                 visible: this.visible,
             },
         ];

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -43,4 +43,12 @@ export abstract class DataModelSeries<
         this.dispatch('data-processed', { dataModel, processedData });
         return { dataModel, processedData };
     }
+
+    protected checkProcessedDataAnimatable() {
+        const { orderedKeys, uniqueKeys } = this.processedData?.reduced?.animationValidation ?? {};
+        const animationValid = !!orderedKeys && !!uniqueKeys;
+        if (!animationValid) {
+            this.ctx.animationManager.skipCurrentBatch();
+        }
+    }
 }

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -39,7 +39,7 @@ import { Caption } from '../../caption';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import type { DataModel } from '../../data/dataModel';
-import { diff, normalisePropertyTo } from '../../data/processors';
+import { animationValidation, diff, normalisePropertyTo } from '../../data/processors';
 import type { LegendItemClickChartEvent } from '../../interaction/chartEventManager';
 import { Label } from '../../label';
 import { Layers } from '../../layers';
@@ -357,15 +357,17 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
 
         if (angleKey == null || data == null) return;
 
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const extraKeyProps = [];
         const extraProps = [];
 
-        if (calloutLabelKey) {
+        // Order here should match `getDatumIdFromData()`.
+        if (legendItemKey) {
+            extraKeyProps.push(keyProperty(this, legendItemKey, false, { id: `legendItemKey` }));
+        } else if (calloutLabelKey) {
             extraKeyProps.push(keyProperty(this, calloutLabelKey, false, { id: `calloutLabelKey` }));
         } else if (sectorLabelKey) {
             extraKeyProps.push(keyProperty(this, sectorLabelKey, false, { id: `sectorLabelKey` }));
-        } else if (legendItemKey) {
-            extraKeyProps.push(keyProperty(this, legendItemKey, false, { id: `legendItemKey` }));
         }
 
         if (radiusKey) {
@@ -388,12 +390,11 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
         if (legendItemKey) {
             extraProps.push(valueProperty(this, legendItemKey, false, { id: `legendItemValue` }));
         }
-        if (
-            !this.ctx.animationManager.isSkipped() &&
-            this.processedData &&
-            (calloutLabelKey || sectorLabelKey || legendItemKey)
-        ) {
-            extraProps.push(diff(this.processedData));
+        if (animationEnabled && this.processedData && extraKeyProps.length > 0) {
+            extraProps.push(diff(this.processedData), animationValidation(this));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
         }
 
         data = data.map((d, idx) => (seriesItemEnabled[idx] ? d : { ...d, [angleKey]: 0 }));
@@ -1469,6 +1470,10 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
 
         this.ctx.animationManager.stopByAnimationGroupId(this.id);
 
+        // if (!this.processedData?.reduced?.animationValidation?.uniqueKeys) {
+        //     this.ctx.animationManager.skipCurrentBatch();
+        // }
+
         const fns = preparePieSeriesAnimationFunctions(this.rotation);
         fromToMotion(
             this.id,
@@ -1501,6 +1506,10 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
 
     getDatumIdFromData(datum: any) {
         const { calloutLabelKey, sectorLabelKey, legendItemKey } = this;
+
+        if (!this.processedData?.reduced?.animationValidation?.uniqueKeys) {
+            return undefined;
+        }
 
         if (legendItemKey) {
             return datum[legendItemKey];

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -88,34 +88,38 @@ export abstract class PolarSeries<TDatum extends SeriesNodeDatum, TNode extends 
         this.sectorGroup.zIndexSubOrder = [() => this._declarationOrder, 1];
         this.animationResetFns = animationResetFns;
 
-        this.animationState = new StateMachine<PolarAnimationState, PolarAnimationEvent>('empty', {
-            empty: {
-                update: {
-                    target: 'ready',
-                    action: (data) => this.animateEmptyUpdateReady(data),
+        this.animationState = new StateMachine<PolarAnimationState, PolarAnimationEvent>(
+            'empty',
+            {
+                empty: {
+                    update: {
+                        target: 'ready',
+                        action: (data) => this.animateEmptyUpdateReady(data),
+                    },
+                },
+                ready: {
+                    updateData: 'waiting',
+                    clear: 'clearing',
+                    update: (data) => this.animateReadyUpdate(data),
+                    highlight: (data) => this.animateReadyHighlight(data),
+                    highlightMarkers: (data) => this.animateReadyHighlightMarkers(data),
+                    resize: (data) => this.animateReadyResize(data),
+                },
+                waiting: {
+                    update: {
+                        target: 'ready',
+                        action: (data) => this.animateWaitingUpdateReady(data),
+                    },
+                },
+                clearing: {
+                    update: {
+                        target: 'empty',
+                        action: (data) => this.animateClearingUpdateEmpty(data),
+                    },
                 },
             },
-            ready: {
-                updateData: 'waiting',
-                clear: 'clearing',
-                update: (data) => this.animateReadyUpdate(data),
-                highlight: (data) => this.animateReadyHighlight(data),
-                highlightMarkers: (data) => this.animateReadyHighlightMarkers(data),
-                resize: (data) => this.animateReadyResize(data),
-            },
-            waiting: {
-                update: {
-                    target: 'ready',
-                    action: (data) => this.animateWaitingUpdateReady(data),
-                },
-            },
-            clearing: {
-                update: {
-                    target: 'empty',
-                    action: (data) => this.animateClearingUpdateEmpty(data),
-                },
-            },
-        });
+            () => this.checkProcessedDataAnimatable()
+        );
     }
 
     protected abstract nodeFactory(): TNode;

--- a/packages/ag-charts-community/src/motion/states.ts
+++ b/packages/ag-charts-community/src/motion/states.ts
@@ -11,12 +11,14 @@ type StateTransitionAction = (data?: any) => void;
 
 export class StateMachine<State extends string, Event extends string> {
     private readonly debug = Debug.create(true, 'animation');
-    private readonly states: Record<State, StateDefinition<State, Event>>;
     private state: State;
 
-    constructor(initialState: State, states: Record<State, StateDefinition<State, Event>>) {
+    constructor(
+        initialState: State,
+        private readonly states: Record<State, StateDefinition<State, Event>>,
+        private readonly preTransitionCb?: (from: State, to: State) => void
+    ) {
         this.state = initialState;
-        this.states = states;
 
         this.debug(`%c${this.constructor.name} | init -> ${initialState}`, 'color: green');
     }
@@ -39,6 +41,8 @@ export class StateMachine<State extends string, Event extends string> {
         }
 
         this.debug(`%c${this.constructor.name} | ${this.state} -> ${event} -> ${destinationState}`, 'color: green');
+
+        this.preTransitionCb?.(this.state, destinationState);
 
         // Change the state before calling the transition action to allow the action to trigger a subsequent transition
         this.state = destinationState;

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -28,6 +28,8 @@ const {
     SMALLEST_KEY_INTERVAL,
     Validate,
     valueProperty,
+    diff,
+    animationValidation,
 } = _ModuleSupport;
 const { motion } = _Scene;
 
@@ -166,7 +168,15 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup
 
         if (!xKey || !minKey || !q1Key || !medianKey || !q3Key || !maxKey) return;
 
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const isContinuousX = this.getCategoryAxis()?.scale instanceof _Scale.ContinuousScale;
+        const extraProps = [];
+        if (animationEnabled && this.processedData) {
+            extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
+        }
 
         const { processedData } = await this.requestDataModel(dataController, data, {
             props: [
@@ -177,6 +187,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup
                 valueProperty(this, q3Key, true, { id: `q3Value` }),
                 valueProperty(this, maxKey, true, { id: `maxValue` }),
                 ...(isContinuousX ? [SMALLEST_KEY_INTERVAL] : []),
+                ...extraProps,
             ],
             dataVisible: this.visible,
         });

--- a/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/histogram/histogramSeries.ts
@@ -399,6 +399,7 @@ export class HistogramSeries extends CartesianSeries<_Scene.Rect, HistogramNodeD
                 nodeData,
                 labelData: nodeData,
                 scales: super.calculateScaling(),
+                animationValid: true,
                 visible: this.visible,
             },
         ];

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -31,6 +31,7 @@ const {
     resetLabelFn,
     seriesLabelFadeInAnimation,
     seriesLabelFadeOutAnimation,
+    animationValidation,
 } = _ModuleSupport;
 
 const { BandScale } = _Scale;
@@ -184,6 +185,9 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDat
         const animationEnabled = !this.ctx.animationManager.isSkipped();
         if (animationEnabled && this.processedData) {
             extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
         }
 
         const visibleProps = this.visible || !animationEnabled ? {} : { forceValue: 0 };

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -30,6 +30,7 @@ const {
     seriesLabelFadeInAnimation,
     seriesLabelFadeOutAnimation,
     valueProperty,
+    animationValidation,
 } = _ModuleSupport;
 
 const { BandScale } = _Scale;
@@ -201,6 +202,9 @@ export abstract class RadialColumnSeriesBase<
         const animationEnabled = !this.ctx.animationManager.isSkipped();
         if (animationEnabled && this.processedData) {
             extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
         }
 
         const visibleProps = this.visible || !animationEnabled ? {} : { forceValue: 0 };

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -34,6 +34,7 @@ const {
     fixNumericExtent,
     seriesLabelFadeInAnimation,
     resetLabelFn,
+    animationValidation,
 } = _ModuleSupport;
 const { ContinuousScale, BandScale, Rect, PointerEvents, motion } = _Scene;
 const { sanitizeHtml, isNumber, extent } = _Util;
@@ -213,8 +214,12 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
         const isContinuousY = ContinuousScale.is(this.getValueAxis()?.scale);
 
         const extraProps = [];
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         if (!this.ctx.animationManager.isSkipped() && this.processedData) {
             extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
         }
 
         const { processedData } = await this.requestDataModel<any, any, true>(dataController, data, {

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -36,6 +36,7 @@ const {
     resetBarSelectionsFn,
     seriesLabelFadeInAnimation,
     resetLabelFn,
+    animationValidation,
 } = _ModuleSupport;
 const { ContinuousScale, Rect, motion } = _Scene;
 const { sanitizeHtml, isContinuous, isNumber } = _Util;
@@ -260,7 +261,13 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
             }
         });
 
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const isContinuousX = ContinuousScale.is(this.getCategoryAxis()?.scale);
+        const extraProps = [];
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
+        }
+
         await this.requestDataModel<any, any, true>(dataController, dataWithTotals, {
             props: [
                 keyProperty(this, xKey, isContinuousX, { id: `xValue` }),
@@ -293,6 +300,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
                     missingValue: undefined,
                     validation: totalTypeValue,
                 }),
+                ...extraProps,
             ],
             dataVisible: this.visible,
         });

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/duplicate-labels/index.html
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/duplicate-labels/index.html
@@ -1,0 +1,3 @@
+<div style="display: flex; flex-direction: column; height: 100%">
+    <div id="myChart" style="flex: 1; height: 100%"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/duplicate-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/duplicate-labels/main.ts
@@ -1,0 +1,27 @@
+import { AgChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+
+function getData() {
+    return [
+        { label: 'Android', value: 56.9, value2: 'duplicate' },
+        { label: 'iOS', value: 56.9, value2: 'duplicate' },
+    ];
+}
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        {
+            type: 'pie',
+            angleKey: 'value',
+            calloutLabelKey: 'value2',
+            sectorLabelKey: 'value2',
+            sectorLabel: {
+                color: 'white',
+                fontWeight: 'bold',
+            },
+        },
+    ],
+};
+
+AgEnterpriseCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/index.mdoc
@@ -5,3 +5,5 @@ title: 'Pie Series Test'
 {% chartExampleRunner title="Animation Example" name="animation" type="generated" /%}
 
 {% chartExampleRunner title="Doughnut Animation Example" name="animation-doughnut" type="generated" /%}
+
+{% chartExampleRunner title="Duplicate Labels Example" name="duplicate-labels" type="generated" /%}


### PR DESCRIPTION
Blocks animations when:
- Chart layout changes.
- Data-validations don't pass:
  - Categories for category data must be unique.
  - The main continuous data axis must be ordered.