### PR TITLE
AG-10154 Make react examples more idiomatic

### DIFF
--- a/packages/ag-charts-community-examples/src/charts-overview/examples/log-axis/index.html
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/log-axis/index.html
@@ -1,8 +1,8 @@
 <div class="wrapper">
     <div class="toolPanel">
-        <button onclick="useNumberAxis()">Number axis</button>
+        <button onclick="setNumberAxis()">Number axis</button>
         <span class="spacer"></span>
-        <button onclick="useLogAxis()">Log axis</button>
+        <button onclick="setLogAxis()">Log axis</button>
     </div>
     <div id="myChart"></div>
 </div>

--- a/packages/ag-charts-community-examples/src/charts-overview/examples/log-axis/main.ts
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/log-axis/main.ts
@@ -1,8 +1,56 @@
-import type { AgCartesianChartOptions} from "ag-charts-community";
+import type { AgCartesianAxisOptions, AgCartesianChartOptions} from "ag-charts-community";
 import { AgCharts } from "ag-charts-community"
 import { getData } from "./data"
 
 const formatter = new Intl.NumberFormat()
+
+const logAxes: AgCartesianAxisOptions[] = [
+  {
+    type: "log",
+    position: "left",
+    title: {
+      text: "Population",
+    },
+    label: {
+      format: ",.0f",
+      fontSize: 10,
+    },
+  },
+  {
+    type: "number",
+    position: "bottom",
+    title: {
+      text: "Year",
+    },
+    label: {
+      fontSize: 10,
+    },
+  },
+]
+
+const linearAxes: AgCartesianAxisOptions[] = [
+  {
+    type: "number",
+    position: "left",
+    title: {
+      text: "Population",
+    },
+    label: {
+      format: ",.0f",
+      fontSize: 10,
+    },
+  },
+  {
+    type: "number",
+    position: "bottom",
+    title: {
+      text: "Year",
+    },
+    label: {
+      fontSize: 10,
+    },
+  },
+]
 
 const options: AgCartesianChartOptions = {
   container: document.getElementById("myChart"),
@@ -25,65 +73,23 @@ const options: AgCartesianChartOptions = {
       },
     },
   ],
-  axes: [
-    {
-      type: "log",
-      position: "left",
-      title: {
-        text: "Population",
-      },
-      label: {
-        format: ",.0f",
-        fontSize: 10,
-      },
-    },
-    {
-      type: "number",
-      position: "bottom",
-      title: {
-        text: "Year",
-      },
-      label: {
-        fontSize: 10,
-      },
-    },
-  ],
+  axes: logAxes
 }
 
 const chart = AgCharts.create(options)
 
