### PR TITLE
Fix broken links

### DIFF
--- a/packages/ag-charts-website/src/content/docs/axes-labels/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-labels/index.mdoc
@@ -204,7 +204,7 @@ The `label` config of the bottom axis in the example below uses the `'%b&nbsp;%Y
 
 Notice that the `label.format` property only affects label formatting but not segmentation. The fact that axis labels were configured to show the name of the month and the year doesn't mean that the axis will show a tick every month. To ensure that it does, we also set the `tick.interval` config to use the `time.month` interval.
 
-Please see the [Axis Ticks](./axis-ticks/) section to learn more about tick intervals.
+Please see the [Axis Ticks](./axes-ticks/) section to learn more about tick intervals.
 
 ## Next Up
 

--- a/packages/ag-charts-website/src/content/docs/axes-types/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-types/index.mdoc
@@ -9,8 +9,8 @@ the relationships between data points on the graph. This section discusses the d
 
 A category axis is used to display distinct categories or groups of data in a chart.
 
-The category axis shows discrete categories or groups of data, unlike the [Number](./axes-types/#number) or
-[Time](./axes-types/#time) axes which use a continuous scale. For instance, in a bar chart of sales per product, the
+The category axis shows discrete categories or groups of data, unlike the [Number](#number) or
+[Time](#time) axes which use a continuous scale. For instance, in a bar chart of sales per product, the
 category axis shows the products as different groups, and the number axis displays the corresponding sale value for each group.
 
 If no `axes` are supplied, a category axis will be used as the x-axis by default. However, it can also
@@ -25,16 +25,16 @@ axes: [
 ];
 ```
 
-The category axis will attempt to render an [Axis Tick](./axes-ticks/), [Axis Label](./axis-labels/) and
-[Grid Line](./axis-grid-lines/) for each category with even spacing.
+The category axis will attempt to render an [Axis Tick](./axes-ticks/), [Axis Label](./axes-labels/) and
+[Grid Line](./axes-grid-lines/) for each category with even spacing.
 
