### PR TITLE
AG-9428 Remove listener handler return types

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -573,7 +573,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
                 title,
                 seriesId,
                 stackGroup,
-                ...this.getModuleTooltipParams(datum),
+                ...this.getModuleTooltipParams(),
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -429,7 +429,7 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
                 title,
                 color,
                 seriesId,
-                ...this.getModuleTooltipParams(datum),
+                ...this.getModuleTooltipParams(),
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -354,7 +354,7 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
                 title,
                 color,
                 seriesId,
-                ...this.getModuleTooltipParams(datum),
+                ...this.getModuleTooltipParams(),
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/seriesEvents.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesEvents.ts
@@ -1,13 +1,6 @@
-import type { ChartAxisDirection } from '../chartAxisDirection';
 import type { DataModel, ProcessedData } from '../data/dataModel';
 
-export type SeriesEventType =
-    | 'data-update'
-    | 'data-prerequest'
-    | 'data-processed'
-    | 'data-getDomain'
-    | 'tooltip-getParams'
-    | 'visibility-changed';
+export type SeriesEventType = 'data-update' | 'data-processed' | 'visibility-changed';
 
 export interface BaseSeriesEvent<_T extends SeriesEventType> {}
 
@@ -16,21 +9,10 @@ export interface SeriesDataUpdateEvent extends BaseSeriesEvent<'data-update'> {
     readonly processedData: ProcessedData<any>;
 }
 
-export interface SeriesDataPrerequestEvent extends BaseSeriesEvent<'data-prerequest'> {
-    readonly isContinuousX: boolean;
-    readonly isContinuousY: boolean;
-}
-
 export interface SeriesDataProcessedEvent extends BaseSeriesEvent<'data-processed'> {
     readonly dataModel: DataModel<any, any, any>;
     readonly processedData: ProcessedData<any>;
 }
-
-export interface SeriesDataGetDomainEvent extends BaseSeriesEvent<'data-getDomain'> {
-    readonly direction: ChartAxisDirection;
-}
-
-export interface SeriesTooltipGetParamsEvent extends BaseSeriesEvent<'tooltip-getParams'> {}
 
 export interface SeriesVisibilityEvent extends BaseSeriesEvent<'visibility-changed'> {
     readonly itemId: any;

--- a/packages/ag-charts-community/src/module/moduleMap.ts
+++ b/packages/ag-charts-community/src/module/moduleMap.ts
@@ -56,6 +56,10 @@ export class ModuleMap<M extends Module<C, I>, C, I extends ModuleInstance = Mod
         return this.modules[module.optionsKey] != null;
     }
 
+    values() {
+        return Object.values(this.modules).map((value) => value.instance);
+    }
+
     *[Symbol.iterator](): IterableIterator<I> {
         for (const { instance } of Object.values(this.modules)) {
             yield instance;

--- a/packages/ag-charts-community/src/module/optionModules.ts
+++ b/packages/ag-charts-community/src/module/optionModules.ts
@@ -1,3 +1,5 @@
+import type { ChartAxisDirection } from '../chart/chartAxisDirection';
+import type { PropertyDefinition } from '../chart/data/dataModel';
 import type { SeriesNodeDatum } from '../chart/series/seriesTypes';
 import type { AgCartesianSeriesOptions } from '../options/series/cartesian/cartesianSeriesTypes';
 import type { AgHierarchySeriesOptions } from '../options/series/hierarchy/hierarchyOptions';
@@ -23,6 +25,10 @@ export interface SeriesOptionInstance extends ModuleInstance {
     pickNodeExact(point: Point): PickNodeDatumResult;
     pickNodeNearest(point: Point): PickNodeDatumResult;
     pickNodeMainAxisFirst(point: Point): PickNodeDatumResult;
+
+    getPropertyDefinitions(opts: { isContinuousX: boolean; isContinuousY: boolean }): PropertyDefinition<unknown>[];
+    getDomain(direction: ChartAxisDirection): any[];
+    getTooltipParams(): object;
 }
 
 export interface SeriesOptionModule<M extends SeriesOptionInstance = SeriesOptionInstance> extends BaseModule {

--- a/packages/ag-charts-community/src/util/listeners.ts
+++ b/packages/ag-charts-community/src/util/listeners.ts
@@ -1,6 +1,6 @@
 import { Logger } from './logger';
 
-type Handler = (...args: any[]) => any;
+type Handler = (...args: any[]) => void;
 
 export type Listener<H extends Handler, Meta = unknown> = {
     symbol?: Symbol;
@@ -36,28 +36,14 @@ export class Listeners<EventType extends string, EventHandler extends Handler, M
         }
     }
 
-    public dispatch<R = never>(eventType: EventType, ...params: Parameters<EventHandler>): R[] | undefined {
-        // This is a utility class to store all the results of Listeners (or do nothing
-        // if R = void).
-        class ResultArray<R> {
-            results?: R[] = undefined;
-
-            push(result?: R) {
-                if (result === undefined) return;
-
-                this.results ??= [];
-                this.results.push(result);
-            }
-        }
-        const results: ResultArray<R> = new ResultArray<R>();
+    public dispatch(eventType: EventType, ...params: Parameters<EventHandler>): void {
         for (const listener of this.getListenersByType(eventType)) {
             try {
-                results.push(listener.handler(...params));
+                listener.handler(...params);
             } catch (e) {
                 Logger.errorOnce(e);
             }
         }
-        return results.results;
     }
 
     public dispatchWrapHandlers(


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9428

This was only required for the series classes to get values from the 'error-bars' series-option module. However, the series classes also get values through the `SeriesOptionInstance` interface (pickNode).

This replaces the following events with SeriesOptionInstance methods:
- `SeriesDataPrerequestEvent`:   getPropertyDefinitions
- `SeriesDataGetDomainEvent`:    getDomain
- `SeriesTooltipGetParamsEvent`: getTooltipParams

This makes _listeners.ts_ and _observable.ts_ more similar to one another, which will therefore make the migration easier.