### PR TITLE
Fix circular dependencies

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -2,7 +2,8 @@ import type { LicenseManager } from '../module/enterpriseModule';
 import { enterpriseModule } from '../module/enterpriseModule';
 import { type Module, REGISTERED_MODULES, hasRegisteredEnterpriseModules } from '../module/module';
 import type { ModuleContext } from '../module/moduleContext';
-import { type AxisOptionModule, ChartOptions, type SeriesOptionModule } from '../module/optionsModule';
+import { type AxisOptionModule, ChartOptions } from '../module/optionsModule';
+import type { SeriesOptionModule } from '../module/optionsModuleTypes';
 import type {
     AgBaseAxisOptions,
     AgBaseSeriesOptions,

--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -42,7 +42,7 @@ import {
     isAgPolarChartOptions,
 } from './mapping/types';
 import { PolarChart } from './polarChart';
-import type { Series } from './series/series';
+import { type Series, checkSeriesUpcast } from './series/series';
 import type { SeriesGrouping } from './series/seriesStateManager';
 
 const debug = Debug.create(true, 'opts');
@@ -563,9 +563,11 @@ function createSeries(chart: Chart, options: SeriesOptionsTypes[]): Series<any>[
             continue;
         }
         const seriesInstance = getSeries(type, moduleContext);
-        applySeriesOptionModules(seriesInstance, seriesOptions);
-        applySeriesValues(seriesInstance, seriesOptions);
-        series.push(seriesInstance);
+        if (checkSeriesUpcast(seriesInstance)) {
+            applySeriesOptionModules(seriesInstance, seriesOptions);
+            applySeriesValues(seriesInstance, seriesOptions);
+            series.push(seriesInstance);
+        }
     }
 
     return series;

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -16,10 +16,11 @@ import {
     TEXT_WRAP,
     Validate,
 } from '../util/validation';
+import type { CaptionLike } from './captionLike';
 import type { InteractionEvent } from './interaction/interactionManager';
 import { toTooltipHtml } from './tooltip/tooltip';
 
-export class Caption extends BaseProperties {
+export class Caption extends BaseProperties implements CaptionLike {
     static readonly SMALL_PADDING = 10;
     static readonly LARGE_PADDING = 20;
 

--- a/packages/ag-charts-community/src/chart/captionLike.ts
+++ b/packages/ag-charts-community/src/chart/captionLike.ts
@@ -1,0 +1,4 @@
+export interface CaptionLike {
+    enabled: boolean;
+    text?: string;
+}

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -67,7 +67,7 @@ import { Tooltip } from './tooltip/tooltip';
 import { BaseLayoutProcessor } from './update/baseLayoutProcessor';
 import { DataWindowProcessor } from './update/dataWindowProcessor';
 import type { UpdateProcessor } from './update/processor';
-import { UpdateService } from './updateService';
+import { UpdateOpts, UpdateService } from './updateService';
 
 type OptionalHTMLElement = HTMLElement | undefined | null;
 
@@ -561,17 +561,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             }
         });
     });
