### PR TITLE
AG-11315 - Add support for specifying tabIndex.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -33,7 +33,7 @@ import { ActionOnSet } from '../util/proxy';
 import { debouncedAnimationFrame, debouncedCallback } from '../util/render';
 import { SizeMonitor } from '../util/sizeMonitor';
 import { isDefined, isFiniteNumber, isFunction, isNumber } from '../util/type-guards';
-import { BOOLEAN, NUMBER, OBJECT, UNION, Validate } from '../util/validation';
+import { BOOLEAN, OBJECT, UNION, Validate } from '../util/validation';
 import { Caption } from './caption';
 import type { ChartAnimationPhase } from './chartAnimationPhase';
 import type { ChartAxis } from './chartAxis';
@@ -192,9 +192,6 @@ export abstract class Chart extends Observable implements AgChartInstance {
     })
     @Validate(BOOLEAN)
     autoSize;
-
-    @Validate(NUMBER)
-    tabIndex?: number;
 
     /** NOTE: This is exposed for use by Integrated charts only. */
     get canvasElement() {
@@ -680,7 +677,8 @@ export abstract class Chart extends Observable implements AgChartInstance {
     }
 
     private updateTabIndex() {
-        this.ctx.scene.canvas.element.tabIndex = this.keyboard.enabled ? this.tabIndex ?? 0 : -1;
+        const { enabled, tabIndex } = this.keyboard;
+        this.ctx.scene.canvas.element.tabIndex = enabled ? tabIndex ?? 0 : -1;
     }
 
     private checkUpdateShortcut(checkUpdateType: ChartUpdateType) {

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -33,7 +33,7 @@ import { ActionOnSet } from '../util/proxy';
 import { debouncedAnimationFrame, debouncedCallback } from '../util/render';
 import { SizeMonitor } from '../util/sizeMonitor';
 import { isDefined, isFiniteNumber, isFunction, isNumber } from '../util/type-guards';
-import { BOOLEAN, OBJECT, UNION, Validate } from '../util/validation';
+import { BOOLEAN, NUMBER, OBJECT, UNION, Validate } from '../util/validation';
 import { Caption } from './caption';
 import type { ChartAnimationPhase } from './chartAnimationPhase';
 import type { ChartAxis } from './chartAxis';
@@ -192,6 +192,9 @@ export abstract class Chart extends Observable implements AgChartInstance {
     })
     @Validate(BOOLEAN)
     autoSize;
+
+    @Validate(NUMBER)
+    tabIndex?: number;
 
     /** NOTE: This is exposed for use by Integrated charts only. */
     get canvasElement() {
@@ -562,6 +565,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
         switch (performUpdateType) {
             case ChartUpdateType.FULL:
                 this.updateThemeClassName();
+                this.updateTabIndex();
             // fallthrough
 
             case ChartUpdateType.UPDATE_DATA:
@@ -673,6 +677,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
         });
 
         element.classList.add(themeClassName);
+    }
+
+    private updateTabIndex() {
+        this.ctx.scene.canvas.element.tabIndex = this.keyboard.enabled ? this.tabIndex ?? 0 : -1;
     }
 
     private checkUpdateShortcut(checkUpdateType: ChartUpdateType) {

--- a/packages/ag-charts-community/src/chart/keyboard.ts
+++ b/packages/ag-charts-community/src/chart/keyboard.ts
@@ -1,7 +1,10 @@
 import { BaseProperties } from '../util/properties';
-import { BOOLEAN, Validate } from '../util/validation';
+import { BOOLEAN, NUMBER, Validate } from '../util/validation';
 
 export class Keyboard extends BaseProperties {
     @Validate(BOOLEAN)
     enabled: boolean = false;
+
+    @Validate(NUMBER)
+    tabIndex?: number;
 }

--- a/packages/ag-charts-community/src/options/chart/chartOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartOptions.ts
@@ -193,6 +193,4 @@ export interface AgBaseChartOptions<TDatum = any> extends AgBaseThemeableChartOp
      * __Important:__ Make sure to read the `autoSize` config description for information on how the container element affects the chart size (by default).
      */
     container?: HTMLElement | null;
-    /** HTML tabIndex to apply to chart canvas to allow keyboard navigation. Defaults to 0. */
-    tabIndex?: number;
 }

--- a/packages/ag-charts-community/src/options/chart/chartOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartOptions.ts
@@ -193,4 +193,6 @@ export interface AgBaseChartOptions<TDatum = any> extends AgBaseThemeableChartOp
      * __Important:__ Make sure to read the `autoSize` config description for information on how the container element affects the chart size (by default).
      */
     container?: HTMLElement | null;
+    /** HTML tabIndex to apply to chart canvas to allow keyboard navigation. Defaults to 0. */
+    tabIndex?: number;
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11315

Adds `tabindex="0"` to the Chart `<canvas />` when `keyboard.enabled: true`, and allows user override via a new `tabIndex` root-level option.