### PR TITLE
Revert "AG-10662 Remove min/max spacing from gradient legend interval"

### DIFF
--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegendThemes.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegendThemes.ts
@@ -16,6 +16,10 @@ export const GRADIENT_LEGEND_THEME: AgGradientLegendOptions = {
             fontFamily: _Theme.DEFAULT_FONT_FAMILY,
             formatter: undefined,
         },
+        interval: {
+            minSpacing: 1,
+            maxSpacing: 50,
+        },
     },
     gradient: {
         preferredLength: 100,


### PR DESCRIPTION
This reverts commit bb21a173a8143969f35e53a7be0f1da2d44db91f.