### PR TITLE
AG-10890 - Allow all cartesian chart types to configure secondary axes.

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -172,7 +172,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
 
     abstract get direction(): ChartAxisDirection;
 
-    boundSeries: ISeries<unknown>[] = [];
+    boundSeries: ISeries<unknown, unknown>[] = [];
     includeInvisibleDomains: boolean = false;
 
     interactionEnabled = true;

--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -30,7 +30,7 @@ export class CartesianChart extends Chart {
 
     private firstSeriesTranslation = true;
 
-    override destroySeries(series: Series<any>[]) {
+    override destroySeries(series: Series<any, any>[]) {
         super.destroySeries(series);
 
         this.firstSeriesTranslation = true;

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -86,7 +86,7 @@ export type TransferableResources = { container?: OptionalHTMLElement; scene: Sc
 type SyncModule = ModuleInstance & { enabled?: boolean; syncAxes: (skipSync: boolean) => void };
 
 type PickedNode = {
-    series: Series<any>;
+    series: Series<any, any>;
     datum: SeriesNodeDatum;
     distance: number;
 };
@@ -500,7 +500,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     private performUpdateType: ChartUpdateType = ChartUpdateType.NONE;
 
     private updateShortcutCount = 0;
-    private seriesToUpdate: Set<ISeries<any>> = new Set();
+    private seriesToUpdate: Set<ISeries<any, any>> = new Set();
     private updateMutex = new Mutex();
     private updateRequestors: Record<string, ChartUpdateType> = {};
     private performUpdateTrigger = debouncedCallback(async ({ count }) => {
@@ -668,7 +668,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         return false;
     }
 
-    private checkFirstAutoSize(seriesToUpdate: ISeries<any>[]) {
+    private checkFirstAutoSize(seriesToUpdate: ISeries<any, any>[]) {
         if (this.autoSize && !this._lastAutoSize) {
             const count = this._performUpdateNoRenderCount++;
             const backOffMs = (count + 1) ** 2 * 40;
@@ -716,9 +716,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.onSeriesChange(newValue, oldValue);
         },
     })
-    series: Series<any>[] = [];
+    series: Series<any, any>[] = [];
 
-    private onSeriesChange(newValue: Series<any>[], oldValue?: Series<any>[]) {
+    private onSeriesChange(newValue: Series<any, any>[], oldValue?: Series<any, any>[]) {
         const seriesToDestroy = oldValue?.filter((series) => !newValue.includes(series)) ?? [];
         this.destroySeries(seriesToDestroy);
         this.seriesLayerManager?.setSeriesCount(newValue.length);
@@ -752,7 +752,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
     }
 
-    protected destroySeries(allSeries: Series<any>[]): void {
+    protected destroySeries(allSeries: Series<any, any>[]): void {
         allSeries?.forEach((series) => {
             series.removeEventListener('nodeClick', this.onSeriesNodeClick);
             series.removeEventListener('nodeDoubleClick', this.onSeriesNodeDoubleClick);
@@ -764,7 +764,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         });
     }
 
-    private addSeriesListeners(series: Series<any>) {
+    private addSeriesListeners(series: Series<any, any>) {
         if (this.hasEventListener('seriesNodeClick')) {
             series.addEventListener('nodeClick', this.onSeriesNodeClick);
         }
@@ -898,8 +898,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.dataProcessListeners.clear();
     }
 
-    placeLabels(): Map<Series<any>, PlacedLabel[]> {
-        const visibleSeries: Series<any>[] = [];
+    placeLabels(): Map<Series<any, any>, PlacedLabel[]> {
+        const visibleSeries: Series<any, any>[] = [];
         const data: (readonly PointLabelDatum[])[] = [];
         for (const series of this.series) {
             if (!series.visible) continue;
@@ -1004,7 +1004,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         // declared series.
         const reverseSeries = [...this.series].reverse();
 
-        let result: { series: Series<any>; datum: SeriesNodeDatum; distance: number } | undefined;
+        let result: { series: Series<any, any>; datum: SeriesNodeDatum; distance: number } | undefined;
         for (const series of reverseSeries) {
             if (!series.visible || !series.rootGroup.visible) {
                 continue;
@@ -1191,7 +1191,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     private checkSeriesNodeRange(
         event: PointerEvent,
-        callback: (series: ISeries<any>, datum: SeriesNodeDatum) => void
+        callback: (series: ISeries<any, any>, datum: SeriesNodeDatum) => void
     ): boolean {
         const nearestNode = this.pickSeriesNode({ x: event.offsetX, y: event.offsetY }, false);
 
@@ -1285,7 +1285,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     };
 
     changeHighlightDatum(event: HighlightChangeEvent) {
-        const seriesToUpdate: Set<ISeries<any>> = new Set();
+        const seriesToUpdate: Set<ISeries<any, any>> = new Set();
         const { series: newSeries = undefined, datum: newDatum } = event.currentHighlight ?? {};
         const { series: lastSeries = undefined, datum: lastDatum } = event.previousHighlight ?? {};
 
@@ -1594,7 +1594,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private applySeries(
-        chart: { series: Series<any>[] },
+        chart: { series: Series<any, any>[] },
         optSeries: AgChartOptionsNext['series'],
         oldOptSeries?: AgChartOptionsNext['series']
     ): SeriesChangeType {
@@ -1704,14 +1704,14 @@ export abstract class Chart extends Observable implements AgChartInstance {
         return true;
     }
 
-    private createSeries(seriesOptions: SeriesOptionsTypes): Series<any> {
-        const seriesInstance = seriesRegistry.create(seriesOptions.type!, this.getModuleContext()) as Series<any>;
+    private createSeries(seriesOptions: SeriesOptionsTypes): Series<any, any> {
+        const seriesInstance = seriesRegistry.create(seriesOptions.type!, this.getModuleContext()) as Series<any, any>;
         this.applySeriesOptionModules(seriesInstance, seriesOptions);
         this.applySeriesValues(seriesInstance, seriesOptions);
         return seriesInstance;
     }
 
-    private applySeriesOptionModules(series: Series<any>, options: AgBaseSeriesOptions<any>) {
+    private applySeriesOptionModules(series: Series<any, any>, options: AgBaseSeriesOptions<any>) {
         const moduleContext = series.createModuleContext();
         const moduleMap = series.getModuleMap();
 
@@ -1723,7 +1723,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
     }
 
-    private applySeriesValues(target: Series<any>, options: AgBaseSeriesOptions<any>) {
+    private applySeriesValues(target: Series<any, any>, options: AgBaseSeriesOptions<any>) {
         const moduleMap = target.getModuleMap();
         const { type: _, data, listeners, seriesGrouping, showInMiniChart: __, ...seriesOptions } = options as any;
 

--- a/packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/packages/ag-charts-community/src/chart/chartAxis.ts
@@ -17,7 +17,7 @@ export type ChartAxisLabelFlipFlag = 1 | -1;
 
 export interface ChartAxis {
     attachAxis(axisGroup: Node, gridGroup: Node): void;
-    boundSeries: ISeries<unknown>[];
+    boundSeries: ISeries<unknown, unknown>[];
     calculateLayout(primaryTickCount?: number): { primaryTickCount: number | undefined; bbox: BBox };
     calculatePadding(min: number, _max: number, reverse: boolean): [number, number];
     clipGrid(x: number, y: number, width: number, height: number): void;

--- a/packages/ag-charts-community/src/chart/chartService.ts
+++ b/packages/ag-charts-community/src/chart/chartService.ts
@@ -6,5 +6,5 @@ import type { ISeries } from './series/seriesTypes';
 export interface ChartService {
     readonly mode: ChartMode;
     readonly title?: CaptionLike;
-    readonly series: ISeries<any>[];
+    readonly series: ISeries<any, any>[];
 }

--- a/packages/ag-charts-community/src/chart/factory/seriesRegistry.ts
+++ b/packages/ag-charts-community/src/chart/factory/seriesRegistry.ts
@@ -66,7 +66,7 @@ export class SeriesRegistry {
         chartTypes.set(seriesType, chartType);
     }
 
-    create(seriesType: SeriesType, moduleContext: ModuleContext): ISeries<any> {
+    create(seriesType: SeriesType, moduleContext: ModuleContext): ISeries<any, any> {
         const SeriesConstructor = this.seriesMap.get(seriesType)?.instanceConstructor;
         if (SeriesConstructor) {
             return new SeriesConstructor(moduleContext);

--- a/packages/ag-charts-community/src/chart/interaction/syncManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/syncManager.ts
@@ -9,7 +9,7 @@ type GroupId = string | symbol;
 
 /** Breaks circular dependencies which occur when importing ChartAxis. */
 type AxisLike = {
-    boundSeries: ISeries<any>[];
+    boundSeries: ISeries<any, any>[];
     direction: ChartAxisDirection;
     keys: string[];
     reverse?: boolean;
@@ -22,7 +22,7 @@ type AxisLike = {
 type ChartLike = {
     id: string;
     axes: AxisLike[];
-    series: ISeries<any>[];
+    series: ISeries<any, any>[];
     highlightManager: HighlightManager;
     modulesManager: { getModule<R>(module: string): R | undefined };
     tooltipManager: TooltipManager;

--- a/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
+++ b/packages/ag-charts-community/src/chart/mapping/prepareSeries.ts
@@ -15,7 +15,7 @@ const MATCHING_KEYS = [
     'stackGroup',
 ];
 
-export function matchSeriesOptions<S extends ISeries<any>>(
+export function matchSeriesOptions<S extends ISeries<any, any>>(
     series: S[],
     optSeries: NonNullable<AgChartOptionsNext['series']>,
     oldOptsSeries?: AgChartOptionsNext['series']

--- a/packages/ag-charts-community/src/chart/polarChart.ts
+++ b/packages/ag-charts-community/src/chart/polarChart.ts
@@ -83,7 +83,7 @@ export class PolarChart extends Chart {
     }
 
     private async computeCircle(seriesBox: BBox) {
-        const polarSeries = this.series.filter((series): series is PolarSeries<any, any> => {
+        const polarSeries = this.series.filter((series): series is PolarSeries<any, any, any> => {
             return series instanceof PolarSeries;
         });
         const polarAxes = this.axes.filter((axis): axis is PolarAxis => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
@@ -18,12 +18,11 @@ export abstract class AbstractBarSeriesProperties<T extends object> extends Cart
 
 export abstract class AbstractBarSeries<
     TNode extends Node,
+    TProps extends AbstractBarSeriesProperties<any>,
     TDatum extends CartesianSeriesNodeDatum,
     TLabel extends SeriesNodeDatum = TDatum,
     TContext extends CartesianSeriesNodeDataContext<TDatum, TLabel> = CartesianSeriesNodeDataContext<TDatum, TLabel>,
-> extends CartesianSeries<TNode, TDatum, TLabel, TContext> {
-    abstract override properties: AbstractBarSeriesProperties<any>;
-
+> extends CartesianSeries<TNode, TProps, TDatum, TLabel, TContext> {
     /**
      * Used to get the position of bars within each group.
      */

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -36,7 +36,11 @@ import {
     prepareAreaPathAnimation,
 } from './areaUtil';
 import type { CartesianAnimationData } from './cartesianSeries';
-import { CartesianSeries } from './cartesianSeries';
+import {
+    CartesianSeries,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
+} from './cartesianSeries';
 import { markerFadeInAnimation, markerSwipeScaleInAnimation, resetMarkerFn, resetMarkerPositionFn } from './markerUtil';
 import { buildResetPathFn, pathFadeInAnimation, pathSwipeInAnimation, updateClipPath } from './pathUtil';
 
@@ -49,6 +53,7 @@ type AreaAnimationData = CartesianAnimationData<
 
 export class AreaSeries extends CartesianSeries<
     Group,
+    AreaSeriesProperties,
     MarkerSelectionDatum,
     LabelSelectionDatum,
     AreaSeriesNodeDataContext

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -66,6 +66,8 @@ export class AreaSeries extends CartesianSeries<
     constructor(moduleCtx: ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             pathsPerSeries: 2,
             pathsZIndexSubOrderOffset: [0, 1000],
             hasMarkers: true,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -92,6 +92,8 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
     constructor(moduleCtx: ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
             pathsPerSeries: 0,
             hasHighlightedLabels: true,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -37,10 +37,12 @@ import {
     resetBarSelectionsFn,
     updateRect,
 } from './barUtil';
-import type {
-    CartesianAnimationData,
-    CartesianSeriesNodeDataContext,
-    CartesianSeriesNodeDatum,
+import {
+    type CartesianAnimationData,
+    type CartesianSeriesNodeDataContext,
+    type CartesianSeriesNodeDatum,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
 } from './cartesianSeries';
 import { adjustLabelPlacement, updateLabelNode } from './labelUtil';
 
@@ -81,7 +83,7 @@ enum BarSeriesNodeTag {
     Label,
 }
 
-export class BarSeries extends AbstractBarSeries<Rect, BarNodeDatum> {
+export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarNodeDatum> {
     static readonly className = 'BarSeries';
     static readonly type = 'bar' as const;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -20,7 +20,12 @@ import { SeriesNodePickMode, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { BubbleNodeDatum, BubbleSeriesProperties } from './bubbleSeriesProperties';
 import type { CartesianAnimationData } from './cartesianSeries';
-import { CartesianSeries, CartesianSeriesNodeEvent } from './cartesianSeries';
+import {
+    CartesianSeries,
+    CartesianSeriesNodeEvent,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
+} from './cartesianSeries';
 import { markerScaleInAnimation, resetMarkerFn } from './markerUtil';
 
 type BubbleAnimationData = CartesianAnimationData<Group, BubbleNodeDatum>;
@@ -34,7 +39,7 @@ class BubbleSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extend
     }
 }
 
-export class BubbleSeries extends CartesianSeries<Group, BubbleNodeDatum> {
+export class BubbleSeries extends CartesianSeries<Group, BubbleSeriesProperties, BubbleNodeDatum> {
     static readonly className = 'BubbleSeries';
     static readonly type = 'bubble' as const;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -54,6 +54,8 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleSeriesProperties,
     constructor(moduleCtx: ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             pickModes: [
                 SeriesNodePickMode.NEAREST_BY_MAIN_CATEGORY_AXIS_FIRST,
                 SeriesNodePickMode.NEAREST_NODE,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -17,7 +17,12 @@ import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
 import { Series, SeriesNodePickMode, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { collapsedStartingBarPosition, prepareBarAnimationFunctions, resetBarSelectionsFn } from './barUtil';
-import { type CartesianAnimationData, CartesianSeries } from './cartesianSeries';
+import {
+    type CartesianAnimationData,
+    CartesianSeries,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
+} from './cartesianSeries';
 import { HistogramNodeDatum, HistogramSeriesProperties } from './histogramSeriesProperties';
 
 enum HistogramSeriesNodeTag {
@@ -29,7 +34,7 @@ const defaultBinCount = 10;
 
 type HistogramAnimationData = CartesianAnimationData<Rect, HistogramNodeDatum>;
 
-export class HistogramSeries extends CartesianSeries<Rect, HistogramNodeDatum> {
+export class HistogramSeries extends CartesianSeries<Rect, HistogramSeriesProperties, HistogramNodeDatum> {
     static readonly className = 'HistogramSeries';
     static readonly type = 'histogram' as const;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -43,6 +43,8 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramSeriesProper
     constructor(moduleCtx: ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
             datumSelectionGarbageCollection: false,
             animationResetFns: {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -43,6 +43,8 @@ export class LineSeries extends CartesianSeries<Group, LineSeriesProperties, Lin
     constructor(moduleCtx: ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             hasMarkers: true,
             pickModes: [
                 SeriesNodePickMode.NEAREST_BY_MAIN_CATEGORY_AXIS_FIRST,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -22,7 +22,11 @@ import { getMarker } from '../../marker/util';
 import { SeriesNodePickMode, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import type { CartesianAnimationData, CartesianSeriesNodeDataContext } from './cartesianSeries';
-import { CartesianSeries } from './cartesianSeries';
+import {
+    CartesianSeries,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
+} from './cartesianSeries';
 import { LineNodeDatum, LineSeriesProperties } from './lineSeriesProperties';
 import { prepareLinePathAnimation } from './lineUtil';
 import { markerFadeInAnimation, markerSwipeScaleInAnimation, resetMarkerFn, resetMarkerPositionFn } from './markerUtil';
@@ -30,7 +34,7 @@ import { buildResetPathFn, pathFadeInAnimation, pathSwipeInAnimation, updateClip
 
 type LineAnimationData = CartesianAnimationData<Group, LineNodeDatum>;
 
-export class LineSeries extends CartesianSeries<Group, LineNodeDatum> {
+export class LineSeries extends CartesianSeries<Group, LineSeriesProperties, LineNodeDatum> {
     static readonly className = 'LineSeries';
     static readonly type = 'line' as const;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -17,13 +17,17 @@ import { getMarker } from '../../marker/util';
 import { SeriesNodePickMode, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import type { CartesianAnimationData } from './cartesianSeries';
-import { CartesianSeries } from './cartesianSeries';
+import {
+    CartesianSeries,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
+} from './cartesianSeries';
 import { markerScaleInAnimation, resetMarkerFn } from './markerUtil';
 import { ScatterNodeDatum, ScatterSeriesProperties } from './scatterSeriesProperties';
 
 type ScatterAnimationData = CartesianAnimationData<Group, ScatterNodeDatum>;
 
-export class ScatterSeries extends CartesianSeries<Group, ScatterNodeDatum> {
+export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesProperties, ScatterNodeDatum> {
     static readonly className = 'ScatterSeries';
     static readonly type = 'scatter' as const;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -38,6 +38,8 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesPropertie
     constructor(moduleCtx: ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             pickModes: [
                 SeriesNodePickMode.NEAREST_BY_MAIN_CATEGORY_AXIS_FIRST,
                 SeriesNodePickMode.NEAREST_NODE,

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -4,13 +4,15 @@ import type { DataController } from '../data/dataController';
 import type { DataModel, DataModelOptions, ProcessedData, PropertyDefinition } from '../data/dataModel';
 import type { SeriesNodeDataContext } from './series';
 import { Series } from './series';
+import type { SeriesProperties } from './seriesProperties';
 import type { SeriesNodeDatum } from './seriesTypes';
 
 export abstract class DataModelSeries<
     TDatum extends SeriesNodeDatum,
+    TProps extends SeriesProperties<any>,
     TLabel = TDatum,
     TContext extends SeriesNodeDataContext<TDatum, TLabel> = SeriesNodeDataContext<TDatum, TLabel>,
-> extends Series<TDatum, TLabel, TContext> {
+> extends Series<TDatum, TProps, TLabel, TContext> {
     protected dataModel?: DataModel<any, any, any>;
     protected processedData?: ProcessedData<any>;
 

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.test.ts
@@ -10,7 +10,7 @@ class ExampleHierarchySeriesProperties extends HierarchySeriesProperties<any> {
     readonly tooltip: SeriesTooltip<any> = null!;
 }
 
-class ExampleHierarchySeries extends HierarchySeries<any> {
+class ExampleHierarchySeries extends HierarchySeries<any, any> {
     override properties = new ExampleHierarchySeriesProperties();
 
     override getSeriesDomain(_direction: ChartAxisDirection): any[] {

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -38,7 +38,7 @@ export class HierarchyNode<TDatum = Record<string, any>>
     readonly midPoint: Point;
 
     constructor(
-        public readonly series: ISeries<any>,
+        public readonly series: ISeries<any, any>,
         public readonly index: number,
         public readonly datum: TDatum | undefined,
         public readonly size: number,
@@ -90,10 +90,9 @@ export class HierarchyNode<TDatum = Record<string, any>>
 
 export abstract class HierarchySeries<
     TNode extends Node = Group,
+    TProps extends HierarchySeriesProperties<any> = HierarchySeriesProperties<any>,
     TDatum extends SeriesNodeDatum = SeriesNodeDatum,
-> extends Series<TDatum> {
-    abstract override properties: HierarchySeriesProperties<any>;
-
+> extends Series<TDatum, TProps> {
     rootNode = new HierarchyNode<TDatum>(
         this,
         0,

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -91,7 +91,7 @@ enum PieNodeTag {
     Label,
 }
 
-export class DonutSeries extends PolarSeries<DonutNodeDatum, Sector> {
+export class DonutSeries extends PolarSeries<DonutNodeDatum, DonutSeriesProperties, Sector> {
     static readonly className = 'DonutSeries';
     static readonly type = 'donut' as const;
 

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -88,7 +88,7 @@ enum PieNodeTag {
     Label,
 }
 
-export class PieSeries extends PolarSeries<PieNodeDatum, Sector> {
+export class PieSeries extends PolarSeries<PieNodeDatum, PieSeriesProperties, Sector> {
     static readonly className = 'PieSeries';
     static readonly type = 'pie' as const;
 

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -12,6 +12,7 @@ import type { ChartAnimationPhase } from '../../chartAnimationPhase';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import { DataModelSeries } from '../dataModelSeries';
 import { SeriesNodePickMode } from '../series';
+import type { SeriesProperties } from '../seriesProperties';
 import type { SeriesNodeDatum } from '../seriesTypes';
 
 export type PolarAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
@@ -26,7 +27,18 @@ export type PolarAnimationEvent =
     | 'skip';
 export type PolarAnimationData = { duration?: number };
 
-export abstract class PolarSeries<TDatum extends SeriesNodeDatum, TNode extends Node> extends DataModelSeries<TDatum> {
+type PolarSeriesProperties = {
+    angleKey: string;
+    angleName?: string;
+    radiusKey?: string;
+    radiusName?: string;
+};
+
+export abstract class PolarSeries<
+    TDatum extends SeriesNodeDatum,
+    TProps extends SeriesProperties<any> & PolarSeriesProperties,
+    TNode extends Node,
+> extends DataModelSeries<TDatum, TProps> {
     protected itemGroup = this.contentGroup.appendChild(new Group());
 
     protected itemSelection: Selection<TNode, TDatum> = Selection.select(

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -3,18 +3,17 @@ import type { Group } from '../../scene/group';
 import type { Point, SizedPoint } from '../../scene/point';
 import type { ChartAxisDirection } from '../chartAxisDirection';
 import type { ChartLegendDatum, ChartLegendType } from '../legendDatum';
-import type { SeriesProperties } from './seriesProperties';
 
 // Breaks circular dependency between ISeries and ChartAxis.
 interface ChartAxisLike {
     id: string;
 }
 
-export interface ISeries<TDatum> {
+export interface ISeries<TDatum, TProps> {
     id: string;
     axes: Record<ChartAxisDirection, ChartAxisLike | undefined>;
     contentGroup: Group;
-    properties: SeriesProperties<any>;
+    properties: TProps;
     hasEventListener(type: string): boolean;
     update(opts: { seriesRect?: BBox }): Promise<void>;
     fireNodeClickEvent(event: Event, datum: TDatum): void;
@@ -39,7 +38,7 @@ export interface ISeries<TDatum> {
  * contains information used to render pie sectors, bars, markers, etc.
  */
 export interface SeriesNodeDatum {
-    readonly series: ISeries<any>;
+    readonly series: ISeries<any, any>;
     readonly itemId?: any;
     readonly datum: any;
     readonly point?: Readonly<SizedPoint>;

--- a/packages/ag-charts-community/src/chart/series/topology/mapSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/topology/mapSeries.ts
@@ -48,7 +48,12 @@ export interface MapAnimationData {
 type MapAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
 type MapAnimationEvent = 'update' | 'updateData' | 'highlight' | 'resize' | 'clear' | 'reset' | 'skip';
 
-export class MapSeries extends DataModelSeries<MapNodeDatum, MapNodeLabelDatum, MapNodeDataContext> {
+export class MapSeries extends DataModelSeries<
+    MapNodeDatum,
+    MapSeriesProperties,
+    MapNodeLabelDatum,
+    MapNodeDataContext
+> {
     scale: MercatorScale | undefined;
 
     override properties = new MapSeriesProperties();

--- a/packages/ag-charts-community/src/chart/updateService.ts
+++ b/packages/ag-charts-community/src/chart/updateService.ts
@@ -15,7 +15,7 @@ export type UpdateOpts = {
     forceNodeDataRefresh?: boolean;
     skipAnimations?: boolean;
     newAnimationBatch?: boolean;
-    seriesToUpdate?: Iterable<ISeries<any>>;
+    seriesToUpdate?: Iterable<ISeries<any, any>>;
     backOffMs?: number;
     skipSync?: boolean;
 };

--- a/packages/ag-charts-community/src/module/coreModules.ts
+++ b/packages/ag-charts-community/src/module/coreModules.ts
@@ -7,7 +7,7 @@ import type { SeriesPaletteFactory } from './coreModulesTypes';
 import type { ModuleContext } from './moduleContext';
 
 type ModuleInstanceConstructor<M> = new (moduleContext: ModuleContext) => M;
-export type SeriesConstructor = ModuleInstanceConstructor<Series<any>>;
+export type SeriesConstructor = ModuleInstanceConstructor<Series<any, any>>;
 export type LegendConstructor = ModuleInstanceConstructor<ChartLegend>;
 
 export interface RootModule<M extends ModuleInstance = ModuleInstance> extends BaseModule {

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -15,7 +15,7 @@ const {
 } = _ModuleSupport;
 
 type ErrorBoundCartesianSeries = Omit<
-    _ModuleSupport.CartesianSeries<_Scene.Node, ErrorBarNodeDatum>,
+    _ModuleSupport.CartesianSeries<_Scene.Node, _ModuleSupport.CartesianSeriesProperties<any>, ErrorBarNodeDatum>,
     'highlightSelection'
 >;
 

--- a/packages/ag-charts-enterprise/src/features/navigator/miniChart.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/miniChart.ts
@@ -68,9 +68,9 @@ export class MiniChart extends _ModuleSupport.BaseModuleInstance implements _Mod
             this.onSeriesChange(newValue, oldValue);
         },
     })
-    series: _ModuleSupport.Series<any>[] = [];
+    series: _ModuleSupport.Series<any, any>[] = [];
 
-    private onSeriesChange(newValue: _ModuleSupport.Series<any>[], oldValue?: _ModuleSupport.Series<any>[]) {
+    private onSeriesChange(newValue: _ModuleSupport.Series<any, any>[], oldValue?: _ModuleSupport.Series<any, any>[]) {
         const seriesToDestroy = oldValue?.filter((series) => !newValue.includes(series)) ?? [];
         this.destroySeries(seriesToDestroy);
 
@@ -103,7 +103,7 @@ export class MiniChart extends _ModuleSupport.BaseModuleInstance implements _Mod
         }
     }
 
-    protected destroySeries(allSeries: _ModuleSupport.Series<any>[]): void {
+    protected destroySeries(allSeries: _ModuleSupport.Series<any, any>[]): void {
         allSeries?.forEach((series) => {
             series.destroy();
 

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -57,6 +57,14 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
         super({
             moduleCtx,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
+            directionKeys: {
+                x: ['xKey'],
+                y: ['medianKey', 'q1Key', 'q3Key', 'minKey', 'maxKey'],
+            },
+            directionNames: {
+                x: ['xName'],
+                y: ['medianName', 'q1Name', 'q3Name', 'minName', 'maxName'],
+            },
             pathsPerSeries: 1,
             hasHighlightedLabels: true,
         });

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -42,7 +42,11 @@ class BoxPlotSeriesNodeEvent<
     }
 }
 
-export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotGroup, BoxPlotNodeDatum> {
+export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
+    BoxPlotGroup,
+    BoxPlotSeriesProperties,
+    BoxPlotNodeDatum
+> {
     static readonly type = 'box-plot' as const;
 
     override properties = new BoxPlotSeriesProperties();

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -53,7 +53,11 @@ const STYLING_KEYS: (keyof _Scene.Shape)[] = [
 
 type BulletAnimationData = _ModuleSupport.CartesianAnimationData<_Scene.Rect, BulletNodeDatum>;
 
-export class BulletSeries extends _ModuleSupport.AbstractBarSeries<_Scene.Rect, BulletNodeDatum> {
+export class BulletSeries extends _ModuleSupport.AbstractBarSeries<
+    _Scene.Rect,
+    BulletSeriesProperties,
+    BulletNodeDatum
+> {
     override properties = new BulletSeriesProperties();
 
     private normalizedColorRanges: NormalizedColorRange[] = [];

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -68,6 +68,8 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<
     constructor(moduleCtx: _ModuleSupport.ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: { y: ['targetKey', 'valueKey'] },
+            directionNames: { y: ['targetName', 'valueName'] },
             pickModes: [_ModuleSupport.SeriesNodePickMode.EXACT_SHAPE_MATCH],
             hasHighlightedLabels: true,
             animationResetFns: {

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
@@ -40,7 +40,11 @@ class CandlestickSeriesNodeEvent<
     }
 }
 
-export class CandlestickSeries extends _ModuleSupport.AbstractBarSeries<CandlestickGroup, CandlestickNodeDatum> {
+export class CandlestickSeries extends _ModuleSupport.AbstractBarSeries<
+    CandlestickGroup,
+    CandlestickSeriesProperties,
+    CandlestickNodeDatum
+> {
     static readonly type = 'candlestick' as const;
 
     override properties = new CandlestickSeriesProperties();

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
@@ -55,6 +55,14 @@ export class CandlestickSeries extends _ModuleSupport.AbstractBarSeries<
         super({
             moduleCtx,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
+            directionKeys: {
+                x: ['xKey'],
+                y: ['lowKey', 'highKey', 'openKey', 'closeKey'],
+            },
+            directionNames: {
+                x: ['xName'],
+                y: ['lowName', 'highName', 'openName', 'closeName'],
+            },
             pathsPerSeries: 1,
         });
     }

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -79,6 +79,8 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
     constructor(moduleCtx: _ModuleSupport.ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
             pathsPerSeries: 0,
             hasMarkers: false,

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -4,7 +4,14 @@ import { _ModuleSupport, _Scale, _Scene, _Util } from 'ag-charts-community';
 import { formatLabels } from '../util/labelFormatter';
 import { HeatmapSeriesProperties } from './heatmapSeriesProperties';
 
-const { SeriesNodePickMode, getMissCount, valueProperty, ChartAxisDirection } = _ModuleSupport;
+const {
+    SeriesNodePickMode,
+    getMissCount,
+    valueProperty,
+    ChartAxisDirection,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
+} = _ModuleSupport;
 const { Rect, PointerEvents } = _Scene;
 const { ColorScale } = _Scale;
 const { sanitizeHtml, Color, Logger } = _Util;
@@ -54,7 +61,12 @@ const verticalAlignFactors: Record<VerticalAlign, number> = {
     bottom: -0.5,
 };
 
-export class HeatmapSeries extends _ModuleSupport.CartesianSeries<_Scene.Rect, HeatmapNodeDatum, HeatmapLabelDatum> {
+export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
+    _Scene.Rect,
+    HeatmapSeriesProperties,
+    HeatmapNodeDatum,
+    HeatmapLabelDatum
+> {
     static readonly className = 'HeatmapSeries';
     static readonly type = 'heatmap' as const;
 

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -39,7 +39,11 @@ class RadarSeriesNodeEvent<
     }
 }
 
-export abstract class RadarSeries extends _ModuleSupport.PolarSeries<RadarNodeDatum, _Scene.Marker> {
+export abstract class RadarSeries extends _ModuleSupport.PolarSeries<
+    RadarNodeDatum,
+    RadarSeriesProperties<any>,
+    _Scene.Marker
+> {
     static readonly className: string = 'RadarSeries';
 
     override properties = new RadarSeriesProperties();

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -56,7 +56,11 @@ export interface RadialBarNodeDatum extends _ModuleSupport.SeriesNodeDatum {
     readonly index: number;
 }
 
-export class RadialBarSeries extends _ModuleSupport.PolarSeries<RadialBarNodeDatum, _Scene.Sector> {
+export class RadialBarSeries extends _ModuleSupport.PolarSeries<
+    RadialBarNodeDatum,
+    RadialBarSeriesProperties<any>,
+    _Scene.Sector
+> {
     static readonly className = 'RadialBarSeries';
     static readonly type = 'radial-bar' as const;
 

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -65,10 +65,8 @@ export interface RadialColumnNodeDatum extends _ModuleSupport.SeriesNodeDatum {
 
 export abstract class RadialColumnSeriesBase<
     ItemPathType extends _Scene.Sector | _Scene.RadialColumnShape,
-> extends _ModuleSupport.PolarSeries<RadialColumnNodeDatum, ItemPathType> {
+> extends _ModuleSupport.PolarSeries<RadialColumnNodeDatum, RadialColumnSeriesBaseProperties<any>, ItemPathType> {
     protected override readonly NodeEvent = RadialColumnSeriesNodeEvent;
-
-    abstract override properties: RadialColumnSeriesBaseProperties<any>;
 
     protected nodeData: RadialColumnNodeDatum[] = [];
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -26,15 +26,6 @@ const {
 const { getMarker, PointerEvents } = _Scene;
 const { sanitizeHtml, extent, isNumber } = _Util;
 
-const DEFAULT_DIRECTION_KEYS = {
-    [_ModuleSupport.ChartAxisDirection.X]: ['xKey'],
-    [_ModuleSupport.ChartAxisDirection.Y]: ['yLowKey', 'yHighKey'],
-};
-const DEFAULT_DIRECTION_NAMES = {
-    [ChartAxisDirection.X]: ['xName'],
-    [ChartAxisDirection.Y]: ['yLowName', 'yHighName', 'yName'],
-};
-
 type RangeAreaLabelDatum = Readonly<_Scene.Point> & {
     text: string;
     textAlign: CanvasTextAlign;
@@ -91,8 +82,14 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
             moduleCtx,
             hasMarkers: true,
             pathsPerSeries: 2,
-            directionKeys: DEFAULT_DIRECTION_KEYS,
-            directionNames: DEFAULT_DIRECTION_NAMES,
+            directionKeys: {
+                [ChartAxisDirection.X]: ['xKey'],
+                [ChartAxisDirection.Y]: ['yLowKey', 'yHighKey'],
+            },
+            directionNames: {
+                [ChartAxisDirection.X]: ['xName'],
+                [ChartAxisDirection.Y]: ['yLowName', 'yHighName', 'yName'],
+            },
             animationResetFns: {
                 path: buildResetPathFn({ getOpacity: () => this.getOpacity() }),
                 label: resetLabelFn,

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -74,6 +74,7 @@ type RadarAreaPathDatum = {
 
 export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
     _Scene.Group,
+    RangeAreaProperties,
     RangeAreaMarkerDatum,
     RangeAreaLabelDatum,
     RangeAreaContext

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -26,15 +26,6 @@ const {
 const { ContinuousScale, Rect, PointerEvents, motion } = _Scene;
 const { sanitizeHtml, isNumber, extent } = _Util;
 
-const DEFAULT_DIRECTION_KEYS = {
-    [_ModuleSupport.ChartAxisDirection.X]: ['xKey'],
-    [_ModuleSupport.ChartAxisDirection.Y]: ['yLowKey', 'yHighKey'],
-};
-const DEFAULT_DIRECTION_NAMES = {
-    [ChartAxisDirection.X]: ['xName'],
-    [ChartAxisDirection.Y]: ['yLowName', 'yHighName', 'yName'],
-};
-
 type Bounds = {
     x: number;
     y: number;
@@ -111,8 +102,14 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
             moduleCtx,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
             hasHighlightedLabels: true,
-            directionKeys: DEFAULT_DIRECTION_KEYS,
-            directionNames: DEFAULT_DIRECTION_NAMES,
+            directionKeys: {
+                x: ['xKey'],
+                y: ['yLowKey', 'yHighKey'],
+            },
+            directionNames: {
+                x: ['xName'],
+                y: ['yLowName', 'yHighName', 'yName'],
+            },
             datumSelectionGarbageCollection: false,
             animationResetFns: {
                 datum: resetBarSelectionsFn,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -95,6 +95,7 @@ class RangeBarSeriesNodeEvent<
 
 export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
     _Scene.Rect,
+    RangeBarProperties,
     RangeBarNodeDatum,
     RangeBarNodeLabelDatum
 > {

--- a/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
@@ -58,7 +58,11 @@ enum TextNodeTag {
     Secondary,
 }
 
-export class SunburstSeries extends _ModuleSupport.HierarchySeries<_Scene.Group, _ModuleSupport.SeriesNodeDatum> {
+export class SunburstSeries extends _ModuleSupport.HierarchySeries<
+    _Scene.Group,
+    SunburstSeriesProperties,
+    _ModuleSupport.SeriesNodeDatum
+> {
     static readonly className = 'SunburstSeries';
     static readonly type = 'sunburst' as const;
 

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -74,7 +74,7 @@ const verticalAlignFactors: Record<VerticalAlign, number | undefined> = {
 
 export class TreemapSeries<
     TDatum extends _ModuleSupport.SeriesNodeDatum = _ModuleSupport.SeriesNodeDatum,
-> extends _ModuleSupport.HierarchySeries<_Scene.Group, TDatum> {
+> extends _ModuleSupport.HierarchySeries<_Scene.Group, TreemapSeriesProperties, TDatum> {
     static readonly className = 'TreemapSeries';
     static readonly type = 'treemap' as const;
 

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -80,6 +80,8 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
     constructor(moduleCtx: _ModuleSupport.ModuleContext) {
         super({
             moduleCtx,
+            directionKeys: DEFAULT_CARTESIAN_DIRECTION_KEYS,
+            directionNames: DEFAULT_CARTESIAN_DIRECTION_NAMES,
             pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
             pathsPerSeries: 1,
             hasHighlightedLabels: true,

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -23,6 +23,8 @@ const {
     seriesLabelFadeInAnimation,
     resetLabelFn,
     animationValidation,
+    DEFAULT_CARTESIAN_DIRECTION_KEYS,
+    DEFAULT_CARTESIAN_DIRECTION_NAMES,
 } = _ModuleSupport;
 const { ContinuousScale, Rect, motion } = _Scene;
 const { sanitizeHtml, isContinuous, isNumber } = _Util;
@@ -65,6 +67,7 @@ type WaterfallAnimationData = _ModuleSupport.CartesianAnimationData<
 
 export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
     _Scene.Rect,
+    WaterfallSeriesProperties,
     WaterfallNodeDatum,
     WaterfallNodeDatum,
     WaterfallContext


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10890

Reworks specification of `directionKeys` and `directionNames` to (see commit https://github.com/ag-grid/ag-charts/commit/7d4c154508e2a4a8f3be680543a2edc5dbca2e44):
- Ensure that these are specified for each series.
- Ensure that they map to known configuration properties for the concrete series type.

Updates these series types to take these keys into account (see commit https://github.com/ag-grid/ag-charts/commit/142b4d7d88b419b97407d6f16e4549c85b94d2af):
- BoxPlot: 'medianKey', 'q1Key', 'q3Key', 'minKey', 'maxKey'
- Bullet: 'targetKey', 'valueKey'
- Candlestick: 'lowKey', 'highKey', 'openKey', 'closeKey'
- Range-area / range-bar **(unchanged)**: 'yLowKey', 'yHighKey'
