### PR TITLE
AG-8555 Fix zoom tick performance

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1115,6 +1115,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             this.defaultTickMinSpacing,
             rangeWithBleed / ContinuousScale.defaultMaxTickCount
         );
+        const clampMaxTickCount = !isNaN(maxSpacing);
 
         if (isNaN(minSpacing)) {
             minSpacing = defaultMinSpacing;
@@ -1133,11 +1134,15 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         }
 
         // Clamps the min spacing between ticks to be no more than the min distance between datums
-        const minRectDistance = minRect ? Math.max(minRect.width, minRect.height) : 1;
+        const minRectDistance = minRect
+            ? this.direction === ChartAxisDirection.X
+                ? minRect.width
+                : minRect.height
+            : 1;
         const maxTickCount = clamp(
             1,
             Math.floor(rangeWithBleed / minSpacing),
-            Math.floor(rangeWithBleed / minRectDistance)
+            clampMaxTickCount ? Math.floor(rangeWithBleed / minRectDistance) : Infinity
         );
         const minTickCount = Math.min(maxTickCount, Math.ceil(rangeWithBleed / maxSpacing));
         const defaultTickCount = clamp(minTickCount, ContinuousScale.defaultTickCount, maxTickCount);

--- a/packages/ag-charts-community/src/util/number.ts
+++ b/packages/ag-charts-community/src/util/number.ts
@@ -10,6 +10,11 @@ export function isNegative(a: number) {
     return Math.sign(a) < 0 || Object.is(a, -0);
 }
 
+export function round(value: number, decimals: number = 2) {
+    const pow = Math.pow(10, decimals);
+    return Math.round(value * pow) / pow;
+}
+
 /**
  * `Number.toFixed(n)` always formats a number so that it has `n` digits after the decimal point.
  * For example, `Number(0.00003427).toFixed(2)` returns `0.00`.


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8555

One part of this is clipping / only creating ticks for the sliding window when panning, as they are the only ones visible.

The other part limits the number of ticks on a continuous axis such that the ticks are never closer than the closest two datums.

Unzoomed ~115fps
Panning/zooming before ~30fps and stuttering
Panning/zooming after ~115fps no stuttering