### PR TITLE
AG-9717 - Rework Axis label selection datums ready for animation.

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -5,7 +5,14 @@ import type { FromToDiff } from '../../motion/fromToMotion';
 import { fromToMotion } from '../../motion/fromToMotion';
 import { resetMotion } from '../../motion/resetMotion';
 import { StateMachine } from '../../motion/states';
-import type { AgAxisCaptionFormatterParams } from '../../options/agChartOptions';
+import type {
+    AgAxisCaptionFormatterParams,
+    CssColor,
+    FontFamily,
+    FontSize,
+    FontStyle,
+    FontWeight,
+} from '../../options/agChartOptions';
 import { ContinuousScale } from '../../scale/continuousScale';
 import { LogScale } from '../../scale/logScale';
 import type { Scale } from '../../scale/scale';
@@ -87,6 +94,24 @@ export type TickDatum = {
     translationY: number;
 };
 
+export type LabelNodeDatum = {
+    tickId: string;
+    fill?: CssColor;
+    fontFamily?: FontFamily;
+    fontSize?: FontSize;
+    fontStyle?: FontStyle;
+    fontWeight?: FontWeight;
+    rotation: number;
+    rotationCenterX: number;
+    text: string;
+    textAlign?: CanvasTextAlign;
+    textBaseline: CanvasTextBaseline;
+    visible: boolean;
+    x: number;
+    y: number;
+    translationY: number;
+};
+
 type TickData = { rawTicks: any[]; ticks: TickDatum[]; labelCount: number };
 
 interface TickGenerationParams {
@@ -164,7 +189,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
     );
 
     protected tickLineGroupSelection = Selection.select(this.tickLineGroup, Line, false);
-    protected tickLabelGroupSelection = Selection.select(this.tickLabelGroup, Text, false);
+    protected tickLabelGroupSelection = Selection.select<Text, LabelNodeDatum>(this.tickLabelGroup, Text, false);
     protected gridLineGroupSelection = Selection.select(this.gridLineGroup, Line, false);
 
     protected abstract assignCrossLineArrayConstructor(crossLines: CrossLine[]): void;
@@ -445,7 +470,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
 
         const { tickData, combinedRotation, textBaseline, textAlign, ...ticksResult } = this.tickGenerationResult;
         const previousTicks = this.tickLabelGroupSelection.nodes().map((node) => node.datum.tickId);
-        this.updateSelections(tickData.ticks);
+        this.updateSelections(tickData.ticks, { combinedRotation, textAlign, textBaseline });
 
         if (this.animationManager.isSkipped()) {
             this.resetSelectionNodes();
@@ -454,12 +479,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             this.animationState.transition('update', diff);
         }
 
-        this.updateLabels({
-            combinedRotation,
-            textBaseline,
-            textAlign,
-        });
-
+        this.updateLabels();
         this.updateVisibility();
         this.updateGridLines(sideFlag);
         this.updateTickLines();
@@ -498,7 +518,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             textBaseline: CanvasTextBaseline;
             textAlign: CanvasTextAlign;
         }
-    ) {
+    ): LabelNodeDatum {
         const { label } = this;
         const { combinedRotation, textBaseline, textAlign } = params;
         const text = datum.tickLabel;
@@ -507,6 +527,8 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         const labelX = sideFlag * (tickSize + label.padding + this.seriesAreaPadding);
         const visible = text !== '' && text != undefined;
         return {
+            tickId: datum.tickId,
+            translationY: datum.translationY,
             fill: label.color,
             fontFamily: label.fontFamily,
             fontSize: label.fontSize,
@@ -807,12 +829,10 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
                     primaryTickCount,
                 }));
 
-                const ticksResult = tickData.ticks;
-
-                textAlign = getTextAlign(parallel, configuredRotation, autoRotation, sideFlag, regularFlipFlag);
                 const rotated = configuredRotation !== 0 || autoRotation !== 0;
                 const rotation = initialRotation + autoRotation;
