### PR TITLE
AG-10657 Fix warnings when scrolling

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -359,7 +359,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
             seriesRegion.addListener('leave', (event) => this.onLeave(event)),
             this.interactionManager.addListener('page-left', () => this.destroy()),
 
-            seriesRegion.addListener('wheel', () => this.resetPointer()),
             this.interactionManager.addListener('drag', () => this.resetPointer()),
             this.interactionManager.addListener('contextmenu', (event) => this.onContextMenu(event), All),
 
@@ -367,9 +366,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
                 this.update(ChartUpdateType.SCENE_RENDER);
             }),
             this.highlightManager.addListener('highlight-change', (event) => this.changeHighlightDatum(event)),
-            this.zoomManager.addListener('zoom-change', () =>
-                this.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true, skipAnimations: true })
-            )
+            this.zoomManager.addListener('zoom-change', () => {
+                this.resetPointer();
+                this.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true, skipAnimations: true });
+            })
         );
     }
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -359,7 +359,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             seriesRegion.addListener('leave', (event) => this.onLeave(event)),
             this.interactionManager.addListener('page-left', () => this.destroy()),
 
-            this.interactionManager.addListener('wheel', () => this.resetPointer()),
+            seriesRegion.addListener('wheel', () => this.resetPointer()),
             this.interactionManager.addListener('drag', () => this.resetPointer()),
             this.interactionManager.addListener('contextmenu', (event) => this.onContextMenu(event), All),
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -346,7 +346,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         this.container = container;
 
         const { All } = InteractionState;
