### PR TITLE
AG-10368 Convert to standalone component

### DIFF
--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
@@ -23,6 +23,7 @@ import {
 // noinspection AngularIncorrectTemplateDefinition
 @Component({
     selector: 'ag-charts-angular',
+    standalone: true,
     template: '',
     encapsulation: ViewEncapsulation.None,
 })

--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.module.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.module.ts
@@ -3,8 +3,8 @@ import { NgModule } from '@angular/core';
 import { AgChartsAngular } from './ag-charts-angular.component';
 
 @NgModule({
-    declarations: [AgChartsAngular],
-    imports: [],
+    declarations: [],
+    imports: [AgChartsAngular],
     exports: [AgChartsAngular],
 })
 export class AgChartsAngularModule {}

--- a/packages/ag-charts-website/src/content/docs/installation/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/installation/index.mdoc
@@ -164,12 +164,12 @@ const MyChart = (options) => {
 {% if isFramework("angular") %}
 
 ```javascript
-import { AgChartsAngularModule } from 'ag-charts-angular';
+import { AgChartsAngular } from 'ag-charts-angular';
 
 @Component({
     selector: 'my-app',
     standalone: true,
-    imports: [AgChartsAngularModule],
+    imports: [AgChartsAngular],
     template: `<ag-charts-angular style="height: 100%" [options]="options"></ag-charts-angular> `,
 })
 export class MyAppComponent {

--- a/packages/ag-charts-website/src/content/docs/quick-start/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/quick-start/index.mdoc
@@ -182,13 +182,13 @@ Replace your `app.component.ts` file (or root component) with the following:
 
 ```js
 import { Component } from '@angular/core';
-import { AgChartsAngularModule } from 'ag-charts-angular';
+import { AgChartsAngular } from 'ag-charts-angular';
 import { AgChartOptions } from 'ag-charts-community';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [AgChartsAngularModule],
+  imports: [AgChartsAngular],
   // ag-charts-angular component with chartOptions attribute
   template:
   `<ag-charts-angular

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
@@ -22,9 +22,7 @@ function getImports(bindings, componentFileNames: string[], { typeParts }): stri
     });
 
     const imports = [`import { Component${bindings.usesChartApi ? ', ViewChild' : ''} } from '@angular/core';`];
-    imports.push(
-        `import { AgChartsAngularModule${bindings.usesChartApi ? ', AgChartsAngular' : ''} } from 'ag-charts-angular';`
-    );
+    imports.push(`import { AgChartsAngular } from 'ag-charts-angular';`);
 
     addBindingImports([...bImports], imports, true, true);
 
@@ -83,7 +81,7 @@ export async function vanillaToAngular(bindings: any, componentFileNames: string
 @Component({
     selector: 'my-app',
     standalone: true,
-    imports: [AgChartsAngularModule],
+    imports: [AgChartsAngular],
     template: \`${template}\`
 })
 


### PR DESCRIPTION
Angular now supports standalone components which means you do not need to use modules. 

By declaring the `AgChartAngular` as `standalone` it can directly be imported instead of via the `AgChartAngularModule`.

This change is backwards compatible.

I have updated the examples to use the component directly as there is no advantage to using the module.