### PR TITLE
AG-10904 - Prevent no-op animations.

### DIFF
--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -323,7 +323,7 @@ export function diff(
                 const prevId = prev ? createDatumId(prev.keys) : '';
                 const datumId = datum ? createDatumId(datum.keys) : '';
 
-                if (prevId === datumId) {
+                if (datum && prev && prevId === datumId) {
                     if (!arraysEqual(prev.values, datum.values)) {
                         updated.set(datumId, datum);
                         updatedIndices.set(datumId, i);

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -53,7 +53,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
 
         const id = opts.id ?? Math.random().toString();
 
-        const skip = this.isSkipped();
+        const skip = this.isSkipped() || opts.phase === 'none';
         if (skip) {
             this.debug('AnimationManager - skipping animation');
         }

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -703,6 +703,8 @@ export class AreaSeries extends CartesianSeries<
             // Un-animatable diff in data, skip all animations.
             skip();
             return;
+        } else if (fns.status === 'no-op') {
+            return;
         }
 
         markerFadeInAnimation(this, animationManager, markerSelections);

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
@@ -156,5 +156,5 @@ export function prepareAreaPathAnimation(
     const fadeMode = stackVisible ? 'none' : 'fade';
     const fill = prepareLinePathAnimationFns(newData, oldData, pairData, fadeMode, renderPartialPath);
     const marker = prepareMarkerAnimation(markerPairMap, status);
-    return { fill, marker };
+    return { status: fill.status, fill, marker };
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -77,12 +77,12 @@ export class LineSeries extends CartesianSeries<Group, LineSeriesProperties, Lin
         // automatically garbage collect the marker selection.
         if (!isContinuousX) {
             props.push(keyProperty(this, xKey, isContinuousX, { id: 'xKey' }));
-            if (animationEnabled && this.processedData) {
-                props.push(diff(this.processedData));
-            }
         }
         if (animationEnabled) {
             props.push(animationValidation(this, isContinuousX ? ['xValue'] : []));
+            if (this.processedData) {
+                props.push(diff(this.processedData));
+            }
         }
 
         props.push(
@@ -469,6 +469,8 @@ export class LineSeries extends CartesianSeries<Group, LineSeriesProperties, Lin
         const fns = prepareLinePathAnimation(newData, oldData, this.processedData?.reduced?.diff);
         if (fns === undefined) {
             skip();
+            return;
+        } else if (fns.status === 'no-op') {
             return;
         }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -278,7 +278,7 @@ export function pairCategoryData(
     return { result, resultMap: resultMapSingle };
 }
 
-export function determinePathStatus(newData: LineContextLike, oldData: LineContextLike) {
+export function determinePathStatus(newData: LineContextLike, oldData: LineContextLike, pairData: PathPoint[]) {
     let status: NodeUpdateState = 'updated';
 
     const visible = (data: LineContextLike) => {
@@ -289,6 +289,15 @@ export function determinePathStatus(newData: LineContextLike, oldData: LineConte
         status = 'added';
     } else if (visible(oldData) && !visible(newData)) {
         status = 'removed';
+    } else {
+        // Verify some points are actually moving.
+        for (let i = 0; i < pairData.length; i++) {
+            if (pairData[i].change !== 'move') break;
+            if (pairData[i].from?.x !== pairData[i].to?.x) break;
+            if (pairData[i].from?.y !== pairData[i].to?.y) break;
+
+            if (i === pairData.length - 1) return 'no-op';
+        }
     }
     return status;
 }
@@ -336,7 +345,7 @@ export function prepareLinePathAnimationFns(
     visibleToggleMode: 'fade' | 'none',
     render: (pairData: PathPoint[], ratios: Partial<Record<PathPointChange, number>>, path: Path) => void
 ) {
-    const status = determinePathStatus(newData, oldData);
+    const status = determinePathStatus(newData, oldData, pairData);
     const removePhaseFn = (ratio: number, path: Path) => {
         render(pairData, { move: 0, out: ratio }, path);
     };

--- a/packages/ag-charts-community/src/motion/animation.ts
+++ b/packages/ag-charts-community/src/motion/animation.ts
@@ -13,7 +13,7 @@ export type AnimationMetadata = {
 };
 export const QUICK_TRANSITION = 0.2;
 
-export const PHASE_ORDER = ['initial', 'remove', 'update', 'add', 'trailing', 'end'] as const;
+export const PHASE_ORDER = ['initial', 'remove', 'update', 'add', 'trailing', 'end', 'none'] as const;
 export type AnimationPhase = (typeof PHASE_ORDER)[number];
 export const PHASE_METADATA: Record<AnimationPhase, AnimationMetadata> = {
     initial: {
@@ -41,6 +41,10 @@ export const PHASE_METADATA: Record<AnimationPhase, AnimationMetadata> = {
         animationDelay: 1 + QUICK_TRANSITION,
         animationDuration: 0,
         skipIfNoEarlierAnimations: true,
+    },
+    none: {
+        animationDuration: 0,
+        animationDelay: 0,
     },
 };
 

--- a/packages/ag-charts-community/src/motion/fromToMotion.ts
+++ b/packages/ag-charts-community/src/motion/fromToMotion.ts
@@ -8,7 +8,7 @@ import { deconstructSelectionsOrNodes } from './animation';
 import type { AnimationPhase, AnimationValue } from './animation';
 import * as easing from './easing';
 
-export type NodeUpdateState = 'unknown' | 'added' | 'removed' | 'updated';
+export type NodeUpdateState = 'unknown' | 'added' | 'removed' | 'updated' | 'no-op';
 export const NODE_UPDATE_PHASES: NodeUpdateState[] = ['removed', 'updated', 'added'];
 
 export type FromToMotionPropFnContext<T> = {
@@ -44,6 +44,7 @@ export const NODE_UPDATE_STATE_TO_PHASE_MAPPING: Record<NodeUpdateState, Animati
     updated: 'update',
     removed: 'remove',
     unknown: 'initial',
+    'no-op': 'none',
 };
 
 export type FromToDiff = Pick<ProcessedOutputDiff, 'added' | 'removed'>;

--- a/packages/ag-charts-community/src/util/json.test.ts
+++ b/packages/ag-charts-community/src/util/json.test.ts
@@ -406,7 +406,7 @@ describe('json module', () => {
     });
 
     describe('#jsonApply', () => {
-        let json: any = {
+        const json: any = {
             str: 'test-string',
             num: 123,
             date: FIXED_DATE,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10904
https://ag-grid.atlassian.net/browse/AG-10861

Attempts to prevent redundant animations when the final rendering state is identical to the starting state.

Explicitly introduces a `no-op` animation phase to allow intermediate calculations to control the animation behaviour more explicitly. (Any animation request reaching the `AnimationManager` with this phase will be treated as-if it has been explicitly skipped).

Specifically fixes area and line series path animations being no-ops, typically causing markers and labels to fade in and out unecessarily.