### PR TITLE
AG-10225 Change context menu to use highlight node for charts without markers

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -196,6 +196,10 @@ export class InteractionManager extends BaseManager<
                 return ['contextmenu'];
 
             case 'mousedown':
+                if (event instanceof MouseEvent && event.button !== 0) {
+                    // Reject this event if it is not the primary mouse button.
+                    return [];
+                }
                 this.mouseDown = true;
                 this.dragStartElement = event.target as HTMLElement;
                 return [dragStart];

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -189,7 +189,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
         this.groups.default = [...ContextMenu.defaultActions];
 
-        this.pickedNode = this.highlightManager.getActivePicked();
+        this.pickedNode = this.highlightManager.getActiveHighlight();
         if (this.pickedNode) {
             this.groups.node = [...ContextMenu.nodeActions];
         }

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -190,9 +190,6 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
 
         const sourceEvent = event.sourceEvent as DragEvent;
 
-        const isPrimaryMouseButton = sourceEvent.button === 0;
-        if (!isPrimaryMouseButton) return;
-
         this.isDragging = true;
         this.tooltipManager.updateTooltip(TOOLTIP_ID);
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10225

When you right click, the `mousedown` event is fired first, then the `contextmenu` event. When a `mousedown` event is triggered we start dragging, which clears the highlighted node. So we have to reject any `mousedown` events not from the primary button.