### PR TITLE
AG-9989 Do not animate error bars when theme changes

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -25,6 +25,7 @@ import { SeriesNodeClickEvent } from '../series';
 import type { SeriesGroupZIndexSubOrderType } from '../seriesLayerManager';
 import { SeriesProperties } from '../seriesProperties';
 import type { SeriesNodeDatum } from '../seriesTypes';
+import type { Scaling } from './scaling';
 
 export interface CartesianSeriesNodeDatum extends SeriesNodeDatum {
     readonly xKey: string;
@@ -105,24 +106,6 @@ export interface CartesianAnimationData<
     paths: Path[][];
     seriesRect?: BBox;
     duration?: number;
-}
-
-export type Scaling = ContinuousScaling | CategoryScaling | LogScaling;
-
-export interface ContinuousScaling<T = 'continuous'> {
-    type: T;
-    domain: [number, number];
-    range: [number, number];
-}
-
-export interface LogScaling extends ContinuousScaling<'log'> {
-    convert(domain: number): number;
-}
-
-export interface CategoryScaling {
-    type: 'category';
-    domain: string[];
-    range: number[];
 }
 
 export abstract class CartesianSeriesProperties<T extends object> extends SeriesProperties<T> {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -32,7 +32,7 @@ import { CartesianSeries } from './cartesianSeries';
 import { LineSeriesProperties } from './lineSeriesProperties';
 import { prepareLinePathAnimation } from './lineUtil';
 import { markerSwipeScaleInAnimation, resetMarkerFn, resetMarkerPositionFn } from './markerUtil';
-import { buildResetPathFn, pathChangeHasMotion, pathSwipeInAnimation, updateClipPath } from './pathUtil';
+import { buildResetPathFn, pathSwipeInAnimation, updateClipPath } from './pathUtil';
 
 export interface LineNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDatum {
     readonly point: CartesianSeriesNodeDatum['point'] & {
@@ -480,8 +480,8 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
         fromToMotion(this.id, 'marker', animationManager, markerSelections, fns.marker as any);
         fromToMotion(this.id, 'path_properties', animationManager, path, fns.pathProperties);
         pathMotion(this.id, 'path_update', animationManager, path, fns.path);
-        seriesLabelFadeInAnimation(this, 'labels', animationManager, labelSelections);
-        if (pathChangeHasMotion(fns.pairData)) {
+        if (fns.hasMotion) {
+            seriesLabelFadeInAnimation(this, 'labels', animationManager, labelSelections);
             seriesLabelFadeInAnimation(this, 'annotations', animationManager, annotationSelections);
         }
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -32,7 +32,7 @@ import { CartesianSeries } from './cartesianSeries';
 import { LineSeriesProperties } from './lineSeriesProperties';
 import { prepareLinePathAnimation } from './lineUtil';
 import { markerSwipeScaleInAnimation, resetMarkerFn, resetMarkerPositionFn } from './markerUtil';
-import { buildResetPathFn, pathSwipeInAnimation, updateClipPath } from './pathUtil';
+import { buildResetPathFn, pathChangeHasMotion, pathSwipeInAnimation, updateClipPath } from './pathUtil';
 
 export interface LineNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDatum {
     readonly point: CartesianSeriesNodeDatum['point'] & {
@@ -481,7 +481,9 @@ export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
         fromToMotion(this.id, 'path_properties', animationManager, path, fns.pathProperties);
         pathMotion(this.id, 'path_update', animationManager, path, fns.path);
         seriesLabelFadeInAnimation(this, 'labels', animationManager, labelSelections);
-        seriesLabelFadeInAnimation(this, 'annotations', animationManager, annotationSelections);
+        if (pathChangeHasMotion(fns.pairData)) {
+            seriesLabelFadeInAnimation(this, 'annotations', animationManager, annotationSelections);
+        }
     }
 
     private getDatumId(datum: LineNodeDatum) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -362,5 +362,5 @@ export function prepareLinePathAnimation(
 
     const pathFns = prepareLinePathAnimationFns(newData, oldData, pairData, 'fade', renderPartialPath);
     const marker = prepareMarkerAnimation(pairMap, status);
-    return { ...pathFns, marker };
+    return { ...pathFns, marker, pairData };
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -1,10 +1,11 @@
 import { FROM_TO_MIXINS, type NodeUpdateState } from '../../../motion/fromToMotion';
 import type { Path } from '../../../scene/shape/path';
 import type { ProcessedOutputDiff } from '../../data/dataModel';
-import type { CartesianSeriesNodeDataContext, Scaling } from './cartesianSeries';
+import type { CartesianSeriesNodeDataContext } from './cartesianSeries';
 import { prepareMarkerAnimation } from './markerUtil';
 import type { BackfillSplitMode, PathNodeDatumLike, PathPoint, PathPointChange, PathPointMap } from './pathUtil';
 import { backfillPathPointData, minMax, renderPartialPath } from './pathUtil';
+import { Scaling, areScalingEqual } from './scaling';
 
 function scale(val: number | string | Date, scaling?: Scaling) {
     if (!scaling) return NaN;
@@ -28,6 +29,10 @@ function scale(val: number | string | Date, scaling?: Scaling) {
 
     // We failed to convert using the scale.
     return NaN;
+}
+
+function scalesChanged(newData: LineContextLike, oldData: LineContextLike) {
+    return !areScalingEqual(newData.scales.x, oldData.scales.x) || !areScalingEqual(newData.scales.y, oldData.scales.y);
 }
 
 function closeMatch<T extends number | string>(a: T, b: T) {
@@ -360,7 +365,8 @@ export function prepareLinePathAnimation(
         return;
     }
 
+    const hasMotion: boolean = (diff?.changed ?? true) || scalesChanged(newData, oldData);
     const pathFns = prepareLinePathAnimationFns(newData, oldData, pairData, 'fade', renderPartialPath);
     const marker = prepareMarkerAnimation(pairMap, status);
-    return { ...pathFns, marker, pairData };
+    return { ...pathFns, marker, hasMotion };
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
@@ -39,7 +39,7 @@ export function minMax(nodeData: PathNodeDatumLike[]) {
     );
 }
 
-export function pathChangeHasMotion(pairData: PathPoint[]) :boolean {
+export function pathChangeHasMotion(pairData: PathPoint[]): boolean {
     for (const pathPoint of pairData) {
         const { from, to } = pathPoint;
         if (from === undefined || to === undefined) {
@@ -47,7 +47,7 @@ export function pathChangeHasMotion(pairData: PathPoint[]) :boolean {
                 return true;
             }
         } else if (from.x !== to.x || from.y !== to.y) {
-            return true
+            return true;
         }
     }
     return false;

--- a/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
@@ -39,6 +39,20 @@ export function minMax(nodeData: PathNodeDatumLike[]) {
     );
 }
 
+export function pathChangeHasMotion(pairData: PathPoint[]) :boolean {
+    for (const pathPoint of pairData) {
+        const { from, to } = pathPoint;
+        if (from === undefined || to === undefined) {
+            if (from !== undefined || to !== undefined) {
+                return true;
+            }
+        } else if (from.x !== to.x || from.y !== to.y) {
+            return true
+        }
+    }
+    return false;
+}
+
 function intersectionOnLine(a: { x: number; y: number }, b: { x: number; y: number }, targetX: number) {
     const m = (b.y - a.y) / (b.x - a.x);
     // Find a point a distance along the line from `a` and `b`

--- a/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/pathUtil.ts
@@ -39,20 +39,6 @@ export function minMax(nodeData: PathNodeDatumLike[]) {
     );
 }
 
-export function pathChangeHasMotion(pairData: PathPoint[]): boolean {
-    for (const pathPoint of pairData) {
-        const { from, to } = pathPoint;
-        if (from === undefined || to === undefined) {
-            if (from !== undefined || to !== undefined) {
-                return true;
-            }
-        } else if (from.x !== to.x || from.y !== to.y) {
-            return true;
-        }
-    }
-    return false;
-}
-
 function intersectionOnLine(a: { x: number; y: number }, b: { x: number; y: number }, targetX: number) {
     const m = (b.y - a.y) / (b.x - a.x);
     // Find a point a distance along the line from `a` and `b`

--- a/packages/ag-charts-community/src/chart/series/cartesian/scaling.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scaling.ts
@@ -1,0 +1,47 @@
+export type Scaling = ContinuousScaling | CategoryScaling | LogScaling;
+
+export interface ContinuousScaling<T = 'continuous'> {
+    type: T;
+    domain: [number, number];
+    range: [number, number];
+}
+
+export interface LogScaling extends ContinuousScaling<'log'> {
+    convert(domain: number): number;
+}
+
+export interface CategoryScaling {
+    type: 'category';
+    domain: string[];
+    range: number[];
+}
+
+function isContinuousScaling(scaling: Scaling): scaling is ContinuousScaling {
+    return scaling.type === 'continuous' || scaling.type === 'log';
+}
+
+function isCategoryScaling(scaling: Scaling): scaling is CategoryScaling {
+    return scaling.type === 'category';
+}
+
+function areEqual<D, R>(a: { domain: D[]; range: R[] }, b: { domain: D[]; range: R[] }): boolean {
+    return (
+        a.domain.length === b.domain.length &&
+        a.range.length === b.range.length &&
+        a.domain.every((val, index) => val === b.domain[index]) &&
+        a.range.every((val, index) => val === b.range[index])
+    );
+}
+
+export function areScalingEqual(a: Scaling | undefined, b: Scaling | undefined): boolean {
+    if (a === undefined || b === undefined) {
+        return a !== undefined || b !== undefined;
+    }
+    if (isContinuousScaling(a) && isContinuousScaling(b)) {
+        return a.type === b.type && areEqual(a, b);
+    }
+    if (isCategoryScaling(a) && isCategoryScaling(b)) {
+        return areEqual(a, b);
+    }
+    return false;
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9989

This changes detect motion in path change to determine whether the error bars of a line series needs to be animated.