### PR TITLE
AG-10430 Update loading overlay style and dark theme

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -192,6 +192,9 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -639,6 +642,9 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -1049,6 +1055,9 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -1682,6 +1691,9 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -2368,6 +2380,9 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -2635,6 +2650,9 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -3092,6 +3110,9 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -3654,6 +3675,9 @@ exports[`prepare #prepareOptions for BAR_CHART_EXAMPLE it should prepare options
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -3931,6 +3955,9 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -4204,6 +4231,9 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -4469,6 +4499,9 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -4733,6 +4766,9 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -5081,6 +5117,9 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -5434,6 +5473,9 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -6066,6 +6108,9 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -7211,6 +7256,9 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -7476,6 +7524,9 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -8200,6 +8251,9 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -8616,6 +8670,9 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -9211,6 +9268,9 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -9691,6 +9751,9 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -9848,6 +9911,9 @@ exports[`prepare #prepareOptions for SIMPLE_DONUT_CHART_EXAMPLE it should prepar
   },
   "listeners": {},
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -10186,6 +10252,9 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -10410,6 +10479,9 @@ exports[`prepare #prepareOptions for SIMPLE_PIE_CHART_EXAMPLE it should prepare 
   },
   "listeners": {},
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -10719,6 +10791,9 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -10981,6 +11056,9 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -11650,6 +11728,9 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },
@@ -12108,6 +12189,9 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
     },
   },
   "overlays": {
+    "loading": {
+      "darkTheme": false,
+    },
     "noData": {
       "darkTheme": false,
     },

--- a/packages/ag-charts-community/src/chart/overlay/chartOverlays.ts
+++ b/packages/ag-charts-community/src/chart/overlay/chartOverlays.ts
@@ -11,6 +11,18 @@ const defaultOverlayCss = `
 .${DEFAULT_OVERLAY_CLASS}.${DEFAULT_OVERLAY_DARK_CLASS} {
     color: #ffffff;
 }
+
+.${DEFAULT_OVERLAY_CLASS}--loading {
+    color: rgb(140, 140, 140); /* DEFAULT_MUTED_LABEL_COLOUR */
+}
+
+.${DEFAULT_OVERLAY_CLASS}__loading-background {
+    background: white; /* DEFAULT_BACKGROUND_FILL */
+}
+
+.${DEFAULT_OVERLAY_CLASS}.${DEFAULT_OVERLAY_DARK_CLASS} .${DEFAULT_OVERLAY_CLASS}__loading-background {
+    background: #192232; /* DEFAULT_DARK_BACKGROUND_FILL */
+}
 `;
 
 export class ChartOverlays {
@@ -44,39 +56,55 @@ export class ChartOverlays {
 
     private renderLoadingSpinner(parent: HTMLElement, animationManager: AnimationManager) {
         const container = this.createElement(parent, 'div');
-        container.style.alignItems = 'center';
-        container.style.boxSizing = 'border-box';
+        container.className = `${DEFAULT_OVERLAY_CLASS}--loading`;
         container.style.display = 'flex';
-        container.style.flexDirection = 'column';
+        container.style.alignItems = 'center';
         container.style.justifyContent = 'center';
-        container.style.margin = '8px';
+        container.style.flexDirection = 'column';
         container.style.height = '100%';
-        container.style.font = '12px Verdana, sans-serif';
-        container.style.background = 'rgba(255, 255, 255, 0.5)';
+        container.style.boxSizing = 'border-box';
+        container.style.font = '13px Verdana, sans-serif'; // FONT_SIZE.MEDIUM
+        container.style.userSelect = 'none';
         container.style.animation = `ag-charts-loading ${
             ADD_PHASE.animationDuration * animationManager.defaultDuration
         }ms linear ${ADD_PHASE.animationDelay * animationManager.defaultDuration}ms both`;
 
-        const spinner = this.createElement(container, 'div');
-        spinner.style.width = '10px';
-        spinner.style.height = '10px';
-        spinner.style.borderRadius = '50%';
-        spinner.style.borderWidth = '2px';
-        spinner.style.borderStyle = 'solid';
-        spinner.style.borderColor = 'rgb(0, 0, 0) rgba(0, 0, 0, 0)';
-        spinner.style.animation = 'ag-charts-loading-spinner 1s infinite';
+        const matrix = this.createElement(container, 'span');
+        matrix.style.width = '45px';
+        matrix.style.height = '40px';
+        matrix.style.backgroundImage = `${[
+            'linear-gradient(#0000 calc(1 * 100% / 6), #ccc 0 calc(3 * 100% / 6), #0000 0), ',
+            'linear-gradient(#0000 calc(2 * 100% / 6), #ccc 0 calc(4 * 100% / 6), #0000 0), ',
+            'linear-gradient(#0000 calc(3 * 100% / 6), #ccc 0 calc(5 * 100% / 6), #0000 0)',
+        ].join('')}`;
+        matrix.style.backgroundSize = '10px 400%';
+        matrix.style.backgroundRepeat = 'no-repeat';
+        matrix.style.animation = 'ag-charts-loading-matrix 1s infinite linear';
 
-        const label = this.createElement(container, 'div');
+        const label = this.createElement(container, 'p');
         label.style.marginTop = '1em';
         label.innerText = this.loading.text ?? 'Loading data...';
+
+        const background = this.createElement(parent, 'div');
+        background.className = `${DEFAULT_OVERLAY_CLASS}__loading-background`;
+        background.style.position = 'absolute';
+        background.style.top = '0';
+        background.style.right = '0';
+        background.style.bottom = '0';
+        background.style.left = '0';
+        background.style.opacity = '0.5';
+        background.style.zIndex = '-1';
 
         const animationStyles = this.createElement(container, 'style');
         animationStyles.innerText = [
             '@keyframes ag-charts-loading { from { opacity: 0 } to { opacity: 1 } }',
-            '@keyframes ag-charts-loading-spinner { to { transform: rotate(0.5turn); } }',
-        ].join('');
+            '@keyframes ag-charts-loading-matrix {',
+            '0% { background-position: 0% 0%, 50% 0%, 100% 0%; }',
+            '100% { background-position: 0% 100%, 50% 100%, 100% 100%; }',
+            '}',
+        ].join(' ');
 
-        container.replaceChildren(animationStyles, spinner, label);
+        container.replaceChildren(animationStyles, matrix, label, background);
 
         return container.outerHTML;
     }

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -278,6 +278,9 @@ export class ChartTheme {
                 delay: 0,
             },
             overlays: {
+                loading: {
+                    darkTheme: IS_DARK_THEME,
+                },
                 noData: {
                     darkTheme: IS_DARK_THEME,
                 },

--- a/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
@@ -1,13 +1,13 @@
 import { ChartUpdateType } from '../chartUpdateType';
 import type { DataService } from '../data/dataService';
-import type { ZoomManager } from '../interaction/zoomManager';
+import type { ZoomManager, ZoomState } from '../interaction/zoomManager';
 import type { UpdateService } from '../updateService';
 import type { AxisLike, ChartLike, UpdateProcessor } from './processor';
 
 export class DataWindowProcessor<D extends object> implements UpdateProcessor {
     private dirtyZoom = false;
     private dirtyDataSource = false;
-    private lastAxisZooms = new Map();
+    private lastAxisZooms = new Map<string, ZoomState>();
 
     private destroyFns: (() => void)[] = [];
 
@@ -50,10 +50,21 @@ export class DataWindowProcessor<D extends object> implements UpdateProcessor {
         if (!this.dataService.isLazy()) return;
 
         const axis = this.getValidAxis();
-        const window = axis ? this.getAxisWindow(axis) : null;
+
+        let window;
+        let shouldRefresh = true;
+
+        if (axis) {
+            const zoom = this.zoomManager.getAxisZoom(axis.id);
+            window = this.getAxisWindow(axis, zoom);
+            shouldRefresh = this.shouldRefresh(axis, zoom);
+        }
 
         this.dirtyZoom = false;
         this.dirtyDataSource = false;
+
+        if (!shouldRefresh) return;
+
         this.dataService.load({ windowStart: window?.min, windowEnd: window?.max });
     }
 
@@ -61,19 +72,24 @@ export class DataWindowProcessor<D extends object> implements UpdateProcessor {
         return this.chart.axes.find((axis) => axis.type === 'time');
     }
 
-    private getAxisWindow(axis: AxisLike) {
-        const zoom = this.zoomManager.getAxisZoom(axis.id);
-        const domain = axis.scale.getDomain?.();
+    private shouldRefresh(axis: AxisLike, zoom: ZoomState) {
+        if (this.dirtyDataSource) return true;
+        if (!this.dirtyZoom) return false;
 
-        if (!zoom || !domain || domain.length === 0 || isNaN(Number(domain[0]))) return;
-
-        if (!this.dirtyDataSource) {
-            // Only run the callback if the zoom has changed on this axis, ignoring invalid axes
-            const lastZoom = this.lastAxisZooms.get(axis.id);
-            if (lastZoom && zoom.min === lastZoom.min && zoom.max === lastZoom.max) return;
+        const lastZoom = this.lastAxisZooms.get(axis.id);
+        if (lastZoom && zoom.min === lastZoom.min && zoom.max === lastZoom.max) {
+            return false;
         }
 
         this.lastAxisZooms.set(axis.id, zoom);
+
+        return true;
+    }
+
+    private getAxisWindow(axis: AxisLike, zoom: ZoomState) {
+        const domain = axis.scale.getDomain?.();
+
+        if (!zoom || !domain || domain.length === 0 || isNaN(Number(domain[0]))) return;
 
         const diff = Number(domain[1]) - Number(domain[0]);
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10430

Also fixes a bug where the data window should not reload the data when the zoom hasn't changed. Previous logic was bust when refactored to the new api.

Also reverts the overlays processor back to using the `layout-complete` event. The original reason for the change was to fix the loading overlay sometimes not showing in rapid changes. But then the background of the loading overlay overlaps the axis tick labels, most notably visible when it stops at the end of the axis line and doesn't cover the full first or last label. The previous issue is hard to reproduce and isn't noticeable.