### PR TITLE
AG-10003 - Don't postinstall, use .patch hashes instead.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
                       packages/*/node_modules/
                       !node_modules/.cache/
                       !packages/*/node_modules/.cache/
-                  key: node_modules-${{hashFiles('yarn.lock')}}
+                  key: node_modules-${{hashFiles('yarn.lock','patches/*.patch')}}
                   restore-keys: node_modules- # Take any latest cache if failed to find it for current yarn.lock
             - name: Cache Nx
               uses: actions/cache@v3
               with:
                   path: .nx/cache
-                  key: cache-nx-v17-${{ hashFiles('yarn.lock') }}-${{ github.sha }}
-                  restore-keys: cache-nx-v17-${{ hashFiles('yarn.lock') }}-
+                  key: cache-nx-v17-${{ hashFiles('yarn.lock','patches/*.patch') }}-${{ github.sha }}
+                  restore-keys: cache-nx-v17-${{ hashFiles('yarn.lock','patches/*.patch') }}-
             - name: Setup Node.js
               id: setup_node
               uses: actions/setup-node@v3
@@ -86,11 +86,6 @@ jobs:
               if: steps.cache.outputs.cache-hit != 'true'
               id: yarn_install
               run: yarn install --ci --prefer-offline
-
-            - name: yarn post-install
-              if: steps.cache.outputs.cache-hit == 'true'
-              id: yarn_postinstall
-              run: yarn postinstall
 
             - name: nx format:check
               id: format
@@ -156,14 +151,14 @@ jobs:
                       packages/*/node_modules/
                       !node_modules/.cache/
                       !packages/*/node_modules/.cache/
-                  key: node_modules-${{hashFiles('yarn.lock')}}
+                  key: node_modules-${{hashFiles('yarn.lock','patches/*.patch')}}
                   restore-keys: node_modules- # Take any latest cache if failed to find it for current yarn.lock
             - name: Cache Nx
               uses: actions/cache@v3
               with:
                   path: .nx/cache
-                  key: cache-nx-v17-${{ hashFiles('yarn.lock') }}-${{ github.sha }}
-                  restore-keys: cache-nx-v17-${{ hashFiles('yarn.lock') }}-
+                  key: cache-nx-v17-${{ hashFiles('yarn.lock','patches/*.patch') }}-${{ github.sha }}
+                  restore-keys: cache-nx-v17-${{ hashFiles('yarn.lock','patches/*.patch') }}-
             - name: nx test
               id: test
               run: yarn nx affected --base ${{ needs.execute_blt.outputs.nx_base }} -t test --configuration=ci --exclude all --shard=${{ matrix.shard }}/${{ strategy.job-total }}


### PR DESCRIPTION
Fixes #708 which fails unless `yarn install` is always run.