### PR TITLE
AG-10110 Center multiple chart example in gallery

### DIFF
--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/ExampleStyle.tsx
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/ExampleStyle.tsx
@@ -42,6 +42,13 @@ export const ExampleStyle = ({ rootId }: { rootId?: string }) => {
             overflow: hidden;
         }
 
+        /* Center charts with explicit width and heights */
+        .ag-chart-wrapper {
+            display: flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+        }
+
         button:not(#myGrid button, #myChart button, button[class*='ag-'], .ag-chart-context-menu button) {
             --background-color: transparent;
             --text-color: #212529;


### PR DESCRIPTION
In v10 we might want to revisit the css & html structure. They have the style

```css
position: relative;
display: block;
width: 100%;
height: 100%;
cursor: default;
```

But that 100% width and height aren't necessarily of the parent