### PR TITLE
Add FW wrapper watches

### DIFF
--- a/.github/workflows/sonar-scanner-release.yml
+++ b/.github/workflows/sonar-scanner-release.yml
@@ -20,14 +20,16 @@ jobs:
             - name: Checkout
               id: checkout
               uses: actions/checkout@v3
-              with:
-                  fetch-depth: 1
             - name: Setup Node.js
               id: setup_node
               uses: actions/setup-node@v3
               with:
                   node-version: '18'
                   cache: 'yarn'
+            - uses: actions/setup-java@v4
+              with:
+                  distribution: 'oracle'
+                  java-version: '17'
             - name: yarn install
               id: yarn_install
               run: yarn install --ci --prefer-offline

--- a/.github/workflows/sonar-scanner.yml
+++ b/.github/workflows/sonar-scanner.yml
@@ -21,14 +21,16 @@ jobs:
             - name: Checkout
               id: checkout
               uses: actions/checkout@v3
-              with:
-                  fetch-depth: 1
             - name: Setup Node.js
               id: setup_node
               uses: actions/setup-node@v3
               with:
                   node-version: '18'
-                  cache: 'yarn'
+                    cache: 'yarn'
+            - uses: actions/setup-java@v4
+              with:
+                distribution: 'oracle'
+                java-version: '17'
             - name: yarn install
               id: yarn_install
               run: yarn install --ci --prefer-offline

--- a/.github/workflows/sonar-scanner.yml
+++ b/.github/workflows/sonar-scanner.yml
@@ -26,11 +26,11 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: '18'
-                    cache: 'yarn'
+                  cache: 'yarn'
             - uses: actions/setup-java@v4
               with:
-                distribution: 'oracle'
-                java-version: '17'
+                  distribution: 'oracle'
+                  java-version: '17'
             - name: yarn install
               id: yarn_install
               run: yarn install --ci --prefer-offline

--- a/nx.json
+++ b/nx.json
@@ -6,17 +6,22 @@
   },
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
-    "production": [
-      "default",
+    "defaultExcludes": [
       "!{projectRoot}/.eslintrc.json",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
       "!{projectRoot}/**/test/**",
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/jest.config.[jt]s"
     ],
+    "production": ["default", "defaultExcludes"],
     "tsDeclarations": [
       {
         "dependentTasksOutputFiles": "**/*.d.ts"
+      }
+    ],
+    "jsOutputs": [
+      {
+        "dependentTasksOutputFiles": "**/*.js"
       }
     ],
     "tsDefaults": [
@@ -49,7 +54,7 @@
     },
     "build:umd": {
       "dependsOn": ["build:package", "^build:package"],
-      "inputs": ["production", "^production"],
+      "inputs": ["^jsOutputs"],
       "cache": true
     },
     "lint": {

--- a/packages/ag-charts-angular/angular.json
+++ b/packages/ag-charts-angular/angular.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+    "$schema": "../../node_modules/@angular/cli/lib/config/schema.json",
     "version": 1,
     "newProjectRoot": "projects",
     "projects": {
@@ -43,5 +43,11 @@
                 }
             }
         }
+    },
+    "cli": {
+      "analytics": false,
+      "cache": {
+        "enabled": false
+      }
     }
 }

--- a/packages/ag-charts-angular/angular.json
+++ b/packages/ag-charts-angular/angular.json
@@ -45,9 +45,9 @@
         }
     },
     "cli": {
-      "analytics": false,
-      "cache": {
-        "enabled": false
-      }
+        "analytics": false,
+        "cache": {
+            "enabled": false
+        }
     }
 }

--- a/packages/ag-charts-angular/project.json
+++ b/packages/ag-charts-angular/project.json
@@ -12,6 +12,7 @@
         "{projectRoot}/projects/**",
         { "externalDependencies": ["@angular/cli", "@angular/core"] }
       ],
