### PR TITLE
Hide alpha features on website

### DIFF
--- a/packages/ag-charts-website/src/components/pages-navigation/PagesNavigation.tsx
+++ b/packages/ag-charts-website/src/components/pages-navigation/PagesNavigation.tsx
@@ -263,6 +263,11 @@ function MenuGroupPagesNavigation({
     const [topLevelSeriesItem] = menuData[menuGroupKey].items;
     const chartsMenuItems = topLevelSeriesItem.items;
 
+    const isHidden = (i: { hidden?: boolean; items?: any[] }): boolean => {
+        return i.hidden === true || (i.items?.every(isHidden) ?? false);
+    };
+    if (chartsMenuItems?.every(isHidden)) return;
+
     return (
         <ul
             className={classnames(
@@ -274,20 +279,22 @@ function MenuGroupPagesNavigation({
             )}
         >
             <MenuHeader title={topLevelSeriesItem.title} />
-            {chartsMenuItems?.map((menuItem) => {
-                const { title, path } = menuItem;
-                const isActive = menuItem === activeTopLevelMenuItem;
+            {chartsMenuItems
+                ?.filter((menuItem) => !isHidden(menuItem))
+                .map((menuItem) => {
+                    const { title, path } = menuItem;
+                    const isActive = menuItem === activeTopLevelMenuItem;
 
-                return (
-                    <NavItemContainer
-                        key={`${title}-${path}`}
-                        framework={framework}
-                        menuItem={menuItem}
-                        isActive={isActive}
-                        activeMenuItem={activeMenuItem}
-                    />
-                );
-            })}
+                    return (
+                        <NavItemContainer
+                            key={`${title}-${path}`}
+                            framework={framework}
+                            menuItem={menuItem}
+                            isActive={isActive}
+                            activeMenuItem={activeMenuItem}
+                        />
+                    );
+                })}
         </ul>
     );
 }
@@ -352,14 +359,14 @@ export function PagesNavigation({
                     menuGroupKey="maps"
                     className={styles.menuGroupTypesNav}
                 />
-                {/* <MenuGroupPagesNavigation
+                <MenuGroupPagesNavigation
                     menuData={menuData}
                     framework={framework}
                     activeMenuItem={activeMenuItem}
                     activeTopLevelMenuItem={activeTopLevelMenuItem}
                     menuGroupKey="financialCharts"
                     className={styles.menuGroupTypesNav}
-                /> */}
+                />
                 <MenuGroupPagesNavigation
                     menuData={menuData}
                     framework={framework}

--- a/packages/ag-charts-website/src/content/config.ts
+++ b/packages/ag-charts-website/src/content/config.ts
@@ -8,6 +8,7 @@ const docs = defineCollection({
         title: z.string(),
         description: z.string().optional(),
         enterprise: z.boolean().optional(),
+        hidden: z.boolean().optional(),
         /**
          * Hide right hand side menu
          */

--- a/packages/ag-charts-website/src/content/config.ts
+++ b/packages/ag-charts-website/src/content/config.ts
@@ -34,6 +34,7 @@ const menuItemBase = {
     frameworks: z.array(z.enum(FRAMEWORKS as any)).optional(),
     isEnterprise: z.boolean().optional(),
     feature: z.boolean().optional(),
+    hidden: z.boolean().optional(),
 };
 
 const level3MenuItem = z.object({

--- a/packages/ag-charts-website/src/content/docs/annotations/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/annotations/index.mdoc
@@ -1,6 +1,7 @@
 ---
 title: 'Annotations'
 enterprise: true
+hidden: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/packages/ag-charts-website/src/content/docs/benchmarks/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/index.mdoc
@@ -1,5 +1,6 @@
 ---
 title: 'Benchmarks'
+hidden: true
 ---
 
 {% warning %}

--- a/packages/ag-charts-website/src/content/docs/financial-charts/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/index.mdoc
@@ -1,6 +1,7 @@
 ---
 title: 'Financial Charts - Examples'
 enterprise: true
+hidden: true
 ---
 
 ## Stock Tracking Chart

--- a/packages/ag-charts-website/src/content/docs/toolbar/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/toolbar/index.mdoc
@@ -1,6 +1,7 @@
 ---
 title: 'Toolbar'
 enterprise: true
+hidden: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/packages/ag-charts-website/src/content/menu/data.json
+++ b/packages/ag-charts-website/src/content/menu/data.json
@@ -250,17 +250,20 @@
                     {
                         "title": "Overview",
                         "path": "financial-charts",
-                        "isEnterprise": true
+                        "isEnterprise": true,
+                        "hidden": true
                     },
                     {
                         "title": "Annotations",
                         "path": "annotations",
-                        "isEnterprise": true
+                        "isEnterprise": true,
+                        "hidden": true
                     },
                     {
                         "title": "Toolbar",
                         "path": "toolbar",
-                        "isEnterprise": true
+                        "isEnterprise": true,
+                        "hidden": true
                     }
                 ]
             }

--- a/packages/ag-charts-website/src/pages/robots.txt.ts
+++ b/packages/ag-charts-website/src/pages/robots.txt.ts
@@ -1,12 +1,12 @@
 import { SITE_URL } from '@constants';
-import { getIsProduction } from '@utils/env';
+import { getIsDev, getIsProduction } from '@utils/env';
 import { pathJoin } from '@utils/pathJoin';
 import { getSitemapIgnorePaths } from '@utils/sitemapPages';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import type { APIContext } from 'astro';
 
 // Disallow the entire site on dev
-const devRobotsTxt = () => 'User-agent: * Disallow: /';
+const disallowAllRobotsTxt = () => 'User-agent: * Disallow: /';
 
 const productionRobotsTxt = (disallowPaths: string[] = []) => `User-agent: *
 ${disallowPaths
@@ -18,11 +18,11 @@ ${disallowPaths
 Sitemap: ${pathJoin(SITE_URL, urlWithBaseUrl('/sitemap-index.xml'))}
 `;
 
-export async function GET(context: APIContext) {
-    const isProduction = getIsProduction();
+export async function GET(_context: APIContext) {
+    const disallowAll = !getIsDev() && !getIsProduction();
 
     const ignorePaths = await getSitemapIgnorePaths();
-    const output = isProduction ? productionRobotsTxt(ignorePaths) : devRobotsTxt();
+    const output = disallowAll ? disallowAllRobotsTxt() : productionRobotsTxt(ignorePaths);
 
     return new Response(output, {
         status: 200,

--- a/packages/ag-charts-website/src/utils/pages.ts
+++ b/packages/ag-charts-website/src/utils/pages.ts
@@ -3,12 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import fs from 'fs/promises';
 import glob from 'glob';
 
-import {
-    DEV_FILE_BASE_PATH,
-    SITE_BASE_URL,
-    TYPESCRIPT_INTERNAL_FRAMEWORKS,
-    USE_PUBLISHED_PACKAGES,
-} from '../constants';
+import { SITE_BASE_URL, TYPESCRIPT_INTERNAL_FRAMEWORKS, USE_PUBLISHED_PACKAGES } from '../constants';
 import { getIsDev } from './env';
 import { pathJoin } from './pathJoin';
 import { urlWithBaseUrl } from './urlWithBaseUrl';

--- a/packages/ag-charts-website/src/utils/sitemap.ts
+++ b/packages/ag-charts-website/src/utils/sitemap.ts
@@ -16,7 +16,7 @@ const isDebugPage = (page: string) => {
  * Test pages for integration testing
  */
 export const isTestPage = (page: string) => {
-    return page.endsWith('-test/') || page.endsWith('-test');
+    return page.endsWith('-test/') || page.endsWith('-test') || page.endsWith('/benchmarks');
 };
 
 const filterIgnoredPages = (page: string) => {

--- a/packages/ag-charts-website/src/utils/sitemapPages.ts
+++ b/packages/ag-charts-website/src/utils/sitemapPages.ts
@@ -68,6 +68,18 @@ const getTestPages = async () => {
     return docsTestPages.concat(urlWithBaseUrl('/gallery-test'));
 };
 
+const getHiddenPages = async () => {
+    const pages = await getCollection('docs');
+    const docsHiddenPages = getDocsPages(pages)
+        .filter(({ props }) => props.page.data.hidden)
+        .map((p) => {
+            const { framework, pageName } = p.params;
+            return getExamplePageUrl({ framework, path: pageName });
+        });
+
+    return docsHiddenPages;
+};
+
 const getIgnoredPages = () => {
     return [urlWithBaseUrl('/404')];
 };
@@ -79,6 +91,7 @@ export async function getSitemapIgnorePaths() {
         getTestPages(),
         getDebugPageUrls(),
         getIgnoredPages(),
+        getHiddenPages(),
     ]);
 
     return paths.flat();

--- a/packages/ag-charts-website/update-algolia.js
+++ b/packages/ag-charts-website/update-algolia.js
@@ -265,7 +265,11 @@ const processIndexForFramework = async (framework) => {
             const breadcrumb = breadcrumbPrefix + item.title;
             // console.log(`=== Walking ${breadcrumb}...`);
 
-            if (item.path && !exclusions.some((exclusion) => exclusion === item.path.replace(/\//g, ''))) {
+            if (
+                item.path &&
+                !item.hidden &&
+                !exclusions.some((exclusion) => exclusion === item.path.replace(/\//g, ''))
+            ) {
                 const newRecords = await createRecords(
                     browser,
                     item.path,


### PR DESCRIPTION
Allows explicit hiding of development-related site pages from the Algolia and external (Google) search crawling indexes.