### PR TITLE
AG-10323 Fix tooltips on mobile devices

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -365,7 +365,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.interactionManager.addListener('wheel', () => this.disablePointer()),
 
             // Block redundant and interfering attempts to update the hovered element during dragging.
-            this.interactionManager.addListener('drag-start', () => this.disablePointer()),
+            this.interactionManager.addListener('drag', () => this.disablePointer()),
 
             this.animationManager.addListener('animation-frame', (_) => {
                 this.update(ChartUpdateType.SCENE_RENDER);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10323

The bug is caused because because we disabled the pointer whenever a drag event starts (i.e. when 'mousedown' or 'touchstart' is received). Now we only disable the pointer when the drag actually starts moving.

This also fixes a bug regression where clicking on a node with the mouse (on desktop) hides the tooltip and highlighting.