### PR TITLE
AG-9301 Set overrideable lengths of bullet graphs node shapes

### DIFF
--- a/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/bulletOptions.ts
@@ -25,8 +25,13 @@ export interface AgBulletScaleOptions {
 }
 
 export interface AgBulletSeriesThemeableOptions extends AgBulletSeriesStyle, AgBaseSeriesThemeableOptions {
+    /* Width of the bar relative to the width/height of the series area. */
+    widthRatio?: number;
     /** Styling options for the target node. */
-    target?: AgBulletSeriesStyle;
+    target?: AgBulletSeriesStyle & {
+        /* Length of target line relative to the width/height of the series area. */
+        lengthRatio?: number;
+    };
 }
 
 export interface AgBulletColorRange {

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletThemes.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletThemes.ts
@@ -6,9 +6,11 @@ export const BULLET_SERIES_THEME = {
     strokeOpacity: 1,
     fill: 'black',
     fillOpacity: 1,
+    widthRatio: 0.5,
     target: {
         stroke: 'black',
         strokeWidth: 3,
         strokeOpacity: 1,
+        lengthRatio: 0.75,
     },
 };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9301
The bar width defaults to 50% of the width/height of the series area. The target line defaults to 75% of the width/height of the series area.