### PR TITLE
AG-8218 Change zoom min/max props to rangeX/Y

### DIFF
--- a/packages/ag-charts-community/src/options/chart/zoomOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/zoomOptions.ts
@@ -11,6 +11,13 @@ export interface AgZoomRange {
     end?: Date | number;
 }
 
+export interface AgZoomRatio {
+    /** The minimum value of the axis zoom ratio. */
+    min?: number;
+    /** The maximum value of the axis zoom ratio. */
+    max?: number;
+}
+
 export interface AgZoomOptions {
     /**
      * The anchor point for the x-axis about which to zoom into when scrolling.
@@ -68,21 +75,25 @@ export interface AgZoomOptions {
      */
     minVisibleItemsY?: number;
     /**
+     * @deprecated v9.2.0 Use `ratioX.min` instead.
      * The initial minimum x-axis position of the zoom, as a ratio of the full chart.
      * Default: `0`
      */
     minX?: number;
     /**
+     * @deprecated v9.2.0 Use `ratioX.max` instead.
      * The initial maximum x-axis position of the zoom, as a ratio of the full chart.
      * Default: `1`
      */
     maxX?: number;
     /**
+     * @deprecated v9.2.0 Use `ratioY.min` instead.
      * The initial minimum y-axis position of the zoom, as a ratio of the full chart.
      * Default: `0`
      */
     minY?: number;
     /**
+     * @deprecated v9.2.0 Use `ratioY.max` instead.
      * The initial maximum y-axis position of the zoom, as a ratio of the full chart.
      * Default: `1`
      */
@@ -94,8 +105,12 @@ export interface AgZoomOptions {
     panKey?: AgZoomPanKey;
     /** The initial x-axis range of the zoom, as values of the axis type. */
     rangeX?: AgZoomRange;
-    /** The initial x-axis range of the zoom, as values of the axis type. */
+    /** The initial y-axis range of the zoom, as values of the axis type. */
     rangeY?: AgZoomRange;
+    /** The initial x-axis range of the zoom, as a ratio between 0 to 1. */
+    ratioX?: AgZoomRatio;
+    /** The initial y-axis range of the zoom, as a ratio between 0 to 1. */
+    ratioY?: AgZoomRatio;
     /**
      * The amount to zoom when scrolling with the mouse wheel, as a ratio of the full chart.
      * Default: `0.1`

--- a/packages/ag-charts-community/src/util/deprecation.ts
+++ b/packages/ag-charts-community/src/util/deprecation.ts
@@ -1,5 +1,6 @@
 import { BREAK_TRANSFORM_CHAIN, addTransformToInstanceProperty } from './decorator';
 import { Logger } from './logger';
+import { getPath, setPath } from './object';
 
 export function createDeprecationWarning() {
     return (key: string, message?: string) => {
@@ -27,13 +28,13 @@ export function DeprecatedAndRenamedTo(newPropName: any, mapValue?: (value: any)
         (target, key, value) => {
             if (value !== target[newPropName]) {
                 warnDeprecated(key.toString(), `Use [${newPropName}] instead.`);
-                target[newPropName] = mapValue ? mapValue(value) : value;
+                setPath(target, newPropName, mapValue ? mapValue(value) : value);
             }
             return BREAK_TRANSFORM_CHAIN;
         },
         (target, key) => {
             warnDeprecated(key.toString(), `Use [${newPropName}] instead.`);
-            return target[newPropName];
+            return getPath(target, newPropName);
         }
     );
 }

--- a/packages/ag-charts-enterprise/src/features/features.test.ts
+++ b/packages/ag-charts-enterprise/src/features/features.test.ts
@@ -125,12 +125,12 @@ describe('Feature Combinations', () => {
         });
 
         it('should init with zoom min/max', async () => {
-            await prepareChart(undefined, { minX: 0.7, maxX: 0.9 });
+            await prepareChart(undefined, { ratioX: { min: 0.7, max: 0.9 } });
             await compare();
         });
 
         it('should prioritise zoom min/max over navigator min/max', async () => {
-            await prepareChart({ min: 0.1, max: 0.3 }, { minX: 0.7, maxX: 0.9 });
+            await prepareChart({ min: 0.1, max: 0.3 }, { ratioX: { min: 0.7, max: 0.9 } });
             expectWarning(
                 'AG Charts - Could not apply [navigator.min] or [navigator.max] as [zoom] has modified the initial zoom state.'
             );

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
@@ -233,7 +233,7 @@ describe('Zoom', () => {
 
     describe('min/max', () => {
         it('should start at the given zoom', async () => {
-            await prepareChart({ minX: 0.2, maxX: 0.8, minY: 0.1, maxY: 0.9 });
+            await prepareChart({ ratioX: { min: 0.2, max: 0.8 }, ratioY: { min: 0.1, max: 0.9 } });
             await compare();
         });
     });

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomRatio.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomRatio.ts
@@ -1,0 +1,23 @@
+import { _ModuleSupport, _Util } from 'ag-charts-community';
+
+import { UNIT } from './zoomUtils';
+
+const { ActionOnSet } = _ModuleSupport;
+
+export class ZoomRatio {
+    @ActionOnSet<ZoomRatio>({
+        changeValue(min?: number) {
+            this.onChange?.({ min: min ?? UNIT.min, max: this.max ?? UNIT.max });
+        },
+    })
+    public min?: number;
+
+    @ActionOnSet<ZoomRatio>({
+        changeValue(max?: number) {
+            this.onChange?.({ min: this.min ?? UNIT.min, max: max ?? UNIT.max });
+        },
+    })
+    public max?: number;
+
+    constructor(private readonly onChange: (ratio: { min: number; max: number }) => void) {}
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8218

Deprecates `minX`, `maxX`, `minY` and `maxY` in favour of `ratioX/Y: { min, max }` to match the `rangeX/Y` props.