### PR TITLE
AG-10007 - Pre Astro 3 upgrade clean up

### DIFF
--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -10,16 +10,18 @@ import agHotModuleReload from './src/astro/plugins/agHotModuleReload';
 import { getDevFileList } from './src/utils/pages';
 import { getSitemapConfig } from './src/utils/sitemap';
 
+const { NODE_ENV } = process.env;
+
 const DEFAULT_BASE_URL = '/';
 const {
     PUBLIC_SITE_URL,
     PUBLIC_BASE_URL = DEFAULT_BASE_URL,
     PUBLIC_HTTPS_SERVER,
-} = loadEnv(process.env.NODE_ENV, process.cwd(), '');
+} = loadEnv(NODE_ENV, process.cwd(), '');
 
 const OUTPUT_DIR = '../../dist/packages/ag-charts-website';
 
-console.log('Astro configuration', JSON.stringify({ PUBLIC_SITE_URL, PUBLIC_BASE_URL, OUTPUT_DIR }, null, 2));
+console.log('Astro configuration', JSON.stringify({ NODE_ENV, PUBLIC_SITE_URL, PUBLIC_BASE_URL, OUTPUT_DIR }, null, 2));
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/ag-charts-website/src/components/link-icon/LinkIcon.module.scss
+++ b/packages/ag-charts-website/src/components/link-icon/LinkIcon.module.scss
@@ -1,6 +1,6 @@
 @use '../../design-system/' as *;
 
-:global(.docs-header-icon) {
+.docsHeaderIcon {
     position: relative;
     padding-left: 0;
     margin-left: $size-1;
@@ -16,9 +16,24 @@
         visibility: visible;
         fill: var(--azure-blue);
     }
+
+    &:hover {
+        opacity: 1;
+    }
 }
 
-// Increase specificity for hover state
-:global(.mainContainer) a:global(.docs-header-icon):hover {
-    opacity: 1;
+// Half highlight icon if hovering over container heading element
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    &:hover .docsHeaderIcon {
+        opacity: 0.5;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
 }

--- a/packages/ag-charts-website/src/components/link-icon/LinkIcon.tsx
+++ b/packages/ag-charts-website/src/components/link-icon/LinkIcon.tsx
@@ -2,11 +2,11 @@ import { Icon } from '@components/icon/Icon';
 import classnames from 'classnames';
 import type { AllHTMLAttributes } from 'react';
 
-import './LinkIcon.module.scss';
+import styles from './LinkIcon.module.scss';
 
 export function LinkIcon({ className, ...props }: AllHTMLAttributes<HTMLAnchorElement> & { children?: never }) {
     return (
-        <a {...props} className={classnames('docs-header-icon', className)}>
+        <a {...props} className={classnames(styles.docsHeaderIcon, className)}>
             <Icon name="link" />
         </a>
     );

--- a/packages/ag-charts-website/src/features/api-documentation/components/ApiReference.module.scss
+++ b/packages/ag-charts-website/src/features/api-documentation/components/ApiReference.module.scss
@@ -50,7 +50,7 @@
         margin-bottom: $size-1;
     }
 
-    :global(a.docs-header-icon) {
+    .linkIcon {
         font-size: var(--font-size-large);
     }
 }
@@ -64,7 +64,7 @@
         border-top: 1px solid var(--border-color);
     }
 
-    &:hover a:global(.docs-header-icon) {
+    &:hover .linkIcon {
         opacity: 0.5;
     }
 
@@ -121,11 +121,11 @@
         font-size: var(--font-size-medium);
     }
 
