### PR TITLE
AG-10428 Add throttling to lazy load callback

### DIFF
--- a/packages/ag-charts-community/src/util/debounceThrottle.ts
+++ b/packages/ag-charts-community/src/util/debounceThrottle.ts
@@ -1,0 +1,77 @@
+/**
+ * Execute a function once after a time period of `ms` milliseconds since it was last called.
+ */
+export function debounce<T extends (...args: Parameters<T>) => any>(this: ThisParameterType<T>, fn: T, ms: number) {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    return (...args: Parameters<T>) => {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => fn.apply(this, args), ms);
+    };
+}
+
+/**
+ * Resolve an asynchronous function once after a time period of `ms` milliseconds since it was last called.
+ */
+export function debounceAsync<T extends (...args: Parameters<T>) => any>(
+    this: ThisParameterType<T>,
+    fn: T,
+    ms: number
+) {
+    let cancel = () => {};
+    return (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
+        cancel();
+        return new Promise((resolve) => {
+            const timeout = setTimeout(() => resolve(fn.apply(this, args)), ms);
+            cancel = () => {
+                clearTimeout(timeout);
+            };
+        });
+    };
+}
+
+/**
+ * Throttle an asynchronous function to be called no more than once in each time period of `ms` milliseconds, at the
+ * leading edge of the period.
+ */
+export function throttleAsyncLeading<T extends (...args: Parameters<T>) => any>(
+    this: ThisParameterType<T>,
+    fn: T,
+    ms: number
+) {
+    let delayPromise = Promise.resolve();
+    let returnPromise: Promise<Awaited<ReturnType<T>>> | undefined;
+
+    return async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
+        await delayPromise;
+        if (returnPromise) return returnPromise;
+        delayPromise = new Promise<void>((resolve) => setTimeout(resolve, ms));
+        returnPromise = (fn.apply(this, args) as Promise<Awaited<ReturnType<T>>>).finally(() => {
+            returnPromise = undefined;
+        });
+        return returnPromise;
+    };
+}
+
+/**
+ * Throttle an asynchronous function to be called no more than once in each time period of `ms` milliseconds, at the
+ * trailing edge of the period.
+ */
+export function throttleAsyncTrailing<T extends (...args: Parameters<T>) => any>(
+    this: ThisParameterType<T>,
+    fn: T,
+    ms: number
+) {
+    let hasTimeout = false;
+    let latestArgs: Parameters<T>;
+    return (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
+        latestArgs = args;
+        return new Promise((resolve) => {
+            if (hasTimeout) return;
+            hasTimeout = true;
+            setTimeout(() => {
+                resolve(fn.apply(this, latestArgs));
+                hasTimeout = false;
+            }, ms);
+        });
+    };
+}

--- a/packages/ag-charts-website/src/content/docs/lazy-test/_examples/lazy/main.ts
+++ b/packages/ag-charts-website/src/content/docs/lazy-test/_examples/lazy/main.ts
@@ -34,6 +34,10 @@ const options: any = {
             type: 'time',
             position: 'bottom',
             nice: false,
+            tick: {
+                minSpacing: 50,
+                maxSpacing: 200,
+            },
         },
     ],
     animation: { enabled: false },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10428

Throttles the lazy load callback to once every 100ms at the trailing edge.

I tested out a few options to see how they feel, and this seemed the best. But I've kept the other util functions as they will likely prove useful in the future.

I looked at using the scheduler from the render sequence, but it has different usage.

Note: When the throttle time is shorter than the request time, requests can come back out of order or on top of other throttled requests. So this can look a bit janky. This will be fixed by https://ag-grid.atlassian.net/browse/AG-10429