### PR TITLE
AG-9963 Mute duplicate warnings when axis position is valid.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -18,6 +18,7 @@ import { jsonApply, jsonDiff, jsonMerge } from '../util/json';
 import { Logger } from '../util/logger';
 import type { TypedEventListener } from '../util/observable';
 import type { DeepPartial } from '../util/types';
+import { AxisPositionGuesser } from './axis/axisUtil';
 import { CartesianChart } from './cartesianChart';
 import type { Chart, ChartExtendedOptions, ChartSpecialOverrides } from './chart';
 import type { ChartAxis } from './chartAxis';
@@ -580,7 +581,7 @@ function applySeriesOptionModules(series: Series<any>, options: AgBaseSeriesOpti
 }
 
 function createAxis(chart: Chart, options: AgBaseAxisOptions[]): ChartAxis[] {
-    const axes: ChartAxis[] = [];
+    const guesser: AxisPositionGuesser = new AxisPositionGuesser();
     const skip = ['axes[].type'];
     const moduleContext = chart.getModuleContext();
 
@@ -591,10 +592,10 @@ function createAxis(chart: Chart, options: AgBaseAxisOptions[]): ChartAxis[] {
         applyAxisModules(axis, axisOptions);
         applyOptionValues(axis, axisOptions, { path, skip });
 
-        axes.push(axis);
+        guesser.push(axis, axisOptions);
     }
 
-    return axes;
+    return guesser.guessInvalidPositions();
 }
 
 function applyAxisModules(axis: ChartAxis, options: AgBaseAxisOptions) {

--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -18,7 +18,6 @@ import { jsonApply, jsonDiff, jsonMerge } from '../util/json';
 import { Logger } from '../util/logger';
 import type { TypedEventListener } from '../util/observable';
 import type { DeepPartial } from '../util/types';
-import { AxisPositionGuesser } from './axis/axisUtil';
 import { CartesianChart } from './cartesianChart';
 import type { Chart, ChartExtendedOptions, ChartSpecialOverrides } from './chart';
 import type { ChartAxis } from './chartAxis';
@@ -33,6 +32,7 @@ import { getSeries } from './factory/seriesTypes';
 import { setupModules } from './factory/setupModules';
 import { HierarchyChart } from './hierarchyChart';
 import { noDataCloneMergeOptions, prepareOptions } from './mapping/prepare';
+import { AxisPositionGuesser } from './mapping/prepareAxis';
 import type { SeriesOptions } from './mapping/prepareSeries';
 import {
     type SeriesOptionsTypes,

--- a/packages/ag-charts-community/src/chart/axis/axisUtil.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisUtil.ts
@@ -1,15 +1,8 @@
 import { FROM_TO_MIXINS } from '../../motion/fromToMotion';
 import type { FromToMotionPropFn, NodeUpdateState } from '../../motion/fromToMotion';
-import type {
-    AgBaseAxisOptions,
-    AgBaseCartesianAxisOptions,
-    AgCartesianAxisPosition,
-    AgCartesianAxisType,
-} from '../../options/agChartOptions';
 import type { Group } from '../../scene/group';
 import type { Line } from '../../scene/shape/line';
 import type { Text } from '../../scene/shape/text';
-import type { ChartAxis } from '../chartAxis';
 
 export type AxisLineDatum = { x: number; y1: number; y2: number };
 export type AxisDatum = {
@@ -218,62 +211,4 @@ export function resetAxisLineSelectionFn() {
     return (_node: Line, datum: AxisLineDatum) => {
         return { ...datum };
     };
-}
-
-const CARTESIAN_AXIS_POSITIONS: AgCartesianAxisPosition[] = ['top', 'right', 'bottom', 'left'];
-const CARTESIAN_AXIS_TYPES: AgCartesianAxisType[] = ['category', 'grouped-category', 'number', 'log', 'time'];
-
-function hasCartesianAxisPosition(axis: ChartAxis): axis is ChartAxis & { position: AgCartesianAxisPosition } {
-    const allowedTypes: string[] = CARTESIAN_AXIS_TYPES;
-    return allowedTypes.includes(axis.type);
-}
-
-function isCartesianAxisOptions(options: AgBaseAxisOptions): options is AgBaseCartesianAxisOptions {
-    const allowedTypes: string[] = CARTESIAN_AXIS_TYPES;
-    return allowedTypes.includes(options.type);
-}
-
-function isAxisPosition(position: unknown): position is AgCartesianAxisPosition {
-    const allowedPositions: string[] = CARTESIAN_AXIS_POSITIONS;
-    return typeof position === 'string' && allowedPositions.includes(position);
-}
-
-// If axis[].position, then we cannot always default to the same value. We need
-// to default to an 'untaken' position (see AG-9963 for more info).
-export class AxisPositionGuesser {
-    private result: ChartAxis[] = [];
-    private valid: ChartAxis[] = [];
-    private invalid: ChartAxis[] = [];
-
-    push(axis: ChartAxis, options: AgBaseAxisOptions) {
-        const { result, valid, invalid } = this;
-        if (isCartesianAxisOptions(options)) {
-            if (isAxisPosition(options.position)) {
-                valid.push(axis);
-            } else {
-                invalid.push(axis);
-            }
-        }
-
-        result.push(axis);
-    }
-
-    guessInvalidPositions() {
-        const takenPosition: (AgCartesianAxisPosition | undefined)[] = this.valid
-            .filter((v) => hasCartesianAxisPosition(v))
-            .map((v) => v.position)
-            .filter((v) => v !== undefined);
-        const guesses: AgCartesianAxisPosition[] = ['top', 'right', 'bottom', 'left'];
-        for (const invalidAxis of this.invalid) {
-            let nextGuess = guesses.pop();
-            while (takenPosition.includes(nextGuess) && nextGuess !== undefined) {
-                nextGuess = guesses.pop();
-            }
-
-            if (nextGuess === undefined) break;
-            invalidAxis.position = nextGuess;
-        }
-
-        return this.result;
-    }
 }

--- a/packages/ag-charts-community/src/chart/mapping/prepareAxis.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepareAxis.ts
@@ -1,0 +1,65 @@
+import type {
+    AgBaseAxisOptions,
+    AgBaseCartesianAxisOptions,
+    AgCartesianAxisPosition,
+    AgCartesianAxisType,
+} from '../../options/agChartOptions';
+import type { ChartAxis } from '../chartAxis';
+
+const CARTESIAN_AXIS_POSITIONS: AgCartesianAxisPosition[] = ['top', 'right', 'bottom', 'left'];
+const CARTESIAN_AXIS_TYPES: AgCartesianAxisType[] = ['category', 'grouped-category', 'number', 'log', 'time'];
+
+function hasCartesianAxisPosition(axis: ChartAxis): axis is ChartAxis & { position: AgCartesianAxisPosition } {
+    const allowedTypes: string[] = CARTESIAN_AXIS_TYPES;
+    return allowedTypes.includes(axis.type);
+}
+
+function isCartesianAxisOptions(options: AgBaseAxisOptions): options is AgBaseCartesianAxisOptions {
+    const allowedTypes: string[] = CARTESIAN_AXIS_TYPES;
+    return allowedTypes.includes(options.type);
+}
+
+function isAxisPosition(position: unknown): position is AgCartesianAxisPosition {
+    const allowedPositions: string[] = CARTESIAN_AXIS_POSITIONS;
+    return typeof position === 'string' && allowedPositions.includes(position);
+}
+
+// If axis[].position, then we cannot always default to the same value. We need
+// to default to an 'untaken' position (see AG-9963 for more info).
+export class AxisPositionGuesser {
+    private result: ChartAxis[] = [];
+    private valid: ChartAxis[] = [];
+    private invalid: ChartAxis[] = [];
+
+    push(axis: ChartAxis, options: AgBaseAxisOptions) {
+        const { result, valid, invalid } = this;
+        if (isCartesianAxisOptions(options)) {
+            if (isAxisPosition(options.position)) {
+                valid.push(axis);
+            } else {
+                invalid.push(axis);
+            }
+        }
+
+        result.push(axis);
+    }
+
+    guessInvalidPositions() {
+        const takenPosition: (AgCartesianAxisPosition | undefined)[] = this.valid
+            .filter((v) => hasCartesianAxisPosition(v))
+            .map((v) => v.position)
+            .filter((v) => v !== undefined);
+        const guesses: AgCartesianAxisPosition[] = ['top', 'right', 'bottom', 'left'];
+        for (const invalidAxis of this.invalid) {
+            let nextGuess = guesses.pop();
+            while (takenPosition.includes(nextGuess) && nextGuess !== undefined) {
+                nextGuess = guesses.pop();
+            }
+
+            if (nextGuess === undefined) break;
+            invalidAxis.position = nextGuess;
+        }
+
+        return this.result;
+    }
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9963

The bug here that the position always defaults to 'left'. This that if the axes configuration something like 0: 'left' and 1: 'bottomasdf' then this will default to 0: 'left' and 1: 'left'.

This is what the causes the duplicate warning, because the library cannot determine which is the X axis.

To get around this, we'll change the default based on any valid positions that have been identified.