### PR TITLE
AG-10875 Fix navigator bounding box region

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -18,6 +18,7 @@ type Region = {
 
 export class RegionManager {
     private currentRegion?: Region;
+    private isDragging = false;
 
     private eventHandler = (event: InteractionEvent<InteractionTypes>) => this.processEvent(event);
     private regions: BBoxSet<Region> = new BBoxSet();
@@ -107,15 +108,33 @@ export class RegionManager {
         }
     }
 
-    private processEvent(event: InteractionEvent<InteractionTypes>) {
+    private handleDragging(event: InteractionEvent<InteractionTypes>): boolean {
         const { currentRegion } = this;
 
         // AG-10875 only dispatch followup drag event to the region that received the 'drag-start'
-        if (event.type === 'drag' || event.type === 'drag-end') {
-            this.dispatch(currentRegion, event);
+        // This logic will deliberatly suppress 'leave' events from the InteractionManager when dragging.
+        if (this.isDragging) {
+            if (event.type === 'drag-end') {
+                this.isDragging = false;
+                this.dispatch(currentRegion, event);
+            } else if (event.type === 'drag') {
+                this.dispatch(currentRegion, event);
+            }
+            return true;
+        } else if (event.type === 'drag-start') {
+            this.isDragging = true;
+        }
+
+        return false;
+    }
+
+    private processEvent(event: InteractionEvent<InteractionTypes>) {
+        if (this.handleDragging(event)) {
+            // We are current dragging, so do not send leave/enter events until dragging is done.
             return;
         }
 
+        const { currentRegion } = this;
         const newRegion = this.pickRegion(event.offsetX, event.offsetY);
         if (currentRegion !== undefined && newRegion?.name !== currentRegion.name) {
             this.dispatch(currentRegion, { ...event, type: 'leave' });

--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -202,9 +202,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
     private layoutNodes(x: number, y: number, width: number, height: number) {
         const { rangeSelector, mask, minHandle, maxHandle, _min: min, _max: max } = this;
 
-        const minOff = minHandle.width / 2;
-        const maxOff = maxHandle.width / 2;
-        rangeSelector.layout(x - minOff, y, width + minOff + maxOff, height);
+        rangeSelector.layout(x, y, width, height, minHandle.width / 2, maxHandle.width / 2);
         mask.layout(x, y, width, height);
 
         minHandle.layout(x + width * min, y + height / 2);

--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -53,7 +53,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
     protected y = 0;
     protected width = 0;
 
-    private rangeSelector = new RangeSelector([this.mask, this.minHandle, this.maxHandle]);
+    private rangeSelector = new RangeSelector(this.mask, this.minHandle, this.maxHandle);
 
     private dragging?: 'min' | 'max' | 'pan';
     private panStart?: number;

--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -129,6 +129,8 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
             this.ctx.cursorManager.updateCursor('navigator', 'ew-resize');
         } else if (mask.computeVisibleRangeBBox().containsPoint(offsetX, offsetY)) {
             this.ctx.cursorManager.updateCursor('navigator', 'grab');
+        } else {
+            this.ctx.cursorManager.updateCursor('navigator');
         }
     }
 

--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -53,7 +53,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
     protected y = 0;
     protected width = 0;
 
-    private rangeSelector = new RangeSelector(this.mask, this.minHandle, this.maxHandle);
+    private rangeSelector = new RangeSelector([this.mask, this.minHandle, this.maxHandle]);
 
     private dragging?: 'min' | 'max' | 'pan';
     private panStart?: number;
@@ -202,7 +202,9 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
     private layoutNodes(x: number, y: number, width: number, height: number) {
         const { rangeSelector, mask, minHandle, maxHandle, _min: min, _max: max } = this;
 
-        rangeSelector.layout(x, y, width, height);
+        const minOff = minHandle.width / 2;
+        const maxOff = maxHandle.width / 2;
+        rangeSelector.layout(x - minOff, y, width + minOff + maxOff, height);
         mask.layout(x, y, width, height);
 
         minHandle.layout(x + width * min, y + height / 2);

--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -184,13 +184,10 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
 
     private onDragEnd() {
         this.dragging = undefined;
-        this.ctx.cursorManager.updateCursor('navigator');
     }
 
     private onLeave(_event: InteractionEvent<'leave'>) {
-        if (this.dragging == null) {
-            this.ctx.cursorManager.updateCursor('navigator');
-        }
+        this.ctx.cursorManager.updateCursor('navigator');
     }
 
     private onZoomChange(event: ZoomChangeEvent) {

--- a/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
+++ b/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
@@ -10,6 +10,8 @@ export class RangeSelector extends Group {
     private y = 0;
     private width = 200;
     private height = 30;
+    private lOffset = 0;
+    private rOffset = 0;
 
     constructor(children: Node[]) {
         super({ name: 'rangeSelectorGroup', layer: true, zIndex: Layers.NAVIGATOR_ZINDEX });
@@ -22,11 +24,13 @@ export class RangeSelector extends Group {
         this.append(children);
     }
 
-    layout(x: number, y: number, width: number, height: number) {
+    layout(x: number, y: number, width: number, height: number, lOffset: number, rOffset: number) {
         this.x = x;
         this.y = y;
         this.width = width;
         this.height = height;
+        this.lOffset = lOffset;
+        this.rOffset = rOffset;
 
         this.background.translationX = x;
         this.background.translationY = y;
@@ -43,7 +47,7 @@ export class RangeSelector extends Group {
     }
 
     override computeBBox() {
-        const { x, y, width, height } = this;
-        return new BBox(x, y, width, height);
+        const { x, y, width, height, lOffset, rOffset } = this;
+        return new BBox(x - lOffset, y, width + (lOffset + rOffset), height);
     }
 }

--- a/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
+++ b/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
@@ -3,9 +3,6 @@ import { Group } from '../../../scene/group';
 import type { Node } from '../../../scene/node';
 import { Layers } from '../../layers';
 
-type WidthProvider = { get width(): number };
-type NodeWithWidth = Node & WidthProvider;
-
 export class RangeSelector extends Group {
     private background: Group;
 
@@ -13,19 +10,16 @@ export class RangeSelector extends Group {
     private y = 0;
     private width = 200;
     private height = 30;
-    private minHandle: WidthProvider;
-    private maxHandle: WidthProvider;
 
-    constructor(mask: Node, minHandle: NodeWithWidth, maxHandle: NodeWithWidth) {
+    constructor(children: Node[]) {
         super({ name: 'rangeSelectorGroup', layer: true, zIndex: Layers.NAVIGATOR_ZINDEX });
         this.isContainerNode = true;
 
-        this.minHandle = minHandle;
-        this.maxHandle = maxHandle;
         this.background = new Group({ name: 'navigator-background' });
         this.background.zIndex = 1;
 
-        this.append([this.background, mask, minHandle, maxHandle]);
+        this.appendChild(this.background);
+        this.append(children);
     }
 
     layout(x: number, y: number, width: number, height: number) {
@@ -50,8 +44,6 @@ export class RangeSelector extends Group {
 
     override computeBBox() {
         const { x, y, width, height } = this;
-        const minOff = this.minHandle.width / 2;
-        const maxOff = this.maxHandle.width / 2;
-        return new BBox(x - minOff, y, width + (minOff + maxOff), height);
+        return new BBox(x, y, width, height);
     }
 }

--- a/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
+++ b/packages/ag-charts-community/src/chart/navigator/shapes/rangeSelector.ts
@@ -3,6 +3,9 @@ import { Group } from '../../../scene/group';
 import type { Node } from '../../../scene/node';
 import { Layers } from '../../layers';
 
+type WidthProvider = { get width(): number };
+type NodeWithWidth = Node & WidthProvider;
+
 export class RangeSelector extends Group {
     private background: Group;
 
@@ -10,16 +13,19 @@ export class RangeSelector extends Group {
     private y = 0;
     private width = 200;
     private height = 30;
+    private minHandle: WidthProvider;
+    private maxHandle: WidthProvider;
 
-    constructor(children: Node[]) {
+    constructor(mask: Node, minHandle: NodeWithWidth, maxHandle: NodeWithWidth) {
         super({ name: 'rangeSelectorGroup', layer: true, zIndex: Layers.NAVIGATOR_ZINDEX });
         this.isContainerNode = true;
 
+        this.minHandle = minHandle;
+        this.maxHandle = maxHandle;
         this.background = new Group({ name: 'navigator-background' });
         this.background.zIndex = 1;
 
-        this.appendChild(this.background);
-        this.append(children);
+        this.append([this.background, mask, minHandle, maxHandle]);
     }
 
     layout(x: number, y: number, width: number, height: number) {
@@ -44,6 +50,8 @@ export class RangeSelector extends Group {
 
     override computeBBox() {
         const { x, y, width, height } = this;
-        return new BBox(x, y, width, height);
+        const minOff = this.minHandle.width / 2;
+        const maxOff = this.maxHandle.width / 2;
+        return new BBox(x - minOff, y, width + (minOff + maxOff), height);
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10875

* When the min/max handles are on the edge of masks they stick out a bit, so take this offset into account. This fixes a bug where the cursor begin reset because the cursor left the region, and set back to 'ew-cursor' immediately after. (copy of https://github.com/ag-grid/ag-charts/pull/1130)
* Reset cursor in the navigator hover handler.
* Lock the `RegionManager.currentRegion` when dragging. This simplifies the navigator input handling logic.