### PR TITLE
AG-10553 - Fix animation NaN delay bug.

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/animationBatch.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationBatch.ts
@@ -19,7 +19,7 @@ export class AnimationBatch {
     /** Guard against premature animation execution. */
     private isReady = false;
 
-    constructor(private readonly maxAnimationTime: number = Infinity) {}
+    constructor(private readonly maxAnimationTime: number) {}
 
     get size() {
         return this.controllers.size;

--- a/packages/ag-charts-community/src/chart/interaction/animationBatch.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationBatch.ts
@@ -19,6 +19,8 @@ export class AnimationBatch {
     /** Guard against premature animation execution. */
     private isReady = false;
 
+    constructor(private readonly maxAnimationTime: number = Infinity) {}
+
     get size() {
         return this.controllers.size;
     }
@@ -118,6 +120,14 @@ export class AnimationBatch {
             this.debug(`AnimationBatch - animationTimeConsumed: ${this.animationTimeConsumed}`);
             progressPhase();
         } while (unusedTime > 0 && !arePhasesComplete());
+
+        if (this.animationTimeConsumed > this.maxAnimationTime) {
+            Logger.warnOnce(
+                'Animation batch exceeded max animation time, skipping.',
+                new Map(this.controllers.entries())
+            );
+            this.stop();
+        }
     }
 
     ready() {

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -14,6 +14,11 @@ interface AnimationEvent {
     deltaMs: number;
 }
 
+function validAnimationDuration(testee?: number) {
+    if (testee == null) return true;
+    return testee < 0 || testee > 2 || !isNaN(testee);
+}
+
 /**
  * Manage animations across a chart, running all animations through only one `requestAnimationFrame` callback,
  * preventing duplicate animations and handling their lifecycle.
@@ -21,7 +26,7 @@ interface AnimationEvent {
 export class AnimationManager extends BaseManager<AnimationEventType, AnimationEvent> {
     public defaultDuration = 1000;
 
-    private batch = new AnimationBatch();
+    private batch = new AnimationBatch(this.defaultDuration * 1.5);
 
     private readonly debug = Debug.create(true, 'animation');
     private readonly rafAvailable = typeof requestAnimationFrame !== 'undefined';
@@ -57,6 +62,15 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         if (skip) {
             this.debug('AnimationManager - skipping animation');
         }
+
+        const { delay, duration } = opts;
+        if (!validAnimationDuration(delay)) {
+            throw new Error(`Animation delay of ${delay} is unsupported (${id})`);
+        }
+        if (!validAnimationDuration(duration)) {
+            throw new Error(`Animation duration of ${duration} is unsupported (${id})`);
+        }
+
         const animation = new Animation({
             ...opts,
             id,
@@ -243,7 +257,7 @@ export class AnimationManager extends BaseManager<AnimationEventType, AnimationE
         this.reset();
         this.batch.stop();
         this.batch.destroy();
-        this.batch = new AnimationBatch();
+        this.batch = new AnimationBatch(this.defaultDuration * 1.5);
         if (skipAnimations === true) {
             this.batch.skip();
         }

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -16,7 +16,7 @@ interface AnimationEvent {
 
 function validAnimationDuration(testee?: number) {
     if (testee == null) return true;
-    return testee < 0 || testee > 2 || !isNaN(testee);
+    return !isNaN(testee) && testee >= 0 && testee <= 2;
 }
 
 /**

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -387,7 +387,7 @@ export function prepareLinePathAnimation(
         return;
     }
 
-    const hasMotion: boolean = (diff?.changed ?? true) || scalesChanged(newData, oldData) || status !== 'updated';
+    const hasMotion = (diff?.changed ?? true) || scalesChanged(newData, oldData) || status !== 'updated';
     const pathFns = prepareLinePathAnimationFns(newData, oldData, pairData, 'fade', renderPartialPath);
     const marker = prepareMarkerAnimation(pairMap, status);
     return { ...pathFns, marker, hasMotion };

--- a/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
@@ -53,7 +53,10 @@ export function markerSwipeScaleInAnimation<T extends CartesianSeriesNodeDatum>(
         //
         // Parallel swipe animations use the function x = easeOut(time). But in this case, we
         // know the x value and need to calculate the time delay. So use the inverse function:
-        const delay = clamp(0, easing.inverseEaseOut(x / seriesWidth), 1);
+        let delay = clamp(0, easing.inverseEaseOut(x / seriesWidth), 1);
+        if (isNaN(delay)) {
+            delay = 0;
+        }
         return { scalingX: 0, scalingY: 0, delay, duration: QUICK_TRANSITION, phase: 'initial' as const };
     };
     const toFn = () => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10553?focusedCommentId=60876

Fixes a very specific bug that happens when zoom with user-specified range is used in conjunction with animations and a series which implements initial-load swipe-in animation for markers.

Root cause: The marker-swipe-in delay animation parameter was evaluating to `NaN`, which stalled all animations from running.

Remediation:
- Detect the `NaN` case in `markerSwipeScaleInAnimation()` and set `delay: 0` instead.
- Defensive changes to `AnimationBatch` so that over-running animations don't run infinitely.
- Defensive changes to `AnimationManager` to hard-stop if a `NaN` or value outside the range `0` and `2`  is provided as an animation duration/delay.