### PR TITLE
AG-9098 - Improve enterprise warning messages.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -25,6 +25,7 @@ import { getJsonApplyOptions } from './chartOptions';
 import { AgChartInstanceProxy } from './chartProxy';
 import { ChartUpdateType } from './chartUpdateType';
 import { getAxis } from './factory/axisTypes';
+import { isEnterpriseSeriesType, isEnterpriseSeriesTypeLoaded } from './factory/expectedEnterpriseModules';
 import { getLegendKeys } from './factory/legendTypes';
 import { registerInbuiltModules } from './factory/registerInbuiltModules';
 import { getSeries } from './factory/seriesTypes';
@@ -553,7 +554,11 @@ function createSeries(chart: Chart, options: SeriesOptionsTypes[]): Series<any>[
     let index = 0;
     for (const seriesOptions of options ?? []) {
         const path = `series[${index++}]`;
-        const seriesInstance = getSeries(seriesOptions.type ?? 'unknown', moduleContext);
+        const type = seriesOptions.type ?? 'unknown';
+        if (isEnterpriseSeriesType(type) && !isEnterpriseSeriesTypeLoaded(type)) {
+            continue;
+        }
+        const seriesInstance = getSeries(type, moduleContext);
         applySeriesOptionModules(seriesInstance, seriesOptions);
         applySeriesValues(seriesInstance, seriesOptions, { path, index });
         series.push(seriesInstance);

--- a/packages/ag-charts-community/src/chart/factory/chartTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/chartTypes.ts
@@ -1,5 +1,4 @@
 import { jsonMerge } from '../../util/json';
-import { getEnterpriseSeriesChartTypes } from './expectedEnterpriseModules';
 
 export type ChartType = 'cartesian' | 'polar' | 'hierarchy';
 
@@ -13,16 +12,13 @@ export const CHART_TYPES = {
     },
 
     isCartesian(seriesType: string) {
-        const type = TYPES[seriesType] ?? getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'cartesian');
-        return type === 'cartesian';
+        return TYPES[seriesType] === 'cartesian';
     },
     isPolar(seriesType: string) {
-        const type = TYPES[seriesType] ?? getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'polar');
-        return type === 'polar';
+        return TYPES[seriesType] === 'polar';
     },
     isHierarchy(seriesType: string) {
-        const type = TYPES[seriesType] ?? getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'hierarchy');
-        return type === 'hierarchy';
+        return TYPES[seriesType] === 'hierarchy';
     },
 
     get seriesTypes() {

--- a/packages/ag-charts-community/src/chart/factory/chartTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/chartTypes.ts
@@ -1,4 +1,5 @@
 import { jsonMerge } from '../../util/json';
+import { getEnterpriseSeriesChartTypes } from './expectedEnterpriseModules';
 
 export type ChartType = 'cartesian' | 'polar' | 'hierarchy';
 
@@ -12,13 +13,16 @@ export const CHART_TYPES = {
     },
 
     isCartesian(seriesType: string) {
-        return TYPES[seriesType] === 'cartesian';
+        const type = TYPES[seriesType] ?? getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'cartesian');
+        return type === 'cartesian';
     },
     isPolar(seriesType: string) {
-        return TYPES[seriesType] === 'polar';
+        const type = TYPES[seriesType] ?? getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'polar');
+        return type === 'polar';
     },
     isHierarchy(seriesType: string) {
-        return TYPES[seriesType] === 'hierarchy';
+        const type = TYPES[seriesType] ?? getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'hierarchy');
+        return type === 'hierarchy';
     },
 
     get seriesTypes() {
@@ -47,6 +51,6 @@ export function getChartDefaults(chartType: ChartType) {
     return DEFAULTS[chartType] ?? {};
 }
 
-export function getChartType(seriesType: string) {
+export function getChartType(seriesType: string): ChartType | 'unknown' {
     return TYPES[seriesType] ?? 'unknown';
 }

--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -132,15 +132,13 @@ export function removeUsedEnterpriseOptions<T extends AgChartOptions>(options: T
             }
         }
     }