-                labelOverlap = this.checkLabelOverlap(rotation, rotated, labelMatrix, ticksResult, labelX, {
+                textAlign = getTextAlign(parallel, configuredRotation, autoRotation, sideFlag, regularFlipFlag);
+                labelOverlap = this.checkLabelOverlap(rotation, rotated, labelMatrix, tickData.ticks, labelX, {
                     ...textProps,
                     textAlign,
                 });
@@ -1198,7 +1218,14 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         throw new Error('AG Charts - unexpected call to updateSecondaryAxisTicks() - check axes configuration.');
     }
 
-    protected updateSelections(data: TickDatum[]) {
+    protected updateSelections(
+        data: TickDatum[],
+        params: {
+            combinedRotation: number;
+            textBaseline: CanvasTextBaseline;
+            textAlign: CanvasTextAlign;
+        }
+    ) {
         this.gridLineGroupSelection.update(
             this.gridLength ? data : [],
             (group) => group.append(new Line({ tag: Tags.GridLine })),
@@ -1210,9 +1237,9 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             (datum: TickDatum) => datum.tickId
         );
         this.tickLabelGroupSelection.update(
-            data,
+            data.map((d) => this.getTickLabelProps(d, params)),
             (group) => group.appendChild(new Text({ tag: Tags.TickLabel })),
-            (datum: TickDatum) => datum.tickId
+            (datum) => datum.tickId
         );
     }
 
@@ -1253,11 +1280,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         });
     }
 
