### PR TITLE
AG-10409 TooltipManager cleanup

### DIFF
--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -101,7 +101,7 @@ export class Caption extends BaseProperties implements CaptionLike {
         }
 
         const bbox = this.node.computeBBox();
-        const { pageX, pageY, offsetX, offsetY } = event;
+        const {  offsetX, offsetY } = event;
         const pointerInsideCaption = this.node.visible && bbox.containsPoint(offsetX, offsetY);
 
         if (!pointerInsideCaption) {
@@ -120,7 +120,7 @@ export class Caption extends BaseProperties implements CaptionLike {
 
         moduleCtx.tooltipManager.updateTooltip(
             this.id,
-            { pageX, pageY, offsetX, offsetY, showArrow: false, addCustomClass: false },
+            {  offsetX, offsetY, showArrow: false, addCustomClass: false },
             toTooltipHtml({ content: this.text })
         );
     }

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -120,7 +120,7 @@ export class Caption extends BaseProperties implements CaptionLike {
 
         moduleCtx.tooltipManager.updateTooltip(
             this.id,
-            { pageX, pageY, offsetX, offsetY, event, showArrow: false, addCustomClass: false },
+            { pageX, pageY, offsetX, offsetY, showArrow: false, addCustomClass: false },
             toTooltipHtml({ content: this.text })
         );
     }

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -101,7 +101,7 @@ export class Caption extends BaseProperties implements CaptionLike {
         }
 
         const bbox = this.node.computeBBox();
-        const {  offsetX, offsetY } = event;
+        const { offsetX, offsetY } = event;
         const pointerInsideCaption = this.node.visible && bbox.containsPoint(offsetX, offsetY);
 
         if (!pointerInsideCaption) {
@@ -120,7 +120,7 @@ export class Caption extends BaseProperties implements CaptionLike {
 
         moduleCtx.tooltipManager.updateTooltip(
             this.id,
-            {  offsetX, offsetY, showArrow: false, addCustomClass: false },
+            { offsetX, offsetY, showArrow: false, addCustomClass: false },
             toTooltipHtml({ content: this.text })
         );
     }

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -656,7 +656,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 const tooltipMeta = this.tooltipManager.getTooltipMeta(this.id);
                 const isHovered = tooltipMeta?.event?.type === 'hover';
                 if (performUpdateType <= ChartUpdateType.SERIES_UPDATE && isHovered) {
-                    this.handlePointer(tooltipMeta.event as InteractionEvent<'hover'>);
+                    this.handlePointer(tooltipMeta.event);
                 }
                 splits['↖'] = performance.now();
             // fallthrough

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1093,9 +1093,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         return result;
     }
 
-    lastPick?: {
-        datum: SeriesNodeDatum;
-    };
+    private lastPick?: SeriesNodeDatum;
 
     protected onMouseMove(event: InteractionEvent<'hover'>): void {
         this.lastInteractionEvent = event;
@@ -1163,7 +1161,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             return;
         }
 
-        const isNewDatum = this.highlight.range === 'node' || !lastPick || lastPick.datum !== pick.datum;
+        const isNewDatum = this.highlight.range === 'node' || !lastPick || lastPick !== pick.datum;
         let html;
 
         if (isNewDatum) {
@@ -1327,7 +1325,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.cursorManager.updateCursor(newSeries.id, newSeries.properties.cursor);
         }
 
-        this.lastPick = event.currentHighlight ? { datum: event.currentHighlight } : undefined;
+        this.lastPick = event.currentHighlight;
 
         const updateAll = newSeries == null || lastSeries == null;
         if (updateAll) {

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -47,7 +47,7 @@ import { GestureDetector } from './interaction/gestureDetector';
 import type { HighlightChangeEvent } from './interaction/highlightManager';
 import { HighlightManager } from './interaction/highlightManager';
 import { InteractionState } from './interaction/interactionManager';
-import type { InteractionEvent, PointerData } from './interaction/interactionManager';
+import type { InteractionEvent, PointerOffsets } from './interaction/interactionManager';
 import { InteractionManager } from './interaction/interactionManager';
 import { SyncManager } from './interaction/syncManager';
 import { TooltipManager } from './interaction/tooltipManager';
@@ -1118,7 +1118,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.lastInteractionEvent = undefined;
         }
     });
