### PR TITLE
AG-11006 Improve label placement performance

### DIFF
--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -231,7 +231,7 @@ export class MapShapeSeries
 
         const labelPlacement = preferredLabelCenter(fixedPolygon, {
             aspectRatio,
-            precision: 1e-4,
+            precision: 1e-2,
         });
         if (labelPlacement == null) return;
 

--- a/packages/ag-charts-enterprise/src/series/map-util/polygonLabelUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/map-util/polygonLabelUtil.ts
@@ -8,8 +8,9 @@ export function preferredLabelCenter(
 ) {
     const result = polygonPointSearch(polygons, precision, (p, cx, cy, stride) => {
         const width = maxWidthOfRectConstrainedByCenterAndAspectRatioToPolygon(p, cx, cy, aspectRatio);
+        const maxWidth = width + 2 * stride * aspectRatio;
         const distance = width * Math.SQRT2;
-        const maxDistance = distance + stride * stride;
+        const maxDistance = maxWidth * Math.SQRT2;
         return { distance, maxDistance };
     });
     if (result == null) return;

--- a/packages/ag-charts-website/src/content/docs/map-lines/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/map-lines/index.mdoc
@@ -60,6 +60,8 @@ In this configuration:
 
 -   `colorKey` is set to 'dailyVehicles', which supplies numerical values for the Colour Scale.
 
+See [Heatmap Series](./heatmap/) for more information on how to customise Colour Scales and the Gradient Legend.
+
 ## Scaling Stroke Widths
 
 A heat map will colour lines in the topology to denote the magnitude of the data values.

--- a/packages/ag-charts-website/src/content/docs/map-shapes/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/map-shapes/index.mdoc
@@ -71,6 +71,8 @@ In this configuration:
 
 -   `colorKey` is set to 'gdp', which supplies numerical values for the Colour Scale.
 
+See [Heatmap Series](./heatmap/) for more information on how to customise Colour Scales and the Gradient Legend.
+
 ## Backgrounds
 
 The Map Shape Background is a way to underlay all the shapes of a topology without accompanying data. This can be useful to keep context as Map Shape Series are toggled off in the legend, or to provide context to [Map Line Series](./map-lines/) and [Map Marker Series](./map-markers/).


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11006

- Ensures `maxValue` bound is greater than all children bounds (a requirement for the algorithm, we did this in 99% of cases, now it's 100%)
- Fix ordering of candidates to try so the ones with the most potential get tried first - rather than the least. This actually fixes a possible infinite loop