### PR TITLE
Heatmap theme

### DIFF
--- a/packages/ag-charts-community/src/chart/themes/darkTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/darkTheme.ts
@@ -4,7 +4,6 @@ import {
     DEFAULT_AXIS_GRID_COLOUR,
     DEFAULT_BACKGROUND_COLOUR,
     DEFAULT_CROSS_LINES_COLOUR,
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_INSIDE_SERIES_LABEL_COLOUR,
     DEFAULT_LABEL_COLOUR,
     DEFAULT_MUTED_LABEL_COLOUR,
@@ -87,10 +86,6 @@ export class DarkTheme extends ChartTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             DarkTheme.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
-            DEFAULT_DARK_FILLS.BLUE,
-            DEFAULT_DARK_FILLS.ORANGE,
-        ]);
         result.properties.set(DEFAULT_POLAR_SERIES_STROKE, DEFAULT_DARK_BACKGROUND_FILL);
 
         result.properties.set(DEFAULT_LABEL_COLOUR, 'white');

--- a/packages/ag-charts-community/src/chart/themes/materialDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/materialDark.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { DarkTheme } from './darkTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -81,10 +80,6 @@ export class MaterialDark extends DarkTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             MaterialDark.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
-            MATERIAL_DARK_FILLS.BLUE,
-            MATERIAL_DARK_FILLS.RED,
-        ]);
 
         return result;
     }

--- a/packages/ag-charts-community/src/chart/themes/materialLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/materialLight.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { ChartTheme } from './chartTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -81,10 +80,6 @@ export class MaterialLight extends ChartTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             MaterialLight.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
-            MATERIAL_LIGHT_FILLS.BLUE,
-            MATERIAL_LIGHT_FILLS.RED,
-        ]);
 
         return result;
     }

--- a/packages/ag-charts-community/src/chart/themes/polychromaDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/polychromaDark.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { DarkTheme } from './darkTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -84,10 +83,6 @@ export class PolychromaDark extends DarkTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             PolychromaDark.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
-            POLYCHROMA_DARK_FILLS.BLUE,
-            POLYCHROMA_DARK_FILLS.RED,
-        ]);
 
         return result;
     }

--- a/packages/ag-charts-community/src/chart/themes/polychromaLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/polychromaLight.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { ChartTheme } from './chartTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -84,10 +83,6 @@ export class PolychromaLight extends ChartTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             PolychromaLight.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
-            POLYCHROMA_LIGHT_FILLS.BLUE,
-            POLYCHROMA_LIGHT_FILLS.RED,
-        ]);
 
         return result;
     }

--- a/packages/ag-charts-community/src/chart/themes/sheetsDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/sheetsDark.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { DarkTheme } from './darkTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -81,10 +80,6 @@ export class SheetsDark extends DarkTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             SheetsDark.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
-            SHEETS_DARK_FILLS.BLUE,
-            SHEETS_DARK_FILLS.ORANGE,
-        ]);
 
         return result;
     }

--- a/packages/ag-charts-community/src/chart/themes/sheetsLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/sheetsLight.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { ChartTheme } from './chartTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -81,10 +80,6 @@ export class SheetsLight extends ChartTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             SheetsLight.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
-            SHEETS_LIGHT_FILLS.BLUE,
-            SHEETS_LIGHT_FILLS.ORANGE,
-        ]);
 
         return result;
     }

--- a/packages/ag-charts-community/src/chart/themes/vividDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/vividDark.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { DarkTheme } from './darkTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -78,7 +77,6 @@ export class VividDark extends DarkTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             VividDark.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [VIVID_DARK_FILLS.BLUE, VIVID_DARK_FILLS.ORANGE]);
 
         return result;
     }

--- a/packages/ag-charts-community/src/chart/themes/vividLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/vividLight.ts
@@ -1,7 +1,6 @@
 import type { AgChartThemePalette } from '../../options/agChartOptions';
 import { ChartTheme } from './chartTheme';
 import {
-    DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
@@ -81,7 +80,6 @@ export class VividLight extends ChartTheme {
             DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
             VividLight.getWaterfallSeriesDefaultTotalColors().stroke
         );
-        result.properties.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [VIVID_FILLS.BLUE, VIVID_FILLS.ORANGE]);
 
         return result;
     }

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -72,7 +72,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, H
     colorName?: string = 'Color';
 
     @Validate(AND(COLOR_STRING_ARRAY, NON_EMPTY_ARRAY))
-    colorRange: string[] = ['#cb4b3f', '#6acb64'];
+    colorRange: string[] = ['black', 'black'];
 
     @Validate(OPT_COLOR_STRING)
     stroke: string = 'black';


### PR DESCRIPTION
- Makes the colours default to black if invalid colour range provided
- Makes the diverging colours use the default theme (for now)

The HSL interpolation didn't work well for when using the theme's colours (since HSL doesn't correct for visual perception of brightness). We came up with a pair of colours that worked well enough, so will use this across all themes until we either add LCH interpolation, or design picks some new colours that work well for each theme