### PR TITLE
AG-10537 - Fix range bar update always triggering initial load.

### DIFF
--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotThemes.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotThemes.ts
@@ -2,5 +2,6 @@ import { _Theme } from 'ag-charts-community';
 
 export const BOX_PLOT_SERIES_THEME = {
     __extends__: _Theme.EXTENDS_SERIES_DEFAULTS,
+    direction: 'vertical' as const,
     strokeWidth: 2,
 };

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletThemes.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletThemes.ts
@@ -1,6 +1,7 @@
 import { _Theme } from 'ag-charts-community';
 
 export const BULLET_SERIES_THEME = {
+    direction: 'vertical' as const,
     strokeWidth: 0,
     strokeOpacity: 1,
     fillOpacity: 1,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarThemes.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarThemes.ts
@@ -2,6 +2,7 @@ import { _Theme } from 'ag-charts-community';
 
 export const RANGE_BAR_SERIES_THEME = {
     __extends__: _Theme.EXTENDS_SERIES_DEFAULTS,
+    direction: 'vertical' as const,
     xKey: '',
     yLowKey: '',
     yHighKey: '',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10537

Fixes range-bar updates via `AgChart.update()` always triggering an animation reset; this was due to `direction` being unset in the default config, so a difference in this property was always detected.

Bonus: Cleaned up `AgChartV2.applySeries()` a bit, to make logging of mismatching properties quicker to identify.