### PR TITLE
AG-11006 Cache label placement for map shape series

### DIFF
--- a/packages/ag-charts-community/src/chart/series/topology/mercatorScale.ts
+++ b/packages/ag-charts-community/src/chart/series/topology/mercatorScale.ts
@@ -8,9 +8,17 @@ const lonX = (lon: number) => lon * radsInDeg;
 const latY = (lat: number) => -Math.log(Math.tan(Math.PI * 0.25 + lat * radsInDeg * 0.5));
 
 export class MercatorScale implements Scale<Position, XY> {
-    private scale: number;
-    private originX: number;
-    private originY: number;
+    scale: number;
+    originX: number;
+    originY: number;
+
+    static fixedScale(scale = 1) {
+        const out = Object.create(MercatorScale.prototype);
+        out.scale = scale;
+        out.originX = 0;
+        out.originY = 0;
+        return out;
+    }
 
     constructor(
         public readonly domain: Position[],

--- a/packages/ag-charts-community/src/options/series/topology/mapShapeOptions.ts
+++ b/packages/ag-charts-community/src/options/series/topology/mapShapeOptions.ts
@@ -1,5 +1,5 @@
 import type { AgChartCallbackParams } from '../../chart/callbackOptions';
-import type { AgChartAutoSizedLabelOptions } from '../../chart/labelOptions';
+import type { AgChartAutoSizedSecondaryLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip } from '../../chart/tooltipOptions';
 import type { CssColor, GeoJSON, PixelSize } from '../../chart/types';
 import type { FillOptions, LineDashOptions, StrokeOptions } from '../cartesian/commonOptions';
@@ -25,7 +25,7 @@ export interface AgMapShapeSeriesThemeableOptions<TDatum = any>
     /** The colour range to interpolate the numeric colour domain (min and max `colorKey` values) into. */
     colorRange?: CssColor[];
     /** Configuration for the labels shown inside the shape. */
-    label?: AgChartAutoSizedLabelOptions<TDatum, AgMapShapeSeriesLabelFormatterParams>;
+    label?: AgChartAutoSizedSecondaryLabelOptions<TDatum, AgMapShapeSeriesLabelFormatterParams>;
     /** Distance between the shape edges and the text. */
     padding?: PixelSize;
     /** Series-specific tooltip configuration. */

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -212,7 +212,9 @@ export class MapShapeSeries
         if (labelText == null) return;
 
         const baseSize = Text.getTextSize(String(labelText), font);
-        const aspectRatio = (baseSize.width + 2 * padding) / (AutoSizedLabel.lineHeight(label.fontSize) + 2 * padding);
+        const numLines = labelText.split('\n').length;
+        const aspectRatio =
+            (baseSize.width + 2 * padding) / (numLines * AutoSizedLabel.lineHeight(label.fontSize) + 2 * padding);
 
         if (
             previousLabelLayout?.geometry === geometry &&

--- a/packages/ag-charts-enterprise/src/series/map-util/markerUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/map-util/markerUtil.ts
@@ -5,13 +5,19 @@ import { lineStringCenter } from './lineStringUtil';
 import { polygonPointSearch } from './polygonPointSearch';
 import { polygonDistance } from './polygonUtil';
 
-export function polygonMarkerCenter(polygons: _ModuleSupport.Position[][], precision: number) {
-    const result = polygonPointSearch(polygons, precision, (p, [x, y], stride) => {
+export function polygonMarkerCenter(
+    polygons: _ModuleSupport.Position[][],
+    precision: number
+): _ModuleSupport.Position | undefined {
+    const result = polygonPointSearch(polygons, precision, (p, x, y, stride) => {
         const distance = -polygonDistance(p, x, y);
         const maxDistance = distance + stride * Math.SQRT2;
         return { distance, maxDistance };
     });
-    return result?.center;
+    if (result == null) return;
+
+    const { x, y } = result;
+    return [x, y];
 }
 
 export function markerPositions(geometry: _ModuleSupport.Geometry, precision: number): _ModuleSupport.Position[] {

--- a/packages/ag-charts-enterprise/src/series/map-util/polygonLabelUtil.test.ts
+++ b/packages/ag-charts-enterprise/src/series/map-util/polygonLabelUtil.test.ts
@@ -5,32 +5,28 @@ import {
 
 describe('maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment', () => {
     test('Top intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-1, -1], [1, -3], [0, 0], 2)).toBe(4);
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([1, -3], [-1, -1], [0, 0], 2)).toBe(4);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-1, -1], [1, -3], 0, 0, 2)).toBe(4);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([1, -3], [-1, -1], 0, 0, 2)).toBe(4);
     });
 
     test('Bottom intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-1, 1], [1, 3], [0, 0], 2)).toBe(4);
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([1, 3], [-1, 1], [0, 0], 2)).toBe(4);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-1, 1], [1, 3], 0, 0, 2)).toBe(4);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([1, 3], [-1, 1], 0, 0, 2)).toBe(4);
     });
 
     test('Left intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-3, 1], [-5, -1], [0, 0], 2)).toBe(6);
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-5, -1], [-3, 1], [0, 0], 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-3, 1], [-5, -1], 0, 0, 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([-5, -1], [-3, 1], 0, 0, 2)).toBe(6);
     });
 
     test('Right intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([3, 1], [5, -1], [0, 0], 2)).toBe(6);
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([5, -1], [3, 1], [0, 0], 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([3, 1], [5, -1], 0, 0, 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([5, -1], [3, 1], 0, 0, 2)).toBe(6);
     });
 
     test('Top right intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([0, -2], [2, 0], [0, 0], 2)).toBe(
-            2 + 2 / 3
-        );
-        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([3, -1], [1, 1], [0, 0], 2)).toBe(
-            2 + 2 / 3
-        );
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([0, -2], [2, 0], 0, 0, 2)).toBe(2 + 2 / 3);
+        expect(maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment([3, -1], [1, 1], 0, 0, 2)).toBe(2 + 2 / 3);
     });
 
     test('Real cases', () => {
@@ -38,7 +34,8 @@ describe('maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment', () => {
             maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment(
                 [183.33757025661066, 337.4861921450947],
                 [183.33757025661066, 320.23561470865684],
-                [244.62282568201414, 354.32237241480544],
+                244.62282568201414,
+                354.32237241480544,
                 1.9576822916666667
             )
         ).toBe(122.57051085080688);
@@ -47,22 +44,22 @@ describe('maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment', () => {
 
 describe('maxWidthOfRectConstrainedByCenterAndHeightToLineSegment', () => {
     test('Left intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-3, 1], [-5, -1], [0, 0], 10)).toBe(6);
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-5, -1], [-3, 1], [0, 0], 10)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-3, 1], [-5, -1], 0, 0, 10)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-5, -1], [-3, 1], 0, 0, 10)).toBe(6);
     });
 
     test('Right intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([3, 1], [5, -1], [0, 0], 10)).toBe(6);
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([5, -1], [3, 1], [0, 0], 10)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([3, 1], [5, -1], 0, 0, 10)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([5, -1], [3, 1], 0, 0, 10)).toBe(6);
     });
 
     test('Top intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([2, 2], [4, 0], [0, 0], 2)).toBe(6);
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-2, 2], [-4, 0], [0, 0], 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([2, 2], [4, 0], 0, 0, 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-2, 2], [-4, 0], 0, 0, 2)).toBe(6);
     });
 
     test('Bottom intersection', () => {
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([2, -2], [4, 0], [0, 0], 2)).toBe(6);
-        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-2, -2], [-4, 0], [0, 0], 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([2, -2], [4, 0], 0, 0, 2)).toBe(6);
+        expect(maxWidthOfRectConstrainedByCenterAndHeightToLineSegment([-2, -2], [-4, 0], 0, 0, 2)).toBe(6);
     });
 });

