### PR TITLE
AG-8219 Fix zoom selection to consider series area padding

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -66,12 +66,12 @@ export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
         let x: ZoomState | undefined;
         let y: ZoomState | undefined;
 
-        // TODO: this only works when there is a single axis on each direction as it gets the last of each
+        // Use the zoom on the primary (first) axis in each direction
         Object.values(this.axes).forEach((axis) => {
             if (axis.getDirection() === ChartAxisDirection.X) {
-                x = axis.getZoom();
+                x ??= axis.getZoom();
             } else if (axis.getDirection() === ChartAxisDirection.Y) {
-                y = axis.getZoom();
+                y ??= axis.getZoom();
             }
         });
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -260,7 +260,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         } else if (this.enablePanning && this.panner.isPanning) {
             this.panner.stop();
         } else if (this.enableSelecting && !this.isMinZoom(zoom)) {
-            const newZoom = this.selector.stop(this.seriesRect, zoom);
+            const newZoom = this.selector.stop(this.seriesRect, this.paddedRect, zoom);
             this.updateZoom(newZoom);
         }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -69,7 +69,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     public axes: 'x' | 'y' | 'xy' = 'x';
 
     @Validate(RATIO)
-    public scrollingStep = UNIT.max / 10;
+    public scrollingStep = (UNIT.max - UNIT.min) / 10;
 
     @Validate(NUMBER.restrict({ min: 1 }))
     public minVisibleItemsX = 2;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTransformers.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTransformers.ts
@@ -116,6 +116,13 @@ export function scaleZoomAxisWithPoint(
     return { min, max };
 }
 
+export function multiplyZoom(zoom: DefinedZoomState, nx: number, ny: number) {
+    return {
+        x: { min: zoom.x.min * nx, max: zoom.x.max * nx },
+        y: { min: zoom.y.min * ny, max: zoom.y.max * ny },
+    };
+}
+
 /**
  * Constrain a zoom bounding box such that no corner exceeds an edge while maintaining the same width and height.
  */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8219

Fixes zoom to correctly consider series area padding, in particular zoom selection.

Also fixes `zoomManager.getZoom()` to return the first axis zoom (per direction), considering that to the be the primary axis. Previously it returned the last axis zoom.

Note in this example, we select the area from 80 to 40 on the y-axis. It zooms such that those are the points at the top and bottom of the series area, but the line can overflow into the padded area.

https://github.com/ag-grid/ag-charts/assets/3817697/dcc538c2-772a-487b-b7ee-6614f928c33f

