### PR TITLE
Fix CI `node_modules` caching setup.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
             - name: Checkout
               id: checkout
               uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+            - name: Fetch Refs
+              run: git fetch origin latest-success latest
             - name: Nx Affected SHA Setup
               id: nx_config
               run: |
@@ -58,6 +58,7 @@ jobs:
                   else
                     echo "base=origin/latest" >> $GITHUB_OUTPUT
                   fi
+                  git fetch origin latest-success latest
             - name: Cache node_modules
               id: cache
               uses: actions/cache@v3
@@ -140,8 +141,8 @@ jobs:
             - name: Checkout
               id: checkout
               uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+            - name: Fetch Refs
+              run: git fetch origin latest-success latest
             - name: Cache node_modules
               id: cache
               uses: actions/cache@v3
@@ -188,8 +189,8 @@ jobs:
             - name: Checkout
               id: checkout
               uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+            - name: Fetch Refs
+              run: git fetch origin latest-success latest
 
             - uses: actions/download-artifact@v3
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
                   path: |
                       node_modules/
                       packages/*/node_modules/
-                      !node_modules/.cache/
-                      !packages/*/node_modules/.cache/
+                      plugins/*/node_modules/
+                      libraries/*/node_modules/
                   key: node_modules-${{hashFiles('yarn.lock','patches/*.patch')}}
                   restore-keys: node_modules- # Take any latest cache if failed to find it for current yarn.lock
             - name: Cache Nx
@@ -77,11 +77,10 @@ jobs:
                   restore-keys: cache-nx-v17-${{ hashFiles('yarn.lock','patches/*.patch') }}-
             - name: Setup Node.js
               id: setup_node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: '18'
-                  cache: ${{ steps.cache.outputs.cache-hit != 'true' && 'yarn' || '' }}
-
+                  cache: 'yarn'
             - name: yarn install
               id: yarn_install
               run: yarn check --integrity || yarn install --ci --prefer-offline
@@ -150,8 +149,8 @@ jobs:
                   path: |
                       node_modules/
                       packages/*/node_modules/
-                      !node_modules/.cache/
-                      !packages/*/node_modules/.cache/
+                      plugins/*/node_modules/
+                      libraries/*/node_modules/
                   key: node_modules-${{hashFiles('yarn.lock','patches/*.patch')}}
                   restore-keys: node_modules- # Take any latest cache if failed to find it for current yarn.lock
             - name: Cache Nx
@@ -160,6 +159,12 @@ jobs:
                   path: .nx/cache
                   key: cache-nx-v17-${{ hashFiles('yarn.lock','patches/*.patch') }}-${{ github.sha }}
                   restore-keys: cache-nx-v17-${{ hashFiles('yarn.lock','patches/*.patch') }}-
+            - name: Setup Node.js
+              id: setup_node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '18'
+                  cache: 'yarn'
             - name: yarn install
               id: yarn_install
               run: yarn check --integrity || yarn install --ci --prefer-offline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,14 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: '18'
-                  cache: 'yarn'
+                  cache: ${{ steps.cache.outputs.cache-hit != 'true' && 'yarn' || '' }}
             - name: yarn install
+              if: steps.cache.outputs.cache-hit != 'true'
               id: yarn_install
               run: yarn check --integrity || yarn install --ci --prefer-offline
-
+            - name: yarn postinstall
+              if: steps.cache.outputs.cache-hit == 'true'
+              run: npx nx build ag-charts-build-tools
             - name: nx format:check
               id: format
               if: steps.yarn_install.outcome == 'success' || steps.yarn_install.outcome == 'skipped'
@@ -165,10 +168,14 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: '18'
-                  cache: 'yarn'
+                  cache: ${{ steps.cache.outputs.cache-hit != 'true' && 'yarn' || '' }}
             - name: yarn install
+              if: steps.cache.outputs.cache-hit != 'true'
               id: yarn_install
               run: yarn check --integrity || yarn install --ci --prefer-offline
+            - name: yarn postinstall
+              if: steps.cache.outputs.cache-hit == 'true'
+              run: npx nx build ag-charts-build-tools
             - name: nx test
               id: test
               run: yarn nx affected --base ${{ needs.execute_blt.outputs.nx_base }} -t test --configuration=ci --exclude all --shard=${{ matrix.shard }}/${{ strategy.job-total }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
             - name: Checkout
               id: checkout
               uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+            - name: Fetch Refs
+              run: git fetch origin latest-success latest
 
             - name: Setup Node.js
               id: setup_node

--- a/.github/workflows/sonar-scanner-release.yml
+++ b/.github/workflows/sonar-scanner-release.yml
@@ -18,7 +18,7 @@ jobs:
               id: checkout
               uses: actions/checkout@v3
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
             - name: Setup Node.js
               id: setup_node
               uses: actions/setup-node@v3

--- a/.github/workflows/sonar-scanner.yml
+++ b/.github/workflows/sonar-scanner.yml
@@ -19,7 +19,7 @@ jobs:
               id: checkout
               uses: actions/checkout@v3
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
             - name: Setup Node.js
               id: setup_node
               uses: actions/setup-node@v3


### PR DESCRIPTION
Fixes CI `node_modules` caching and re-applies optimisations that we had in `latest` until earlier today.

- Fixes caching of `node_modules` (now includes `libraries/*` and `plugins/*` cases).
- Fixes `postinstall` script handling (now explicitly runs post-install steps if we don't run `yarn install`).
- Improved detection of when to run `yarn install` on cache miss.
- Reduces depth of clone to be shallow (previously `fetch-depth: 0` meant fetch EVERYTHING).