--- a/packages/ag-charts-enterprise/src/series/map-util/polygonLabelUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/map-util/polygonLabelUtil.ts
@@ -6,24 +6,25 @@ export function preferredLabelCenter(
     polygons: _ModuleSupport.Position[][],
     { aspectRatio, precision }: { aspectRatio: number; precision: number }
 ) {
-    const result = polygonPointSearch(polygons, precision, (p, center, stride) => {
-        const width = maxWidthOfRectConstrainedByCenterAndAspectRatioToPolygon(p, center, aspectRatio);
+    const result = polygonPointSearch(polygons, precision, (p, cx, cy, stride) => {
+        const width = maxWidthOfRectConstrainedByCenterAndAspectRatioToPolygon(p, cx, cy, aspectRatio);
         const distance = width * Math.SQRT2;
         const maxDistance = distance + stride * stride;
         return { distance, maxDistance };
     });
     if (result == null) return;
 
-    const { center, distance } = result;
+    const { x, y, distance } = result;
     const maxWidth = distance / Math.SQRT2;
 
-    return { center, maxWidth };
+    return { x, y, maxWidth };
 }
 
 export function maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment(
     a: _ModuleSupport.Position,
     b: _ModuleSupport.Position,
-    [cx, cy]: _ModuleSupport.Position,
+    cx: number,
+    cy: number,
     aspectRatio: number
 ) {
     const [ax, ay] = a;
@@ -107,13 +108,12 @@ export function maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment(
 
 export function maxWidthOfRectConstrainedByCenterAndAspectRatioToPolygon(
     polygons: _ModuleSupport.Position[][],
-    center: _ModuleSupport.Position,
+    cx: number,
+    cy: number,
     aspectRatio: number
 ) {
     let inside = false;
     let minWidth = Infinity;
-
-    const [cx, cy] = center;
 
     for (const polygon of polygons) {
         let p0 = polygon[polygon.length - 1];
@@ -126,7 +126,7 @@ export function maxWidthOfRectConstrainedByCenterAndAspectRatioToPolygon(
                 inside = !inside;
             }
 
-            const width = maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment(p0, p1, center, aspectRatio);
+            const width = maxWidthOfRectConstrainedByCenterAndAspectRatioToLineSegment(p0, p1, cx, cy, aspectRatio);
 
             minWidth = Math.min(minWidth, width);
             p0 = p1;
@@ -141,7 +141,8 @@ export function maxWidthOfRectConstrainedByCenterAndAspectRatioToPolygon(
 export function maxWidthOfRectConstrainedByCenterAndHeightToLineSegment(
     a: _ModuleSupport.Position,
     b: _ModuleSupport.Position,
-    [cx, cy]: _ModuleSupport.Position,
+    cx: number,
+    cy: number,
     height: number
 ) {
     const ry0 = cy - height / 2;
@@ -190,7 +191,8 @@ export function maxWidthOfRectConstrainedByCenterAndHeightToLineSegment(
 
 export function maxWidthInPolygonForRectOfHeight(
     polygons: _ModuleSupport.Position[][],
-    center: _ModuleSupport.Position,
+    cx: number,
+    cy: number,
     height: number
 ) {
     let minWidth = Infinity;
@@ -199,7 +201,7 @@ export function maxWidthInPolygonForRectOfHeight(
         let p0 = polygon[polygon.length - 1];
 
         for (const p1 of polygon) {
-            const width = maxWidthOfRectConstrainedByCenterAndHeightToLineSegment(p0, p1, center, height);
+            const width = maxWidthOfRectConstrainedByCenterAndHeightToLineSegment(p0, p1, cx, cy, height);
 
             minWidth = Math.min(minWidth, width);
             p0 = p1;


### PR DESCRIPTION
Computes the label placement on a fixed scale rather than using the current scale, then converts back to the current scale. This means we can cache the label placement values between resizes