### PR TITLE
Add SeriesConstructorOpts type

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -24,6 +24,7 @@ import type { Marker } from '../../marker/marker';
 import { getMarker } from '../../marker/util';
 import { DataModelSeries } from '../dataModelSeries';
 import type {
+    SeriesConstructorOpts,
     SeriesDirectionKeysMapping,
     SeriesNodeDataContext,
     SeriesNodeEventTypes,
@@ -197,7 +198,7 @@ export abstract class CartesianSeries<
         ...otherOpts
     }: Partial<CartesianSeriesOpts<TNode, TProps, TDatum, TLabel>> &
         Pick<CartesianSeriesOpts<TNode, TProps, TDatum, TLabel>, 'directionKeys' | 'directionNames'> &
-        ConstructorParameters<typeof DataModelSeries<TDatum, TProps, TLabel>>[0]) {
+        SeriesConstructorOpts<TProps>) {
         super({
             directionKeys,
             directionNames,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -244,6 +244,16 @@ export class SeriesGroupingChangedEvent implements TypedEvent {
     ) {}
 }
 
+export type SeriesConstructorOpts<TProps extends SeriesProperties<any>> = {
+    moduleCtx: ModuleContext;
+    useLabelLayer?: boolean;
+    pickModes?: SeriesNodePickMode[];
+    contentGroupVirtual?: boolean;
+    directionKeys?: SeriesDirectionKeysMapping<TProps>;
+    directionNames?: SeriesDirectionKeysMapping<TProps>;
+    canHaveAxes?: boolean;
+};
+
 export abstract class Series<
         TDatum extends SeriesNodeDatum,
         TProps extends SeriesProperties<any>,
@@ -374,15 +384,7 @@ export abstract class Series<
 
     protected readonly ctx: ModuleContext;
 
-    constructor(seriesOpts: {
-        moduleCtx: ModuleContext;
-        useLabelLayer?: boolean;
-        pickModes?: SeriesNodePickMode[];
-        contentGroupVirtual?: boolean;
-        directionKeys?: SeriesDirectionKeysMapping<TProps>;
-        directionNames?: SeriesDirectionKeysMapping<TProps>;
-        canHaveAxes?: boolean;
-    }) {
+    constructor(seriesOpts: SeriesConstructorOpts<TProps>) {
         super();
 
         const {


### PR DESCRIPTION
The ConstructorParameters type in CartesianSeries is causing errors with the TSServer in Emacs, so create a generic type for the base ctor options. This also makes the code a bit more readable.