### PR TITLE
AG-10766 Fix async zoom to only consider visible items for min rect

### DIFF
--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
@@ -80,13 +80,13 @@ export class AgChartsAngular implements AfterViewInit, OnChanges, OnDestroy {
             listenerConfig: undefined | AgChartLegendListeners | AgSeriesListeners<any> | AgBaseChartListeners<any>
         ) => {
             const config = listenerConfig ?? ({} as any);
-            Object.entries(config).forEach(([listenerName, listener]) => {
-                if (listener && typeof listener === 'function') {
-                    config[listenerName] = (...args: any) => {
-                        this.runInsideAngular(() => listener(...args));
-                    };
-                }
-            });
+            for (const [listenerName, listener] of Object.entries(config)) {
+                if (!listener || typeof listener !== 'function') continue;
+
+                config[listenerName] = (...args: any) => {
+                    this.runInsideAngular(() => listener(...args));
+                };
+            }
         };
 
         patchListeners(propsOptions?.legend?.listeners);

--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -305,7 +305,7 @@ export class CartesianChart extends Chart {
         this.axes.forEach((axis) => {
             if (axis.crossLines) {
                 axis.crossLines.forEach((crossLine) => {
-                    crossLine.calculatePadding(crossLinePadding);
+                    crossLine.calculatePadding?.(crossLinePadding);
                 });
             }
         });

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -672,7 +672,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
 
         if (!updateDeferred) {
-            this.updateService.dispatchUpdateComplete(this.getMinRect());
+            this.updateService.dispatchUpdateComplete(this.getMinRects());
         }
 
         const end = performance.now();
@@ -1412,16 +1412,21 @@ export abstract class Chart extends Observable implements AgChartInstance {
         });
     }
 
