### PR TITLE
AG-10789 - Improve series grouping change animations.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1462,12 +1462,15 @@ export abstract class Chart extends Observable implements AgChartInstance {
             miniChart.axes = [];
         }
 
-        const majorChange =
-            forceNodeDataRefresh || modulesChanged || this.shouldForceNodeDataRefresh(deltaOptions, seriesStatus);
+        forceNodeDataRefresh ||= this.shouldForceNodeDataRefresh(deltaOptions, seriesStatus);
+        const majorChange = forceNodeDataRefresh || modulesChanged;
         const updateType = majorChange ? ChartUpdateType.UPDATE_DATA : ChartUpdateType.PERFORM_LAYOUT;
         this.maybeResetAnimations(seriesStatus);
 
-        debug('AgChartV2.applyChartOptions() - update type', ChartUpdateType[updateType]);
+        debug('AgChartV2.applyChartOptions() - update type', ChartUpdateType[updateType], {
+            seriesStatus,
+            forceNodeDataRefresh,
+        });
         this.update(updateType, { forceNodeDataRefresh, newAnimationBatch: true });
     }
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1424,13 +1424,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
             forceNodeDataRefresh = true;
         }
 
-        const seriesDataUpdate = !!deltaOptions.data || seriesStatus === 'data-change' || seriesStatus === 'replaced';
-        const legendKeys = legendRegistry.getKeys();
-        const optionsHaveLegend = Object.values(legendKeys).some(
-            (legendKey) => (deltaOptions as any)[legendKey] != null
-        );
-        const otherRefreshUpdate = deltaOptions.title != null && deltaOptions.subtitle != null;
-        forceNodeDataRefresh = forceNodeDataRefresh || seriesDataUpdate || optionsHaveLegend || otherRefreshUpdate;
         if (deltaOptions.data) {
             this.data = deltaOptions.data;
         }
