### PR TITLE
AG-8595 Performance improvements (part 1)

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -299,6 +299,7 @@ export abstract class CartesianSeries<
             this._contextNodeData.forEach((nodeData) => {
                 nodeData.animationValid ??= animationValid;
             });
+            this.minRect = this.computeMinRect();
 
             await this.updateSeriesGroups();
 
@@ -775,6 +776,11 @@ export abstract class CartesianSeries<
      * between any two adjacent nodes.
      */
     override getMinRect() {
+        return this.minRect;
+    }
+
+    private minRect?: BBox;
+    private computeMinRect() {
         const [context] = this._contextNodeData;
 
         if (!context?.nodeData.length) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8595

Cache CartesianSeries.getMinRect - This is a very expensive operation if there is a lot of data, but the minRect is always the unless createNodeData() is called.

Split off PR https://github.com/ag-grid/ag-charts/pull/1081