### PR TITLE
AG-11190 Restore keyboard navigation highlight update

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1135,6 +1135,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
             this.lastInteractionEvent = keyboardEvent;
             const html = focusedSeries.getTooltipHtml(datum);
             const meta = TooltipManager.makeTooltipMeta(this.lastInteractionEvent, datum);
+            this.ctx.highlightManager.updateHighlight(this.id, datum);
             this.ctx.tooltipManager.updateTooltip(this.id, meta, html);
             this.ctx.ariaAnnouncementService.announceHtml(html);
         }


### PR DESCRIPTION
This functionality was accidentally removed in commit 4462650fe65fdd6a957d9c0f5d209c988cf800dc.