### PR TITLE
AG-9649 - Fix initial load for several series.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -19,7 +19,7 @@ import { COLOR_STRING_ARRAY, NUMBER, OPT_NUMBER_ARRAY, OPT_STRING, Validate } fr
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
-import { createDatumId, diff } from '../../data/processors';
+import { createDatumId } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum } from '../../legendDatum';
 import type { Marker } from '../../marker/marker';

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -19,7 +19,7 @@ import { COLOR_STRING_ARRAY, NUMBER, OPT_NUMBER_ARRAY, OPT_STRING, Validate } fr
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
-import { animationValidation, createDatumId, diff } from '../../data/processors';
+import { createDatumId, diff } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum } from '../../legendDatum';
 import type { Marker } from '../../marker/marker';
@@ -152,9 +152,6 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
         const extraProps = [];
         if (animationEnabled && this.processedData) {
             extraProps.push(diff(this.processedData));
-        }
-        if (animationEnabled) {
-            extraProps.push(animationValidation(this));
         }
 
         const { dataModel, processedData } = await this.requestDataModel<any, any, true>(dataController, data, {

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -146,13 +146,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
 
         if (xKey == null || yKey == null || sizeKey === null || data == null) return;
 
-        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const { isContinuousX, isContinuousY } = this.isContinuous();
-
-        const extraProps = [];
-        if (animationEnabled && this.processedData) {
-            extraProps.push(diff(this.processedData));
-        }
 
         const { dataModel, processedData } = await this.requestDataModel<any, any, true>(dataController, data, {
             props: [
@@ -164,7 +158,6 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
                 valueProperty(this, sizeKey, true, { id: `sizeValue` }),
                 ...(colorKey ? [valueProperty(this, colorKey, true, { id: `colorValue` })] : []),
                 ...(labelKey ? [valueProperty(this, labelKey, false, { id: `labelValue` })] : []),
-                ...extraProps,
             ],
             dataVisible: this.visible,
         });

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -178,7 +178,7 @@ export abstract class CartesianSeries<
         markerSelectionGarbageCollection = true,
         animationResetFns,
         ...otherOpts
-    }: Partial<SeriesOpts<TNode, TDatum, TLabel>> & ConstructorParameters<typeof Series>[0]) {
+    }: Partial<SeriesOpts<TNode, TDatum, TLabel>> & ConstructorParameters<typeof DataModelSeries>[0]) {
         super({
             directionKeys,
             directionNames,
@@ -287,8 +287,7 @@ export abstract class CartesianSeries<
             this.debug(`CartesianSeries.updateSelections() - calling createNodeData() for`, this.id);
 
             this._contextNodeData = await this.createNodeData();
-            const { orderedKeys, uniqueKeys } = this.processedData?.reduced?.animationValidation ?? {};
-            const animationValid = !!orderedKeys && !!uniqueKeys;
+            const animationValid = this.isProcessedDataAnimatable();
             this._contextNodeData.forEach((nodeData) => {
                 nodeData.animationValid ??= animationValid;
             });

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -17,7 +17,6 @@ import { COLOR_STRING_ARRAY, OPT_NUMBER_ARRAY, OPT_STRING, Validate } from '../.
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
-import { diff } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import type { Marker } from '../../marker/marker';
@@ -106,14 +105,8 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
 
         if (xKey == null || yKey == null || data == null) return;
 
-        const animationEnabled = !this.ctx.animationManager.isSkipped();
         const { isContinuousX, isContinuousY } = this.isContinuous();
         const { colorScale, colorDomain, colorRange, colorKey } = this;
-
-        const extraProps = [];
-        if (animationEnabled && this.processedData) {
-            extraProps.push(diff(this.processedData));
-        }
 
         const { dataModel, processedData } = await this.requestDataModel<any, any, true>(dataController, data, {
             props: [
@@ -124,7 +117,6 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
                 valueProperty(this, yKey, isContinuousY, { id: `yValue` }),
                 ...(colorKey ? [valueProperty(this, colorKey, true, { id: `colorValue` })] : []),
                 ...(labelKey ? [valueProperty(this, labelKey, false, { id: `labelValue` })] : []),
-                ...extraProps,
             ],
             dataVisible: this.visible,
         });

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -17,7 +17,7 @@ import { COLOR_STRING_ARRAY, OPT_NUMBER_ARRAY, OPT_STRING, Validate } from '../.
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
-import { animationValidation, diff } from '../../data/processors';
+import { diff } from '../../data/processors';
 import { Label } from '../../label';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import type { Marker } from '../../marker/marker';
@@ -113,9 +113,6 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
         const extraProps = [];
         if (animationEnabled && this.processedData) {
             extraProps.push(diff(this.processedData));
-        }
-        if (animationEnabled) {
-            extraProps.push(animationValidation(this));
         }
 
         const { dataModel, processedData } = await this.requestDataModel<any, any, true>(dataController, data, {

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -44,10 +44,16 @@ export abstract class DataModelSeries<
         return { dataModel, processedData };
     }
 
+    protected isProcessedDataAnimatable() {
+        const validationResults = this.processedData?.reduced?.animationValidation;
+        if (!validationResults) return true;
+
+        const { orderedKeys, uniqueKeys } = validationResults;
+        return !!orderedKeys && !!uniqueKeys;
+    }
+
     protected checkProcessedDataAnimatable() {
-        const { orderedKeys, uniqueKeys } = this.processedData?.reduced?.animationValidation ?? {};
-        const animationValid = !!orderedKeys && !!uniqueKeys;
-        if (!animationValid) {
+        if (!this.isProcessedDataAnimatable()) {
             this.ctx.animationManager.skipCurrentBatch();
         }
     }

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -24,6 +24,8 @@ const {
     seriesLabelFadeInAnimation,
     markerFadeInAnimation,
     resetMarkerFn,
+    diff,
+    animationValidation,
     ADD_PHASE,
 } = _ModuleSupport;
 
@@ -170,10 +172,20 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
 
         if (!angleKey || !radiusKey) return;
 
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
+        const extraProps = [];
+        if (animationEnabled && this.processedData) {
+            extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
+        }
+
         await this.requestDataModel<any, any, true>(dataController, data, {
             props: [
                 valueProperty(this, angleKey, false, { id: 'angleValue' }),
                 valueProperty(this, radiusKey, false, { id: 'radiusValue', invalidValue: undefined }),
+                ...extraProps,
             ],
         });
     }

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -30,6 +30,8 @@ const {
     resetMotion,
     markerSwipeScaleInAnimation,
     seriesLabelFadeInAnimation,
+    animationValidation,
+    diff,
 } = _ModuleSupport;
 const { getMarker, PointerEvents, Path2D } = _Scene;
 const { sanitizeHtml, extent, isNumber } = _Util;
@@ -179,6 +181,15 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
 
         const { isContinuousX, isContinuousY } = this.isContinuous();
 
+        const extraProps = [];
+        const animationEnabled = !this.ctx.animationManager.isSkipped();
+        if (!this.ctx.animationManager.isSkipped() && this.processedData) {
+            extraProps.push(diff(this.processedData));
+        }
+        if (animationEnabled) {
+            extraProps.push(animationValidation(this));
+        }
+
         await this.requestDataModel<any, any, true>(dataController, data, {
             props: [
                 keyProperty(this, xKey, isContinuousX, { id: `xValue` }),
@@ -192,6 +203,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
                     id: `yHighTrailingValue`,
                     invalidValue: undefined,
                 }),
+                ...extraProps,
             ],
             dataVisible: this.visible,
         });


### PR DESCRIPTION
#507 blocked initial load animation for a few series (scatter, histogram, radar area/line and range-area are affected) - this change rectifies that state by making the validation checks introduced skippable for series-types where the validations don't make sense.

Additionally adds animation validation to a few cases that were missed in the previous PR.