-    protected getMinRect() {
-        const minRects = this.series.map((series) => series.getMinRect()).filter(isDefined);
-        if (minRects.length) {
-            return new BBox(
-                0,
-                0,
-                minRects.reduce((max, rect) => Math.max(max, rect.width), 0),
-                minRects.reduce((max, rect) => Math.max(max, rect.height), 0)
-            );
-        }
+    protected getMinRects() {
+        const { width, height } = this.scene;
+        const minRects = this.series.map((series) => series.getMinRects(width, height)).filter(isDefined);
+
+        if (minRects.length === 0) return;
+
+        const maxWidth = minRects.reduce((max, { minRect }) => Math.max(max, minRect.width), 0);
+        const maxHeight = minRects.reduce((max, { minRect }) => Math.max(max, minRect.height), 0);
+        const maxVisibleWidth = minRects.reduce((max, { minVisibleRect }) => Math.max(max, minVisibleRect.width), 0);
+        const maxVisibleHeight = minRects.reduce((max, { minVisibleRect }) => Math.max(max, minVisibleRect.height), 0);
+
+        const minRect = new BBox(0, 0, maxWidth, maxHeight);
+        const minVisibleRect = new BBox(0, 0, maxVisibleWidth, maxVisibleHeight);
+
+        return { minRect, minVisibleRect };
     }
 
     private filterMiniChartSeries(series: AgChartOptions['series'] | undefined): AgChartOptions['series'] | undefined;

--- a/packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/packages/ag-charts-community/src/chart/chartAxis.ts
@@ -9,6 +9,7 @@ import type { AxisLine } from './axis/axisLine';
 import type { AxisTick } from './axis/axisTick';
 import type { ChartAnimationPhase } from './chartAnimationPhase';
 import type { ChartAxisDirection } from './chartAxisDirection';
+import type { CrossLine } from './crossline/crossLine';
 import type { AxisLayout } from './layout/layoutService';
 import type { ISeries } from './series/seriesTypes';
 
@@ -23,7 +24,7 @@ export interface ChartAxis {
     clipTickLines(x: number, y: number, width: number, height: number): void;
     computeBBox(): BBox;
     isReversed(): boolean;
-    crossLines?: any[];
+    crossLines?: CrossLine[];
     dataDomain: { domain: any[]; clipped: boolean };
     destroy(): void;
     detachAxis(axisGroup: Node, gridGroup: Node): void;

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.ts
@@ -57,7 +57,7 @@ export const validateCrossLineValues = (
             message.push(`range start ${stringify(start)}`);
         }
         if (!validEnd) {
-            message.push(`${!validStart ? 'and ' : ''}range end ${stringify(end)}`);
+            message.push(`${validStart ? '' : 'and '}range end ${stringify(end)}`);
         }
     } else {
         message.push(`value ${stringify(start)}`);
@@ -72,7 +72,7 @@ export const validateCrossLineValues = (
 
 export interface CrossLine<LabelType = AgBaseCrossLineLabelOptions> {
     calculateLayout(visible: boolean, reversedAxis?: boolean): BBox | undefined;
-    calculatePadding(padding: Partial<Record<AgCrossLineLabelPosition, number>>): void;
+    calculatePadding?: (padding: Partial<Record<AgCrossLineLabelPosition, number>>) => void;
     clippedRange: [number, number];
     direction: ChartAxisDirection;
     enabled?: boolean;

--- a/packages/ag-charts-community/src/chart/gridLayout.ts
+++ b/packages/ag-charts-community/src/chart/gridLayout.ts
@@ -83,7 +83,8 @@ function processBBoxes(
         startingGuess = minGuess;
     }
 
-    for (let guess = startingGuess; guess >= minGuess; guess--) {
+    let guess = startingGuess;
+    while (guess >= minGuess) {
         const pageIndices = calculatePage(bboxes, indexOffset, guess, primary, secondary, forceResult);
 
         if (pageIndices == null && guess <= minGuess) {
@@ -93,6 +94,7 @@ function processBBoxes(
 
         if (pageIndices == null) {
             // Guess again!
+            guess--;
             continue;
         }
 
@@ -104,6 +106,7 @@ function processBBoxes(
             }
 
             guess = pageIndices < guess && pageIndices > minGuess ? pageIndices : guess;
+            guess--;
             continue;
         }
 

--- a/packages/ag-charts-community/src/chart/interaction/animationBatch.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationBatch.ts
@@ -205,5 +205,8 @@ export class AnimationBatch {
         return this.skipAnimations;
     }
 
-    destroy() {}
+    destroy() {
+        this.stop();
+        this.controllers.clear();
+    }
 }

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -758,7 +758,7 @@ export abstract class Series<
         }
     }
 
-    getMinRect(): BBox | undefined {
+    getMinRects(_width: number, _height: number): { minRect: BBox; minVisibleRect: BBox } | undefined {
         return;
     }
 

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -28,7 +28,7 @@ export interface ISeries<TDatum> {
     getDomain(direction: ChartAxisDirection): any[];
     getKeys(direction: ChartAxisDirection): string[];
     getNames(direction: ChartAxisDirection): (string | undefined)[];
-    getMinRect(): BBox | undefined;
+    getMinRects(width: number, height: number): { minRect: BBox; minVisibleRect: BBox } | undefined;
     isEnabled(): boolean;
     type: string;
     visible: boolean;

--- a/packages/ag-charts-community/src/chart/updateService.ts
+++ b/packages/ag-charts-community/src/chart/updateService.ts
@@ -8,6 +8,7 @@ type UpdateCallback = (type: ChartUpdateType, opts?: UpdateOpts) => void;
 export interface UpdateCompleteEvent {
     type: 'update-complete';
     minRect?: BBox;
+    minVisibleRect?: BBox;
 }
 
 export type UpdateOpts = {
@@ -28,7 +29,11 @@ export class UpdateService extends Listeners<'update-complete', (event: UpdateCo
         this.updateCallback(type, options);
     }
 
-    public dispatchUpdateComplete(minRect?: BBox) {
-        this.dispatch('update-complete', { type: 'update-complete', minRect });
+    public dispatchUpdateComplete(rects?: { minRect: BBox; minVisibleRect: BBox }) {
+        this.dispatch('update-complete', {
+            type: 'update-complete',
+            minRect: rects?.minRect,
+            minVisibleRect: rects?.minVisibleRect,
+        });
     }
 }

--- a/packages/ag-charts-community/src/util/array.ts
+++ b/packages/ag-charts-community/src/util/array.ts
@@ -6,18 +6,19 @@ export function extent(values: Array<number | Date>): [number, number] | undefin
     let min = Infinity;
     let max = -Infinity;
 
-    for (let v of values) {
-        if (v instanceof Date) {
-            v = v.getTime();
+    for (const v of values) {
+        let n = v;
+        if (n instanceof Date) {
+            n = n.getTime();
         }
-        if (typeof v !== 'number') {
+        if (typeof n !== 'number') {
             continue;
         }
-        if (v < min) {
-            min = v;
+        if (n < min) {
+            min = n;
         }
-        if (v > max) {
-            max = v;
+        if (n > max) {
+            max = n;
         }
     }
     const extent = [min, max];

--- a/packages/ag-charts-enterprise/src/axes/polar-crosslines/polarCrossLine.ts
+++ b/packages/ag-charts-enterprise/src/axes/polar-crosslines/polarCrossLine.ts
@@ -116,8 +116,6 @@ export abstract class PolarCrossLine implements _ModuleSupport.CrossLine {
 
     abstract update(visible: boolean): void;
 
-    calculatePadding() {}
-
     protected setSectorNodeProps(node: _Scene.Path | _Scene.Sector) {
         node.fill = this.fill;
         node.fillOpacity = this.fillOpacity ?? 1;

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -397,7 +397,9 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup
     protected async updateLabelNodes(_opts: {
         labelSelection: _Scene.Selection<_Scene.Text, BoxPlotNodeDatum>;
         seriesIdx: number;
-    }) {}
+    }) {
+        // Labels are unsupported.
+    }
 
     protected async updateLabelSelection(opts: {
         labelData: BoxPlotNodeDatum[];

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -372,20 +372,21 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<_Scene.Rect, 
 
     protected override async updateLabelNodes(_opts: {
         labelSelection: _Scene.Selection<_Scene.Text, BulletNodeDatum>;
-    }) {}
+    }) {
+        // Labels are unsupported.
+    }
 
     override animateEmptyUpdateReady(data: BulletAnimationData) {
-        const { datumSelections, labelSelections, annotationSelections } = data;
+        const { datumSelections, annotationSelections } = data;
 
         const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'normal'));
 
         fromToMotion(this.id, 'nodes', this.ctx.animationManager, datumSelections, fns);
-        seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);
         seriesLabelFadeInAnimation(this, 'annotations', this.ctx.animationManager, annotationSelections);
     }
 
     override animateWaitingUpdateReady(data: BulletAnimationData) {
-        const { datumSelections, labelSelections, annotationSelections } = data;
+        const { datumSelections, annotationSelections } = data;
 
         this.ctx.animationManager.stopByAnimationGroupId(this.id);
 
@@ -404,7 +405,6 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<_Scene.Rect, 
 
         const hasMotion = diff?.changed ?? true;
         if (hasMotion) {
-            seriesLabelFadeInAnimation(this, 'labels', this.ctx.animationManager, labelSelections);
             seriesLabelFadeInAnimation(this, 'annotations', this.ctx.animationManager, annotationSelections);
         }
     }

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -259,7 +259,8 @@ export class TreemapSeries<
         const innerBox = new BBox(bbox.x + padding.left, bbox.y + padding.top, width, height);
         const partition = innerBox.clone();
 
-        for (let i = 0; i < numChildren; i++) {
+        let i = 0;
+        while (i < numChildren) {
             const value = nodeSize(childAt(i));
             const firstValue = nodeSize(childAt(startIndex));
             const isVertical = partition.width < partition.height;
@@ -274,6 +275,7 @@ export class TreemapSeries<
             const diff = Math.abs(targetTileAspectRatio - ratio);
             if (diff < minRatioDiff) {
                 minRatioDiff = diff;
+                i++;
                 continue;
             }
 
@@ -309,7 +311,7 @@ export class TreemapSeries<
             startIndex = i;
             stackSum = 0;
             minRatioDiff = Infinity;
-            i--;
+            // Deliberately don't increment i on this control flow.
         }
 
         // Process remaining space

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -703,7 +703,9 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
         return legendData;
     }
 
-    protected override toggleSeriesItem(): void {}
+    protected override toggleSeriesItem(): void {
+        // Legend item toggling is unsupported.
+    }
 
     override animateEmptyUpdateReady({ datumSelections, labelSelections, contextData, paths }: WaterfallAnimationData) {
         const fns = prepareBarAnimationFunctions(collapsedStartingBarPosition(this.isVertical(), this.axes, 'normal'));

--- a/patches/eslint+8.56.0.patch
+++ b/patches/eslint+8.56.0.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/eslint/lib/rules/no-negated-condition.js b/node_modules/eslint/lib/rules/no-negated-condition.js
+index 3cb7590..aebaed6 100644
+--- a/node_modules/eslint/lib/rules/no-negated-condition.js
++++ b/node_modules/eslint/lib/rules/no-negated-condition.js
+@@ -83,7 +83,7 @@ module.exports = {
+                 }
+             },
+             ConditionalExpression(node) {
+-                if (isNegatedIf(node)) {
++                if (isNegatedIf(node) && !allowedCase(node)) {
+                     context.report({
+                         node,
+                         messageId: "unexpectedNegated"
+@@ -93,3 +93,12 @@ module.exports = {
+         };
+     }
+ };
++
++function allowedCase(node) {
++    if (node.consequent?.type == 'TSNonNullExpression') return true;
++
++    const { test: { operator, right: { type, value } = {} } = {} } = node;
++    if (operator === '!=' && type === 'Literal' && value == null) return true;
++        
++    return false;
++}
+\ No newline at end of file

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.organization=ag-grid
 sonar.projectKey=ag-charts-community-latest
 sonar.projectBaseDir=./
 sonar.host.url=https://sonarcloud.io
-sonar.exclusions=**/tsconfig.spec.json,**/LICENSE.html,**/*.md,**/*.mdoc,**/dist,**/node_modules,**/typings,**/lib,**/*spec.js,packages/*/tools/**,packages/*/src/**/test/**,**/*.test.*
+sonar.exclusions=**/tsconfig.spec.json,**/LICENSE.html,**/*.md,**/*.mdoc,**/dist,**/node_modules,**/typings,**/lib,**/*spec.js,packages/*/tools/**,packages/*/src/**/test/**,**/*.test.*,**/__mocks__/**
 sonar.coverage.exclusions=**/*
 sonar.scanner.force-deprecated-java-version=true


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10766

This adds `minVisibleRect` to the `update-complete` event. The `minRect` is still used by the axes.

The existing `minRect` is defined as the maximum unassociated x & y distance between two adjacent points.

The new `minVisibleRect` takes this but only considers points >= 0 and <= width or height.

This also removes the rounding on zoom ratios as they can get to 4 decimal points and smaller now with fine grained data. It was there to fix flickering, it seems that is not an issue anymore but something keep an eye out for.