-    public update(
-        type = ChartUpdateType.FULL,
-        opts?: {
-            forceNodeDataRefresh?: boolean;
-            skipAnimations?: boolean;
-            newAnimationBatch?: boolean;
-            seriesToUpdate?: Iterable<ISeries<any>>;
-            backOffMs?: number;
-            skipSync?: boolean;
-        }
-    ) {
+    public update(type = ChartUpdateType.FULL, opts?: UpdateOpts) {
         const {
             forceNodeDataRefresh = false,
             skipAnimations,

--- a/packages/ag-charts-community/src/chart/chartService.ts
+++ b/packages/ag-charts-community/src/chart/chartService.ts
@@ -1,10 +1,10 @@
-import type { Caption } from './caption';
+import type { CaptionLike } from './captionLike';
 import type { ChartMode } from './chartMode';
 import type { ISeries } from './series/seriesTypes';
 
 // Subset of chart.ts exposed in the module context:
 export interface ChartService {
     readonly mode: ChartMode;
-    readonly title?: Caption;
+    readonly title?: CaptionLike;
     readonly series: ISeries<any>[];
 }

--- a/packages/ag-charts-community/src/chart/factory/axisTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/axisTypes.ts
@@ -1,20 +1,9 @@
-import type { AxisConstructor } from '../../module/coreModules';
 import type { ModuleContext } from '../../module/moduleContext';
-import { CategoryAxis } from '../axis/categoryAxis';
-import { GroupedCategoryAxis } from '../axis/groupedCategoryAxis';
-import { LogAxis } from '../axis/logAxis';
-import { NumberAxis } from '../axis/numberAxis';
-import { TimeAxis } from '../axis/timeAxis';
+import type { ChartAxis } from '../chartAxis';
 
-const AXIS_CONSTRUCTORS: Record<string, AxisConstructor> = {
-    [NumberAxis.type]: NumberAxis,
-    [CategoryAxis.type]: CategoryAxis,
-    [TimeAxis.type]: TimeAxis,
-    [GroupedCategoryAxis.type]: GroupedCategoryAxis,
-    [LogAxis.type]: LogAxis,
-};
+const AXIS_CONSTRUCTORS: Record<string, new (moduleContext: ModuleContext) => ChartAxis> = {};
 
-export function registerAxis(axisType: string, ctor: AxisConstructor) {
+export function registerAxis(axisType: string, ctor: new (moduleContext: ModuleContext) => ChartAxis) {
     AXIS_CONSTRUCTORS[axisType] = ctor;
 }
 

--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-collapsible-if */
-import type { Module } from '../../module-support';
+import type { Module } from '../../module/module';
 
 type EnterpriseModuleStub = Pick<Module<any>, 'type' | 'identifier' | 'optionsKey' | 'chartTypes'> & {
     useCount?: number;

--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -1,7 +1,10 @@
 /* eslint-disable sonarjs/no-collapsible-if */
-import type { Module } from '../../module/module';
-
-type EnterpriseModuleStub = Pick<Module<any>, 'type' | 'identifier' | 'optionsKey' | 'chartTypes'> & {
+type EnterpriseModuleStub = {
+    type: 'axis' | 'axis-option' | 'series' | 'series-option' | 'root' | 'legend';
+    packageType?: 'enterprise';
+    identifier?: string;
+    optionsKey: string;
+    chartTypes: ('cartesian' | 'polar' | 'hierarchy')[];
     useCount?: number;
     optionsInnerKey?: string;
 };
@@ -69,8 +72,13 @@ export function isEnterpriseHierarchy(seriesType: string) {
     return type === 'hierarchy';
 }
 
-export function verifyIfModuleExpected(module: Module<any>) {
-    if (module.packageType !== 'enterprise') {
+type UnknownPackage = { packageType: string } | EnterpriseModuleStub;
+function isEnterpriseModule(module: UnknownPackage): module is EnterpriseModuleStub {
+    return module.packageType === 'enterprise';
+}
+
+export function verifyIfModuleExpected(module: UnknownPackage) {
+    if (!isEnterpriseModule(module)) {
         throw new Error('AG Charts - internal configuration error, only enterprise modules need verification.');
     }
 

--- a/packages/ag-charts-community/src/chart/factory/legendTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/legendTypes.ts
@@ -1,15 +1,10 @@
 import type { LegendConstructor } from '../../module/coreModules';
 import type { ModuleContext } from '../../module/moduleContext';
-import { Legend } from '../legend';
 import type { ChartLegend, ChartLegendType } from '../legendDatum';
 
-const LEGEND_FACTORIES: Partial<Record<ChartLegendType, LegendConstructor>> = {
-    category: Legend,
-};
+const LEGEND_FACTORIES: Partial<Record<ChartLegendType, LegendConstructor>> = {};
 
-const LEGEND_KEYS: Partial<Record<ChartLegendType, string>> = {
-    category: 'legend',
-};
+const LEGEND_KEYS: Partial<Record<ChartLegendType, string>> = {};
 
 export function registerLegend(type: ChartLegendType, key: string, ctr: LegendConstructor, theme: {} | undefined) {
     LEGEND_FACTORIES[type] = ctr;

--- a/packages/ag-charts-community/src/chart/factory/registerInbuiltModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/registerInbuiltModules.ts
@@ -1,5 +1,11 @@
 import { registerModule } from '../../module/module';
+import { CategoryAxis } from '../axis/categoryAxis';
+import { GroupedCategoryAxis } from '../axis/groupedCategoryAxis';
+import { LogAxis } from '../axis/logAxis';
+import { NumberAxis } from '../axis/numberAxis';
+import { TimeAxis } from '../axis/timeAxis';
 import { BackgroundModule } from '../background/backgroundModule';
+import { Legend } from '../legend';
 import { NavigatorModule } from '../navigator/navigatorModule';
 import { AreaSeriesModule } from '../series/cartesian/areaSeriesModule';
 import { BarSeriesModule } from '../series/cartesian/barSeriesModule';
@@ -9,6 +15,8 @@ import { LineSeriesModule } from '../series/cartesian/lineSeriesModule';
 import { ScatterSeriesModule } from '../series/cartesian/scatterSeriesModule';
 import { DonutSeriesModule } from '../series/polar/donutSeriesModule';
 import { PieSeriesModule } from '../series/polar/pieSeriesModule';
+import { registerAxis } from './axisTypes';
+import { registerLegend } from './legendTypes';
 
 export function registerInbuiltModules() {
     registerModule(BackgroundModule);
@@ -22,4 +30,17 @@ export function registerInbuiltModules() {
     registerModule(DonutSeriesModule);
     registerModule(PieSeriesModule);
     registerModule(HistogramSeriesModule);
+
+    const inbuiltAxes = new Map<string, any>([
+        [NumberAxis.type, NumberAxis],
+        [CategoryAxis.type, CategoryAxis],
+        [TimeAxis.type, TimeAxis],
+        [GroupedCategoryAxis.type, GroupedCategoryAxis],
+        [LogAxis.type, LogAxis],
+    ]);
+    inbuiltAxes.forEach((impl, type) => {
+        registerAxis(type, impl);
+    });
+
+    registerLegend('category', 'legend', Legend, undefined);
 }

--- a/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
@@ -12,7 +12,7 @@ import { deepClone } from '../../sparklines-util';
 import { mergeDefaults } from '../../util/object';
 import { isFunction } from '../../util/type-guards';
 import type { SeriesType } from '../mapping/types';
-import type { Series } from '../series/series';
+import type { ISeries } from '../series/seriesTypes';
 import { registerChartSeriesType } from './chartTypes';
 
 export type SeriesOptions = AgCartesianSeriesOptions | AgPolarSeriesOptions | AgHierarchySeriesOptions;
@@ -83,7 +83,7 @@ export function registerSeriesThemeTemplate(
     );
 }
 
-export function getSeries(chartType: string, moduleCtx: ModuleContext): Series<any> {
+export function getSeries(chartType: string, moduleCtx: ModuleContext): ISeries<any> {
     const seriesConstructor = SERIES_FACTORIES[chartType];
     if (seriesConstructor) {
         return new seriesConstructor(moduleCtx);

--- a/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/seriesTypes.ts
@@ -1,4 +1,5 @@
-import type { SeriesConstructor, SeriesModule, SeriesPaletteFactory } from '../../module/coreModules';
+import type { SeriesConstructor, SeriesModule } from '../../module/coreModules';
+import type { SeriesPaletteFactory } from '../../module/coreModulesTypes';
 import { hasRegisteredEnterpriseModules } from '../../module/module';
 import type { ModuleContext } from '../../module/moduleContext';
 import type {

--- a/packages/ag-charts-community/src/chart/factory/setupModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/setupModules.ts
@@ -1,4 +1,5 @@
-import { REGISTERED_MODULES, hasRegisteredEnterpriseModules, registerModuleConflicts } from '../../module/module';
+import { REGISTERED_MODULES, hasRegisteredEnterpriseModules } from '../../module/module';
+import { registerModuleConflicts } from '../../module/moduleConflicts';
 import type { AgChartOptions } from '../../options/agChartOptions';
 import { Logger } from '../../util/logger';
 import { registerAxis, registerAxisThemeTemplate } from './axisTypes';

--- a/packages/ag-charts-community/src/chart/interaction/syncManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/syncManager.ts
@@ -1,13 +1,29 @@
-import type { Chart } from '../chart';
+import type { ChartAxisDirection } from '../chartAxisDirection';
+import type { ISeries } from '../series/seriesTypes';
 import { BaseManager } from './baseManager';
+import type { ZoomManager } from './zoomManager';
 
 type GroupId = string | symbol;
 
+/** Breaks circular dependencies which occur when importing ChartAxis. */
+type AxisLike = {
+    boundSeries: ISeries<any>[];
+    direction: ChartAxisDirection;
+    keys: string[];
+};
+
+/** Breaks circular dependencies which occur when importing Chart. */
+type ChartLike = {
+    axes: AxisLike[];
+    series: ISeries<any>[];
+    zoomManager: ZoomManager;
+};
+
 export class SyncManager extends BaseManager {
-    static chartsGroups = new Map<GroupId, Set<Chart>>();
+    static chartsGroups = new Map<GroupId, Set<ChartLike>>();
     static DEFAULT_GROUP = Symbol('sync-group-default');
 
-    constructor(protected chart: Chart) {
+    constructor(protected chart: ChartLike) {
         super();
     }
 

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,4 +1,3 @@
-import type { ChartAxis } from '../chartAxis';
 import { ChartAxisDirection } from '../chartAxisDirection';
 import { BaseManager } from './baseManager';
 
@@ -17,6 +16,12 @@ export interface ZoomChangeEvent extends AxisZoomState {
     axes: Record<string, ZoomState | undefined>;
 }
 
+type ChartAxisLike = {
+    id: string;
+    direction: ChartAxisDirection;
+    visibleRange: [number, number];
+};
+
 /**
  * Manages the current zoom state for a chart. Tracks the requested zoom from distinct dependents
  * and handles conflicting zoom requests.
@@ -25,7 +30,7 @@ export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
     private axisZoomManagers = new Map<string, AxisZoomManager>();
     private initialZoom?: { callerId: string; newZoom?: AxisZoomState };
 
-    public updateAxes(axes: Array<ChartAxis>) {
+    public updateAxes(axes: Array<ChartAxisLike>) {
         const zoomManagers = new Map(axes.map((axis) => [axis.id, this.axisZoomManagers.get(axis.id)]));
 
         this.axisZoomManagers.clear();
@@ -112,9 +117,9 @@ export class ZoomManager extends BaseManager<'zoom-change', ZoomChangeEvent> {
 class AxisZoomManager {
     private readonly states = new Map<string, ZoomState>();
     private currentZoom: ZoomState;
-    private axis: ChartAxis;
+    private axis: ChartAxisLike;
 
-    constructor(axis: ChartAxis) {
+    constructor(axis: ChartAxisLike) {
         this.axis = axis;
 
         const [min = 0, max = 1] = axis.visibleRange;

--- a/packages/ag-charts-community/src/chart/series/polar/pieTheme.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieTheme.ts
@@ -1,4 +1,5 @@
-import type { ExtensibleTheme, SeriesPaletteFactory } from '../../../module/coreModules';
+import type { ExtensibleTheme } from '../../../module/coreModules';
+import type { SeriesPaletteFactory } from '../../../module/coreModulesTypes';
 import { FONT_WEIGHT } from '../../themes/constants';
 import {
     DEFAULT_BACKGROUND_COLOUR,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -184,7 +184,7 @@ export function groupAccumulativeValueProperty<K>(
 
 // Series is the only class that implements ISeries. However using a type-guard is safer and
 // more maintainable that using `as Series<T>` to upcast an ISeries object.
-export function checkSeriesUpcast<T extends SeriesNodeDatum>(_s: ISeries<T>) : _s is Series<T> {
+export function checkSeriesUpcast<T extends SeriesNodeDatum>(_s: ISeries<T>): _s is Series<T> {
     return true;
 }
 

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -182,6 +182,12 @@ export function groupAccumulativeValueProperty<K>(
     ];
 }
 
+// Series is the only class that implements ISeries. However using a type-guard is safer and
+// more maintainable that using `as Series<T>` to upcast an ISeries object.
+export function checkSeriesUpcast<T extends SeriesNodeDatum>(_s: ISeries<T>) : _s is Series<T> {
+    return true;
+}
+
 export type SeriesNodeEventTypes = 'nodeClick' | 'nodeDoubleClick';
 
 interface INodeClickEvent<TEvent extends string = SeriesNodeEventTypes> extends TypedEvent {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1,6 +1,6 @@
 import type { ModuleContext, SeriesContext } from '../../module/moduleContext';
 import { ModuleMap } from '../../module/moduleMap';
-import type { SeriesOptionInstance, SeriesOptionModule, SeriesType } from '../../module/optionsModule';
+import type { SeriesOptionInstance, SeriesOptionModule, SeriesType } from '../../module/optionsModuleTypes';
 import type { AgChartLabelFormatterParams, AgChartLabelOptions } from '../../options/agChartOptions';
 import type {
     AgSeriesMarkerFormatterParams,

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -1,14 +1,18 @@
 import type { BBox } from '../../scene/bbox';
 import type { Group } from '../../scene/group';
 import type { Point, SizedPoint } from '../../scene/point';
-import type { ChartAxis } from '../chartAxis';
 import type { ChartAxisDirection } from '../chartAxisDirection';
 import type { ChartLegendDatum, ChartLegendType } from '../legendDatum';
 import type { SeriesProperties } from './seriesProperties';
 
+// Breaks circular dependency between ISeries and ChartAxis.
+interface ChartAxisLike {
+    id: string;
+}
+
 export interface ISeries<TDatum> {
     id: string;
-    axes: Record<ChartAxisDirection, ChartAxis | undefined>;
+    axes: Record<ChartAxisDirection, ChartAxisLike | undefined>;
     contentGroup: Group;
     properties: SeriesProperties<any>;
     hasEventListener(type: string): boolean;

--- a/packages/ag-charts-community/src/chart/updateService.ts
+++ b/packages/ag-charts-community/src/chart/updateService.ts
@@ -1,21 +1,30 @@
 import type { BBox } from '../scene/bbox';
 import { Listeners } from '../util/listeners';
-import type { Chart } from './chart';
 import { ChartUpdateType } from './chartUpdateType';
+import type { ISeries } from './series/seriesTypes';
 
-type UpdateCallback = (...args: Parameters<Chart['update']>) => void;
+type UpdateCallback = (type: ChartUpdateType, opts?: UpdateOpts) => void;
 
 export interface UpdateCompleteEvent {
     type: 'update-complete';
     minRect?: BBox;
 }
 
+export type UpdateOpts = {
+    forceNodeDataRefresh?: boolean;
+    skipAnimations?: boolean;
+    newAnimationBatch?: boolean;
+    seriesToUpdate?: Iterable<ISeries<any>>;
+    backOffMs?: number;
+    skipSync?: boolean;
+};
+
 export class UpdateService extends Listeners<'update-complete', (event: UpdateCompleteEvent) => void> {
     constructor(private readonly updateCallback: UpdateCallback) {
         super();
     }
 
-    public update(type = ChartUpdateType.FULL, options?: Parameters<Chart['update']>[1]) {
+    public update(type = ChartUpdateType.FULL, options?: UpdateOpts) {
         this.updateCallback(type, options);
     }
 

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -16,6 +16,7 @@ export * from './util/theme';
 export * from './module/baseModule';
 export * from './module/coreModules';
 export * from './module/optionsModule';
+export * from './module/optionsModuleTypes';
 export * from './module/module';
 export * from './module/moduleContext';
 export * from './module/enterpriseModule';

--- a/packages/ag-charts-community/src/module/coreModules.ts
+++ b/packages/ag-charts-community/src/module/coreModules.ts
@@ -3,38 +3,12 @@ import type { ChartLegend, ChartLegendType } from '../chart/legendDatum';
 import type { Series } from '../chart/series/series';
 import type { AgChartOptions, AgChartThemeOverrides } from '../options/agChartOptions';
 import type { BaseModule, ModuleInstance } from './baseModule';
+import type { SeriesPaletteFactory } from './coreModulesTypes';
 import type { ModuleContext } from './moduleContext';
 
 export type AxisConstructor = new (moduleContext: ModuleContext) => ChartAxis;
 export type SeriesConstructor = new (moduleContext: ModuleContext) => Series<any>;
 export type LegendConstructor = new (moduleContext: ModuleContext) => ChartLegend;
-
-export type SeriesPaletteOptions<
-    SeriesType extends RequiredSeriesType,
-    SeriesOpts = NonNullable<AgChartOptions['series']>[number] & { type: SeriesType },
-    ColourKeys = 'stroke' | 'fill' | 'fills' | 'strokes' | 'colors',
-    NestedKeys = 'marker' | 'calloutLine',
-> = {
-    [K in keyof SeriesOpts & ColourKeys]: NonNullable<SeriesOpts[K]>;
-} & {
-    [K in keyof SeriesOpts & NestedKeys]: {
-        [K2 in keyof NonNullable<SeriesOpts[K]> & ColourKeys]: NonNullable<NonNullable<SeriesOpts[K]>[K2]>;
-    };
-};
-
-export interface SeriesPaletteFactoryParams {
-    takeColors: (count: number) => { fills: string[]; strokes: string[] };
-    colorsCount: number;
-    userPalette: boolean;
-    themeTemplateParameters: {
-        extensions: Map<string, any>;
-        properties: Map<string, string | string[]>;
-    };
-}
-
-export type SeriesPaletteFactory<SeriesType extends RequiredSeriesType = RequiredSeriesType> = (
-    params: SeriesPaletteFactoryParams
-) => SeriesPaletteOptions<SeriesType>;
 
 export interface RootModule<M extends ModuleInstance = ModuleInstance> extends BaseModule {
     type: 'root';

--- a/packages/ag-charts-community/src/module/coreModulesTypes.ts
+++ b/packages/ag-charts-community/src/module/coreModulesTypes.ts
@@ -1,0 +1,31 @@
+import type { SeriesOptionsTypes } from '../chart/mapping/types';
+import type { AgChartOptions } from '../options/agChartOptions';
+
+type RequiredSeriesType = NonNullable<SeriesOptionsTypes['type']>;
+
+export interface SeriesPaletteFactoryParams {
+    takeColors: (count: number) => { fills: string[]; strokes: string[] };
+    colorsCount: number;
+    userPalette: boolean;
+    themeTemplateParameters: {
+        extensions: Map<string, any>;
+        properties: Map<string, string | string[]>;
+    };
+}
+
+export type SeriesPaletteFactory<SeriesType extends RequiredSeriesType = RequiredSeriesType> = (
+    params: SeriesPaletteFactoryParams
+) => SeriesPaletteOptions<SeriesType>;
+
+export type SeriesPaletteOptions<
+    SeriesType extends RequiredSeriesType,
+    SeriesOpts = NonNullable<AgChartOptions['series']>[number] & { type: SeriesType },
+    ColourKeys = 'stroke' | 'fill' | 'fills' | 'strokes' | 'colors',
+    NestedKeys = 'marker' | 'calloutLine',
+> = {
+    [K in keyof SeriesOpts & ColourKeys]: NonNullable<SeriesOpts[K]>;
+} & {
+    [K in keyof SeriesOpts & NestedKeys]: {
+        [K2 in keyof NonNullable<SeriesOpts[K]> & ColourKeys]: NonNullable<NonNullable<SeriesOpts[K]>[K2]>;
+    };
+};

--- a/packages/ag-charts-community/src/module/module.ts
+++ b/packages/ag-charts-community/src/module/module.ts
@@ -1,7 +1,8 @@
 import type { AgChartOptions } from '../options/agChartOptions';
 import type { ModuleInstance } from './baseModule';
 import type { AxisModule, LegendModule, RootModule, SeriesModule } from './coreModules';
-import type { AxisOptionModule, SeriesOptionModule } from './optionsModule';
+import type { AxisOptionModule } from './optionsModule';
+import type { SeriesOptionModule } from './optionsModuleTypes';
 
 export type Module<M extends ModuleInstance = ModuleInstance> =
     | RootModule<M>

--- a/packages/ag-charts-community/src/module/module.ts
+++ b/packages/ag-charts-community/src/module/module.ts
@@ -1,4 +1,3 @@
-import type { AgChartOptions } from '../options/agChartOptions';
 import type { ModuleInstance } from './baseModule';
 import type { AxisModule, LegendModule, RootModule, SeriesModule } from './coreModules';
 import type { AxisOptionModule } from './optionsModule';
@@ -48,10 +47,4 @@ export function registerModule(module: Module) {
 
 export function hasRegisteredEnterpriseModules() {
     return REGISTERED_MODULES.some((m) => m.packageType === 'enterprise');
-}
-
-type AgChartOptionsKeys = keyof AgChartOptions;
-export const MODULE_CONFLICTS: Map<AgChartOptionsKeys, AgChartOptionsKeys[]> = new Map();
-export function registerModuleConflicts(source: AgChartOptionsKeys, targets: AgChartOptionsKeys[]) {
-    MODULE_CONFLICTS.set(source, targets);
 }

--- a/packages/ag-charts-community/src/module/moduleConflicts.ts
+++ b/packages/ag-charts-community/src/module/moduleConflicts.ts
@@ -1,0 +1,7 @@
+import type { AgChartOptions } from '../options/agChartOptions';
+
+type AgChartOptionsKeys = keyof AgChartOptions;
+export const MODULE_CONFLICTS: Map<AgChartOptionsKeys, AgChartOptionsKeys[]> = new Map();
+export function registerModuleConflicts(source: AgChartOptionsKeys, targets: AgChartOptionsKeys[]) {
+    MODULE_CONFLICTS.set(source, targets);
+}

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -34,7 +34,7 @@ import { mergeArrayDefaults, mergeDefaults } from '../util/object';
 import { isEnumValue, isFiniteNumber, isObject, isPlainObject, isString } from '../util/type-guards';
 import type { BaseModule, ModuleInstance } from './baseModule';
 import { enterpriseModule } from './enterpriseModule';
-import { MODULE_CONFLICTS } from './module';
+import { MODULE_CONFLICTS } from './moduleConflicts';
 import type { AxisContext, ModuleContextWithParent } from './moduleContext';
 import type { SeriesType } from './optionsModuleTypes';
 

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -1,5 +1,3 @@
-import type { ChartAxisDirection } from '../chart/chartAxisDirection';
-import type { PropertyDefinition } from '../chart/data/dataModel';
 import { AXIS_TYPES } from '../chart/factory/axisTypes';
 import { CHART_TYPES } from '../chart/factory/chartTypes';
 import { isEnterpriseSeriesType } from '../chart/factory/expectedEnterpriseModules';
@@ -22,16 +20,12 @@ import {
     isAxisOptionType,
     isSeriesOptionType,
 } from '../chart/mapping/types';
-import type { SeriesNodeDatum } from '../chart/series/seriesTypes';
 import type { ChartTheme } from '../chart/themes/chartTheme';
 import type { AgBaseAxisOptions } from '../options/chart/axisOptions';
 import type { AgCartesianChartOptions, AgChartOptions } from '../options/chart/chartBuilderOptions';
 import { type AgTooltipPositionOptions, AgTooltipPositionType } from '../options/chart/tooltipOptions';
 import type { AgCartesianAxisOptions } from '../options/series/cartesian/cartesianOptions';
-import type { AgCartesianSeriesOptions } from '../options/series/cartesian/cartesianSeriesTypes';
-import type { AgHierarchySeriesOptions } from '../options/series/hierarchy/hierarchyOptions';
-import type { AgPolarAxisOptions, AgPolarSeriesOptions } from '../options/series/polar/polarOptions';
-import type { Point } from '../scene/point';
+import type { AgPolarAxisOptions } from '../options/series/polar/polarOptions';
 import { circularSliceArray, groupBy, unique } from '../util/array';
 import { Debug } from '../util/debug';
 import { deepClone, jsonDiff, jsonWalk } from '../util/json';
@@ -41,13 +35,8 @@ import { isEnumValue, isFiniteNumber, isObject, isPlainObject, isString } from '
 import type { BaseModule, ModuleInstance } from './baseModule';
 import { enterpriseModule } from './enterpriseModule';
 import { MODULE_CONFLICTS } from './module';
-import type { AxisContext, ModuleContextWithParent, SeriesContext } from './moduleContext';
-
-export type SeriesType = NonNullable<
-    AgCartesianSeriesOptions['type'] | AgPolarSeriesOptions['type'] | AgHierarchySeriesOptions['type']
->;
-
-export type PickNodeDatumResult = { datum: SeriesNodeDatum; distanceSquared: number } | undefined;
+import type { AxisContext, ModuleContextWithParent } from './moduleContext';
+import type { SeriesType } from './optionsModuleTypes';
 
 type AxisType = 'category' | 'number' | 'log' | 'time';
 
@@ -56,23 +45,6 @@ export interface AxisOptionModule<M extends ModuleInstance = ModuleInstance> ext
     axisTypes: AxisType[];
     instanceConstructor: new (ctx: ModuleContextWithParent<AxisContext>) => M;
     themeTemplate: { [K in AxisType]?: object };
-}
-
-export interface SeriesOptionInstance extends ModuleInstance {
-    pickNodeExact(point: Point): PickNodeDatumResult;
-    pickNodeNearest(point: Point): PickNodeDatumResult;
-    pickNodeMainAxisFirst(point: Point): PickNodeDatumResult;
-
-    getPropertyDefinitions(opts: { isContinuousX: boolean; isContinuousY: boolean }): PropertyDefinition<unknown>[];
-    getDomain(direction: ChartAxisDirection): any[];
-    getTooltipParams(): object;
-}
-
-export interface SeriesOptionModule<M extends SeriesOptionInstance = SeriesOptionInstance> extends BaseModule {
-    type: 'series-option';
-    seriesTypes: readonly SeriesType[];
-    instanceConstructor: new (ctx: SeriesContext) => M;
-    themeTemplate: {};
 }
 
 type GroupingOptions = {

--- a/packages/ag-charts-community/src/module/optionsModuleTypes.ts
+++ b/packages/ag-charts-community/src/module/optionsModuleTypes.ts
@@ -1,0 +1,32 @@
+import type { ChartAxisDirection } from '../chart/chartAxisDirection';
+import type { PropertyDefinition } from '../chart/data/dataModel';
+import type { SeriesNodeDatum } from '../chart/series/seriesTypes';
+import type { AgCartesianSeriesOptions } from '../options/series/cartesian/cartesianSeriesTypes';
+import type { AgHierarchySeriesOptions } from '../options/series/hierarchy/hierarchyOptions';
+import type { AgPolarSeriesOptions } from '../options/series/polar/polarOptions';
+import type { Point } from '../scene/point';
+import type { BaseModule, ModuleInstance } from './baseModule';
+import type { SeriesContext } from './moduleContext';
+
+export type PickNodeDatumResult = { datum: SeriesNodeDatum; distanceSquared: number } | undefined;
+
+export type SeriesType = NonNullable<
+    AgCartesianSeriesOptions['type'] | AgPolarSeriesOptions['type'] | AgHierarchySeriesOptions['type']
+>;
+
+export interface SeriesOptionInstance extends ModuleInstance {
+    pickNodeExact(point: Point): PickNodeDatumResult;
+    pickNodeNearest(point: Point): PickNodeDatumResult;
+    pickNodeMainAxisFirst(point: Point): PickNodeDatumResult;
+
+    getPropertyDefinitions(opts: { isContinuousX: boolean; isContinuousY: boolean }): PropertyDefinition<unknown>[];
+    getDomain(direction: ChartAxisDirection): any[];
+    getTooltipParams(): object;
+}
+
+export interface SeriesOptionModule<M extends SeriesOptionInstance = SeriesOptionInstance> extends BaseModule {
+    type: 'series-option';
+    seriesTypes: readonly SeriesType[];
+    instanceConstructor: new (ctx: SeriesContext) => M;
+    themeTemplate: {};
+}

--- a/packages/ag-charts-community/src/options/chart/gradientLegendOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/gradientLegendOptions.ts
@@ -1,4 +1,4 @@
-import type { AgAxisLabelFormatterParams } from '../agChartOptions';
+import type { AgAxisLabelFormatterParams } from './axisOptions';
 import type { AgChartLegendPosition } from './legendOptions';
 import type { CssColor, FontFamily, FontSize, FontStyle, FontWeight, PixelSize } from './types';
 

--- a/packages/ag-charts-community/src/util/theme.ts
+++ b/packages/ag-charts-community/src/util/theme.ts
@@ -1,4 +1,4 @@
-import type { SeriesPaletteFactoryParams } from '../module/coreModules';
+import type { SeriesPaletteFactoryParams } from '../module/coreModulesTypes';
 
 export const singleSeriesPaletteFactory = ({ takeColors }: SeriesPaletteFactoryParams) => {
     const {


### PR DESCRIPTION
Drops us down from 200 issues to:
```
 warn no-circular: src/chart/themes/chartTheme.ts → 
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/themes/chartTheme.ts
  warn no-circular: src/chart/series/cartesian/scatterSeries.ts → 
      src/chart/series/cartesian/scatterSeriesProperties.ts →
      src/chart/series/cartesian/scatterSeries.ts
  warn no-circular: src/chart/series/cartesian/lineSeries.ts → 
      src/chart/series/cartesian/lineSeriesProperties.ts →
      src/chart/series/cartesian/lineSeries.ts
  warn no-circular: src/chart/series/cartesian/histogramSeries.ts → 
      src/chart/series/cartesian/histogramSeriesProperties.ts →
      src/chart/series/cartesian/histogramSeries.ts
  warn no-circular: src/chart/series/cartesian/bubbleSeries.ts → 
      src/chart/series/cartesian/bubbleSeriesProperties.ts →
      src/chart/series/cartesian/bubbleSeries.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/vividLight.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/vividDark.ts →
      src/chart/themes/darkTheme.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/sheetsLight.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/sheetsDark.ts →
      src/chart/themes/darkTheme.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/polychromaLight.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/polychromaDark.ts →
      src/chart/themes/darkTheme.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/materialLight.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/materialDark.ts →
      src/chart/themes/darkTheme.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/darkTheme.ts →
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/mapping/themes.ts → 
      src/chart/themes/chartTheme.ts →
      src/chart/factory/seriesTypes.ts →
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/mapping/themes.ts
  warn no-circular: src/chart/factory/seriesTypes.ts → 
      src/module/module.ts →
      src/module/optionsModule.ts →
      src/chart/factory/seriesTypes.ts
✘ 16 dependency violations (0 errors, 16 warnings). 451 modules, 2414 dependencies cruised.
```