### PR TITLE
CRT-271 Use canvas width/height as defaults

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -276,7 +276,8 @@ class AgChartsInternal {
     }
 
     private static async prepareResizedChart({ chart }: AgChartInstanceProxy, opts: DownloadOptions = {}) {
-        const { width = chart.width, height = chart.height } = opts;
+        const width: number = opts.width ?? chart.width ?? chart.scene.canvas.width;
+        const height: number = opts.height ?? chart.height ?? chart.scene.canvas.height;
 
         const options: ChartExtendedOptions = mergeDefaults(
             {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-271

This is a regression caused by the fix for [CRT-218](https://ag-grid.atlassian.net/browse/CRT-218). To avoid this problem in the future, `width` and `height` are explicitly defined as `number` types so that the compiler can spot `undefined` values.