### PR TITLE
CRT-84 Fix Vue Crosshairs example

### DIFF
--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/main.ts
@@ -71,10 +71,7 @@ const options: AgCartesianChartOptions = {
 const chart = AgCharts.create(options);
 
 function crosshairLabelFormat() {
-    const crosshair = options.axes?.[0]?.crosshair;
-    if (!crosshair) {
-        return;
-    }
+    const crosshair = options.axes![0].crosshair!;
     crosshair.label = {
         format: `%b %Y`,
     };
@@ -82,29 +79,23 @@ function crosshairLabelFormat() {
 }
 
 function axisLabelFormat() {
-    const axes0 = options.axes?.[0];
-    if (!axes0) {
-        return;
+    const axes0 = options.axes![0]!;
+    const crosshair = axes0.crosshair!;
+    if (crosshair.label && crosshair.label.format) {
+        delete axes0.crosshair!.label!.format;
     }
-    if (axes0.crosshair?.label?.format) {
-        delete axes0.crosshair.label.format;
-    }
-    axes0.label = {
-        format: `%Y`,
-    };
+    axes0.label = { format: `%Y` };
     AgCharts.update(chart, options);
 }
 
 function defaultFormat() {
-    const axes0 = options.axes?.[0];
-    if (!axes0) {
-        return;
+    const axes0 = options.axes![0]!;
+    const crosshair = axes0.crosshair!;
+    if (crosshair.label && crosshair.label.format) {
+        delete axes0.crosshair!.label!.format;
     }
-    if (axes0.crosshair?.label?.format) {
-        delete axes0.crosshair.label.format;
-    }
-    if (axes0.label?.format) {
-        delete axes0.label.format;
+    if (axes0.label && axes0.label.format) {
+        delete axes0.label!.format;
     }
     AgCharts.update(chart, options);
 }


### PR DESCRIPTION
The '?' operator causes problem with the exampleRunner generator for the Vue framework. So use the '!' operator instead to tell TypeScript to assume that the types on non-nullable.