### PR TITLE
AG-9022: QA Feedback: Error Bar Docs

### DIFF
--- a/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/errorBarOptions.ts
@@ -61,10 +61,17 @@ interface ErrorBarNameOptions {
     yUpperName?: string;
 }
 
-interface ErrorBarCapOptions extends ErrorBarCapLengthOptions, ErrorBarStylingOptions {
+interface ErrorBarCapFormatterOption {
     /** Function used to return formatting for individual caps, based on the given parameters. If the current error bar is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */
     formatter?: (params: AgErrorBarFormatterParams) => AgErrorBarOptions['cap'] | undefined;
 }
+
+interface ErrorBarFormatterOption {
+    /** Function used to return formatting for individual error bars, based on the given parameters. If the current error bar is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */
+    formatter?: (params: AgErrorBarFormatterParams) => AgErrorBarOptions | undefined;
+}
+
+interface ErrorBarCapOptions extends ErrorBarCapFormatterOption, ErrorBarCapLengthOptions, ErrorBarStylingOptions {}
 
 export interface AgErrorBarThemeableOptions extends ErrorBarStylingOptions {
     /** Options to style error bars' caps */
@@ -73,10 +80,11 @@ export interface AgErrorBarThemeableOptions extends ErrorBarStylingOptions {
 
 export const AgErrorBarSupportedSeriesTypes = ['bar', 'line', 'scatter'] as const;
 
-export interface AgErrorBarOptions extends ErrorBarKeyOptions, ErrorBarNameOptions, AgErrorBarThemeableOptions {
-    /** Function used to return formatting for individual error bars, based on the given parameters. If the current error bar is highlighted, the `highlighted` property will be set to `true`; make sure to check this if you want to differentiate between the highlighted and un-highlighted states. */
-    formatter?: (params: AgErrorBarFormatterParams) => AgErrorBarOptions | undefined;
-}
+export interface AgErrorBarOptions
+    extends ErrorBarKeyOptions,
+        ErrorBarNameOptions,
+        ErrorBarFormatterOption,
+        AgErrorBarThemeableOptions {}
 
 export interface AgErrorBarTooltipParams
     // Note: AgCartesianSeriesTooltipRendererParams includes SeriesKeyOptions & SeriesNameOptions

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -62,9 +62,9 @@ In this configuration:
 -   `errorBar.xLowerKey` and `errorBar.xUpperKey` denote the x-axis bounds.
 -   `errorBar.yLowerKey` and `errorBar.yUpperKey` denote the y-axis bounds.
 
-A custom [Tooltip](./tooltip/) is also provided to the series `tooltip` option
-to display the x and y axis bounds. [Additional parameters](#api-reference)
-are available to the renderer when Error Bars are enabled.
+A custom [Tooltip](./tooltips/) is also provided to the series `tooltip` option
+to display the x and y axis bounds. The X & Y keys and names are availabe to the
+renderer when Error Bars are enabled.
 
 {% note %}
 Double Error Bars require the x-axis to be a [Number Axis](./axes-types/#number), limiting them to [Line](./line-series/)
@@ -102,9 +102,8 @@ The default Cap length is determined based on the type of series:
 {% /note %}
 
 [Formatters](./formatters) can also be used for customisation using
-`errorBar.formatter` or `errorBar.cap.formatter` properties. The
-[Parameters](#api-reference) include properties from the Series and
-Error Bars.
+`errorBar.formatter` or `errorBar.cap.formatter` properties. The Parameters
+includes properties from the Series and Error Bars.
 
 ## API Reference
 
@@ -112,14 +111,6 @@ Error Bars.
 
 {% tabItem id="AgErrorBarOptions" label="Error Bar Options" %}
 {% apiReference id="AgErrorBarOptions" /%}
-{% /tabItem %}
-
-{% tabItem id="AgErrorBarTooltipParams" label="Tooltip Parameters" %}
-{% apiReference id="AgErrorBarTooltipParams" /%}
-{% /tabItem %}
-
-{% tabItem id="AgErrorBarFormatterParams" label="Formatter Parameters" %}
-{% apiReference id="AgErrorBarFormatterParams" /%}
 {% /tabItem %}
 
 {% /tabs %}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9022
- Remove error bar API tabs

https://ag-grid.atlassian.net/browse/AG-9017
- Move the `formatter` errorbar option. This puts it after the errorbar keys/names and before the `cap` and styling options.
