### PR TITLE
AG-10483 - Fix consideration of `seriesGrouping` for series recreation cases.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -464,7 +464,7 @@ function applySeries(chart: Chart, options: AgChartOptions) {
         return false;
     }
 
-    const keysToConsider = ['direction', 'xKey', 'yKey', 'sizeKey', 'angleKey', 'stacked', 'stackGroup'];
+    const keysToConsider = ['direction', 'xKey', 'yKey', 'sizeKey', 'angleKey', 'normalizedTo'];
 
     let matchingTypes = chart.series.length === optSeries.length;
     for (let i = 0; i < chart.series.length && matchingTypes; i++) {
@@ -474,20 +474,27 @@ function applySeries(chart: Chart, options: AgChartOptions) {
         }
     }
 
+    let seriesDiffs = []; // Only diff if coarsely series types are matching.
+    if (matchingTypes) {
+        seriesDiffs = chart.series.map((_, i) => {
+            const previousOpts = chart.processedOptions.series?.[i] ?? {};
+            return jsonDiff(previousOpts, optSeries[i] ?? {}) as any;
+        });
+
+        // Check if seriesGrouping has changed.
+        matchingTypes = seriesDiffs.every((diff) => !('seriesGrouping' in (diff ?? {})));
+    }
+
     // Try to optimise series updates if series count and types didn't change.
     if (matchingTypes) {
-        chart.series.forEach((s, i) => {
-            const previousOpts = chart.processedOptions.series?.[i] ?? {};
-            const seriesDiff = jsonDiff(previousOpts, optSeries[i] ?? {});
-
-            if (!seriesDiff) {
-                return;
-            }
+        seriesDiffs.forEach((seriesDiff, i) => {
+            if (!seriesDiff) return;
 
             debug(`AgChartV2.applySeries() - applying series diff idx ${i}`, seriesDiff);
 
-            applySeriesValues(s as any, seriesDiff);
-            s.markNodeDataDirty();
+            const series = chart.series[i];
+            applySeriesValues(series as any, seriesDiff);
+            series.markNodeDataDirty();
         });
 
         return false;

--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -533,6 +533,7 @@ function applyAxes(chart: Chart, options: AgChartOptions, forceRecreate: boolean
         }
     }
 
+    debug(`AgChartV2.applyAxes() - creating new axes instances`);
     chart.axes = createAxis(chart, axes);
     return true;
 }

--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -28,6 +28,12 @@ export class CartesianChart extends Chart {
 
     private firstSeriesTranslation = true;
 
+    override removeAllSeries() {
+        super.removeAllSeries();
+
+        this.firstSeriesTranslation = true;
+    }
+
     override async performLayout() {
         const shrinkRect = await super.performLayout();
         const { firstSeriesTranslation, seriesRoot } = this;

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -788,6 +788,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             series.chart = undefined;
         });
         this._series = []; // using `_series` instead of `series` to prevent infinite recursion
+        this.animationRect = undefined; // reset animation state.
     }
 
     private addSeriesListeners(series: Series<any>) {

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -779,7 +779,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         series.addChartEventListeners();
     }
 
-    private removeAllSeries(): void {
+    protected removeAllSeries(): void {
         this.series.forEach((series) => {
             series.removeEventListener('nodeClick', this.onSeriesNodeClick);
             series.removeEventListener('nodeDoubleClick', this.onSeriesNodeDoubleClick);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10483

Fixes for Integrated Charts:
- switching between bar-series types causing an unexpected 'series removal' animation, rather than immediately initiating an 'initial load' animation.
- seriesRect translation animation state is reset (so there is no animation of the seriesRect location during the series initial load animation).
- skipping of animation on layout changes (Chart.animationRect is now reset on series changes, which caused skipping here: https://github.com/ag-grid/ag-charts/blob/db3dced5aeca0f9f2abcb634e33eee8a069d499b/packages/ag-charts-community/src/chart/chart.ts#L1004)