### PR TITLE
AG-9881 - Fix API docs framework selector

### DIFF
--- a/packages/ag-charts-website/src/components/footer/Footer.tsx
+++ b/packages/ag-charts-website/src/components/footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { SITE_BASE_URL } from '@constants';
-import { urlWithBaseUrl } from '@utils/pages';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import classNames from 'classnames';
 
 import { Icon } from '../icon/Icon';

--- a/packages/ag-charts-website/src/components/site-header/SiteHeader.astro
+++ b/packages/ag-charts-website/src/components/site-header/SiteHeader.astro
@@ -8,16 +8,28 @@ import { SiteLogo } from './SiteLogo';
 import Search from '../search/Search';
 import { getFrameworkFromPath } from '../../features/docs/utils/urlPaths';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import { isDynamicFrameworkPath, replaceDynamicFrameworkPath } from '@utils/framework';
 
 const { pathname } = Astro.url;
 const { data: menuData } = await getEntry('menu', 'data');
 const topNavItems = menuData.header.items;
 const framework = getFrameworkFromPath(pathname);
 const isDev = getIsDev();
-const apiPaths = menuData.api.items.map(({ path }) => ({
-    title: 'API',
-    path: urlWithBaseUrl(path),
-}));
+const apiPaths = menuData.api.items.flatMap(({ path }) => {
+    const pathWithBaseUrl = urlWithBaseUrl(path);
+
+    if (isDynamicFrameworkPath(pathWithBaseUrl)) {
+        return FRAMEWORKS.map((framework) => ({
+            title: 'API',
+            path: replaceDynamicFrameworkPath({ dynamicFrameworkPath: pathWithBaseUrl, framework }),
+        }));
+    }
+
+    return {
+        title: 'API',
+        path: urlWithBaseUrl(path),
+    };
+});
 const frameworkPaths = FRAMEWORKS.map((framework) => ({
     title: 'Docs',
     path: urlWithBaseUrl(framework),
@@ -29,6 +41,7 @@ const allPaths = [
     ...apiPaths,
     ...frameworkPaths,
 ];
+
 export interface Props {
     showSearchBar?: boolean;
 }

--- a/packages/ag-charts-website/src/components/site-header/SiteHeader.astro
+++ b/packages/ag-charts-website/src/components/site-header/SiteHeader.astro
@@ -4,10 +4,11 @@ import { HeaderNav } from './HeaderNav';
 import { getEntry } from 'astro:content';
 import { FRAMEWORKS } from '@constants';
 import gridStyles from './gridSiteHeader.module.scss';
-import { urlWithBaseUrl } from '@utils/pages';
 import { SiteLogo } from './SiteLogo';
 import Search from '../search/Search';
 import { getFrameworkFromPath } from '../../features/docs/utils/urlPaths';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
 const { pathname } = Astro.url;
 const { data: menuData } = await getEntry('menu', 'data');
 const topNavItems = menuData.header.items;

--- a/packages/ag-charts-website/src/components/top-bar/ApiTopBar.tsx
+++ b/packages/ag-charts-website/src/components/top-bar/ApiTopBar.tsx
@@ -1,6 +1,7 @@
 import type { ApiMenuItem } from '@ag-grid-types';
-import { getPathFromUrlPathname, urlWithBaseUrl } from '@utils/pages';
+import { getPathFromUrlPathname } from '@utils/getPathFromUrlPathname';
 import { pathJoin } from '@utils/pathJoin';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import classnames from 'classnames';
 import type { FunctionComponent } from 'react';
 

--- a/packages/ag-charts-website/src/components/top-bar/ApiTopBar.tsx
+++ b/packages/ag-charts-website/src/components/top-bar/ApiTopBar.tsx
@@ -1,9 +1,13 @@
-import type { ApiMenuItem } from '@ag-grid-types';
+import type { ApiMenuItem, Framework } from '@ag-grid-types';
+import { DEFAULT_FRAMEWORK } from '@constants';
+import { useStore } from '@nanostores/react';
+import { $internalFramework } from '@stores/frameworkStore';
+import { getFrameworkFromInternalFramework, replaceDynamicFrameworkPath } from '@utils/framework';
 import { getPathFromUrlPathname } from '@utils/getPathFromUrlPathname';
 import { pathJoin } from '@utils/pathJoin';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import classnames from 'classnames';
-import type { FunctionComponent } from 'react';
+import { type FunctionComponent, useEffect, useMemo, useState } from 'react';
 
 import styles from './ApiTopBar.module.scss';
 
@@ -14,14 +18,35 @@ interface Props {
 
 export const ApiTopBar: FunctionComponent<Props> = ({ menuItems, fullPath }) => {
     const pagePath = pathJoin('/', getPathFromUrlPathname(fullPath));
+    const [framework, setFramework] = useState<Framework>(DEFAULT_FRAMEWORK);
+    const internalFramework = useStore($internalFramework);
+
+    useEffect(() => {
+        setFramework(getFrameworkFromInternalFramework(internalFramework));
+    }, [internalFramework]);
+
+    const menuItemsWithFrameworkLinks = useMemo(
+        () =>
+            menuItems.map((item) => {
+                const path = replaceDynamicFrameworkPath({
+                    dynamicFrameworkPath: item.path,
+                    framework,
+                });
+                return {
+                    ...item,
+                    path,
+                };
+            }),
+        [framework, menuItems]
+    );
 
     return (
         <div className={styles.topBar}>
             <div className={classnames(styles.topBarInner, 'page-margin')}>
                 <nav>
                     <ul className="list-style-none">
-                        {menuItems.map(({ title, path }) => (
-                            <li className={pagePath === path ? styles.active : ''}>
+                        {menuItemsWithFrameworkLinks.map(({ title, path }) => (
+                            <li key={path} className={pagePath === path ? styles.active : ''}>
                                 <a href={urlWithBaseUrl(path)}>{title}</a>
                             </li>
                         ))}

--- a/packages/ag-charts-website/src/constants.ts
+++ b/packages/ag-charts-website/src/constants.ts
@@ -1,6 +1,7 @@
 import type { Framework, InternalFramework } from './types/ag-grid';
 
 export const FRAMEWORKS: readonly Framework[] = ['react', 'angular', 'vue', 'javascript'] as const;
+export const DEFAULT_FRAMEWORK: Framework = FRAMEWORKS[0];
 
 export const INTERNAL_FRAMEWORKS: readonly InternalFramework[] = [
     'vanilla',

--- a/packages/ag-charts-website/src/content/menu/data.json
+++ b/packages/ag-charts-website/src/content/menu/data.json
@@ -41,15 +41,15 @@
             },
             {
                 "title": "Chart API",
-                "path": "/javascript/api-create-update"
+                "path": "/[framework]/api-create-update"
             },
             {
                 "title": "Events API",
-                "path": "/javascript/events"
+                "path": "/[framework]/events"
             },
             {
                 "title": "Download API",
-                "path": "/javascript/api-download"
+                "path": "/[framework]/api-download"
             }
         ]
     },

--- a/packages/ag-charts-website/src/layouts/Layout.astro
+++ b/packages/ag-charts-website/src/layouts/Layout.astro
@@ -8,6 +8,7 @@ import type { ApiMenuItem } from '@ag-grid-types';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import { ApiTopBar } from '@components/top-bar/ApiTopBar';
 import { getIsProduction } from '@utils/env';
+import { isDynamicFrameworkPath, isDynamicFrameworkPathMatch } from '@utils/framework';
 
 export interface Props {
     title?: string;
@@ -34,6 +35,12 @@ const isApiLayout = apiMenuItems.some((item) => {
     const removeTrailingSlash = (s: string) => s.replace(/\/$/, '');
     const currentPath = removeTrailingSlash(path);
     const itemPath = removeTrailingSlash(urlWithBaseUrl(item.path));
+    if (isDynamicFrameworkPath(itemPath)) {
+        return isDynamicFrameworkPathMatch({
+            dynamicFrameworkPath: itemPath,
+            pathToMatch: currentPath
+        });
+    }
     return currentPath.startsWith(itemPath);
 });
 ---
@@ -86,7 +93,7 @@ const isApiLayout = apiMenuItems.some((item) => {
                     }
                 </style>
 
-                <ApiTopBar menuItems={apiMenuItems} fullPath={path} />
+                <ApiTopBar client:load menuItems={apiMenuItems} fullPath={path} />
             )}
 
             <slot />

--- a/packages/ag-charts-website/src/layouts/Layout.astro
+++ b/packages/ag-charts-website/src/layouts/Layout.astro
@@ -5,7 +5,7 @@ import SiteHeader from '@components/site-header/SiteHeader.astro';
 import '@design-system/design-system.scss';
 import { Footer } from '@components/footer/Footer';
 import type { ApiMenuItem } from '@ag-grid-types';
-import { urlWithBaseUrl } from '@utils/pages';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import { ApiTopBar } from '@components/top-bar/ApiTopBar';
 import { getIsProduction } from '@utils/env';
 

--- a/packages/ag-charts-website/src/pages/documentation.astro
+++ b/packages/ag-charts-website/src/pages/documentation.astro
@@ -1,8 +1,9 @@
 ---
 import { DOCS_FRAMEWORK_REDIRECT_PAGE } from '@features/docs/constants';
 import { urlWithPrefix } from '@utils/urlWithPrefix';
+import { DEFAULT_FRAMEWORK } from '@constants';
 
-const defaultFramework = 'react';
+const defaultFramework = DEFAULT_FRAMEWORK;
 const docsRedirectPage = DOCS_FRAMEWORK_REDIRECT_PAGE;
 ---
 

--- a/packages/ag-charts-website/src/pages/robots.txt.ts
+++ b/packages/ag-charts-website/src/pages/robots.txt.ts
@@ -1,8 +1,8 @@
 import { SITE_URL } from '@constants';
 import { getIsProduction } from '@utils/env';
-import { urlWithBaseUrl } from '@utils/pages';
 import { pathJoin } from '@utils/pathJoin';
 import { getSitemapIgnorePaths } from '@utils/sitemapPages';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import type { APIContext } from 'astro';
 
 // Disallow the entire site on dev

--- a/packages/ag-charts-website/src/utils/framework.ts
+++ b/packages/ag-charts-website/src/utils/framework.ts
@@ -1,5 +1,6 @@
 import type { Framework, InternalFramework } from '@ag-grid-types';
 import { FRAMEWORK_DISPLAY_TEXT } from '@constants';
+import { DOCS_FRAMEWORK_PATH_INDEX } from '@features/docs/constants';
 
 export const getFrameworkDisplayText = (framework: Framework): string => {
     return FRAMEWORK_DISPLAY_TEXT[framework];
@@ -82,3 +83,31 @@ export const isVueInternalFramework = (internalFramework: InternalFramework) => 
 
     return reactInternalFrameworks.includes(internalFramework);
 };
+
+export function replaceDynamicFrameworkPath({
+    dynamicFrameworkPath,
+    framework,
+}: {
+    dynamicFrameworkPath: string;
+    framework: Framework;
+}) {
+    return dynamicFrameworkPath.replace('[framework]', framework);
+}
+
+export function isDynamicFrameworkPath(path: string) {
+    return path.includes('[framework]');
+}
+
+export function isDynamicFrameworkPathMatch({
+    dynamicFrameworkPath,
+    pathToMatch,
+}: {
+    dynamicFrameworkPath: string;
+    pathToMatch: string;
+}) {
+    const pathSegments = pathToMatch.split('/');
+    const framework = pathSegments[DOCS_FRAMEWORK_PATH_INDEX] as Framework;
+    const itemWithFrameworkPath = replaceDynamicFrameworkPath({ dynamicFrameworkPath, framework });
+
+    return itemWithFrameworkPath === pathToMatch;
+}

--- a/packages/ag-charts-website/src/utils/getPathFromUrlPathname.ts
+++ b/packages/ag-charts-website/src/utils/getPathFromUrlPathname.ts
@@ -1,0 +1,8 @@
+import { SITE_BASE_URL } from '../constants';
+
+export const getPathFromUrlPathname = (pathname: string) => {
+    const regex = new RegExp(`^${SITE_BASE_URL}(.*)`);
+    const substitution = '$1';
+
+    return pathname.replace(regex, substitution);
+};

--- a/packages/ag-charts-website/src/utils/pages.ts
+++ b/packages/ag-charts-website/src/utils/pages.ts
@@ -6,6 +6,7 @@ import glob from 'glob';
 import { DEV_FILE_BASE_PATH, SITE_BASE_URL, TYPESCRIPT_INTERNAL_FRAMEWORKS } from '../constants';
 import { getIsDev } from './env';
 import { pathJoin } from './pathJoin';
+import { urlWithBaseUrl } from './urlWithBaseUrl';
 
 export type DocsPage =
     | CollectionEntry<'docs'>
@@ -111,20 +112,6 @@ const getRootUrl = (): URL => {
         : // Relative to `/dist/packages/ag-charts-website/chunks/pages` folder (Nx specific)
           '../../../../../';
     return new URL(root, import.meta.url);
-};
-
-export const urlWithBaseUrl = (url: string = '') => {
-    const regex = /^\/(.*)/gm;
-    const substitution = `${SITE_BASE_URL}$1`;
-
-    return url.match(regex) ? url.replace(regex, substitution) : url;
-};
-
-export const getPathFromUrlPathname = (pathname: string) => {
-    const regex = new RegExp(`^${SITE_BASE_URL}(.*)`);
-    const substitution = '$1';
-
-    return pathname.replace(regex, substitution);
 };
 
 // TODO: Figure out published packages

--- a/packages/ag-charts-website/src/utils/urlWithBaseUrl.ts
+++ b/packages/ag-charts-website/src/utils/urlWithBaseUrl.ts
@@ -1,0 +1,8 @@
+import { SITE_BASE_URL } from '../constants';
+
+export const urlWithBaseUrl = (url: string = '') => {
+    const regex = /^\/(.*)/gm;
+    const substitution = `${SITE_BASE_URL}$1`;
+
+    return url.match(regex) ? url.replace(regex, substitution) : url;
+};


### PR DESCRIPTION
## Changes

* Use first framework as default instead of hard coding
* Extract urlWithBaseUrl and getPathFromUrlPathname from pages
* Fix API docs pages to switching framework 
  * Add dynamic framework URL support (`[framework]`) for different frameworks in the nav for API docs pages