### PR TITLE
AG-9649 - Fix LineSeries animation validation.

### DIFF
--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -22,7 +22,6 @@
         "tsConfig": "packages/ag-charts-community/tsconfig.lib.json",
         "rollupConfig": "packages/ag-charts-community/rollup.config.cjs",
         "project": "packages/ag-charts-community/package.json",
-        "deleteOutputPath": false,
         "compiler": "tsc",
         "format": ["cjs", "esm"]
       },
@@ -43,7 +42,6 @@
         "tsConfig": "packages/ag-charts-community/tsconfig.lib.json",
         "rollupConfig": "packages/ag-charts-community/rollup.umd.config.cjs",
         "project": "packages/ag-charts-community/package.json",
-        "deleteOutputPath": false,
         "compiler": "tsc",
         "format": ["cjs"]
       },

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -139,7 +139,7 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
             }
         }
         if (animationEnabled) {
-            props.push(animationValidation(this));
+            props.push(animationValidation(this, isContinuousX ? ['xValue'] : []));
         }
 
         props.push(

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -22,7 +22,6 @@
         "tsConfig": "packages/ag-charts-enterprise/tsconfig.lib.json",
         "rollupConfig": "packages/ag-charts-enterprise/rollup.config.cjs",
         "project": "packages/ag-charts-enterprise/package.json",
-        "deleteOutputPath": false,
         "compiler": "tsc",
         "format": ["cjs", "esm"]
       },
@@ -44,7 +43,6 @@
         "tsConfig": "packages/ag-charts-enterprise/tsconfig.lib.json",
         "rollupConfig": "packages/ag-charts-enterprise/rollup.umd.config.cjs",
         "project": "packages/ag-charts-enterprise/package.json",
-        "deleteOutputPath": false,
         "compiler": "tsc",
         "format": ["cjs"]
       },

--- a/packages/all/project.json
+++ b/packages/all/project.json
@@ -82,6 +82,17 @@
         "update": {},
         "production": {}
       }
+    },
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "commands": [
+          {
+            "command": "rimraf dist/ 'packages/*/dist/'"
+          }
+        ]
+      }
     }
   },
   "implicitDependencies": [


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9649

Handle non-category cases correctly for `LineSeries` - don't animate if data is not in ascending order.