### PR TITLE
AG-11268 Add toolbar alignment and svg icons

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
@@ -1,3 +1,4 @@
+import type { AgToolbarOptions } from '../../options/chart/toolbarOptions';
 import { BaseManager } from './baseManager';
 
 export type ToolbarGroup = 'annotations' | 'ranges';
@@ -17,12 +18,19 @@ export interface ToolbarGroupToggledEvent extends Event<ToolbarGroupToggled> {
     visible: boolean;
 }
 
-export interface ToolbarButtonPressedEvent extends Event<ToolbarButtonPressed> {
+export interface ToolbarButtonPressedEvent<T = any> extends Event<ToolbarButtonPressed> {
     group: ToolbarGroup;
-    value: any;
+    value: T;
 }
 
 export class ToolbarManager extends BaseManager<EventTypes, ToolbarEvent> {
+    static isGroup<T extends ToolbarGroup>(
+        group: T,
+        event: ToolbarEvent
+    ): event is ToolbarButtonPressedEvent<NonNullable<NonNullable<AgToolbarOptions[T]>['buttons']>[number]['value']> {
+        return event.group === group;
+    }
+
     constructor(readonly element: HTMLElement) {
         super();
     }

--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -417,6 +417,7 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -432,6 +433,7 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -925,6 +927,7 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -940,6 +943,7 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -1609,6 +1613,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -1624,6 +1629,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -2347,6 +2353,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -2362,6 +2369,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -2664,6 +2672,7 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -2679,6 +2688,7 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -3170,6 +3180,7 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -3185,6 +3196,7 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -3782,6 +3794,7 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -3797,6 +3810,7 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -4109,6 +4123,7 @@ by Occupation",
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -4124,6 +4139,7 @@ by Occupation",
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -4427,6 +4443,7 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -4442,6 +4459,7 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -4743,6 +4761,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -4758,6 +4777,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -5061,6 +5081,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -5076,6 +5097,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -5459,6 +5481,7 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -5474,6 +5497,7 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -5861,6 +5885,7 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -5876,6 +5901,7 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -6540,6 +6566,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -6555,6 +6582,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -7740,6 +7768,7 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -7755,6 +7784,7 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -8053,6 +8083,7 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -8068,6 +8099,7 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -8826,6 +8858,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -8841,6 +8874,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -9293,6 +9327,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -9308,6 +9343,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -9935,6 +9971,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -9950,6 +9987,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -10468,6 +10506,7 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -10483,6 +10522,7 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -10787,6 +10827,7 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -10802,6 +10843,7 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -11402,6 +11444,7 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -11417,6 +11460,7 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -11909,6 +11953,7 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -11924,6 +11969,7 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -12633,6 +12679,7 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -12648,6 +12695,7 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -13140,6 +13188,7 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -13155,6 +13204,7 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",
@@ -13728,6 +13778,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
   },
   "toolbar": {
     "annotations": {
+      "align": "start",
       "buttons": [
         {
           "label": "Li",
@@ -13743,6 +13794,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
     },
     "enabled": true,
     "ranges": {
+      "align": "start",
       "buttons": [
         {
           "label": "1m",

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -7,7 +7,7 @@ import { BOOLEAN, Validate } from '../../util/validation';
 import type { ToolbarGroup } from '../interaction/toolbarManager';
 import { ToolbarGroupProperties } from './toolbarProperties';
 import * as styles from './toolbarStyles';
-import { TOOLBAR_POSITIONS, type ToolbarPosition } from './toolbarTypes';
+import { TOOLBAR_ALIGNMENTS, TOOLBAR_POSITIONS, type ToolbarPosition } from './toolbarTypes';
 
 export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     @Validate(BOOLEAN)
@@ -25,8 +25,8 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     private margin = 10;
     private readonly container: HTMLElement;
     private elements: {
-        fixed: Record<ToolbarPosition, HTMLDivElement>;
-        floating?: Record<'top' | 'bottom', HTMLDivElement>;
+        fixed: Record<ToolbarPosition, HTMLElement>;
+        floating?: Record<'top' | 'bottom', HTMLElement>;
     };
 
     private positions: Record<ToolbarPosition, Set<ToolbarGroup>> = {
@@ -69,12 +69,14 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     }
 
     private onGroupButtonsChanged(group: ToolbarGroup, buttons: ToolbarGroupProperties['buttons']) {
+        const align = this[group].align ?? 'start';
         const position = this[group].position ?? 'top';
         const toolbar = this.elements.fixed[position as ToolbarPosition];
 
         for (const options of buttons ?? []) {
             const button = this.createButtonElement(group, options);
-            toolbar.appendChild(button);
+            const parent = toolbar.getElementsByClassName(styles.elements[align]).item(0);
+            parent?.appendChild(button);
         }
     }
 
@@ -94,7 +96,7 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         const buttons = this.elements.fixed[this[group].position].children;
         for (let i = 0; i < buttons.length; i++) {
             const child = buttons[i];
-            if (!(child instanceof HTMLDivElement)) continue;
+            if (!(child instanceof HTMLElement)) continue;
             if (child.dataset.toolbarGroup === group) {
                 child.classList.toggle(styles.modifiers.button.hidden, !enabled);
             }
@@ -160,6 +162,12 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     private renderToolbar(position: ToolbarPosition = 'top') {
         const element = this.elements.fixed[position];
         element.classList.add(styles.block, styles.modifiers[position]);
+
+        for (const align of TOOLBAR_ALIGNMENTS) {
+            const alignmentElement = createElement('div');
+            alignmentElement.classList.add(styles.elements[align]);
+            element.appendChild(alignmentElement);
+        }
     }
 
     private createButtonElement(group: ToolbarGroup, options: { label: string; value: any }) {

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -7,7 +7,7 @@ import { BOOLEAN, Validate } from '../../util/validation';
 import type { ToolbarGroup } from '../interaction/toolbarManager';
 import { ToolbarGroupProperties } from './toolbarProperties';
 import * as styles from './toolbarStyles';
-import { TOOLBAR_ALIGNMENTS, TOOLBAR_POSITIONS, type ToolbarPosition } from './toolbarTypes';
+import { TOOLBAR_ALIGNMENTS, TOOLBAR_POSITIONS, ToolbarButton, type ToolbarPosition } from './toolbarTypes';
 
 export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     @Validate(BOOLEAN)
@@ -68,7 +68,7 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         );
     }
 
-    private onGroupButtonsChanged(group: ToolbarGroup, buttons: ToolbarGroupProperties['buttons']) {
+    private onGroupButtonsChanged(group: ToolbarGroup, buttons?: Array<ToolbarButton>) {
         const align = this[group].align ?? 'start';
         const position = this[group].position ?? 'top';
         const toolbar = this.elements.fixed[position as ToolbarPosition];
@@ -170,12 +170,23 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         }
     }
 
-    private createButtonElement(group: ToolbarGroup, options: { label: string; value: any }) {
+    private createButtonElement(group: ToolbarGroup, options: ToolbarButton) {
         const button = createElement('button');
         button.classList.add(styles.elements.button);
         button.classList.toggle(styles.modifiers.button.hidden, !this[group].enabled);
         button.dataset.toolbarGroup = group;
-        button.innerHTML = options.label;
+
+        let inner = '';
+
+        if (options.icon != null) {
+            inner = `<span class="${styles.elements.icon}">${options.icon}</span>`;
+        }
+
+        if (options.label != null) {
+            inner = `${inner}<span class="${styles.elements.label}">${options.label}</span>`;
+        }
+
+        button.innerHTML = inner;
         button.onclick = this.onButtonPress.bind(this, group, options.value);
 
         this.destroyFns.push(() => button.remove());

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
@@ -9,6 +9,7 @@ const YEAR = DAY * 365;
 const annotations: AgToolbarOptions['annotations'] = {
     enabled: false,
     position: 'left',
+    align: 'start',
     buttons: [
         { label: 'Li', value: 'line' },
         { label: 'PCh', value: 'parallel-channel' },
@@ -18,6 +19,7 @@ const annotations: AgToolbarOptions['annotations'] = {
 const ranges: AgToolbarOptions['ranges'] = {
     enabled: false,
     position: 'top',
+    align: 'start',
     buttons: [
         { label: '1m', value: MONTH },
         { label: '3m', value: 3 * MONTH },

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarProperties.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarProperties.ts
@@ -1,7 +1,7 @@
 import { BaseProperties } from '../../util/properties';
 import { ObserveChanges } from '../../util/proxy';
 import { ARRAY, BOOLEAN, UNION, Validate } from '../../util/validation';
-import type { ToolbarAlignment, ToolbarPosition } from './toolbarTypes';
+import type { ToolbarAlignment, ToolbarButton, ToolbarPosition } from './toolbarTypes';
 
 export class ToolbarGroupProperties extends BaseProperties {
     @ObserveChanges<ToolbarGroupProperties>((target) => {
@@ -29,11 +29,11 @@ export class ToolbarGroupProperties extends BaseProperties {
         target.onButtonsChange(target.buttons);
     })
     @Validate(ARRAY, { optional: true })
-    buttons?: [{ label: string; value: any }];
+    buttons?: Array<ToolbarButton>;
 
     constructor(
         private readonly onChange: (enabled?: boolean) => void,
-        private readonly onButtonsChange: (buttons?: [{ label: string; value: any }]) => void
+        private readonly onButtonsChange: (buttons?: Array<ToolbarButton>) => void
     ) {
         super();
     }

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarProperties.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarProperties.ts
@@ -1,7 +1,7 @@
 import { BaseProperties } from '../../util/properties';
 import { ObserveChanges } from '../../util/proxy';
 import { ARRAY, BOOLEAN, UNION, Validate } from '../../util/validation';
-import type { ToolbarPosition } from './toolbarTypes';
+import type { ToolbarAlignment, ToolbarPosition } from './toolbarTypes';
 
 export class ToolbarGroupProperties extends BaseProperties {
     @ObserveChanges<ToolbarGroupProperties>((target) => {
@@ -9,6 +9,12 @@ export class ToolbarGroupProperties extends BaseProperties {
     })
     @Validate(BOOLEAN)
     enabled?: boolean;
+
+    @ObserveChanges<ToolbarGroupProperties>((target) => {
+        target.onChange(target.enabled);
+    })
+    @Validate(UNION(['start', 'middle', 'end']), { optional: true })
+    align: ToolbarAlignment = 'start';
 
     @ObserveChanges<ToolbarGroupProperties>((target) => {
         target.onChange(target.enabled);

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
@@ -4,6 +4,8 @@ export const elements = {
     start: `${block}__start`,
     center: `${block}__center`,
     end: `${block}__end`,
+    icon: `${block}__icon`,
+    label: `${block}__label`,
 };
 export const modifiers = {
     top: `${block}--top`,
@@ -90,4 +92,17 @@ export const css = `
 .${elements.button}:hover {
     background: var(--ag-charts-hover-color);
 }
+
+.${elements.button} svg {
+    display: inline-block;
+    width: 1.5em;
+    height: 1.5em;
+    fill: none;
+    stroke: var(--ag-charts-header-foreground-color);
+}
+
+.${elements.icon} + .${elements.label} {
+    margin-left: var(--ag-charts-size);
+}
+
 `;

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
@@ -1,6 +1,9 @@
 export const block = 'ag-charts-toolbar';
 export const elements = {
     button: `${block}__button`,
+    start: `${block}__start`,
+    center: `${block}__center`,
+    end: `${block}__end`,
 };
 export const modifiers = {
     top: `${block}--top`,
@@ -21,7 +24,7 @@ export const css = `
     border-right: var(--ag-charts-borders);
     border-color: var(--ag-charts-border-color);
     display: flex;
-    overflow: hidden;
+    flex-wrap: wrap;
     position: absolute;
     visibility: hidden;
 }
@@ -38,6 +41,26 @@ export const css = `
     width: var(--ag-charts-header-height);
 }
 
+.${elements.start}, .${elements.center}, .${elements.end} {
+    display: flex;
+    flex-direction: inherit;
+    flex-wrap: inherit;
+}
+
+.${modifiers.top} .${elements.center},
+.${modifiers.top} .${elements.end},
+.${modifiers.bottom} .${elements.center},
+.${modifiers.bottom} .${elements.end} {
+    margin-left: auto;
+}
+
+.${modifiers.left} .${elements.center},
+.${modifiers.left} .${elements.end},
+.${modifiers.right} .${elements.center},
+.${modifiers.right} .${elements.end} {
+    margin-top: auto;
+}
+
 .${elements.button} {
     align-items: center;
     color: var(--ag-charts-header-foreground-color);
@@ -45,11 +68,18 @@ export const css = `
     font-weight: 500;
     height: 100%;
     justify-content: center;
+    margin: 0;
+    padding: 0;
+}
+
+.${modifiers.top} .${elements.button},
+.${modifiers.bottom} .${elements.button} {
     min-width: var(--ag-charts-header-height);
     padding: 0 var(--ag-charts-horizontal-padding);
 }
 
-.${modifiers.left} .${elements.button}, .${modifiers.right} .${elements.button} {
+.${modifiers.left} .${elements.button},
+.${modifiers.right} .${elements.button} {
     height: 48px;
 }
 

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
@@ -1,2 +1,5 @@
+export type ToolbarAlignment = 'start' | 'center' | 'end';
+export const TOOLBAR_ALIGNMENTS: ToolbarAlignment[] = ['start', 'center', 'end'];
+
 export type ToolbarPosition = 'top' | 'right' | 'bottom' | 'left';
 export const TOOLBAR_POSITIONS: ToolbarPosition[] = ['top', 'right', 'bottom', 'left'];

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
@@ -3,3 +3,9 @@ export const TOOLBAR_ALIGNMENTS: ToolbarAlignment[] = ['start', 'center', 'end']
 
 export type ToolbarPosition = 'top' | 'right' | 'bottom' | 'left';
 export const TOOLBAR_POSITIONS: ToolbarPosition[] = ['top', 'right', 'bottom', 'left'];
+
+export interface ToolbarButton {
+    icon?: string;
+    label?: string;
+    value: any;
+}

--- a/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
@@ -6,9 +6,10 @@ export interface AgToolbarOptions extends Toggleable {
 }
 
 export interface AgToolbarGroup extends Toggleable {
-    /** Position of the toolbar section on the outside of the chart. */
+    /** Alignment of the toolbar group. */
+    align?: 'start' | 'middle' | 'end';
+    /** Position of the toolbar group on the outside of the chart. */
     position?: 'top' | 'left' | 'right' | 'bottom';
-    // floating?: boolean;
     buttons?: AgToolbarButton[];
 }
 
@@ -18,17 +19,18 @@ export interface AgToolbarButton {
     value: any;
 }
 
+/* Annotations */
 export interface AgToolbarAnnotationsGroup extends AgToolbarGroup {
     buttons?: AgToolbarAnnotationsButton[];
 }
 
 export interface AgToolbarAnnotationsButton extends AgToolbarButton {
-    // TODO: fix docs to use this type
-    // value: AgAnnotation['type'];
+    // TODO: fix docs to use this type - AgAnnotation['type']
     /** An annotation type. */
     value: 'line' | 'parallel-channel';
 }
 
+/* Ranges */
 export interface AgToolbarRangesGroup extends AgToolbarGroup {
     buttons?: AgToolbarRangesButton[];
 }

--- a/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
@@ -14,8 +14,11 @@ export interface AgToolbarGroup extends Toggleable {
 }
 
 export interface AgToolbarButton {
+    /** SVG icon to display on the button. */
+    icon?: string;
     /** Text label to display on the button. */
-    label: string;
+    label?: string;
+    /** Value provided to caller when the button is pressed. */
     value: any;
 }
 

--- a/packages/ag-charts-community/src/styles/reset.ts
+++ b/packages/ag-charts-community/src/styles/reset.ts
@@ -4,7 +4,6 @@ export default `
 [class^='ag-charts']:after,
 [class^='ag-charts']:before {
     box-sizing: border-box;
-    margin: 0;
     outline: none;
 }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,4 +1,4 @@
-import type { AgToolbarRangesButtonValue, AgZoomAnchorPoint, _Scene } from 'ag-charts-community';
+import type { AgZoomAnchorPoint, _Scene } from 'ag-charts-community';
 import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 import { ZoomRect } from './scenes/zoomRect';
@@ -34,6 +34,7 @@ const {
     ActionOnSet,
     ChartAxisDirection,
     ChartUpdateType,
+    ToolbarManager,
     Validate,
     ProxyProperty,
     round: sharedRound,
@@ -470,15 +471,15 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private onToolbarButtonPress(event: _ModuleSupport.ToolbarButtonPressedEvent) {
-        if (event.group !== 'ranges') return;
-
-        const time = event.value as AgToolbarRangesButtonValue;
-        if (typeof time === 'number') {
-            this.rangeX.extendToEnd(time);
-        } else if (Array.isArray(time)) {
-            this.rangeX.updateWith(() => time);
-        } else if (typeof time === 'function') {
-            this.rangeX.updateWith(time);
+        if (ToolbarManager.isGroup('ranges', event)) {
+            const time = event.value;
+            if (typeof time === 'number') {
+                this.rangeX.extendToEnd(time);
+            } else if (Array.isArray(time)) {
+                this.rangeX.updateWith(() => time);
+            } else if (typeof time === 'function') {
+                this.rangeX.updateWith(time);
+            }
         }
     }
 

--- a/packages/ag-charts-website/src/content/docs/toolbar/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/toolbar/index.mdoc
@@ -47,6 +47,30 @@ toolbar: {
 }
 ```
 
+## Groups
+
+### Annotations
+
+```ts
+toolbar: {
+    annotations: {
+        enabled: true,
+    }
+}
+```
+
+[Further reading on Annotations](./annotations/#adding--editing).
+
+### Ranges
+
+```ts
+toolbar: {
+    ranges: {
+        enabled: true,
+    }
+}
+```
+
 ## API Reference
 
 {% tabs %}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11268

- Adds toolbar group align property `{ align: 'start' | 'center' | 'end' }`
- Adds support for svg icons in toolbar buttons (currently as html strings, examples in forthcoming default zoom buttons)