### PR TITLE
Use Angular packages directly

### DIFF
--- a/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
@@ -44,15 +44,9 @@
         },
         // map tells the System loader where to look for things
         map: {
-            // Angular bundles in System.register format via esm-bundle
-            // Cell renderers only work with the esm-bundle version
-            // TemplateUrls only works with platform-browser-dynamic from esm-bundle
-            '@angular/compiler':
-                'npm:@esm-bundle/angular__compiler@' + ANGULAR_VERSION + '/system/es2015/ivy/angular-compiler.min.js',
+            '@angular/compiler': 'npm:@angular/compiler@' + ANGULAR_VERSION + '/fesm2015/compiler.mjs',
             '@angular/platform-browser-dynamic':
-                'npm:@esm-bundle/angular__platform-browser-dynamic@' +
-                ANGULAR_VERSION +
-                '/system/es2015/ivy/angular-platform-browser-dynamic.min.js',
+                'npm:@angular/platform-browser-dynamic@' + ANGULAR_VERSION + '/fesm2015/platform-browser-dynamic.mjs',
 
             '@angular/core': 'npm:@angular/core@' + ANGULAR_VERSION + '/fesm2015/core.mjs',
             '@angular/common': 'npm:@angular/common@' + ANGULAR_VERSION + '/fesm2015/common.mjs',

--- a/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.js
+++ b/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.js
@@ -50,15 +50,9 @@
         },
         // map tells the System loader where to look for things
         map: {
-            // Angular bundles in System.register format via esm-bundle
-            // Cell renderers only work with the esm-bundle version
-            // TemplateUrls only works with platform-browser-dynamic from esm-bundle
-            '@angular/compiler':
-                'npm:@esm-bundle/angular__compiler@' + ANGULAR_VERSION + '/system/es2015/ivy/angular-compiler.min.js',
+            '@angular/compiler': 'npm:@angular/compiler@' + ANGULAR_VERSION + '/fesm2015/compiler.mjs',
             '@angular/platform-browser-dynamic':
-                'npm:@esm-bundle/angular__platform-browser-dynamic@' +
-                ANGULAR_VERSION +
-                '/system/es2015/ivy/angular-platform-browser-dynamic.min.js',
+                'npm:@angular/platform-browser-dynamic@' + ANGULAR_VERSION + '/fesm2015/platform-browser-dynamic.mjs',
 
             '@angular/core': 'npm:@angular/core@' + ANGULAR_VERSION + '/fesm2015/core.mjs',
             '@angular/common': 'npm:@angular/common@' + ANGULAR_VERSION + '/fesm2015/common.mjs',


### PR DESCRIPTION
On the current version and with the switch to standalone we can use the Angular compiler directly. This is a very nice thing to be able to get rid off as it is a totally external lib that we are depending on currently. 

I have made the same change to Grid Examples which previously required this for cell renderers. As charts is not even using custom Angular components it probably never needed these anyway. 