### PR TITLE
AG-10941 - Fix momentum panning cancel.

### DIFF
--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -160,7 +160,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
         }
 
         if (this.dragging != null) {
-            this.ctx.zoomManager.fireZoomPanStartEvent();
+            this.ctx.zoomManager.fireZoomPanStartEvent('navigator');
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -140,8 +140,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     // TODO: This will become an option soon, and I don't want to delete my code in the meantime
     private enableSecondaryAxis = false;
 
-    @Validate(NUMBER.restrict({ min: 0.0001, max: 1 }))
     @ProxyProperty('panner.deceleration')
+    @Validate(NUMBER.restrict({ min: 0.0001, max: 1 }))
     deceleration: number = 1;
 
     constructor(readonly ctx: _ModuleSupport.ModuleContext) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -177,7 +177,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
             ctx.toolbarManager.addListener('button-pressed', (event) => this.onToolbarButtonPress(event)),
             ctx.layoutService.addListener('layout-complete', (event) => this.onLayoutComplete(event)),
             ctx.updateService.addListener('update-complete', (event) => this.onUpdateComplete(event)),
-            ctx.zoomManager.addListener('zoom-change', () => this.onZoomChange()),
+            ctx.zoomManager.addListener('zoom-change', (e) => this.onZoomChange(e)),
+            ctx.zoomManager.addListener('zoom-pan-start', (e) => this.onZoomPanStart(e)),
             this.panner.addListener('update', (event) => this.onPanUpdate(event))
         );
     }
@@ -290,7 +291,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         }
 
         if ((this.dragState = newDragState) !== DragState.None) {
-            this.zoomManager.fireZoomPanStartEvent();
+            this.zoomManager.fireZoomPanStartEvent('zoom');
         }
     }
 
@@ -588,8 +589,17 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         this.updateZoom(constrainZoom(newZoom));
     }
 
-    private onZoomChange() {
+    private onZoomChange(e: _ModuleSupport.ZoomChangeEvent) {
+        if (e.callerId !== 'zoom') {
+            this.panner.stopInteractions();
+        }
         this.toggleContextMenuActions(definedZoomState(this.zoomManager.getZoom()));
+    }
+
+    onZoomPanStart(e: _ModuleSupport.ZoomPanStartEvent): void {
+        if (e.callerId !== 'zoom') {
+            this.panner.stopInteractions();
+        }
     }
 
     private onPanUpdate(e: ZoomPanUpdate) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -140,6 +140,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     // TODO: This will become an option soon, and I don't want to delete my code in the meantime
     private enableSecondaryAxis = false;
 
+    @Validate(NUMBER.restrict({ min: 0.0001, max: 1 }))
     @ProxyProperty('panner.deceleration')
     deceleration: number = 1;
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
@@ -134,10 +134,10 @@ export class ZoomPanner {
     }
 
     private updateCoords(x: number, y: number) {
-        if (!this.coords) {
-            this.coords = { x1: x, y1: y, x2: x, y2: y };
-        } else {
+        if (this.coords) {
             this.coords = { x1: this.coords.x2, y1: this.coords.y2, x2: x, y2: y };
+        } else {
+            this.coords = { x1: x, y1: y, x2: x, y2: y };
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
@@ -4,7 +4,6 @@ import { _ModuleSupport, _Util } from 'ag-charts-community';
 import type { AxisZoomStates, ZoomCoords } from './zoomTypes';
 import { constrainZoom, definedZoomState, dx, dy, pointToRatio, translateZoom } from './zoomUtils';
 
-const { RATIO, Validate } = _ModuleSupport;
 export interface ZoomPanUpdate {
     type: 'update';
     deltaX: number;
@@ -20,7 +19,6 @@ interface ZoomCoordHistory {
 const maxZoomCoords = 16;
 
 export class ZoomPanner {
-    @Validate(RATIO)
     deceleration: number = 1;
 
     private onUpdate: ((e: ZoomPanUpdate) => void) | undefined;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10941

Fixes:
- Navigator scroll/click now cancels momentum panning.
- Refines `zoom.deceleration` validation by preventing `0` as a value (crashes chart) and fixing validation message to reference `Zoom` rather than `ZoomPanner`.