### PR TITLE
AG-11315 - Align element where focus-related listeners and tabindex are applied.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -314,14 +314,12 @@ export abstract class Chart extends Observable implements AgChartInstance {
         scene.setRoot(root).setContainer(element);
         this.autoSize = true;
 
-        const interactiveContainer = container ?? options.userOptions.container ?? undefined;
         this.tooltip = new Tooltip();
         this.seriesLayerManager = new SeriesLayerManager(this.seriesRoot, this.highlightRoot, this.annotationRoot);
         const ctx = (this.ctx = new ChartContext(this, {
             scene,
             syncManager: new SyncManager(this),
             element,
-            interactiveContainer,
             updateCallback: (type = ChartUpdateType.FULL, opts) => this.update(type, opts),
             updateMutex: this.updateMutex,
         }));
@@ -679,7 +677,7 @@ export abstract class Chart extends Observable implements AgChartInstance {
 
     private updateTabIndex() {
         const { enabled, tabIndex } = this.keyboard;
-        this.ctx.scene.canvas.element.tabIndex = enabled ? tabIndex ?? 0 : -1;
+        this.element.tabIndex = enabled ? tabIndex ?? 0 : -1;
     }
 
     private checkUpdateShortcut(checkUpdateType: ChartUpdateType) {

--- a/packages/ag-charts-community/src/chart/chartContext.ts
+++ b/packages/ag-charts-community/src/chart/chartContext.ts
@@ -57,12 +57,11 @@ export class ChartContext implements ModuleContext {
             scene: Scene;
             syncManager: SyncManager;
             element: HTMLElement;
-            interactiveContainer: HTMLElement | undefined;
             updateCallback: UpdateCallback;
             updateMutex: Mutex;
         }
     ) {
-        const { scene, syncManager, element, interactiveContainer, updateCallback, updateMutex } = vars;
+        const { scene, syncManager, element, updateCallback, updateMutex } = vars;
         this.chartService = chart;
         this.scene = scene;
         this.syncManager = syncManager;
@@ -74,8 +73,8 @@ export class ChartContext implements ModuleContext {
         this.contextMenuRegistry = new ContextMenuRegistry();
         this.cursorManager = new CursorManager(element);
         this.highlightManager = new HighlightManager();
-        this.interactionManager = new InteractionManager(chart.keyboard, element, interactiveContainer);
-        this.regionManager = new RegionManager(this.interactionManager, element, interactiveContainer);
+        this.interactionManager = new InteractionManager(chart.keyboard, element);
+        this.regionManager = new RegionManager(this.interactionManager, element);
         this.toolbarManager = new ToolbarManager(element);
         this.gestureDetector = new GestureDetector(element);
         this.layoutService = new LayoutService();

--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -65,6 +65,10 @@ const EVENT_HANDLERS: SUPPORTED_EVENTS[] = [
     'touchend',
     'touchcancel',
     'wheel',
+    'blur',
+    'focus',
+    'keydown',
+    'keyup',
 ];
 
 type BaseInteractionEvent<T extends InteractionTypes, TEvent extends Event> = ConsumableEvent & {
@@ -158,8 +162,7 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
 
     public constructor(
         private readonly keyboardOptions: { readonly enabled: boolean },
-        element: HTMLElement,
-        container?: HTMLElement
+        element: HTMLElement
     ) {
         super();
 
@@ -178,12 +181,6 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
 
         for (const type of WINDOW_EVENT_HANDLERS) {
             getWindow().addEventListener(type, this.eventHandler);
-        }
-
-        if (container) {
-            for (const type of ['blur', 'focus', 'keydown', 'keyup']) {
-                container.addEventListener(type, this.eventHandler);
-            }
         }
 
         injectStyle(CSS, 'interactionManager');

--- a/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
@@ -47,7 +47,7 @@ export class KeyNavManager extends BaseManager<KeyNavEventType, KeyNavEvent> {
 
     constructor(
         interactionManager: InteractionManager,
-        private readonly container: HTMLElement | undefined
+        private readonly element: HTMLElement | undefined
     ) {
         super();
         this.destroyFns.push(
@@ -93,7 +93,7 @@ export class KeyNavManager extends BaseManager<KeyNavEventType, KeyNavEvent> {
         if (this.isClicking) {
             this.isMouseBlurred = true;
         } else {
-            const delta = guessDirection(this.container, event.sourceEvent.relatedTarget);
+            const delta = guessDirection(this.element, event.sourceEvent.relatedTarget);
             this.dispatch('browserfocus', delta, event);
             this.dispatch('tab', 0, event);
         }

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -59,10 +59,9 @@ export class RegionManager {
 
     constructor(
         private readonly interactionManager: InteractionManager,
-        element: HTMLElement,
-        container: HTMLElement | undefined
+        element: HTMLElement
     ) {
-        this.keyNavManager = new KeyNavManager(interactionManager, container);
+        this.keyNavManager = new KeyNavManager(interactionManager, element);
         this.destroyFns.push(
             ...POINTER_INTERACTION_TYPES.map((eventName) =>
                 interactionManager.addListener(eventName, this.processPointerEvent.bind(this), InteractionState.All)


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11315

Aligns the element where we set `tabindex="0"` and where we add focus-related event listeners, so that tab-handling behaviour is correct for Standalone AND Integrated cases.