### PR TITLE
AG-9954 Swipe-in marker animation out of sync (part 1)

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -649,12 +649,11 @@ export class AreaSeries extends CartesianSeries<
     override animateEmptyUpdateReady(animationData: AreaAnimationData) {
         const { markerSelections, labelSelections, contextData, paths } = animationData;
         const { animationManager } = this.ctx;
-        const { seriesRectWidth: width = 0 } = this.nodeDataDependencies;
 
         this.updateAreaPaths(paths, contextData);
         pathSwipeInAnimation(this, animationManager, paths.flat());
         resetMotion(markerSelections, resetMarkerPositionFn);
-        markerSwipeScaleInAnimation(this, animationManager, markerSelections, width);
+        markerSwipeScaleInAnimation(this, animationManager, markerSelections);
         seriesLabelFadeInAnimation(this, 'labels', animationManager, labelSelections);
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -5,7 +5,6 @@ import { resetMotion } from '../../../motion/resetMotion';
 import { ContinuousScale } from '../../../scale/continuousScale';
 import { Group } from '../../../scene/group';
 import { PointerEvents } from '../../../scene/node';
-import { Path2D } from '../../../scene/path2D';
 import type { SizedPoint } from '../../../scene/point';
 import type { Selection } from '../../../scene/selection';
 import type { Path } from '../../../scene/shape/path';
@@ -39,7 +38,7 @@ import {
 import type { CartesianAnimationData } from './cartesianSeries';
 import { CartesianSeries } from './cartesianSeries';
 import { markerSwipeScaleInAnimation, resetMarkerFn, resetMarkerPositionFn } from './markerUtil';
-import { buildResetPathFn, pathFadeInAnimation, pathSwipeInAnimation } from './pathUtil';
+import { buildResetPathFn, pathFadeInAnimation, pathSwipeInAnimation, updateClipPath } from './pathUtil';
 
 type AreaAnimationData = CartesianAnimationData<
     Group,
@@ -407,7 +406,6 @@ export class AreaSeries extends CartesianSeries<
     }) {
         const { opacity, visible, animationEnabled } = opts;
         const [fill, stroke] = opts.paths;
-        const { seriesRectHeight: height, seriesRectWidth: width } = this.nodeDataDependencies;
 
         const strokeWidth = this.getStrokeWidth(this.properties.strokeWidth);
         stroke.setProperties({
@@ -439,17 +437,8 @@ export class AreaSeries extends CartesianSeries<
             strokeWidth,
         });
 
-        const updateClipPath = (path: Path) => {
-            if (path.clipPath == null) {
-                path.clipPath = new Path2D();
-                path.clipScalingX = 1;
-                path.clipScalingY = 1;
-            }
-            path.clipPath?.clear({ trackChanges: true });
-            path.clipPath?.rect(-25, -25, (width ?? 0) + 50, (height ?? 0) + 50);
-        };
-        updateClipPath(stroke);
-        updateClipPath(fill);
+        updateClipPath(this, stroke);
+        updateClipPath(this, fill);
     }
 
     protected override async updatePaths(opts: { contextData: AreaSeriesNodeDataContext; paths: Path[] }) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -445,12 +445,11 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
     protected override animateEmptyUpdateReady(animationData: LineAnimationData) {
         const { markerSelections, labelSelections, annotationSelections, contextData, paths } = animationData;
         const { animationManager } = this.ctx;
-        const { seriesRectWidth: width = 0 } = this.nodeDataDependencies;
 
         this.updateLinePaths(paths, contextData);
         pathSwipeInAnimation(this, animationManager, paths.flat());
         resetMotion(markerSelections, resetMarkerPositionFn);
-        markerSwipeScaleInAnimation(this, animationManager, markerSelections, width);
+        markerSwipeScaleInAnimation(this, animationManager, markerSelections);
         seriesLabelFadeInAnimation(this, 'labels', animationManager, labelSelections);
         seriesLabelFadeInAnimation(this, 'annotations', animationManager, annotationSelections);
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -5,7 +5,6 @@ import { resetMotion } from '../../../motion/resetMotion';
 import type { FontStyle, FontWeight } from '../../../options/agChartOptions';
 import { Group } from '../../../scene/group';
 import { PointerEvents } from '../../../scene/node';
-import { Path2D } from '../../../scene/path2D';
 import type { Selection } from '../../../scene/selection';
 import type { Path } from '../../../scene/shape/path';
 import type { Text } from '../../../scene/shape/text';
@@ -33,7 +32,7 @@ import { CartesianSeries } from './cartesianSeries';
 import { LineSeriesProperties } from './lineSeriesProperties';
 import { prepareLinePathAnimation } from './lineUtil';
 import { markerSwipeScaleInAnimation, resetMarkerFn, resetMarkerPositionFn } from './markerUtil';
-import { buildResetPathFn, pathSwipeInAnimation } from './pathUtil';
+import { buildResetPathFn, pathSwipeInAnimation, updateClipPath } from './pathUtil';
 
 export interface LineNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDatum {
     readonly point: CartesianSeriesNodeDatum['point'] & {
@@ -243,7 +242,6 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
             visible,
             animationEnabled,
         } = opts;
-        const { seriesRectHeight: height, seriesRectWidth: width } = this.nodeDataDependencies;
 
         lineNode.setProperties({
             fill: undefined,
@@ -261,13 +259,7 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
             lineNode.visible = visible;
         }
 
-        if (lineNode.clipPath == null) {
-            lineNode.clipPath = new Path2D();
-            lineNode.clipScalingX = 1;
-            lineNode.clipScalingY = 1;
-        }
-        lineNode.clipPath?.clear({ trackChanges: true });
-        lineNode.clipPath?.rect(-25, -25, (width ?? 0) + 50, (height ?? 0) + 50);
+        updateClipPath(this, lineNode);
     }
 
     protected override async updateMarkerSelection(opts: {

--- a/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
@@ -7,6 +7,7 @@ import { Debug } from '../../../util/debug';
 import { clamp } from '../../../util/number';
 import type { AnimationManager } from '../../interaction/animationManager';
 import type { Marker } from '../../marker/marker';
+import type { NodeDataDependant } from '../seriesTypes';
 import * as easing from './../../../motion/easing';
 import type { CartesianSeriesNodeDatum } from './cartesianSeries';
 import type { PathNodeDatumLike, PathPoint, PathPointMap } from './pathUtil';
@@ -40,11 +41,11 @@ export function markerScaleInAnimation<T>(
 }
 
 export function markerSwipeScaleInAnimation<T extends CartesianSeriesNodeDatum>(
-    { id }: { id: string },
+    { id, nodeDataDependencies }: { id: string } & NodeDataDependant,
     animationManager: AnimationManager,
-    markerSelections: Selection<Node, T>[],
-    seriesWidth: number
+    markerSelections: Selection<Node, T>[]
 ) {
+    const seriesWidth: number = nodeDataDependencies.seriesRectWidth;
     const fromFn = (_: Node, datum: T) => {
         const x = datum.midPoint?.x ?? seriesWidth;
         // Calculate a delay that depends on the X position of the datum, so that nodes appear

--- a/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
@@ -4,6 +4,7 @@ import { Path2D } from '../../../scene/path2D';
 import type { Point } from '../../../scene/point';
 import type { Selection } from '../../../scene/selection';
 import type { Path } from '../../../scene/shape/path';
+import { toReal } from '../../../util/number';
 import type { AnimationManager } from '../../interaction/animationManager';
 import type { NodeDataDependant } from '../seriesTypes';
 import type { CartesianSeriesNodeDatum } from './cartesianSeries';
@@ -196,5 +197,5 @@ export function updateClipPath({ nodeDataDependencies }: NodeDataDependant, path
         path.clipScalingY = 1;
     }
     path.clipPath?.clear({ trackChanges: true });
-    path.clipPath?.rect(-25, -25, (width ?? 0) + 50, (height ?? 0) + 50);
+    path.clipPath?.rect(-25, -25, toReal(width) + 50, toReal(height) + 50);
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
@@ -1,9 +1,11 @@
 import { LABEL_PHASE } from '../../../motion/animation';
 import { staticFromToMotion } from '../../../motion/fromToMotion';
+import { Path2D } from '../../../scene/path2D';
 import type { Point } from '../../../scene/point';
 import type { Selection } from '../../../scene/selection';
 import type { Path } from '../../../scene/shape/path';
 import type { AnimationManager } from '../../interaction/animationManager';
+import type { NodeDataDependant } from '../seriesTypes';
 import type { CartesianSeriesNodeDatum } from './cartesianSeries';
 
 export type PathPointChange = 'move' | 'in' | 'out';
@@ -184,4 +186,15 @@ export function buildResetPathFn(opts: { getOpacity(): number }) {
     return (_node: Path) => {
         return { opacity: opts.getOpacity(), clipScalingX: 1, clipMode: undefined };
     };
+}
+
+export function updateClipPath({ nodeDataDependencies }: NodeDataDependant, path: Path): void {
+    const { seriesRectHeight: height, seriesRectWidth: width } = nodeDataDependencies;
+    if (path.clipPath == null) {
+        path.clipPath = new Path2D();
+        path.clipScalingX = 1;
+        path.clipScalingY = 1;
+    }
+    path.clipPath?.clear({ trackChanges: true });
+    path.clipPath?.rect(-25, -25, (width ?? 0) + 50, (height ?? 0) + 50);
 }

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -558,7 +558,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
         };
         const resize = jsonDiff(this.nodeDataDependencies, newNodeDataDependencies) != null;
         if (resize) {
-            this.nodeDataDependencies = newNodeDataDependencies;
+            this._nodeDataDependencies = newNodeDataDependencies;
         }
 
         await this.maybeRefreshNodeData();

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -34,7 +34,7 @@ import type { BaseSeriesEvent, SeriesEventType } from './seriesEvents';
 import type { SeriesGroupZIndexSubOrderType } from './seriesLayerManager';
 import type { SeriesProperties } from './seriesProperties';
 import type { SeriesGrouping } from './seriesStateManager';
-import type { ISeries, SeriesNodeDatum } from './seriesTypes';
+import type { ISeries, NodeDataDependencies, SeriesNodeDatum } from './seriesTypes';
 
 /** Modes of matching user interactions to rendered nodes (e.g. hover or click) */
 export enum SeriesNodePickMode {
@@ -762,15 +762,18 @@ export abstract class Series<
         return undefined;
     }
 
-    protected nodeDataDependencies: { seriesRectWidth?: number; seriesRectHeight?: number } = {};
+    protected _nodeDataDependencies?: NodeDataDependencies;
+
+    public get nodeDataDependencies(): NodeDataDependencies {
+        return this._nodeDataDependencies ?? { seriesRectWidth: NaN, seriesRectHeight: NaN };
+    }
+
     protected checkResize(newSeriesRect?: BBox) {
-        const newNodeDataDependencies = {
-            seriesRectWidth: newSeriesRect?.width,
-            seriesRectHeight: newSeriesRect?.height,
-        };
+        const { width: seriesRectWidth, height: seriesRectHeight } = newSeriesRect ?? { width: NaN, height: NaN };
+        const newNodeDataDependencies = newSeriesRect ? { seriesRectWidth, seriesRectHeight } : undefined;
         const resize = jsonDiff(this.nodeDataDependencies, newNodeDataDependencies) != null;
         if (resize) {
-            this.nodeDataDependencies = newNodeDataDependencies;
+            this._nodeDataDependencies = newNodeDataDependencies;
             this.markNodeDataDirty();
         }
 

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -48,3 +48,6 @@ export interface ErrorBoundSeriesNodeDatum {
     xBar?: { lowerPoint: Point; upperPoint: Point };
     yBar?: { lowerPoint: Point; upperPoint: Point };
 }
+
+export type NodeDataDependencies = { seriesRectWidth: number; seriesRectHeight: number };
+export type NodeDataDependant = { readonly nodeDataDependencies: NodeDataDependencies };

--- a/packages/ag-charts-community/src/motion/animation.ts
+++ b/packages/ag-charts-community/src/motion/animation.ts
@@ -1,5 +1,6 @@
 import { interpolateColor, interpolateNumber } from '../interpolate';
 import { Node } from '../scene/node';
+import type { Selection } from '../scene/selection';
 import { clamp } from '../util/number';
 import { linear } from './easing';
 
@@ -80,8 +81,16 @@ export interface IAnimation<T extends AnimationValue> {
     readonly update: (time: number) => this;
 }
 
-export function isNodeArray<N extends Node>(array: (object | N)[]): array is N[] {
+function isNodeArray<N extends Node>(array: (object | N)[]): array is N[] {
     return array.every((n) => n instanceof Node);
+}
+
+export function deconstructSelectionsOrNodes<N extends Node, D>(
+    selectionsOrNodes: Selection<N, D>[] | N[]
+): { nodes: N[]; selections: Selection<N, D>[] } {
+    return isNodeArray(selectionsOrNodes)
+        ? { nodes: selectionsOrNodes, selections: [] }
+        : { nodes: [], selections: selectionsOrNodes };
 }
 
 export class Animation<T extends AnimationValue> implements IAnimation<T> {

--- a/packages/ag-charts-community/src/motion/easing.test.ts
+++ b/packages/ag-charts-community/src/motion/easing.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { easeOut, inverseEaseOut } from './easing';
+
+describe('easing', () => {
+    test('inverseEaseOut', () => {
+        // Calculate [0, 0.01, 0.02, ..., 1]
+        const step = 0.01;
+        const expectedTimeValues = Array.from({ length: 1 / step + 1 }, (_, index) => index * step);
+
+        for (const t of expectedTimeValues) {
+            const x = easeOut(t);
+            expect(inverseEaseOut(x)).toBeCloseTo(t, 14);
+        }
+    });
+});

--- a/packages/ag-charts-community/src/motion/fromToMotion.ts
+++ b/packages/ag-charts-community/src/motion/fromToMotion.ts
@@ -3,7 +3,7 @@ import type { AnimationManager } from '../chart/interaction/animationManager';
 import type { Node } from '../scene/node';
 import type { Selection } from '../scene/selection';
 import { zipObject } from '../util/zip';
-import { ADD_PHASE, INITIAL_LOAD, REMOVE_PHASE, UPDATE_PHASE, isNodeArray } from './animation';
+import { ADD_PHASE, INITIAL_LOAD, REMOVE_PHASE, UPDATE_PHASE, deconstructSelectionsOrNodes } from './animation';
 import type { AnimationTiming, AnimationValue } from './animation';
 import * as easing from './easing';
 
@@ -77,9 +77,7 @@ export function fromToMotion<N extends Node, T extends Record<string, string | n
 ) {
     const { defaultDuration } = animationManager;
     const { fromFn, toFn, intermediateFn } = fns;
-    const isNodes = isNodeArray(selectionsOrNodes);
-    const nodes = isNodes ? selectionsOrNodes : [];
-    const selections = !isNodes ? selectionsOrNodes : [];
+    const { nodes, selections } = deconstructSelectionsOrNodes(selectionsOrNodes);
 
     // Dynamic case with varying add/update/remove behavior.
     const ids = { added: {}, removed: {} };
@@ -201,9 +199,7 @@ export function staticFromToMotion<N extends Node, T extends AnimationValue & Pa
     to: T,
     extraOpts: ExtraOpts<N> = {}
 ) {
-    const isNodes = isNodeArray(selectionsOrNodes);
-    const nodes = isNodes ? selectionsOrNodes : [];
-    const selections = !isNodes ? selectionsOrNodes : [];
+    const { nodes, selections } = deconstructSelectionsOrNodes(selectionsOrNodes);
     const { animationDelay = 0, animationDuration = 1, start = {}, finish = {} } = extraOpts;
     const { defaultDuration } = animationManager;
 

--- a/packages/ag-charts-community/src/motion/resetMotion.ts
+++ b/packages/ag-charts-community/src/motion/resetMotion.ts
@@ -1,6 +1,6 @@
 import type { Node } from '../scene/node';
 import type { Selection } from '../scene/selection';
-import { isNodeArray } from './animation';
+import { deconstructSelectionsOrNodes } from './animation';
 
 /**
  * Implements a per-node reset.
@@ -12,9 +12,7 @@ export function resetMotion<N extends Node, T extends Partial<N>, D>(
     selectionsOrNodes: Selection<N, D>[] | N[],
     propsFn: (node: N, datum: D) => T
 ) {
-    const isNodes = isNodeArray<N>(selectionsOrNodes);
-    const nodes = isNodes ? selectionsOrNodes : [];
-    const selections = !isNodes ? selectionsOrNodes : [];
+    const { nodes, selections } = deconstructSelectionsOrNodes(selectionsOrNodes);
 
     for (const selection of selections) {
         for (const node of selection.nodes()) {

--- a/packages/ag-charts-community/src/util/number.ts
+++ b/packages/ag-charts-community/src/util/number.ts
@@ -40,6 +40,10 @@ export function toFixed(value: number, fractionOrSignificantDigits: number = 2):
     return value.toFixed(Math.abs(power) - 1 + fractionOrSignificantDigits); // significant digits
 }
 
+export function toReal(value: number) {
+    return isReal(value) ? value : 0;
+}
+
 /**
  * Returns the mathematically correct n modulus of m. For context, the JS % operator is remainder
  * NOT modulus, which is why this is needed.

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -655,12 +655,11 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
     ) {
         const { markerSelections, labelSelections, contextData, paths } = animationData;
         const { animationManager } = this.ctx;
-        const { seriesRectWidth: width = 0 } = this.nodeDataDependencies;
 
         this.updateAreaPaths(paths, contextData);
         pathSwipeInAnimation(this, animationManager, paths.flat());
         resetMotion(markerSelections, resetMarkerPositionFn);
-        markerSwipeScaleInAnimation(this, animationManager, markerSelections, width);
+        markerSwipeScaleInAnimation(this, animationManager, markerSelections);
         seriesLabelFadeInAnimation(this, 'labels', animationManager, labelSelections);
     }
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -21,8 +21,9 @@ const {
     seriesLabelFadeInAnimation,
     animationValidation,
     diff,
+    updateClipPath,
 } = _ModuleSupport;
-const { getMarker, PointerEvents, Path2D } = _Scene;
+const { getMarker, PointerEvents } = _Scene;
 const { sanitizeHtml, extent, isNumber } = _Util;
 
 const DEFAULT_DIRECTION_KEYS = {
@@ -393,7 +394,6 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
     protected override async updatePathNodes(opts: { paths: _Scene.Path[]; opacity: number; visible: boolean }) {
         const { opacity, visible } = opts;
         const [fill, stroke] = opts.paths;
-        const { seriesRectHeight: height, seriesRectWidth: width } = this.nodeDataDependencies;
 
         const strokeWidth = this.getStrokeWidth(this.properties.strokeWidth);
         stroke.setProperties({
@@ -425,17 +425,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
             visible,
         });
 
-        const updateClipPath = (path: _Scene.Path) => {
-            if (path.clipPath == null) {
-                path.clipPath = new Path2D();
-                path.clipScalingX = 1;
-                path.clipScalingY = 1;
-            }
-            path.clipPath?.clear({ trackChanges: true });
-            path.clipPath?.rect(-25, -25, (width ?? 0) + 50, (height ?? 0) + 50);
-        };
-        updateClipPath(stroke);
-        updateClipPath(fill);
+        updateClipPath(this, stroke);
+        updateClipPath(this, fill);
     }
 
     protected override async updatePaths(opts: { contextData: RangeAreaContext; paths: _Scene.Path[] }) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9954

(Follow-up WIP PR https://github.com/ag-grid/ag-charts/pull/811)

**Key changes:**
- Add unit tests to check that the math of `easeOut` and `inverseEaseOut` is correct.
- Refactor `Series.nodeDataDependencies`:
    - Declaring new types in _seriesTypes.ts_ that the utility files can use.
    - Move duplicate `updateClipPath` code into _pathUtil.ts_