### PR TITLE
AG-10853 Remove obsolete RTI-1406 fix

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -341,7 +341,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         ];
 
         this.tooltip = new Tooltip(this.scene.canvas.element);
-        this.tooltipManager = new TooltipManager(this.tooltip, this.interactionManager);
+        this.tooltipManager = new TooltipManager(this.tooltip);
         this.highlight = new ChartHighlight();
         this.container = container;
 

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -973,9 +973,6 @@ export class Legend extends BaseProperties {
             const legendPositionedBBox = legendBBox.clone();
             legendPositionedBBox.x += this.group.translationX;
             legendPositionedBBox.y += this.group.translationY;
-            this.ctx.tooltipManager.updateExclusiveRect(this.id, legendPositionedBBox);
-        } else {
-            this.ctx.tooltipManager.updateExclusiveRect(this.id);
         }
 
         return { shrinkRect: newShrinkRect };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10853
https://ag-grid.atlassian.net/browse/RTI-1406

The RegionManager will ensure that a 'leave' event is dispatched when the mouse pointer exits the seriesRect, so the tooltip will automatically get cleared anyway. No need for additional hit-testing in the tooltipManager.