-For a full list of configuration options see [Category Axis Options](#category-axis-options).
+For a full list of configuration options see [Category Axis Options](#reference-AgCategoryAxisOptions).
 
 ## Number
 
 A number axis is used to display continuous numerical values in a chart.
 
-The number axis displays continuous numerical values, unlike the [Category](./axes-types/#category) axis which displays
+The number axis displays continuous numerical values, unlike the [Category](#reference-AgCategoryAxisOptions) axis which displays
 discrete categories or groups of data. This means that while categories are spaced out evenly, the distance between values
 in a number axis will depend on their magnitude.
 
@@ -53,7 +53,7 @@ axes: [
 ];
 ```
 
-For a full list of configuration options see [Number Axis Options](#number-axis-options).
+For a full list of configuration options see [Number Axis Options](#reference-AgNumberAxisOptions).
 
 ## Time
 
@@ -74,7 +74,7 @@ simplest time axis config looks like this:
 }
 ```
 
-For a full list of configuration options see [Time Axis Options](#time-axis-options).
+For a full list of configuration options see [Time Axis Options](#reference-AgTimeAxisOptions).
 
 ## Log
 
@@ -118,7 +118,7 @@ you to change the base to any number you like, for example `Math.E` for natural 
 }
 ```
 
-For a full list of configuration options see [Log Axis Options](#log-axis-options).
+For a full list of configuration options see [Log Axis Options](#reference-AgLogAxisOptions).
 
 These configurations above are demonstrated in the following example:
 

--- a/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
@@ -179,7 +179,7 @@ const options = ref({
 
 Let's breakdown whats happening here:
 
--   **Type:** The type of axis to use - one of [Category](./axes-types#category/), [Number](./axes-types#number/), [Time](./axes-types#time/) or [Log](./axes-types#log/).
+-   **Type:** The type of axis to use - one of [Category](./axes-types/#category), [Number](./axes-types/#number), [Time](./axes-types/#time) or [Log](./axes-types/#log).
 -   **Position:** The position on the chart where the axis should be rendered, e.g. 'top', 'bottom', 'right' or 'left'.
 -   **Keys:** Associates the axis with a given series, with the keys axis property linking the appropriate series to the axis.
 
@@ -245,7 +245,7 @@ const options = ref({
 
 {% chartExampleRunner title="Titles Example" name="title-example" type="generated" /%}
 
-_Note: Refer to the [title](/options/#reference-AgChartOptions-title/) and [subtitle](./options/#reference-AgChartOptions-subtitle/) API docs for a full list of properties that can be configured_
+_Note: Refer to the [title](/options/#reference-AgChartOptions-title) and [subtitle](/options/#reference-AgChartOptions-subtitle) API docs for a full list of properties that can be configured_
 
 ### Legend
 

--- a/packages/ag-charts-website/src/content/docs/installation/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/installation/index.mdoc
@@ -222,15 +222,15 @@ agCharts.AgCharts.setLicenseKey('your license key');
 ## Without a Bundled Project
 
 {% if isFramework("react") %}
-We don't support pre-built bundles for React - see the [Javascript](../javascript/installation) documentation for more information.
+We don't support pre-built bundles for React - see the [JavaScript](../../javascript/installation/) documentation for more information.
 {% /if %}
 
 {% if isFramework("angular") %}
-We don't support pre-built bundles for Angular - see the [Javascript](../javascript/installation) documentation for more information.
+We don't support pre-built bundles for Angular - see the [JavaScript](../../javascript/installation/) documentation for more information.
 {% /if %}
 
 {% if isFramework("vue") %}
-We don't support pre-built bundles for Vue - see the [Javascript](../javascript/installation) documentation for more information.
+We don't support pre-built bundles for Vue - see the [JavaScript](../../javascript/installation/) documentation for more information.
 {% /if %}
 
 {% if isFramework("javascript") %}

--- a/packages/ag-charts-website/src/content/gallery/data.json
+++ b/packages/ag-charts-website/src/content/gallery/data.json
@@ -65,17 +65,17 @@
                 "examples": [
                     {
                         "title": "Simple Bar",
-                        "description": "Bar charts (also known as vertical <a href='./simple-bar/'>bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the value being plotted. They can be used to plot both nominal and ordinal data, and are simple to interpret. They work best where the number of data points is limited.",
+                        "description": "Bar charts (also known as vertical <a href='../simple-bar/'>bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the value being plotted. They can be used to plot both nominal and ordinal data, and are simple to interpret. They work best where the number of data points is limited.",
                         "name": "simple-bar"
                     },
                     {
                         "title": "Grouped Stacked Bar",
-                        "description": "Bar charts (also known as vertical <a href='./simple-bar/'>bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the value being plotted. They can be used to plot both nominal and ordinal data, and are simple to interpret. They work best where the number of data points is limited.",
+                        "description": "Bar charts (also known as vertical <a href='../simple-bar/'>bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the value being plotted. They can be used to plot both nominal and ordinal data, and are simple to interpret. They work best where the number of data points is limited.",
                         "name": "grouped-stacked-bar"
                     },
                     {
                         "title": "Stacked Bar",
-                        "description": "Stacked Bar charts allow part-to-whole comparisons, with series stacked on top of each other in the vertical <a href='./simple-bar/'>bars</a>.",
+                        "description": "Stacked Bar charts allow part-to-whole comparisons, with series stacked on top of each other in the vertical <a href='../simple-bar/'>bars</a>.",
                         "name": "stacked-bar"
                     },
                     {
@@ -85,12 +85,12 @@
                     },
                     {
                         "title": "Stacked Horizontal Bar",
-                        "description": "Stacked Horizontal Bar charts allow part-to-whole comparisons, with series stacked from left to right in the horizontal <a href='./simple-bar/'>bars</a>. They make it easy to compare combined bar lengths.",
+                        "description": "Stacked Horizontal Bar charts allow part-to-whole comparisons, with series stacked from left to right in the horizontal <a href='../simple-bar/'>bars</a>. They make it easy to compare combined bar lengths.",
                         "name": "stacked-horizontal-bar"
                     },
                     {
                         "title": "Grouped Horizontal Bar",
-                        "description": "Grouped Horizontal Bar charts (also known as clustered bar charts) show multiple series with the <a href='./simple-bar/'>bars</a> grouped by category, to allow for easier comparisons across different series.",
+                        "description": "Grouped Horizontal Bar charts (also known as clustered bar charts) show multiple series with the <a href='../simple-bar/'>bars</a> grouped by category, to allow for easier comparisons across different series.",
                         "name": "grouped-horizontal-bar"
                     }
                 ]
@@ -105,7 +105,7 @@
                 "examples": [
                     {
                         "title": "Simple Line",
-                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='./simple-bar/'>bar</a> charts.",
+                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='../simple-bar/'>bar</a> charts.",
                         "name": "simple-line"
                     },
                     {
@@ -115,12 +115,12 @@
                     },
                     {
                         "title": "Multiple Line Series",
-                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='./simple-bar/'>bar</a> charts.",
+                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='../simple-bar/'>bar</a> charts.",
                         "name": "multiple-line-series"
                     },
                     {
                         "title": "Line With Time Axis",
-                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='./simple-bar/'>bar</a> charts.",
+                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='../simple-bar/'>bar</a> charts.",
                         "name": "line-legend-pagination"
                     },
                     {
@@ -130,7 +130,7 @@
                     },
                     {
                         "title": "Line With Labels",
-                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='./simple-bar/'>bar</a> charts.",
+                        "description": "Line charts represent each series as a separate line. They are useful to show change or trends over time, and are able to better present more data points than <a href='../simple-bar/'>bar</a> charts.",
                         "name": "line-with-labels"
                     }
                 ]
@@ -150,27 +150,27 @@
                     },
                     {
                         "title": "Area With Labels",
-                        "description": "<a href='./simple-area/'>Area charts</a> can also be used with negative values, with the area between the line and the axis being filled.",
+                        "description": "<a href='../simple-area/'>Area charts</a> can also be used with negative values, with the area between the line and the axis being filled.",
                         "name": "area-with-labels"
                     },
                     {
                         "title": "Stacked Area",
-                        "description": "Stacked area charts plot multiple <a href='./simple-area/'>area</a> series stacked on top of each other, showing how part-to-whole relationships change over time.",
+                        "description": "Stacked area charts plot multiple <a href='../simple-area/'>area</a> series stacked on top of each other, showing how part-to-whole relationships change over time.",
                         "name": "stacked-area"
                     },
                     {
                         "title": "Area With Markers",
-                        "description": "<a href='./simple-area/'>Area charts</a> can also be used with negative values, with the area between the line and the axis being filled.",
+                        "description": "<a href='../simple-area/'>Area charts</a> can also be used with negative values, with the area between the line and the axis being filled.",
                         "name": "area-with-markers"
                     },
                     {
                         "title": "100% Stacked Area",
-                        "description": "100% stacked area charts show the relative percentage of multiple series in <a href='./stacked-area/'>stacked areas</a>, where the cumulative area always totals to 100%.",
+                        "description": "100% stacked area charts show the relative percentage of multiple series in <a href='../stacked-area/'>stacked areas</a>, where the cumulative area always totals to 100%.",
                         "name": "100--stacked-area"
                     },
                     {
                         "title": "Area With Negative Values",
-                        "description": "<a href='./simple-area/'>Area charts</a> can also be used with negative values, with the area between the line and the axis being filled.",
+                        "description": "<a href='../simple-area/'>Area charts</a> can also be used with negative values, with the area between the line and the axis being filled.",
                         "name": "area-with-negative-values"
                     }
                 ]
@@ -290,17 +290,17 @@
                 "examples": [
                     {
                         "title": "Simple Doughnut",
-                        "description": "Doughnut charts are similar to <a href='./simple-pie/'>pie charts</a>, being used to express a part-to-whole relationship, but allow for multiple series to be shown on the same chart for comparison.",
+                        "description": "Doughnut charts are similar to <a href='../simple-pie/'>pie charts</a>, being used to express a part-to-whole relationship, but allow for multiple series to be shown on the same chart for comparison.",
                         "name": "simple-doughnut"
                     },
                     {
                         "title": "Doughnut With Variable Radius",
-                        "description": "Doughnut charts are similar to <a href='./simple-pie/'>pie charts</a>, being used to express a part-to-whole relationship, but allow for multiple series to be shown on the same chart for comparison.",
+                        "description": "Doughnut charts are similar to <a href='../simple-pie/'>pie charts</a>, being used to express a part-to-whole relationship, but allow for multiple series to be shown on the same chart for comparison.",
                         "name": "doughnut-with-variable-radius"
                     },
                     {
                         "title": "Multiple Doughnuts",
-                        "description": "Doughnut charts are similar to <a href='./simple-pie/'>pie charts</a>, being used to express a part-to-whole relationship, but allow for multiple series to be shown on the same chart for comparison.",
+                        "description": "Doughnut charts are similar to <a href='../simple-pie/'>pie charts</a>, being used to express a part-to-whole relationship, but allow for multiple series to be shown on the same chart for comparison.",
                         "name": "multiple-doughnuts"
                     }
                 ]
@@ -339,17 +339,17 @@
                 "examples": [
                     {
                         "title": "Simple Range Bar",
-                        "description": "Range Bar charts (also known as vertical <a href='./simple-bar/'> range bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the range value being plotted. They work best where the number of data points is limited.",
+                        "description": "Range Bar charts (also known as vertical <a href='../simple-bar/'> range bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the range value being plotted. They work best where the number of data points is limited.",
                         "name": "simple-range-bar"
                     },
                     {
                         "title": "Range Bar With Labels",
-                        "description": "Range Bar charts (also known as vertical <a href='./simple-bar/'> range bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the range value being plotted. They work best where the number of data points is limited.",
+                        "description": "Range Bar charts (also known as vertical <a href='../simple-bar/'> range bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the range value being plotted. They work best where the number of data points is limited.",
                         "name": "range-bar-with-labels"
                     },
                     {
                         "title": "Multiple Range Bars",
-                        "description": "Range Bar charts (also known as vertical <a href='./simple-bar/'> range bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the range value being plotted. They work best where the number of data points is limited.",
+                        "description": "Range Bar charts (also known as vertical <a href='../simple-bar/'> range bar charts</a>) represent data using vertical bars, with the height of each bar proportional to the range value being plotted. They work best where the number of data points is limited.",
                         "name": "multiple-range-bars"
                     },
                     {

--- a/packages/ag-charts-website/src/features/docs/constants.ts
+++ b/packages/ag-charts-website/src/features/docs/constants.ts
@@ -3,4 +3,4 @@ import { SITE_BASE_URL_SEGMENTS } from '@constants';
 export const DOCS_FRAMEWORK_PATH_INDEX = SITE_BASE_URL_SEGMENTS + 1;
 export const DOCS_PAGE_NAME_PATH_INDEX = SITE_BASE_URL_SEGMENTS + 2;
 
-export const DOCS_FRAMEWORK_REDIRECT_PAGE = './quick-start';
+export const DOCS_FRAMEWORK_REDIRECT_PAGE = './quick-start/';

--- a/packages/ag-charts-website/src/features/docs/utils/urlPaths.ts
+++ b/packages/ag-charts-website/src/features/docs/utils/urlPaths.ts
@@ -10,7 +10,7 @@ export function getFrameworkFromPath(path: string) {
 }
 
 export const getExamplePageUrl = ({ framework, path }: { framework: Framework; path: string }) => {
-    return pathJoin(SITE_BASE_URL, framework, path);
+    return pathJoin(SITE_BASE_URL, framework, path) + '/';
 };
 
 /**

--- a/packages/ag-charts-website/src/features/gallery/utils/urlPaths.ts
+++ b/packages/ag-charts-website/src/features/gallery/utils/urlPaths.ts
@@ -53,12 +53,12 @@ export const getExampleWithRelativePathUrl = ({ exampleName }: { exampleName: st
 };
 
 export const getPageUrl = (pageName: string) => {
-    return pathJoin(SITE_BASE_URL, 'gallery', pageName);
+    return pathJoin(SITE_BASE_URL, 'gallery', pageName) + '/';
 };
 
 export const getPageHashUrl = ({ chartSeriesName, isRelative }: { chartSeriesName: string; isRelative?: boolean }) => {
     const hash = `#${chartSeriesName}`;
-    return isRelative ? hash : pathJoin(SITE_BASE_URL, 'gallery', hash);
+    return isRelative ? hash : pathJoin(SITE_BASE_URL, 'gallery', hash) + '/';
 };
 
 export const getExampleContentsUrl = ({ exampleName }: { exampleName: string }) => {

--- a/packages/ag-charts-website/src/pages/index.astro
+++ b/packages/ag-charts-website/src/pages/index.astro
@@ -129,7 +129,7 @@ const isEnterprise = true;
                 </div>
                 <!-- Dummy copy, to be reviewed -->
                 <p class="font-size-large">
-                    <b>AG Charts</b> was created by the amazing team behind <a href="ag-grid.com"><b>AG Grid</b></a>,
+                    <b>AG Charts</b> was created by the amazing team behind <a href="https://ag-grid.com/"><b>AG Grid</b></a>,
                     the best javascript grid in the world.
                 </p>
                 <p class="font-size-large">

--- a/packages/ag-charts-website/src/utils/urlWithPrefix.ts
+++ b/packages/ag-charts-website/src/utils/urlWithPrefix.ts
@@ -2,6 +2,7 @@ import type { Framework } from '@ag-grid-types';
 import { SITE_BASE_URL } from '@constants';
 
 import { pathJoin } from './pathJoin';
+import { validateUrl } from './validateUrl';
 
 export const urlWithPrefix = ({
     url = '',
@@ -9,11 +10,13 @@ export const urlWithPrefix = ({
     siteBaseUrl = SITE_BASE_URL,
 }: {
     url: string;
-    framework: Framework;
+    framework?: Framework;
     siteBaseUrl?: string;
 }): string => {
     const hasRelativePathRegex = /(^\.\/)(.*)/;
     const substitution = '$2';
+
+    validateUrl(url);
 
     let path = url;
     if (url.match(hasRelativePathRegex)) {

--- a/packages/ag-charts-website/src/utils/validateUrl.ts
+++ b/packages/ag-charts-website/src/utils/validateUrl.ts
@@ -1,0 +1,18 @@
+const IS_SSR = typeof window === 'undefined';
+
+export const validateUrl = (url: string) => {
+    if (!IS_SSR) {
+        return;
+    }
+
+    if (!url.includes(':') && !url.startsWith('#')) {
+        if (!/^(\.|\.\.)?\//.test(url)) {
+            console.warn(
+                `Expected url "${url}" to start with either a slash (/), a dot slash (./), or a dot dot slash (../)`
+            );
+        }
+        if (!url.split('#')[0].endsWith('/')) {
+            console.warn(`Expected url "${url}" to end with a trailing slash (/)`);
+        }
+    }
+};

--- a/packages/ag-charts-website/src/utils/validateUrl.ts
+++ b/packages/ag-charts-website/src/utils/validateUrl.ts
@@ -7,11 +7,13 @@ export const validateUrl = (url: string) => {
 
     if (!url.includes(':') && !url.startsWith('#')) {
         if (!/^(\.|\.\.)?\//.test(url)) {
+            // eslint-disable-next-line no-console
             console.warn(
                 `Expected url "${url}" to start with either a slash (/), a dot slash (./), or a dot dot slash (../)`
             );
         }
         if (!url.split('#')[0].endsWith('/')) {
+            // eslint-disable-next-line no-console
             console.warn(`Expected url "${url}" to end with a trailing slash (/)`);
         }
     }


### PR DESCRIPTION
Fixes broken links in multiple tickets

Adds a terminal-only warning for when internal links don't have a trailing slash so the development experience is closer to staging. I've fixed a few of these, but it's too risky to attempt to fix everything now. Running the website build will log all links that need updating. This link checking only works for astro and mdoc pages. React links will need to call out to the `validateUrl` function to get this validation