### PR TITLE
CRT-250 Fix overlay rect

### DIFF
--- a/packages/ag-charts-community/src/chart/overlay/overlay.ts
+++ b/packages/ag-charts-community/src/chart/overlay/overlay.ts
@@ -1,3 +1,4 @@
+import type { BBox } from '../../scene/bbox';
 import { createElement } from '../../util/dom';
 import { BaseProperties } from '../../util/properties';
 import { BOOLEAN, FUNCTION, STRING, Validate } from '../../util/validation';
@@ -29,14 +30,18 @@ export class Overlay extends BaseProperties {
         return this.text ?? this.defaultText;
     }
 
-    getElement(animationManager?: AnimationManager) {
+    getElement(animationManager: AnimationManager | undefined, rect: BBox) {
         this.element ??= createElement('div');
         this.element.classList.add(this.className, DEFAULT_OVERLAY_CLASS);
         this.element.classList.toggle(DEFAULT_OVERLAY_DARK_CLASS, this.darkTheme);
 
         const element = this.element;
 
-        Object.assign(element.style, { position: 'absolute', inset: '0' });
+        element.style.position = 'absolute';
+        element.style.left = `${rect.x}px`;
+        element.style.top = `${rect.y}px`;
+        element.style.width = `${rect.width}px`;
+        element.style.height = `${rect.height}px`;
 
         if (this.renderer) {
             const htmlContent = this.renderer();

--- a/packages/ag-charts-community/src/chart/update/overlaysProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/overlaysProcessor.ts
@@ -1,6 +1,7 @@
+import type { BBox } from '../../scene/bbox';
 import type { DataService } from '../data/dataService';
 import type { AnimationManager } from '../interaction/animationManager';
-import type { LayoutService } from '../layout/layoutService';
+import type { LayoutCompleteEvent, LayoutService } from '../layout/layoutService';
 import type { ChartOverlays } from '../overlay/chartOverlays';
 import type { Overlay } from '../overlay/overlay';
 import type { ChartLike, UpdateProcessor } from './processor';
@@ -15,26 +16,26 @@ export class OverlaysProcessor<D extends object> implements UpdateProcessor {
         private readonly layoutService: LayoutService,
         private readonly animationManager: AnimationManager
     ) {
-        this.destroyFns.push(this.layoutService.addListener('layout-complete', () => this.onLayoutComplete()));
+        this.destroyFns.push(this.layoutService.addListener('layout-complete', (e) => this.onLayoutComplete(e)));
     }
 
     public destroy() {
         this.destroyFns.forEach((cb) => cb());
     }
 
-    private onLayoutComplete() {
+    private onLayoutComplete({ series: { rect } }: LayoutCompleteEvent) {
         const isLoading = this.dataService.isLoading();
         const hasData = this.chartLike.series.some((s) => s.hasData);
         const anySeriesVisible = this.chartLike.series.some((s) => s.visible);
 
-        this.toggleOverlay(this.overlays.loading, isLoading);
-        this.toggleOverlay(this.overlays.noData, !isLoading && !hasData);
-        this.toggleOverlay(this.overlays.noVisibleSeries, hasData && !anySeriesVisible);
+        this.toggleOverlay(this.overlays.loading, rect, isLoading);
+        this.toggleOverlay(this.overlays.noData, rect, !isLoading && !hasData);
+        this.toggleOverlay(this.overlays.noVisibleSeries, rect, hasData && !anySeriesVisible);
     }
 
-    private toggleOverlay(overlay: Overlay, visible: boolean) {
+    private toggleOverlay(overlay: Overlay, seriesRect: BBox, visible: boolean) {
         if (visible) {
-            const element = overlay.getElement(this.animationManager);
+            const element = overlay.getElement(this.animationManager, seriesRect);
             (this.chartLike as any).element.append(element);
         } else {
             overlay.removeElement(this.animationManager);


### PR DESCRIPTION
The bounds of the overlay element overlapped with the legend as of https://github.com/ag-grid/ag-charts/pull/1187

Restoring the correct bounds fixes the legend interaction when the overlay is display. This also seems to fix CRT-248.