-        const seriesRegion = this.regionManager.addRegion('series', this.seriesRoot);
+        const seriesRegion = this.regionManager.addRegion('series', this.seriesRoot, this.axisGroup);
 
         this._destroyFns.push(
             this.dataService.addListener('data-load', (event) => {

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -100,14 +100,6 @@ export class RegionManager {
         return true;
     }
 
-    private dispatch(region: Region | undefined, event: InteractionEvent<InteractionTypes>) {
-        // Async dispatch to avoid blocking the event-processing thread.
-        if (region !== undefined) {
-            const dispatcher = async () => region.listeners.dispatch(event.type, event);
-            dispatcher().catch((e) => Logger.errorOnce(e));
-        }
-    }
-
     private handleDragging(event: InteractionEvent<InteractionTypes>): boolean {
         const { currentRegion } = this;
 
@@ -116,9 +108,9 @@ export class RegionManager {
         if (this.isDragging) {
             if (event.type === 'drag-end') {
                 this.isDragging = false;
-                this.dispatch(currentRegion, event);
+                currentRegion?.listeners.dispatch(event.type, event);
             } else if (event.type === 'drag') {
-                this.dispatch(currentRegion, event);
+                currentRegion?.listeners.dispatch(event.type, event);
             }
             return true;
         } else if (event.type === 'drag-start') {
@@ -137,13 +129,13 @@ export class RegionManager {
         const { currentRegion } = this;
         const newRegion = this.pickRegion(event.offsetX, event.offsetY);
         if (currentRegion !== undefined && newRegion?.name !== currentRegion.name) {
-            this.dispatch(currentRegion, { ...event, type: 'leave' });
+            currentRegion.listeners.dispatch('leave', { ...event, type: 'leave' });
         }
         if (newRegion !== undefined && newRegion.name !== currentRegion?.name) {
-            this.dispatch(newRegion, { ...event, type: 'enter' });
+            newRegion.listeners.dispatch('enter', { ...event, type: 'enter' });
         }
         if (newRegion !== undefined && this.checkPointerHistory(newRegion, event)) {
-            this.dispatch(newRegion, event);
+            newRegion.listeners.dispatch(event.type, event);
         }
         this.currentRegion = newRegion;
     }

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -42,14 +42,14 @@ export class RegionManager {
         this.regions.clear();
     }
 
-    private pushRegion(name: RegionName, bboxprovider: BBoxProvider): Region {
+    private pushRegion(name: RegionName, bboxproviders: BBoxProvider[]): Region {
         const region = { name, listeners: new RegionListeners() };
-        this.regions.add(region, bboxprovider);
+        this.regions.add(region, bboxproviders);
         return region;
     }
 
-    public addRegion(name: RegionName, bboxprovider: BBoxProvider) {
-        return this.makeObserver(this.pushRegion(name, bboxprovider));
+    public addRegion(name: RegionName, bboxprovider: BBoxProvider, ...extraProviders: BBoxProvider[]) {
+        return this.makeObserver(this.pushRegion(name, [bboxprovider, ...extraProviders]));
     }
 
     public getRegion(name: RegionName) {

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -100,6 +100,10 @@ export class RegionManager {
         return true;
     }
 
+    private dispatch(region: Region | undefined, event: InteractionEvent<InteractionTypes>) {
+        region?.listeners.dispatch(event.type, event);
+    }
+
     private handleDragging(event: InteractionEvent<InteractionTypes>): boolean {
         const { currentRegion } = this;
 
@@ -108,9 +112,9 @@ export class RegionManager {
         if (this.isDragging) {
             if (event.type === 'drag-end') {
                 this.isDragging = false;
-                currentRegion?.listeners.dispatch(event.type, event);
+                this.dispatch(currentRegion, event);
             } else if (event.type === 'drag') {
-                currentRegion?.listeners.dispatch(event.type, event);
+                this.dispatch(currentRegion, event);
             }
             return true;
         } else if (event.type === 'drag-start') {
@@ -129,13 +133,13 @@ export class RegionManager {
         const { currentRegion } = this;
         const newRegion = this.pickRegion(event.offsetX, event.offsetY);
         if (currentRegion !== undefined && newRegion?.name !== currentRegion.name) {
-            currentRegion.listeners.dispatch('leave', { ...event, type: 'leave' });
+            this.dispatch(currentRegion, { ...event, type: 'leave' });
         }
         if (newRegion !== undefined && newRegion.name !== currentRegion?.name) {
-            newRegion.listeners.dispatch('enter', { ...event, type: 'enter' });
+            this.dispatch(newRegion, { ...event, type: 'enter' });
         }
         if (newRegion !== undefined && this.checkPointerHistory(newRegion, event)) {
-            newRegion.listeners.dispatch(event.type, event);
+            this.dispatch(newRegion, event);
         }
         this.currentRegion = newRegion;
     }

--- a/packages/ag-charts-community/src/util/bboxset.ts
+++ b/packages/ag-charts-community/src/util/bboxset.ts
@@ -25,8 +25,8 @@ function nodeArea<V>(elem: BBoxElem<V>): number {
 export class BBoxSet<V> {
     private elems: BBoxElem<V>[] = [];
 
-    add(value: V, getter: BBoxProvider): void {
-        this.elems.push({ value, getter });
+    add(value: V, getters: BBoxProvider[]): void {
+        getters.forEach((getter) => this.elems.push({ value, getter }));
     }
 
     find(x: number, y: number): V[] {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -150,7 +150,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
             region.addListener('drag-start', (event) => this.onDragStart(event), draggableState),
             region.addListener('drag-end', () => this.onDragEnd(), draggableState),
             region.addListener('wheel', (event) => this.onWheel(event), clickableState),
-            region.addListener('hover', () => this.onHover(), clickableState),
+            region.addListener('hover', () => this.onAxisLeave(), clickableState),
+            region.addListener('leave', () => this.onAxisLeave(), clickableState),
             ctx.chartEventManager.addListener('axis-hover', (event) => this.onAxisHover(event)),
             ctx.gestureDetector.addListener('pinch-move', (event) => this.onPinchMove(event as PinchEvent)),
             ctx.layoutService.addListener('layout-complete', (event) => this.onLayoutComplete(event)),
@@ -396,7 +397,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         this.updateZoom(newZoom);
     }
 
-    private onHover() {
+    private onAxisLeave() {
         if (!this.enabled) return;
 
         this.hoveredAxis = undefined;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -142,14 +142,15 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const { Default, ZoomDrag, Animation } = _ModuleSupport.InteractionState;
         const draggableState = Default | Animation | ZoomDrag;
         const clickableState = Default | Animation;
+        const region = ctx.regionManager.getRegion('series');
         this.destroyFns.push(
             this.scene.attachNode(selectionRect),
-            ctx.interactionManager.addListener('dblclick', (event) => this.onDoubleClick(event), clickableState),
-            ctx.interactionManager.addListener('drag', (event) => this.onDrag(event), draggableState),
-            ctx.interactionManager.addListener('drag-start', (event) => this.onDragStart(event), draggableState),
-            ctx.interactionManager.addListener('drag-end', () => this.onDragEnd(), draggableState),
-            ctx.interactionManager.addListener('wheel', (event) => this.onWheel(event), clickableState),
-            ctx.interactionManager.addListener('hover', () => this.onHover(), clickableState),
+            region.addListener('dblclick', (event) => this.onDoubleClick(event), clickableState),
+            region.addListener('drag', (event) => this.onDrag(event), draggableState),
+            region.addListener('drag-start', (event) => this.onDragStart(event), draggableState),
+            region.addListener('drag-end', () => this.onDragEnd(), draggableState),
+            region.addListener('wheel', (event) => this.onWheel(event), clickableState),
+            region.addListener('hover', () => this.onHover(), clickableState),
             ctx.chartEventManager.addListener('axis-hover', (event) => this.onAxisHover(event)),
             ctx.gestureDetector.addListener('pinch-move', (event) => this.onPinchMove(event as PinchEvent)),
             ctx.layoutService.addListener('layout-complete', (event) => this.onLayoutComplete(event)),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10657

This restores https://github.com/ag-grid/ag-charts/pull/1139 and fixes warnings that were caused by it.

---

The `'series'` region from the `RegionManager` is the first listener to
receive `'wheel'` events. The Zoom module consumes `'wheel'` events which
prevents the Chart class from receiving these events and removing the
highlight.

Changing the Chart to listen for `'wheel'` events in the `'series'`
region ensures that it receives these events before the Zoom module.

Without this change, the following warning would be printing when
scrolling on a zoomable chart:

```
AG Charts - exceeded the maximum number of simultaneous updates (4), discarding changes and rendering
```