### PR TITLE
AG-11125 Fix highlight layer not being clipped

### DIFF
--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -72,6 +72,11 @@ export class CartesianChart extends Chart {
 
         this.hoverRect = seriesPaddedRect;
 
+        const clipRect = this.seriesArea.clip || clipSeries ? seriesPaddedRect : undefined;
+        seriesRoot.setClipRectInGroupCoordinateSpace(clipRect);
+        highlightRoot.setClipRectInGroupCoordinateSpace(clipRect);
+        annotationRoot.setClipRectInGroupCoordinateSpace(clipRect);
+
         this.layoutService.dispatchLayoutComplete({
             type: 'layout-complete',
             chart: { width: this.scene.width, height: this.scene.height },

--- a/packages/ag-charts-community/src/chart/update/baseLayoutProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/baseLayoutProcessor.ts
@@ -3,7 +3,7 @@ import type { BBox } from '../../scene/bbox';
 import { Text } from '../../scene/shape/text';
 import { Logger } from '../../util/logger';
 import { Caption } from '../caption';
-import type { LayoutCompleteEvent, LayoutService } from '../layout/layoutService';
+import type { LayoutService } from '../layout/layoutService';
 import type { ChartLike, UpdateProcessor } from './processor';
 
 export class BaseLayoutProcessor implements UpdateProcessor {
@@ -15,7 +15,6 @@ export class BaseLayoutProcessor implements UpdateProcessor {
     ) {
         this.destroyFns.push(
             // eslint-disable-next-line sonarjs/no-duplicate-string
-            this.layoutService.addListener('layout-complete', (e) => this.layoutComplete(e)),
             this.layoutService.addListener('start-layout', (e) => this.positionPadding(e.shrinkRect)),
             this.layoutService.addListener('start-layout', (e) => this.positionCaptions(e.shrinkRect))
         );
@@ -23,15 +22,6 @@ export class BaseLayoutProcessor implements UpdateProcessor {
 
     destroy() {
         this.destroyFns.forEach((cb) => cb());
-    }
-
-    private layoutComplete({ clipSeries, series: { paddedRect } }: LayoutCompleteEvent): void {
-        const { seriesArea, seriesRoot } = this.chartLike;
-        if (seriesArea.clip || clipSeries) {
-            seriesRoot.setClipRectInGroupCoordinateSpace(paddedRect);
-        } else {
-            seriesRoot.setClipRectInGroupCoordinateSpace();
-        }
     }
 
     private positionPadding(shrinkRect: BBox) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11125

If you'd prefer, I can keep this logic in `BaseLayoutProcessor` by extending `ChartLike` to include these two layers - let me know