### PR TITLE
AG-11013 Implement tooltip position type node for map shape series

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -83,7 +83,7 @@ export class TooltipManager {
 
         // On `line` and `scatter` series, the tooltip covers the top of error-bars when using datum.midPoint.
         // Using datum.yBar.upperPoint renders the tooltip higher up.
-        const refPoint = datum.yBar?.upperPoint ?? datum.midPoint;
+        const refPoint = datum.yBar?.upperPoint ?? datum.midPoint ?? datum.series.datumMidPoint?.(datum);
 
         if (tooltip.position.type === 'node' && refPoint) {
             const { x, y } = refPoint;

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -28,6 +28,7 @@ export interface ISeries<TDatum, TProps> {
     getKeys(direction: ChartAxisDirection): string[];
     getNames(direction: ChartAxisDirection): (string | undefined)[];
     getMinRects(width: number, height: number): { minRect: BBox; minVisibleRect: BBox } | undefined;
+    datumMidPoint?<T extends SeriesNodeDatum>(datum: T): Point | undefined;
     isEnabled(): boolean;
     type: string;
     visible: boolean;

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineModule.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineModule.ts
@@ -34,11 +34,6 @@ export const MapLineModule: _ModuleSupport.SeriesModule<'map-line'> = {
                 fontFamily: DEFAULT_FONT_FAMILY,
                 color: DEFAULT_LABEL_COLOUR,
             },
-            tooltip: {
-                position: {
-                    type: 'node',
-                },
-            },
         },
         legend: {
             enabled: false,

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerModule.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerModule.ts
@@ -26,11 +26,6 @@ export const MapMarkerModule: _ModuleSupport.SeriesModule<'map-marker'> = {
             label: {
                 color: DEFAULT_LABEL_COLOUR,
             },
-            tooltip: {
-                position: {
-                    type: 'node',
-                },
-            },
         },
         legend: {
             enabled: false,

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -452,7 +452,7 @@ export class MapMarkerSeries
         this.contentGroup.opacity = this.getOpacity();
 
         let highlightedDatum: MapMarkerNodeDatum | undefined = this.ctx.highlightManager?.getActiveHighlight() as any;
-        if (highlightedDatum != null && (highlightedDatum.series !== this || highlightedDatum.point == null)) {
+        if (highlightedDatum != null && (highlightedDatum.series !== this || highlightedDatum.datum == null)) {
             highlightedDatum = undefined;
         }
 

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeModule.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeModule.ts
@@ -30,11 +30,6 @@ export const MapShapeModule: _ModuleSupport.SeriesModule<'map-shape'> = {
                 color: DEFAULT_INVERTED_LABEL_COLOUR,
                 fontWeight: 'bold',
             },
-            tooltip: {
-                position: {
-                    type: 'node',
-                },
-            },
         },
         legend: {
             enabled: false,

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -8,7 +8,14 @@ import {
 } from 'ag-charts-community';
 
 import { GeoGeometry, GeoGeometryRenderMode } from '../map-util/geoGeometry';
-import { GeometryType, containsType, geometryBbox, labelPosition, projectGeometry } from '../map-util/geometryUtil';
+import {
+    GeometryType,
+    containsType,
+    geometryBbox,
+    labelPosition,
+    markerPositions,
+    projectGeometry,
+} from '../map-util/geometryUtil';
 import { GEOJSON_OBJECT } from '../map-util/validation';
 import { MapShapeNodeDatum, MapShapeNodeLabelDatum, MapShapeSeriesProperties } from './mapShapeSeriesProperties';
 
@@ -309,7 +316,7 @@ export class MapShapeSeries
         this.contentGroup.opacity = this.getOpacity();
 
         let highlightedDatum: MapShapeNodeDatum | undefined = this.ctx.highlightManager?.getActiveHighlight() as any;
-        if (highlightedDatum != null && (highlightedDatum.series !== this || highlightedDatum.idValue == null)) {
+        if (highlightedDatum != null && (highlightedDatum.series !== this || highlightedDatum.datum == null)) {
             highlightedDatum = undefined;
         }
 
@@ -471,6 +478,25 @@ export class MapShapeSeries
         });
 
         return minDatum != null ? { datum: minDatum, distance: minDistance } : undefined;
+    }
+
+    private _previousDatumMidPoint:
+        | { datum: _ModuleSupport.SeriesNodeDatum; point: _Scene.Point | undefined }
+        | undefined = undefined;
+    datumMidPoint(datum: _ModuleSupport.SeriesNodeDatum): _Scene.Point | undefined {
+        const { _previousDatumMidPoint } = this;
+        if (_previousDatumMidPoint?.datum === datum) {
+            return _previousDatumMidPoint.point;
+        }
+
+        const projectedGeometry = (datum as MapShapeNodeDatum).projectedGeometry;
+        const positions = projectedGeometry != null ? markerPositions(projectedGeometry, 2) : undefined;
+        const firstPoint = positions != null && positions.length > 0 ? positions[0] : undefined;
+        const point = firstPoint != null ? { x: firstPoint[0], y: firstPoint[1] } : undefined;
+
+        this._previousDatumMidPoint = { datum, point };
+
+        return point;
     }
 
     override getLegendData(

--- a/packages/ag-charts-enterprise/src/series/map-util/lineStringUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/map-util/lineStringUtil.ts
@@ -167,11 +167,11 @@ export function lineStringCenter(
     let totalDistance = 0;
     for (let i = 1; i < lineSegment.length; i += 1) {
         const [x1, y1] = lineSegment[i];
-        const distance = Math.hypot(x1 - x0, y1 - y0);
-        const nextDistance = totalDistance + distance;
+        const segmentDistance = Math.hypot(x1 - x0, y1 - y0);
+        const nextDistance = totalDistance + segmentDistance;
 
         if (nextDistance > targetDistance) {
-            const ratio = (targetDistance - distance) / totalDistance;
+            const ratio = (targetDistance - totalDistance) / segmentDistance;
             const point: _ModuleSupport.Position = [x0 + (x1 - x0) * ratio, y0 + (y1 - y0) * ratio];
             const angle = Math.atan2(y1 - y0, x1 - x0);
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11013

We need to defer this midpoint calculation because it's really expensive - possibly we could refactor here not rely on `midPoint` and always ask the series what the value is