-    for (const enterpriseOption of usedOptions) {
+    if (usedOptions.length > 0) {
         Logger.warnOnce(
             [
-                `AG Charts: unable to use ${enterpriseOption} as package 'ag-charts-enterprise' has not been imported.`,
-                'Check that you have imported the package:',
-                '',
-                '    import "ag-charts-enterprise";',
-                '',
-                'For more info see: https://charts.ag-grid.com/javascript/installation/',
+                `unable to use enterprise features as package 'ag-charts-enterprise' has not been loaded; affected options provided are:`,
+                ...usedOptions,
+                ``,
+                'See: https://charts.ag-grid.com/javascript/installation/',
             ].join('\n')
         );
     }

--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -47,6 +47,18 @@ const EXPECTED_ENTERPRISE_MODULES: EnterpriseModuleStub[] = [
     { type: 'series-option', optionsKey: 'errorBar', chartTypes: ['cartesian'], identifier: 'error-bars' },
 ];
 
+export function isEnterpriseSeriesType(type: string) {
+    return EXPECTED_ENTERPRISE_MODULES.some((s) => s.type === 'series' && s.identifier === type);
+}
+
+export function getEnterpriseSeriesChartTypes(type: string) {
+    return EXPECTED_ENTERPRISE_MODULES.find((s) => s.type === 'series' && s.identifier === type)?.chartTypes;
+}
+
+export function isEnterpriseSeriesTypeLoaded(type: string) {
+    return (EXPECTED_ENTERPRISE_MODULES.find((s) => s.type === 'series' && s.identifier === type)?.useCount ?? 0) > 0;
+}
+
 export function verifyIfModuleExpected(module: Module<any>) {
     if (module.packageType !== 'enterprise') {
         throw new Error('AG Charts - internal configuration error, only enterprise modules need verification.');
@@ -77,7 +89,7 @@ export function removeUsedEnterpriseOptions<T extends AgChartOptions>(options: T
     const usedOptions: string[] = [];
     const optionsChartType = getChartType(optionsType(options));
     for (const { type, chartTypes, optionsKey, optionsInnerKey, identifier } of EXPECTED_ENTERPRISE_MODULES) {
-        if (!chartTypes.includes(optionsChartType)) continue;
+        if (optionsChartType !== 'unknown' && !chartTypes.includes(optionsChartType)) continue;
 
         if (type === 'root' || type === 'legend') {
             const optionValue = options[optionsKey as keyof T] as any;

--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -1,16 +1,12 @@
 /* eslint-disable sonarjs/no-collapsible-if */
 import type { Module } from '../../module-support';
-import type { AgChartOptions } from '../../options/chart/chartBuilderOptions';
-import { Logger } from '../../util/logger';
-import { optionsType } from '../mapping/types';
-import { getChartType } from './chartTypes';
 
 type EnterpriseModuleStub = Pick<Module<any>, 'type' | 'identifier' | 'optionsKey' | 'chartTypes'> & {
     useCount?: number;
     optionsInnerKey?: string;
 };
 
-const EXPECTED_ENTERPRISE_MODULES: EnterpriseModuleStub[] = [
+export const EXPECTED_ENTERPRISE_MODULES: EnterpriseModuleStub[] = [
     { type: 'root', optionsKey: 'animation', chartTypes: ['cartesian', 'polar', 'hierarchy'] },
     {
         type: 'root',
@@ -59,6 +55,19 @@ export function isEnterpriseSeriesTypeLoaded(type: string) {
     return (EXPECTED_ENTERPRISE_MODULES.find((s) => s.type === 'series' && s.identifier === type)?.useCount ?? 0) > 0;
 }
 
+export function isEnterpriseCartesian(seriesType: string) {
+    const type = getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'cartesian');
+    return type === 'cartesian';
+}
+export function isEnterprisePolar(seriesType: string) {
+    const type = getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'polar');
+    return type === 'polar';
+}
+export function isEnterpriseHierarchy(seriesType: string) {
+    const type = getEnterpriseSeriesChartTypes(seriesType)?.find((v) => v === 'hierarchy');
+    return type === 'hierarchy';
+}
+
 export function verifyIfModuleExpected(module: Module<any>) {
     if (module.packageType !== 'enterprise') {
         throw new Error('AG Charts - internal configuration error, only enterprise modules need verification.');
@@ -83,63 +92,4 @@ export function verifyIfModuleExpected(module: Module<any>) {
 
 export function getUnusedExpectedModules() {
     return EXPECTED_ENTERPRISE_MODULES.filter(({ useCount }) => useCount == null || useCount === 0);
-}
-
-export function removeUsedEnterpriseOptions<T extends AgChartOptions>(options: T) {
-    const usedOptions: string[] = [];
-    const optionsChartType = getChartType(optionsType(options));
-    for (const { type, chartTypes, optionsKey, optionsInnerKey, identifier } of EXPECTED_ENTERPRISE_MODULES) {
-        if (optionsChartType !== 'unknown' && !chartTypes.includes(optionsChartType)) continue;
-
-        if (type === 'root' || type === 'legend') {
-            const optionValue = options[optionsKey as keyof T] as any;
-            if (optionValue != null) {
-                if (!optionsInnerKey) {
-                    usedOptions.push(optionsKey);
-                    delete options[optionsKey as keyof T];
-                } else if (optionValue[optionsInnerKey]) {
-                    usedOptions.push(`${optionsKey}.${optionsInnerKey}`);
-                    delete optionValue[optionsInnerKey];
-                }
-            }
-        } else if (type === 'axis') {
-            if ('axes' in options && options.axes?.some((axis) => axis.type === identifier)) {
-                usedOptions.push(`axis[type=${identifier}]`);
-                options.axes = (options.axes as any).filter((axis: any) => axis.type !== identifier);
-            }
-        } else if (type === 'axis-option') {
-            if ('axes' in options && options.axes?.some((axis) => axis[optionsKey as keyof typeof axis])) {
-                usedOptions.push(`axis.${optionsKey}`);
-                options.axes.forEach((axis) => {
-                    if (axis[optionsKey as keyof typeof axis]) {
-                        delete axis[optionsKey as keyof typeof axis];
-                    }
-                });
-            }
-        } else if (type === 'series') {
-            if (options.series?.some((series) => series.type === identifier)) {
-                usedOptions.push(`series[type=${identifier}]`);
-                options.series = (options.series as any).filter((series: any) => series.type !== identifier);
-            }
-        } else if (type === 'series-option') {
-            if (options.series?.some((series) => series[optionsKey as keyof typeof series])) {
-                usedOptions.push(`series.${optionsKey}`);
-                options.series.forEach((series) => {
-                    if (series[optionsKey as keyof typeof series]) {
-                        delete series[optionsKey as keyof typeof series];
-                    }
-                });
-            }
-        }
-    }
-    if (usedOptions.length > 0) {
-        Logger.warnOnce(
-            [
-                `unable to use enterprise features as package 'ag-charts-enterprise' has not been loaded; affected options provided are:`,
-                ...usedOptions,
-                ``,
-                'See: https://charts.ag-grid.com/javascript/installation/',
-            ].join('\n')
-        );
-    }
 }

--- a/packages/ag-charts-community/src/chart/factory/processEnterpriseOptions.ts
+++ b/packages/ag-charts-community/src/chart/factory/processEnterpriseOptions.ts
@@ -1,0 +1,65 @@
+import type { AgChartOptions } from '../../options/agChartOptions';
+import { Logger } from '../../util/logger';
+import { optionsType } from '../mapping/types';
+import { getChartType } from './chartTypes';
+import { EXPECTED_ENTERPRISE_MODULES } from './expectedEnterpriseModules';
+
+export function removeUsedEnterpriseOptions<T extends AgChartOptions>(options: T) {
+    const usedOptions: string[] = [];
+    const optionsChartType = getChartType(optionsType(options));
+    for (const { type, chartTypes, optionsKey, optionsInnerKey, identifier } of EXPECTED_ENTERPRISE_MODULES) {
+        if (optionsChartType !== 'unknown' && !chartTypes.includes(optionsChartType)) continue;
+
+        if (type === 'root' || type === 'legend') {
+            const optionValue = options[optionsKey as keyof T] as any;
+            if (optionValue != null) {
+                if (!optionsInnerKey) {
+                    usedOptions.push(optionsKey);
+                    delete options[optionsKey as keyof T];
+                } else if (optionValue[optionsInnerKey]) {
+                    usedOptions.push(`${optionsKey}.${optionsInnerKey}`);
+                    delete optionValue[optionsInnerKey];
+                }
+            }
+        } else if (type === 'axis') {
+            if ('axes' in options && options.axes?.some((axis) => axis.type === identifier)) {
+                usedOptions.push(`axis[type=${identifier}]`);
+                options.axes = (options.axes as any).filter((axis: any) => axis.type !== identifier);
+            }
+        } else if (type === 'axis-option') {
+            if ('axes' in options && options.axes?.some((axis) => axis[optionsKey as keyof typeof axis])) {
+                usedOptions.push(`axis.${optionsKey}`);
+                options.axes.forEach((axis) => {
+                    if (axis[optionsKey as keyof typeof axis]) {
+                        delete axis[optionsKey as keyof typeof axis];
+                    }
+                });
+            }
+        } else if (type === 'series') {
+            if (options.series?.some((series) => series.type === identifier)) {
+                usedOptions.push(`series[type=${identifier}]`);
+                options.series = (options.series as any).filter((series: any) => series.type !== identifier);
+            }
+        } else if (type === 'series-option') {
+            if (options.series?.some((series) => series[optionsKey as keyof typeof series])) {
+                usedOptions.push(`series.${optionsKey}`);
+                options.series.forEach((series) => {
+                    if (series[optionsKey as keyof typeof series]) {
+                        delete series[optionsKey as keyof typeof series];
+                    }
+                });
+            }
+        }
+    }
+    if (usedOptions.length > 0) {
+        Logger.warnOnce(
+            [
+                `unable to use these enterprise features as 'ag-charts-enterprise' has not been loaded:`,
+                ``,
+                ...usedOptions,
+                ``,
+                'See: https://charts.ag-grid.com/javascript/installation/',
+            ].join('\n')
+        );
+    }
+}

--- a/packages/ag-charts-community/src/chart/factory/processEnterpriseOptions.ts
+++ b/packages/ag-charts-community/src/chart/factory/processEnterpriseOptions.ts
@@ -12,43 +12,43 @@ export function removeUsedEnterpriseOptions<T extends AgChartOptions>(options: T
 
         if (type === 'root' || type === 'legend') {
             const optionValue = options[optionsKey as keyof T] as any;
-            if (optionValue != null) {
-                if (!optionsInnerKey) {
-                    usedOptions.push(optionsKey);
-                    delete options[optionsKey as keyof T];
-                } else if (optionValue[optionsInnerKey]) {
-                    usedOptions.push(`${optionsKey}.${optionsInnerKey}`);
-                    delete optionValue[optionsInnerKey];
-                }
+            if (optionValue == null) continue;
+
+            if (!optionsInnerKey) {
+                usedOptions.push(optionsKey);
+                delete options[optionsKey as keyof T];
+            } else if (optionValue[optionsInnerKey]) {
+                usedOptions.push(`${optionsKey}.${optionsInnerKey}`);
+                delete optionValue[optionsInnerKey];
             }
         } else if (type === 'axis') {
-            if ('axes' in options && options.axes?.some((axis) => axis.type === identifier)) {
-                usedOptions.push(`axis[type=${identifier}]`);
-                options.axes = (options.axes as any).filter((axis: any) => axis.type !== identifier);
-            }
+            if (!('axes' in options) || !options.axes?.some((axis) => axis.type === identifier)) continue;
+
+            usedOptions.push(`axis[type=${identifier}]`);
+            options.axes = (options.axes as any).filter((axis: any) => axis.type !== identifier);
         } else if (type === 'axis-option') {
-            if ('axes' in options && options.axes?.some((axis) => axis[optionsKey as keyof typeof axis])) {
-                usedOptions.push(`axis.${optionsKey}`);
-                options.axes.forEach((axis) => {
-                    if (axis[optionsKey as keyof typeof axis]) {
-                        delete axis[optionsKey as keyof typeof axis];
-                    }
-                });
-            }
+            if (!('axes' in options) || !options.axes?.some((axis) => axis[optionsKey as keyof typeof axis])) continue;
+
+            usedOptions.push(`axis.${optionsKey}`);
+            options.axes.forEach((axis) => {
+                if (axis[optionsKey as keyof typeof axis]) {
+                    delete axis[optionsKey as keyof typeof axis];
+                }
+            });
         } else if (type === 'series') {
-            if (options.series?.some((series) => series.type === identifier)) {
-                usedOptions.push(`series[type=${identifier}]`);
-                options.series = (options.series as any).filter((series: any) => series.type !== identifier);
-            }
+            if (!options.series?.some((series) => series.type === identifier)) continue;
+
+            usedOptions.push(`series[type=${identifier}]`);
+            options.series = (options.series as any).filter((series: any) => series.type !== identifier);
         } else if (type === 'series-option') {
-            if (options.series?.some((series) => series[optionsKey as keyof typeof series])) {
-                usedOptions.push(`series.${optionsKey}`);
-                options.series.forEach((series) => {
-                    if (series[optionsKey as keyof typeof series]) {
-                        delete series[optionsKey as keyof typeof series];
-                    }
-                });
-            }
+            if (!options.series?.some((series) => series[optionsKey as keyof typeof series])) continue;
+
+            usedOptions.push(`series.${optionsKey}`);
+            options.series.forEach((series) => {
+                if (series[optionsKey as keyof typeof series]) {
+                    delete series[optionsKey as keyof typeof series];
+                }
+            });
         }
     }
     if (usedOptions.length > 0) {

--- a/packages/ag-charts-community/src/chart/mapping/prepare.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepare.ts
@@ -14,7 +14,7 @@ import { Logger } from '../../util/logger';
 import type { DeepPartial } from '../../util/types';
 import { AXIS_TYPES } from '../factory/axisTypes';
 import { CHART_TYPES } from '../factory/chartTypes';
-import { removeUsedEnterpriseOptions } from '../factory/expectedEnterpriseModules';
+import { isEnterpriseSeriesType, removeUsedEnterpriseOptions } from '../factory/expectedEnterpriseModules';
 import {
     executeCustomDefaultsFunctions,
     getSeriesDefaults,
@@ -91,7 +91,7 @@ export function prepareOptions<T extends AgChartOptions>(options: T): T {
     const globalTooltipPositionOptions = getGlobalTooltipPositionOptions(options.tooltip?.position);
 
     const checkSeriesType = (type?: string) => {
-        if (type != null && !(isSeriesOptionType(type) || getSeriesDefaults(type))) {
+        if (type != null && !(isSeriesOptionType(type) || isEnterpriseSeriesType(type) || getSeriesDefaults(type))) {
             throw new Error(`AG Charts - unknown series type: ${type}; expected one of: ${CHART_TYPES.seriesTypes}`);
         }
     };
@@ -285,9 +285,9 @@ function prepareTheme<T extends AgChartOptions>(options: T) {
 
     return {
         theme,
-        axesThemes: themeConfig['axes'] ?? {},
+        axesThemes: themeConfig?.['axes'] ?? {},
         seriesThemes: seriesThemes,
-        cleanedTheme: jsonMerge([themeConfig, { axes: DELETE, series: DELETE }]),
+        cleanedTheme: jsonMerge([themeConfig ?? {}, { axes: DELETE, series: DELETE }]),
         userPalette,
     };
 }

--- a/packages/ag-charts-community/src/chart/mapping/prepare.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepare.ts
@@ -14,7 +14,8 @@ import { Logger } from '../../util/logger';
 import type { DeepPartial } from '../../util/types';
 import { AXIS_TYPES } from '../factory/axisTypes';
 import { CHART_TYPES } from '../factory/chartTypes';
-import { isEnterpriseSeriesType, removeUsedEnterpriseOptions } from '../factory/expectedEnterpriseModules';
+import { isEnterpriseSeriesType } from '../factory/expectedEnterpriseModules';
+import { removeUsedEnterpriseOptions } from '../factory/processEnterpriseOptions';
 import {
     executeCustomDefaultsFunctions,
     getSeriesDefaults,

--- a/packages/ag-charts-community/src/chart/mapping/types.ts
+++ b/packages/ag-charts-community/src/chart/mapping/types.ts
@@ -7,6 +7,7 @@ import type {
 import { Logger } from '../../util/logger';
 import { AXIS_TYPES } from '../factory/axisTypes';
 import { CHART_TYPES } from '../factory/chartTypes';
+import { isEnterpriseCartesian, isEnterpriseHierarchy, isEnterprisePolar } from '../factory/expectedEnterpriseModules';
 
 export type AxesOptionsTypes = NonNullable<AgCartesianChartOptions['axes']>[number];
 export type SeriesOptionsTypes = NonNullable<AgChartOptions['series']>[number];
@@ -29,7 +30,7 @@ export function isAgCartesianChartOptions(input: AgChartOptions): input is AgCar
         return true;
     }
 
-    return CHART_TYPES.isCartesian(specifiedType);
+    return CHART_TYPES.isCartesian(specifiedType) || isEnterpriseCartesian(specifiedType);
 }
 
 export function isAgHierarchyChartOptions(input: AgChartOptions): input is AgHierarchyChartOptions {
@@ -43,7 +44,7 @@ export function isAgHierarchyChartOptions(input: AgChartOptions): input is AgHie
         return true;
     }
 
-    return CHART_TYPES.isHierarchy(specifiedType);
+    return CHART_TYPES.isHierarchy(specifiedType) || isEnterpriseHierarchy(specifiedType);
 }
 
 export function isAgPolarChartOptions(input: AgChartOptions): input is AgPolarChartOptions {
@@ -57,7 +58,7 @@ export function isAgPolarChartOptions(input: AgChartOptions): input is AgPolarCh
         return true;
     }
 
-    return CHART_TYPES.isPolar(specifiedType);
+    return CHART_TYPES.isPolar(specifiedType) || isEnterprisePolar(specifiedType);
 }
 
 export function isSeriesOptionType(input?: string): input is NonNullable<SeriesOptionsTypes['type']> {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9098

Addresses enterprise option warning message feedback:
- Enterprise series type are now correctly warned, rather than getting a hard-error with no information to go on.
- Formatting of the message is improved (one message per chart create/update, simplified English):
```
AG Charts - unable to use these enterprise features as 'ag-charts-enterprise' has not been loaded:

background.image
series[type=range-bar]

See: https://charts.ag-grid.com/javascript/installation/
```