### PR TITLE
AG-9790 - Fix dark mode for homepage and gallery

### DIFF
--- a/packages/ag-charts-website/src/components/site-header/DarkModeToggle.jsx
+++ b/packages/ag-charts-website/src/components/site-header/DarkModeToggle.jsx
@@ -22,15 +22,19 @@ export const DarkModeToggle = () => {
                 className={classNames(styles.toggle, darkmode ? styles.dark : styles.light, 'button-style-none')}
                 onClick={() => {
                     setDarkmode(!darkmode);
+                    const darkModeEvent = {
+                        type: 'color-scheme-change',
+                        darkmode: !darkmode,
+                    };
 
                     // post message for example runner to listen for user initiated color scheme changes
                     const iframes = document.querySelectorAll('.exampleRunner') || [];
                     iframes.forEach((iframe) => {
-                        iframe.contentWindow.postMessage({
-                            type: 'color-scheme-change',
-                            darkmode: !darkmode,
-                        });
+                        iframe.contentWindow.postMessage(darkModeEvent);
                     });
+
+                    // Send on event on page for charts that are embeded on the page
+                    window.dispatchEvent(new CustomEvent('message', { detail: darkModeEvent }));
                 }}
             >
                 {darkmode ? <Icon name="sun" /> : <Icon name="moon" />}

--- a/packages/ag-charts-website/src/components/site-header/getDarkModeSnippet.ts
+++ b/packages/ag-charts-website/src/components/site-header/getDarkModeSnippet.ts
@@ -1,0 +1,121 @@
+export const DARK_MODE_START = '/** DARK MODE START **/';
+export const DARK_MODE_END = '/** DARK MODE END **/';
+
+const DARK_MODE_SNIPPETS = {
+    homepageHero: () => `
+        heroChartOptions.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
+        agCharts.AgChart.update(chart, heroChartOptions);
+        window.addEventListener('message', (event) => {
+            const data = event.detail;
+            if (data?.type === 'color-scheme-change') {
+                heroChartOptions.theme = data.darkmode ? 'ag-default-dark' : 'ag-default';
+                agCharts.AgChart.update(chart, heroChartOptions);
+            }
+        });`,
+    vanilla: () => `
+        options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
+        agCharts.AgChart.update(chart, options);
+        window.addEventListener('message', (event) => {
+            if (event.data?.type === 'color-scheme-change') {
+                options.theme = event.data.darkmode ? 'ag-default-dark' : 'ag-default';
+                agCharts.AgChart.update(chart, options);
+            }
+        });`,
+    typescript: ({ chartAPI }: { chartAPI: string }) => `
+        options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
+        ${chartAPI}.update(chart, options);
+        window.addEventListener('message', (event) => {
+            if (event.data?.type === 'color-scheme-change') {
+                options.theme = event.data.darkmode ? 'ag-default-dark' : 'ag-default';
+                ${chartAPI}.update(chart, options);
+            }
+        });`,
+    angular: () => `
+        this.options = {
+            ...this.options,
+            theme: localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default'
+        };
+        window.addEventListener('message', (event) => {
+            if (event.data && event.data.type === 'color-scheme-change') {
+                this.options = {
+                    ...this.options,
+                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
+                };
+            }
+        });`,
+    react: () => `
+        this.setState((prevState) => ({
+            options: {
+                ...prevState.options,
+                theme:
+                    localStorage['documentation:darkmode'] === 'true'
+                        ? 'ag-default-dark'
+                        : 'ag-default'
+            }
+        }));
+        window.addEventListener('message', (event) => {
+            if (event.data && event.data.type === 'color-scheme-change') {
+                this.setState((prevState) => ({
+                    options: {
+                        ...prevState.options,
+                        theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
+                    }
+                }));
+            }
+        });`,
+    reactFunctional: () => `
+        options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
+        window.addEventListener('message', (event) => {
+            if (event.data && event.data.type === 'color-scheme-change') {
+                setOptions((currentOptions) => ({
+                    ...currentOptions,
+                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default',
+                }));
+            }
+        });`,
+    reactFunctionalTs: () => `
+        options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
+        window.addEventListener('message', (event) => {
+            if (event.data?.type === 'color-scheme-change') {
+                setOptions((currentOptions) => ({
+                    ...currentOptions,
+                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default',
+                }));
+            }
+        });`,
+    vue: () => `
+        this.options = {
+            ...this.options,
+            theme: localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default'
+        };
+        window.addEventListener('message', (event) => {
+            if (event.data && event.data.type === 'color-scheme-change') {
+                this.options = {
+                    ...this.options,
+                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
+                };
+            }
+        });`,
+    vue3: () => `
+        this.options = {
+            ...this.options,
+            theme: localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default'
+        };
+        window.addEventListener('message', (event) => {
+            if (event.data && event.data.type === 'color-scheme-change') {
+                this.options = {
+                    ...this.options,
+                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
+                };
+            }
+        });`,
+};
+
+export type SnippetType = keyof typeof DARK_MODE_SNIPPETS;
+
+export function getDarkModeSnippet(snippetType: SnippetType, options?: any) {
+    return `${DARK_MODE_START}
+    ${DARK_MODE_SNIPPETS[snippetType](options)}
+    ${DARK_MODE_END}
+    `;
+}

--- a/packages/ag-charts-website/src/features/docs/utils/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/docs/utils/examplesGenerator.ts
@@ -28,10 +28,12 @@ export const getGeneratedDocsContents = async ({
     internalFramework,
     pageName,
     exampleName,
+    ignoreDarkMode,
 }: {
     internalFramework: InternalFramework;
     pageName: string;
     exampleName: string;
+    ignoreDarkMode?: boolean;
 }): Promise<GeneratedContents | undefined> => {
     const folderUrl = getFolderUrl({
         pageName,
@@ -41,5 +43,6 @@ export const getGeneratedDocsContents = async ({
     return getGeneratedContents({
         internalFramework,
         folderUrl,
+        ignoreDarkMode,
     });
 };

--- a/packages/ag-charts-website/src/features/example-runner/components/CodeViewer.tsx
+++ b/packages/ag-charts-website/src/features/example-runner/components/CodeViewer.tsx
@@ -1,6 +1,7 @@
 import type { InternalFramework } from '@ag-grid-types';
 import Code from '@components/Code';
 import { Icon } from '@components/icon/Icon';
+import { DARK_MODE_END, DARK_MODE_START } from '@components/site-header/getDarkModeSnippet';
 import type { ExampleType, FileContents } from '@features/examples-generator/types';
 import { doOnEnter } from '@utils/doOnEnter';
 import classnames from 'classnames';
@@ -9,8 +10,8 @@ import { useEffect, useState } from 'react';
 import { CodeOptions } from './CodeOptions';
 import styles from './CodeViewer.module.scss';
 
-const startDelimiter = '/** DARK MODE START **/';
-const endDelimiter = '/** DARK MODE END **/';
+const startDelimiter = DARK_MODE_START;
+const endDelimiter = DARK_MODE_END;
 const escapedStart = startDelimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const escapedEnd = endDelimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const regex = new RegExp(`${escapedStart}[\\s\\S]*?${escapedEnd}`, 'g');

--- a/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
@@ -52,11 +52,11 @@ export const getGeneratedContentsFileList = async ({
 export const getGeneratedContents = async ({
     internalFramework,
     folderUrl,
-    isGalleryExample,
+    ignoreDarkMode,
 }: {
     internalFramework: InternalFramework;
     folderUrl: URL;
-    isGalleryExample?: boolean;
+    ignoreDarkMode?: boolean;
 }): Promise<GeneratedContents | undefined> => {
     const sourceFileList = await fs.readdir(folderUrl);
 
@@ -110,7 +110,7 @@ export const getGeneratedContents = async ({
         bindings,
         typedBindings,
         otherScriptFiles,
-        isGalleryExample,
+        ignoreDarkMode,
     });
     const contents: GeneratedContents = {
         isEnterprise,

--- a/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
@@ -56,7 +56,7 @@ export const getGeneratedContents = async ({
 }: {
     internalFramework: InternalFramework;
     folderUrl: URL;
-    isGalleryExample: boolean;
+    isGalleryExample?: boolean;
 }): Promise<GeneratedContents | undefined> => {
     const sourceFileList = await fs.readdir(folderUrl);
 

--- a/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-angular.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-angular.ts
@@ -1,3 +1,5 @@
+import { getDarkModeSnippet } from '@components/site-header/getDarkModeSnippet';
+
 import { convertTemplate, getImport, toAssignment, toConst, toInput, toMember } from './angular-utils';
 import { wrapOptionsUpdateCode } from './chart-utils';
 import { templatePlaceholder } from './chart-vanilla-src-parser';
@@ -100,20 +102,7 @@ export class AppComponent {
 
     ngOnInit() {
         ${bindings.init.join(';\n    ')}
-        /** DARK MODE START **/
-        this.options = {
-            ...this.options,
-            theme: localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default'
-        };
-        window.addEventListener('message', (event) => {
-            if (event.data && event.data.type === 'color-scheme-change') {
-                this.options = {
-                    ...this.options,
-                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
-                };
-            }
-        });
-        /** DARK MODE END **/
+        ${getDarkModeSnippet('angular')}
     }
 
     ${instanceMethods

--- a/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-react-functional.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-react-functional.ts
@@ -1,3 +1,5 @@
+import { getDarkModeSnippet } from '@components/site-header/getDarkModeSnippet';
+
 import { toTitleCase } from './angular-utils';
 import { getChartImports, wrapOptionsUpdateCode } from './chart-utils';
 import { templatePlaceholder } from './chart-vanilla-src-parser';
@@ -104,17 +106,7 @@ const ChartExample = () => {
         ${instanceBindings.join(';\n        ')}
         ${instanceMethods.concat(externalEventHandlers).join('\n\n    ')}
 
-        /** DARK MODE START **/
-        options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
-        window.addEventListener('message', (event) => {
-            if (event.data && event.data.type === 'color-scheme-change') {
-                setOptions((currentOptions) => ({
-                    ...currentOptions,
-                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default',
-                }));
-            }
-        });
-        /** DARK MODE END **/
+        ${getDarkModeSnippet('reactFunctional')}
         return ${template};
     }
 

--- a/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-react.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-react.ts
@@ -1,3 +1,5 @@
+import { getDarkModeSnippet } from '@components/site-header/getDarkModeSnippet';
+
 import { getChartImports, wrapOptionsUpdateCode } from './chart-utils';
 import { templatePlaceholder } from './chart-vanilla-src-parser';
 import { convertFunctionToProperty, isInstanceMethod } from './parser-utils';
@@ -97,27 +99,7 @@ class ChartExample extends Component {
 
     componentDidMount() {
         ${bindings.init.join(';\n        ')}
-        /** DARK MODE START **/
-        this.setState((prevState) => ({
-            options: {
-                ...prevState.options,
-                theme:
-                    localStorage['documentation:darkmode'] === 'true'
-                        ? 'ag-default-dark'
-                        : 'ag-default'
-            }
-        }));
-        window.addEventListener('message', (event) => {
-            if (event.data && event.data.type === 'color-scheme-change') {
-                this.setState((prevState) => ({
-                    options: {
-                        ...prevState.options,
-                        theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
-                    }
-                }));
-            }
-        });
-        /** DARK MODE END **/
+        ${getDarkModeSnippet('react')}
     }
 
     ${instanceMethods.concat(externalEventHandlers).join('\n\n    ')}

--- a/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-vue.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-vue.ts
@@ -1,3 +1,5 @@
+import { getDarkModeSnippet } from '@components/site-header/getDarkModeSnippet';
+
 import { getChartImports, wrapOptionsUpdateCode } from './chart-utils';
 import { templatePlaceholder } from './chart-vanilla-src-parser';
 import { getFunctionName, isInstanceMethod, removeFunctionKeyword } from './parser-utils';
@@ -106,20 +108,7 @@ const ChartExample = {
     },
     mounted() {
         ${bindings.init.join(';\n        ')}
-        /** DARK MODE START **/
-        this.options = {
-            ...this.options,
-            theme: localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default'
-        };
-        window.addEventListener('message', (event) => {
-            if (event.data && event.data.type === 'color-scheme-change') {
-                this.options = {
-                    ...this.options,
-                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
-                };
-            }
-        });
-        /** DARK MODE END **/
+        ${getDarkModeSnippet('vue')}
     },
     methods: {
         ${instanceMethods

--- a/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-vue3.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/transformation-scripts/chart-vanilla-to-vue3.ts
@@ -1,3 +1,5 @@
+import { getDarkModeSnippet } from '@components/site-header/getDarkModeSnippet';
+
 import { getChartImports, wrapOptionsUpdateCode } from './chart-utils';
 import { templatePlaceholder } from './chart-vanilla-src-parser';
 import { getFunctionName, isInstanceMethod, removeFunctionKeyword } from './parser-utils';
@@ -106,20 +108,7 @@ const ChartExample = {
     },
     mounted() {
         ${bindings.init.join(';\n        ')}
-        /** DARK MODE START **/
-        this.options = {
-            ...this.options,
-            theme: localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default'
-        };
-        window.addEventListener('message', (event) => {
-            if (event.data && event.data.type === 'color-scheme-change') {
-                this.options = {
-                    ...this.options,
-                    theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default'
-                };
-            }
-        });
-        /** DARK MODE END **/
+        ${getDarkModeSnippet('vue3')}
     },
     methods: {
         ${instanceMethods

--- a/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
@@ -1,4 +1,5 @@
 import type { InternalFramework } from '@ag-grid-types';
+import { getDarkModeSnippet } from '@components/site-header/getDarkModeSnippet';
 
 import { ANGULAR_GENERATED_MAIN_FILE_NAME } from '../constants';
 import { vanillaToAngular } from '../transformation-scripts/chart-vanilla-to-angular';
@@ -106,8 +107,9 @@ const createVueFilesGenerator =
 
 export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator> = {
     vanilla: ({ entryFile, indexHtml, typedBindings, isEnterprise, otherScriptFiles, isGalleryExample }) => {
-        const entryFileName = getEntryFileName('vanilla')!;
-        const mainFileName = getMainFileName('vanilla')!;
+        const internalFramework: InternalFramework = 'vanilla';
+        const entryFileName = getEntryFileName(internalFramework)!;
+        const mainFileName = getMainFileName(internalFramework)!;
         let mainJs = readAsJsFile(entryFile);
 
         // replace Typescript new Grid( with Javascript new agGrid.Grid(
@@ -136,17 +138,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
             mainJs =
                 mainJs +
                 `\n
-                /** DARK MODE START **/
-                options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
-                agCharts.AgChart.update(chart, options);
-                window.addEventListener('message', (event) => {
-                    if (event.data?.type === 'color-scheme-change') {
-                        options.theme = event.data.darkmode ? 'ag-default-dark' : 'ag-default';
-                        agCharts.AgChart.update(chart, options);
-                    }
-                });
-                /** DARK MODE END **/
-            `;
+                ${getDarkModeSnippet(internalFramework)}`;
         }
 
         return {
@@ -193,16 +185,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
             mainTsx =
                 mainTsx +
                 `\n
-                /** DARK MODE START **/
-                options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
-                ${chartAPI}.update(chart, options);
-                window.addEventListener('message', (event) => {
-                    if (event.data?.type === 'color-scheme-change') {
-                        options.theme = event.data.darkmode ? 'ag-default-dark' : 'ag-default';
-                        ${chartAPI}.update(chart, options);
-                    }
-                });
-                /** DARK MODE END **/
+                ${getDarkModeSnippet(internalFramework, { chartAPI })}
             `;
         }
 
@@ -237,17 +220,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
 
         // add website dark mode handling code to doc examples - this code is later striped out from the code viewer / plunker
         if (!isGalleryExample) {
-            const codeToInsert = `/** DARK MODE START **/
-                options.theme = localStorage['documentation:darkmode'] === 'true' ? 'ag-default-dark' : 'ag-default';
-                window.addEventListener('message', (event) => {
-                    if (event.data?.type === 'color-scheme-change') {
-                        setOptions((currentOptions) => ({
-                            ...currentOptions,
-                            theme: event.data.darkmode ? 'ag-default-dark' : 'ag-default',
-                        }));
-                    }
-                });
-                /** DARK MODE END **/`;
+            const codeToInsert = getDarkModeSnippet(internalFramework);
 
             const regex = /(const \[options, setOptions] = useState<[\s\S]*?\);)/;
             indexTsx = indexTsx.replace(regex, `$1${codeToInsert}`);

--- a/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/frameworkFilesGenerator.ts
@@ -34,7 +34,7 @@ type ConfigGenerator = ({
     bindings,
     typedBindings,
     otherScriptFiles,
-    isGalleryExample,
+    ignoreDarkMode,
 }: {
     entryFile: string;
     indexHtml: string;
@@ -42,7 +42,7 @@ type ConfigGenerator = ({
     bindings: any;
     typedBindings: any;
     otherScriptFiles: FileContents;
-    isGalleryExample: boolean;
+    ignoreDarkMode?: boolean;
 }) => FrameworkFiles | Promise<FrameworkFiles>;
 
 const createReactFilesGenerator =
@@ -106,7 +106,7 @@ const createVueFilesGenerator =
     };
 
 export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator> = {
-    vanilla: ({ entryFile, indexHtml, typedBindings, isEnterprise, otherScriptFiles, isGalleryExample }) => {
+    vanilla: ({ entryFile, indexHtml, typedBindings, isEnterprise, otherScriptFiles, ignoreDarkMode }) => {
         const internalFramework: InternalFramework = 'vanilla';
         const entryFileName = getEntryFileName(internalFramework)!;
         const mainFileName = getMainFileName(internalFramework)!;
@@ -128,7 +128,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         }
 
         // add website dark mode handling code to doc examples - this code is later striped out from the code viewer / plunker
-        if (!isGalleryExample) {
+        if (!ignoreDarkMode) {
             const chartAPI = isEnterprise ? 'agChartsEnterprise.AgEnterprise' : 'agCharts.AgChart';
 
             if (!mainJs.includes(`chart = ${chartAPI}`)) {
@@ -152,7 +152,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
             mainFileName,
         };
     },
-    typescript: async ({ entryFile, indexHtml, otherScriptFiles, bindings, isEnterprise, isGalleryExample }) => {
+    typescript: async ({ entryFile, indexHtml, otherScriptFiles, bindings, isEnterprise, ignoreDarkMode }) => {
         const internalFramework: InternalFramework = 'typescript';
         const entryFileName = getEntryFileName(internalFramework)!;
         const mainFileName = getMainFileName(internalFramework)!;
@@ -176,7 +176,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         let mainTsx = externalEventHandlersCode ? `${entryFile}${externalEventHandlersCode}` : entryFile;
 
         // add website dark mode handling code to doc examples - this code is later striped out from the code viewer / plunker
-        if (!isGalleryExample) {
+        if (!ignoreDarkMode) {
             const chartAPI = isEnterprise ? 'AgEnterpriseCharts' : 'AgChart';
             if (!mainTsx.includes(`chart = ${chartAPI}`)) {
                 mainTsx = mainTsx.replace(`${chartAPI}.create(options);`, `var chart = ${chartAPI}.create(options);`);
@@ -209,7 +209,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         sourceGenerator: vanillaToReactFunctional,
         internalFramework: 'reactFunctional',
     }),
-    reactFunctionalTs: async ({ typedBindings, indexHtml, otherScriptFiles, isGalleryExample }) => {
+    reactFunctionalTs: async ({ typedBindings, indexHtml, otherScriptFiles, ignoreDarkMode }) => {
         const internalFramework: InternalFramework = 'reactFunctionalTs';
         const entryFileName = getEntryFileName(internalFramework)!;
         const mainFileName = getMainFileName(internalFramework)!;
@@ -219,7 +219,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         let indexTsx = getSource();
 
         // add website dark mode handling code to doc examples - this code is later striped out from the code viewer / plunker
-        if (!isGalleryExample) {
+        if (!ignoreDarkMode) {
             const codeToInsert = getDarkModeSnippet(internalFramework);
 
             const regex = /(const \[options, setOptions] = useState<[\s\S]*?\);)/;

--- a/packages/ag-charts-website/src/features/gallery/components/GalleryExampleThemeDropdown.tsx
+++ b/packages/ag-charts-website/src/features/gallery/components/GalleryExampleThemeDropdown.tsx
@@ -1,46 +1,19 @@
-import { useStore } from '@nanostores/react';
-import { $darkmode } from '@stores/darkmodeStore';
-import { $theme, ThemeName, setTheme } from '@stores/themeStore';
-import type { ChangeEvent, FunctionComponent } from 'react';
-import { useEffect } from 'react';
+import { useTheme } from '@utils/hooks/useTheme';
+import { type ChangeEvent, type FunctionComponent, useMemo } from 'react';
 
+import { ThemeName } from '../../../stores/themeStore';
 import styles from './GalleryExampleThemeDropdown.module.scss';
 
-const getTheme = (currentTheme: ThemeName, isDarkMode: boolean): ThemeName => {
-    const darkThemeSuffix = '-dark';
-    const hasDarkSuffix = currentTheme.endsWith(darkThemeSuffix);
-
-    if (isDarkMode === hasDarkSuffix) return currentTheme;
-
-    return isDarkMode
-        ? (`${currentTheme}${darkThemeSuffix}` as ThemeName)
-        : (currentTheme.substring(0, currentTheme.length - darkThemeSuffix.length) as ThemeName);
-};
-
 export const GalleryExampleThemeDropdown: FunctionComponent = () => {
-    const darkmode = useStore($darkmode);
-    const theme = useStore($theme);
-    const isDarkMode = typeof darkmode === 'string' ? darkmode === 'true' : darkmode;
-
-    const getThemeName = () => theme.replace('-dark', '');
-
-    const updateTheme = (newTheme: ThemeName) => {
-        if (newTheme !== theme) {
-            setTheme(newTheme);
-        }
-    };
+    const { updateDarkModeTheme, theme, displayName } = useTheme();
 
     const applyTheme = (event: ChangeEvent<HTMLSelectElement>) => {
-        updateTheme(getTheme(event.target.value as ThemeName, isDarkMode));
+        updateDarkModeTheme(event.target.value as ThemeName);
     };
-
-    useEffect(() => {
-        updateTheme(getTheme(theme, isDarkMode));
-    }, [isDarkMode, theme]);
 
     return (
         <div className={styles.toolPanel}>
-            <select id="theme-select" value={getThemeName()} onChange={applyTheme}>
+            <select id="theme-select" value={displayName} onChange={applyTheme}>
                 <option value="ag-default">ag-default</option>
                 <option value="ag-sheets">ag-sheets</option>
                 <option value="ag-polychroma">ag-polychroma</option>

--- a/packages/ag-charts-website/src/features/gallery/utils/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/examplesGenerator.ts
@@ -22,8 +22,10 @@ export const getGeneratedGalleryContentsFileList = async ({
 
 export const getGeneratedGalleryContents = async ({
     exampleName,
+    ignoreDarkMode,
 }: {
     exampleName: string;
+    ignoreDarkMode?: boolean;
 }): Promise<GeneratedContents | undefined> => {
     const folderUrl = getFolderUrl({
         exampleName,
@@ -32,13 +34,14 @@ export const getGeneratedGalleryContents = async ({
     return getGeneratedContents({
         internalFramework: GALLERY_INTERNAL_FRAMEWORK,
         folderUrl,
-        ignoreDarkMode: true,
+        ignoreDarkMode,
     });
 };
 
 export const getGeneratedPlainGalleryContents = async ({ exampleName }: { exampleName: string }) => {
     const generatedContents = await getGeneratedGalleryContents({
         exampleName,
+        ignoreDarkMode: true,
     });
     const { entryFileName, files = {} } = generatedContents || {};
     const { [entryFileName!]: entryFile, ...otherFiles } = files;

--- a/packages/ag-charts-website/src/features/gallery/utils/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/examplesGenerator.ts
@@ -32,7 +32,7 @@ export const getGeneratedGalleryContents = async ({
     return getGeneratedContents({
         internalFramework: GALLERY_INTERNAL_FRAMEWORK,
         folderUrl,
-        isGalleryExample: true,
+        ignoreDarkMode: true,
     });
 };
 

--- a/packages/ag-charts-website/src/features/gallery/utils/getDarkModeTheme.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/getDarkModeTheme.ts
@@ -1,0 +1,12 @@
+import { type ThemeName } from '@stores/themeStore';
+
+export const getDarkModeTheme = (currentTheme: ThemeName, isDarkMode: boolean): ThemeName => {
+    const darkThemeSuffix = '-dark';
+    const hasDarkSuffix = currentTheme.endsWith(darkThemeSuffix);
+
+    if (isDarkMode === hasDarkSuffix) return currentTheme;
+
+    return isDarkMode
+        ? (`${currentTheme}${darkThemeSuffix}` as ThemeName)
+        : (currentTheme.substring(0, currentTheme.length - darkThemeSuffix.length) as ThemeName);
+};

--- a/packages/ag-charts-website/src/features/homepage/components/HomepageExampleRunner.astro
+++ b/packages/ag-charts-website/src/features/homepage/components/HomepageExampleRunner.astro
@@ -3,6 +3,7 @@ import { InternalFramework } from '@ag-grid-types';
 import { getExampleUrl } from '@features/docs/utils/urlPaths';
 import HomepageChart from './HomepageChart.astro';
 import { getGeneratedDocsContents } from '@features/docs/utils/examplesGenerator';
+import { getDarkModeSnippet } from '@components/site-header/getDarkModeSnippet';
 
 interface Props {
     internalFramework: InternalFramework;
@@ -17,15 +18,20 @@ const exampleUrl = getExampleUrl({
     pageName,
     exampleName,
 });
-const generatedContents =
-    await getGeneratedDocsContents({
-        internalFramework,
-        pageName,
-        exampleName,
-    });
+const generatedContents = await getGeneratedDocsContents({
+    internalFramework,
+    pageName,
+    exampleName,
+    // Ignore dark mode and add on page manually
+    ignoreDarkMode: true,
+});
 const { scriptFiles, styleFiles, files } = generatedContents!;
 const indexFragment = files && files['index.html'];
 const appLocation = exampleUrl;
+
+const darkModeSnippet = `<script>
+    ${getDarkModeSnippet('homepageHero')}
+</script>`;
 ---
 
 <div class="container">
@@ -51,3 +57,5 @@ const appLocation = exampleUrl;
         }
     }
 </style>
+
+<Fragment set:html={darkModeSnippet} />

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/[theme]-plain.png.ts
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/[theme]-plain.png.ts
@@ -45,6 +45,7 @@ export async function get({ params }: { params: Params }) {
         const { entryFileName, files = {} } =
             (await getGeneratedGalleryContents({
                 exampleName,
+                ignoreDarkMode: true,
             })) || {};
         const entryFile = files[entryFileName!];
         let { options } = transformPlainEntryFile(entryFile, files['data.js'], theme);

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plain-main.ts
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plain-main.ts
@@ -19,6 +19,7 @@ export async function get({ params }: { params: Params }) {
     const { entryFileName, files = {} } =
         (await getGeneratedGalleryContents({
             exampleName,
+            ignoreDarkMode: true,
         })) || {};
     const entryFile = files[entryFileName!];
     const { code } = transformPlainEntryFile(entryFile, files['data.js']);

--- a/packages/ag-charts-website/src/utils/hooks/useTheme.ts
+++ b/packages/ag-charts-website/src/utils/hooks/useTheme.ts
@@ -1,0 +1,34 @@
+import { getDarkModeTheme } from '@features/gallery/utils/getDarkModeTheme';
+import { useStore } from '@nanostores/react';
+import { $darkmode } from '@stores/darkmodeStore';
+import { $theme, type ThemeName, setTheme } from '@stores/themeStore';
+import { useCallback, useEffect, useMemo } from 'react';
+
+export function useTheme() {
+    const darkmode = useStore($darkmode);
+    const theme = useStore($theme);
+    const displayName = useMemo(() => theme.replace('-dark', ''), [theme]);
+
+    const updateDarkModeTheme = useCallback(
+        (newTheme: ThemeName) => {
+            const isDarkMode = typeof darkmode === 'string' ? darkmode === 'true' : darkmode;
+            const newDarkModeTheme = getDarkModeTheme(newTheme, isDarkMode);
+
+            if (newDarkModeTheme !== theme) {
+                setTheme(newDarkModeTheme);
+            }
+        },
+        [darkmode, theme]
+    );
+
+    // Update theme if darkmode changes
+    useEffect(() => {
+        updateDarkModeTheme(theme);
+    }, [darkmode, theme]);
+
+    return {
+        theme,
+        displayName,
+        updateDarkModeTheme,
+    };
+}


### PR DESCRIPTION
## Changes

* Extract dark mode snippets into a file
* Rename `isGalleryExample` flag to `ignoreDarkMode` 
* Add dark mode change custom event for homepage hero chart changes
* Ignore dark mode injection for gallery thumbnails, but not for the gallery pages
* Extract theme hook
* Inject homepage dark mode snippet manually, as the chart is loaded onto the page