### PR TITLE
AG-9323 Add optionConstructor for 'series[].colorRanges'

### DIFF
--- a/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletModule.ts
@@ -2,7 +2,7 @@ import type { _ModuleSupport } from 'ag-charts-community';
 import { _Theme } from 'ag-charts-community';
 
 import { BULLET_DEFAULTS } from './bulletDefaults';
-import { BulletSeries } from './bulletSeries';
+import { BulletColorRange, BulletSeries } from './bulletSeries';
 import { BULLET_SERIES_THEME } from './bulletThemes';
 
 const { CARTESIAN_AXIS_POSITIONS } = _Theme;
@@ -13,6 +13,7 @@ export const BulletModule: _ModuleSupport.SeriesModule<'bullet'> = {
     packageType: 'enterprise',
     chartTypes: ['cartesian'],
     identifier: 'bullet',
+    optionConstructors: { 'series[].colorRanges': BulletColorRange },
     instanceConstructor: BulletSeries,
     seriesDefaults: BULLET_DEFAULTS,
     themeTemplate: BULLET_SERIES_THEME,

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -38,7 +38,7 @@ interface BulletNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum {
     };
 }
 
-class BulletColorRange {
+export class BulletColorRange {
     @Validate(COLOR_STRING)
     color: string = 'lightgrey';
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9323

This enables console warning when invalid color options are used. Without this, the @Validate annotations of the BulletColorRange class have no effect.