### PR TITLE
AG-10524 Avoid firing two events when legend is clicked

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -354,6 +354,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.highlight = new ChartHighlight();
         this.container = container;
 
+        this.attachLegend('category', Legend);
+        this.legend = this.legends.get('category');
+
         SizeMonitor.observe(this.element, (size) => this.rawResize(size));
         this._destroyFns.push(
             this.interactionManager.addListener('click', (event) => this.onClick(event)),
@@ -374,9 +377,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 this.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true, skipAnimations: true })
             )
         );
-
-        this.attachLegend('category', Legend);
-        this.legend = this.legends.get('category');
     }
 
     addModule<T extends RootModule | LegendModule>(module: T) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10524

Before this change, the 'click' events were dispatched first to the chart and then to the legend.

The legend.ts file consumes the click events, but this consume() call can only affects the global chart if the legend listeners receive the 'click' message.

After this change, the 'click' events get dispatched first to the legend and then to the chart.