### PR TITLE
AG-8598 Fix double validation warning with tooltip

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/prepare.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepare.ts
@@ -9,6 +9,7 @@ import type {
 import type { JsonMergeOptions } from '../../util/json';
 import { DELETE, jsonMerge, jsonWalk } from '../../util/json';
 import { Logger } from '../../util/logger';
+import { partialAssign } from '../../util/object';
 import type { DeepPartial } from '../../util/types';
 import { AXIS_TYPES } from '../factory/axisTypes';
 import { CHART_TYPES } from '../factory/chartTypes';
@@ -56,13 +57,23 @@ export const noDataCloneMergeOptions: JsonMergeOptions = {
     avoidDeepClone: ['data'],
 };
 
+function getGlobalTooltipPositionOptions(position: unknown): AgTooltipPositionOptions {
+    if (position === undefined || typeof position !== 'object' || position === null) {
+        return {};
+    }
+
+    const result = {};
+    partialAssign<AgTooltipPositionOptions>(['type', 'xOffset', 'yOffset'], result, position);
+    return result;
+}
+
 export function prepareOptions<T extends AgChartOptions>(options: T): T {
     sanityCheckOptions(options);
 
     // Determine type and ensure it's explicit in the options config.
     const type = optionsType(options);
 
-    const globalTooltipPositionOptions = options.tooltip?.position ?? {};
+    const globalTooltipPositionOptions = getGlobalTooltipPositionOptions(options.tooltip?.position);
 
     const checkSeriesType = (type?: string) => {
         if (type != null && !(isSeriesOptionType(type) || getSeriesDefaults(type))) {

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.test.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { toMatchImageSnapshot } from 'jest-image-snapshot';
+
+import { AgCharts } from '../agChartV2';
+import type { Chart } from '../chart';
+import { prepareTestOptions, waitForChartStability } from '../test/utils';
+
+expect.extend({ toMatchImageSnapshot });
+
+/* eslint-disable no-console */
+describe('TooltipValidation', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
+    const opts = prepareTestOptions({});
+
+    it('should show 1 warning for invalid tooltip value', async () => {
+        const chart = AgCharts.create({
+            ...opts,
+            data: [
+                { month: 'Jun', sweaters: 50 },
+                { month: 'Jul', sweaters: 70 },
+                { month: 'Aug', sweaters: 60 },
+            ],
+            series: [{ type: 'line', xKey: 'month', yKey: 'sweaters', yName: 'Sweaters Made' }],
+            tooltip: {
+                position: '2' as any,
+            },
+        }) as Chart;
+        await waitForChartStability(chart);
+
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith(
+            `AG Charts - unable to set [tooltip.position] in Tooltip - can't apply type of [primitive], allowed types are: [class-instance]`
+        );
+    });
+});
+/* eslint-enable no-console */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8598

Although `options.tooltip?.position` is of type AgTooltipPositionOptions, this isn't guaranteed because this value is user data. mergeSeriesOptions expands the globalTooltipPositionOptions using ..., which doesn't do what we want when the position isn't a valid type (such as a string in the example AG-8598).

Therefore, force the globalTooltipPositionOptions to be the correct type by converting it to `unknown` and explicitly validating the assumptions.