### PR TITLE
AG-9042 - Disable key paths for Integrated Charts cases.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -33,6 +33,7 @@ import type { Caption } from './caption';
 import type { ChartAxis } from './chartAxis';
 import type { ChartAxisDirection } from './chartAxisDirection';
 import { ChartHighlight } from './chartHighlight';
+import type { ChartMode } from './chartMode';
 import { ChartUpdateType } from './chartUpdateType';
 import { DataController } from './data/dataController';
 import { DataService } from './dataService';
@@ -247,7 +248,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     public footnote?: Caption = undefined;
 
     @Validate(STRING_UNION('standalone', 'integrated'))
-    mode: 'standalone' | 'integrated' = 'standalone';
+    mode: ChartMode = 'standalone';
 
     private _destroyed: boolean = false;
     private readonly _destroyFns: (() => void)[] = [];
@@ -920,7 +921,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.assignSeriesToAxes();
         }
 
-        const dataController = new DataController();
+        const dataController = new DataController(this.mode);
         const seriesPromises = this.series.map((s) => s.processData(dataController));
         await dataController.execute();
         await Promise.all(seriesPromises);

--- a/packages/ag-charts-community/src/chart/chartMode.ts
+++ b/packages/ag-charts-community/src/chart/chartMode.ts
@@ -1,0 +1,1 @@
+export type ChartMode = 'standalone' | 'integrated';

--- a/packages/ag-charts-community/src/chart/data/dataController.ts
+++ b/packages/ag-charts-community/src/chart/data/dataController.ts
@@ -1,5 +1,6 @@
 import { Debug } from '../../util/debug';
 import { jsonDiff } from '../../util/json';
+import type { ChartMode } from '../chartMode';
 import type { DataModelOptions, DatumPropertyDefinition, ProcessedData, PropertyDefinition } from './dataModel';
 import { DataModel } from './dataModel';
 
@@ -40,7 +41,7 @@ export class DataController {
     private requested: RequestedProcessing<any, any, any>[] = [];
     private status: 'setup' | 'executed' = 'setup';
 
-    public constructor() {}
+    public constructor(private readonly mode: ChartMode) {}
 
     public async request<
         D extends object,
@@ -76,7 +77,7 @@ export class DataController {
 
         for (const { opts, data, resultCbs, rejects, ids } of merged) {
             try {
-                const dataModel = new DataModel<any>(opts);
+                const dataModel = new DataModel<any>({ ...opts, mode: this.mode });
                 const processedData = dataModel.processData(data);
 
                 if (debugMode) {

--- a/packages/ag-charts-community/src/chart/data/dataModel.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.ts
@@ -3,6 +3,7 @@ import { Logger } from '../../util/logger';
 import { isNegative } from '../../util/number';
 import { isNumber } from '../../util/value';
 import type { ChartAxis } from '../chartAxis';
+import type { ChartMode } from '../chartMode';
 import { DataDomain } from './dataDomain';
 import type { ContinuousDomain } from './utilFunctions';
 import { extendDomain } from './utilFunctions';
@@ -165,6 +166,7 @@ export type DataModelOptions<K, Grouped extends boolean | undefined> = {
     readonly groupByKeys?: Grouped;
     readonly groupByFn?: GroupByFn;
     readonly dataVisible?: boolean;
+    readonly mode?: ChartMode;
 };
 
 export type PropertyDefinition<K> =
@@ -279,9 +281,11 @@ export class DataModel<
     private readonly propertyProcessors: (PropertyValueProcessorDefinition<D> & InternalDefinition)[];
     private readonly reducers: (ReducerOutputPropertyDefinition & InternalDefinition)[];
     private readonly processors: (ProcessorOutputPropertyDefinition & InternalDefinition)[];
+    private readonly mode: ChartMode;
 
     public constructor(opts: DataModelOptions<K, Grouped>) {
-        const { props } = opts;
+        const { props, mode = 'standalone' } = opts;
+        this.mode = mode;
 
         // Validate that keys appear before values in the definitions, as output ordering depends
         // on configuration ordering, but we process keys before values.
@@ -984,6 +988,8 @@ export class DataModel<
 
     buildAccessors(...defs: { property: string }[]) {
         const result: Record<string, (d: any) => any> = {};
+        if (this.mode === 'integrated') return result;
+
         for (const def of defs) {
             const isPath = def.property.indexOf('.') >= 0 || def.property.indexOf('[') >= 0;
             if (!isPath) continue;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -33,6 +33,7 @@ import {
 import { checkDatum } from '../../util/value';
 import type { ChartAxis } from '../chartAxis';
 import { ChartAxisDirection } from '../chartAxisDirection';
+import type { ChartMode } from '../chartMode';
 import { accumulatedValue, trailingAccumulatedValue } from '../data/aggregateFunctions';
 import type { DataController } from '../data/dataController';
 import type { DatumPropertyDefinition, ScopeProvider } from '../data/dataModel';
@@ -327,7 +328,7 @@ export abstract class Series<
 
     // Package-level visibility, not meant to be set by the user.
     chart?: {
-        mode: 'standalone' | 'integrated';
+        mode: ChartMode;
         placeLabels(): Map<Series<any>, PlacedLabel[]>;
         seriesRect?: BBox;
     };

--- a/packages/ag-charts-community/src/module/moduleContext.ts
+++ b/packages/ag-charts-community/src/module/moduleContext.ts
@@ -1,3 +1,4 @@
+import type { ChartMode } from '../chart/chartMode';
 import type { DataService } from '../chart/dataService';
 import type { AnimationManager } from '../chart/interaction/animationManager';
 import type { ChartEventManager } from '../chart/interaction/chartEventManager';
@@ -19,7 +20,7 @@ export interface ModuleContext {
     document: Document;
     window: Window;
     scene: Scene;
-    mode: 'standalone' | 'integrated';
+    mode: ChartMode;
     animationManager: AnimationManager;
     chartEventManager: ChartEventManager;
     cursorManager: CursorManager;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9042

Fixes errors in Integrated Charts, where there are several cases that keys can be supplied with `.` or `[` characters, which is the trigger for us to treat the key as a JSON property path:
- Use of property paths in Grid field specifications.
- Pivot table cases where user-values are used in derived column names (and then chart keys).