+      "cache": true,
       "outputs": ["{projectRoot}/dist"],
       "options": {
         "script": "build"
@@ -20,13 +21,11 @@
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/dist/ag-charts-angular/"],
       "outputs": ["{workspaceRoot}/dist/packages/ag-charts-angular.tgz"],
       "options": {
-        "cwd": "packages/ag-charts-angular/dist/ag-charts-angular",
-        "commands": [
-          "mkdir -p ../../../../dist/packages",
-          "yarn pack -f ../../../../dist/packages/ag-charts-angular.tgz"
-        ]
+        "cwd": "{projectRoot}//dist/ag-charts-angular",
+        "commands": ["mkdir -p ../../../../dist/packages", "yarn pack -f ../../../../dist/{projectRoot}.tgz"]
       }
     },
     "pack:extract": {

--- a/packages/ag-charts-angular/project.json
+++ b/packages/ag-charts-angular/project.json
@@ -22,7 +22,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "inputs": ["{projectRoot}/dist/ag-charts-angular/"],
-      "outputs": ["{workspaceRoot}/dist/packages/ag-charts-angular.tgz"],
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "options": {
         "cwd": "{projectRoot}//dist/ag-charts-angular",
         "commands": ["mkdir -p ../../../../dist/packages", "yarn pack -f ../../../../dist/{projectRoot}.tgz"]
@@ -31,17 +31,19 @@
     "pack:extract": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack"],
+      "inputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "outputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-angular/"],
       "options": {
         "commands": [
           "mkdir -p dist/packages/contents/ag-charts-angular",
-          "tar -xzf dist/packages/ag-charts-angular.tgz -C dist/packages/contents/ag-charts-angular/"
+          "tar -xzf dist/{projectRoot}.tgz -C dist/packages/contents/ag-charts-angular/"
         ]
       }
     },
     "pack:verify": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack:extract"],
+      "inputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-angular/"],
       "options": {
         "commands": ["node tools/sanity-check-package.js dist/packages/contents/ag-charts-angular/package"]
       }

