### PR TITLE
AG-8448 Fix zoom toolbar button disabling

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -450,31 +450,38 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -980,31 +987,38 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -1660,31 +1674,38 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -2396,31 +2417,38 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -2746,31 +2774,38 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -3266,31 +3301,38 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -3886,31 +3928,38 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -4246,31 +4295,38 @@ by Occupation",
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -4598,31 +4654,38 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -4947,31 +5010,38 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -5298,31 +5368,38 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -5724,31 +5801,38 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -6154,31 +6238,38 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -6836,31 +6927,38 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -7978,31 +8076,38 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -8323,31 +8428,38 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -9092,31 +9204,38 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -9582,31 +9701,38 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -10232,31 +10358,38 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -10779,31 +10912,38 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -11132,31 +11272,38 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -11770,31 +11917,38 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -12307,31 +12461,38 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -13033,31 +13194,38 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -13558,31 +13726,38 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],
@@ -14159,31 +14334,38 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
       "buttons": [
         {
           "icon": "asc",
+          "tooltip": "Zoom in",
           "value": "zoom-in",
         },
         {
           "icon": "desc",
+          "tooltip": "Zoom out",
           "value": "zoom-out",
         },
         {
           "icon": "left",
+          "tooltip": "Pan left",
           "value": "pan-left",
         },
         {
           "icon": "right",
+          "tooltip": "Pan right",
           "value": "pan-right",
         },
         {
           "icon": "first",
+          "tooltip": "Pan to the start",
           "value": "pan-start",
         },
         {
           "icon": "last",
+          "tooltip": "Pan to the end",
           "value": "pan-end",
         },
         {
           "icon": "arrows",
           "label": "Reset",
+          "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
       ],

--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -466,11 +466,11 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -996,11 +996,11 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -1676,11 +1676,11 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -2412,11 +2412,11 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -2762,11 +2762,11 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -3282,11 +3282,11 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -3902,11 +3902,11 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -4262,11 +4262,11 @@ by Occupation",
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -4614,11 +4614,11 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -4963,11 +4963,11 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -5314,11 +5314,11 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -5740,11 +5740,11 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -6170,11 +6170,11 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -6852,11 +6852,11 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -7994,11 +7994,11 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -8339,11 +8339,11 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -9108,11 +9108,11 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -9598,11 +9598,11 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -10248,11 +10248,11 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -10795,11 +10795,11 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -11148,11 +11148,11 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -11786,11 +11786,11 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -12323,11 +12323,11 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -13049,11 +13049,11 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -13574,11 +13574,11 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",
@@ -14175,11 +14175,11 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
         },
         {
           "icon": "first",
-          "value": "start",
+          "value": "pan-start",
         },
         {
           "icon": "last",
-          "value": "end",
+          "value": "pan-end",
         },
         {
           "icon": "arrows",

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -19,6 +19,7 @@ import {
 
 export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     @ObserveChanges<Toolbar>((target) => {
+        target.processPendingEvents();
         target.toggleVisibilities();
     })
     @Validate(BOOLEAN)
@@ -60,6 +61,8 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         ranges: [],
         zoom: [],
     };
+
+    private pendingButtonToggledEvents: Array<ToolbarButtonToggledEvent> = [];
 
     constructor(private readonly ctx: ModuleContext) {
         super();
@@ -128,6 +131,11 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     private onButtonToggled(event: ToolbarButtonToggledEvent) {
         const { group, value, enabled } = event;
 
+        if (this.groupButtons[group].length === 0) {
+            this.pendingButtonToggledEvents.push(event);
+            return;
+        }
+
         for (const button of this.groupButtons[group]) {
             if (button.dataset.toolbarValue !== `${value}`) continue;
             button.disabled = !enabled;
@@ -144,6 +152,16 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         }
 
         this.toggleVisibilities();
+    }
+
+    private processPendingEvents() {
+        const pendingButtonToggledEvents = (this.pendingButtonToggledEvents ?? []).slice();
+
+        for (const event of pendingButtonToggledEvents) {
+            this.onButtonToggled(event);
+        }
+
+        this.pendingButtonToggledEvents = [];
     }
 
     async performLayout({ shrinkRect }: { shrinkRect: BBox }): Promise<{ shrinkRect: BBox }> {

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -247,6 +247,10 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
             button.dataset.toolbarValue = `${options.value}`;
         }
 
+        if (options.tooltip) {
+            button.title = options.tooltip;
+        }
+
         let inner = '';
 
         if (options.icon != null) {

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
@@ -53,11 +53,11 @@ const zoom: AgToolbarOptions['zoom'] = {
         },
         {
             icon: 'first',
-            value: 'start',
+            value: 'pan-start',
         },
         {
             icon: 'last',
-            value: 'end',
+            value: 'pan-end',
         },
         {
             icon: 'arrows',

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
@@ -37,31 +37,38 @@ const zoom: AgToolbarOptions['zoom'] = {
     buttons: [
         {
             icon: 'asc',
+            tooltip: 'Zoom in',
             value: 'zoom-in',
         },
         {
             icon: 'desc',
+            tooltip: 'Zoom out',
             value: 'zoom-out',
         },
         {
             icon: 'left',
+            tooltip: 'Pan left',
             value: 'pan-left',
         },
         {
             icon: 'right',
+            tooltip: 'Pan right',
             value: 'pan-right',
         },
         {
             icon: 'first',
+            tooltip: 'Pan to the start',
             value: 'pan-start',
         },
         {
             icon: 'last',
+            tooltip: 'Pan to the end',
             value: 'pan-end',
         },
         {
             icon: 'arrows',
             label: 'Reset',
+            tooltip: 'Reset the zoom',
             value: 'reset-zoom',
         },
     ],

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
@@ -10,5 +10,6 @@ export const TOOLBAR_POSITIONS: ToolbarPosition[] = ['top', 'right', 'bottom', '
 export interface ToolbarButton {
     icon?: string;
     label?: string;
+    tooltip?: string;
     value: any;
 }

--- a/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
@@ -22,6 +22,8 @@ export interface AgToolbarButton {
     icon?: AgIconName;
     /** Text label to display on the button. */
     label?: string;
+    /** Tooltip text to display on hover over the button. */
+    tooltip?: string;
     /** Value provided to caller when the button is pressed. */
     value: any;
 }

--- a/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
@@ -71,5 +71,5 @@ export type AgToolbarZoomButtonValue =
     | 'zoom-out'
     | 'pan-left'
     | 'pan-right'
-    | 'start'
-    | 'end';
+    | 'pan-start'
+    | 'pan-end';

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -230,8 +230,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const isMinZoom = this.isMinZoom(zoom);
         const isResetZoom = isZoomEqual(zoom, this.getResetZoom());
 
-        this.toolbarManager.toggleButton('zoom', 'start', zoom.x.min > UNIT.min);
-        this.toolbarManager.toggleButton('zoom', 'end', zoom.x.max < UNIT.max);
+        this.toolbarManager.toggleButton('zoom', 'pan-start', zoom.x.min > UNIT.min);
+        this.toolbarManager.toggleButton('zoom', 'pan-end', zoom.x.max < UNIT.max);
         this.toolbarManager.toggleButton('zoom', 'pan-left', zoom.x.min > UNIT.min);
         this.toolbarManager.toggleButton('zoom', 'pan-right', zoom.x.max < UNIT.max);
         this.toolbarManager.toggleButton('zoom', 'zoom-out', !isMaxZoom);
@@ -515,12 +515,12 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
                 zoom = this.getResetZoom();
                 break;
 
-            case 'start':
+            case 'pan-start':
                 zoom.x.max = dx(zoom);
                 zoom.x.min = 0;
                 break;
 
-            case 'end':
+            case 'pan-end':
                 zoom.x.min = UNIT.max - dx(zoom);
                 zoom.x.max = UNIT.max;
                 break;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -17,12 +17,14 @@ import {
     definedZoomState,
     dx,
     dy,
+    isZoomEqual,
     pointToRatio,
     scaleZoom,
     scaleZoomAxisWithAnchor,
     scaleZoomAxisWithPoint,
     scaleZoomCenter,
     translateZoom,
+    unitZoomState,
 } from './zoomUtils';
 
 type PinchEvent = _ModuleSupport.PinchEvent;
@@ -226,6 +228,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     private toggleToolbarButtons(zoom: DefinedZoomState) {
         const isMaxZoom = this.isMaxZoom(zoom);
         const isMinZoom = this.isMinZoom(zoom);
+        const isResetZoom = isZoomEqual(zoom, this.getResetZoom());
 
         this.toolbarManager.toggleButton('zoom', 'start', zoom.x.min > UNIT.min);
         this.toolbarManager.toggleButton('zoom', 'end', zoom.x.max < UNIT.max);
@@ -233,6 +236,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         this.toolbarManager.toggleButton('zoom', 'pan-right', zoom.x.max < UNIT.max);
         this.toolbarManager.toggleButton('zoom', 'zoom-out', !isMaxZoom);
         this.toolbarManager.toggleButton('zoom', 'zoom-in', !isMinZoom);
+        this.toolbarManager.toggleButton('zoom', 'reset-zoom', !isResetZoom);
     }
 
     private onRangeChange(direction: _ModuleSupport.ChartAxisDirection, rangeZoom?: DefinedZoomState['x' | 'y']) {
@@ -718,7 +722,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     }
 
     private isMaxZoom(zoom: DefinedZoomState): boolean {
-        return zoom.x.min === UNIT.min && zoom.x.max === UNIT.max && zoom.y.min === UNIT.min && zoom.y.max === UNIT.max;
+        return isZoomEqual(zoom, unitZoomState());
     }
 
     private updateZoom(zoom: DefinedZoomState) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -64,11 +64,12 @@ enum DragState {
 export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     @ActionOnSet<Zoom>({
         newValue(enabled) {
-            if (enabled) {
-                this.registerContextMenuActions();
-            }
             this.toolbarManager?.toggleGroup('ranges', Boolean(enabled));
             this.toolbarManager?.toggleGroup('zoom', Boolean(enabled));
+            if (enabled) {
+                this.registerContextMenuActions();
+                this.toggleToolbarButtons(definedZoomState(this.zoomManager?.getZoom()));
+            }
         },
     })
     @Validate(BOOLEAN)

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -2,7 +2,7 @@ import { AgZoomAnchorPoint, _ModuleSupport, _Scene } from 'ag-charts-community';
 
 import type { DefinedZoomState } from './zoomTypes';
 
-const { clamp } = _ModuleSupport;
+const { clamp, isEqual } = _ModuleSupport;
 
 export const UNIT = { min: 0, max: 1 };
 
@@ -18,6 +18,15 @@ export function dx(zoom: DefinedZoomState) {
 
 export function dy(zoom: DefinedZoomState) {
     return zoom.y.max - zoom.y.min;
+}
+
+export function isZoomEqual(left: DefinedZoomState, right: DefinedZoomState, epsilon: number = 1e-10) {
+    return (
+        isEqual(left.x.min, right.x.min, epsilon) &&
+        isEqual(left.x.max, right.x.max, epsilon) &&
+        isEqual(left.y.min, right.y.min, epsilon) &&
+        isEqual(left.y.max, right.y.max, epsilon)
+    );
 }
 
 export function definedZoomState(zoom?: _ModuleSupport.AxisZoomState): DefinedZoomState {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8448

The zoom module can be enabled, and tries to enable the toolbar buttons, before the toolbar module is enabled and the buttons have been added to the dom. So this captures the pending events and iterates them when the toolbar module is enabled.