### PR TITLE
AG-10525 Fix tooltip positioning

### DIFF
--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -259,9 +259,7 @@ export class ErrorBars extends _ModuleSupport.BaseModuleInstance implements _Mod
 
         // The datum has an error value for `key`. Validate this user input value:
         if (typeof value !== 'number') {
-            _Util.Logger.warnOnce(
-                `Found [${key}] error value (${value}) of type ${typeof value}. Expected number type`
-            );
+            _Util.Logger.warnOnce(`Found [${key}] error value of type ${typeof value}. Expected number type`);
             return undefined;
         }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10525

The bug was happening only when the enterprise package was used. It happened on line/scatter series when error bars were disabled.

This happened because ErrorBars.getDatum was adding an `undefined` and number value together, which apparently results in NaN. So the module was creating error bars with NaN translations.

To safe-guard against this, ErrorBars.getDatum now explicitly returns `number | undefined` types instead of `any` types.

Additionally, ErrorBars.createNodeData() has been modified to avoid creating error bar node-data when error bars are disabled.