### PR TITLE
Enable batched builds for faster e2e CI times.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,22 @@ jobs:
                   check_id: ${{ steps.init_lint.outputs.check_id }}
                   conclusion: ${{ steps.lint.outcome }}
 
+            - name: nx batched build
+              id: batched_build
+              if: steps.yarn_install.outcome == 'success' || steps.yarn_install.outcome == 'skipped'
+              run: |
+                  COUNT=$(yarn --silent nx show projects --affected -t generate-examples,generate-thumbnails | wc -l)
+                  if [[ "${{ github.event.inputs.nx_command || 'affected' }}" != "affected" ]] ; then
+                    # Always run the Nx commands.
+                    echo "Forcibly running batched generation."
+                  elif [[ "${COUNT}" == "0" ]] ; then
+                    exit
+                  fi
+
+                  yarn nx ${{ github.event.inputs.nx_command || 'affected' }} -t build:types,
+                  yarn nx ${{ github.event.inputs.nx_command || 'affected' }} -t generate-examples --batch
+                  yarn nx ${{ github.event.inputs.nx_command || 'affected' }} -t generate-thumbnails --batch
+
             - name: nx build
               id: build
               if: steps.yarn_install.outcome == 'success' || steps.yarn_install.outcome == 'skipped'


### PR DESCRIPTION
Enable `--batch` for CI executions.