-    protected handlePointer(event: PointerData) {
+    protected handlePointer(event: PointerOffsets) {
         if (this.interactionManager.getState() !== InteractionState.Default) {
             return;
         }
@@ -1144,7 +1144,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.handlePointerNode(event);
     }
 
-    protected handlePointerTooltip(event: PointerData, disablePointer: (highlightOnly?: boolean) => void) {
+    protected handlePointerTooltip(event: PointerOffsets, disablePointer: (highlightOnly?: boolean) => void) {
         const { lastPick, tooltip } = this;
         const { range } = tooltip;
         const { offsetX, offsetY } = event;
@@ -1178,14 +1178,14 @@ export abstract class Chart extends Observable implements AgChartInstance {
         const rangeMatched = range === 'nearest' || isPixelRange || exactlyMatched;
         const shouldUpdateTooltip = tooltipEnabled && rangeMatched && (!isNewDatum || html !== undefined);
 
-        const meta = TooltipManager.makeTooltipMeta(event, this.scene.canvas, pick.datum, this.specialOverrides.window);
+        const meta = TooltipManager.makeTooltipMeta(event, pick.datum);
 
         if (shouldUpdateTooltip) {
             this.tooltipManager.updateTooltip(this.id, meta, html);
         }
     }
 
-    protected handlePointerNode(event: PointerData) {
+    protected handlePointerNode(event: PointerOffsets) {
         const found = this.checkSeriesNodeRange(event, (series, datum) => {
             if (series.hasEventListener('nodeClick') || series.hasEventListener('nodeDoubleClick')) {
                 this.cursorManager.updateCursor('chart', 'pointer');
@@ -1238,7 +1238,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private checkSeriesNodeRange(
-        event: PointerData,
+        event: PointerOffsets,
         callback: (series: ISeries<any>, datum: SeriesNodeDatum) => void
     ): boolean {
         const nearestNode = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY }, false);

--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -46,12 +46,15 @@ const EVENT_HANDLERS: SUPPORTED_EVENTS[] = [
     'wheel',
 ];
 
-export type InteractionEvent<T extends InteractionTypes = InteractionTypes> = {
-    type: T;
-    offsetX: number;
-    offsetY: number;
+export type PointerData = {
     pageX: number;
     pageY: number;
+    offsetX: number;
+    offsetY: number;
+};
+
+export type InteractionEvent<T extends InteractionTypes = InteractionTypes> = PointerData & {
+    type: T;
     deltaX: number;
     deltaY: number;
     sourceEvent: Event;

--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -46,15 +46,15 @@ const EVENT_HANDLERS: SUPPORTED_EVENTS[] = [
     'wheel',
 ];
 
-export type PointerData = {
-    pageX: number;
-    pageY: number;
+export type PointerOffsets = {
     offsetX: number;
     offsetY: number;
 };
 
-export type InteractionEvent<T extends InteractionTypes = InteractionTypes> = PointerData & {
+export type InteractionEvent<T extends InteractionTypes = InteractionTypes> = PointerOffsets & {
     type: T;
+    pageX: number;
+    pageY: number;
     deltaX: number;
     deltaY: number;
     sourceEvent: Event;

--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -1,9 +1,8 @@
 import type { BBox } from '../../scene/bbox';
-import type { HdpiCanvas } from '../../scene/canvas/hdpiCanvas';
 import type { Point } from '../../scene/point';
 import type { ErrorBoundSeriesNodeDatum, SeriesNodeDatum } from '../series/seriesTypes';
 import type { Tooltip, TooltipMeta } from '../tooltip/tooltip';
-import type { InteractionEvent, InteractionManager, PointerData } from './interactionManager';
+import type { InteractionEvent, InteractionManager, PointerOffsets } from './interactionManager';
 
 interface TooltipState {
     content: string;
@@ -115,20 +114,16 @@ export class TooltipManager {
     }
 
     public static makeTooltipMeta(
-        event: PointerData,
-        canvas: HdpiCanvas,
-        datum: SeriesNodeDatum & Pick<ErrorBoundSeriesNodeDatum, 'yBar'>,
-        window: Window
+        event: PointerOffsets,
+        datum: SeriesNodeDatum & Pick<ErrorBoundSeriesNodeDatum, 'yBar'>
     ): TooltipMeta {
-        const { pageX, pageY, offsetX, offsetY } = event;
+        const { offsetX, offsetY } = event;
         const { tooltip } = datum.series.properties;
         const position = {
             xOffset: tooltip.position.xOffset,
             yOffset: tooltip.position.yOffset,
         };
         const meta: TooltipMeta = {
-            pageX,
-            pageY,
             offsetX,
             offsetY,
             showArrow: tooltip.showArrow,
@@ -142,11 +137,8 @@ export class TooltipManager {
         if (tooltip.position.type === 'node' && refPoint) {
             const { x, y } = refPoint;
             const point = datum.series.contentGroup.inverseTransformPoint(x, y);
-            const canvasRect = canvas.element.getBoundingClientRect();
             return {
                 ...meta,
-                pageX: Math.round(canvasRect.left + window.scrollX + point.x),
-                pageY: Math.round(canvasRect.top + window.scrollY + point.y),
                 offsetX: Math.round(point.x),
                 offsetY: Math.round(point.y),
             };

--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -3,7 +3,7 @@ import type { HdpiCanvas } from '../../scene/canvas/hdpiCanvas';
 import type { Point } from '../../scene/point';
 import type { ErrorBoundSeriesNodeDatum, SeriesNodeDatum } from '../series/seriesTypes';
 import type { Tooltip, TooltipMeta } from '../tooltip/tooltip';
-import type { InteractionEvent, InteractionManager } from './interactionManager';
+import type { InteractionEvent, InteractionManager, PointerData } from './interactionManager';
 
 interface TooltipState {
     content: string;
@@ -115,7 +115,7 @@ export class TooltipManager {
     }
 
     public static makeTooltipMeta(
-        event: InteractionEvent<'hover'>,
+        event: PointerData,
         canvas: HdpiCanvas,
         datum: SeriesNodeDatum & Pick<ErrorBoundSeriesNodeDatum, 'yBar'>,
         window: Window
@@ -131,7 +131,6 @@ export class TooltipManager {
             pageY,
             offsetX,
             offsetY,
-            event,
             showArrow: tooltip.showArrow,
             position,
         };

--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -131,7 +131,7 @@ export class TooltipManager {
             pageY,
             offsetX,
             offsetY,
-            event: event,
+            event,
             showArrow: tooltip.showArrow,
             position,
         };

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -893,7 +893,7 @@ export class Legend extends BaseProperties {
         if (datum && this.truncatedItems.has(datum.itemId ?? datum.id)) {
             this.ctx.tooltipManager.updateTooltip(
                 this.id,
-                { pageX, pageY, offsetX, offsetY, event, showArrow: false, addCustomClass: false },
+                { pageX, pageY, offsetX, offsetY, showArrow: false, addCustomClass: false },
                 toTooltipHtml({ content: this.getItemLabel(datum) })
             );
         } else {

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -867,7 +867,7 @@ export class Legend extends BaseProperties {
         }
 
         const legendBBox = this.computeBBox();
-        const { pageX, pageY, offsetX, offsetY } = event;
+        const {  offsetX, offsetY } = event;
         const pointerInsideLegend = this.group.visible && legendBBox.containsPoint(offsetX, offsetY);
 
         if (!pointerInsideLegend) {
@@ -893,7 +893,7 @@ export class Legend extends BaseProperties {
         if (datum && this.truncatedItems.has(datum.itemId ?? datum.id)) {
             this.ctx.tooltipManager.updateTooltip(
                 this.id,
-                { pageX, pageY, offsetX, offsetY, showArrow: false, addCustomClass: false },
+                {  offsetX, offsetY, showArrow: false, addCustomClass: false },
                 toTooltipHtml({ content: this.getItemLabel(datum) })
             );
         } else {

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -867,7 +867,7 @@ export class Legend extends BaseProperties {
         }
 
         const legendBBox = this.computeBBox();
-        const {  offsetX, offsetY } = event;
+        const { offsetX, offsetY } = event;
         const pointerInsideLegend = this.group.visible && legendBBox.containsPoint(offsetX, offsetY);
 
         if (!pointerInsideLegend) {
@@ -893,7 +893,7 @@ export class Legend extends BaseProperties {
         if (datum && this.truncatedItems.has(datum.itemId ?? datum.id)) {
             this.ctx.tooltipManager.updateTooltip(
                 this.id,
-                {  offsetX, offsetY, showArrow: false, addCustomClass: false },
+                { offsetX, offsetY, showArrow: false, addCustomClass: false },
                 toTooltipHtml({ content: this.getItemLabel(datum) })
             );
         } else {

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -13,7 +13,7 @@ import {
     UNION,
     Validate,
 } from '../../util/validation';
-import type { InteractionEvent, PointerData } from '../interaction/interactionManager';
+import type { InteractionEvent, PointerOffsets } from '../interaction/interactionManager';
 
 const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
 const DEFAULT_TOOLTIP_DARK_CLASS = 'ag-chart-dark-tooltip';
@@ -141,7 +141,7 @@ const defaultTooltipCss = `
 }
 `;
 
-export type TooltipMeta = PointerData & {
+export type TooltipMeta = PointerOffsets & {
     showArrow?: boolean;
     position?: {
         xOffset?: number;

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -152,7 +152,7 @@ export interface TooltipMeta {
         yOffset?: number;
     };
     enableInteraction?: boolean;
-    event: Event | InteractionEvent<any>;
+    event: InteractionEvent<'hover'>;
     addCustomClass?: boolean;
 }
 

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -13,7 +13,7 @@ import {
     UNION,
     Validate,
 } from '../../util/validation';
-import type { InteractionEvent } from '../interaction/interactionManager';
+import type { InteractionEvent, PointerData } from '../interaction/interactionManager';
 
 const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
 const DEFAULT_TOOLTIP_DARK_CLASS = 'ag-chart-dark-tooltip';
@@ -141,18 +141,13 @@ const defaultTooltipCss = `
 }
 `;
 
-export interface TooltipMeta {
-    pageX: number;
-    pageY: number;
-    offsetX: number;
-    offsetY: number;
+export type TooltipMeta = PointerData & {
     showArrow?: boolean;
     position?: {
         xOffset?: number;
         yOffset?: number;
     };
     enableInteraction?: boolean;
-    event: InteractionEvent<'hover'>;
     addCustomClass?: boolean;
 }
 

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -149,7 +149,7 @@ export type TooltipMeta = PointerOffsets & {
     };
     enableInteraction?: boolean;
     addCustomClass?: boolean;
-}
+};
 
 export function toTooltipHtml(input: string | AgTooltipRendererResult, defaults?: AgTooltipRendererResult): string {
     if (typeof input === 'string') {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10409

Avoid caching event objects in `Chart` and `TooltipMeta`. The only things that's need is `offsetX` and `offsetY`