### PR TITLE
AG-10411 - Detect @deprecated options and hide them in the API section.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -163,7 +163,7 @@ export abstract class AgCharts {
     }
 }
 
-/** @deprecated use AgCharts instead */
+/** @deprecated v9.0 use AgCharts instead */
 export class AgChart {
     private static warnDeprecated(memberName: string) {
         const warnDeprecated = createDeprecationWarning();

--- a/packages/ag-charts-community/src/options/chart/gradientLegendOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/gradientLegendOptions.ts
@@ -51,7 +51,7 @@ export interface AgGradientLegendOptions {
     /** The spacing in pixels to use outside the legend. */
     spacing?: PixelSize;
     /**
-     * @deprecated Use `scale` instead.
+     * @deprecated v9.0.2 Use `scale` instead.
      * Configuration for the legend gradient stops that consist of a color and a label.
      */
     stop?: AgGradientLegendScaleOptions;

--- a/plugins/ag-charts-generate-code-reference-files/src/executors/generate/types-utils.ts
+++ b/plugins/ag-charts-generate-code-reference-files/src/executors/generate/types-utils.ts
@@ -183,6 +183,9 @@ export class TypeMapper {
                 }
                 return isFirstAppearance;
             })
+            .filter(({ docs }) => {
+                return docs?.some((d) => d.includes('@deprecated')) !== true;
+            })
             .sort((a, b) => (a.optional && !b.optional ? 1 : !a.optional && b.optional ? -1 : 0))
             .sort((a, b) => (prioritisedMembers.includes(a.name) ? -1 : prioritisedMembers.includes(b.name) ? 1 : 0));
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10411

Stop displaying @deprecated properties in the API website pages.