### PR TITLE
AG-10483 - Integrated charts animation fixes

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -788,7 +788,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
             series.chart = undefined;
         });
         this._series = []; // using `_series` instead of `series` to prevent infinite recursion
-        this.animationRect = undefined; // reset animation state.
+
+        // Reset animation state.
+        this.animationRect = undefined;
+        this.animationManager.reset();
     }
 
     private addSeriesListeners(series: Series<any>) {

--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -671,6 +671,7 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
   },
   "series": [
     {
+      "direction": "vertical",
       "fill": "#c16068",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -728,6 +729,7 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
       "yName": "Male cattle",
     },
     {
+      "direction": "vertical",
       "fill": "#a2bf8a",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -1745,6 +1747,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
   },
   "series": [
     {
+      "direction": "vertical",
       "fill": "#5090dc",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -1802,6 +1805,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "yName": "Large household appliances",
     },
     {
+      "direction": "vertical",
       "fill": "#ffa03a",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -1859,6 +1863,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "yName": "Small household appliances",
     },
     {
+      "direction": "vertical",
       "fill": "#459d55",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -1916,6 +1921,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "yName": "IT and telecomms equipment",
     },
     {
+      "direction": "vertical",
       "fill": "#34bfe1",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -1973,6 +1979,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "yName": "Consumer equipment",
     },
     {
+      "direction": "vertical",
       "fill": "#e1cc00",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -2030,6 +2037,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "yName": "Electrical and electronic tools",
     },
     {
+      "direction": "vertical",
       "fill": "#9669cb",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -2087,6 +2095,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "yName": "Display equipment",
     },
     {
+      "direction": "vertical",
       "fill": "#b5b5b5",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -2144,6 +2153,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "yName": "Cooling appliances containing refrigerants",
     },
     {
+      "direction": "vertical",
       "fill": "#bd5aa7",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -4885,6 +4895,7 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
   },
   "series": [
     {
+      "direction": "vertical",
       "fill": "#19A0AA",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -4942,6 +4953,7 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
       "yName": "Male",
     },
     {
+      "direction": "vertical",
       "fill": "#F15F36",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -5605,6 +5617,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
   },
   "series": [
     {
+      "direction": "vertical",
       "fill": "#5090dc",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -5662,6 +5675,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "yKey": "16-24",
     },
     {
+      "direction": "vertical",
       "fill": "#ffa03a",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -5719,6 +5733,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "yKey": "25-34",
     },
     {
+      "direction": "vertical",
       "fill": "#459d55",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -5776,6 +5791,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "yKey": "35-44",
     },
     {
+      "direction": "vertical",
       "fill": "#34bfe1",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -5833,6 +5849,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "yKey": "45-54",
     },
     {
+      "direction": "vertical",
       "fill": "#e1cc00",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -5890,6 +5907,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "yKey": "55-64",
     },
     {
+      "direction": "vertical",
       "fill": "#9669cb",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -5947,6 +5965,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "yKey": "65-74",
     },
     {
+      "direction": "vertical",
       "fill": "#b5b5b5",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -8880,6 +8899,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
   },
   "series": [
     {
+      "direction": "vertical",
       "fill": "#f1c40f",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -8938,6 +8958,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
       "yName": "White",
     },
     {
+      "direction": "vertical",
       "fill": "#e67e22",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -8996,6 +9017,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
       "yName": "Mixed",
     },
     {
+      "direction": "vertical",
       "fill": "#2ecc71",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -9054,6 +9076,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
       "yName": "Asian",
     },
     {
+      "direction": "vertical",
       "fill": "#3498db",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -9112,6 +9135,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
       "yName": "Black",
     },
     {
+      "direction": "vertical",
       "fill": "#9b59b6",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -9170,6 +9194,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
       "yName": "Chinese",
     },
     {
+      "direction": "vertical",
       "fill": "#34495e",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -9975,6 +10000,7 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
   },
   "series": [
     {
+      "direction": "vertical",
       "fill": "#0084e7",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -12449,6 +12475,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
   },
   "series": [
     {
+      "direction": "vertical",
       "fill": "#5BC0EB",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -12507,6 +12534,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
       "yName": "Early",
     },
     {
+      "direction": "vertical",
       "fill": "#FDE74C",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -12565,6 +12593,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
       "yName": "Morning peak",
     },
     {
+      "direction": "vertical",
       "fill": "#9BC53D",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -12623,6 +12652,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
       "yName": "Between peak",
     },
     {
+      "direction": "vertical",
       "fill": "#E55934",
       "fillOpacity": 1,
       "highlightStyle": {
@@ -12681,6 +12711,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
       "yName": "Afternoon peak",
     },
     {
+      "direction": "vertical",
       "fill": "#FA7921",
       "fillOpacity": 1,
       "highlightStyle": {

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeriesModule.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeriesModule.ts
@@ -34,6 +34,7 @@ export const BarSeriesModule: SeriesModule<'bar'> = {
     swapDefaultAxesCondition: (series) => series?.direction === 'horizontal',
     themeTemplate: {
         __extends__: EXTENDS_SERIES_DEFAULTS,
+        direction: 'vertical',
         fillOpacity: 1,
         strokeWidth: 0,
         lineDash: [0],


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10483

Fixes Integrated Charts use-cases:
- Switching theme for combo charts triggered initial load (now just changes palette).
- Switching chart-type now ALWAYS triggers initial load, and isn't subject to the animation debounce skip delay.