### PR TITLE
AG-9301 Disable bullet selection garbage selection

### DIFF
--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -156,9 +156,9 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<_Scene.Rect, 
             },
         });
         this.colorRangesGroup = new _Scene.Group({ name: `${this.id}-colorRanges` });
-        this.colorRangesSelection = _Scene.Selection.select(this.colorRangesGroup, _Scene.Rect);
+        this.colorRangesSelection = _Scene.Selection.select(this.colorRangesGroup, _Scene.Rect, false);
         this.rootGroup.append(this.colorRangesGroup);
-        this.targetLinesSelection = _Scene.Selection.select(this.annotationGroup, _Scene.Line);
+        this.targetLinesSelection = _Scene.Selection.select(this.annotationGroup, _Scene.Line, false);
     }
 
     override destroy() {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9301

This fixes a bug where the target line disappears after hovering over & off the datum.