@@ -1456,71 +1449,92 @@ export abstract class Chart extends Observable implements AgChartInstance {
         const miniChart = navigatorModule?.miniChart;
         const miniChartSeries = deltaOptions?.navigator?.miniChart?.series ?? deltaOptions?.series;
         if (miniChart?.enabled === true && miniChartSeries != null) {
-            const oldSeries = oldOpts?.navigator?.miniChart?.series ?? oldOpts?.series;
-            const miniChartSeriesStatus = this.applySeries(
-                miniChart,
-                this.filterMiniChartSeries(miniChartSeries),
-                this.filterMiniChartSeries(oldSeries)
-            );
-            this.applyAxes(miniChart, deltaOptions, oldOpts, miniChartSeriesStatus, [
-                'axes[].tick',
-                'axes[].thickness',
-                'axes[].title',
-                'axes[].crosshair',
-                'axes[].gridLine',
-                'axes[].label',
-            ]);
-
-            const axes = miniChart.axes as ChartAxis[];
-            const horizontalAxis = axes.find((axis) => axis.direction === ChartAxisDirection.X);
-
-            for (const axis of axes) {
-                axis.gridLine.enabled = false;
-                axis.label.enabled = axis === horizontalAxis;
-                axis.tick.enabled = false;
-                axis.interactionEnabled = false;
-            }
-
-            if (horizontalAxis != null) {
-                const labelOptions = deltaOptions.navigator?.miniChart?.label;
-                const intervalOptions = deltaOptions.navigator?.miniChart?.label?.interval;
-
-                jsonApply(horizontalAxis.label, labelOptions, {
-                    path: 'navigator.miniChart.label',
-                    skip: [
-                        'navigator.miniChart.label.interval',
-                        'navigator.miniChart.label.rotation',
-                        'navigator.miniChart.label.minSpacing',
-                        'navigator.miniChart.label.autoRotate',
-                        'navigator.miniChart.label.autoRotateAngle',
-                    ],
-                });
-                jsonApply(horizontalAxis.tick, intervalOptions, {
-                    path: 'navigator.miniChart.interval',
-                    skip: [
-                        'navigator.miniChart.interval.enabled',
-                        'navigator.miniChart.interval.width',
-                        'navigator.miniChart.interval.size',
-                        'navigator.miniChart.interval.color',
-                        'navigator.miniChart.interval.interval',
-                        'navigator.miniChart.interval.step',
-                    ],
-                });
-
-                const step = intervalOptions?.step;
-                if (step != null) {
-                    horizontalAxis.tick.interval = step;
-                }
-            }
+            this.applyMiniChartOptions(oldOpts, miniChart, miniChartSeries, deltaOptions);
         } else if (miniChart?.enabled === false) {
             miniChart.series = [];
             miniChart.axes = [];
         }
 
-        const majorChange = forceNodeDataRefresh || modulesChanged;
+        const majorChange =
+            forceNodeDataRefresh || modulesChanged || this.shouldForceNodeDataRefresh(deltaOptions, seriesStatus);
         const updateType = majorChange ? ChartUpdateType.UPDATE_DATA : ChartUpdateType.PERFORM_LAYOUT;
+
         debug('AgChartV2.applyChartOptions() - update type', ChartUpdateType[updateType]);
         this.update(updateType, { forceNodeDataRefresh, newAnimationBatch: true });
+    }
+
+    private shouldForceNodeDataRefresh(deltaOptions: AgChartOptionsNext, seriesStatus: SeriesChangeType) {
+        const seriesDataUpdate = !!deltaOptions.data || seriesStatus === 'data-change' || seriesStatus === 'replaced';
+        const legendKeys = legendRegistry.getKeys();
+        const optionsHaveLegend = Object.values(legendKeys).some(
+            (legendKey) => (deltaOptions as any)[legendKey] != null
+        );
+        const otherRefreshUpdate = deltaOptions.title != null && deltaOptions.subtitle != null;
+        return seriesDataUpdate || optionsHaveLegend || otherRefreshUpdate;
+    }
+
+    private applyMiniChartOptions(
+        oldOpts: AgChartOptions & { type?: SeriesOptionsTypes['type'] },
+        miniChart: any,
+        miniChartSeries: NonNullable<AgChartOptionsNext['series']>,
+        deltaOptions: AgChartOptionsNext
+    ) {
+        const oldSeries = oldOpts?.navigator?.miniChart?.series ?? oldOpts?.series;
+        const miniChartSeriesStatus = this.applySeries(
+            miniChart,
+            this.filterMiniChartSeries(miniChartSeries),
+            this.filterMiniChartSeries(oldSeries)
+        );
+        this.applyAxes(miniChart, deltaOptions, oldOpts, miniChartSeriesStatus, [
+            'axes[].tick',
+            'axes[].thickness',
+            'axes[].title',
+            'axes[].crosshair',
+            'axes[].gridLine',
+            'axes[].label',
+        ]);
+
+        const axes = miniChart.axes as ChartAxis[];
+        const horizontalAxis = axes.find((axis) => axis.direction === ChartAxisDirection.X);
+
+        for (const axis of axes) {
+            axis.gridLine.enabled = false;
+            axis.label.enabled = axis === horizontalAxis;
+            axis.tick.enabled = false;
+            axis.interactionEnabled = false;
+        }
+
+        if (horizontalAxis != null) {
+            const labelOptions = deltaOptions.navigator?.miniChart?.label;
+            const intervalOptions = deltaOptions.navigator?.miniChart?.label?.interval;
+
+            jsonApply(horizontalAxis.label, labelOptions, {
+                path: 'navigator.miniChart.label',
+                skip: [
+                    'navigator.miniChart.label.interval',
+                    'navigator.miniChart.label.rotation',
+                    'navigator.miniChart.label.minSpacing',
+                    'navigator.miniChart.label.autoRotate',
+                    'navigator.miniChart.label.autoRotateAngle',
+                ],
+            });
+            jsonApply(horizontalAxis.tick, intervalOptions, {
+                path: 'navigator.miniChart.interval',
+                skip: [
+                    'navigator.miniChart.interval.enabled',
+                    'navigator.miniChart.interval.width',
+                    'navigator.miniChart.interval.size',
+                    'navigator.miniChart.interval.color',
+                    'navigator.miniChart.interval.interval',
+                    'navigator.miniChart.interval.step',
+                ],
+            });
+
+            const step = intervalOptions?.step;
+            if (step != null) {
+                horizontalAxis.tick.interval = step;
+            }
+        }
     }
 
     private applyModules(options: AgChartOptions) {

--- a/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
@@ -2,7 +2,18 @@ import type { AgChartOptionsNext } from '../../options/chart/chartBuilderOptions
 import { jsonDiff } from '../../util/json';
 import type { ISeries } from '../series/seriesTypes';
 
-const MATCHING_KEYS = ['direction', 'xKey', 'yKey', 'sizeKey', 'angleKey', 'radiusKey', 'normalizedTo'];
+const MATCHING_KEYS = [
+    'direction',
+    'xKey',
+    'yKey',
+    'sizeKey',
+    'angleKey',
+    'radiusKey',
+    'normalizedTo',
+    'stacked',
+    'grouped',
+    'stackGroup',
+];
 
 export function matchSeriesOptions<S extends ISeries<any>>(
     series: S[],
@@ -62,7 +73,10 @@ export function matchSeriesOptions<S extends ISeries<any>>(
             const previousOpts = oldOptsSeries?.[outputIdx] ?? {};
             const diff = jsonDiff(previousOpts, opts ?? {}) as any;
 
-            if (diff) {
+            const { groupIndex, stackIndex } = diff?.seriesGrouping ?? {};
+            if (groupIndex != null || stackIndex != null) {
+                changes.push({ opts, series: outputSeries, diff, idx: outputIdx, status: 'series-grouping' as const });
+            } else if (diff) {
                 changes.push({ opts, series: outputSeries, diff, idx: outputIdx, status: 'update' as const });
             } else {
                 changes.push({ opts, series: outputSeries, idx: outputIdx, status: 'no-op' as const });

--- a/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
@@ -2,16 +2,16 @@ import type { AgChartOptionsNext } from '../../options/chart/chartBuilderOptions
 import { jsonDiff } from '../../util/json';
 import type { ISeries } from '../series/seriesTypes';
 
+const MATCHING_KEYS = ['direction', 'xKey', 'yKey', 'sizeKey', 'angleKey', 'radiusKey', 'normalizedTo'];
+
 export function matchSeriesOptions<S extends ISeries<any>>(
     series: S[],
     optSeries: NonNullable<AgChartOptionsNext['series']>,
     oldOptsSeries?: AgChartOptionsNext['series']
 ) {
-    const keysToConsider = ['direction', 'xKey', 'yKey', 'sizeKey', 'angleKey', 'radiusKey', 'normalizedTo'];
-
     const generateKey = (type: string | undefined, i: any) => {
         const result = [type];
-        for (const key of keysToConsider) {
+        for (const key of MATCHING_KEYS) {
             if (key in i && i[key] != null) result.push(`${key}=${i[key]}`);
         }
         return result.join(';');

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/index.html
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/index.html
@@ -1,6 +1,7 @@
 <div style="display: flex; flex-direction: column">
     <div style="flex: none">
         <button onclick="reset()">Reset</button>
+        <button onclick="toggleMode()" id="modeButton">Mode: standalone</button>
         <button onclick="randomise()">Randomise</button>
         <button onclick="removeData()">Remove Data</button>
         <button onclick="removeSeries()">Remove Series</button>

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
@@ -27,7 +27,7 @@ function toIntegratedData(key: string, d: any[]) {
 
 let data = toIntegratedData('quarter', getData());
 
-const series: NonNullable<AgChartOptions['series']> = [
+const series: NonNullable<AgCartesianChartOptions['series']> = [
     {
         type: 'bar',
         direction: 'horizontal',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10789

Changes the series-grouping change case so that we reset animations back to the initial load case, whilst matching the Integrated Charts series add/remove and data-update cases.

Bonus: Breaks some of the series options processing into distinct methods to reduce cyclomatic complexity of `Chart. applyOptions()`.