### PR TITLE
CRT-217 Fix crosshair/highlight on mobile

### DIFF
--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -272,10 +272,10 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private onDragEnd() {
+        this.ctx.interactionManager.popState(_ModuleSupport.InteractionState.ZoomDrag);
+
         // Stop single clicks from triggering drag end and resetting the zoom
         if (!this.enabled || !this.isDragging) return;
-
-        this.ctx.interactionManager.popState(_ModuleSupport.InteractionState.ZoomDrag);
 
         const zoom = definedZoomState(this.zoomManager.getZoom());
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-217

We must always reset the interaction state in the zoom module. Otherwise the interaction manager could stay stuck in `InteractionState.ZoomDrag`.