### PR TITLE
AG-9588 Add validation for user theme

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/themes.test.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { toMatchImageSnapshot } from 'jest-image-snapshot';
+
+import type { AgChartOptions, AgChartTheme, AgChartThemePalette } from '../../options/agChartOptions';
+import { AgCharts } from '../agChartV2';
+import type { Chart } from '../chart';
+import { prepareTestOptions, waitForChartStability } from '../test/utils';
+
+expect.extend({ toMatchImageSnapshot });
+
+/* eslint-disable no-console */
+describe('ThemesValidation', () => {
+    beforeEach(() => {
+        console.warn = jest.fn();
+    });
+
+    const opts: AgChartOptions = {
+        ...prepareTestOptions({}),
+        data: [
+            { label: 'Android', v1: 5.67, v2: 8.63, v3: 8.14, v4: 6.45, v5: 1.37 },
+            { label: 'iOS', v1: 7.01, v2: 8.04, v3: 1.338, v4: 6.78, v5: 5.45 },
+            { label: 'BlackBerry', v1: 7.54, v2: 1.98, v3: 9.88, v4: 1.38, v5: 4.44 },
+            { label: 'Symbian', v1: 9.27, v2: 4.21, v3: 2.53, v4: 6.31, v5: 4.44 },
+            { label: 'Windows', v1: 2.8, v2: 1.908, v3: 7.48, v4: 5.29, v5: 8.8 },
+        ],
+        series: [
+            { type: 'bar', xKey: 'label', yKey: 'v1', stacked: true, yName: 'Reliability' },
+            { type: 'bar', xKey: 'label', yKey: 'v2', stacked: true, yName: 'Ease of use' },
+            { type: 'bar', xKey: 'label', yKey: 'v3', stacked: true, yName: 'Performance' },
+            { type: 'bar', xKey: 'label', yKey: 'v4', stacked: true, yName: 'Price' },
+            { type: 'bar', xKey: 'label', yKey: 'v5', stacked: true, yName: 'Market share' },
+        ],
+    };
+
+    it('should show 1 warning for invalid theme type', async () => {
+        const chart = AgCharts.create({
+            ...opts,
+            theme: true as unknown as AgChartTheme,
+        }) as Chart;
+        await waitForChartStability(chart);
+
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith('AG Charts - invalid theme value type boolean, expected object.');
+    });
+
+    it('should show 1 warning for missing strokes', async () => {
+        const chart = AgCharts.create({
+            ...opts,
+            theme: {
+                baseTheme: 'ag-default-dark',
+                palette: {
+                    fills: ['#5C2983', '#0076C5', '#21B372', '#FDDE02', '#F76700', '#D30018'],
+                } as AgChartThemePalette,
+            },
+        }) as Chart;
+        await waitForChartStability(chart);
+
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith('AG Charts - theme.overrides.strokes must be a defined array');
+    });
+
+    it('should show 1 warning for missing fills', async () => {
+        const chart = AgCharts.create({
+            ...opts,
+            theme: {
+                baseTheme: 'ag-default-dark',
+                palette: {
+                    strokes: ['black'],
+                } as AgChartThemePalette,
+            },
+        }) as Chart;
+        await waitForChartStability(chart);
+
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith('AG Charts - theme.overrides.fills must be a defined array');
+    });
+
+    it('should show 3 warnings for invalid types', async () => {
+        const chart = AgCharts.create({
+            ...opts,
+            theme: {
+                baseTheme: NaN,
+                palette: 'foobar',
+                overrides: true,
+            } as unknown as AgChartTheme,
+        }) as Chart;
+        await waitForChartStability(chart);
+
+        expect(console.warn).toBeCalledTimes(3);
+        expect(console.warn).nthCalledWith(1, 'AG Charts - invalid theme.baseTheme type number, expected string.');
+        expect(console.warn).nthCalledWith(2, 'AG Charts - invalid theme.overrides type boolean, expected object.');
+        expect(console.warn).nthCalledWith(3, 'AG Charts - invalid theme.palette type string, expected object.');
+    });
+
+    it('should show 2 warnings for invalid types - palette', async () => {
+        const chart = AgCharts.create({
+            ...opts,
+            theme: {
+                baseTheme: 'ag-default-dark',
+                palette: {
+                    fills: 'red',
+                    strokes: 'black',
+                } as unknown as AgChartThemePalette,
+            },
+        }) as Chart;
+        await waitForChartStability(chart);
+
+        expect(console.warn).toBeCalledTimes(2);
+        expect(console.warn).nthCalledWith(1, 'AG Charts - theme.overrides.fills must be a defined array');
+        expect(console.warn).nthCalledWith(2, 'AG Charts - theme.overrides.strokes must be a defined array');
+    });
+});
+/* eslint-enable no-console */

