### PR TITLE
AG-10528 - Integrated animation fixes.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -598,12 +598,13 @@ export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
     }
 
     override animateWaitingUpdateReady(data: BarAnimationData) {
-        const { datumSelections, labelSelections, annotationSelections } = data;
+        const { datumSelections, labelSelections, annotationSelections, previousContextData } = data;
 
         this.ctx.animationManager.stopByAnimationGroupId(this.id);
 
         const diff = this.processedData?.reduced?.diff;
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'fade'));
+        const mode = previousContextData?.length === 0 ? 'fade' : 'normal';
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, mode));
 
         fromToMotion(
             this.id,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -66,6 +66,7 @@ interface BarNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDat
     readonly height: number;
     readonly fill: string | undefined;
     readonly stroke: string | undefined;
+    readonly opacity: number | undefined;
     readonly strokeWidth: number;
     readonly cornerRadius: number;
     readonly topLeftCornerRadius: boolean;
@@ -393,6 +394,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
                     midPoint: { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 },
                     fill,
                     stroke,
+                    opacity: 1,
                     strokeWidth,
                     cornerRadius,
                     topLeftCornerRadius: !(barAlongX === isUpward),
@@ -588,7 +590,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
     }
 
     override animateEmptyUpdateReady({ datumSelections, labelSelections, annotationSelections }: BarAnimationData) {
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes));
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'normal'));
 
         fromToMotion(this.id, 'nodes', this.ctx.animationManager, datumSelections, fns);
         seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);
@@ -601,7 +603,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
         this.ctx.animationManager.stopByAnimationGroupId(this.id);
 
         const diff = this.processedData?.reduced?.diff;
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes));
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'fade'));
 
         fromToMotion(
             this.id,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -297,6 +297,7 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramNodeDatum> {
                 midPoint: nodeMidPoint,
                 fill: fill,
                 stroke: stroke,
+                opacity: 1,
                 strokeWidth: strokeWidth,
                 label: selectionDatumLabel,
             });
@@ -484,7 +485,7 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramNodeDatum> {
     }
 
     override animateEmptyUpdateReady({ datumSelections, labelSelections }: HistogramAnimationData) {
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(true, this.axes));
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(true, this.axes, 'normal'));
         fromToMotion(this.id, 'datums', this.ctx.animationManager, datumSelections, fns);
 
         seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);
@@ -492,7 +493,7 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramNodeDatum> {
 
     override animateWaitingUpdateReady(data: HistogramAnimationData) {
         const diff = this.processedData?.reduced?.diff;
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(true, this.axes));
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(true, this.axes, 'normal'));
 
         fromToMotion(
             this.id,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
@@ -29,6 +29,7 @@ export interface HistogramNodeDatum extends CartesianSeriesNodeDatum {
     readonly height: number;
     readonly fill?: string;
     readonly stroke?: string;
+    readonly opacity?: number;
     readonly strokeWidth: number;
     readonly aggregatedValue: number;
     readonly frequency: number;

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -24,6 +24,7 @@ interface BulletNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum {
     readonly width: number;
     readonly height: number;
     readonly cumulativeValue: number;
+    readonly opacity: number;
     readonly target?: {
         readonly value: number;
         readonly x1: number;
@@ -231,6 +232,7 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<_Scene.Rect, 
                 target,
                 ...rect,
                 midPoint: { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 },
+                opacity: 1,
             };
             context.nodeData.push(nodeData);
         }
@@ -374,7 +376,7 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<_Scene.Rect, 
     override animateEmptyUpdateReady(data: BulletAnimationData) {
         const { datumSelections, labelSelections, annotationSelections } = data;
 
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes));
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'normal'));
 
         fromToMotion(this.id, 'nodes', this.ctx.animationManager, datumSelections, fns);
         seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);
@@ -387,7 +389,7 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<_Scene.Rect, 
         this.ctx.animationManager.stopByAnimationGroupId(this.id);
 
         const diff = this.processedData?.reduced?.diff;
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes));
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'normal'));
 
         fromToMotion(
             this.id,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -67,6 +67,7 @@ interface RangeBarNodeDatum
     readonly fill: string;
     readonly stroke: string;
     readonly strokeWidth: number;
+    readonly opacity: number;
 }
 
 type RangeBarContext = _ModuleSupport.CartesianSeriesNodeDataContext<RangeBarNodeDatum, RangeBarNodeLabelDatum>;
@@ -345,6 +346,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
                     fill,
                     stroke,
                     strokeWidth,
+                    opacity: 1,
                     labels: labelData,
                 };
 
