### PR TITLE
AG-10528 - Add chart-level animation phases.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -467,6 +467,7 @@ function applySeries(chart: Chart, options: AgChartOptions): SeriesChangeType {
     const matchResult = matchSeriesOptions(chart.series, chart.processedOptions, optSeries);
     if (matchResult.status === 'no-overlap' || matchResult.status === 'series-grouping-changed') {
         debug(`AgChartV2.applySeries() - creating new series instances, status: ${matchResult.status}`, matchResult);
+        chart.resetAnimations();
         chart.series = createSeries(chart, optSeries);
         return 'replaced';
     }

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1033,6 +1033,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     // Should be available after the first layout.
     protected seriesRect?: BBox;
+    // BBox of the chart area containing animatable elements; if this changes, we skip animations.
     protected animationRect?: BBox;
 
     // x/y are local canvas coordinates in CSS pixels, not actual pixels

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -33,6 +33,7 @@ import { isFiniteNumber } from '../util/type-guards';
 import type { PickRequired } from '../util/types';
 import { BOOLEAN, OBJECT, UNION, Validate } from '../util/validation';
 import type { Caption } from './caption';
+import type { ChartAnimationPhase } from './chartAnimationPhase';
 import type { ChartAxis } from './chartAxis';
 import { ChartHighlight } from './chartHighlight';
 import type { ChartMode } from './chartMode';
@@ -248,6 +249,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
         return this._destroyed;
     }
 
+    chartAnimationPhase: ChartAnimationPhase = 'initial';
+
     protected readonly animationManager: AnimationManager;
     protected readonly chartEventManager: ChartEventManager;
     protected readonly cursorManager: CursorManager;
@@ -437,6 +440,18 @@ export abstract class Chart extends Observable implements AgChartInstance {
         };
     }
 
+    resetAnimations() {
+        this.chartAnimationPhase = 'initial';
+
+        for (const series of this.series) {
+            series.resetAnimation(this.chartAnimationPhase);
+        }
+
+        // Reset animation state.
+        this.animationRect = undefined;
+        this.animationManager?.reset();
+    }
+
     destroy(opts?: { keepTransferableResources: boolean }): TransferableResources | undefined {
         if (this._destroyed) {
             return;
@@ -595,6 +610,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
         if (this.updateShortcutCount === 0 && performUpdateType < ChartUpdateType.SCENE_RENDER) {
             this.animationManager.startBatch(this._performUpdateSkipAnimations);
+            this.animationManager.onBatchStop(() => (this.chartAnimationPhase = 'ready'));
         }
 
         this.debug('Chart.performUpdate() - start', ChartUpdateType[performUpdateType]);
@@ -765,13 +781,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 },
             };
 
+            series.resetAnimation(this.chartAnimationPhase);
             this.addSeriesListeners(series);
             series.addChartEventListeners();
         }
-
-        // Reset animation state.
-        this.animationRect = undefined;
-        this.animationManager?.reset();
     }
 
     protected destroySeries(series: Series<any>[]): void {

--- a/packages/ag-charts-community/src/chart/chartAnimationPhase.ts
+++ b/packages/ag-charts-community/src/chart/chartAnimationPhase.ts
@@ -1,0 +1,2 @@
+/** Chart animation phases - determines the top-level animation lifecycle phase for the overall chart */
+export type ChartAnimationPhase = 'initial' | 'ready';

--- a/packages/ag-charts-community/src/chart/chartProxy.ts
+++ b/packages/ag-charts-community/src/chart/chartProxy.ts
@@ -51,6 +51,10 @@ export class AgChartInstanceProxy implements AgChartProxy {
         return this.chart.getOptions();
     }
 
+    resetAnimations(): void {
+        this.chart.resetAnimations();
+    }
+
     destroy() {
         this.chart.destroy();
     }

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -289,7 +289,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
     }
 
     public onBatchStop(cb: () => void) {
-        this.batch.stoppedCbs.push(cb);
+        this.batch.stoppedCbs.add(cb);
     }
 }
 
@@ -299,7 +299,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
  */
 class AnimationBatch {
     public readonly controllers: Map<string, IAnimation<any>> = new Map();
-    public readonly stoppedCbs: (() => void)[] = [];
+    public readonly stoppedCbs: Set<() => void> = new Set();
 
     private skipAnimations = false;
     // private phase?: 'initial-load' | 'remove' | 'update' | 'add';
@@ -320,7 +320,7 @@ class AnimationBatch {
 
     dispatchStopped() {
         this.stoppedCbs.forEach((cb) => cb());
-        this.stoppedCbs.length = 0;
+        this.stoppedCbs.clear();
     }
 
     isSkipped() {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -22,6 +22,7 @@ import { Observable } from '../../util/observable';
 import { ActionOnSet } from '../../util/proxy';
 import { isFiniteNumber } from '../../util/type-guards';
 import { checkDatum } from '../../util/value';
+import type { ChartAnimationPhase } from '../chartAnimationPhase';
 import type { ChartAxis } from '../chartAxis';
 import { ChartAxisDirection } from '../chartAxisDirection';
 import type { ChartMode } from '../chartMode';
@@ -484,6 +485,8 @@ export abstract class Series<
         this.ctx.seriesStateManager.deregisterSeries(this);
         this.ctx.seriesLayerManager.releaseGroup(this);
     }
+
+    abstract resetAnimation(chartAnimationPhase: ChartAnimationPhase): void;
 
     private getDirectionValues(
         direction: ChartAxisDirection,

--- a/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
@@ -26,6 +26,8 @@ export type AgChartOptions = AgCartesianChartOptions | AgPolarChartOptions | AgH
 export interface AgChartInstance {
     /** Get the `AgChartOptions` representing the current chart configuration. */
     getOptions(): AgChartOptions;
+    /** Reset animation state; treat the next AgChart.update() as-if the chart is being created from scratch. */
+    resetAnimations(): void;
     /** Destroy the chart instance and any allocated resources to support its rendering. */
     destroy(): void;
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10528

Adds a concept of Chart-level animation phase. This allows us to handle series add/remove cases more gracefully for Integrated Charts cases.

This PR doesn't intentionally change the animation behaviour, I'll follow-up with a PR to actually change behaviour distinctly.