### PR TITLE
AG-10143

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -633,6 +633,9 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             labelX,
             sideFlag,
         });
+
+        this.updateLayoutState();
+
         const { tickData, combinedRotation, textBaseline, textAlign, ...ticksResult } = this.tickGenerationResult;
 
         const boxes: BBox[] = [];
@@ -725,8 +728,6 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
             crossLine.regularFlipRotation = regularFlipRotation;
             crossLine.calculateLayout(anySeriesActive, this.reverse);
         });
-
-        this.updateLayoutState();
 
         primaryTickCount = ticksResult.primaryTickCount;
         return { primaryTickCount, bbox: transformedBBox };
@@ -1063,10 +1064,10 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
                 break;
         }
 
-        // When the scale domain or the ticks change, the label format may change
-        this.onLabelFormatChange(rawTicks, this.label.format);
         // `ticks instanceof NumericTicks` doesn't work here, so we feature detect.
         this.fractionDigits = (rawTicks as any).fractionDigits >= 0 ? (rawTicks as any).fractionDigits : 0;
+        // When the scale domain or the ticks change, the label format may change
+        this.onLabelFormatChange(rawTicks, this.label.format);
 
         const halfBandwidth = (scale.bandwidth ?? 0) / 2;
         const ticks: TickDatum[] = [];

--- a/packages/ag-charts-community/src/util/number.test.ts
+++ b/packages/ag-charts-community/src/util/number.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals';
 
-import { toFixed } from './number';
+import { countFractionDigits, toFixed } from './number';
 
 describe('number module', () => {
     test('toFixed', () => {
@@ -11,5 +11,16 @@ describe('number module', () => {
         expect(toFixed(-0.0830894028175203)).toBe('-0.083');
         expect(toFixed(-0.0830894028175203, 4)).toBe('-0.08309');
         expect(toFixed(0)).toBe('0.00');
+    });
+
+    test('countFractionDigits', () => {
+        expect(countFractionDigits(0)).toBe(0);
+        expect(countFractionDigits(0.5)).toBe(1);
+        expect(countFractionDigits(0.25)).toBe(2);
+        expect(countFractionDigits(1)).toBe(0);
+        expect(countFractionDigits(1.5)).toBe(1);
+        expect(countFractionDigits(1.25)).toBe(2);
+        // AG-10143
+        expect(countFractionDigits(400 - 0.6)).toBe(1);
     });
 });

--- a/packages/ag-charts-community/src/util/number.ts
+++ b/packages/ag-charts-community/src/util/number.ts
@@ -55,3 +55,13 @@ export function mod(n: number, m: number) {
 
     return Math.floor((n % m) + m);
 }
+
+export const countFractionDigits = (value: number, maxFractionDigits = 10) => {
+    const decimal = (Math.abs(value) % 1).toFixed(maxFractionDigits); // 0.123 or 1.000
+    for (let i = decimal.length - 1; i >= 2 /* Decimal characters from index >= 2 */; i -= 1) {
+        if (decimal[i] !== '0') {
+            return maxFractionDigits - (decimal.length - 1 - i);
+        }
+    }
+    return 0;
+};

--- a/packages/ag-charts-community/src/util/ticks.ts
+++ b/packages/ag-charts-community/src/util/ticks.ts
@@ -1,3 +1,5 @@
+import { countFractionDigits } from './number';
+
 // @todo(AG-10085): Improve types for this
 export type NumericTicks = number[] & {
     fractionDigits: number;
@@ -73,15 +75,10 @@ export function singleTickDomain(a: number, b: number): number[] {
 }
 
 export function range(start: number, stop: number, step: number): NumericTicks {
-    const countDigits = (expNo: string) => {
-        const parts = expNo.split('e');
-        return Math.max((parts[0].split('.')[1]?.length ?? 0) - Number(parts[1]), 0);
-    };
-
     const d0 = Math.min(start, stop);
     const d1 = Math.max(start, stop);
 
-    const fractionalDigits = countDigits((step % 1).toExponential());
+    const fractionalDigits = countFractionDigits(step);
     const f = Math.pow(10, fractionalDigits);
     const n = Math.ceil((d1 - d0) / step);
     const values = createNumericTicks(fractionalDigits);


### PR DESCRIPTION
The issue was two parts. Firstly, the axis computes fractional digits, but these weren't used on the first layout. Secondly, the fraction digit logic was prone to floating point weirdness

Fix axis fraction digits not being used on first render, improve countFractionDigits logic

https://ag-grid.atlassian.net/browse/AG-10143