### PR TITLE
AG-9869 - Fix RadarSeries resize.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -11,7 +11,6 @@ import { Selection } from '../../../scene/selection';
 import { Path } from '../../../scene/shape/path';
 import { Text } from '../../../scene/shape/text';
 import { Debug } from '../../../util/debug';
-import { jsonDiff } from '../../../util/json';
 import type { PointLabelDatum } from '../../../util/labelPlacement';
 import { OPT_STRING, Validate } from '../../../util/validation';
 import { CategoryAxis } from '../../axis/categoryAxis';
@@ -150,8 +149,6 @@ export abstract class CartesianSeries<
 
     protected override readonly NodeClickEvent = CartesianSeriesNodeClickEvent;
 
-    protected nodeDataDependencies: { seriesRectWidth?: number; seriesRectHeight?: number } = {};
-
     private highlightSelection = Selection.select(this.highlightNode, () =>
         this.opts.hasMarkers ? this.markerFactory() : this.nodeFactory()
     ) as Selection<TNode, TDatum>;
@@ -251,16 +248,7 @@ export abstract class CartesianSeries<
         const { series } = this.ctx.highlightManager?.getActiveHighlight() ?? {};
         const seriesHighlighted = series ? series === this : undefined;
 
-        const newNodeDataDependencies = {
-            seriesRectWidth: seriesRect?.width,
-            seriesRectHeight: seriesRect?.height,
-        };
-        const resize = jsonDiff(this.nodeDataDependencies, newNodeDataDependencies) != null;
-        if (resize) {
-            this.nodeDataDependencies = newNodeDataDependencies;
-            this.markNodeDataDirty();
-        }
-
+        const resize = this.checkResize(seriesRect);
         const highlightItems = await this.updateHighlightSelection(seriesHighlighted);
 
         await this.updateSelections(visible);

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -136,8 +136,6 @@ export abstract class HierarchySeries<
         datum?: (node: TNode, datum: HierarchyNode<TDatum>) => AnimationValue & Partial<TNode>;
     };
 
-    private nodeDataDependencies?: { seriesRectWidth: number; seriesRectHeight: number } = undefined;
-
     constructor(moduleCtx: ModuleContext) {
         super({
             moduleCtx,
@@ -306,22 +304,7 @@ export abstract class HierarchySeries<
         await this.updateNodes();
 
         const animationData = this.getAnimationData();
-        const newNodeDataDependencies =
-            seriesRect != null
-                ? {
-                      seriesRectWidth: seriesRect?.width,
-                      seriesRectHeight: seriesRect?.height,
-                  }
-                : undefined;
-
-        const resize =
-            this.nodeDataDependencies != null &&
-            newNodeDataDependencies != null &&
-            (this.nodeDataDependencies.seriesRectWidth !== newNodeDataDependencies.seriesRectWidth ||
-                this.nodeDataDependencies.seriesRectHeight !== newNodeDataDependencies.seriesRectHeight);
-
-        this.nodeDataDependencies = newNodeDataDependencies;
-
+        const resize = this.checkResize(seriesRect);
         if (resize) {
             this.animationState.transition('resize', animationData);
         }

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -52,7 +52,6 @@ export abstract class PolarSeries<TDatum extends SeriesNodeDatum, TNode extends 
     radius: number = 0;
 
     protected animationState: StateMachine<PolarAnimationState, PolarAnimationEvent>;
-    protected nodeDataDependencies: { seriesRectWidth?: number; seriesRectHeight?: number } = {};
 
     constructor({
         useLabelLayer = false,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -14,6 +14,7 @@ import { Group } from '../../scene/group';
 import type { ZIndexSubOrder } from '../../scene/node';
 import type { Point } from '../../scene/point';
 import { createId } from '../../util/id';
+import { jsonDiff } from '../../util/json';
 import type { PlacedLabel, PointLabelDatum } from '../../util/labelPlacement';
 import { Listeners } from '../../util/listeners';
 import { mergeDefaults } from '../../util/object';
@@ -829,5 +830,20 @@ export abstract class Series<
 
     getMinRect(): BBox | undefined {
         return undefined;
+    }
+
+    protected nodeDataDependencies: { seriesRectWidth?: number; seriesRectHeight?: number } = {};
+    protected checkResize(newSeriesRect?: BBox) {
+        const newNodeDataDependencies = {
+            seriesRectWidth: newSeriesRect?.width,
+            seriesRectHeight: newSeriesRect?.height,
+        };
+        const resize = jsonDiff(this.nodeDataDependencies, newNodeDataDependencies) != null;
+        if (resize) {
+            this.nodeDataDependencies = newNodeDataDependencies;
+            this.markNodeDataDirty();
+        }
+
+        return resize;
     }
 }

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -288,7 +288,9 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         return [{ itemId: radiusKey, nodeData, labelData: nodeData }];
     }
 
-    async update() {
+    async update({ seriesRect }: { seriesRect?: _Scene.BBox }) {
+        const resize = this.checkResize(seriesRect);
+
         await this.maybeRefreshNodeData();
 
         this.contentGroup.translationX = this.centerX;
@@ -305,6 +307,9 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         this.updateMarkers(this.highlightSelection, true);
         this.updateLabels();
 
+        if (resize) {
+            this.animationState.transition('resize');
+        }
         this.animationState.transition('update');
     }
 
@@ -638,12 +643,13 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
         seriesLabelFadeInAnimation(this, 'labels', animationManager, [labelSelection]);
     }
 
-    override animateWaitingUpdateReady() {
-        this.ctx.animationManager.skipCurrentBatch();
+    override animateWaitingUpdateReady(data: _ModuleSupport.PolarAnimationData) {
+        super.animateReadyResize(data);
         this.resetPaths();
     }
 
-    override animateReadyResize() {
+    override animateReadyResize(data: _ModuleSupport.PolarAnimationData) {
+        super.animateReadyResize(data);
         this.resetPaths();
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9869

Pulls `nodeDataDependencies` up to `Series`, and adds use in the `RadarSeries` to detect resize cases correctly.