### PR TITLE
AG-10657 Always pop InteractionState.ZoomDrag

### DIFF
--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -320,10 +320,10 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private onDragEnd() {
+        this.ctx.interactionManager.popState(_ModuleSupport.InteractionState.ZoomDrag);
+
         // Stop single clicks from triggering drag end and resetting the zoom
         if (!this.enabled || this.dragState === DragState.None) return;
-
-        this.ctx.interactionManager.popState(_ModuleSupport.InteractionState.ZoomDrag);
 
         switch (this.dragState) {
             case DragState.Axis:


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10657

There's no harm in popping ZoomDrag if it isn't pushed, because it just sets a flag to 0. This ensures that the chart remains interactable after the dragging when enablePanning=false.