### PR TITLE
AG-10230 Update context menu callback to use series node event

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
@@ -15,7 +15,7 @@ export class ContextMenuRegistry {
     private defaultActions: Array<ContextMenuAction> = [];
     private disabledActions: Set<string> = new Set();
 
-    public copyDefaultAction(): ContextMenuAction[] {
+    public copyDefaultActions(): ContextMenuAction[] {
         return [...this.defaultActions];
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -20,14 +20,12 @@ import { SeriesNodePickMode, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { BubbleNodeDatum, BubbleSeriesProperties } from './bubbleSeriesProperties';
 import type { CartesianAnimationData } from './cartesianSeries';
-import { CartesianSeries, CartesianSeriesNodeClickEvent } from './cartesianSeries';
+import { CartesianSeries, CartesianSeriesNodeEvent } from './cartesianSeries';
 import { markerScaleInAnimation, resetMarkerFn } from './markerUtil';
 
 type BubbleAnimationData = CartesianAnimationData<Group, BubbleNodeDatum>;
 
-class BubbleSeriesNodeClickEvent<
-    TEvent extends string = SeriesNodeEventTypes,
-> extends CartesianSeriesNodeClickEvent<TEvent> {
+class BubbleSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends CartesianSeriesNodeEvent<TEvent> {
     readonly sizeKey?: string;
 
     constructor(type: TEvent, nativeEvent: MouseEvent, datum: BubbleNodeDatum, series: BubbleSeries) {
@@ -40,7 +38,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
     static className = 'BubbleSeries';
     static type = 'bubble' as const;
 
-    protected override readonly NodeClickEvent = BubbleSeriesNodeClickEvent;
+    protected override readonly NodeEvent = BubbleSeriesNodeEvent;
 
     override properties = new BubbleSeriesProperties();
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -21,11 +21,11 @@ import { Layers } from '../../layers';
 import type { Marker } from '../../marker/marker';
 import { getMarker } from '../../marker/util';
 import { DataModelSeries } from '../dataModelSeries';
-import type { Series, SeriesNodeDataContext, SeriesNodeEventTypes, SeriesNodePickMatch } from '../series';
-import { SeriesNodeClickEvent } from '../series';
+import type { SeriesNodeDataContext, SeriesNodeEventTypes, SeriesNodePickMatch } from '../series';
+import { SeriesNodeEvent } from '../series';
 import type { SeriesGroupZIndexSubOrderType } from '../seriesLayerManager';
 import { SeriesProperties } from '../seriesProperties';
-import type { SeriesNodeDatum } from '../seriesTypes';
+import type { ISeries, SeriesNodeDatum } from '../seriesTypes';
 import type { Scaling } from './scaling';
 
 export interface CartesianSeriesNodeDatum extends SeriesNodeDatum {
@@ -72,7 +72,7 @@ const DEFAULT_DIRECTION_NAMES: { [key in ChartAxisDirection]?: string[] } = {
     [ChartAxisDirection.Y]: ['yName'],
 };
 
-export class CartesianSeriesNodeClickEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeClickEvent<
+export class CartesianSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeEvent<
     SeriesNodeDatum,
     TEvent
 > {
@@ -82,7 +82,7 @@ export class CartesianSeriesNodeClickEvent<TEvent extends string = SeriesNodeEve
         type: TEvent,
         nativeEvent: MouseEvent,
         datum: SeriesNodeDatum,
-        series: Series<any, any> & { properties: { xKey?: string; yKey?: string } }
+        series: ISeries<SeriesNodeDatum> & { properties: { xKey?: string; yKey?: string } }
     ) {
         super(type, nativeEvent, datum, series);
         this.xKey = series.properties.xKey;
@@ -145,7 +145,7 @@ export abstract class CartesianSeries<
         return this._contextNodeData.slice();
     }
 
-    protected override readonly NodeClickEvent = CartesianSeriesNodeClickEvent;
+    protected override readonly NodeEvent = CartesianSeriesNodeEvent;
 
     private highlightSelection = Selection.select(this.highlightNode, () =>
         this.opts.hasMarkers ? this.markerFactory() : this.nodeFactory()

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -27,13 +27,7 @@ import { Layers } from '../../layers';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import { Circle } from '../../marker/circle';
 import type { SeriesNodeEventTypes } from '../series';
-import {
-    SeriesNodeClickEvent,
-    accumulativeValueProperty,
-    keyProperty,
-    rangedValueProperty,
-    valueProperty,
-} from '../series';
+import { SeriesNodeEvent, accumulativeValueProperty, keyProperty, rangedValueProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation, seriesLabelFadeOutAnimation } from '../seriesLabelUtil';
 import type { SeriesNodeDatum } from '../seriesTypes';
 import type { DonutInnerLabel, DonutTitle } from './donutSeriesProperties';
@@ -41,7 +35,7 @@ import { DonutSeriesProperties } from './donutSeriesProperties';
 import { preparePieSeriesAnimationFunctions, resetPieSelectionsFn } from './pieUtil';
 import { type PolarAnimationData, PolarSeries } from './polarSeries';
 
-class DonutSeriesNodeClickEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeClickEvent<
+class DonutSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeEvent<
     DonutNodeDatum,
     TEvent
 > {
@@ -1238,7 +1232,7 @@ export class DonutSeries extends PolarSeries<DonutNodeDatum, Sector> {
         this.zerosumInnerRing.size = this.getInnerRadius() * 2;
     }
 
-    protected override readonly NodeClickEvent = DonutSeriesNodeClickEvent;
+    protected override readonly NodeEvent = DonutSeriesNodeEvent;
 
     private getDatumLegendName(nodeDatum: DonutNodeDatum) {
         const { angleKey, calloutLabelKey, sectorLabelKey, legendItemKey } = this.properties;

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -27,13 +27,7 @@ import { Layers } from '../../layers';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import { Circle } from '../../marker/circle';
 import type { SeriesNodeEventTypes } from '../series';
-import {
-    SeriesNodeClickEvent,
-    accumulativeValueProperty,
-    keyProperty,
-    rangedValueProperty,
-    valueProperty,
-} from '../series';
+import { SeriesNodeEvent, accumulativeValueProperty, keyProperty, rangedValueProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation, seriesLabelFadeOutAnimation } from '../seriesLabelUtil';
 import type { SeriesNodeDatum } from '../seriesTypes';
 import type { DonutInnerLabel, PieTitle } from './pieSeriesProperties';
@@ -41,10 +35,7 @@ import { PieSeriesProperties } from './pieSeriesProperties';
 import { preparePieSeriesAnimationFunctions, resetPieSelectionsFn } from './pieUtil';
 import { type PolarAnimationData, PolarSeries } from './polarSeries';
 
-class PieSeriesNodeClickEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeClickEvent<
-    PieNodeDatum,
-    TEvent
-> {
+class PieSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeEvent<PieNodeDatum, TEvent> {
     readonly angleKey: string;
     readonly radiusKey?: string;
     readonly calloutLabelKey?: string;
@@ -1239,7 +1230,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
         this.zerosumInnerRing.size = this.getInnerRadius() * 2;
     }
 
-    protected override readonly NodeClickEvent = PieSeriesNodeClickEvent;
+    protected override readonly NodeEvent = PieSeriesNodeEvent;
 
     private getDatumLegendName(nodeDatum: PieNodeDatum) {
         const { angleKey, calloutLabelKey, sectorLabelKey, legendItemKey } = this.properties;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -182,25 +182,25 @@ export function groupAccumulativeValueProperty<K>(
     ];
 }
 
-export type SeriesNodeEventTypes = 'nodeClick' | 'nodeDoubleClick' | 'groupingChanged';
+export type SeriesNodeEventTypes = 'nodeClick' | 'nodeDoubleClick' | 'nodeContextMenuAction' | 'groupingChanged';
 
-interface INodeClickEvent<TEvent extends string = SeriesNodeEventTypes> extends TypedEvent {
+interface INodeEvent<TEvent extends string = SeriesNodeEventTypes> extends TypedEvent {
     readonly type: TEvent;
     readonly event: MouseEvent;
     readonly datum: unknown;
     readonly seriesId: string;
 }
 
-export interface INodeClickEventConstructor<
+export interface INodeEventConstructor<
     TDatum extends SeriesNodeDatum,
     TSeries extends Series<TDatum, any>,
     TEvent extends string = SeriesNodeEventTypes,
 > {
-    new (type: TEvent, event: MouseEvent, { datum }: TDatum, series: TSeries): INodeClickEvent<TEvent>;
+    new (type: TEvent, event: MouseEvent, { datum }: TDatum, series: TSeries): INodeEvent<TEvent>;
 }
 
-export class SeriesNodeClickEvent<TDatum extends SeriesNodeDatum, TEvent extends string = SeriesNodeEventTypes>
-    implements INodeClickEvent<TEvent>
+export class SeriesNodeEvent<TDatum extends SeriesNodeDatum, TEvent extends string = SeriesNodeEventTypes>
+    implements INodeEvent<TEvent>
 {
     readonly datum: unknown;
     readonly seriesId: string;
@@ -209,7 +209,7 @@ export class SeriesNodeClickEvent<TDatum extends SeriesNodeDatum, TEvent extends
         readonly type: TEvent,
         readonly event: MouseEvent,
         { datum }: TDatum,
-        series: Series<TDatum, any>
+        series: ISeries<TDatum>
     ) {
         this.datum = datum;
         this.seriesId = series.id;
@@ -262,7 +262,7 @@ export abstract class Series<
 
     protected static readonly highlightedZIndex = 1000000000000;
 
-    protected readonly NodeClickEvent: INodeClickEventConstructor<TDatum, any> = SeriesNodeClickEvent;
+    protected readonly NodeEvent: INodeEventConstructor<TDatum, any> = SeriesNodeEvent;
 
     readonly internalId = createId(this);
 
@@ -668,11 +668,15 @@ export abstract class Series<
     abstract getLabelData(): PointLabelDatum[];
 
     fireNodeClickEvent(event: MouseEvent, datum: TDatum): void {
-        this.fireEvent(new this.NodeClickEvent('nodeClick', event, datum, this));
+        this.fireEvent(new this.NodeEvent('nodeClick', event, datum, this));
     }
 
     fireNodeDoubleClickEvent(event: MouseEvent, datum: TDatum): void {
-        this.fireEvent(new this.NodeClickEvent('nodeDoubleClick', event, datum, this));
+        this.fireEvent(new this.NodeEvent('nodeDoubleClick', event, datum, this));
+    }
+
+    createNodeContextMenuActionEvent(event: MouseEvent, datum: TDatum): INodeEvent {
+        return new this.NodeEvent('nodeContextMenuAction', event, datum, this);
     }
 
     abstract getLegendData<T extends ChartLegendType>(legendType: T): ChartLegendDatum<T>[];

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -19,6 +19,7 @@ export interface ISeries<TDatum> {
     update(opts: { seriesRect?: BBox }): Promise<void>;
     fireNodeClickEvent(event: Event, datum: TDatum): void;
     fireNodeDoubleClickEvent(event: Event, datum: TDatum): void;
+    createNodeContextMenuActionEvent(event: Event, datum: TDatum): any;
     getLegendData<T extends ChartLegendType>(legendType: T): ChartLegendDatum<T>[];
     getLegendData(legendType: ChartLegendType): ChartLegendDatum<ChartLegendType>[];
     // BoundSeries

--- a/packages/ag-charts-community/src/options/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/contextMenuOptions.ts
@@ -1,4 +1,4 @@
-import type { AgChartCallbackParams } from './callbackOptions';
+import type { AgNodeContextMenuActionEvent } from './eventOptions';
 
 export interface AgContextMenuOptions {
     /**  Whether to show the context menu. */
@@ -13,9 +13,5 @@ export interface AgContextMenuAction {
     /** The text to display in the context menu for the custom action. */
     label: string;
     /** Callback function for the custom action. */
-    action: (params: AgContextMenuActionParams) => void;
-}
-
-export interface AgContextMenuActionParams<TDatum = any> extends AgChartCallbackParams<TDatum> {
-    event: MouseEvent;
+    action: (params: AgNodeContextMenuActionEvent<any>) => void;
 }

--- a/packages/ag-charts-community/src/options/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/contextMenuOptions.ts
@@ -1,3 +1,4 @@
+import type { AgChartCallbackParams } from './callbackOptions';
 import type { AgNodeContextMenuActionEvent } from './eventOptions';
 
 export interface AgContextMenuOptions {
@@ -13,5 +14,12 @@ export interface AgContextMenuAction {
     /** The text to display in the context menu for the custom action. */
     label: string;
     /** Callback function for the custom action. */
-    action: (params: AgNodeContextMenuActionEvent<any>) => void;
+    action: (event: AgNodeContextMenuActionEvent) => void;
+}
+
+/**
+ * @deprecated v9.2 use AgNodeContextMenuActionEvent instead.
+ */
+export interface AgContextMenuActionParams<TDatum = any> extends AgChartCallbackParams<TDatum> {
+    event: MouseEvent;
 }

--- a/packages/ag-charts-community/src/options/chart/eventOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/eventOptions.ts
@@ -3,7 +3,7 @@ interface AgChartEvent<T extends string> {
     event: Event;
 }
 
-export interface AgNodeBaseEvent<TEvent extends string, TDatum> extends AgChartEvent<TEvent> {
+export interface AgNodeBaseClickEvent<TEvent extends string, TDatum> extends AgChartEvent<TEvent> {
     /** Event type. */
     type: TEvent;
     /** Series ID, as specified in series.id (or generated if not specified) */
@@ -30,19 +30,19 @@ export interface AgNodeBaseEvent<TEvent extends string, TDatum> extends AgChartE
     radiusKey?: string;
 }
 
-export interface AgSeriesNodeClickEvent<TDatum> extends AgNodeBaseEvent<'seriesNodeClick', TDatum> {
+export interface AgSeriesNodeClickEvent<TDatum> extends AgNodeBaseClickEvent<'seriesNodeClick', TDatum> {
     /** Event type. */ type: 'seriesNodeClick';
 }
 
-export interface AgSeriesNodeDoubleClickEvent<TDatum> extends AgNodeBaseEvent<'seriesNodeDoubleClick', TDatum> {
+export interface AgSeriesNodeDoubleClickEvent<TDatum> extends AgNodeBaseClickEvent<'seriesNodeDoubleClick', TDatum> {
     /** Event type. */ type: 'seriesNodeDoubleClick';
 }
 
-export interface AgNodeClickEvent<TDatum> extends AgNodeBaseEvent<'nodeClick', TDatum> {
+export interface AgNodeClickEvent<TDatum> extends AgNodeBaseClickEvent<'nodeClick', TDatum> {
     /** Event type. */ type: 'nodeClick';
 }
 
-export interface AgNodeDoubleClickEvent<TDatum> extends AgNodeBaseEvent<'nodeDoubleClick', TDatum> {
+export interface AgNodeDoubleClickEvent<TDatum> extends AgNodeBaseClickEvent<'nodeDoubleClick', TDatum> {
     /** Event type. */ type: 'nodeDoubleClick';
 }
 
@@ -54,7 +54,7 @@ export interface AgChartDoubleClickEvent extends AgChartEvent<'doubleClick'> {
     /** Event type. */ type: 'doubleClick';
 }
 
-export interface AgNodeContextMenuActionEvent<TDatum> extends AgNodeBaseEvent<'contextMenuAction', TDatum> {
+export interface AgNodeContextMenuActionEvent<TDatum = any> extends AgNodeBaseClickEvent<'contextMenuAction', TDatum> {
     /** Event type. */ type: 'contextMenuAction';
 
     /** @deprecated v9.2 use `xKey`, `yKey`, `angleKey` etc instead. */

--- a/packages/ag-charts-community/src/options/chart/eventOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/eventOptions.ts
@@ -3,7 +3,7 @@ interface AgChartEvent<T extends string> {
     event: Event;
 }
 
-export interface AgNodeBaseClickEvent<TEvent extends string, TDatum> extends AgChartEvent<TEvent> {
+export interface AgNodeBaseEvent<TEvent extends string, TDatum> extends AgChartEvent<TEvent> {
     /** Event type. */
     type: TEvent;
     /** Series ID, as specified in series.id (or generated if not specified) */
@@ -30,19 +30,19 @@ export interface AgNodeBaseClickEvent<TEvent extends string, TDatum> extends AgC
     radiusKey?: string;
 }
 
-export interface AgSeriesNodeClickEvent<TDatum> extends AgNodeBaseClickEvent<'seriesNodeClick', TDatum> {
+export interface AgSeriesNodeClickEvent<TDatum> extends AgNodeBaseEvent<'seriesNodeClick', TDatum> {
     /** Event type. */ type: 'seriesNodeClick';
 }
 
-export interface AgSeriesNodeDoubleClickEvent<TDatum> extends AgNodeBaseClickEvent<'seriesNodeDoubleClick', TDatum> {
+export interface AgSeriesNodeDoubleClickEvent<TDatum> extends AgNodeBaseEvent<'seriesNodeDoubleClick', TDatum> {
     /** Event type. */ type: 'seriesNodeDoubleClick';
 }
 
-export interface AgNodeClickEvent<TDatum> extends AgNodeBaseClickEvent<'nodeClick', TDatum> {
+export interface AgNodeClickEvent<TDatum> extends AgNodeBaseEvent<'nodeClick', TDatum> {
     /** Event type. */ type: 'nodeClick';
 }
 
-export interface AgNodeDoubleClickEvent<TDatum> extends AgNodeBaseClickEvent<'nodeDoubleClick', TDatum> {
+export interface AgNodeDoubleClickEvent<TDatum> extends AgNodeBaseEvent<'nodeDoubleClick', TDatum> {
     /** Event type. */ type: 'nodeDoubleClick';
 }
 
@@ -52,6 +52,13 @@ export interface AgChartClickEvent extends AgChartEvent<'click'> {
 
 export interface AgChartDoubleClickEvent extends AgChartEvent<'doubleClick'> {
     /** Event type. */ type: 'doubleClick';
+}
+
+export interface AgNodeContextMenuActionEvent<TDatum> extends AgNodeBaseEvent<'contextMenuAction', TDatum> {
+    /** Event type. */ type: 'contextMenuAction';
+
+    /** @deprecated v9.2 use `xKey`, `yKey`, `angleKey` etc instead. */
+    itemId?: string;
 }
 
 export interface AgBaseChartListeners<TDatum> {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -1,5 +1,5 @@
 import type { _Scene } from 'ag-charts-community';
-import { _ModuleSupport } from 'ag-charts-community';
+import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 import {
     DEFAULT_CONTEXT_MENU_CLASS,
@@ -264,10 +264,16 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         el.onclick = () => {
             const event = this.pickedNode?.series.createNodeContextMenuActionEvent(this.showEvent!, this.pickedNode);
             if (event) {
-                callback({
-                    ...event,
-                    itemId: this.pickedNode!.itemId, // @deprecated v9.2
+                Object.defineProperty(event, 'itemId', {
+                    enumerable: false,
+                    get: () => {
+                        _Util.Logger.warnOnce(
+                            `Property [AgNodeContextMenuActionEvent.itemId] is deprecated. Use [yKey], [angleKey] and others instead.`
+                        );
+                        return this.pickedNode?.itemId;
+                    },
                 });
+                callback(event);
             } else {
                 callback({ event: this.showEvent! });
             }

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -157,7 +157,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         this.x = event.pageX;
         this.y = event.pageY;
 
-        this.groups.default = this.registry.copyDefaultAction();
+        this.groups.default = this.registry.copyDefaultActions();
 
         this.pickedNode = this.highlightManager.getActivePicked();
         if (this.extraActions.length > 0) {
@@ -212,21 +212,28 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         menuElement.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__menu`);
         menuElement.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
 
-        this.groups.default.forEach((i) => {
+        this.appendMenuGroup(menuElement, this.groups.default, false);
+
+        if (this.pickedNode) {
+            this.appendMenuGroup(menuElement, this.groups.node);
+        }
+
+        this.appendMenuGroup(menuElement, this.groups.extra);
+
+        if (this.pickedNode) {
+            this.appendMenuGroup(menuElement, this.groups.extraNode);
+        }
+
+        return menuElement;
+    }
+
+    public appendMenuGroup(menuElement: HTMLElement, group: ContextMenuItem[], divider = true) {
+        if (group.length === 0) return;
+        if (divider) menuElement.appendChild(this.createDividerElement());
+        group.forEach((i) => {
             const item = this.renderItem(i);
             if (item) menuElement.appendChild(item);
         });
-
-        (['node', 'extra', 'extraNode'] as Array<keyof ContextMenuGroups>).forEach((group) => {
-            if (this.groups[group].length === 0 || (['node', 'extraNode'].includes(group) && !this.pickedNode)) return;
-            menuElement.appendChild(this.createDividerElement());
-            this.groups[group].forEach((i) => {
-                const item = this.renderItem(i);
-                if (item) menuElement.appendChild(item);
-            });
-        });
-
-        return menuElement;
     }
 
     public renderItem(item: ContextMenuItem): HTMLElement | void {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -255,13 +255,16 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
         el.innerHTML = label;
         el.onclick = () => {
-            const params: ContextMenuActionParams = {
-                event: this.showEvent!,
-                datum: this.pickedNode?.datum,
-                itemId: this.pickedNode?.itemId,
-                seriesId: this.pickedNode?.series.id,
-            };
-            callback(params);
+            const event = this.pickedNode?.series.createNodeContextMenuActionEvent(this.showEvent!, this.pickedNode);
+            if (event) {
+                callback({
+                    ...event,
+                    itemId: this.pickedNode!.itemId, // @deprecated v9.2
+                });
+            } else {
+                callback({ event: this.showEvent! });
+            }
+
             this.hide();
         };
         return el;

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -20,9 +20,9 @@ const {
 } = _ModuleSupport;
 const { motion } = _Scene;
 
-class BoxPlotSeriesNodeClickEvent<
+class BoxPlotSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeClickEvent<BoxPlotNodeDatum, TEvent> {
+> extends _ModuleSupport.SeriesNodeEvent<BoxPlotNodeDatum, TEvent> {
     readonly xKey?: string;
     readonly minKey?: string;
     readonly q1Key?: string;
@@ -46,7 +46,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup
 
     override properties = new BoxPlotSeriesProperties();
 
-    protected override readonly NodeClickEvent = BoxPlotSeriesNodeClickEvent;
+    protected override readonly NodeEvent = BoxPlotSeriesNodeEvent;
 
     /**
      * Used to get the position of items within each group.

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -31,9 +31,9 @@ interface HeatmapLabelDatum extends _Scene.Point {
     verticalAlign: VerticalAlign;
 }
 
-class HeatmapSeriesNodeClickEvent<
+class HeatmapSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.CartesianSeriesNodeClickEvent<TEvent> {
+> extends _ModuleSupport.CartesianSeriesNodeEvent<TEvent> {
     readonly colorKey?: string;
 
     constructor(type: TEvent, nativeEvent: MouseEvent, datum: HeatmapNodeDatum, series: HeatmapSeries) {
@@ -60,7 +60,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, H
 
     override properties = new HeatmapSeriesProperties();
 
-    protected override readonly NodeClickEvent = HeatmapSeriesNodeClickEvent;
+    protected override readonly NodeEvent = HeatmapSeriesNodeEvent;
 
     readonly colorScale = new ColorScale();
 

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -27,9 +27,9 @@ export interface RadarPathPoint {
     arc?: boolean;
 }
 
-class RadarSeriesNodeClickEvent<
+class RadarSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeClickEvent<RadarNodeDatum, TEvent> {
+> extends _ModuleSupport.SeriesNodeEvent<RadarNodeDatum, TEvent> {
     readonly angleKey?: string;
     readonly radiusKey?: string;
     constructor(type: TEvent, nativeEvent: MouseEvent, datum: RadarNodeDatum, series: RadarSeries) {
@@ -56,7 +56,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDa
 
     override properties = new RadarSeriesProperties();
 
-    protected override readonly NodeClickEvent = RadarSeriesNodeClickEvent;
+    protected override readonly NodeEvent = RadarSeriesNodeEvent;
 
     protected lineSelection: _Scene.Selection<_Scene.Path, boolean>;
 

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -25,9 +25,9 @@ const { BandScale } = _Scale;
 const { Sector, motion } = _Scene;
 const { angleBetween, isNumber, sanitizeHtml } = _Util;
 
-class RadialBarSeriesNodeClickEvent<
+class RadialBarSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeClickEvent<RadialBarNodeDatum, TEvent> {
+> extends _ModuleSupport.SeriesNodeEvent<RadialBarNodeDatum, TEvent> {
     readonly angleKey?: string;
     readonly radiusKey?: string;
     constructor(type: TEvent, nativeEvent: MouseEvent, datum: RadialBarNodeDatum, series: RadialBarSeries) {
@@ -62,7 +62,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDat
 
     override properties = new RadialBarSeriesProperties();
 
-    protected override readonly NodeClickEvent = RadialBarSeriesNodeClickEvent;
+    protected override readonly NodeEvent = RadialBarSeriesNodeEvent;
 
     protected nodeData: RadialBarNodeDatum[] = [];
 

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -24,9 +24,9 @@ const { BandScale } = _Scale;
 const { motion } = _Scene;
 const { isNumber, normalizeAngle360, sanitizeHtml } = _Util;
 
-class RadialColumnSeriesNodeClickEvent<
+class RadialColumnSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeClickEvent<RadialColumnNodeDatum, TEvent> {
+> extends _ModuleSupport.SeriesNodeEvent<RadialColumnNodeDatum, TEvent> {
     readonly angleKey?: string;
     readonly radiusKey?: string;
     constructor(
@@ -66,7 +66,7 @@ export interface RadialColumnNodeDatum extends _ModuleSupport.SeriesNodeDatum {
 export abstract class RadialColumnSeriesBase<
     ItemPathType extends _Scene.Sector | _Scene.RadialColumnShape,
 > extends _ModuleSupport.PolarSeries<RadialColumnNodeDatum, ItemPathType> {
-    protected override readonly NodeClickEvent = RadialColumnSeriesNodeClickEvent;
+    protected override readonly NodeEvent = RadialColumnSeriesNodeEvent;
 
     abstract override properties: RadialColumnSeriesBaseProperties<any>;
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -59,9 +59,9 @@ interface RangeAreaContext
     strokeData: RadarAreaPathDatum;
 }
 
-class RangeAreaSeriesNodeClickEvent<
+class RangeAreaSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeClickEvent<RangeAreaMarkerDatum, TEvent> {
+> extends _ModuleSupport.SeriesNodeEvent<RangeAreaMarkerDatum, TEvent> {
     readonly xKey?: string;
     readonly yLowKey?: string;
     readonly yHighKey?: string;
@@ -92,7 +92,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
 
     override properties = new RangeAreaProperties();
 
-    protected override readonly NodeClickEvent = RangeAreaSeriesNodeClickEvent;
+    protected override readonly NodeEvent = RangeAreaSeriesNodeEvent;
 
     constructor(moduleCtx: _ModuleSupport.ModuleContext) {
         super({

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -78,9 +78,9 @@ type RangeBarAnimationData = _ModuleSupport.CartesianAnimationData<
     RangeBarNodeLabelDatum
 >;
 
-class RangeBarSeriesNodeClickEvent<
+class RangeBarSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeClickEvent<RangeBarNodeDatum, TEvent> {
+> extends _ModuleSupport.SeriesNodeEvent<RangeBarNodeDatum, TEvent> {
     readonly xKey?: string;
     readonly yLowKey?: string;
     readonly yHighKey?: string;
@@ -103,7 +103,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
 
     override properties = new RangeBarProperties();
 
-    protected override readonly NodeClickEvent = RangeBarSeriesNodeClickEvent;
+    protected override readonly NodeEvent = RangeBarSeriesNodeEvent;
 
     /**
      * Used to get the position of bars within each group.


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10230

This updates the context menu to create a series node event (using the same per-series type constructor). It deprecates the `itemId` property on the params, this is covered by the `xKey` etc and is also not a useful value for polar series (where it is the index of the sector). Now it has the same signature as other series node click events.