### PR TITLE
AG-10110 Fix theme overrides in example thumbnails

### DIFF
--- a/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/thumbnailGenerator.ts
+++ b/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/thumbnailGenerator.ts
@@ -73,7 +73,6 @@ export async function generateExample({ example, theme, outputPath }: Params) {
 
         AgCharts.update(chartProxy, {
             ...options,
-            theme,
             animation: { enabled: false },
             document,
             window,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10110

`transformPlainFileEntry` defines a theme object with `baseTheme` and `overrides`. I was overwriting this object so the overrides weren't applied