### PR TITLE
AG-8416 Add range to other series types (part 2)

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -25,13 +25,7 @@ import {
     normaliseGroupTo,
 } from '../../data/processors';
 import type { CategoryLegendDatum, ChartLegendType } from '../../legendDatum';
-import {
-    SeriesNodePickMatch,
-    SeriesNodePickMode,
-    groupAccumulativeValueProperty,
-    keyProperty,
-    valueProperty,
-} from '../series';
+import { SeriesNodePickMode, groupAccumulativeValueProperty, keyProperty, valueProperty } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import type { ErrorBoundSeriesNodeDatum } from '../seriesTypes';
 import { AbstractBarSeries } from './abstractBarSeries';
@@ -52,7 +46,6 @@ import {
     DEFAULT_CARTESIAN_DIRECTION_NAMES,
 } from './cartesianSeries';
 import { adjustLabelPlacement, updateLabelNode } from './labelUtil';
-import { addHitTestersToQuadtree, childrenOfChildrenIter, findQuadtreeMatch } from './quadtreeUtil';
 
 interface BarNodeLabelDatum extends Readonly<Point> {
     readonly text: string;
@@ -476,14 +469,6 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
         opts.labelSelection.each((textNode, datum) => {
             updateLabelNode(textNode, this.properties.label, datum.label);
         });
-    }
-
-    protected override initQuadTree(quadtree: QuadtreeNearest<BarNodeDatum>) {
-        addHitTestersToQuadtree(quadtree, childrenOfChildrenIter<Rect>(this.contentGroup));
-    }
-
-    protected override pickNodeClosestDatum(point: Point): SeriesNodePickMatch | undefined {
-        return findQuadtreeMatch(this, point);
     }
 
     getTooltipHtml(nodeDatum: BarNodeDatum): string {

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -9,7 +9,6 @@ import type { Point } from '../../../scene/point';
 import type { Selection } from '../../../scene/selection';
 import { Rect } from '../../../scene/shape/rect';
 import type { Text } from '../../../scene/shape/text';
-import type { QuadtreeNearest } from '../../../scene/util/quadtree';
 import { extent } from '../../../util/array';
 import { sanitizeHtml } from '../../../util/sanitize';
 import { isFiniteNumber } from '../../../util/type-guards';

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -530,10 +530,8 @@ export abstract class CartesianSeries<
     }
 
     protected *datumNodesIter(): Iterable<TNode> {
-        for (const subGroup of this.subGroups) {
-            for (const { node } of subGroup.datumSelection) {
-                yield node;
-            }
+        for (const { node } of this.datumSelection) {
+            yield node;
         }
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -529,6 +529,14 @@ export abstract class CartesianSeries<
         this.quadtree = undefined;
     }
 
+    protected *datumNodesIter(): Iterable<TNode> {
+        for (const subGroup of this.subGroups) {
+            for (const { node } of subGroup.datumSelection) {
+                yield node;
+            }
+        }
+    }
+
     public getQuadTree(): QuadtreeNearest<TDatum> {
         if (this.quadtree === undefined) {
             const { width, height } = this.ctx.scene.canvas;

--- a/packages/ag-charts-community/src/chart/series/cartesian/quadtreeUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/quadtreeUtil.ts
@@ -5,21 +5,14 @@ import type { Point } from '../../../scene/point';
 import type { QuadtreeNearest } from '../../../scene/util/quadtree';
 import { Logger } from '../../../util/logger';
 import type { SeriesNodePickMatch } from '../series';
+// TODO(olegat) is this import needed?
 import type { CartesianSeriesNodeDatum } from './cartesianSeries';
 
-type QuadtreeCompatibleNode = Node & DistantObject & { readonly midPoint: { x: number; y: number } };
+export type QuadtreeCompatibleNode = Node & DistantObject & { readonly midPoint: { x: number; y: number } };
 
 export function* childrenIter<TNode extends Node = Node>(parent: Node): Iterable<TNode> {
     for (const node of parent.children) {
         yield node as TNode;
-    }
-}
-
-export function* childrenOfChildrenIter<TNode extends Node = Node>(contentGroup: Node): Iterable<TNode> {
-    for (const children of contentGroup.children) {
-        for (const node of children.children) {
-            yield node as TNode;
-        }
     }
 }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/quadtreeUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/quadtreeUtil.ts
@@ -5,8 +5,7 @@ import type { Point } from '../../../scene/point';
 import type { QuadtreeNearest } from '../../../scene/util/quadtree';
 import { Logger } from '../../../util/logger';
 import type { SeriesNodePickMatch } from '../series';
-// TODO(olegat) is this import needed?
-import type { CartesianSeriesNodeDatum } from './cartesianSeries';
+import type { SeriesNodeDatum } from '../seriesTypes';
 
 export type QuadtreeCompatibleNode = Node & DistantObject & { readonly midPoint: { x: number; y: number } };
 
@@ -16,7 +15,7 @@ export function* childrenIter<TNode extends Node = Node>(parent: Node): Iterable
     }
 }
 
-export function addHitTestersToQuadtree<TNode extends QuadtreeCompatibleNode, TDatum extends CartesianSeriesNodeDatum>(
+export function addHitTestersToQuadtree<TNode extends QuadtreeCompatibleNode, TDatum extends SeriesNodeDatum>(
     quadtree: QuadtreeNearest<TDatum>,
     hitTesters: Iterable<TNode>
 ) {
@@ -30,12 +29,12 @@ export function addHitTestersToQuadtree<TNode extends QuadtreeCompatibleNode, TD
     }
 }
 
-type SeriesWithQuadtreeNearest<TDatum extends CartesianSeriesNodeDatum> = {
+type SeriesWithQuadtreeNearest<TDatum extends SeriesNodeDatum> = {
     readonly contentGroup: Group;
     getQuadTree(): QuadtreeNearest<TDatum>;
 };
 
-export function findQuadtreeMatch<TDatum extends CartesianSeriesNodeDatum>(
+export function findQuadtreeMatch<TDatum extends SeriesNodeDatum>(
     series: SeriesWithQuadtreeNearest<TDatum>,
     point: Point
 ): SeriesNodePickMatch | undefined {

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -12,7 +12,7 @@ import type { PointLabelDatum } from '../../../scene/util/labelPlacement';
 import type { ChartAnimationPhase } from '../../chartAnimationPhase';
 import type { HighlightNodeDatum } from '../../interaction/highlightManager';
 import type { ChartLegendType, GradientLegendDatum } from '../../legendDatum';
-import { Series, SeriesNodePickMatch, SeriesNodePickMode } from '../series';
+import { Series, SeriesNodePickMode } from '../series';
 import type { ISeries, SeriesNodeDatum } from '../seriesTypes';
 import type { HierarchySeriesProperties } from './hierarchySeriesProperties';
 
@@ -302,10 +302,6 @@ export abstract class HierarchySeries<
             this.animationState.transition('resize', animationData);
         }
         this.animationState.transition('update', animationData);
-    }
-
-    protected override pickNodeClosestDatum(_point: Point): SeriesNodePickMatch | undefined {
-        return undefined;
     }
 
     protected resetAllAnimation(data: HierarchyAnimationData<TNode, TDatum>) {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -10,7 +10,10 @@ import type {
 import type { BBox } from '../../scene/bbox';
 import { Group } from '../../scene/group';
 import type { ZIndexSubOrder } from '../../scene/layersManager';
+import { DistantObject, nearestSquared } from '../../scene/nearest';
+import type { Node } from '../../scene/node';
 import type { Point } from '../../scene/point';
+import type { Selection } from '../../scene/selection';
 import type { PlacedLabel, PointLabelDatum } from '../../scene/util/labelPlacement';
 import { createId } from '../../util/id';
 import { jsonDiff } from '../../util/json';
@@ -672,6 +675,14 @@ export abstract class Series<
         // Override point for subclasses - but if this is invoked, the subclass specified it wants
         // to use this feature.
         throw new Error('AG Charts - Series.pickNodeClosestDatum() not implemented');
+    }
+
+    protected pickNodeNearestDistantObject<T extends Node & DistantObject>(point: Point, items: Iterable<T>) {
+        const match = nearestSquared(point.x, point.y, items);
+        if (match.nearest !== undefined) {
+            return { datum: match.nearest.datum, distance: Math.sqrt(match.distanceSquared) };
+        }
+        return undefined;
     }
 
     protected pickNodeMainAxisFirst(_point: Point, _requireCategoryAxis: boolean): SeriesNodePickMatch | undefined {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -13,7 +13,6 @@ import type { ZIndexSubOrder } from '../../scene/layersManager';
 import { DistantObject, nearestSquared } from '../../scene/nearest';
 import type { Node } from '../../scene/node';
 import type { Point } from '../../scene/point';
-import type { Selection } from '../../scene/selection';
 import type { PlacedLabel, PointLabelDatum } from '../../scene/util/labelPlacement';
 import { createId } from '../../util/id';
 import { jsonDiff } from '../../util/json';

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -65,6 +65,7 @@ export * from './chart/series/cartesian/areaUtil';
 export * from './chart/series/cartesian/markerUtil';
 export * from './chart/series/cartesian/labelUtil';
 export * from './chart/series/cartesian/pathUtil';
+export * from './chart/series/cartesian/quadtreeUtil';
 export * from './chart/series/dataModelSeries';
 export * from './chart/series/polar/polarSeries';
 export * from './chart/series/hierarchy/hierarchySeries';

--- a/packages/ag-charts-community/src/scene/path2D.ts
+++ b/packages/ag-charts-community/src/scene/path2D.ts
@@ -318,6 +318,8 @@ export class Path2D {
                     const counterClockwise = Boolean(params[pi++]);
                     best = lineDistanceSquared(x, y, px, py, startX, startY, best);
                     best = arcDistanceSquared(x, y, cx, cy, r, startAngle, endAngle, counterClockwise, best);
+                    px = cx + Math.cos(endAngle) * r;
+                    py = cy + Math.sin(endAngle) * r;
                     break;
                 }
                 case Command.ClosePath:

--- a/packages/ag-charts-community/src/scene/selection.ts
+++ b/packages/ag-charts-community/src/scene/selection.ts
@@ -26,8 +26,14 @@ export class Selection<TChild extends Node = Node, TDatum = any> {
         return results;
     }
 
-    static selectByClass<TChild extends Node = Node>(node: Node, Class: new () => TChild): TChild[] {
-        return Selection.selectAll(node, (n: Node): n is TChild => n instanceof Class);
+    static selectByClass<TChild extends Node = Node>(
+        node: Node,
+        Class: new () => TChild,
+        ...ExtraClasses: Array<new () => TChild>
+    ): TChild[] {
+        return Selection.selectAll(node, (n: Node): n is TChild => {
+            return n instanceof Class || ExtraClasses.some((C) => n instanceof C);
+        });
     }
 
     static selectByTag<TChild extends Node = Node>(node: Node, tag: number): TChild[] {

--- a/packages/ag-charts-community/src/scene/shape/line.ts
+++ b/packages/ag-charts-community/src/scene/shape/line.ts
@@ -1,9 +1,11 @@
+import { lineDistanceSquared } from '../../util/distance';
 import { BBox } from '../bbox';
+import type { DistantObject } from '../nearest';
 import type { NodeOptions, RenderContext } from '../node';
 import { RedrawType, SceneChangeDetection } from '../node';
 import { Shape } from './shape';
 
-export class Line extends Shape {
+export class Line extends Shape implements DistantObject {
     static readonly className = 'Line';
 
     protected static override defaultStyles = Object.assign({}, Shape.defaultStyles, {
@@ -55,6 +57,11 @@ export class Line extends Shape {
                 .containsPoint(x, y);
         }
         return false;
+    }
+
+    distanceSquared(px: number, py: number): number {
+        const { x1, y1, x2, y2 } = this;
+        return lineDistanceSquared(px, py, x1, y1, x2, y2, Infinity);
     }
 
     override render(renderCtx: RenderContext) {

--- a/packages/ag-charts-community/src/scene/shape/path.ts
+++ b/packages/ag-charts-community/src/scene/shape/path.ts
@@ -1,3 +1,4 @@
+import type { DistantObject } from '../nearest';
 import type { RenderContext } from '../node';
 import { RedrawType, SceneChangeDetection } from '../node';
 import { Path2D } from '../path2D';
@@ -13,7 +14,7 @@ export function ScenePathChangeDetection(opts?: {
     return SceneChangeDetection({ redraw, type: 'path', convertor, changeCb });
 }
 
-export class Path extends Shape {
+export class Path extends Shape implements DistantObject {
     static readonly className: string = 'Path';
 
     /**
@@ -73,6 +74,11 @@ export class Path extends Shape {
     isPointInPath(x: number, y: number): boolean {
         const point = this.transformPoint(x, y);
         return this.path.closedPath && this.path.isPointInPath(point.x, point.y);
+    }
+
+    distanceSquared(x: number, y: number): number {
+        const point = this.transformPoint(x, y);
+        return this.path.distanceSquared(point.x, point.y);
     }
 
     protected isDirtyPath(): boolean {

--- a/packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.ts
@@ -425,7 +425,7 @@ export class Rect extends Path implements DistantObject {
                 const point = this.transformPoint(hitX, hitY);
                 return this.getCachedBBox().containsPoint(point.x, point.y);
             };
-            this.distanceSquared = (x: number, y: number) => this.getCachedBBox().distanceSquared(x, y);
+            this.distanceSquared = (hitX: number, hitY: number) => this.getCachedBBox().distanceSquared(hitX, hitY);
         } else {
             this.hittester = super.isPointInPath;
             this.distanceCalculator = super.distanceSquared;

--- a/packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.ts
@@ -318,6 +318,7 @@ export class Rect extends Path implements DistantObject {
     private effectiveStrokeWidth: number = Shape.defaultStyles.strokeWidth;
 
     private hittester = super.isPointInPath;
+    private distanceCalculator = super.distanceSquared;
 
     /**
      * When the rectangle's width or height is less than a pixel
@@ -417,14 +418,17 @@ export class Rect extends Path implements DistantObject {
             insetCornerRadiusRect(path, x, y, w, h, cornerRadii, clipBBox);
         }
 
-        // Path.isPointInPath is expensive, so just use a BBox if the corners aren't rounded.
+        // Path's isPointInPath and distanceSquared are expensive computations,
+        // so just use a BBox if the corners aren't rounded.
         if ([topLeft, topRight, bottomRight, bottomLeft].every((r) => r === 0)) {
             this.hittester = (hitX: number, hitY: number) => {
                 const point = this.transformPoint(hitX, hitY);
                 return this.getCachedBBox().containsPoint(point.x, point.y);
             };
+            this.distanceSquared = (x: number, y: number) => this.getCachedBBox().distanceSquared(x, y);
         } else {
             this.hittester = super.isPointInPath;
+            this.distanceCalculator = super.distanceSquared;
         }
 
         this.effectiveStrokeWidth = strokeWidth;
@@ -445,8 +449,8 @@ export class Rect extends Path implements DistantObject {
         return { x: this.x + this.width / 2, y: this.y + this.height / 2 };
     }
 
-    distanceSquared(x: number, y: number): number {
-        return this.getCachedBBox().distanceSquared(x, y);
+    override distanceSquared(x: number, y: number): number {
+        return this.distanceCalculator(x, y);
     }
 
     protected override applyFillAlpha(ctx: CanvasRenderingContext2D) {

--- a/packages/ag-charts-community/src/util/distance.ts
+++ b/packages/ag-charts-community/src/util/distance.ts
@@ -15,6 +15,11 @@ export function lineDistanceSquared(
     y2: number,
     best: number
 ): number {
+    if (x1 === x2 && y1 === y2) {
+        // The input line isn't a line (it's a point). Just return the distance to this point,
+        // otherwise we'll get t = NaN due to a division by 0.
+        return Math.min(best, pointsDistanceSquared(x, y, x1, y1));
+    }
     const dx = x2 - x1;
     const dy = y2 - y1;
     // Find the normalised [0,1] position on the input line ((x1,y1),(x2,y2)) which is perdendicular

--- a/packages/ag-charts-community/src/util/distance.ts
+++ b/packages/ag-charts-community/src/util/distance.ts
@@ -1,0 +1,56 @@
+import { isBetweenAngles } from './angle';
+
+function pointsDistanceSquared(x1: number, y1: number, x2: number, y2: number) {
+    const dx = x1 - x2;
+    const dy = y1 - y2;
+    return dx * dx + dy * dy;
+}
+
+export function lineDistanceSquared(
+    x: number,
+    y: number,
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    best: number
+): number {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    // Find the normalised [0,1] position on the input line ((x1,y1),(x2,y2)) which is perdendicular
+    // to (px,py). Clip to [0,1] if the perdendicular line does not cross the input line.
+    const t = Math.max(0, Math.min(1, ((x - x1) * dx + (y - y1) * dy) / (dx * dx + dy * dy)));
+    const ix = x1 + t * dx;
+    const iy = y1 + t * dy;
+    return Math.min(best, pointsDistanceSquared(x, y, ix, iy));
+}
+
+export function arcDistanceSquared(
+    x: number,
+    y: number,
+    cx: number,
+    cy: number,
+    radius: number,
+    startAngle: number,
+    endAngle: number,
+    counterClockwise: boolean,
+    best: number
+): number {
+    if (counterClockwise) {
+        [endAngle, startAngle] = [startAngle, endAngle];
+    }
+
+    // Calculate the angle between the point and the center of the arc
+    const angle = Math.atan2(y - cy, x - cx);
+    if (!isBetweenAngles(angle, startAngle, endAngle)) {
+        // If the input point's angle is not in the arc, then the nearest point is the arc's start or end.
+        const startX = cx + Math.cos(startAngle) * radius;
+        const startY = cy + Math.sin(startAngle) * radius;
+        const endX = cx + Math.cos(startAngle) * radius;
+        const endY = cy + Math.sin(startAngle) * radius;
+        return Math.min(best, pointsDistanceSquared(x, y, startX, startY), pointsDistanceSquared(x, y, endX, endY));
+    }
+
+    const distToArc = radius - Math.sqrt(pointsDistanceSquared(x, y, cx, cy));
+    return Math.min(best, distToArc * distToArc);
+}

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotGroup.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotGroup.ts
@@ -1,9 +1,10 @@
 import type { AgBoxPlotSeriesStyles } from 'ag-charts-community';
-import { _ModuleSupport, _Scene } from 'ag-charts-community';
+import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
 import type { BoxPlotNodeDatum } from './boxPlotTypes';
 
 const { Group, Rect, Line, BBox, Selection } = _Scene;
+const { Logger } = _Util;
 
 enum GroupTags {
     Box,
@@ -13,7 +14,7 @@ enum GroupTags {
     Cap,
 }
 
-export class BoxPlotGroup extends Group {
+export class BoxPlotGroup extends Group implements _Scene.DistantObject {
     constructor() {
         super();
         this.append([
@@ -158,5 +159,19 @@ export class BoxPlotGroup extends Group {
             cornerRadius,
             fillOpacity: 0,
         });
+    }
+
+    distanceSquared(x: number, y: number): number {
+        const nodes = Selection.selectByClass<_Scene.Rect | _Scene.Line>(this, Rect, Line);
+        return _Scene.nearestSquared(x, y, nodes).distanceSquared;
+    }
+
+    get midPoint(): { x: number; y: number } {
+        const datum: { midPoint?: { readonly x: number; readonly y: number } } = this.datum;
+        if (datum.midPoint === undefined) {
+            Logger.error('BoxPlotGroup.datum.midPoint is undefined');
+            return { x: NaN, y: NaN };
+        }
+        return datum.midPoint;
     }
 }

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickGroup.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickGroup.ts
@@ -9,8 +9,25 @@ export enum GroupTags {
     Wick,
 }
 
-export abstract class CandlestickBaseGroup<TNodeDatum, TStyles> extends _Scene.Group {
+export abstract class CandlestickBaseGroup<TNodeDatum, TStyles>
+    extends _Scene.Group
+    implements _ModuleSupport.QuadtreeCompatibleNode
+{
     abstract updateDatumStyles(datum: TNodeDatum, activeStyles: TStyles): void;
+
+    distanceSquared(x: number, y: number): number {
+        const nodes = _Scene.Selection.selectByClass<_Scene.Rect | _Scene.Line>(this, _Scene.Rect, _Scene.Line);
+        return _Scene.nearestSquared(x, y, nodes).distanceSquared;
+    }
+
+    get midPoint(): { x: number; y: number } {
+        const datum: { midPoint?: { readonly x: number; readonly y: number } } = this.datum;
+        if (datum.midPoint === undefined) {
+            _Util.Logger.error('CandlestickBaseGroup.datum.midPoint is undefined');
+            return { x: NaN, y: NaN };
+        }
+        return datum.midPoint;
+    }
 }
 
 export class CandlestickGroup extends CandlestickBaseGroup<CandlestickNodeDatum, AgCandlestickSeriesItemOptions> {
@@ -88,19 +105,5 @@ export class CandlestickGroup extends CandlestickBaseGroup<CandlestickNodeDatum,
             x: Math.floor(axisValue + bandwidth / 2),
         });
         wicks[1].setProperties(wickStyles);
-    }
-
-    distanceSquared(x: number, y: number): number {
-        const nodes = _Scene.Selection.selectByClass<_Scene.Rect | _Scene.Line>(this, _Scene.Rect, _Scene.Line);
-        return _Scene.nearestSquared(x, y, nodes).distanceSquared;
-    }
-
-    get midPoint(): { x: number; y: number } {
-        const datum: { midPoint?: { readonly x: number; readonly y: number } } = this.datum;
-        if (datum.midPoint === undefined) {
-            _Util.Logger.error('BoxPlotGroup.datum.midPoint is undefined');
-            return { x: NaN, y: NaN };
-        }
-        return datum.midPoint;
     }
 }

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickGroup.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickGroup.ts
@@ -89,4 +89,18 @@ export class CandlestickGroup extends CandlestickBaseGroup<CandlestickNodeDatum,
         });
         wicks[1].setProperties(wickStyles);
     }
+
+    distanceSquared(x: number, y: number): number {
+        const nodes = _Scene.Selection.selectByClass<_Scene.Rect | _Scene.Line>(this, _Scene.Rect, _Scene.Line);
+        return _Scene.nearestSquared(x, y, nodes).distanceSquared;
+    }
+
+    get midPoint(): { x: number; y: number } {
+        const datum: { midPoint?: { readonly x: number; readonly y: number } } = this.datum;
+        if (datum.midPoint === undefined) {
+            _Util.Logger.error('BoxPlotGroup.datum.midPoint is undefined');
+            return { x: NaN, y: NaN };
+        }
+        return datum.midPoint;
+    }
 }

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -19,6 +19,7 @@ const {
     valueProperty,
     animationValidation,
     isFiniteNumber,
+    SeriesNodePickMode,
 } = _ModuleSupport;
 
 const { BandScale } = _Scale;
@@ -93,6 +94,7 @@ export abstract class RadialColumnSeriesBase<
             moduleCtx,
             useLabelLayer: true,
             canHaveAxes: true,
+            pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH, SeriesNodePickMode.NEAREST_NODE],
             animationResetFns: {
                 ...animationResetFns,
                 label: resetLabelFn,
@@ -500,6 +502,10 @@ export abstract class RadialColumnSeriesBase<
             { title, backgroundColor: fill, content },
             { seriesId, datum, color, title, angleKey, radiusKey, angleName, radiusName }
         );
+    }
+
+    protected override pickNodeClosestDatum(point: _Scene.Point): _ModuleSupport.SeriesNodePickMatch | undefined {
+        return this.pickNodeNearestDistantObject(point, this.itemSelection.nodes());
     }
 
     getLegendData(legendType: _ModuleSupport.ChartLegendType): _ModuleSupport.CategoryLegendDatum[] {

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -94,7 +94,7 @@ export abstract class RadialColumnSeriesBase<
             moduleCtx,
             useLabelLayer: true,
             canHaveAxes: true,
-            pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH, SeriesNodePickMode.NEAREST_NODE],
+            pickModes: [SeriesNodePickMode.EXACT_SHAPE_MATCH],
             animationResetFns: {
                 ...animationResetFns,
                 label: resetLabelFn,

--- a/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
@@ -563,6 +563,10 @@ export class SunburstSeries extends _ModuleSupport.HierarchySeries<
         return undefined;
     }
 
+    protected override pickNodeClosestDatum(point: _Scene.Point): _ModuleSupport.SeriesNodePickMatch | undefined {
+        return this.pickNodeNearestDistantObject(point, this.groupSelection.selectByClass(Sector));
+    }
+
     protected override animateEmptyUpdateReady({
         datumSelections,
     }: _ModuleSupport.HierarchyAnimationData<_Scene.Group, _ModuleSupport.SeriesNodeDatum>) {

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -671,17 +671,10 @@ export class TreemapSeries<
     }
 
     protected override pickNodeClosestDatum(point: _Scene.Point): _ModuleSupport.SeriesNodePickMatch | undefined {
-        const { x, y } = this.contentGroup.transformPoint(point.x, point.y);
-
         // We don't need to recurse on the tree because the root's nodes bounding-box contain all bounding boxes
         // of the descendants. Therefore the nearest node is always a child of the root. If there is an exact
         // match, then the pickNodeExactShape function will return a result, and this function wouldn't be called.
-        const { nearest, distanceSquared } = _Scene.nearestSquared(x, y, this.groupSelection.nodes());
-        if (nearest !== undefined) {
-            return { datum: nearest.datum, distance: Math.sqrt(distanceSquared) };
-        }
-
-        return undefined;
+        return this.pickNodeNearestDistantObject(point, this.groupSelection.nodes());
     }
 
     getTooltipHtml(node: _ModuleSupport.HierarchyNode): string {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8416

Depends on https://github.com/ag-grid/ag-charts/pull/1243

This adds the implementation of `tooltip.range = 'nearest'` to the following series types:
- Waterfall
- Box Plot
- Range Bar
- Bullet
- Candlestick
- Sunburst
- Radial Column