### PR TITLE
AG-9976: [Docs] Use specific type alias for degrees instead of `number`

### DIFF
--- a/packages/ag-charts-community/src/options/chart/animationOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/animationOptions.ts
@@ -1,8 +1,8 @@
-import type { Duration } from './types';
+import type { DurationMs } from './types';
 
 export interface AgAnimationOptions {
     /** Set to `true` to enable the animation module. */
     enabled?: boolean;
     /** The total duration of the animation for each series on initial load and updates */
-    duration?: Duration;
+    duration?: DurationMs;
 }

--- a/packages/ag-charts-community/src/options/chart/animationOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/animationOptions.ts
@@ -1,8 +1,8 @@
-import type { MilliSeconds } from './types';
+import type { Duration } from './types';
 
 export interface AgAnimationOptions {
     /** Set to `true` to enable the animation module. */
     enabled?: boolean;
     /** The total duration of the animation for each series on initial load and updates */
-    duration?: MilliSeconds;
+    duration?: Duration;
 }

--- a/packages/ag-charts-community/src/options/chart/axisOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/axisOptions.ts
@@ -1,4 +1,4 @@
-import type { CssColor, FontFamily, FontSize, FontStyle, FontWeight, PixelSize } from './types';
+import type { CssColor, Degree, FontFamily, FontSize, FontStyle, FontWeight, PixelSize } from './types';
 
 export interface AgAxisBoundSeries {
     /** Key used by the series for values on the related axis. */
@@ -105,13 +105,11 @@ export interface AgBaseAxisLabelOptions {
     /** The colour to use for the labels */
     color?: CssColor;
     /** The rotation of the axis labels in degrees. Note: for integrated charts the default is 335 degrees, unless the axis shows grouped or default categories (indexes). The first row of labels in a grouped category axis is rotated perpendicular to the axis line. */
-    rotation?: number;
+    rotation?: Degree;
     /** Avoid axis label collision by automatically reducing the number of ticks displayed. If set to `false`, axis labels may collide. */
     avoidCollisions?: boolean;
     /** Minimum gap in pixels between the axis labels before being removed to avoid collisions. */
     minSpacing?: PixelSize;
-    // mirrored?: boolean;
-    // parallel?: boolean;
     /** Format string used when rendering labels. */
     format?: string;
     /** Function used to render axis labels. If `value` is a number, `fractionDigits` will also be provided, which indicates the number of fractional digits used in the step between ticks; for example, a tick step of `0.0005` would have `fractionDigits` set to `4` */

--- a/packages/ag-charts-community/src/options/chart/polarAxisOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/polarAxisOptions.ts
@@ -1,7 +1,7 @@
 import type { AgAxisCategoryTickOptions, AgAxisNumberTickOptions } from '../series/cartesian/cartesianOptions';
 import type { AgBaseAxisLabelOptions, AgBaseAxisOptions } from './axisOptions';
 import type { AgBaseCrossLineOptions } from './crossLineOptions';
-import type { Ratio } from './types';
+import type { Degree, Ratio } from './types';
 
 export type AgPolarAxisType = 'angle-category' | 'angle-number' | 'radius-category' | 'radius-number';
 export type AgPolarAxisShape = 'polygon' | 'circle';
@@ -13,9 +13,9 @@ export interface AgAngleCategoryAxisOptions extends AgBaseAxisOptions<AgAngleAxi
     /** Shape of axis. Default: `polygon` */
     shape?: AgPolarAxisShape;
     /** Angle in degrees to start ticks positioning from. */
-    startAngle?: number;
+    startAngle?: Degree;
     /** Angle in degrees to end ticks positioning at. It should be greater than `startAngle`. */
-    endAngle?: number;
+    endAngle?: Degree;
     /** Add cross lines or regions corresponding to data values. */
     crossLines?: AgAngleCrossLineOptions[];
     /**
@@ -35,9 +35,9 @@ export interface AgAngleNumberAxisOptions extends AgBaseAxisOptions<AgAngleAxisL
     /** Configuration for the axis ticks. */
     tick?: AgAxisNumberTickOptions;
     /** Angle in degrees to start ticks positioning from. */
-    startAngle?: number;
+    startAngle?: Degree;
     /** Angle in degrees to end ticks positioning at. It should be greater than `startAngle`. */
-    endAngle?: number;
+    endAngle?: Degree;
     /** Add cross lines or regions corresponding to data values. */
     crossLines?: AgAngleCrossLineOptions[];
     /** If `true`, the range will be rounded up to ensure nice equal spacing between the ticks. */

--- a/packages/ag-charts-community/src/options/chart/radiusAxisOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/radiusAxisOptions.ts
@@ -2,7 +2,7 @@ import type { AgAxisCategoryTickOptions, AgAxisNumberTickOptions } from '../seri
 import type { AgAxisCaptionOptions, AgBaseAxisOptions } from './axisOptions';
 import type { AgBaseCrossLineLabelOptions, AgBaseCrossLineOptions } from './crossLineOptions';
 import type { AgPolarAxisShape } from './polarAxisOptions';
-import type { Ratio } from './types';
+import type { Degree, Ratio } from './types';
 
 export interface AgRadiusNumberAxisOptions extends AgBaseAxisOptions {
     type: 'radius-number';
@@ -13,7 +13,7 @@ export interface AgRadiusNumberAxisOptions extends AgBaseAxisOptions {
     /** User override for the automatically determined max value (based on series data). */
     max?: number;
     /** The rotation angle of axis line and labels in degrees. */
-    positionAngle?: number;
+    positionAngle?: Degree;
     /** Configuration for the axis ticks. */
     tick?: AgAxisNumberTickOptions;
     /** Shape of axis. Default: `polygon` */
@@ -29,7 +29,7 @@ export interface AgRadiusNumberAxisOptions extends AgBaseAxisOptions {
 export interface AgRadiusCategoryAxisOptions extends AgBaseAxisOptions {
     type: 'radius-category';
     /** The rotation angle of axis line and labels in degrees. */
-    positionAngle?: number;
+    positionAngle?: Degree;
     /** Configuration for the axis ticks. */
     tick?: AgAxisCategoryTickOptions;
     /** Configuration for the title shown next to the axis. */
@@ -58,5 +58,5 @@ export interface AgRadiusCategoryAxisOptions extends AgBaseAxisOptions {
 export interface AgRadiusCrossLineOptions extends AgBaseCrossLineOptions<AgRadiusCrossLineLabelOptions> {}
 
 export interface AgRadiusCrossLineLabelOptions extends AgBaseCrossLineLabelOptions {
-    positionAngle?: number;
+    positionAngle?: Degree;
 }

--- a/packages/ag-charts-community/src/options/chart/tooltipOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/tooltipOptions.ts
@@ -1,5 +1,5 @@
 import type { AgChartCallbackParams } from './callbackOptions';
-import type { CssColor, Duration, InteractionRange, PixelSize } from './types';
+import type { CssColor, DurationMs, InteractionRange, PixelSize } from './types';
 
 export interface AgChartTooltipOptions {
     /** Set to `false` to disable tooltips for all series in the chart. */
@@ -13,7 +13,7 @@ export interface AgChartTooltipOptions {
     /** The position of the tooltip. */
     position?: AgTooltipPositionOptions;
     /** The time interval (in milliseconds) after which the tooltip is shown. */
-    delay?: Duration;
+    delay?: DurationMs;
 }
 
 export type AgTooltipPositionType = 'pointer' | 'node';

--- a/packages/ag-charts-community/src/options/chart/tooltipOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/tooltipOptions.ts
@@ -1,5 +1,5 @@
 import type { AgChartCallbackParams } from './callbackOptions';
-import type { CssColor, InteractionRange, PixelSize } from './types';
+import type { CssColor, Duration, InteractionRange, PixelSize } from './types';
 
 export interface AgChartTooltipOptions {
     /** Set to `false` to disable tooltips for all series in the chart. */
@@ -13,7 +13,7 @@ export interface AgChartTooltipOptions {
     /** The position of the tooltip. */
     position?: AgTooltipPositionOptions;
     /** The time interval (in milliseconds) after which the tooltip is shown. */
-    delay?: number;
+    delay?: Duration;
 }
 
 export type AgTooltipPositionType = 'pointer' | 'node';

--- a/packages/ag-charts-community/src/options/chart/types.ts
+++ b/packages/ag-charts-community/src/options/chart/types.ts
@@ -31,7 +31,10 @@ export type PixelSize = number;
 export type Ratio = number;
 
 /** Alias to denote that a value is a duration in milliseconds */
-export type MilliSeconds = number;
+export type Duration = number;
+
+/** Alias to denote that a value is an angle in degrees */
+export type Degree = number;
 
 /** Alias to denote that a value is an axis value. */
 export type AxisValue = any;

--- a/packages/ag-charts-community/src/options/chart/types.ts
+++ b/packages/ag-charts-community/src/options/chart/types.ts
@@ -31,7 +31,7 @@ export type PixelSize = number;
 export type Ratio = number;
 
 /** Alias to denote that a value is a duration in milliseconds */
-export type Duration = number;
+export type DurationMs = number;
 
 /** Alias to denote that a value is an angle in degrees */
 export type Degree = number;

--- a/packages/ag-charts-community/src/options/series/cartesian/cartesianOptions.ts
+++ b/packages/ag-charts-community/src/options/series/cartesian/cartesianOptions.ts
@@ -12,7 +12,7 @@ import type {
     AgCrossLineThemeOptions,
 } from '../../chart/crossLineOptions';
 import type { AgCrosshairOptions } from '../../chart/crosshairOptions';
-import type { PixelSize, Ratio } from '../../chart/types';
+import type { Degree, PixelSize, Ratio } from '../../chart/types';
 import type { AgCartesianSeriesOptions } from './cartesianSeriesTypes';
 
 /** Configuration for axes in cartesian charts. */
@@ -33,7 +33,7 @@ export interface AgCartesianAxisLabelOptions extends AgBaseAxisLabelOptions {
     /** If specified and axis labels may collide, they are rotated so that they are positioned at the supplied angle. This is enabled by default for category. If the `rotation` property is specified, it takes precedence. */
     autoRotate?: boolean;
     /** If autoRotate is enabled, specifies the rotation angle to use when autoRotate is activated. Defaults to an angle of 335 degrees if unspecified. */
-    autoRotateAngle?: number;
+    autoRotateAngle?: Degree;
 }
 
 export interface AgBaseCartesianChartOptions {
@@ -173,7 +173,7 @@ export interface AgCartesianCrossLineLabelOptions extends AgBaseCrossLineLabelOp
     /** The position of the cross-line label. */
     position?: AgCrossLineLabelPosition;
     /** The rotation of the cross-line label in degrees. */
-    rotation?: number;
+    rotation?: Degree;
 }
 
 export interface AgAxisCategoryTickOptions extends AgAxisBaseTickOptions {}
@@ -181,15 +181,13 @@ export interface AgAxisCategoryTickOptions extends AgAxisBaseTickOptions {}
 export interface AgAxisNumberTickOptions extends AgAxisBaseTickOptions {
     /** Maximum gap in pixels between tick lines. */
     maxSpacing?: PixelSize;
-    /** The step value between ticks specified as a number. If the configured interval results in too many ticks given the chart size, it will be ignored.
-     */
+    /** The step value between ticks specified as a number. If the configured interval results in too many ticks given the chart size, it will be ignored. */
     interval?: number;
 }
 
 export interface AgAxisTimeTickOptions extends AgAxisBaseTickOptions {
     /** Maximum gap in pixels between tick lines. */
     maxSpacing?: PixelSize;
-    /** The step value between ticks specified as a TimeInterval or a number. If the configured interval results in dense ticks given the data domain, the ticks will be removed.
-     */
+    /** The step value between ticks specified as a TimeInterval or a number. If the configured interval results in dense ticks given the data domain, the ticks will be removed. */
     interval?: any;
 }

--- a/packages/ag-charts-community/src/options/series/polar/pieOptions.ts
+++ b/packages/ag-charts-community/src/options/series/polar/pieOptions.ts
@@ -2,7 +2,7 @@ import type { AgChartCallbackParams } from '../../chart/callbackOptions';
 import type { AgDropShadowOptions } from '../../chart/dropShadowOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip, AgSeriesTooltipRendererParams } from '../../chart/tooltipOptions';
-import type { CssColor, Opacity, PixelSize, Ratio } from '../../chart/types';
+import type { CssColor, Degree, Opacity, PixelSize, Ratio } from '../../chart/types';
 import type { FillOptions, FontOptions, LineDashOptions, StrokeOptions, Toggleable } from '../cartesian/commonOptions';
 import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../seriesOptions';
 
@@ -10,7 +10,7 @@ export interface AgPieSeriesLabelOptions<TDatum, TParams> extends AgChartLabelOp
     /** Distance in pixels between the callout line and the label text. */
     offset?: PixelSize;
     /** Minimum angle in degrees required for a sector to show a label. */
-    minAngle?: number;
+    minAngle?: Degree;
     /** Avoid callout label collision and overflow by automatically moving colliding labels or reducing the pie radius. If set to `false`, callout labels may collide with each other and the pie radius will not change to prevent clipping of callout labels. */
     avoidCollisions?: boolean;
 }
@@ -88,7 +88,7 @@ export interface AgPieSeriesThemeableOptions<TDatum = any> extends AgBaseSeriesT
     /** The width in pixels of the stroke for the sectors. */
     strokeWidth?: PixelSize;
     /** The rotation of the pie series in degrees. */
-    rotation?: number;
+    rotation?: Degree;
     /** The offset in pixels of the outer radius of the series. Used to construct doughnut charts. */
     outerRadiusOffset?: PixelSize;
     /** The ratio of the outer radius of the series. Used to adjust the outer radius proportionally to the automatically calculated value. */


### PR DESCRIPTION
Seems that we're using degrees everywhere in our API (no radians)