@@ -607,7 +609,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
     }
 
     override animateEmptyUpdateReady({ datumSelections, labelSelections }: RangeBarAnimationData) {
-        const fns = prepareBarAnimationFunctions(midpointStartingBarPosition(this.isVertical()));
+        const fns = prepareBarAnimationFunctions(midpointStartingBarPosition(this.isVertical(), 'normal'));
         motion.fromToMotion(this.id, 'datums', this.ctx.animationManager, datumSelections, fns);
         seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);
     }
@@ -619,7 +621,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
 
         this.ctx.animationManager.stopByAnimationGroupId(this.id);
 
-        const fns = prepareBarAnimationFunctions(midpointStartingBarPosition(this.isVertical()));
+        const fns = prepareBarAnimationFunctions(midpointStartingBarPosition(this.isVertical(), 'fade'));
         motion.fromToMotion(
             this.id,
             'datums',

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -48,6 +48,7 @@ interface WaterfallNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum, Re
     readonly fill: string;
     readonly stroke: string;
     readonly strokeWidth: number;
+    readonly opacity: number;
 }
 
 interface WaterfallContext extends _ModuleSupport.CartesianSeriesNodeDataContext<WaterfallNodeDatum> {
@@ -444,6 +445,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
                 fill,
                 stroke,
                 strokeWidth,
+                opacity: 1,
                 label: {
                     text: labelText,
                     ...adjustLabelPlacement({
@@ -704,7 +706,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
     protected override toggleSeriesItem(): void {}
 
     override animateEmptyUpdateReady({ datumSelections, labelSelections, contextData, paths }: WaterfallAnimationData) {
-        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes));
+        const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'normal'));
         motion.fromToMotion(this.id, 'datums', this.ctx.animationManager, datumSelections, fns);
 
         seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/index.html
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/index.html
@@ -1,6 +1,8 @@
 <div class="wrapper">
     <div class="toolPanel">
         <button onclick="actionReset()">Reset</button>
+        <button onclick="actionAddSeries()">Add Series</button>
+        <button onclick="actionRemoveSeries()">Remove Series</button>
     </div>
     <div class="toolPanel">
         <button onclick="actionRemovePoints()">Remove points middle</button>

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
@@ -3,6 +3,26 @@ import { AgChartOptions, AgCharts, time } from 'ag-charts-enterprise';
 import { getData } from './data';
 
 const data = getData();
+const series: NonNullable<AgChartOptions['series']> = [
+    {
+        type: 'area',
+        xKey: 'date',
+        yKey: 'petrol',
+        marker: {},
+        label: {},
+        strokeWidth: 5,
+        stacked: true,
+    },
+    {
+        type: 'area',
+        xKey: 'date',
+        yKey: 'diesel',
+        marker: {},
+        label: {},
+        strokeWidth: 5,
+        stacked: true,
+    },
+];
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     animation: {
@@ -12,26 +32,7 @@ const options: AgChartOptions = {
         // enabled: false,
     },
     data,
-    series: [
-        {
-            type: 'area',
-            xKey: 'date',
-            yKey: 'petrol',
-            marker: {},
-            label: {},
-            strokeWidth: 5,
-            stacked: true,
-        },
-        {
-            type: 'area',
-            xKey: 'date',
-            yKey: 'diesel',
-            marker: {},
-            label: {},
-            strokeWidth: 5,
-            stacked: true,
-        },
-    ],
+    series,
     axes: [
         {
             position: 'bottom',
@@ -75,6 +76,16 @@ function times<T>(cb: () => T, count: number) {
 
 function actionReset() {
     options.data = [...data];
+    AgCharts.update(chart, options);
+}
+
+function actionAddSeries() {
+    options.series = [...options.series!, series[options.series!.length % series.length]] as any;
+    AgCharts.update(chart, options);
+}
+
+function actionRemoveSeries() {
+    options.series = options.series!.slice(0, options.series!.length - 1);
     AgCharts.update(chart, options);
 }
 

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/index.html
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/index.html
@@ -2,7 +2,9 @@
     <div style="flex: none">
         <button onclick="reset()">Reset</button>
         <button onclick="randomise()">Randomise</button>
-        <button onclick="remove()">Remove</button>
+        <button onclick="removeData()">Remove Data</button>
+        <button onclick="removeSeries()">Remove Series</button>
+        <button onclick="addSeries()">Add Series</button>
         <button onclick="switchDirection()">Switch Direction</button>
         <button onclick="switchToGrouped()">Switch to Grouped</button>
         <button onclick="switchToStacked()">Switch to Stacked</button>

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
@@ -24,6 +24,62 @@ function toIntegratedData(key: string, d: any[]) {
 
 let data = toIntegratedData('quarter', getData());
 
+const series: NonNullable<AgChartOptions['series']> = [
+    {
+        type: 'bar',
+        direction: 'horizontal',
+        xKey: 'quarter',
+        yKey: 'iphone',
+        yName: 'iPhone',
+        stackGroup: 'Devices',
+        label: {
+            color: 'white',
+        },
+    },
+    {
+        type: 'bar',
+        direction: 'horizontal',
+        xKey: 'quarter',
+        yKey: 'mac',
+        yName: 'Mac',
+        stackGroup: 'Devices',
+        label: {
+            color: 'white',
+        },
+    },
+    {
+        type: 'bar',
+        direction: 'horizontal',
+        xKey: 'quarter',
+        yKey: 'ipad',
+        yName: 'iPad',
+        stackGroup: 'Devices',
+        label: {
+            color: 'white',
+        },
+    },
+    {
+        type: 'bar',
+        direction: 'horizontal',
+        xKey: 'quarter',
+        yKey: 'wearables',
+        yName: 'Wearables',
+        label: {
+            color: 'white',
+        },
+    },
+    {
+        type: 'bar',
+        direction: 'horizontal',
+        xKey: 'quarter',
+        yKey: 'services',
+        yName: 'Services',
+        label: {
+            color: 'white',
+        },
+    },
+];
+
 const options: AgChartOptions = {
     theme: 'ag-default',
     container: document.getElementById('myChart'),
@@ -31,61 +87,7 @@ const options: AgChartOptions = {
         enabled: true,
     },
     data,
-    series: [
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'iphone',
-            yName: 'iPhone',
-            stackGroup: 'Devices',
-            label: {
-                color: 'white',
-            },
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'mac',
-            yName: 'Mac',
-            stackGroup: 'Devices',
-            label: {
-                color: 'white',
-            },
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'ipad',
-            yName: 'iPad',
-            stackGroup: 'Devices',
-            label: {
-                color: 'white',
-            },
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'wearables',
-            yName: 'Wearables',
-            label: {
-                color: 'white',
-            },
-        },
-        {
-            type: 'bar',
-            direction: 'horizontal',
-            xKey: 'quarter',
-            yKey: 'services',
-            yName: 'Services',
-            label: {
-                color: 'white',
-            },
-        },
-    ],
+    series,
     legend: {},
 };
 
@@ -107,13 +109,18 @@ function randomise() {
     AgCharts.update(chart, options as any);
 }
 
-function remove() {
-    options.data = [
-        ...data.filter(
-            (d: any) =>
-                !d.quarter.startsWith("Q1'19") && !d.quarter.startsWith("Q3'19") && !d.quarter.startsWith("Q4'18")
-        ),
-    ];
+function removeData() {
+    options.data = options.data?.slice(0, options.data.length - 1);
+    AgCharts.update(chart, options as any);
+}
+
+function removeSeries() {
+    options.series = series.slice(0, options.series!.length - 1);
+    AgCharts.update(chart, options as any);
+}
+
+function addSeries() {
+    options.series = series.slice(0, options.series!.length + 1);
     AgCharts.update(chart, options as any);
 }
 

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/index.html
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/index.html
@@ -1,6 +1,8 @@
 <div class="wrapper">
     <div class="toolPanel">
         <button onclick="actionReset()">Reset</button>
+        <button onclick="actionAddSeries()">Add Series</button>
+        <button onclick="actionRemoveSeries()">Remove Series</button>
     </div>
     <div class="toolPanel">
         <button onclick="actionRemovePoints()">Remove points middle</button>

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
@@ -2,6 +2,22 @@ import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
+const series: NonNullable<AgChartOptions['series']> = [
+    {
+        type: 'line',
+        xKey: 'date',
+        yKey: 'petrol',
+        marker: {},
+        label: {},
+    },
+    {
+        type: 'line',
+        xKey: 'date',
+        yKey: 'diesel',
+        marker: {},
+        label: {},
+    },
+];
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     animation: {
@@ -9,22 +25,7 @@ const options: AgChartOptions = {
     },
     legend: {},
     data: getData(),
-    series: [
-        {
-            type: 'line',
-            xKey: 'date',
-            yKey: 'petrol',
-            marker: {},
-            label: {},
-        },
-        {
-            type: 'line',
-            xKey: 'date',
-            yKey: 'diesel',
-            marker: {},
-            label: {},
-        },
-    ],
+    series,
     axes: [
         {
             position: 'bottom',
@@ -62,6 +63,16 @@ function times<T>(cb: () => T, count: number) {
 
 function actionReset() {
     options.data = getData();
+    AgCharts.update(chart, options);
+}
+
+function actionAddSeries() {
+    options.series = [...options.series!, series[options.series!.length % series.length]] as any;
+    AgCharts.update(chart, options);
+}
+
+function actionRemoveSeries() {
+    options.series = options.series!.slice(0, options.series!.length - 1);
     AgCharts.update(chart, options);
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10528

Improves the animation of series add/remove for (stacked) bar, area and line series - series now fade in rather than a) trying to animation incorrectly, or b) skip animations completely.

I've updated the animation regressions tests to cover these cases too.