-    protected updateLabels(params: {
-        combinedRotation: number;
-        textBaseline: CanvasTextBaseline;
-        textAlign: CanvasTextAlign;
-    }) {
+    protected updateLabels() {
         const { label } = this;
         if (!label.enabled) {
             return;
@@ -1265,11 +1288,21 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
 
         // Apply label option values
         this.tickLabelGroupSelection.each((node, datum) => {
-            const props = this.getTickLabelProps(datum, params);
-            node.setProperties({
-                ...props,
-                fill: label.color,
-            });
+            node.setProperties(datum, [
+                'fill',
+                'fontFamily',
+                'fontSize',
+                'fontStyle',
+                'fontWeight',
+                'rotation',
+                'rotationCenterX',
+                'text',
+                'textAlign',
+                'textBaseline',
+                'visible',
+                'x',
+                'y',
+            ]);
         });
     }
 

--- a/packages/ag-charts-community/src/chart/axis/axisUtil.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisUtil.ts
@@ -1,4 +1,5 @@
-import { FROM_TO_MIXINS, type NodeUpdateState } from '../../motion/fromToMotion';
+import { FROM_TO_MIXINS } from '../../motion/fromToMotion';
+import type { NodeUpdateState } from '../../motion/fromToMotion';
 import type { Line } from '../../scene/shape/line';
 import type { Text } from '../../scene/shape/text';
 

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -16,6 +16,7 @@ export * from './module/moduleContext';
 export * from './chart/background/backgroundModule';
 export * from './chart/chartAxisDirection';
 export { assignJsonApplyConstructedArray } from './chart/chartOptions';
+export * from './chart/axis/axisUtil';
 export * from './chart/data/dataModel';
 export * from './chart/data/dataController';
 export * from './chart/data/processors';

--- a/packages/ag-charts-enterprise/src/axes/angle/angleAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle/angleAxis.ts
@@ -194,7 +194,7 @@ export abstract class AngleAxis<
         const { label, tickLabelGroupSelection } = this;
 
         const ticks = this.tickData;
-        tickLabelGroupSelection.update(label.enabled ? ticks : []).each((node, _, index) => {
+        tickLabelGroupSelection.update(label.enabled ? (ticks as any[]) : []).each((node, _, index) => {
             const labelDatum = this.labelData[index];
             if (!labelDatum || labelDatum.hidden) {
                 node.visible = false;

--- a/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
@@ -75,8 +75,15 @@ export abstract class RadiusAxis extends _ModuleSupport.PolarAxis {
     protected abstract prepareTickData(tickData: _ModuleSupport.TickDatum[]): _ModuleSupport.TickDatum[];
     protected abstract getTickRadius(tickDatum: _ModuleSupport.TickDatum): number;
 
-    protected override updateSelections(data: _ModuleSupport.TickDatum[]) {
-        super.updateSelections(data);
+    protected override updateSelections(
+        data: _ModuleSupport.TickDatum[],
+        params: {
+            combinedRotation: number;
+            textBaseline: CanvasTextBaseline;
+            textAlign: CanvasTextAlign;
+        }
+    ) {
+        super.updateSelections(data, params);
 
         const {
             gridLine: { enabled, style, width },

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/data.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/data.ts
@@ -1,0 +1,36 @@
+const years: number[] = [];
+for (let year = 2005; year <= 2022; year++) {
+    years.push(year);
+}
+
+const countries = [
+    'Ireland',
+    'Spain',
+    'United Kingdom',
+    'France',
+    'Germany',
+    'Luxembourg',
+    'Sweden',
+    'Norway',
+    'Italy',
+    'Greece',
+    'Iceland',
+    'Portugal',
+    'Malta',
+    'Brazil',
+    'Argentina',
+    'Colombia',
+    'Peru',
+    'Venezuela',
+    'Uruguay',
+    'Belgium',
+];
+countries.sort();
+
+export function getData(): any[] {
+    return years.map((year, idx) => ({
+        year,
+        country: countries[idx],
+        value: Math.round(Math.random() * 1000),
+    }));
+}

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/index.html
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/index.html
@@ -1,0 +1,22 @@
+<div class="wrapper">
+    <div id="toolPanel">
+        Rotation:
+        <button onclick="disableRotation()">No rotation</button>
+        <button onclick="fixedRotation()">Fixed rotation</button>
+        <button onclick="autoRotation()">Auto rotation (default)</button>
+    </div>
+    <div id="toolPanel">
+        Values:
+        <button onclick="uniformLabels()">Uniform labels</button>
+        <button onclick="irregularLabels()">Irregular labels</button>
+    </div>
+    <div id="toolPanel">
+        Avoid Collisions:
+        <button onclick="noCollisionDetection()">Off</button>
+        <button onclick="autoCollisionDetection()">On (default)</button>
+    </div>
+    <div id="toolPanel" style="position: absolute; top: 0; right: 0">
+        <button onclick="reset()">Reset</button>
+    </div>
+    <div id="myChart"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/main.ts
@@ -1,0 +1,96 @@
+import { AgCartesianChartOptions, AgEnterpriseCharts } from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        {
+            type: 'bar',
+            xKey: 'year',
+            yKey: 'value',
+        },
+    ],
+    axes: [
+        {
+            type: 'category',
+            position: 'bottom',
+            label: {},
+        },
+        {
+            type: 'number',
+            position: 'left',
+            label: {},
+        },
+    ],
+};
+
+const chart = AgEnterpriseCharts.create(options);
+
+function reset() {
+    const element = document.getElementsByClassName('ag-chart-wrapper')![0]! as HTMLElement;
+    element.style.width = '100%';
+    element.style.height = '100%';
+
+    delete options.axes![0].label!.rotation;
+    delete options.axes![0].label!.autoRotate;
+    delete options.axes![0].label!.avoidCollisions;
+    delete options.axes![1].label!.rotation;
+    delete options.axes![1].label!.autoRotate;
+    delete options.axes![1].label!.avoidCollisions;
+
+    options.series![0].xKey = 'year';
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function disableRotation() {
+    delete options.axes![0].label!.rotation;
+    delete options.axes![1].label!.rotation;
+    options.axes![0].label!.autoRotate = false;
+    options.axes![1].label!.autoRotate = false;
+
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function fixedRotation() {
+    options.axes![0].label!.rotation = 45;
+    options.axes![1].label!.rotation = 45;
+    options.axes![0].label!.autoRotate = false;
+    options.axes![1].label!.autoRotate = false;
+
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function autoRotation() {
+    delete options.axes![0].label!.rotation;
+    delete options.axes![1].label!.rotation;
+    options.axes![0].label!.autoRotate = true;
+    options.axes![1].label!.autoRotate = true;
+
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function uniformLabels() {
+    options.series![0].xKey = 'year';
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function irregularLabels() {
+    options.series![0].xKey = 'country';
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function noCollisionDetection() {
+    options.axes![0].label!.avoidCollisions = false;
+    options.axes![1].label!.avoidCollisions = false;
+
+    AgEnterpriseCharts.update(chart, options);
+}
+
+function autoCollisionDetection() {
+    options.axes![0].label!.avoidCollisions = true;
+    options.axes![1].label!.avoidCollisions = true;
+
+    AgEnterpriseCharts.update(chart, options);
+}

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/styles.css
@@ -1,0 +1,28 @@
+.wrapper {
+    height: 100%;
+    display: flex;
+    position: relative;
+    flex-direction: column;
+}
+
+#toolPanel {
+    text-align: center;
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    font-size: 13px;
+    margin-bottom: 5px;
+}
+
+.spacer {
+    display: inline-block;
+    min-width: 20px;
+}
+
+#myChart {
+    height: 100%;
+}
+
+.ag-chart-wrapper {
+    resize: both;
+    /* 'auto' has different behaviour on Windows! */
+    overflow: hidden;
+}

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/index.mdoc
@@ -1,0 +1,5 @@
+---
+title: 'Axis Labels Test'
+---
+
+{% chartExampleRunner title="Axis Label Rotation Example" name="axis-label-rotation" type="generated" /%}


### PR DESCRIPTION
Attempts to rework the axis label processing flow so that we end up with most label properties as a `AxisLabelNodeDatum` managed by the label-related `Selection` - this should make animating the individual labels easier in a follow-up PR.