### PR TITLE
Remove use strict from modules

### DIFF
--- a/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/provided/modules/reactFunctional/index.jsx
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/provided/modules/reactFunctional/index.jsx
@@ -1,5 +1,3 @@
-"use strict"
-
 import { AgChartsReact } from "ag-charts-react"
 import { time } from 'ag-charts-community';
 import React, { useCallback, useEffect, useRef, useState } from "react"

--- a/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/provided/modules/reactFunctionalTs/index.tsx
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/provided/modules/reactFunctionalTs/index.tsx
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AgChartsReact } from 'ag-charts-react';

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctional/index.jsx
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctional/index.jsx
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, { useCallback, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctionalTs/index.tsx
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctionalTs/index.tsx
@@ -1,9 +1,7 @@
-'use strict';
-
 import React, { useCallback, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { AgChartOptions, AgCharts, time } from 'ag-charts-community';
+import { AgChartOptions, time } from 'ag-charts-community';
 import { AgChartsReact } from 'ag-charts-react';
 
 const ChartExample = () => {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/provided/modules/reactFunctional/index.jsx
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/provided/modules/reactFunctional/index.jsx
@@ -1,9 +1,6 @@
-'use strict';
-
 import React, { useCallback, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { AgCharts } from 'ag-charts-community';
 import { AgChartsReact } from 'ag-charts-react';
 
 const ChartExample = () => {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/provided/modules/reactFunctionalTs/index.tsx
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/provided/modules/reactFunctionalTs/index.tsx
@@ -1,9 +1,7 @@
-'use strict';
-
 import React, { useCallback, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { AgChartOptions, AgChartThemeName, AgCharts } from 'ag-charts-community';
+import { AgChartOptions } from 'ag-charts-community';
 import { AgChartsReact } from 'ag-charts-react';
 
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/provided/modules/reactFunctional/index.jsx
+++ b/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/provided/modules/reactFunctional/index.jsx
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/provided/modules/reactFunctionalTs/index.tsx
+++ b/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/provided/modules/reactFunctionalTs/index.tsx
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 


### PR DESCRIPTION
Removes `'use strict'` from examples. Any files with imports and exports implicitly has this anyway