### PR TITLE
AG-10875 Fix navigator bounding box region

### DIFF
--- a/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
+++ b/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
@@ -1,3 +1,5 @@
+import { BBox } from 'packages/ag-charts-community/src/scene/bbox';
+
 import { Group } from '../../../scene/group';
 import { ProxyProperty } from '../../../util/proxy';
 import { Layers } from '../../layers';
@@ -95,7 +97,10 @@ export class RangeSelector extends Group {
     }
 
     override computeBBox() {
-        return this.mask.computeBBox();
+        const { x, y, width, height } = this.mask;
+        const minOff = this.minHandle.width / 2;
+        const maxOff = this.maxHandle.width / 2;
+        return new BBox(x - minOff, y, width + (minOff + maxOff), height);
     }
 
     computeVisibleRangeBBox() {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10875

When the min/max handles are on the edge of masks they stick out a bit, so take this offset into account. This fixes a bug where the cursor begin reset because the cursor left the region, and set back to 'ew-cursor' immediately after.