-    :hover :global(a.docs-header-icon) {
+    :hover .linkIcon {
         opacity: 0.5;
     }
 
-    :global(a.docs-header-icon) {
+    .linkIcon {
         position: absolute;
         bottom: -0.125em;
     }

--- a/packages/ag-charts-website/src/features/api-documentation/components/Properies.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/Properies.tsx
@@ -26,7 +26,7 @@ export function PropertyTitle({ name, anchorId, prefixPath, required }: Property
         <h6 className={classnames(styles.name, 'side-menu-exclude')}>
             <PropertyNamePrefix prefixPath={prefixPath} />
             <PropertyName isRequired={required}>{name}</PropertyName>
-            <LinkIcon href={`#${anchorId}`} onClick={handleClick} />
+            <LinkIcon href={`#${anchorId}`} onClick={handleClick} className={styles.linkIcon} />
         </h6>
     );
 }

--- a/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/examplesGenerator.ts
@@ -1,4 +1,5 @@
 import type { InternalFramework } from '@ag-grid-types';
+import { getFileContents } from '@utils/getFileContents';
 import fs from 'node:fs/promises';
 
 import { getIsDev } from '../../utils/env';
@@ -7,7 +8,6 @@ import chartVanillaSrcParser from './transformation-scripts/chart-vanilla-src-pa
 import type { GeneratedContents } from './types.d';
 import {
     getEntryFileName,
-    getFileContents,
     getIsEnterprise,
     getProvidedExampleFiles,
     getProvidedExampleFolder,

--- a/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.ts
+++ b/packages/ag-charts-website/src/features/examples-generator/utils/fileUtils.ts
@@ -1,5 +1,6 @@
 import type { InternalFramework } from '@ag-grid-types';
 import { getIsDev } from '@utils/env';
+import { getFileContents } from '@utils/getFileContents';
 import { isTypescriptInternalFramework } from '@utils/pages';
 import { pathJoin } from '@utils/pathJoin';
 import { existsSync } from 'node:fs';
@@ -126,12 +127,6 @@ export const getMainFileName = (internalFramework: InternalFramework) => {
         default:
             return getEntryFileName(internalFramework);
     }
-};
-
-export const getFileContents = ({ folderUrl, fileName }: { folderUrl: URL; fileName: string }) => {
-    const filePath = pathJoin(folderUrl.pathname, fileName);
-
-    return fs.readFile(filePath, 'utf-8');
 };
 
 export const getProvidedExampleFolder = ({

--- a/packages/ag-charts-website/src/features/gallery/components/GalleryExampleLink.module.scss
+++ b/packages/ag-charts-website/src/features/gallery/components/GalleryExampleLink.module.scss
@@ -49,3 +49,47 @@
         background-color: #182732;
     }
 }
+
+.layout-5-col {
+    --columns: 1;
+
+    width: calc(100% / var(--columns) - var(--gallery-list-gap) / var(--columns) * (var(--columns) - 1));
+
+    @media screen and (min-width: 720px) {
+        --columns: 2;
+    }
+
+    @media screen and (min-width: 1120px) {
+        --columns: 3;
+    }
+
+    @media screen and (min-width: 2000px) {
+        --columns: 4;
+    }
+
+    @media screen and (min-width: 2500px) {
+        --columns: 5;
+    }
+}
+
+.layout-3-col {
+    --columns: 1;
+
+    width: calc(100% / var(--columns) - #{$size-3} / var(--columns) * (var(--columns) - 1));
+
+    @media screen and (min-width: 720px) {
+        --columns: 2;
+    }
+
+    @media screen and (min-width: 1120px) {
+        --columns: 3;
+    }
+}
+
+.onlyShowOnLargeScreen {
+    display: none !important;
+
+    @media screen and (min-width: 1120px) {
+        display: block !important;
+    }
+}

--- a/packages/ag-charts-website/src/features/gallery/components/GalleryExampleLink.tsx
+++ b/packages/ag-charts-website/src/features/gallery/components/GalleryExampleLink.tsx
@@ -8,13 +8,29 @@ import styles from './GalleryExampleLink.module.scss';
 interface Props {
     label: string;
     exampleName: string;
-    className?: string;
+    layout?: '5-col' | '3-col';
+    onlyShowOnLargeScreen?: boolean;
 }
 
-export const GalleryExampleLink: FunctionComponent<Props> = ({ label, exampleName, className }) => {
+export const GalleryExampleLink: FunctionComponent<Props> = ({
+    label,
+    exampleName,
+    layout = '5-col',
+    onlyShowOnLargeScreen,
+}) => {
     return (
         <a
-            className={classnames(styles.link, className, 'font-size-responsive', 'font-size-small', 'text-secondary')}
+            className={classnames(
+                styles.link,
+                'galleryExample',
+                styles[`layout-${layout}`],
+                'font-size-responsive',
+                'font-size-small',
+                'text-secondary',
+                {
+                    [styles.onlyShowOnLargeScreen]: onlyShowOnLargeScreen,
+                }
+            )}
             href={getPageUrl(exampleName)}
         >
             <GalleryExampleImage label={label} exampleName={exampleName} />

--- a/packages/ag-charts-website/src/pages/debug/meta.json.ts
+++ b/packages/ag-charts-website/src/pages/debug/meta.json.ts
@@ -7,7 +7,7 @@ export async function get() {
     const shortHash = execSync('git rev-parse --short HEAD').toString().replace(removeNewlineRegex, '');
     const gitDate = execSync('git --no-pager log -1 --format="%ai"').toString().replace(removeNewlineRegex, '');
 
-    const response = {
+    const body = {
         buildDate,
         git: {
             hash,
@@ -15,9 +15,11 @@ export async function get() {
             date: gitDate,
         },
     };
-    const body = JSON.stringify(response);
 
-    return {
-        body,
-    };
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
 }

--- a/packages/ag-charts-website/src/pages/dev/[...filePath].ts
+++ b/packages/ag-charts-website/src/pages/dev/[...filePath].ts
@@ -13,16 +13,9 @@ export async function get({ props }: DevFileRoute) {
     const { fullFilePath } = props;
 
     const fileExists = fsOriginal.existsSync(fullFilePath);
-    if (fileExists) {
-        const body = await fs.readFile(fullFilePath, 'utf-8');
-        return {
-            body,
-        };
-    } else {
-        // Show error on dev console when file is loaded
-        const body = `throw new Error("File does not exist: '${fullFilePath}'. You may need to generate it, or try reloading again.");`;
-        return {
-            body,
-        };
-    }
+    const body = fileExists
+        ? await fs.readFile(fullFilePath, 'utf-8')
+        : `throw new Error("File does not exist: '${fullFilePath}'. You may need to generate it, or try reloading again.");`;
+
+    return new Response(body);
 }

--- a/packages/ag-charts-website/src/pages/gallery-test.astro
+++ b/packages/ag-charts-website/src/pages/gallery-test.astro
@@ -26,12 +26,7 @@ const { series } = galleryData;
                                         {title}
                                     </h3>
                                     {examples.map(({ title, name }: GalleryExample) => (
-                                        <GalleryExampleLink
-                                            client:visible
-                                            className="galleryExample"
-                                            label={title}
-                                            exampleName={name}
-                                        />
+                                        <GalleryExampleLink client:visible label={title} exampleName={name} />
                                     ))}
                                 </>
                             ))}
@@ -198,28 +193,6 @@ const { series } = galleryData;
     .gallery-list-title {
         position: absolute;
         visibility: hidden;
-    }
-
-    .galleryExample {
-        --columns: 1;
-
-        width: calc(100% / var(--columns) - var(--gallery-list-gap) / var(--columns) * (var(--columns) - 1));
-
-        @media screen and (min-width: 720px) {
-            --columns: 2;
-        }
-
-        @media screen and (min-width: 1120px) {
-            --columns: 3;
-        }
-
-        @media screen and (min-width: 2000px) {
-            --columns: 4;
-        }
-
-        @media screen and (min-width: 2500px) {
-            --columns: 5;
-        }
     }
 </style>
 

--- a/packages/ag-charts-website/src/pages/gallery.astro
+++ b/packages/ag-charts-website/src/pages/gallery.astro
@@ -51,12 +51,7 @@ const { series } = galleryData;
                                             {title}
                                         </h3>
                                         {examples.map(({ title, name }: GalleryExample) => (
-                                            <GalleryExampleLink
-                                                client:visible
-                                                className="galleryExample"
-                                                label={title}
-                                                exampleName={name}
-                                            />
+                                            <GalleryExampleLink client:visible label={title} exampleName={name} />
                                         ))}
                                     </>
                                 ))}
@@ -255,28 +250,6 @@ const { series } = galleryData;
     .gallery-list-title {
         position: absolute;
         visibility: hidden;
-    }
-
-    .galleryExample {
-        --columns: 1;
-
-        width: calc(100% / var(--columns) - var(--gallery-list-gap) / var(--columns) * (var(--columns) - 1));
-
-        @media screen and (min-width: 720px) {
-            --columns: 2;
-        }
-
-        @media screen and (min-width: 1120px) {
-            --columns: 3;
-        }
-
-        @media screen and (min-width: 2000px) {
-            --columns: 4;
-        }
-
-        @media screen and (min-width: 2500px) {
-            --columns: 5;
-        }
     }
 </style>
 

--- a/packages/ag-charts-website/src/pages/gallery/[pageName].astro
+++ b/packages/ag-charts-website/src/pages/gallery/[pageName].astro
@@ -41,23 +41,19 @@ const { page, prevExample, nextExampleOne, nextExampleTwo } = Astro.props;
         <p class="moreExampleLabel text-secondary">More from the charts gallery...</p>
 
         <div class="moreExamples">
-            <GalleryExampleLink
-                client:load
-                className="galleryExample"
-                label={prevExample.title}
-                exampleName={prevExample.name}
-            />
+            <GalleryExampleLink client:load layout="3-col" label={prevExample.title} exampleName={prevExample.name} />
 
             <GalleryExampleLink
                 client:load
-                className="galleryExample"
+                layout="3-col"
                 label={nextExampleOne.title}
                 exampleName={nextExampleOne.name}
             />
 
             <GalleryExampleLink
                 client:load
-                className="galleryExample nextExampleTwo"
+                layout="3-col"
+                onlyShowOnLargeScreen={true}
                 label={nextExampleTwo.title}
                 exampleName={nextExampleTwo.name}
             />
@@ -101,28 +97,6 @@ const { page, prevExample, nextExampleOne, nextExampleTwo } = Astro.props;
         flex-wrap: wrap;
         justify-content: space-between;
         gap: $size-3;
-    }
-
-    .galleryExample {
-        --columns: 1;
-
-        width: calc(100% / var(--columns) - #{$size-3} / var(--columns) * (var(--columns) - 1));
-
-        @media screen and (min-width: 720px) {
-            --columns: 2;
-        }
-
-        @media screen and (min-width: 1120px) {
-            --columns: 3;
-        }
-    }
-
-    .nextExampleTwo {
-        display: none !important;
-
-        @media screen and (min-width: 1120px) {
-            display: block !important;
-        }
     }
 </style>
 

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/[fileName].ts
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/[fileName].ts
@@ -42,7 +42,5 @@ export async function get({ params }: { params: Params }) {
     const file = files && files[fileName];
     const body = file ? file : createErrorBody({ availableFiles: files });
 
-    return {
-        body,
-    };
+    return new Response(body);
 }

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plain-contents.json.ts
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plain-contents.json.ts
@@ -19,10 +19,12 @@ export async function get({ params }: { params: Params }) {
         (await getGeneratedPlainGalleryContents({
             exampleName,
         })) || {};
-    const response = generatedContents;
-    const body = JSON.stringify(response);
+    const body = generatedContents;
 
-    return {
-        body,
-    };
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
 }

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plain-main.ts
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plain-main.ts
@@ -24,7 +24,5 @@ export async function get({ params }: { params: Params }) {
     const entryFile = files[entryFileName!];
     const { code } = transformPlainEntryFile(entryFile, files['data.js']);
 
-    return {
-        body: code,
-    };
+    return new Response(JSON.stringify(code));
 }

--- a/packages/ag-charts-website/src/styles/docs.module.scss
+++ b/packages/ag-charts-website/src/styles/docs.module.scss
@@ -35,17 +35,6 @@
             }
         }
     }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        &:hover .docs-header-icon {
-            opacity: 0.5;
-        }
-    }
 }
 
 %enterprise-icon {

--- a/packages/ag-charts-website/src/utils/devFiles.ts
+++ b/packages/ag-charts-website/src/utils/devFiles.ts
@@ -1,12 +1,12 @@
 import type { ApiReferenceType } from '@features/api-documentation/api-reference-types';
+import { DEV_FILE_PATH_MAP, getRootUrl } from '@utils/pages';
+import { pathJoin } from '@utils/pathJoin';
 import { readFileSync } from 'node:fs';
-
-import { DEV_FILE_PATH_MAP } from './pages';
 
 type DevFileKey = keyof typeof DEV_FILE_PATH_MAP;
 
 function getJsonFromDevFile(devFileKey: DevFileKey) {
-    const file = DEV_FILE_PATH_MAP[devFileKey];
+    const file = pathJoin(getRootUrl().pathname, DEV_FILE_PATH_MAP[devFileKey]);
     const fileContents = readFileSync(file).toString();
     return fileContents ? JSON.parse(fileContents) : null;
 }

--- a/packages/ag-charts-website/src/utils/format.ts
+++ b/packages/ag-charts-website/src/utils/format.ts
@@ -1,4 +1,5 @@
-import { readFile } from 'fs/promises';
+import { getFileContents } from '@utils/getFileContents';
+import { getRootUrl } from '@utils/pages';
 import * as prettier from 'prettier';
 
 /**
@@ -42,7 +43,10 @@ const prettierParsers: { [T in PrettierExtension]: string } = {
 };
 
 async function getPrettierConfig(extension: PrettierExtension) {
-    const prettierRC = await readFile('.prettierrc', 'utf8');
+    const prettierRC = await getFileContents({
+        folderUrl: getRootUrl(),
+        fileName: '.prettierrc',
+    });
     const json = JSON.parse(prettierRC);
 
     const prettierConfig: any = {};

--- a/packages/ag-charts-website/src/utils/getFileContents.ts
+++ b/packages/ag-charts-website/src/utils/getFileContents.ts
@@ -1,0 +1,8 @@
+import { pathJoin } from '@utils/pathJoin';
+import fs from 'node:fs/promises';
+
+export const getFileContents = ({ folderUrl, fileName }: { folderUrl: URL; fileName: string }) => {
+    const filePath = pathJoin(folderUrl.pathname, fileName);
+
+    return fs.readFile(filePath, 'utf-8');
+};

--- a/packages/ag-charts-website/src/utils/pages.ts
+++ b/packages/ag-charts-website/src/utils/pages.ts
@@ -57,7 +57,7 @@ export const DEV_FILE_PATH_MAP: Record<string, string> = {
 /**
  * The root url where the monorepo exists
  */
-const getRootUrl = (): URL => {
+export const getRootUrl = (): URL => {
     const root = getIsDev()
         ? // Relative to the folder of this file
           '../../../../'


### PR DESCRIPTION
Extracted clean up before Astro 3 upgrade (https://github.com/ag-grid/ag-charts/pull/678)

## Changes

* Show `NODE_ENV` on server startup
* Update get endpoints to return response object
* Use root url for dev file paths and prettier
* Fix header hover link icon styles
* Move gallery example link styles into component (get rid of global styles)