### PR TITLE
AG-8880 Fix legend and node click to only trigger when mouse down is over same element

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -12,6 +12,7 @@ type InteractionTypes =
     | 'drag'
     | 'drag-end'
     | 'leave'
+    | 'mouse-down'
     | 'page-left'
     | 'wheel';
 
@@ -196,11 +197,11 @@ export class InteractionManager extends BaseManager<
             case 'mousedown':
                 this.mouseDown = true;
                 this.dragStartElement = event.target as HTMLElement;
-                return [dragStart];
+                return ['mouse-down', dragStart];
             case 'touchstart':
                 this.touchDown = true;
                 this.dragStartElement = event.target as HTMLElement;
-                return [dragStart];
+                return ['mouse-down', dragStart];
 
             case 'touchmove':
             case 'mousemove':

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -154,6 +154,12 @@ export function mouseMoveEvent({ offsetX, offsetY }: { offsetX: number; offsetY:
     return event;
 }
 
+export function mouseDownEvent({ offsetX, offsetY }: { offsetX: number; offsetY: number }): MouseEvent {
+    const event = new MouseEvent('mousedown', { bubbles: true });
+    Object.assign(event, { offsetX, offsetY, pageX: offsetX, pageY: offsetY });
+    return event;
+}
+
 export function clickEvent({ offsetX, offsetY }: { offsetX: number; offsetY: number }): MouseEvent {
     const event = new MouseEvent('click', { bubbles: true });
     Object.assign(event, { offsetX, offsetY, pageX: offsetX, pageY: offsetY });
@@ -236,6 +242,7 @@ export function clickAction(x: number, y: number): (chart: Chart | AgChartProxy)
         const target = chart.scene.canvas.element;
         checkTargetValid(target);
 
+        target?.dispatchEvent(mouseDownEvent({ offsetX: x, offsetY: y }));
         target?.dispatchEvent(clickEvent({ offsetX: x, offsetY: y }));
         return delay(50);
     };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8880

For legend item clicks and series node clicks, tracks the element that the `mousedown` event targeted then compares it to the element the `click` event targets. Only fires the listener events if these match.