### PR TITLE
AG-9260 - Hide example runner loading spinner

### DIFF
--- a/packages/ag-charts-website/src/features/docs/components/DocsExampleRunner.astro
+++ b/packages/ag-charts-website/src/features/docs/components/DocsExampleRunner.astro
@@ -19,7 +19,7 @@ const framework = pathSegments[DOCS_FRAMEWORK_PATH_INDEX];
 const pageName = pathSegments[DOCS_PAGE_NAME_PATH_INDEX];
 ---
 
-<ExampleRunnerContainer exampleHeight={options?.exampleHeight}>
+<ExampleRunnerContainer exampleHeight={options?.exampleHeight} pageName={pageName} exampleName={name}>
     <DocsExampleRunner
         client:only
         title={title}

--- a/packages/ag-charts-website/src/features/docs/components/DocsExampleRunner.tsx
+++ b/packages/ag-charts-website/src/features/docs/components/DocsExampleRunner.tsx
@@ -9,7 +9,12 @@ import { getFrameworkFromInternalFramework } from '@utils/framework';
 import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 
-import { getExampleContentsUrl, getExampleUrl, getExampleWithRelativePathUrl } from '../utils/urlPaths';
+import {
+    getExampleContentsUrl,
+    getExampleRunnerExampleUrl,
+    getExampleUrl,
+    getExampleWithRelativePathUrl,
+} from '../utils/urlPaths';
 
 interface Props {
     name: string;
@@ -51,6 +56,7 @@ const DocsExampleRunnerInner = ({ name, title, exampleType, options, framework, 
     const internalFramework = useStore($internalFramework);
     const [initialSelectedFile, setInitialSelectedFile] = useState();
     const [exampleUrl, setExampleUrl] = useState<string>();
+    const [exampleRunnerExampleUrl, setExampleRunnerExampleUrl] = useState<string>();
     const [plunkrHtmlUrl, setPlunkrHtmlUrl] = useState<string>();
     const [exampleFiles, setExampleFiles] = useState();
     const [exampleBoilerPlateFiles, setExampleBoilerPlateFiles] = useState();
@@ -92,6 +98,13 @@ const DocsExampleRunnerInner = ({ name, title, exampleType, options, framework, 
 
         setExampleUrl(
             getExampleUrl({
+                internalFramework,
+                pageName,
+                exampleName,
+            })
+        );
+        setExampleRunnerExampleUrl(
+            getExampleRunnerExampleUrl({
                 internalFramework,
                 pageName,
                 exampleName,
@@ -148,6 +161,7 @@ const DocsExampleRunnerInner = ({ name, title, exampleType, options, framework, 
         <ExampleRunner
             id={id}
             exampleUrl={exampleUrl}
+            exampleRunnerExampleUrl={exampleRunnerExampleUrl}
             exampleType={exampleType}
             exampleHeight={options?.exampleHeight}
             exampleFiles={exampleFiles}

--- a/packages/ag-charts-website/src/features/docs/components/DocsFrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/features/docs/components/DocsFrameworkTemplate.astro
@@ -12,9 +12,13 @@ interface Props {
      * Whether to use relative paths for script files references
      */
     relativePath?: boolean;
+    /**
+     * Whether to add a script to post an `init` message to the parent
+     */
+    addInitMessageScript?: boolean;
 }
 
-const { internalFramework, pageName, exampleName, relativePath } = Astro.props as Props;
+const { internalFramework, pageName, exampleName, relativePath, addInitMessageScript } = Astro.props as Props;
 
 const generatedContents = await getGeneratedDocsContents({
     internalFramework,
@@ -35,4 +39,5 @@ const exampleUrl = getExampleUrl({
     exampleUrl={exampleUrl}
     generatedContents={generatedContents!}
     relativePath={relativePath}
+    addInitMessageScript={addInitMessageScript}
 />

--- a/packages/ag-charts-website/src/features/docs/utils/urlPaths.ts
+++ b/packages/ag-charts-website/src/features/docs/utils/urlPaths.ts
@@ -29,6 +29,21 @@ export const getExampleUrl = ({
 };
 
 /**
+ * Dynamic path where docs example runner examples are
+ */
+export const getExampleRunnerExampleUrl = ({
+    internalFramework,
+    pageName,
+    exampleName,
+}: {
+    internalFramework: InternalFramework;
+    pageName: string;
+    exampleName: string;
+}) => {
+    return pathJoin(SITE_BASE_URL, internalFramework, pageName, 'examples', exampleName, 'example-runner');
+};
+
+/**
  * Dynamic path where examples are with relative path for script files
  */
 export const getExampleWithRelativePathUrl = ({

--- a/packages/ag-charts-website/src/features/example-runner/components/ExampleRunner.tsx
+++ b/packages/ag-charts-website/src/features/example-runner/components/ExampleRunner.tsx
@@ -14,6 +14,7 @@ import styles from './ExampleRunner.module.scss';
 interface Props {
     id: string;
     exampleUrl?: string;
+    exampleRunnerExampleUrl?: string;
     exampleType?: ExampleType;
     initialShowCode?: boolean;
     externalLinkButton?: ReactElement;
@@ -29,6 +30,7 @@ const DEFAULT_HEIGHT = 500;
 export const ExampleRunner: FunctionComponent<Props> = ({
     id,
     exampleUrl,
+    exampleRunnerExampleUrl,
     exampleType,
     initialShowCode,
     externalLinkButton,
@@ -51,7 +53,7 @@ export const ExampleRunner: FunctionComponent<Props> = ({
                     aria-labelledby={`${showCode ? 'Preview' : 'Code'} tab`}
                     style={{ height: exampleHeight, width: '100%' }}
                 >
-                    <ExampleIFrame isHidden={showCode} url={exampleUrl!} />
+                    <ExampleIFrame isHidden={showCode} url={exampleRunnerExampleUrl!} />
                     {exampleFiles && (
                         <CodeViewer
                             id={id}

--- a/packages/ag-charts-website/src/features/example-runner/components/ExampleRunnerContainer.astro
+++ b/packages/ag-charts-website/src/features/example-runner/components/ExampleRunnerContainer.astro
@@ -1,19 +1,24 @@
 ---
 import { ReactComponent as LoadingLogo } from '@images/inline-svgs/ag-grid-logomark-loading.svg';
+import RemoveLogoOnInitScript from './RemoveLogoOnInitScript.astro';
+import { getLoadingLogoId } from '@features/example-runner/utils/getLoadingLogoId';
 
 interface Props {
     exampleHeight?: number;
+    pageName: string;
+    exampleName: string;
 }
 
 const DEFAULT_HEIGHT = 500;
 const FRAME_WRAPPER_HEIGHT = 48 + 26;
 
-const exampleHeight = Astro.props.exampleHeight || DEFAULT_HEIGHT;
+const { exampleHeight = DEFAULT_HEIGHT, pageName, exampleName } = Astro.props as Props;
 const minHeight = exampleHeight + FRAME_WRAPPER_HEIGHT;
+const loadingLogoId = getLoadingLogoId({ pageName, exampleName });
 ---
 
 <div class="container" style={{ minHeight: `${minHeight}px` }}>
-    <LoadingLogo />
+    <LoadingLogo id={loadingLogoId} />
     <slot />
 </div>
 
@@ -29,3 +34,5 @@ const minHeight = exampleHeight + FRAME_WRAPPER_HEIGHT;
         }
     }
 </style>
+
+<RemoveLogoOnInitScript pageName={pageName} exampleName={exampleName} />

--- a/packages/ag-charts-website/src/features/example-runner/components/FrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/components/FrameworkTemplate.astro
@@ -8,6 +8,7 @@ import ReactTemplate from '../framework-templates/ReactTemplate.astro';
 import VueTemplate from '../framework-templates/VueTemplate.astro';
 import type { GeneratedContents } from '@features/examples-generator/types';
 import AngularTemplate from '../framework-templates/AngularTemplate.astro';
+import PostInitMessageScript from '@features/example-runner/components/PostInitMessageScript.astro';
 
 interface Props {
     internalFramework: InternalFramework;
@@ -19,9 +20,14 @@ interface Props {
      * Whether to use relative paths for script files references
      */
     relativePath?: boolean;
+    /**
+     * Whether to add a script to post an `init` message to the parent
+     */
+    addInitMessageScript?: boolean;
 }
 
-const { internalFramework, pageName, exampleName, exampleUrl, generatedContents, relativePath } = Astro.props as Props;
+const { internalFramework, pageName, exampleName, exampleUrl, generatedContents, relativePath, addInitMessageScript } =
+    Astro.props as Props;
 
 const isDev = getIsDev();
 
@@ -60,7 +66,9 @@ const timeNow = Date.now();
             styleFiles={styleFiles}
             indexFragment={indexFragment!}
             appLocation={appLocation}
-        />
+        >
+            {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
+        </JavascriptTemplate>
     )
 }
 
@@ -78,7 +86,9 @@ const timeNow = Date.now();
             appLocation={appLocation}
             library={library}
             boilerplatePath={boilerPlateUrl}
-        />
+        >
+            {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
+        </TypescriptTemplate>
     )
 }
 
@@ -96,7 +106,9 @@ const timeNow = Date.now();
             appLocation={appLocation}
             library={library}
             boilerplatePath={boilerPlateUrl}
-        />
+        >
+            {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
+        </ReactTemplate>
     )
 }
 
@@ -114,7 +126,9 @@ const timeNow = Date.now();
             appLocation={appLocation}
             library={library}
             boilerplatePath={boilerPlateUrl}
-        />
+        >
+            {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
+        </AngularTemplate>
     )
 }
 
@@ -133,6 +147,8 @@ const timeNow = Date.now();
             library={library}
             boilerplatePath={boilerPlateUrl}
             vueFramework={internalFramework}
-        />
+        >
+            {addInitMessageScript && <PostInitMessageScript pageName={pageName} exampleName={exampleName} />}
+        </VueTemplate>
     )
 }

--- a/packages/ag-charts-website/src/features/example-runner/components/FrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/components/FrameworkTemplate.astro
@@ -44,6 +44,7 @@ const boilerPlateUrl = relativePath
       });
 
 const timeNow = Date.now();
+const title = `${pageName} - ${exampleName}`;
 ---
 
 {
@@ -58,8 +59,7 @@ const timeNow = Date.now();
     internalFramework === 'vanilla' && (
         <JavascriptTemplate
             isDev={isDev}
-            pageName={pageName}
-            exampleName={exampleName}
+            title={title}
             modifiedTimeMs={timeNow}
             isEnterprise={isEnterprise}
             scriptFiles={scriptFiles}
@@ -76,8 +76,7 @@ const timeNow = Date.now();
     internalFramework === 'typescript' && (
         <TypescriptTemplate
             isDev={isDev}
-            pageName={pageName}
-            exampleName={exampleName}
+            title={title}
             modifiedTimeMs={timeNow}
             isEnterprise={isEnterprise}
             entryFileName={entryFileName!}
@@ -96,8 +95,7 @@ const timeNow = Date.now();
     ['react', 'reactFunctional', 'reactFunctionalTs'].includes(internalFramework) && (
         <ReactTemplate
             isDev={isDev}
-            pageName={pageName}
-            exampleName={exampleName}
+            title={title}
             modifiedTimeMs={timeNow}
             isEnterprise={isEnterprise}
             entryFileName={entryFileName!}
@@ -116,8 +114,7 @@ const timeNow = Date.now();
     internalFramework === 'angular' && (
         <AngularTemplate
             isDev={isDev}
-            pageName={pageName}
-            exampleName={exampleName}
+            title={title}
             modifiedTimeMs={timeNow}
             isEnterprise={isEnterprise}
             entryFileName={entryFileName!}
@@ -136,8 +133,7 @@ const timeNow = Date.now();
     (internalFramework === 'vue' || internalFramework === 'vue3') && (
         <VueTemplate
             isDev={isDev}
-            pageName={pageName}
-            exampleName={exampleName}
+            title={title}
             modifiedTimeMs={timeNow}
             isEnterprise={isEnterprise}
             entryFileName={entryFileName!}

--- a/packages/ag-charts-website/src/features/example-runner/components/FrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/components/FrameworkTemplate.astro
@@ -9,6 +9,7 @@ import VueTemplate from '../framework-templates/VueTemplate.astro';
 import type { GeneratedContents } from '@features/examples-generator/types';
 import AngularTemplate from '../framework-templates/AngularTemplate.astro';
 import PostInitMessageScript from '@features/example-runner/components/PostInitMessageScript.astro';
+import { toTitle } from '@utils/toTitle';
 
 interface Props {
     internalFramework: InternalFramework;
@@ -44,7 +45,7 @@ const boilerPlateUrl = relativePath
       });
 
 const timeNow = Date.now();
-const title = `${pageName} - ${exampleName}`;
+const title = `${toTitle(pageName)} - ${toTitle(exampleName)}`;
 ---
 
 {

--- a/packages/ag-charts-website/src/features/example-runner/components/PostInitMessageScript.astro
+++ b/packages/ag-charts-website/src/features/example-runner/components/PostInitMessageScript.astro
@@ -1,0 +1,25 @@
+---
+import { POST_INIT_MESSAGE_START, POST_INIT_MESSAGE_END } from '@features/example-runner/constants';
+interface Props {
+    pageName: string;
+    exampleName: string;
+}
+
+const { pageName, exampleName } = Astro.props as Props;
+---
+
+<Fragment set:html={POST_INIT_MESSAGE_START} />
+<script
+    define:vars={{
+        pageName,
+        exampleName,
+    }}
+>
+    const loadedEvent = {
+        type: 'init',
+        pageName,
+        exampleName,
+    };
+    window.parent?.postMessage(loadedEvent);
+</script>
+<Fragment set:html={POST_INIT_MESSAGE_END} />

--- a/packages/ag-charts-website/src/features/example-runner/components/RemoveLogoOnInitScript.astro
+++ b/packages/ag-charts-website/src/features/example-runner/components/RemoveLogoOnInitScript.astro
@@ -1,0 +1,27 @@
+---
+import { getLoadingLogoId } from '@features/example-runner/utils/getLoadingLogoId';
+interface Props {
+    pageName: string;
+    exampleName: string;
+}
+
+const { pageName, exampleName } = Astro.props as Props;
+const loadingLogoId = getLoadingLogoId({ pageName, exampleName });
+---
+
+<script
+    define:vars={{
+        pageName,
+        exampleName,
+        loadingLogoId,
+    }}
+>
+    window.addEventListener('message', ({ data }) => {
+        if (data?.type === 'init') {
+            const isExample = pageName === data.pageName && exampleName === data.exampleName;
+            if (isExample) {
+                document.getElementById(loadingLogoId)?.remove();
+            }
+        }
+    });
+</script>

--- a/packages/ag-charts-website/src/features/example-runner/constants.ts
+++ b/packages/ag-charts-website/src/features/example-runner/constants.ts
@@ -1,0 +1,2 @@
+export const POST_INIT_MESSAGE_START = '<!-- INIT MESSAGE START -->';
+export const POST_INIT_MESSAGE_END = '<!-- INIT MESSAGE END -->';

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/AngularTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/AngularTemplate.astro
@@ -10,8 +10,7 @@ import { Scripts } from './lib/Scripts';
 
 interface Props {
     isDev: boolean;
-    pageName: string;
-    exampleName: string;
+    title: string;
 
     modifiedTimeMs: number;
     isEnterprise: boolean;
@@ -25,8 +24,7 @@ interface Props {
 }
 
 const {
-    pageName,
-    exampleName,
+    title,
     isDev,
     modifiedTimeMs,
     isEnterprise,
@@ -43,7 +41,7 @@ const startFile = pathJoin(appLocation, entryFileName);
 
 <html lang="en">
     <head>
-        <MetaData isDev={isDev} title={`Angular - ${pageName} - ${exampleName}`} modifiedTimeMs={modifiedTimeMs} />
+        <MetaData isDev={isDev} title={`Angular Example - ${title}`} modifiedTimeMs={modifiedTimeMs} />
         <ExampleStyle rootId="app" />
         <Styles
             baseUrl={appLocation}

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/AngularTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/AngularTemplate.astro
@@ -43,12 +43,8 @@ const startFile = pathJoin(appLocation, entryFileName);
 
 <html lang="en">
     <head>
-        <MetaData
-            isDev={isDev}
-            title={`Angular - ${pageName} - ${exampleName}`}
-            modifiedTimeMs={modifiedTimeMs}
-        />
-        <ExampleStyle rootId="app"/>
+        <MetaData isDev={isDev} title={`Angular - ${pageName} - ${exampleName}`} modifiedTimeMs={modifiedTimeMs} />
+        <ExampleStyle rootId="app" />
         <Styles
             baseUrl={appLocation}
             files={isDev && styleFiles
@@ -83,5 +79,6 @@ const startFile = pathJoin(appLocation, entryFileName);
                 ? styleFiles.filter((file: string) => file.includes('style.css') || file.includes('styles.css'))
                 : []}
         />
+        <slot />
     </body>
 </html>

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/JavascriptTemplate.astro
@@ -1,8 +1,7 @@
 ---
 interface Props {
     isDev: boolean;
-    pageName: string;
-    exampleName: string;
+    title: string;
 
     modifiedTimeMs: number;
     isEnterprise: boolean;
@@ -16,17 +15,8 @@ interface Props {
     appLocation: string;
 }
 
-const {
-    isDev,
-    pageName,
-    exampleName,
-    modifiedTimeMs,
-    isEnterprise,
-    styleFiles,
-    scriptFiles,
-    indexFragment,
-    appLocation,
-} = Astro.props as Props;
+const { isDev, title, modifiedTimeMs, isEnterprise, styleFiles, scriptFiles, indexFragment, appLocation } =
+    Astro.props as Props;
 
 import { MetaData } from './lib/MetaData';
 import { ExampleStyle } from './lib/ExampleStyle';
@@ -44,7 +34,7 @@ const chartScriptEnterprisePath = getCacheBustingUrl(getChartEnterpriseScriptPat
 
 <html lang="en">
     <head>
-        <MetaData isDev={isDev} title={`${pageName} - ${exampleName}`} modifiedTimeMs={modifiedTimeMs} />
+        <MetaData isDev={isDev} title={`JavaScript Example - ${title}`} modifiedTimeMs={modifiedTimeMs} />
         <ExampleStyle />
         <Styles
             baseUrl={appLocation}

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/JavascriptTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/JavascriptTemplate.astro
@@ -66,7 +66,7 @@ const chartScriptEnterprisePath = getCacheBustingUrl(getChartEnterpriseScriptPat
         >
             window.__basePath = appLocation;
         </script>
-        <script src={isEnterprise ? chartScriptEnterprisePath : chartScriptPath} />
+        <script src={isEnterprise ? chartScriptEnterprisePath : chartScriptPath}></script>
         <Scripts baseUrl={appLocation} files={scriptFiles} />
         <Styles
             baseUrl={appLocation}
@@ -74,5 +74,6 @@ const chartScriptEnterprisePath = getCacheBustingUrl(getChartEnterpriseScriptPat
                 ? styleFiles.filter((file: string) => file.includes('style.css') || file.includes('styles.css'))
                 : []}
         />
+        <slot />
     </body>
 </html>

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/ReactTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/ReactTemplate.astro
@@ -9,8 +9,7 @@ import type { Library } from '@ag-grid-types';
 
 interface Props {
     isDev: boolean;
-    pageName: string;
-    exampleName: string;
+    title: string;
 
     modifiedTimeMs: number;
     isEnterprise: boolean;
@@ -26,8 +25,7 @@ interface Props {
 }
 
 const {
-    pageName,
-    exampleName,
+    title,
     isDev,
     modifiedTimeMs,
     isEnterprise,
@@ -44,11 +42,7 @@ const startFile = pathJoin(appLocation, entryFileName);
 
 <html lang="en">
     <head>
-        <MetaData
-            isDev={isDev}
-            title={`React example - ${pageName} - ${exampleName}`}
-            modifiedTimeMs={modifiedTimeMs}
-        />
+        <MetaData isDev={isDev} title={`React Example - ${title}`} modifiedTimeMs={modifiedTimeMs} />
         <ExampleStyle rootId="root" />
         <Styles baseUrl={appLocation} files={styleFiles} />
     </head>

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/ReactTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/ReactTemplate.astro
@@ -64,5 +64,6 @@ const startFile = pathJoin(appLocation, entryFileName);
             internalFramework={'react'}
             isEnterprise={isEnterprise}
         />
+        <slot />
     </body>
 </html>

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
@@ -9,8 +9,7 @@ import type { Library } from '@ag-grid-types';
 
 interface Props {
     isDev: boolean;
-    pageName: string;
-    exampleName: string;
+    title: string;
 
     modifiedTimeMs: number;
     isEnterprise: boolean;
@@ -24,8 +23,7 @@ interface Props {
 }
 
 const {
-    pageName,
-    exampleName,
+    title,
     isDev,
     modifiedTimeMs,
     isEnterprise,
@@ -42,7 +40,7 @@ const startFile = pathJoin(appLocation, entryFileName);
 
 <html lang="en">
     <head>
-        <MetaData isDev={isDev} title={`Typescript - ${pageName} - ${exampleName}`} modifiedTimeMs={modifiedTimeMs} />
+        <MetaData isDev={isDev} title={`Typescript Example - ${title}`} modifiedTimeMs={modifiedTimeMs} />
         <ExampleStyle />
         <Styles
             baseUrl={appLocation}

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/TypescriptTemplate.astro
@@ -42,11 +42,7 @@ const startFile = pathJoin(appLocation, entryFileName);
 
 <html lang="en">
     <head>
-        <MetaData
-            isDev={isDev}
-            title={`Typescript - ${pageName} - ${exampleName}`}
-            modifiedTimeMs={modifiedTimeMs}
-        />
+        <MetaData isDev={isDev} title={`Typescript - ${pageName} - ${exampleName}`} modifiedTimeMs={modifiedTimeMs} />
         <ExampleStyle />
         <Styles
             baseUrl={appLocation}
@@ -84,5 +80,6 @@ const startFile = pathJoin(appLocation, entryFileName);
                 ? styleFiles.filter((file: string) => file.includes('style.css') || file.includes('styles.css'))
                 : []}
         />
+        <slot />
     </body>
 </html>

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/VueTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/VueTemplate.astro
@@ -9,8 +9,7 @@ import { pathJoin } from '@utils/pathJoin';
 
 interface Props {
     isDev: boolean;
-    pageName: string;
-    exampleName: string;
+    title: string;
 
     modifiedTimeMs: number;
     isEnterprise: boolean;
@@ -29,8 +28,7 @@ interface Props {
 
 const {
     isDev,
-    pageName,
-    exampleName,
+    title,
     modifiedTimeMs,
     library,
     boilerplatePath,
@@ -48,11 +46,7 @@ const vueFrameworkTitle = vueFramework === 'vue3' ? 'Vue 3' : 'Vue';
 
 <html lang="en">
     <head>
-        <MetaData
-            isDev={isDev}
-            title={`${vueFrameworkTitle} example - ${pageName} - ${exampleName}`}
-            modifiedTimeMs={modifiedTimeMs}
-        />
+        <MetaData isDev={isDev} title={`${vueFrameworkTitle} Example - ${title}`} modifiedTimeMs={modifiedTimeMs} />
         <ExampleStyle rootId="app" />
         <Styles baseUrl={appLocation} files={styleFiles} />
     </head>

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/VueTemplate.astro
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/VueTemplate.astro
@@ -69,5 +69,6 @@ const vueFrameworkTitle = vueFramework === 'vue3' ? 'Vue 3' : 'Vue';
             internalFramework={vueFramework}
             isEnterprise={isEnterprise}
         />
+        <slot />
     </body>
 </html>

--- a/packages/ag-charts-website/src/features/example-runner/utils/getLoadingLogoId.ts
+++ b/packages/ag-charts-website/src/features/example-runner/utils/getLoadingLogoId.ts
@@ -1,0 +1,3 @@
+export function getLoadingLogoId({ pageName, exampleName }: { pageName: string; exampleName: string }) {
+    return `loading-${pageName}-${exampleName}`;
+}

--- a/packages/ag-charts-website/src/features/gallery/components/GalleryExampleRunner.astro
+++ b/packages/ag-charts-website/src/features/gallery/components/GalleryExampleRunner.astro
@@ -2,7 +2,7 @@
 import { getEntry } from 'astro:content';
 import ExampleRunnerContainer from '@features/example-runner/components/ExampleRunnerContainer.astro';
 import { GalleryExampleRunner } from './GalleryExampleRunner';
-import { getChartExampleTitle } from '../utils/filesData';
+import { getChartExampleTitle, getSeriesTypeSlug } from '../utils/filesData';
 import { GALLERY_EXAMPLE_NAME_PATH_INDEX } from '../constants';
 
 const pathSegments = Astro.url.pathname.split('/');
@@ -13,8 +13,12 @@ const title = getChartExampleTitle({
     galleryData: galleryDataEntry.data,
     exampleName,
 });
+const pageName = getSeriesTypeSlug({
+    galleryData: galleryDataEntry.data,
+    exampleName,
+});
 ---
 
-<ExampleRunnerContainer>
+<ExampleRunnerContainer pageName={pageName} exampleName={exampleName}>
     <GalleryExampleRunner client:load title={title} exampleName={exampleName} />
 </ExampleRunnerContainer>

--- a/packages/ag-charts-website/src/features/gallery/components/GalleryExampleRunner.tsx
+++ b/packages/ag-charts-website/src/features/gallery/components/GalleryExampleRunner.tsx
@@ -4,7 +4,12 @@ import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 
 import { GALLERY_EXAMPLE_TYPE, GALLERY_INTERNAL_FRAMEWORK } from '../constants';
-import { getExampleContentsUrl, getExampleUrl, getExampleWithRelativePathUrl } from '../utils/urlPaths';
+import {
+    getExampleContentsUrl,
+    getExampleRunnerExampleUrl,
+    getExampleUrl,
+    getExampleWithRelativePathUrl,
+} from '../utils/urlPaths';
 
 interface Props {
     title: string;
@@ -25,6 +30,7 @@ const queryOptions = {
 const GalleryExampleRunnerInner = ({ title, exampleName }: Props) => {
     const [initialSelectedFile, setInitialSelectedFile] = useState();
     const [exampleUrl, setExampleUrl] = useState<string>();
+    const [exampleRunnerExampleUrl, setExampleRunnerExampleUrl] = useState<string>();
     const [plunkrHtmlUrl, setPlunkrHtmlUrl] = useState<string>();
     const [exampleFiles, setExampleFiles] = useState();
     const [exampleBoilerPlateFiles, setExampleBoilerPlateFiles] = useState();
@@ -58,8 +64,18 @@ const GalleryExampleRunnerInner = ({ title, exampleName }: Props) => {
     );
 
     useEffect(() => {
+        if (!exampleName) {
+            return;
+        }
+
         setExampleUrl(
             getExampleUrl({
+                exampleName,
+            })
+        );
+
+        setExampleRunnerExampleUrl(
+            getExampleRunnerExampleUrl({
                 exampleName,
             })
         );
@@ -110,6 +126,7 @@ const GalleryExampleRunnerInner = ({ title, exampleName }: Props) => {
         <ExampleRunner
             id={id}
             exampleUrl={exampleUrl}
+            exampleRunnerExampleUrl={exampleRunnerExampleUrl}
             exampleType={exampleType}
             exampleFiles={exampleFiles}
             initialSelectedFile={initialSelectedFile}

--- a/packages/ag-charts-website/src/features/gallery/components/GalleryFrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/features/gallery/components/GalleryFrameworkTemplate.astro
@@ -4,9 +4,8 @@ import { getGeneratedGalleryContents } from '../utils/examplesGenerator';
 import { getExampleUrl } from '../utils/urlPaths';
 import FrameworkTemplate from '@features/example-runner/components/FrameworkTemplate.astro';
 import { GALLERY_INTERNAL_FRAMEWORK } from '../constants';
-import { getSeriesTypeName, getExampleName } from '../utils/filesData';
+import { getExampleName, getSeriesTypeSlug } from '../utils/filesData';
 import type { GeneratedContents } from '@features/examples-generator/types';
-
 interface Props {
     exampleName: string;
     /**
@@ -14,12 +13,21 @@ interface Props {
      */
     relativePath?: boolean;
     /**
+     * Whether to add a script to post an `init` message to the parent
+     */
+    addInitMessageScript?: boolean;
+    /**
      * Override to be used for generated contents
      */
     generatedContents?: GeneratedContents;
 }
 
-const { exampleName, relativePath, generatedContents: generatedContentsOverride } = Astro.props as Props;
+const {
+    exampleName,
+    relativePath,
+    addInitMessageScript,
+    generatedContents: generatedContentsOverride,
+} = Astro.props as Props;
 
 const internalFramework = GALLERY_INTERNAL_FRAMEWORK;
 const generatedContents = generatedContentsOverride
@@ -33,11 +41,10 @@ const exampleUrl = getExampleUrl({
 });
 
 const galleryDataEntry = await getEntry('gallery', 'data');
-const chartSeriesName = getSeriesTypeName({
+const pageName = getSeriesTypeSlug({
     galleryData: galleryDataEntry.data,
     exampleName,
 });
-const pageName = `${chartSeriesName} Chart`;
 const displayExampleName = getExampleName({
     galleryData: galleryDataEntry.data,
     exampleName,
@@ -51,4 +58,5 @@ const displayExampleName = getExampleName({
     exampleUrl={exampleUrl}
     generatedContents={generatedContents!}
     relativePath={relativePath}
+    addInitMessageScript={addInitMessageScript}
 />

--- a/packages/ag-charts-website/src/features/gallery/utils/filesData.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/filesData.ts
@@ -94,14 +94,8 @@ export const getChartExampleTitle = ({
         galleryData,
         exampleName,
     });
-    const chartSeriesName = example?.title;
-    const pageName = `${chartSeriesName} Chart`;
-    const displayExampleName = getExampleName({
-        galleryData,
-        exampleName,
-    });
 
-    return `${pageName} - ${displayExampleName}`;
+    return example?.title;
 };
 
 export const getGalleryExamples = ({ galleryData }: { galleryData: GalleryData }) => {

--- a/packages/ag-charts-website/src/features/gallery/utils/filesData.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/filesData.ts
@@ -1,7 +1,8 @@
-import type { GalleryData } from '@ag-grid-types';
+import type { GalleryData, GalleryExample } from '@ag-grid-types';
 import { getContentRootFileUrl, getPublicFileUrl } from '@utils/pages';
 import { pathJoin } from '@utils/pathJoin';
 import { readFileSync } from 'fs';
+import GithubSlugger from 'github-slugger';
 
 import { getPageHashUrl } from './urlPaths';
 
@@ -44,7 +45,20 @@ export const getSeriesTypeName = ({ galleryData, exampleName }: { galleryData: G
     return foundSeries?.title;
 };
 
-export const getExampleName = ({ galleryData, exampleName }: { galleryData: GalleryData; exampleName: string }) => {
+export const getSeriesTypeSlug = ({ galleryData, exampleName }: { galleryData: GalleryData; exampleName: string }) => {
+    const slugger = new GithubSlugger();
+    const name = getSeriesTypeName({ galleryData, exampleName });
+    const slug = name ? slugger.slug(name) : undefined;
+    return slug;
+};
+
+export const getExample = ({
+    galleryData,
+    exampleName,
+}: {
+    galleryData: GalleryData;
+    exampleName: string;
+}): undefined | GalleryExample => {
     const { series } = galleryData;
     let result;
     series.forEach(({ examples }) => {
@@ -53,11 +67,20 @@ export const getExampleName = ({ galleryData, exampleName }: { galleryData: Gall
         });
 
         if (foundExample) {
-            result = foundExample.title;
+            result = foundExample;
         }
     });
 
     return result;
+};
+
+export const getExampleName = ({ galleryData, exampleName }: { galleryData: GalleryData; exampleName: string }) => {
+    const example = getExample({
+        galleryData,
+        exampleName,
+    });
+
+    return example?.name;
 };
 
 export const getChartExampleTitle = ({
@@ -67,10 +90,11 @@ export const getChartExampleTitle = ({
     galleryData: GalleryData;
     exampleName: string;
 }) => {
-    const chartSeriesName = getSeriesTypeName({
+    const example = getExample({
         galleryData,
         exampleName,
     });
+    const chartSeriesName = example?.title;
     const pageName = `${chartSeriesName} Chart`;
     const displayExampleName = getExampleName({
         galleryData,

--- a/packages/ag-charts-website/src/features/gallery/utils/urlPaths.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/urlPaths.ts
@@ -8,6 +8,18 @@ export const getExampleUrl = ({ exampleName, isFullPath }: { exampleName: string
     return isFullPath ? fullPath : path;
 };
 
+export const getExampleRunnerExampleUrl = ({
+    exampleName,
+    isFullPath,
+}: {
+    exampleName: string;
+    isFullPath?: boolean;
+}) => {
+    const path = pathJoin(SITE_BASE_URL, 'gallery', 'examples', exampleName, 'example-runner');
+    const fullPath = pathJoin(import.meta.env?.PUBLIC_SITE_URL, path);
+    return isFullPath ? fullPath : path;
+};
+
 export const getPlainExampleImageUrl = ({ exampleName, theme }: { exampleName: string; theme: ThemeName }) => {
     const imageUrl = pathJoin(SITE_BASE_URL, 'gallery', 'examples', `${exampleName}/${theme}-plain.png`);
     return imageUrl;

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/example-runner.astro
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/example-runner.astro
@@ -1,0 +1,22 @@
+---
+import { getCollection } from 'astro:content';
+import type { InternalFramework } from '@ag-grid-types';
+import DocsFrameworkTemplate from '@features/docs/components/DocsFrameworkTemplate.astro';
+import { getDocsExamplePages } from '@features/docs/utils/pageData';
+
+export async function getStaticPaths() {
+    const pages = await getCollection('docs');
+    return getDocsExamplePages({
+        pages,
+    });
+}
+
+const { internalFramework, pageName, exampleName } = Astro.params;
+---
+
+<DocsFrameworkTemplate
+    internalFramework={internalFramework as InternalFramework}
+    pageName={pageName!}
+    exampleName={exampleName!}
+    addInitMessageScript={true}
+/>

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/example-runner.astro
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/example-runner.astro
@@ -1,0 +1,15 @@
+---
+import { getEntry } from 'astro:content';
+import GalleryFrameworkTemplate from '@features/gallery/components/GalleryFrameworkTemplate.astro';
+import { getGalleryExamplePages } from '@features/gallery/utils/pageData';
+
+export async function getStaticPaths() {
+    const galleryDataEntry = await getEntry('gallery', 'data');
+    const pages = getGalleryExamplePages({ galleryData: galleryDataEntry.data });
+    return pages;
+}
+
+const { exampleName } = Astro.params;
+---
+
+<GalleryFrameworkTemplate exampleName={exampleName!} addInitMessageScript={true} />

--- a/packages/ag-charts-website/src/utils/toTitle.test.ts
+++ b/packages/ag-charts-website/src/utils/toTitle.test.ts
@@ -1,0 +1,15 @@
+import { toTitle } from './toTitle';
+
+describe('toTitle', () => {
+    test.each`
+        str               | expected
+        ${undefined}      | ${''}
+        ${''}             | ${''}
+        ${'title'}        | ${'Title'}
+        ${'title-kebab'}  | ${'Title Kebab'}
+        ${'title kebab'}  | ${'Title Kebab'}
+        ${'title- kebab'} | ${'Title Kebab'}
+    `('returns "$expected" for $str', ({ str, expected }) => {
+        expect(toTitle(str)).toBe(expected);
+    });
+});

--- a/packages/ag-charts-website/src/utils/toTitle.ts
+++ b/packages/ag-charts-website/src/utils/toTitle.ts
@@ -1,0 +1,16 @@
+export function toTitle(str: string) {
+    if (!str) {
+        return '';
+    }
+    const replacedDashes = str.replaceAll('-', ' ');
+    const strSplit = replacedDashes.split(' ');
+    const capitalised = strSplit
+        .map((s) => {
+            if (!s[0]) {
+                return '';
+            }
+            return s[0].toLocaleUpperCase() + s.slice(1);
+        })
+        .filter(Boolean);
+    return capitalised.join(' ');
+}


### PR DESCRIPTION
## Changes

* Hide example runner loading spinner when example is loaded 
  * Add post message script to all the framework templates using `<slot />`, and add listener to example runner to remove the loading spinner.
  * Update both docs and gallery example runner.
  * Create new endpoint (`.../example-runner`) for docs and gallery to add the the script
* Extract title for framework templates and make it consistent
* Capitalise title of examples in plunkr