### PR TITLE
Add expected memory limits to benchmarks.

### DIFF
--- a/libraries/ag-charts-test/src/benchmarks/timing.ts
+++ b/libraries/ag-charts-test/src/benchmarks/timing.ts
@@ -22,12 +22,14 @@ type TestName = string;
 
 const records: Map<SuiteName, Map<TestName, BenchmarkMeasurement>> = new Map();
 
-export function recordTiming(suitePath: string, name: string, measurement: number | BenchmarkMeasurement) {
+export function recordTiming(suitePath: string, name: string, measurement: BenchmarkMeasurement) {
     suitePath = suitePath.replace(process.cwd(), '');
     if (!records.has(suitePath)) {
         records.set(suitePath, new Map());
     }
-    records.get(suitePath)!.set(name, typeof measurement === 'number' ? { timeMs: measurement } : measurement);
+    records.get(suitePath)?.set(name, measurement);
+
+    return measurement.memory ? getTotalMemoryUsage(measurement.memory) : undefined;
 }
 
 export function logTimings() {

--- a/packages/ag-charts-community/benchmarks/integratedChartsLargeScale.test.ts
+++ b/packages/ag-charts-community/benchmarks/integratedChartsLargeScale.test.ts
@@ -3,10 +3,14 @@ import { beforeEach, describe } from '@jest/globals';
 import { AgCartesianChartOptions } from '../src/main';
 import { benchmark, setupBenchmark } from './benchmark';
 
+const EXPECTATIONS = {
+    expectedMaxMemoryMB: 280,
+};
+
 describe('integrated charts large scale benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('integrated-large-scale');
 
-    benchmark('initial load', ctx, async () => {
+    benchmark('initial load', ctx, EXPECTATIONS, async () => {
         await await ctx.create();
     });
 
@@ -15,7 +19,7 @@ describe('integrated charts large scale benchmark', () => {
             await ctx.create();
         });
 
-        benchmark('1x legend toggle', ctx, async () => {
+        benchmark('1x legend toggle', ctx, EXPECTATIONS, async () => {
             ctx.options.series![0].visible = false;
             await ctx.update();
 
@@ -23,7 +27,7 @@ describe('integrated charts large scale benchmark', () => {
             await ctx.update();
         });
 
-        benchmark('4x legend toggle', ctx, async () => {
+        benchmark('4x legend toggle', ctx, EXPECTATIONS, async () => {
             for (let i = 0; i < 2; i++) {
                 for (const visible of [false, true]) {
                     ctx.options.series![i].visible = visible;

--- a/packages/ag-charts-community/benchmarks/largeDataset.test.ts
+++ b/packages/ag-charts-community/benchmarks/largeDataset.test.ts
@@ -4,10 +4,14 @@ import { hoverAction } from '../src/chart/test/utils';
 import { AgCartesianChartOptions } from '../src/main';
 import { addSeriesNodePoints, benchmark, setupBenchmark } from './benchmark';
 
+const EXPECTATIONS = {
+    expectedMaxMemoryMB: 900,
+};
+
 describe('large-dataset benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('large-dataset');
 
-    benchmark('initial load', ctx, async () => {
+    benchmark('initial load', ctx, EXPECTATIONS, async () => {
         await ctx.create();
     });
 
@@ -17,7 +21,7 @@ describe('large-dataset benchmark', () => {
             addSeriesNodePoints(ctx, 0, 4);
         });
 
-        benchmark('1x legend toggle', ctx, async () => {
+        benchmark('1x legend toggle', ctx, EXPECTATIONS, async () => {
             ctx.options.series![0].visible = false;
             await ctx.update();
 
@@ -25,7 +29,7 @@ describe('large-dataset benchmark', () => {
             await ctx.update();
         });
 
-        benchmark('1x datum highlight', ctx, async () => {
+        benchmark('1x datum highlight', ctx, EXPECTATIONS, async () => {
             const point = ctx.nodePositions[0][1];
             await hoverAction(point.x, point.y)(ctx.chart);
             await ctx.waitForUpdate();
@@ -34,6 +38,7 @@ describe('large-dataset benchmark', () => {
         benchmark(
             '4x datum highlight',
             ctx,
+            EXPECTATIONS,
             async () => {
                 for (const point of ctx.nodePositions[0]) {
                     await hoverAction(point.x, point.y)(ctx.chart);

--- a/packages/ag-charts-community/benchmarks/largeScaleMultiSeries.test.ts
+++ b/packages/ag-charts-community/benchmarks/largeScaleMultiSeries.test.ts
@@ -3,10 +3,14 @@ import { beforeEach, describe } from '@jest/globals';
 import { AgCartesianChartOptions } from '../src/main';
 import { benchmark, setupBenchmark } from './benchmark';
 
+const EXPECTATIONS = {
+    expectedMaxMemoryMB: 280,
+};
+
 describe('large-scale multi-series benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('large-scale-multi-series');
 
-    benchmark('initial load', ctx, async () => {
+    benchmark('initial load', ctx, EXPECTATIONS, async () => {
         await ctx.create();
     });
 
@@ -15,7 +19,7 @@ describe('large-scale multi-series benchmark', () => {
             await ctx.create();
         });
 
-        benchmark('1x legend toggle', ctx, async () => {
+        benchmark('1x legend toggle', ctx, EXPECTATIONS, async () => {
             ctx.options.series![0].visible = false;
             await ctx.update();
 
@@ -23,7 +27,7 @@ describe('large-scale multi-series benchmark', () => {
             await ctx.update();
         });
 
-        benchmark('4x legend toggle', ctx, async () => {
+        benchmark('4x legend toggle', ctx, EXPECTATIONS, async () => {
             for (let i = 0; i < 2; i++) {
                 for (const visible of [false, true]) {
                     ctx.options.series![i].visible = visible;

--- a/packages/ag-charts-community/benchmarks/multiSeries.test.ts
+++ b/packages/ag-charts-community/benchmarks/multiSeries.test.ts
@@ -4,10 +4,14 @@ import { hoverAction } from '../src/chart/test/utils';
 import { AgCartesianChartOptions } from '../src/main';
 import { addSeriesNodePoints, benchmark, setupBenchmark } from './benchmark';
 
+const EXPECTATIONS = {
+    expectedMaxMemoryMB: 270,
+};
+
 describe('multi-series benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('multi-series');
 
-    benchmark('initial load', ctx, async () => {
+    benchmark('initial load', ctx, EXPECTATIONS, async () => {
         await ctx.create();
     });
 
@@ -19,7 +23,7 @@ describe('multi-series benchmark', () => {
             addSeriesNodePoints(ctx, 5, 5);
         });
 
-        benchmark('1x legend toggle', ctx, async () => {
+        benchmark('1x legend toggle', ctx, EXPECTATIONS, async () => {
             ctx.options.series![0].visible = false;
             await ctx.update();
 
@@ -27,7 +31,7 @@ describe('multi-series benchmark', () => {
             await ctx.update();
         });
 
-        benchmark('10x legend toggle', ctx, async () => {
+        benchmark('10x legend toggle', ctx, EXPECTATIONS, async () => {
             for (let i = 0; i < 5; i++) {
                 for (const visible of [false, true]) {
                     ctx.options.series![i].visible = visible;
@@ -36,13 +40,13 @@ describe('multi-series benchmark', () => {
             }
         });
 
-        benchmark('1x datum highlight', ctx, async () => {
+        benchmark('1x datum highlight', ctx, EXPECTATIONS, async () => {
             const point = ctx.nodePositions[0][2];
             await hoverAction(point.x, point.y)(ctx.chart);
             await ctx.waitForUpdate();
         });
 
-        benchmark('15x datum highlight', ctx, async () => {
+        benchmark('15x datum highlight', ctx, EXPECTATIONS, async () => {
             for (let nodeIdx = 0; nodeIdx < 5; nodeIdx++) {
                 for (let seriesIdx = 0; seriesIdx < 3; seriesIdx++) {
                     const point = ctx.nodePositions[seriesIdx][nodeIdx];

--- a/packages/ag-charts-enterprise/benchmarks/multiSeries.test.ts
+++ b/packages/ag-charts-enterprise/benchmarks/multiSeries.test.ts
@@ -4,11 +4,15 @@ import { beforeEach, describe } from '@jest/globals';
 import { benchmark, setupBenchmark } from '../../ag-charts-community/benchmarks/benchmark';
 import { AgCartesianChartOptions } from '../src/main';
 
+const EXPECTATIONS = {
+    expectedMaxMemoryMB: 270,
+};
+
 /** Placeholder tests until we have real tests for Enterprise. */
 describe('multi-series benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('multi-series');
 
-    benchmark('initial load', ctx, async () => {
+    benchmark('initial load', ctx, EXPECTATIONS, async () => {
         await ctx.create();
     });
 
@@ -17,7 +21,7 @@ describe('multi-series benchmark', () => {
             await ctx.create();
         });
 
-        benchmark('1x legend toggle', ctx, async () => {
+        benchmark('1x legend toggle', ctx, EXPECTATIONS, async () => {
             ctx.options.series![0].visible = false;
             await ctx.update();
 
@@ -25,7 +29,7 @@ describe('multi-series benchmark', () => {
             await ctx.update();
         });
 
-        benchmark('10x legend toggle', ctx, async () => {
+        benchmark('10x legend toggle', ctx, EXPECTATIONS, async () => {
             for (let i = 0; i < 5; i++) {
                 for (const visible of [false, true]) {
                     ctx.options.series![i].visible = visible;


### PR DESCRIPTION
Adds expectations for memory usage to benchmarks, so leaks (such as that addressed by https://github.com/ag-grid/ag-charts/commit/7afc22a78f7fb65a8760a7c639fe8050ebec4122)  are caught on CI / PRs.