### PR TITLE
AG-10766 Fix async zoom to only consider visible items for min rect

### DIFF
--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -758,7 +758,7 @@ export abstract class Series<
         }
     }
 
-    getMinRect(): BBox | undefined {
+    getMinRects(_width: number, _height: number): { minRect: BBox; minVisibleRect: BBox } | undefined {
         return;
     }
 

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -28,7 +28,7 @@ export interface ISeries<TDatum> {
     getDomain(direction: ChartAxisDirection): any[];
     getKeys(direction: ChartAxisDirection): string[];
     getNames(direction: ChartAxisDirection): (string | undefined)[];
-    getMinRect(): BBox | undefined;
+    getMinRects(width: number, height: number): { minRect: BBox; minVisibleRect: BBox } | undefined;
     isEnabled(): boolean;
     type: string;
     visible: boolean;

--- a/packages/ag-charts-community/src/chart/updateService.ts
+++ b/packages/ag-charts-community/src/chart/updateService.ts
@@ -8,6 +8,7 @@ type UpdateCallback = (type: ChartUpdateType, opts?: UpdateOpts) => void;
 export interface UpdateCompleteEvent {
     type: 'update-complete';
     minRect?: BBox;
+    minVisibleRect?: BBox;
 }
 
 export type UpdateOpts = {
@@ -28,7 +29,11 @@ export class UpdateService extends Listeners<'update-complete', (event: UpdateCo
         this.updateCallback(type, options);
     }
 
-    public dispatchUpdateComplete(minRect?: BBox) {
-        this.dispatch('update-complete', { type: 'update-complete', minRect });
+    public dispatchUpdateComplete(rects?: { minRect: BBox; minVisibleRect: BBox }) {
+        this.dispatch('update-complete', {
+            type: 'update-complete',
+            minRect: rects?.minRect,
+            minVisibleRect: rects?.minVisibleRect,
+        });
     }
 }

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -12,6 +12,8 @@ import {
     UNIT,
     constrainZoom,
     definedZoomState,
+    dx,
+    dy,
     pointToRatio,
     scaleZoomAxisWithPoint,
     scaleZoomCenter,
@@ -429,7 +431,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const origin = pointToRatio(this.seriesRect, event.origin.x, event.origin.y);
 
         if (this.isScalingX()) {
-            newZoom.x.max += delta * (oldZoom.x.max - oldZoom.x.min);
+            newZoom.x.max += delta * dx(oldZoom);
             newZoom.x = scaleZoomAxisWithPoint(newZoom.x, oldZoom.x, origin.x);
         }
         if (this.isScalingY()) {
@@ -509,8 +511,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const zoom = definedZoomState(this.zoomManager.getZoom());
         const origin = pointToRatio(this.paddedRect, event.clientX, event.clientY);
 
-        const scaledOriginX = origin.x * (zoom.x.max - zoom.x.min);
-        const scaledOriginY = origin.y * (zoom.y.max - zoom.y.min);
+        const scaledOriginX = origin.x * dx(zoom);
+        const scaledOriginY = origin.y * dy(zoom);
 
         const size = UNIT.max - UNIT.min;
         const halfSize = size / 2;
@@ -536,8 +538,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const zoom = definedZoomState(this.zoomManager.getZoom());
         const origin = pointToRatio(this.paddedRect, event.clientX, event.clientY);
 
-        const scaleX = zoom.x.max - zoom.x.min;
-        const scaleY = zoom.y.max - zoom.y.min;
+        const scaleX = dx(zoom);
+        const scaleY = dy(zoom);
 
         const scaledOriginX = origin.x * scaleX;
         const scaledOriginY = origin.y * scaleY;
@@ -587,13 +589,13 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private isMinZoom(zoom: DefinedZoomState): boolean {
-        const minXCheckValue = this.enableScrolling
-            ? (zoom.x.max - zoom.x.min) * (1 - this.scrollingStep)
-            : round(zoom.x.max - zoom.x.min);
+        let minXCheckValue = dx(zoom);
+        let minYCheckValue = dy(zoom);
 
-        const minYCheckValue = this.enableScrolling
-            ? (zoom.y.max - zoom.y.min) * (1 - this.scrollingStep)
-            : round(zoom.y.max - zoom.y.min);
+        if (this.enableScrolling) {
+            minXCheckValue *= 1 - this.scrollingStep;
+            minYCheckValue *= 1 - this.scrollingStep;
+        }
 
         const isMinXZoom = !this.isScalingX() || minXCheckValue <= this.minRatioX;
         const isMinYZoom = !this.isScalingY() || minYCheckValue <= this.minRatioX;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -608,11 +608,15 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private updateZoom(zoom: DefinedZoomState) {
-        const dx = round(zoom.x.max - zoom.x.min);
-        const dy = round(zoom.y.max - zoom.y.min);
+        const dx_ = dx(zoom);
+        const dy_ = dy(zoom);
 
-        // Discard the zoom update if it would take us below either min ratio
-        if (dx < this.minRatioX || dy < this.minRatioY) {
+        const oldZoom = definedZoomState(this.zoomManager.getZoom());
+
+        const zoomedInTooFarX = dx_ < dx(oldZoom) && dx_ < this.minRatioX;
+        const zoomedInTooFarY = dy_ < dy(oldZoom) && dy_ < this.minRatioY;
+
+        if (zoomedInTooFarX || zoomedInTooFarY) {
             this.contextMenuRegistry.disableAction(CONTEXT_ZOOM_ACTION_ID);
             this.contextMenuRegistry.enableAction(CONTEXT_PAN_ACTION_ID);
             return;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -2,7 +2,7 @@ import type { AgZoomAnchorPoint, _Scene } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
 
 import type { DefinedZoomState, ZoomCoords } from './zoomTypes';
-import { constrainZoom, definedZoomState, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
+import { constrainZoom, definedZoomState, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
 
 export class ZoomAxisDragger {
     public isAxisDragging: boolean = false;
@@ -63,7 +63,7 @@ export class ZoomAxisDragger {
         const target = pointToRatio(bbox, coords.x2, coords.y2);
 
         if (direction === _ModuleSupport.ChartAxisDirection.X) {
-            const scaleX = (target.x - origin.x) * (oldZoom.x.max - oldZoom.x.min);
+            const scaleX = (target.x - origin.x) * dx(oldZoom);
 
             newZoom.x.max += scaleX;
             newZoom.x = scaleZoomAxisWithAnchor(newZoom.x, oldZoom.x, anchor, origin.x);
@@ -72,7 +72,7 @@ export class ZoomAxisDragger {
             return newZoom.x;
         }
 
-        const scaleY = (target.y - origin.y) * (oldZoom.y.max - oldZoom.y.min);
+        const scaleY = (target.y - origin.y) * dy(oldZoom);
 
         newZoom.y.max -= scaleY;
         newZoom.y = scaleZoomAxisWithAnchor(newZoom.y, oldZoom.y, anchor, origin.y);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -12,6 +12,14 @@ export function unitZoomState(): DefinedZoomState {
     return { x: { ...UNIT }, y: { ...UNIT } };
 }
 
+export function dx(zoom: DefinedZoomState) {
+    return zoom.x.max - zoom.x.min;
+}
+
+export function dy(zoom: DefinedZoomState) {
+    return zoom.y.max - zoom.y.min;
+}
+
 export function definedZoomState(zoom?: _ModuleSupport.AxisZoomState): DefinedZoomState {
     return {
         x: { min: zoom?.x?.min ?? UNIT.min, max: zoom?.x?.max ?? UNIT.max },
@@ -50,12 +58,9 @@ export function translateZoom(zoom: DefinedZoomState, x: number, y: number): Def
  * Scale a zoom bounding box from the top left corner.
  */
 export function scaleZoom(zoom: DefinedZoomState, sx: number, sy: number): DefinedZoomState {
-    const dx = zoom.x.max - zoom.x.min;
-    const dy = zoom.y.max - zoom.y.min;
-
     return {
-        x: { min: zoom.x.min, max: zoom.x.min + dx * sx },
-        y: { min: zoom.y.min, max: zoom.y.min + dy * sy },
+        x: { min: zoom.x.min, max: zoom.x.min + dx(zoom) * sx },
+        y: { min: zoom.y.min, max: zoom.y.min + dy(zoom) * sy },
     };
 }
 
@@ -63,15 +68,15 @@ export function scaleZoom(zoom: DefinedZoomState, sx: number, sy: number): Defin
  * Scale a zoom bounding box from the center.
  */
 export function scaleZoomCenter(zoom: DefinedZoomState, sx: number, sy: number): DefinedZoomState {
-    const dx = zoom.x.max - zoom.x.min;
-    const dy = zoom.y.max - zoom.y.min;
+    const dx_ = dx(zoom);
+    const dy_ = dy(zoom);
 
-    const cx = zoom.x.min + dx / 2;
-    const cy = zoom.y.min + dy / 2;
+    const cx = zoom.x.min + dx_ / 2;
+    const cy = zoom.y.min + dy_ / 2;
 
     return {
-        x: { min: cx - (dx * sx) / 2, max: cx + (dx * sx) / 2 },
-        y: { min: cy - (dy * sy) / 2, max: cy + (dy * sy) / 2 },
+        x: { min: cx - (dx_ * sx) / 2, max: cx + (dx_ * sx) / 2 },
+        y: { min: cy - (dy_ * sy) / 2, max: cy + (dy_ * sy) / 2 },
     };
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10766

1. Adds `minVisibleRect` to the `update-complete` event. The `minRect` is still used by the axes.
	a. The existing `minRect` is defined as the maximum unassociated x & y distance between two adjacent points.
	b. The new `minVisibleRect` takes this but only considers points >= 0 and <= width or height.
2. Removes the rounding on zoom ratios as they can get to 4 decimal points and smaller now with fine grained data. It was there to fix flickering, it seems that is not an issue anymore but something keep an eye out for.
3. Changes the zoom to only discard zooms that violate the `minRatioX/Y` when zooming in, allowing zooming out and and panning.
4. Optimises the `CartesianSeries.getMinRects()` call to minimise looping of the data.
5. Recreates the caching from this change https://github.com/ag-grid/ag-charts/pull/1088 to take the scene width & height into account. I looked at using `memo()` but the stringify of the node data would probably be super slow and defeat the point.