### PR TITLE
AG-10409 Avoid unnecessary array allocations

### DIFF
--- a/packages/ag-charts-community/src/scene/intersection.ts
+++ b/packages/ag-charts-community/src/scene/intersection.ts
@@ -15,25 +15,22 @@ export function segmentIntersection(
     by1: number,
     bx2: number,
     by2: number
-): { x: number; y: number } | null {
+): number {
     const d = (ax2 - ax1) * (by2 - by1) - (ay2 - ay1) * (bx2 - bx1);
 
     if (d === 0) {
         // The lines are parallel.
-        return null;
+        return 0;
     }
 
     const ua = ((bx2 - bx1) * (ay1 - by1) - (ax1 - bx1) * (by2 - by1)) / d;
     const ub = ((ax2 - ax1) * (ay1 - by1) - (ay2 - ay1) * (ax1 - bx1)) / d;
 
     if (ua >= 0 && ua <= 1 && ub >= 0 && ub <= 1) {
-        return {
-            x: ax1 + ua * (ax2 - ax1),
-            y: ay1 + ua * (ay2 - ay1),
-        };
+        return 1;
     }
 
-    return null; // The intersection point is outside either or both segments.
+    return 0; // The intersection point is outside either or both segments.
 }
 
 /**
@@ -54,8 +51,8 @@ export function cubicSegmentIntersections(
     y1: number,
     x2: number,
     y2: number
-): { x: number; y: number }[] {
-    const intersections: { x: number; y: number }[] = [];
+): number {
+    let intersections = 0;
 
     // Find line equation coefficients.
     const A = y1 - y2;
@@ -93,7 +90,7 @@ export function cubicSegmentIntersections(
             s = (x - x1) / (x2 - x1);
         }
         if (s >= 0 && s <= 1) {
-            intersections.push({ x, y });
+            intersections++;
         }
     }
     return intersections;
@@ -127,7 +124,10 @@ export function arcIntersections(
     y1: number,
     x2: number,
     y2: number
-): Array<{ x: number; y: number }> {
+): number {
+    if (isNaN(cx) || isNaN(cy)) {
+        return 0;
+    }
     if (counterClockwise) {
         [endAngle, startAngle] = [startAngle, endAngle];
     }
@@ -143,13 +143,13 @@ export function arcIntersections(
     const c = Math.pow(cx, 2) + Math.pow(y0 - cy, 2) - Math.pow(r, 2);
     const d = Math.pow(b, 2) - 4 * a * c;
     if (d < 0) {
-        return [];
+        return 0;
     }
 
     const i1x = (-b + Math.sqrt(d)) / 2 / a;
     const i2x = (-b - Math.sqrt(d)) / 2 / a;
 
-    const intersections: { x: number; y: number }[] = [];
+    let intersections = 0;
     [i1x, i2x].forEach((x) => {
         const isXInsideLine = x >= Math.min(x1, x2) && x <= Math.max(x1, x2);
         if (!isXInsideLine) {
@@ -162,7 +162,7 @@ export function arcIntersections(
         const opposite = y - cy;
         const angle = Math.atan2(opposite, adjacent);
         if (isBetweenAngles(angle, startAngle, endAngle)) {
-            intersections.push({ x, y });
+            intersections++;
         }
     });
 

--- a/packages/ag-charts-community/src/scene/path2D.ts
+++ b/packages/ag-charts-community/src/scene/path2D.ts
@@ -211,18 +211,14 @@ export class Path2D {
         for (let ci = 0, pi = 0; ci < cn; ci++) {
             switch (commands[ci]) {
                 case Command.Move:
-                    if (!isNaN(sx) && segmentIntersection(sx, sy, px, py, ox, oy, x, y)) {
-                        intersectionCount++;
-                    }
+                    intersectionCount += segmentIntersection(sx, sy, px, py, ox, oy, x, y);
                     px = params[pi++];
                     sx = px;
                     py = params[pi++];
                     sy = py;
                     break;
                 case Command.Line:
-                    if (segmentIntersection(px, py, params[pi++], params[pi++], ox, oy, x, y)) {
-                        intersectionCount++;
-                    }
+                    intersectionCount += segmentIntersection(px, py, params[pi++], params[pi++], ox, oy, x, y);
                     px = params[pi - 2];
                     py = params[pi - 1];
                     break;
@@ -240,7 +236,7 @@ export class Path2D {
                         oy,
                         x,
                         y
-                    ).length;
+                    );
                     px = params[pi - 2];
                     py = params[pi - 1];
                     break;
@@ -251,7 +247,7 @@ export class Path2D {
                     const startAngle = params[pi++];
                     const endAngle = params[pi++];
                     const counterClockwise = Boolean(params[pi++]);
-                    const arcIntersects = arcIntersections(
+                    intersectionCount += arcIntersections(
                         cx,
                         cy,
                         r,
@@ -263,23 +259,18 @@ export class Path2D {
                         x,
                         y
                     );
-                    intersectionCount += arcIntersects.length;
                     if (!isNaN(sx)) {
                         // AG-10199 the arc() command draws a connector line between previous position and the starting
                         // position of the arc. So we need to check if there's an intersection with this connector line.
                         const startX = cx + Math.cos(startAngle) * r;
                         const startY = cy + Math.sin(startAngle) * r;
-                        if (segmentIntersection(px, py, startX, startY, ox, oy, x, y)) {
-                            intersectionCount++;
-                        }
+                        intersectionCount += segmentIntersection(px, py, startX, startY, ox, oy, x, y);
                     }
                     px = cx + Math.cos(endAngle) * r;
                     py = cy + Math.sin(endAngle) * r;
                     break;
                 case Command.ClosePath:
-                    if (!isNaN(sx) && segmentIntersection(sx, sy, px, py, ox, oy, x, y)) {
-                        intersectionCount++;
-                    }
+                    intersectionCount += segmentIntersection(sx, sy, px, py, ox, oy, x, y);
                     break;
             }
         }

--- a/packages/ag-charts-community/src/scene/util/sector.ts
+++ b/packages/ag-charts-community/src/scene/util/sector.ts
@@ -57,7 +57,7 @@ function lineCollidesSector(line: LineCoordinates, sector: SectorBoundaries) {
             outerStart.y,
             innerStart.x,
             innerStart.y
-        ) != null ||
+        ) ||
         segmentIntersection(
             line.start.x,
             line.start.y,
@@ -67,7 +67,7 @@ function lineCollidesSector(line: LineCoordinates, sector: SectorBoundaries) {
             outerEnd.y,
             innerEnd.x,
             innerEnd.y
-        ) != null ||
+        ) ||
         arcIntersections(
             0,
             0,
@@ -79,7 +79,7 @@ function lineCollidesSector(line: LineCoordinates, sector: SectorBoundaries) {
             line.start.y,
             line.end.x,
             line.end.y
-        ).length > 0
+        )
     );
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10409

We only ever use the intersection values, just the count.