--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -63,6 +63,7 @@
     "build:umd": {
       "executor": "@nx/esbuild:esbuild",
       "dependsOn": ["build:package"],
+      "inputs": ["jsOutputs"],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "packages/ag-charts-community/dist/umd",

--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -187,7 +187,7 @@
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
-      "outputs": ["{workspaceRoot}/dist/packages/ag-charts-community.tgz"],
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "options": {
         "cwd": "packages/ag-charts-community",
         "commands": ["mkdir -p ../../dist/packages", "yarn pack -f ../../dist/packages/ag-charts-community.tgz"]
@@ -196,6 +196,7 @@
     "pack:extract": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack"],
+      "inputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "outputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-community/"],
       "options": {
         "commands": [
@@ -207,6 +208,7 @@
     "pack:verify": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack:extract"],
+      "inputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-community/"],
       "options": {
         "commands": ["node tools/sanity-check-package.js dist/packages/contents/ag-charts-community/package"]
       }

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -144,7 +144,7 @@
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
-      "outputs": ["{workspaceRoot}/dist/packages/ag-charts-enterprise.tgz"],
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "options": {
         "cwd": "packages/ag-charts-enterprise",
         "commands": ["mkdir -p ../../dist/packages", "yarn pack -f ../../dist/packages/ag-charts-enterprise.tgz"]
@@ -153,6 +153,7 @@
     "pack:extract": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack"],
+      "inputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "outputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-enterprise/"],
       "options": {
         "commands": [
@@ -164,6 +165,7 @@
     "pack:verify": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack:extract"],
+      "inputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-enterprise/"],
       "options": {
         "commands": ["node tools/sanity-check-package.js dist/packages/contents/ag-charts-enterprise/package"]
       }

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -64,6 +64,7 @@
     "build:umd": {
       "executor": "@nx/esbuild:esbuild",
       "dependsOn": ["build:package", "^build:package"],
+      "inputs": ["jsOutputs"],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "packages/ag-charts-enterprise/dist/umd",

--- a/packages/ag-charts-react/project.json
+++ b/packages/ag-charts-react/project.json
@@ -85,7 +85,7 @@
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
-      "outputs": ["{workspaceRoot}/dist/packages/ag-charts-react.tgz"],
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "options": {
         "cwd": "packages/ag-charts-react",
         "commands": ["mkdir -p ../../dist/packages", "yarn pack -f ../../dist/packages/ag-charts-react.tgz"]
@@ -94,6 +94,7 @@
     "pack:extract": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack"],
+      "inputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "outputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-react/"],
       "options": {
         "commands": [
@@ -105,6 +106,7 @@
     "pack:verify": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack:extract"],
+      "inputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-react/"],
       "options": {
         "commands": ["node tools/sanity-check-package.js dist/packages/contents/ag-charts-react/package"]
       }

--- a/packages/ag-charts-vue/project.json
+++ b/packages/ag-charts-vue/project.json
@@ -21,7 +21,7 @@
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
-      "outputs": ["{workspaceRoot}/dist/packages/ag-charts-vue.tgz"],
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "options": {
         "cwd": "packages/ag-charts-vue",
         "commands": ["mkdir -p ../../dist/packages", "yarn pack -f ../../dist/packages/ag-charts-vue.tgz"]
@@ -30,6 +30,7 @@
     "pack:extract": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack"],
+      "inputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "outputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-vue/"],
       "options": {
         "commands": [
@@ -41,6 +42,7 @@
     "pack:verify": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack:extract"],
+      "inputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-vue/"],
       "options": {
         "commands": ["node tools/sanity-check-package.js dist/packages/contents/ag-charts-vue/package"]
       }

--- a/packages/ag-charts-vue3/project.json
+++ b/packages/ag-charts-vue3/project.json
@@ -21,7 +21,7 @@
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
-      "outputs": ["{workspaceRoot}/dist/packages/ag-charts-vue3.tgz"],
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "options": {
         "cwd": "packages/ag-charts-vue3",
         "commands": ["mkdir -p ../../dist/packages", "yarn pack -f ../../dist/packages/ag-charts-vue3.tgz"]
@@ -30,6 +30,7 @@
     "pack:extract": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack"],
+      "inputs": ["{workspaceRoot}/dist/{projectRoot}.tgz"],
       "outputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-vue3/"],
       "options": {
         "commands": [
@@ -41,6 +42,7 @@
     "pack:verify": {
       "executor": "nx:run-commands",
       "dependsOn": ["pack:extract"],
+      "inputs": ["{workspaceRoot}/dist/packages/contents/ag-charts-vue3/"],
       "options": {
         "commands": ["node tools/sanity-check-package.js dist/packages/contents/ag-charts-vue3/package"]
       }

--- a/packages/all/dev.sh
+++ b/packages/all/dev.sh
@@ -4,6 +4,9 @@ MODIFIED=$1
 
 if [[ "${MODIFIED}" == "ag-charts-community" ]] ; then
   nx run-many -p ag-charts-community,ag-charts-enterprise -t build:types,build:package,build:umd,docs-resolved-interfaces -c watch
-else
+elif [[ "${MODIFIED}" == "ag-charts-enterprise" ]] ; then
   nx run-many -p ${MODIFIED} -t build:types,build:package,build:umd -c watch
+else
+  echo $NX_FILE_CHANGES
+  nx run-many -p ${MODIFIED} -t build
 fi

--- a/packages/all/project.json
+++ b/packages/all/project.json
@@ -67,6 +67,7 @@
         "parallel": true,
         "commands": [
           "while true ; do nx watch -p ag-charts-community,ag-charts-enterprise -- {projectRoot}/dev.sh \\${NX_PROJECT_NAME} ; done",
+          "while true ; do nx watch -p ag-charts-angular,ag-charts-react,ag-charts-vue,ag-charts-vue3 -- {projectRoot}/dev.sh \\${NX_PROJECT_NAME} ; done",
           "while true ; do nx watch -p ag-charts-website-* -- nx build \\${NX_PROJECT_NAME}:generate; done",
           "nx run ag-charts-website:dev"
         ]


### PR DESCRIPTION
Several tooling fixes:
- Adds FW wrappers watching to `nx dev`.
- SonarCloud bump to Java 17 (fixes warnings in reports)
- Perform full clone for SonarCloud blame handling.
- Improves cachability of several build targets.