### PR TITLE
AG-8218 Add warning when navigator initial values are rejected

### DIFF
--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -3,6 +3,7 @@ import { BaseModuleInstance } from '../../module/module';
 import type { ModuleContext } from '../../module/moduleContext';
 import type { BBox } from '../../scene/bbox';
 import type { Group } from '../../scene/group';
+import { Logger } from '../../util/logger';
 import { clamp } from '../../util/number';
 import { ActionOnSet, ObserveChanges } from '../../util/proxy';
 import { BOOLEAN, OBJECT, POSITIVE_NUMBER, RATIO, Validate } from '../../util/validation';
@@ -30,23 +31,23 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
     @Validate(POSITIVE_NUMBER)
     public margin: number = 10;
 
-    @Validate(RATIO)
+    @Validate(RATIO, { optional: true })
     @ActionOnSet<Navigator>({
         newValue(min) {
             this._min = min;
             this.updateZoom(min, this._max);
         },
     })
-    public min: number = 0;
+    public min?: number;
 
-    @Validate(RATIO)
+    @Validate(RATIO, { optional: true })
     @ActionOnSet<Navigator>({
         newValue(max) {
             this._max = max;
             this.updateZoom(this._min, max);
         },
     })
-    public max: number = 1;
+    public max?: number;
 
     @Validate(BOOLEAN)
     @ObserveChanges<Navigator>((target) => target.updateGroupVisibility())
@@ -229,8 +230,15 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
         if (!this.enabled) return;
 
         const zoom = this.ctx.zoomManager.getZoom();
-        if (min != null && max != null) {
-            this.ctx.zoomManager.updateZoom('navigator', { x: { min, max }, y: zoom?.y }, false);
-        }
+        if (min == null || max == null) return;
+
+        const warnOnConflict = (stateId: string) => {
+            if (this.min == null && this.max == null) return;
+            Logger.warnOnce(
+                `Could not apply [navigator.min] or [navigator.max] as [${stateId}] has modified the initial zoom state.`
+            );
+        };
+
+        return this.ctx.zoomManager.updateZoom('navigator', { x: { min, max }, y: zoom?.y }, false, warnOnConflict);
     }
 }

--- a/packages/ag-charts-community/src/options/chart/zoomOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/zoomOptions.ts
@@ -22,9 +22,15 @@ export interface AgZoomOptions {
      * Default: `middle`
      */
     anchorPointY?: AgZoomAnchorPoint;
-    /** The axes on which to zoom, one of `xy`, `x`, or `y`. */
+    /**
+     * The axes on which to zoom, one of `xy`, `x`, or `y`.
+     * Default: `x`
+     */
     axes?: AgZoomAxes;
-    /** Set to `true` to enable the zoom module, defaults to `false`. */
+    /**
+     *  Set to `true` to enable the zoom module.
+     * Default: `false`
+     */
     enabled?: boolean;
     /**
      * Set to `true` to enable dragging an axis to zoom series attached to that axis.
@@ -63,22 +69,22 @@ export interface AgZoomOptions {
     minVisibleItemsY?: number;
     /**
      * The initial minimum x-axis position of the zoom, as a ratio of the full chart.
-     * Default: '0'
+     * Default: `0`
      */
     minX?: number;
     /**
      * The initial maximum x-axis position of the zoom, as a ratio of the full chart.
-     * Default: '1'
+     * Default: `1`
      */
     maxX?: number;
     /**
      * The initial minimum y-axis position of the zoom, as a ratio of the full chart.
-     * Default: '0'
+     * Default: `0`
      */
     minY?: number;
     /**
      * The initial maximum y-axis position of the zoom, as a ratio of the full chart.
-     * Default: '1'
+     * Default: `1`
      */
     maxY?: number;
     /**

--- a/packages/ag-charts-enterprise/src/features/features.test.ts
+++ b/packages/ag-charts-enterprise/src/features/features.test.ts
@@ -4,6 +4,7 @@ import { type AgChartOptions, AgCharts } from 'ag-charts-community';
 import {
     clickAction,
     dragAction,
+    expectWarning,
     extractImageData,
     hoverAction,
     scrollAction,
@@ -130,6 +131,9 @@ describe('Feature Combinations', () => {
 
         it('should prioritise zoom min/max over navigator min/max', async () => {
             await prepareChart({ min: 0.1, max: 0.3 }, { minX: 0.7, maxX: 0.9 });
+            expectWarning(
+                'AG Charts - Could not apply [navigator.min] or [navigator.max] as [zoom] has modified the initial zoom state.'
+            );
             await compare();
         });
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8218

Also fixes the formatting on the zoom options comments for the default values.