--- a/packages/ag-charts-community/src/chart/mapping/themes.test.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.test.ts
@@ -87,7 +87,10 @@ describe('ThemesValidation', () => {
         await waitForChartStability(chart);
 
         expect(console.warn).toBeCalledTimes(3);
-        expect(console.warn).nthCalledWith(1, 'AG Charts - invalid theme.baseTheme type number, expected string.');
+        expect(console.warn).nthCalledWith(
+            1,
+            'AG Charts - invalid theme.baseTheme type number, expected (string | object).'
+        );
         expect(console.warn).nthCalledWith(2, 'AG Charts - invalid theme.overrides type boolean, expected object.');
         expect(console.warn).nthCalledWith(3, 'AG Charts - invalid theme.palette type string, expected object.');
     });

--- a/packages/ag-charts-community/src/chart/mapping/themes.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.ts
@@ -101,6 +101,11 @@ function validateChartTheme(value: unknown): string | ChartTheme | AgChartTheme 
 }
 
 export function getChartTheme(unvalidatedValue: unknown): ChartTheme {
+    // unvalidatedValue is either a built-in theme (`string | ChartTheme`) or a user defined
+    // theme (`AgChartTheme`). In the latter case, we can't make any assumption about the
+    // property types, hence why the input parameter is `unknown`. This abnormal validation
+    // is tech debt; the ideal solution would be to integrate user themes with the @Validate
+    // decorator like other chart options.
     let value = validateChartTheme(unvalidatedValue);
 
     if (value instanceof ChartTheme) {

--- a/packages/ag-charts-community/src/chart/mapping/themes.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.ts
@@ -1,4 +1,9 @@
-import type { AgChartTheme, AgChartThemeName, AgChartThemeOverrides } from '../../options/agChartOptions';
+import type {
+    AgChartTheme,
+    AgChartThemeName,
+    AgChartThemeOverrides,
+    AgChartThemePalette,
+} from '../../options/agChartOptions';
 import { jsonMerge } from '../../util/json';
 import { Logger } from '../../util/logger';
 import { ChartTheme } from '../themes/chartTheme';
@@ -42,12 +47,67 @@ export const themes: ThemeMap = {
     ...lightThemes,
 };
 
-export function getChartTheme(value?: string | ChartTheme | AgChartTheme): ChartTheme {
+type Unvalidate<T> = { [K in keyof T]?: unknown };
+function validateChartThemeObject(unknownObject: object | null): AgChartTheme | undefined {
+    if (unknownObject === null) {
+        return undefined;
+    }
+
+    let valid = true;
+    const { baseTheme, palette, overrides } = unknownObject as Unvalidate<AgChartTheme>;
+
+    if (baseTheme !== undefined && typeof baseTheme !== 'string') {
+        Logger.warn(`invalid theme.baseTheme type ${typeof baseTheme}, expected string.`);
+        valid = false;
+    }
+    if (overrides !== undefined && typeof overrides !== 'object') {
+        Logger.warn(`invalid theme.overrides type ${typeof overrides}, expected object.`);
+        valid = false;
+    }
+    if (typeof palette === 'object') {
+        if (palette !== null) {
+            const { fills, strokes } = palette as Unvalidate<AgChartThemePalette>;
+            if (!Array.isArray(fills)) {
+                Logger.warn(`theme.overrides.fills must be a defined array`);
+                valid = false;
+            }
+            if (strokes === undefined) {
+                Logger.warn(`theme.overrides.strokes must be a defined array`);
+                valid = false;
+            }
+        }
+    } else {
+        Logger.warn(`invalid theme.palette type ${typeof palette}, expected object.`);
+        valid = false;
+    }
+
+    if (valid) {
+        return unknownObject as AgChartTheme;
+    }
+    return undefined;
+}
+
+function validateChartTheme(value: unknown): string | ChartTheme | AgChartTheme | undefined {
+    if (value === undefined || typeof value === 'string' || value instanceof ChartTheme) {
+        return value;
+    }
+
+    if (typeof value === 'object') {
+        return validateChartThemeObject(value);
+    }
+
+    Logger.warn(`invalid theme value type ${typeof value}, expected object.`);
+    return undefined;
+}
+
+export function getChartTheme(unvalidatedValue: unknown): ChartTheme {
+    let value = validateChartTheme(unvalidatedValue);
+
     if (value instanceof ChartTheme) {
         return value;
     }
 
-    if (typeof value === 'string') {
+    if (value === undefined || typeof value === 'string') {
         const stockTheme = themes[value as AgChartThemeName];
         if (stockTheme) {
             return stockTheme();
@@ -55,8 +115,6 @@ export function getChartTheme(value?: string | ChartTheme | AgChartTheme): Chart
         Logger.warnOnce(`the theme [${value}] is invalid, using [ag-default] instead.`);
         return lightTheme();
     }
-
-    value = value as AgChartTheme;
 
     // Flatten recursive themes.
     const overrides: AgChartThemeOverrides[] = [];

--- a/packages/ag-charts-community/src/chart/mapping/themes.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.ts
@@ -56,8 +56,8 @@ function validateChartThemeObject(unknownObject: object | null): AgChartTheme | 
     let valid = true;
     const { baseTheme, palette, overrides } = unknownObject as Unvalidate<AgChartTheme>;
 
-    if (baseTheme !== undefined && typeof baseTheme !== 'string') {
-        Logger.warn(`invalid theme.baseTheme type ${typeof baseTheme}, expected string.`);
+    if (baseTheme !== undefined && typeof baseTheme !== 'string' && typeof baseTheme !== 'object') {
+        Logger.warn(`invalid theme.baseTheme type ${typeof baseTheme}, expected (string | object).`);
         valid = false;
     }
     if (overrides !== undefined && typeof overrides !== 'object') {
@@ -71,12 +71,12 @@ function validateChartThemeObject(unknownObject: object | null): AgChartTheme | 
                 Logger.warn(`theme.overrides.fills must be a defined array`);
                 valid = false;
             }
-            if (strokes === undefined) {
+            if (!Array.isArray(strokes)) {
                 Logger.warn(`theme.overrides.strokes must be a defined array`);
                 valid = false;
             }
         }
-    } else {
+    } else if (palette !== undefined) {
         Logger.warn(`invalid theme.palette type ${typeof palette}, expected object.`);
         valid = false;
     }


### PR DESCRIPTION
This isn't an ideal solution, but it's an improvement to just naively converting user data to a theme with `as AgChartTheme` with no validation whatsoever.

In long term, we should find some way to integrate this with the _validatation.ts_ utility.

This will solve the bug where nothing is rendered, but it’s not an ideal solution. Unfortunately it seems like user themes are not integrated with our _validation.ts_ utility (which would be an ideal solution).

This PR implements some rudimentary validation to try to prevent unexpected behaviours like no rendering. However, as a consequence, the entire `options.theme` value is thrown away if an error is found. Migrating to the _validation.ts_ will enhance our ability to control the defaults when validation fails.

I think that the current state of the solution is acceptable; nevertheless, it is tech debt. I don’t believe that making further enhancements to this solution is a good idea.