-function useNumberAxis() {
+function setNumberAxis() {
   options.subtitle = {
     text: "linear scale",
   }
-  options.axes![0] = {
-    type: "number",
-    position: "left",
-    title: {
-      text: "Population",
-    },
-    label: {
-      format: ",.0f",
-      fontSize: 10,
-    },
-  }
+  options.axes = linearAxes
   AgCharts.update(chart, options)
 }
 
-function useLogAxis() {
+function setLogAxis() {
   options.subtitle = {
     text: "log scale",
   }
-  options.axes![0] = {
-    type: "log",
-    position: "left",
-    title: {
-      text: "Population",
-    },
-    label: {
-      format: ",.0f",
-      fontSize: 10,
-    },
-  }
+  options.axes = logAxes
   AgCharts.update(chart, options)
 }

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
@@ -76,29 +76,33 @@ function actionAddStartWeek() {
 }
 
 function actionAddWeek12and13() {
-    options.data = [
+    const data = [
         ...(options.data ?? []),
         { quarter: 'week 12', week: 12, iphone: 78 },
         { quarter: 'week 13', week: 13, iphone: 138 },
     ];
-    options.data.sort((a: any, b: any) => a.week - b.week);
+    data.sort((a: any, b: any) => a.week - b.week);
+    options.data = data;
+
     AgCharts.update(chart, options);
 }
 
 function actionAddWeek7and8() {
-    options.data = [
+    const data = [
         ...(options.data ?? []),
         { quarter: 'week 7', week: 7, iphone: 142 },
         { quarter: 'week 8', week: 8, iphone: 87 },
     ];
-    options.data.sort((a: any, b: any) => a.week - b.week);
+    data.sort((a: any, b: any) => a.week - b.week);
+    options.data = data;
+
     AgCharts.update(chart, options);
 }
 
 function reorder() {
-    options.data = [...(options.data ?? [])];
-    options.data?.forEach((d) => (d.random = Math.random()));
-    options.data?.sort((a, b) => a.random - b.random);
+    const data = (options.data ?? []).map((d) => ({ ...d, random: Math.random() }));
+    data.sort((a, b) => a.random - b.random);
+    options.data = data;
 
     AgCharts.update(chart, options);
 }

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
@@ -90,8 +90,9 @@ function actionRemoveSeries() {
 }
 
 function actionRemovePoints() {
-    options.data = [...(options.data ?? [])];
-    options.data.splice(options.data.length / 2 - 5, 10);
+    const data = [...(options.data ?? [])];
+    data.splice(data.length / 2 - 5, 10);
+    options.data = data;
     AgCharts.update(chart, options);
 }
 
@@ -114,33 +115,37 @@ function actionRemoveHalf() {
 }
 
 function actionAddPoints() {
-    options.data = [...(options.data ?? [])];
-    const { length } = options.data;
+    const data = [...(options.data ?? [])];
+    const { length } = data;
     for (const idx of [length / 4, length / 2, (length * 3) / 4]) {
         const dataIdx = Math.floor(idx);
-        const [datum, nextDatum] = options.data.slice(dataIdx, dataIdx + 2);
+        const [datum, nextDatum] = data.slice(dataIdx, dataIdx + 2);
 
         const date = new Date((datum.date.getTime() + nextDatum.date.getTime()) / 2);
-        options.data.splice(dataIdx + 1, 0, genDataPoint({ ...datum, date }, 0));
+        data.splice(dataIdx + 1, 0, genDataPoint({ ...datum, date }, 0));
     }
+    options.data = data;
     AgCharts.update(chart, options);
 }
 
 function actionAddPointsBefore() {
-    options.data = [...(options.data ?? [])];
+    const data = [...(options.data ?? [])];
 
-    const ref = options.data[0];
-    options.data.splice(0, 0, genDataPoint(ref, -14), genDataPoint(ref, -7));
+    const ref = data[0];
+    data.splice(0, 0, genDataPoint(ref, -14), genDataPoint(ref, -7));
+    options.data = data;
     AgCharts.update(chart, options);
 }
 
 function actionAddPointsAfter(count = 2) {
-    options.data = [...(options.data ?? [])];
+    const data = [...(options.data ?? [])];
 
-    const [ref] = options.data.slice(-1);
+    const [ref] = data.slice(-1);
     for (let idx = 0; idx < count; idx++) {
-        options.data.push(genDataPoint(ref, (idx + 1) * 7));
+        data.push(genDataPoint(ref, (idx + 1) * 7));
     }
+
+    options.data = data;
     AgCharts.update(chart, options);
 }
 

--- a/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/index.html
+++ b/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/index.html
@@ -1,10 +1,10 @@
 <div class="wrapper">
     <div class="toolPanel">
-        <button onclick="useGridStyle1()">Grid Style #1</button>
+        <button onclick="setGridStyle1()">Grid Style #1</button>
         <span class="spacer"></span>
-        <button onclick="useGridStyle2()">Grid Style #2</button>
+        <button onclick="setGridStyle2()">Grid Style #2</button>
         <span class="spacer"></span>
-        <button onclick="useDefaultGridStyle()">Default Grid Style</button>
+        <button onclick="setDefaultGridStyle()">Default Grid Style</button>
     </div>
     <div id="myChart"></div>
 </div>

--- a/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/main.ts
@@ -52,7 +52,7 @@ const options: AgCartesianChartOptions = {
 
 const chart = AgCharts.create(options);
 
-function useGridStyle1() {
+function setGridStyle1() {
     var gridStyle = [
         {
             stroke: 'gray',
@@ -68,7 +68,7 @@ function useGridStyle1() {
     AgCharts.update(chart, options);
 }
 
-function useGridStyle2() {
+function setGridStyle2() {
     var xGridStyle = [
         {
             stroke: 'red',
@@ -86,7 +86,7 @@ function useGridStyle2() {
     AgCharts.update(chart, options);
 }
 
-function useDefaultGridStyle() {
+function setDefaultGridStyle() {
     var gridStyle = [
         {
             stroke: 'rgba(219, 219, 219, 1)',

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-placement/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-placement/main.ts
@@ -1,6 +1,6 @@
-import { AgCartesianChartOptions, AgCharts, AgNumberAxisThemeOptions } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-community';
 
-const options: AgCartesianChartOptions & { axes: AgNumberAxisThemeOptions[] } = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: generateSpiralData(),
     series: [

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/index.html
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/index.html
@@ -1,8 +1,8 @@
 <div class="wrapper">
     <div class="toolPanel">
-        <button onclick="useOneMonthInterval()">1 Month Interval</button>
+        <button onclick="setOneMonthInterval()">1 Month Interval</button>
         <span class="spacer"></span>
-        <button onclick="useTwoMonthInterval()">2 Month Interval</button>
+        <button onclick="setTwoMonthInterval()">2 Month Interval</button>
     </div>
     <div id="myChart"></div>
 </div>

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/main.ts
@@ -66,12 +66,12 @@ const options: AgCartesianChartOptions & { axes: AgTimeAxisThemeOptions[] } = {
 
 const chart = AgCharts.create(options);
 
-function useOneMonthInterval() {
+function setOneMonthInterval() {
     options.axes![0].tick!.interval = time.month;
     AgCharts.update(chart, options);
 }
 
-function useTwoMonthInterval() {
+function setTwoMonthInterval() {
     options.axes![0].tick!.interval = time.month.every(2);
     AgCharts.update(chart, options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/index.html
+++ b/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/index.html
@@ -1,12 +1,12 @@
 <div class="wrapper">
     <div class="toolPanel">
-        <button onclick="useNumberAxis()">Number axis</button>
+        <button onclick="setNumberAxis()">Number axis</button>
         <span class="spacer"></span>
-        <button onclick="useLogAxis()">Base 10 log axis</button>
+        <button onclick="setLogAxis()">Base 10 log axis</button>
         <span class="spacer"></span>
-        <button onclick="useBaseTwoLogAxis()">Base 2 log axis</button>
+        <button onclick="setBaseTwoLogAxis()">Base 2 log axis</button>
         <span class="spacer"></span>
-        <button onclick="useLogAxisWithFewerTicks()">Log axis with fewer ticks (base 10)</button>
+        <button onclick="setLogAxisWithFewerTicks()">Log axis with fewer ticks (base 10)</button>
     </div>
     <div id="myChart"></div>
 </div>

--- a/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/main.ts
@@ -31,7 +31,7 @@ const options: AgCartesianChartOptions = {
 
 const chart = AgCharts.create(options);
 
-function useNumberAxis() {
+function setNumberAxis() {
     options.axes = [
         {
             type: 'category',
@@ -49,7 +49,7 @@ function useNumberAxis() {
     AgCharts.update(chart, options);
 }
 
-function useLogAxis() {
+function setLogAxis() {
     options.axes = [
         {
             type: 'category',
@@ -67,7 +67,7 @@ function useLogAxis() {
     AgCharts.update(chart, options);
 }
 
-function useBaseTwoLogAxis() {
+function setBaseTwoLogAxis() {
     options.axes = [
         {
             type: 'category',
@@ -86,7 +86,7 @@ function useBaseTwoLogAxis() {
     AgCharts.update(chart, options);
 }
 
-function useLogAxisWithFewerTicks() {
+function setLogAxisWithFewerTicks() {
     options.axes = [
         {
             type: 'category',

--- a/packages/ag-charts-website/src/content/docs/events/_examples/interaction-ranges/main.ts
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/interaction-ranges/main.ts
@@ -51,31 +51,28 @@ let options: AgCartesianChartOptions = {
 const chart = AgCharts.create(options);
 
 function exact() {
-    if (!options.series) return;
-
-    for (let i = 0; i < options.series.length; i++) {
-        options.series[i].nodeClickRange = 'exact';
-    }
+    options.series = options.series?.map((series) => ({
+        ...series,
+        nodeClickRange: 'exact',
+    }));
 
     AgCharts.update(chart, options);
 }
 
 function nearest() {
-    if (!options.series) return;
-
-    for (let i = 0; i < options.series.length; i++) {
-        options.series[i].nodeClickRange = 'nearest';
-    }
+    options.series = options.series?.map((series) => ({
+        ...series,
+        nodeClickRange: 'nearest',
+    }));
 
     AgCharts.update(chart, options);
 }
 
 function distance() {
-    if (!options.series) return;
-
-    for (let i = 0; i < options.series.length; i++) {
-        options.series[i].nodeClickRange = 10;
-    }
+    options.series = options.series?.map((series) => ({
+        ...series,
+        nodeClickRange: 10,
+    }));
 
     AgCharts.update(chart, options);
 }

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/interaction-range/main.ts
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/interaction-range/main.ts
@@ -27,16 +27,16 @@ const options: AgCartesianChartOptions = {
 const chart = AgCharts.create(options);
 
 function nearest() {
-    if (options.tooltip) options.tooltip.range = 'nearest';
+    options.tooltip = { range: 'nearest' };
     AgCharts.update(chart, options);
 }
 
 function exact() {
-    if (options.tooltip) options.tooltip.range = 'exact';
+    options.tooltip = { range: 'exact' };
     AgCharts.update(chart, options);
 }
 
 function distance() {
-    if (options.tooltip) options.tooltip.range = 10;
+    options.tooltip = { range: 10 };
     AgCharts.update(chart, options);
 }

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/main.ts
@@ -21,22 +21,34 @@ const options: AgChartOptions = {
 const chart = AgCharts.create(options);
 
 function fixTooltipToTopRight() {
-    options.tooltip!.position!.type = 'top-right';
-    options.tooltip!.position!.xOffset = -20;
-    options.tooltip!.position!.yOffset = 0;
+    options.tooltip = {
+        position: {
+            type: 'top-right',
+            xOffset: -20,
+            yOffset: 0,
+        },
+    };
     AgCharts.update(chart, options);
 }
 
 function fixTooltipToPointer() {
-    options.tooltip!.position!.type = 'pointer';
-    options.tooltip!.position!.xOffset = 80;
-    options.tooltip!.position!.yOffset = 80;
+    options.tooltip = {
+        position: {
+            type: 'pointer',
+            xOffset: 80,
+            yOffset: 8,
+        },
+    };
     AgCharts.update(chart, options);
 }
 
 function reset() {
-    options.tooltip!.position!.type = 'node';
-    options.tooltip!.position!.xOffset = 0;
-    options.tooltip!.position!.yOffset = 0;
+    options.tooltip = {
+        position: {
+            type: 'node',
+            xOffset: 0,
+            yOffset: 0,
+        },
+    };
     AgCharts.update(chart, options);
 }

--- a/packages/ag-charts-website/src/content/gallery/_examples/log-axis/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/log-axis/main.ts
@@ -48,7 +48,7 @@ const options: AgCartesianChartOptions = {
 
 const chart = AgCharts.create(options);
 
-function useNumberAxis() {
+function setNumberAxis() {
     options.subtitle = {
         text: 'linear scale',
     };
@@ -66,7 +66,7 @@ function useNumberAxis() {
     AgCharts.update(chart, options);
 }
 
-function useLogAxis() {
+function setLogAxis() {
     options.subtitle = {
         text: 'log scale',
     };

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
@@ -6,7 +6,7 @@ import { toTitleCase } from './string-utils';
 export function processFunction(code: string): string {
     return wrapOptionsUpdateCode(
         convertFunctionToProperty(code),
-        'const clone = {...options};',
+        'const clone = structuredClone(options);',
         'setOptions(clone);',
         'clone'
     );

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
@@ -6,7 +6,7 @@ import { toTitleCase } from './string-utils';
 export function processFunction(code: string): string {
     return wrapOptionsUpdateCode(
         convertFunctionToProperty(code),
-        'const clone = {...options};',
+        'const clone = structuredClone(options);',
         'setOptions(clone);',
         'clone'
     );


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10154

- Use the function naming format `setXY` rather than `useXY`
- Use `structuredClone(options)` rather than shallow cloning
- Simplify a few examples where it makes sense