### PR TITLE
AG-10514 - Fix BarSeries legend toggle using stale from position.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -96,6 +96,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
             pathsPerSeries: 0,
             hasHighlightedLabels: true,
             datumSelectionGarbageCollection: false,
+            animationAlwaysUpdateSelections: true,
             animationResetFns: {
                 datum: resetBarSelectionsFn,
                 label: resetLabelFn,

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -53,6 +53,7 @@ interface SeriesOpts<TNode extends Node, TDatum extends CartesianSeriesNodeDatum
     directionNames: { [key in ChartAxisDirection]?: string[] };
     datumSelectionGarbageCollection: boolean;
     markerSelectionGarbageCollection: boolean;
+    animationAlwaysUpdateSelections: boolean;
     animationResetFns?: {
         path?: (path: Path) => Partial<Path>;
         datum?: (node: TNode, datum: TDatum) => AnimationValue & Partial<TNode>;
@@ -170,6 +171,7 @@ export abstract class CartesianSeries<
         directionNames = DEFAULT_DIRECTION_NAMES,
         datumSelectionGarbageCollection = true,
         markerSelectionGarbageCollection = true,
+        animationAlwaysUpdateSelections = false,
         animationResetFns,
         ...otherOpts
     }: Partial<SeriesOpts<TNode, TDatum, TLabel>> & ConstructorParameters<typeof DataModelSeries>[0]) {
@@ -189,6 +191,7 @@ export abstract class CartesianSeries<
             directionKeys,
             directionNames,
             animationResetFns,
+            animationAlwaysUpdateSelections,
             datumSelectionGarbageCollection,
             markerSelectionGarbageCollection,
         };
@@ -277,7 +280,8 @@ export abstract class CartesianSeries<
     }
 
     protected async updateSelections(anySeriesItemEnabled: boolean) {
-        if (!anySeriesItemEnabled && this.ctx.animationManager.isSkipped()) {
+        const animationSkipUpdate = !this.opts.animationAlwaysUpdateSelections && this.ctx.animationManager.isSkipped();
+        if (!anySeriesItemEnabled && animationSkipUpdate) {
             return;
         }
         if (!this.nodeDataRefresh && !this.isPathOrSelectionDirty()) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10514

Fixes BarSeries legend toggle animation for Integrated Charts cases, and any case where a resize happens between legend toggles.

The root cause was that because `CartesianSeries.updateSelections()` was not running for hidden series, the `Node.datum` was left in a stale state, meaning when animating a visibility toggle that bars scaled in from stale X/Y coordinates.