### PR TITLE
AG-10003 - Add batching support for example generation.

### DIFF
--- a/packages/all/project.json
+++ b/packages/all/project.json
@@ -48,7 +48,7 @@
       }
     },
     "dev:setup": {
-      "command": "nx build ag-charts-website:generate-examples --parallel 8"
+      "command": "nx build ag-charts-website:generate-examples --batch"
     },
     "dev": {
       "executor": "nx:run-commands",

--- a/plugins/ag-charts-build-tools/executors.json
+++ b/plugins/ag-charts-build-tools/executors.json
@@ -7,6 +7,7 @@
         },
         "generate-example-files": {
             "implementation": "./src/executors/generate-example-files/executor",
+            "batchImplementation": "./src/executors/generate-example-files/batch-executor",
             "schema": "./src/executors/generate-example-files/schema.json",
             "description": "generate-example-files executor"
         }

--- a/plugins/ag-charts-build-tools/src/executors/generate-example-files/batch-executor.ts
+++ b/plugins/ag-charts-build-tools/src/executors/generate-example-files/batch-executor.ts
@@ -1,0 +1,62 @@
+import type { ExecutorContext, TaskGraph } from '@nx/devkit';
+
+import * as executor from './executor';
+
+type TaskResult = {
+    success: boolean;
+    terminalOutput: string;
+    startTime?: number;
+    endTime?: number;
+};
+
+type BatchExecutorTaskResult = {
+    task: string;
+    result: TaskResult;
+};
+
+type ExecutorOptions = {
+    mode: 'dev' | 'prod';
+    outputPath: string;
+    examplePath: string;
+    inputs: string[];
+    output: string;
+};
+
+export default async function* (
+    _taskGraph: TaskGraph,
+    inputs: Record<string, ExecutorOptions>,
+    overrides: ExecutorOptions,
+    _context: ExecutorContext
+): AsyncGenerator<BatchExecutorTaskResult, any, unknown> {
+    const tasks = Object.keys(inputs);
+    let taskIndex = 0;
+
+    return yield* {
+        [Symbol.asyncIterator]() {
+            return {
+                async next() {
+                    if (taskIndex >= tasks.length) {
+                        return { value: undefined, done: true };
+                    }
+
+                    const task = tasks[taskIndex++];
+                    const inputOptions = inputs[task];
+
+                    let success = false;
+                    let terminalOutput = '';
+                    try {
+                        await executor.generateFiles({ ...inputOptions, ...overrides });
+                        success = true;
+                    } catch (e) {
+                        terminalOutput += `${e}`;
+                    }
+
+                    return {
+                        value: { task, result: { success, terminalOutput } },
+                        done: false,
+                    };
+                },
+            };
+        },
+    };
+}

--- a/plugins/ag-charts-build-tools/src/executors/generate-example-files/executor.ts
+++ b/plugins/ag-charts-build-tools/src/executors/generate-example-files/executor.ts
@@ -15,18 +15,16 @@ type ExecutorOptions = {
 
 export default async function (options: ExecutorOptions) {
     try {
-        console.log(`Generating example [${options.examplePath}]`);
-
         await generateFiles(options);
 
-        return { success: true };
+        return { success: true, terminalOutput: `Generating example [${options.examplePath}]` };
     } catch (e) {
-        console.error(e, { options });
-        return { success: false };
+        const terminalOutput = `${e}`;
+        return { success: false, terminalOutput };
     }
 }
 
-async function generateFiles(options: ExecutorOptions) {
+export async function generateFiles(options: ExecutorOptions) {
     for (const ignoreDarkMode of [false, true]) {
         const darkModePath = ignoreDarkMode ? 'plain' : 'dark-mode';
         for (const internalFramework of FRAMEWORKS) {


### PR DESCRIPTION
Adds batch-execution support to the new Nx-based example generator.

Uncached execution time for `nx build ag-charts-website:generate-examples` goes from ~60s to ~10s when using the `--batch` options.