### PR TITLE
AG-10620 - Only support initial-load animation in mini-charts.

### DIFF
--- a/packages/ag-charts-community/src/chart/chartAnimationPhase.ts
+++ b/packages/ag-charts-community/src/chart/chartAnimationPhase.ts
@@ -1,2 +1,2 @@
 /** Chart animation phases - determines the top-level animation lifecycle phase for the overall chart */
-export type ChartAnimationPhase = 'initial' | 'ready';
+export type ChartAnimationPhase = 'initial' | 'ready' | 'disabled';

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -104,7 +104,7 @@ export class CartesianSeriesNodeEvent<TEvent extends string = SeriesNodeEventTyp
     }
 }
 
-type CartesianAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
+type CartesianAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing' | 'disabled';
 type CartesianAnimationEvent =
     | 'update'
     | 'updateData'
@@ -113,7 +113,8 @@ type CartesianAnimationEvent =
     | 'resize'
     | 'clear'
     | 'reset'
-    | 'skip';
+    | 'skip'
+    | 'disable';
 
 export interface CartesianAnimationData<
     TNode extends Node,
@@ -231,6 +232,7 @@ export abstract class CartesianSeries<
                     },
                     reset: 'empty',
                     skip: 'ready',
+                    disable: 'disabled',
                 },
                 ready: {
                     updateData: 'waiting',
@@ -240,6 +242,7 @@ export abstract class CartesianSeries<
                     resize: (data) => this.animateReadyResize(data),
                     reset: 'empty',
                     skip: 'ready',
+                    disable: 'disabled',
                 },
                 waiting: {
                     update: {
@@ -248,6 +251,11 @@ export abstract class CartesianSeries<
                     },
                     reset: 'empty',
                     skip: 'ready',
+                    disable: 'disabled',
+                },
+                disabled: {
+                    update: (data) => this.resetAllAnimation(data),
+                    reset: 'empty',
                 },
                 clearing: {
                     update: {
@@ -267,6 +275,8 @@ export abstract class CartesianSeries<
             this.animationState.transition('reset');
         } else if (phase === 'ready') {
             this.animationState.transition('skip');
+        } else if (phase === 'disabled') {
+            this.animationState.transition('disable');
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
@@ -8,7 +8,13 @@ export class Navigator extends _ModuleSupport.Navigator {
     @ObserveChanges<Navigator, MiniChart>((target, value, oldValue) => {
         target.updateBackground(oldValue?.root, value?.root);
     })
-    override miniChart: MiniChart = new MiniChart();
+    override miniChart: MiniChart;
+
+    public constructor(ctx: _ModuleSupport.ModuleContext) {
+        super(ctx);
+
+        this.miniChart = new MiniChart(ctx);
+    }
 
     async updateData(opts: { data: any }): Promise<void> {
         await this.miniChart.updateData(opts);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10620

Adds a new `ChartAnimationPhase` of `disabled`, so that for the mini-chart case we can disable everything except the initial load animation.