### PR TITLE
Ag 10245/gallery examples

### DIFF
--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-horizontal-bar/data.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-horizontal-bar/data.ts
@@ -1,0 +1,36 @@
+export function getData() {
+    return [
+        {
+            quarter: "Q1'19",
+            iphone: 104,
+            mac: 18,
+            ipad: 16,
+            wearables: 18,
+            services: 26,
+        },
+        {
+            quarter: "Q2'19",
+            iphone: 88,
+            mac: 20,
+            ipad: 16,
+            wearables: 18,
+            services: 40,
+        },
+        {
+            quarter: "Q3'19",
+            iphone: 76,
+            mac: 22,
+            ipad: 18,
+            wearables: 24,
+            services: 42,
+        },
+        {
+            quarter: "Q4'19",
+            iphone: 84,
+            mac: 22,
+            ipad: 14,
+            wearables: 20,
+            services: 40,
+        },
+    ];
+}

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-horizontal-bar/index.html
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-horizontal-bar/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-horizontal-bar/main.ts
@@ -1,0 +1,111 @@
+import { AgChartLabelFormatterParams, AgChartOptions, AgCharts } from 'ag-charts-community';
+
+import { getData } from './data';
+
+const label = {
+    formatter: ({ value }: AgChartLabelFormatterParams<number>) => value.toFixed(0),
+};
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: "Apple's Revenue by Product Category",
+    },
+    subtitle: {
+        text: 'In Billion U.S. Dollars',
+    },
+    data: getData(),
+    series: [
+        {
+            type: 'bar',
+            direction: 'horizontal',
+            xKey: 'quarter',
+            yKey: 'iphone',
+            yName: 'iPhone',
+            stackGroup: 'Devices',
+            strokeWidth: 2,
+            stroke: 'transparent',
+            label,
+        },
+        {
+            type: 'bar',
+            direction: 'horizontal',
+            xKey: 'quarter',
+            yKey: 'mac',
+            yName: 'Mac',
+            stackGroup: 'Devices',
+            strokeWidth: 2,
+            stroke: 'transparent',
+            label,
+        },
+        {
+            type: 'bar',
+            direction: 'horizontal',
+            xKey: 'quarter',
+            yKey: 'ipad',
+            yName: 'iPad',
+            stackGroup: 'Devices',
+            strokeWidth: 2,
+            stroke: 'transparent',
+            label,
+        },
+        {
+            type: 'bar',
+            direction: 'horizontal',
+            xKey: 'quarter',
+            yKey: 'wearables',
+            yName: 'Wearables',
+            stackGroup: 'Other',
+            strokeWidth: 2,
+            stroke: 'transparent',
+            label,
+        },
+        {
+            type: 'bar',
+            direction: 'horizontal',
+            xKey: 'quarter',
+            yKey: 'services',
+            yName: 'Services',
+            stackGroup: 'Other',
+            strokeWidth: 2,
+            stroke: 'transparent',
+            label,
+        },
+    ],
+    axes: [
+        {
+            position: 'left',
+            type: 'category',
+            paddingInner: 0.2,
+            paddingOuter: 0.2,
+            groupPaddingInner: 0.2,
+            crossLines: [
+                {
+                    type: 'range',
+                    range: ["Q1'19", "Q1'19"],
+                    strokeWidth: 0,
+                },
+                {
+                    type: 'range',
+                    range: ["Q3'19", "Q3'19"],
+                    strokeWidth: 0,
+                },
+            ],
+            label: {
+                enabled: false,
+            },
+            line: {
+                enabled: false,
+            },
+        },
+        {
+            position: 'top',
+            type: 'number',
+            tick: {
+                interval: 20,
+            },
+        },
+    ],
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-gaps/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-gaps/main.ts
@@ -81,7 +81,13 @@ const options: AgChartOptions = {
                 text: 'Week',
             },
             label: {
-                formatter: (params) => (params.index % 3 ? '' : params.value),
+                enabled: false,
+            },
+            gridLine: {
+                enabled: true,
+            },
+            line: {
+                enabled: false,
             },
         },
         {
@@ -89,6 +95,13 @@ const options: AgChartOptions = {
             position: 'left',
             title: {
                 text: '£ per kg',
+            },
+            tick: {
+                size: 0,
+                interval: 0.05,
+            },
+            label: {
+                enabled: false,
             },
         },
     ],

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-bar/main.ts
@@ -23,6 +23,7 @@ const options: AgChartOptions = {
             xKey: 'quarter',
             yKey: 'ipad',
             yName: 'iPad',
+            fillOpacity: 0.6,
         },
         {
             type: 'bar',
@@ -35,6 +36,7 @@ const options: AgChartOptions = {
             xKey: 'quarter',
             yKey: 'services',
             yName: 'Services',
+            fillOpacity: 0.6,
         },
     ],
     axes: [

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-horizontal-bar/data.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-horizontal-bar/data.ts
@@ -1,36 +1,20 @@
 export function getData() {
     return [
         {
-            quarter: "Q1'18",
-            iphone: 55,
-            mac: 16,
-            ipad: 14,
-            wearables: 12,
-            services: 20,
+            quarter: 'Q1',
+            sales: 16,
         },
         {
-            quarter: "Q2'18",
-            iphone: 44,
-            mac: 20,
-            ipad: 14,
-            wearables: 12,
-            services: 30,
+            quarter: 'Q2',
+            sales: 20,
         },
         {
-            quarter: "Q3'18",
-            iphone: 52,
-            mac: 20,
-            ipad: 18,
-            wearables: 14,
-            services: 36,
+            quarter: 'Q3',
+            sales: 19,
         },
         {
-            quarter: "Q4'18",
-            iphone: 58,
-            mac: 24,
-            ipad: 14,
-            wearables: 14,
-            services: 36,
+            quarter: 'Q4',
+            sales: 24,
         },
     ];
 }

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-horizontal-bar/main.ts
@@ -5,7 +5,7 @@ import { getData } from './data';
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {
-        text: 'MacBook Sales',
+        text: 'Laptop Sales',
     },
     subtitle: {
         text: 'In Billion U.S. Dollars',

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-horizontal-bar/main.ts
@@ -5,7 +5,7 @@ import { getData } from './data';
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {
-        text: "Apple's Revenue by Product Category",
+        text: 'MacBook Sales',
     },
     subtitle: {
         text: 'In Billion U.S. Dollars',
@@ -16,44 +16,28 @@ const options: AgChartOptions = {
             type: 'bar',
             direction: 'horizontal',
             xKey: 'quarter',
-            yKey: 'iphone',
-            yName: 'iPhone',
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'mac',
-            yName: 'Mac',
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'ipad',
-            yName: 'iPad',
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'wearables',
-            yName: 'Wearables',
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'services',
-            yName: 'Services',
+            yKey: 'sales',
+            yName: 'Sales',
+            label: {
+                formatter: ({ value }) => `$${value.toFixed(0)}B`,
+            },
         },
     ],
     axes: [
         {
             type: 'category',
             position: 'left',
+            paddingInner: 0.4,
+            paddingOuter: 0.5,
+            groupPaddingInner: 0,
             line: {
                 enabled: false,
+            },
+            gridLine: {
+                enabled: true,
+            },
+            tick: {
+                enabled: true,
             },
         },
         {
@@ -61,7 +45,7 @@ const options: AgChartOptions = {
             position: 'bottom',
             reverse: true,
             tick: {
-                interval: 60,
+                enabled: true,
             },
         },
     ],

--- a/packages/ag-charts-website/src/content/gallery/data.json
+++ b/packages/ag-charts-website/src/content/gallery/data.json
@@ -63,6 +63,11 @@
                         "name": "grouped-horizontal-bar"
                     },
                     {
+                        "title": "Grouped Stacked Horizontal Bar",
+                        "description": "",
+                        "name": "grouped-stacked-horizontal-bar"
+                    },
+                    {
                         "title": "Reversed Horizontal Bar",
                         "description": "",
                         "name": "reversed-horizontal-bar"


### PR DESCRIPTION
PR for gallery examples, added another bar example to make it a multiple of 3 so that the line series doesn't display on the same row as the bars in the 3 column layout. Plus minor improvements to other examples.

<img width="1270" alt="Screenshot 2024-01-12 at 18 01 08" src="https://github.com/ag-grid/ag-charts/assets/25513526/5c339f23-106f-43d1-abe4-25ec7f832840">
<img width="1270" alt="Screenshot 2024-01-12 at 18 01 37" src="https://github.com/ag-grid/ag-charts/assets/25513526/325232a9-4057-4bf1-814a-61b5818195ec">
