### PR TITLE
AG-10546 + AG-10547 - Dark mode/theme context menu and overlay support.

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -199,6 +199,14 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 30,
     "left": 10,
@@ -422,6 +430,7 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -663,6 +672,14 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -895,6 +912,7 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -1082,6 +1100,14 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -1550,6 +1576,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -1737,6 +1764,14 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -2247,6 +2282,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
   },
   "tooltip": {
     "class": "my-tooltip",
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -2434,6 +2470,14 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -2523,6 +2567,7 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -2709,6 +2754,14 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -2996,6 +3049,7 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -3183,6 +3237,14 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -3577,6 +3639,7 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -3766,6 +3829,14 @@ exports[`prepare #prepareOptions for BAR_CHART_EXAMPLE it should prepare options
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -3864,6 +3935,7 @@ by Occupation",
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4053,6 +4125,14 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -4142,6 +4222,7 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4336,6 +4417,14 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -4419,6 +4508,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4612,6 +4702,14 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -4698,6 +4796,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4887,6 +4986,14 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -5057,6 +5164,7 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -5246,6 +5354,14 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -5420,6 +5536,7 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -5607,6 +5724,14 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -6064,6 +6189,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -6254,6 +6380,14 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -7254,6 +7388,7 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -7442,6 +7577,14 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -7527,6 +7670,7 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -7715,6 +7859,14 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -8273,6 +8425,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -8461,6 +8614,14 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -8701,6 +8862,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -8889,6 +9051,14 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -9308,6 +9478,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -9498,6 +9669,14 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -9803,6 +9982,7 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -9992,6 +10172,14 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -10080,6 +10268,7 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -10148,6 +10337,14 @@ exports[`prepare #prepareOptions for SIMPLE_DOUGHNUT_CHART_EXAMPLE it should pre
     "spacing": 30,
   },
   "listeners": {},
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -10303,6 +10500,7 @@ exports[`prepare #prepareOptions for SIMPLE_DOUGHNUT_CHART_EXAMPLE it should pre
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -10497,6 +10695,14 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -10654,6 +10860,7 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -10722,6 +10929,14 @@ exports[`prepare #prepareOptions for SIMPLE_PIE_CHART_EXAMPLE it should prepare 
     "spacing": 30,
   },
   "listeners": {},
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -10855,6 +11070,7 @@ exports[`prepare #prepareOptions for SIMPLE_PIE_CHART_EXAMPLE it should prepare 
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -11042,6 +11258,14 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
       "width": 8,
     },
   },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
+    },
+  },
   "padding": {
     "bottom": 20,
     "left": 20,
@@ -11120,6 +11344,7 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -11312,6 +11537,14 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -11808,6 +12041,7 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -11996,6 +12230,14 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -12278,6 +12520,7 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -12465,6 +12708,14 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
       "stroke": "#999999",
       "strokeWidth": 1,
       "width": 8,
+    },
+  },
+  "overlays": {
+    "noData": {
+      "darkMode": false,
+    },
+    "noVisibleSeries": {
+      "darkMode": false,
     },
   },
   "padding": {
@@ -12823,6 +13074,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
     "wrapping": "hyphenate",
   },
   "tooltip": {
+    "darkMode": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",

--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -201,10 +201,10 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -430,7 +430,7 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -674,10 +674,10 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -912,7 +912,7 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -1104,10 +1104,10 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -1576,7 +1576,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -1768,10 +1768,10 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -2282,7 +2282,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
   },
   "tooltip": {
     "class": "my-tooltip",
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -2472,10 +2472,10 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -2567,7 +2567,7 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -2758,10 +2758,10 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -3049,7 +3049,7 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -3241,10 +3241,10 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -3639,7 +3639,7 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -3831,10 +3831,10 @@ exports[`prepare #prepareOptions for BAR_CHART_EXAMPLE it should prepare options
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -3935,7 +3935,7 @@ by Occupation",
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4127,10 +4127,10 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -4222,7 +4222,7 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4419,10 +4419,10 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -4508,7 +4508,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4704,10 +4704,10 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -4796,7 +4796,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -4988,10 +4988,10 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -5164,7 +5164,7 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -5356,10 +5356,10 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -5536,7 +5536,7 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -5728,10 +5728,10 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -6189,7 +6189,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -6384,10 +6384,10 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -7388,7 +7388,7 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -7579,10 +7579,10 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -7670,7 +7670,7 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -7863,10 +7863,10 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -8425,7 +8425,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -8618,10 +8618,10 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -8862,7 +8862,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -9055,10 +9055,10 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -9478,7 +9478,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -9673,10 +9673,10 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -9982,7 +9982,7 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -10174,10 +10174,10 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -10268,7 +10268,7 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -10339,10 +10339,10 @@ exports[`prepare #prepareOptions for SIMPLE_DOUGHNUT_CHART_EXAMPLE it should pre
   "listeners": {},
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -10500,7 +10500,7 @@ exports[`prepare #prepareOptions for SIMPLE_DOUGHNUT_CHART_EXAMPLE it should pre
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -10697,10 +10697,10 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -10860,7 +10860,7 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -10931,10 +10931,10 @@ exports[`prepare #prepareOptions for SIMPLE_PIE_CHART_EXAMPLE it should prepare 
   "listeners": {},
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -11070,7 +11070,7 @@ exports[`prepare #prepareOptions for SIMPLE_PIE_CHART_EXAMPLE it should prepare 
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -11260,10 +11260,10 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -11344,7 +11344,7 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -11541,10 +11541,10 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -12041,7 +12041,7 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -12234,10 +12234,10 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -12520,7 +12520,7 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",
@@ -12712,10 +12712,10 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
   },
   "overlays": {
     "noData": {
-      "darkMode": false,
+      "darkTheme": false,
     },
     "noVisibleSeries": {
-      "darkMode": false,
+      "darkTheme": false,
     },
   },
   "padding": {
@@ -13074,7 +13074,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
     "wrapping": "hyphenate",
   },
   "tooltip": {
-    "darkMode": false,
+    "darkTheme": false,
     "delay": 0,
     "enabled": true,
     "range": "nearest",

--- a/packages/ag-charts-community/src/chart/overlay/overlay.ts
+++ b/packages/ag-charts-community/src/chart/overlay/overlay.ts
@@ -19,7 +19,7 @@ export class Overlay {
     text?: string;
 
     @Validate(BOOLEAN)
-    darkMode = false;
+    darkTheme = false;
 
     show(rect: BBox) {
         if (!this.element) {
@@ -27,11 +27,7 @@ export class Overlay {
             this.element.className = this.className;
         }
 
-        if (this.darkMode) {
-            this.element.classList.add(`${this.className}-dark`);
-        } else {
-            this.element.classList.remove(`${this.className}-dark`);
-        }
+        this.element.classList.toggle(`${this.className}-dark`, this.darkTheme);
 
         const { element } = this;
         element.style.position = 'absolute';

--- a/packages/ag-charts-community/src/chart/overlay/overlay.ts
+++ b/packages/ag-charts-community/src/chart/overlay/overlay.ts
@@ -1,6 +1,6 @@
 import { ADD_PHASE, REMOVE_PHASE } from '../../motion/animation';
 import type { BBox } from '../../scene/bbox';
-import { FUNCTION, STRING, Validate } from '../../util/validation';
+import { BOOLEAN, FUNCTION, STRING, Validate } from '../../util/validation';
 import type { AnimationManager } from '../interaction/animationManager';
 
 export class Overlay {
@@ -18,10 +18,19 @@ export class Overlay {
     @Validate(STRING, { optional: true })
     text?: string;
 
+    @Validate(BOOLEAN)
+    darkMode = false;
+
     show(rect: BBox) {
         if (!this.element) {
             this.element = this.createElement('div');
             this.element.className = this.className;
+        }
+
+        if (this.darkMode) {
+            this.element.classList.add(`${this.className}-dark`);
+        } else {
+            this.element.classList.remove(`${this.className}-dark`);
         }
 
         const { element } = this;

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -294,6 +294,14 @@ export class ChartTheme {
                 range: 'nearest' as InteractionRange,
                 delay: 0,
             },
+            overlays: {
+                noData: {
+                    darkMode: IS_DARK_MODE,
+                },
+                noVisibleSeries: {
+                    darkMode: IS_DARK_MODE,
+                },
+            },
             listeners: {},
         };
     }

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -45,7 +45,7 @@ import {
     EXTENDS_LEGEND_ITEM_DEFAULTS,
     EXTENDS_LEGEND_ITEM_MARKER_DEFAULTS,
     EXTENDS_SERIES_DEFAULTS,
-    IS_DARK_MODE,
+    IS_DARK_THEME,
     OVERRIDE_SERIES_LABEL_DEFAULTS,
 } from './symbols';
 
@@ -290,16 +290,16 @@ export class ChartTheme {
             },
             tooltip: {
                 enabled: true,
-                darkMode: IS_DARK_MODE,
+                darkTheme: IS_DARK_THEME,
                 range: 'nearest' as InteractionRange,
                 delay: 0,
             },
             overlays: {
                 noData: {
-                    darkMode: IS_DARK_MODE,
+                    darkTheme: IS_DARK_THEME,
                 },
                 noVisibleSeries: {
-                    darkMode: IS_DARK_MODE,
+                    darkTheme: IS_DARK_THEME,
                 },
             },
             listeners: {},
@@ -537,7 +537,7 @@ export class ChartTheme {
         extensions.set(EXTENDS_CARTESIAN_MARKER_DEFAULTS, ChartTheme.getCartesianSeriesMarkerDefaults());
 
         const properties = new Map();
-        properties.set(IS_DARK_MODE, false);
+        properties.set(IS_DARK_THEME, false);
         properties.set(DEFAULT_FONT_FAMILY, 'Verdana, sans-serif');
         properties.set(DEFAULT_LABEL_COLOUR, 'rgb(70, 70, 70)');
         properties.set(DEFAULT_INVERTED_LABEL_COLOUR, 'white');

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -45,6 +45,7 @@ import {
     EXTENDS_LEGEND_ITEM_DEFAULTS,
     EXTENDS_LEGEND_ITEM_MARKER_DEFAULTS,
     EXTENDS_SERIES_DEFAULTS,
+    IS_DARK_MODE,
     OVERRIDE_SERIES_LABEL_DEFAULTS,
 } from './symbols';
 
@@ -289,6 +290,7 @@ export class ChartTheme {
             },
             tooltip: {
                 enabled: true,
+                darkMode: IS_DARK_MODE,
                 range: 'nearest' as InteractionRange,
                 delay: 0,
             },
@@ -527,6 +529,7 @@ export class ChartTheme {
         extensions.set(EXTENDS_CARTESIAN_MARKER_DEFAULTS, ChartTheme.getCartesianSeriesMarkerDefaults());
 
         const properties = new Map();
+        properties.set(IS_DARK_MODE, false);
         properties.set(DEFAULT_FONT_FAMILY, 'Verdana, sans-serif');
         properties.set(DEFAULT_LABEL_COLOUR, 'rgb(70, 70, 70)');
         properties.set(DEFAULT_INVERTED_LABEL_COLOUR, 'white');

--- a/packages/ag-charts-community/src/chart/themes/darkTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/darkTheme.ts
@@ -15,6 +15,7 @@ import {
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
+    IS_DARK_MODE,
 } from './symbols';
 
 // If this changes, update plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/constants.ts
@@ -85,6 +86,7 @@ export class DarkTheme extends ChartTheme {
     override getTemplateParameters() {
         const result = super.getTemplateParameters();
 
+        result.properties.set(IS_DARK_MODE, true);
         result.properties.set(
             DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
             DarkTheme.getWaterfallSeriesDefaultPositiveColors()

--- a/packages/ag-charts-community/src/chart/themes/darkTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/darkTheme.ts
@@ -15,7 +15,7 @@ import {
     DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
     DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
-    IS_DARK_MODE,
+    IS_DARK_THEME,
 } from './symbols';
 
 // If this changes, update plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/constants.ts
@@ -86,7 +86,7 @@ export class DarkTheme extends ChartTheme {
     override getTemplateParameters() {
         const result = super.getTemplateParameters();
 
-        result.properties.set(IS_DARK_MODE, true);
+        result.properties.set(IS_DARK_THEME, true);
         result.properties.set(
             DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
             DarkTheme.getWaterfallSeriesDefaultPositiveColors()

--- a/packages/ag-charts-community/src/chart/themes/symbols.ts
+++ b/packages/ag-charts-community/src/chart/themes/symbols.ts
@@ -1,3 +1,4 @@
+export const IS_DARK_MODE = Symbol('is-dark-mode') as unknown as string;
 export const EXTENDS_CHART_DEFAULTS = Symbol('extends-chart-defaults') as unknown as string;
 export const EXTENDS_LEGEND_DEFAULTS = Symbol('extends-legend-defaults') as unknown as string;
 export const EXTENDS_LEGEND_ITEM_DEFAULTS = Symbol('extends-legend-item-defaults') as unknown as string;

--- a/packages/ag-charts-community/src/chart/themes/symbols.ts
+++ b/packages/ag-charts-community/src/chart/themes/symbols.ts
@@ -1,4 +1,4 @@
-export const IS_DARK_MODE = Symbol('is-dark-mode') as unknown as string;
+export const IS_DARK_THEME = Symbol('is-dark-theme') as unknown as string;
 export const EXTENDS_CHART_DEFAULTS = Symbol('extends-chart-defaults') as unknown as string;
 export const EXTENDS_LEGEND_DEFAULTS = Symbol('extends-legend-defaults') as unknown as string;
 export const EXTENDS_LEGEND_ITEM_DEFAULTS = Symbol('extends-legend-item-defaults') as unknown as string;

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -136,12 +136,12 @@ const defaultTooltipCss = `
 }
 
 .${DEFAULT_TOOLTIP_CLASS}.${DEFAULT_TOOLTIP_DARK_CLASS} {
-    color: white;
-    background: #15181c;
+    // color: white;
+    // background: #15181c;
 }
 
 .${DEFAULT_TOOLTIP_CLASS}.${DEFAULT_TOOLTIP_DARK_CLASS} .${DEFAULT_TOOLTIP_CLASS}-content {
-    border-color: rgba(255, 255, 255, 0.15);
+    // border-color: rgba(255, 255, 255, 0.15);
 }
 
 .ag-chart-wrapper {
@@ -233,6 +233,9 @@ export class Tooltip {
     @Validate(TEXT_WRAP)
     wrapping: TextWrap = 'hyphenate';
 
+    @Validate(BOOLEAN)
+    darkMode: boolean = false;
+
     private lastVisibilityChange: number = Date.now();
 
     readonly position: TooltipPosition = new TooltipPosition();
@@ -322,6 +325,12 @@ export class Tooltip {
         toggleClass('no-interaction', !enableInteraction); // Prevent interaction.
         toggleClass('hidden', !visible); // Hide if not visible.
         toggleClass('arrow', !!showArrow); // Add arrow if tooltip is constrained.
+
+        if (this.darkMode) {
+            element.classList.add(DEFAULT_TOOLTIP_DARK_CLASS);
+        } else {
+            element.classList.remove(DEFAULT_TOOLTIP_DARK_CLASS);
+        }
 
         this.updateWrapping();
 

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -135,15 +135,6 @@ const defaultTooltipCss = `
     margin: 0 auto;
 }
 
-.${DEFAULT_TOOLTIP_CLASS}.${DEFAULT_TOOLTIP_DARK_CLASS} {
-    // color: white;
-    // background: #15181c;
-}
-
-.${DEFAULT_TOOLTIP_CLASS}.${DEFAULT_TOOLTIP_DARK_CLASS} .${DEFAULT_TOOLTIP_CLASS}-content {
-    // border-color: rgba(255, 255, 255, 0.15);
-}
-
 .ag-chart-wrapper {
     box-sizing: border-box;
     overflow: hidden;
@@ -234,7 +225,7 @@ export class Tooltip {
     wrapping: TextWrap = 'hyphenate';
 
     @Validate(BOOLEAN)
-    darkMode: boolean = false;
+    darkTheme = false;
 
     private lastVisibilityChange: number = Date.now();
 
@@ -326,11 +317,7 @@ export class Tooltip {
         toggleClass('hidden', !visible); // Hide if not visible.
         toggleClass('arrow', !!showArrow); // Add arrow if tooltip is constrained.
 
-        if (this.darkMode) {
-            element.classList.add(DEFAULT_TOOLTIP_DARK_CLASS);
-        } else {
-            element.classList.remove(DEFAULT_TOOLTIP_DARK_CLASS);
-        }
+        element.classList.toggle(DEFAULT_TOOLTIP_DARK_CLASS, this.darkTheme);
 
         this.updateWrapping();
 

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -1,7 +1,11 @@
 import type { _Scene } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
 
-import { DEFAULT_CONTEXT_MENU_CLASS, defaultContextMenuCss } from './contextMenuStyles';
+import {
+    DEFAULT_CONTEXT_MENU_CLASS,
+    DEFAULT_CONTEXT_MENU_DARK_CLASS,
+    defaultContextMenuCss,
+} from './contextMenuStyles';
 
 type ContextMenuGroups = {
     default: Array<ContextMenuItem>;
@@ -28,6 +32,9 @@ const TOOLTIP_ID = 'context-menu';
 export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     @Validate(BOOLEAN)
     enabled = true;
+
+    @Validate(BOOLEAN)
+    darkMode: boolean = false;
 
     /**
      * Extra menu actions with a label and callback.
@@ -215,6 +222,12 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     public show() {
         if (!this.coverElement) return;
 
+        if (this.darkMode) {
+            this.element.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
+        } else {
+            this.element.classList.remove(DEFAULT_CONTEXT_MENU_DARK_CLASS);
+        }
+
         const newMenuElement = this.renderMenu();
 
         if (this.menuElement) {
@@ -255,6 +268,9 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     public renderMenu() {
         const menuElement = this.ctx.document.createElement('div');
         menuElement.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__menu`);
+        if (this.darkMode) {
+            menuElement.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
+        }
 
         this.groups.default.forEach((i) => {
             const item = this.renderItem(i);
@@ -282,6 +298,9 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createDividerElement(): HTMLElement {
         const el = this.ctx.document.createElement('div');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__divider`);
+        if (this.darkMode) {
+            el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
+        }
         return el;
     }
 
@@ -295,6 +314,9 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createButtonElement(label: string, callback: (params: ContextMenuActionParams) => void): HTMLElement {
         const el = this.ctx.document.createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
+        if (this.darkMode) {
+            el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
+        }
         el.innerHTML = label;
         el.onclick = () => {
             const params: ContextMenuActionParams = {
@@ -312,6 +334,9 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createDisabledElement(label: string): HTMLElement {
         const el = this.ctx.document.createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
+        if (this.darkMode) {
+            el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
+        }
         el.disabled = true;
         el.innerHTML = label;
         return el;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -34,7 +34,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     enabled = true;
 
     @Validate(BOOLEAN)
-    darkMode: boolean = false;
+    darkTheme = false;
 
     /**
      * Extra menu actions with a label and callback.
@@ -222,11 +222,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     public show() {
         if (!this.coverElement) return;
 
-        if (this.darkMode) {
-            this.element.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
-        } else {
-            this.element.classList.remove(DEFAULT_CONTEXT_MENU_DARK_CLASS);
-        }
+        this.element.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
 
         const newMenuElement = this.renderMenu();
 
@@ -268,7 +264,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     public renderMenu() {
         const menuElement = this.ctx.document.createElement('div');
         menuElement.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__menu`);
-        if (this.darkMode) {
+        if (this.darkTheme) {
             menuElement.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
         }
 
@@ -298,7 +294,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createDividerElement(): HTMLElement {
         const el = this.ctx.document.createElement('div');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__divider`);
-        if (this.darkMode) {
+        if (this.darkTheme) {
             el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
         }
         return el;
@@ -314,7 +310,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createButtonElement(label: string, callback: (params: ContextMenuActionParams) => void): HTMLElement {
         const el = this.ctx.document.createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
-        if (this.darkMode) {
+        if (this.darkTheme) {
             el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
         }
         el.innerHTML = label;
@@ -334,7 +330,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createDisabledElement(label: string): HTMLElement {
         const el = this.ctx.document.createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
-        if (this.darkMode) {
+        if (this.darkTheme) {
             el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
         }
         el.disabled = true;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -264,9 +264,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     public renderMenu() {
         const menuElement = this.ctx.document.createElement('div');
         menuElement.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__menu`);
-        if (this.darkTheme) {
-            menuElement.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
-        }
+        menuElement.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
 
         this.groups.default.forEach((i) => {
             const item = this.renderItem(i);
@@ -294,9 +292,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createDividerElement(): HTMLElement {
         const el = this.ctx.document.createElement('div');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__divider`);
-        if (this.darkTheme) {
-            el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
-        }
+        el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
         return el;
     }
 
@@ -310,9 +306,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createButtonElement(label: string, callback: (params: ContextMenuActionParams) => void): HTMLElement {
         const el = this.ctx.document.createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
-        if (this.darkTheme) {
-            el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
-        }
+        el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
         el.innerHTML = label;
         el.onclick = () => {
             const params: ContextMenuActionParams = {
@@ -330,9 +324,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createDisabledElement(label: string): HTMLElement {
         const el = this.ctx.document.createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
-        if (this.darkTheme) {
-            el.classList.add(DEFAULT_CONTEXT_MENU_DARK_CLASS);
-        }
+        el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
         el.disabled = true;
         el.innerHTML = label;
         return el;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
@@ -1,4 +1,5 @@
 import type { _ModuleSupport } from 'ag-charts-community';
+import { _Theme } from 'ag-charts-community';
 
 import { ContextMenu } from './contextMenu';
 
@@ -14,6 +15,7 @@ export const ContextMenuModule: _ModuleSupport.Module = {
     themeTemplate: {
         contextMenu: {
             enabled: true,
+            darkMode: _Theme.IS_DARK_MODE,
         },
     },
 };

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
@@ -15,7 +15,7 @@ export const ContextMenuModule: _ModuleSupport.Module = {
     themeTemplate: {
         contextMenu: {
             enabled: true,
-            darkMode: _Theme.IS_DARK_MODE,
+            darkTheme: _Theme.IS_DARK_THEME,
         },
     },
 };

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_CONTEXT_MENU_CLASS = 'ag-chart-context-menu';
+export const DEFAULT_CONTEXT_MENU_DARK_CLASS = `ag-charts-dark-context-menu`;
 
 export const defaultContextMenuCss = `
 .${DEFAULT_CONTEXT_MENU_CLASS} {
@@ -12,6 +13,11 @@ export const defaultContextMenuCss = `
     transition: transform 0.1s ease;
     white-space: nowrap;
     z-index: 99999;
+}
+
+.${DEFAULT_CONTEXT_MENU_CLASS}.${DEFAULT_CONTEXT_MENU_DARK_CLASS} {
+    color: white;
+    background: #15181c;
 }
 
 .${DEFAULT_CONTEXT_MENU_CLASS}__cover {
@@ -37,12 +43,24 @@ export const defaultContextMenuCss = `
     -moz-appearance: none;
 }
 
+.${DEFAULT_CONTEXT_MENU_CLASS}__item.${DEFAULT_CONTEXT_MENU_DARK_CLASS} {
+    color: white;
+}
+
 .${DEFAULT_CONTEXT_MENU_CLASS}__item:hover {
+    background: rgb(33, 150, 243, 0.1);
+}
+
+.${DEFAULT_CONTEXT_MENU_CLASS}__item:hover.${DEFAULT_CONTEXT_MENU_DARK_CLASS} {
     background: rgb(33, 150, 243, 0.1);
 }
 
 .${DEFAULT_CONTEXT_MENU_CLASS}__item:active {
     background: rgb(33, 150, 243, 0.2);
+}
+
+.${DEFAULT_CONTEXT_MENU_CLASS}__item:active.${DEFAULT_CONTEXT_MENU_DARK_CLASS} {
+    background: rgb(33, 150, 243, 0.1);
 }
 
 .${DEFAULT_CONTEXT_MENU_CLASS}__item[disabled] {
@@ -60,5 +78,9 @@ export const defaultContextMenuCss = `
     margin: 5px 0;
     background: #babfc7;
     height: 1px;
+}
+
+.${DEFAULT_CONTEXT_MENU_CLASS}__divider.${DEFAULT_CONTEXT_MENU_DARK_CLASS} {
+    background: rgb(33, 150, 243, 0.1);
 }
 `;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10546
https://ag-grid.atlassian.net/browse/AG-10547

Adds dark-theme detection for overlays and context menu; this activates an extra CSS class to enable overrides of specific styles (background + text color typically).

I've laid the groundwork for tooltips too, but the logic is much more complicated due to user overrides and series overrides, so we may need to evaluate the priority of that.