### PR TITLE
AG-10337 Count missing datums per series

### DIFF
--- a/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -8,7 +8,9 @@ exports[`DataModel empty data set processing should generated the expected resul
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "year",
         "scopes": [
           "test",
@@ -22,7 +24,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "groupId": undefined,
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "ie",
         "scopes": [
           "test",
@@ -35,7 +39,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "groupId": undefined,
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "chrome",
         "scopes": [
           "test",
@@ -48,7 +54,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "groupId": undefined,
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "firefox",
         "scopes": [
           "test",
@@ -61,7 +69,9 @@ exports[`DataModel empty data set processing should generated the expected resul
         "groupId": undefined,
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "safari",
         "scopes": [
           "test",
@@ -272,7 +282,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "curb-weight",
         "scope": "test",
         "type": "key",
@@ -284,7 +296,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         "groupId": "weight",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "curb-weight",
         "scopes": [
           "test",
@@ -551,7 +565,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "engine-size",
         "scopes": [
           "test",
@@ -565,7 +581,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
         "groupId": "mpg",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "highway-mpg",
         "scopes": [
           "test",
@@ -774,7 +792,9 @@ exports[`DataModel grouped processing - calculated grouping should generated the
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "engine-size",
         "scopes": [
           "test",
@@ -1025,7 +1045,9 @@ exports[`DataModel grouped processing - grouped example should generated the exp
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "type",
         "scopes": [
           "test",
@@ -1039,7 +1061,9 @@ exports[`DataModel grouped processing - grouped example should generated the exp
         "groupId": "all",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "total",
         "scopes": [
           "test",
@@ -1052,7 +1076,9 @@ exports[`DataModel grouped processing - grouped example should generated the exp
         "groupId": "all",
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "regular",
         "scopes": [
           "test",
@@ -1541,7 +1567,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "month",
         "scopes": [
           "test",
@@ -1555,7 +1583,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "petroleum",
         "scopes": [
           "test",
@@ -1568,7 +1598,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "naturalGas",
         "scopes": [
           "test",
@@ -1581,7 +1613,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "bioenergyWaste",
         "scopes": [
           "test",
@@ -1594,7 +1628,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "nuclear",
         "scopes": [
           "test",
@@ -1607,7 +1643,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 4,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "windSolarHydro",
         "scopes": [
           "test",
@@ -1620,7 +1658,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 5,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "imported",
         "scopes": [
           "test",
@@ -1908,7 +1948,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "type",
         "scopes": [
           "test",
@@ -1922,7 +1964,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "white",
         "scopes": [
           "test",
@@ -1935,7 +1979,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "mixed",
         "scopes": [
           "test",
@@ -1948,7 +1994,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "asian",
         "scopes": [
           "test",
@@ -1961,7 +2009,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "black",
         "scopes": [
           "test",
@@ -1974,7 +2024,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 4,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "chinese",
         "scopes": [
           "test",
@@ -1987,7 +2039,9 @@ exports[`DataModel grouped processing - stacked and normalised example should ge
         "groupId": "all",
         "id": undefined,
         "index": 5,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "other",
         "scopes": [
           "test",
@@ -2314,7 +2368,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "type",
         "scopes": [
           "test",
@@ -2328,7 +2384,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "groupId": "all",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "ownerOccupied",
         "scopes": [
           "test",
@@ -2341,7 +2399,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "groupId": "all",
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "privateRented",
         "scopes": [
           "test",
@@ -2354,7 +2414,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "groupId": "all",
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "localAuthority",
         "scopes": [
           "test",
@@ -2367,7 +2429,9 @@ exports[`DataModel grouped processing - stacked example should generated the exp
         "groupId": "all",
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "housingAssociation",
         "scopes": [
           "test",
@@ -2698,7 +2762,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "type",
         "scopes": [
           "test",
@@ -2712,7 +2778,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "groupId": "all",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "ownerOccupied",
         "scopes": [
@@ -2726,7 +2794,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "groupId": "all",
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "privateRented",
         "scopes": [
@@ -2740,7 +2810,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "groupId": "all",
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "localAuthority",
         "scopes": [
@@ -2754,7 +2826,9 @@ exports[`DataModel grouped processing - stacked with accumulation and normalised
         "groupId": "all",
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "housingAssociation",
         "scopes": [
@@ -3038,7 +3112,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "type",
         "scopes": [
           "test",
@@ -3052,7 +3128,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "groupId": "ownerOccupied",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "ownerOccupied",
         "scopes": [
@@ -3066,7 +3144,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "groupId": "privateRented",
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "privateRented",
         "scopes": [
@@ -3080,7 +3160,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "groupId": "localAuthority",
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "localAuthority",
         "scopes": [
@@ -3094,7 +3176,9 @@ exports[`DataModel grouped processing - stacked with accumulation example should
         "groupId": "housingAssociation",
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "housingAssociation",
         "scopes": [
@@ -3367,7 +3451,9 @@ exports[`DataModel missing and invalid data processing - multiple scopes should 
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "year",
         "scopes": [
           "test",
@@ -3381,7 +3467,9 @@ exports[`DataModel missing and invalid data processing - multiple scopes should 
         "groupId": undefined,
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "ie",
         "scopes": undefined,
@@ -3394,7 +3482,9 @@ exports[`DataModel missing and invalid data processing - multiple scopes should 
         "groupId": undefined,
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "chrome",
         "scopes": [
@@ -3409,7 +3499,9 @@ exports[`DataModel missing and invalid data processing - multiple scopes should 
         "groupId": undefined,
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "firefox",
         "scopes": [
@@ -3424,7 +3516,9 @@ exports[`DataModel missing and invalid data processing - multiple scopes should 
         "groupId": undefined,
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "safari",
         "scopes": [
@@ -3677,7 +3771,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "year",
         "scopes": [
           "test",
@@ -3692,7 +3788,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "id": undefined,
         "index": 0,
         "invalidValue": NaN,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "ie",
         "scopes": [
@@ -3708,7 +3806,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "id": undefined,
         "index": 1,
         "invalidValue": NaN,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "chrome",
         "scopes": [
@@ -3724,7 +3824,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "id": undefined,
         "index": 2,
         "invalidValue": NaN,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "firefox",
         "scopes": [
@@ -3740,7 +3842,9 @@ exports[`DataModel missing and invalid data processing should generated the expe
         "id": undefined,
         "index": 3,
         "invalidValue": NaN,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "missingValue": null,
         "property": "safari",
         "scopes": [
@@ -4268,7 +4372,9 @@ exports[`DataModel multiple data sources should generate the expected results 1`
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "year",
         "scopes": [
           "test1",
@@ -4284,7 +4390,9 @@ exports[`DataModel multiple data sources should generate the expected results 1`
         "groupId": undefined,
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "ie",
         "scopes": [
           "test1",
@@ -4298,7 +4406,9 @@ exports[`DataModel multiple data sources should generate the expected results 1`
         "groupId": undefined,
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "chrome",
         "scopes": [
           "test1",
@@ -4312,7 +4422,9 @@ exports[`DataModel multiple data sources should generate the expected results 1`
         "groupId": undefined,
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "firefox",
         "scopes": [
           "test1",
@@ -4326,7 +4438,9 @@ exports[`DataModel multiple data sources should generate the expected results 1`
         "groupId": undefined,
         "id": undefined,
         "index": 3,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "safari",
         "scopes": [
           "test1",
@@ -4454,7 +4568,9 @@ exports[`DataModel repeated property processing should generated the expected re
         "groupId": "angleGroup",
         "id": "angle",
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "share",
         "scopes": [
@@ -4467,7 +4583,9 @@ exports[`DataModel repeated property processing should generated the expected re
       {
         "id": "radius",
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "share",
         "scopes": [
@@ -4609,7 +4727,9 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
         "groupId": "population",
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "processor": [Function],
         "property": "population",
         "scopes": [
@@ -4621,7 +4741,9 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
       },
       {
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "religion",
         "scopes": [
           "test",
@@ -4633,7 +4755,9 @@ exports[`DataModel ungrouped processing - accumulated and normalised properties 
         "groupId": undefined,
         "id": undefined,
         "index": 2,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "population",
         "scopes": [
           "test",
@@ -5413,7 +5537,9 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
     "keys": [
       {
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "date",
         "scope": "test",
         "type": "key",
@@ -5425,7 +5551,9 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
         "groupId": undefined,
         "id": undefined,
         "index": 0,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "petrol",
         "scopes": [
           "test",
@@ -5438,7 +5566,9 @@ exports[`DataModel ungrouped processing should generated the expected results 1`
         "groupId": undefined,
         "id": undefined,
         "index": 1,
-        "missing": 0,
+        "missing": Map {
+          undefined => 0,
+        },
         "property": "diesel",
         "scopes": [
           "test",

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -4,6 +4,7 @@ import { isNumber } from '../../util/value';
 import { rangedValueProperty } from '../series/series';
 import { DATA_BROWSER_MARKET_SHARE } from '../test/data';
 import * as examples from '../test/examples';
+import { expectWarning, expectWarnings, setupMockConsole } from '../test/mockConsole';
 import {
     accumulatedValue,
     area as actualArea,
@@ -69,6 +70,8 @@ const normalisePropertyTo = (prop: PropertyId<any>, normaliseTo: [number, number
     actualNormalisePropertyTo({ id: 'test' }, prop, normaliseTo);
 
 describe('DataModel', () => {
+    setupMockConsole();
+
     describe('ungrouped processing', () => {
         it('should generated the expected results', () => {
             const data = examples.SIMPLE_LINE_CHART_EXAMPLE.data ?? [];
@@ -431,6 +434,7 @@ describe('DataModel', () => {
                 expect(result?.data[1].keys).toEqual([new Date('2023-01-02T00:00:00.000Z')]);
                 expect(result?.data[2].keys).toEqual([new Date('2023-01-03T00:00:00.000Z')]);
                 expect(result?.data[3].keys).toEqual([new Date('2023-01-04T00:00:00.000Z')]);
+                expectWarning('AG Charts - invalid value of type [object] ignored:', '[null]');
             });
 
             it('should extract the configured values', () => {
@@ -442,6 +446,7 @@ describe('DataModel', () => {
                 expect(result?.data[1].values).toEqual([[1, 2]]);
                 expect(result?.data[2].values).toEqual([[6, 9]]);
                 expect(result?.data[3].values).toEqual([[6, 9]]);
+                expectWarning('AG Charts - invalid value of type [object] ignored:', '[null]');
             });
 
             it('should calculate the domains', () => {
@@ -453,6 +458,7 @@ describe('DataModel', () => {
                     [1, 6],
                     [2, 9],
                 ]);
+                expectWarning('AG Charts - invalid value of type [object] ignored:', '[null]');
             });
 
             it('should not include sums', () => {
@@ -460,6 +466,7 @@ describe('DataModel', () => {
 
                 expect(result?.data.filter((g) => g.aggValues != null)).toEqual([]);
                 expect(result?.domain.aggValues).toBeUndefined();
+                expectWarning('AG Charts - invalid value of type [object] ignored:', '[null]');
             });
 
             it('should only sum per data-item', () => {
@@ -1002,6 +1009,10 @@ describe('DataModel', () => {
             expect(dataModel.processData(data)).toMatchSnapshot({
                 time: expect.any(Number),
             });
+            expectWarnings([
+                ['AG Charts - invalid value of type [string] ignored:', '[illegal value]'],
+                ['AG Charts - invalid value of type [undefined] ignored:', '[undefined]'],
+            ]);
         });
 
         describe('property tests', () => {
@@ -1030,6 +1041,7 @@ describe('DataModel', () => {
                 expect(result?.data[0].validScopes).toEqual(['scope-2']);
                 expect(result?.data[1].validScopes).toBeUndefined();
                 expect(result?.data[2].validScopes).toBeUndefined();
+                expectWarning('AG Charts - invalid value of type [string] ignored:', '[illegal value]');
             });
 
             it('should handle scope validations distinctly for values', () => {
@@ -1039,6 +1051,7 @@ describe('DataModel', () => {
                 expect(result?.data[0].values).toEqual([[1, undefined, 2]]);
                 expect(result?.data[1].values).toEqual([[6, 9, 'illegal value']]);
                 expect(result?.data[2].values).toEqual([[6, 9, 4]]);
+                expectWarning('AG Charts - invalid value of type [string] ignored:', '[illegal value]');
             });
         });
     });

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -20,7 +20,7 @@ import type { Has } from '../../../util/types';
 import { isNumber } from '../../../util/value';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
-import type { DataModel } from '../../data/dataModel';
+import { DataModel, getMissCount } from '../../data/dataModel';
 import { animationValidation, diff, normalisePropertyTo } from '../../data/processors';
 import type { LegendItemClickChartEvent } from '../../interaction/chartEventManager';
 import { Layers } from '../../layers';
@@ -270,10 +270,11 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
             // If any 'angleRaw' values are missing, then we'll also be missing 'angleValue' values and
             // will log a warning anyway.
             const { id, missing, property } = valueDef;
-            if (id !== 'angleRaw' && missing !== undefined && missing > 0) {
+            const missCount = getMissCount(this, missing);
+            if (id !== 'angleRaw' && missCount > 0) {
                 Logger.warnOnce(
-                    `no value was found for the key '${String(property)}' on ${missing} data element${
-                        missing > 1 ? 's' : ''
+                    `no value was found for the key '${String(property)}' on ${missCount} data element${
+                        missCount > 1 ? 's' : ''
                     }`
                 );
             }

--- a/packages/ag-charts-community/src/chart/test/mockConsole.ts
+++ b/packages/ag-charts-community/src/chart/test/mockConsole.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-console */
+import { expect } from '@jest/globals';
+
+import { clearDoOnceFlags } from '../../util/function';
+
+export function setupMockConsole() {
+    beforeEach(() => {
+        console.warn = jest.fn();
+        console.error = jest.fn();
+    });
+
+    afterEach(() => {
+        expect(console.warn).not.toBeCalled();
+        expect(console.error).not.toBeCalled();
+        (console.warn as jest.Mock).mockClear();
+        (console.error as jest.Mock).mockClear();
+        clearDoOnceFlags();
+    });
+}
+
+export function expectWarnings(callArgs: any[][]) {
+    for (let i = 0; i < callArgs.length; i++) {
+        expect(console.warn).nthCalledWith(i + 1, ...callArgs[i]);
+    }
+    expect(console.warn).toBeCalledTimes(callArgs.length);
+    (console.warn as jest.Mock).mockClear();
+}
+
+export function expectWarning(...args: any) {
+    expectWarnings([[...args]]);
+}
+
+/* eslint-enable no-console */

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -4,7 +4,7 @@ import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 import { formatLabels } from '../util/labelFormatter';
 import { HeatmapSeriesProperties } from './heatmapSeriesProperties';
 
-const { SeriesNodePickMode, valueProperty, ChartAxisDirection } = _ModuleSupport;
+const { SeriesNodePickMode, getMissCount, valueProperty, ChartAxisDirection } = _ModuleSupport;
 const { Rect, PointerEvents } = _Scene;
 const { ColorScale } = _Scale;
 const { sanitizeHtml, Color, Logger } = _Util;
@@ -114,7 +114,8 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, H
 
         const colorDataIdx = dataModel.resolveProcessedDataIndexById(this, 'colorValue').index;
         const dataCount = processedData.data.length;
-        const colorDataMissing = dataCount === 0 || dataCount === processedData.defs.values[colorDataIdx].missing;
+        const missCount = getMissCount(this, processedData.defs.values[colorDataIdx].missing);
+        const colorDataMissing = dataCount === 0 || dataCount === missCount;
         return !colorDataMissing;
     }
 


### PR DESCRIPTION
The fundamental difference is that `DatumPropertyDefinition.missing` is now a map type instead of number type.

When `missing` was a number type it would globally keep track of all missing values (i.e. so the missing values in one series would affect the miss-count in another series and vice-versa).

This commit uses a miss-map to count to the number of missing values that each series has.