### PR TITLE
AG-9885 Fix secondary number axes with no domain rendering NaN ticks

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -58,6 +58,8 @@ export class NumberAxis extends CartesianAxis<LinearScale | LogScale, number> {
             throw new Error('AG Charts - dataDomain not calculated, cannot perform tick calculation.');
         }
 
+        if (this.dataDomain.domain.length === 0) return [];
+
         const [d, ticks] = calculateNiceSecondaryAxis(this.dataDomain.domain, primaryTickCount ?? 0);
 
         this.scale.nice = false;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9885

Did not appear to be related to recent axis/zoom changes (bug remained when those were reverted).

It's caused by an empty domain being found when there are no visible series in the `calculateDomain()` fn. I considered hiding the axis components when there are no active series, but the tests indicate that we need to continue showing them when there is a fixed domain. So instead, shortcutting the secondary axis ticks calculation with an empty array of ticks seems the correct fix.