### PR TITLE
AG-10341 Fix line labels not animating when visibility changes

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -365,7 +365,7 @@ export function prepareLinePathAnimation(
         return;
     }
 
-    const hasMotion: boolean = (diff?.changed ?? true) || scalesChanged(newData, oldData);
+    const hasMotion: boolean = (diff?.changed ?? true) || scalesChanged(newData, oldData) || status !== 'updated';
     const pathFns = prepareLinePathAnimationFns(newData, oldData, pairData, 'fade', renderPartialPath);
     const marker = prepareMarkerAnimation(pairMap, status);
     return { ...pathFns, marker, hasMotion };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10341 

Label animation was skipped when the visibility changed from the legend toggle as neither the diff nor the scales had changed.

This is the simplest fix, but may be missing something?