### PR TITLE
AG-11291 - Ensure Event.preventDefault() on consumed keyboard events.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1095,23 +1095,27 @@ export abstract class Chart extends Observable implements AgChartInstance {
         }
     }
 
-    private onBlur(_event: KeyNavEvent<'blur'>): void {
+    private onBlur(event: KeyNavEvent<'blur'>): void {
         this.ctx.regionManager.updateFocusIndicatorRect(undefined);
         this.resetPointer();
+        event.consume();
     }
 
-    private onTab(_event: KeyNavEvent<'tab'>): void {
+    private onTab(event: KeyNavEvent<'tab'>): void {
         this.handleFocus();
+        event.consume();
     }
 
     private onNavVert(event: KeyNavEvent<'nav-vert'>): void {
         this.focus.series += event.delta;
         this.handleFocus();
+        event.consume();
     }
 
     private onNavHori(event: KeyNavEvent<'nav-hori'>): void {
         this.focus.datum += event.delta;
         this.handleFocus();
+        event.consume();
     }
 
     private onContextMenu(event: PointerInteractionEvent<'contextmenu'>): void {
@@ -1131,11 +1135,11 @@ export abstract class Chart extends Observable implements AgChartInstance {
     private focus = { series: 0, datum: 0 };
     private handleFocus() {
         const overlayFocus = this.overlays.getFocusInfo();
-        if (overlayFocus !== undefined) {
+        if (overlayFocus == null) {
+            this.handleSeriesFocus();
+        } else {
             this.ctx.regionManager.updateFocusIndicatorRect(overlayFocus.rect);
             this.ctx.ariaAnnouncementService.announceValue(overlayFocus.text);
-        } else {
-            this.handleSeriesFocus();
         }
     }
 

--- a/packages/ag-charts-community/src/chart/interaction/consumableEvent.ts
+++ b/packages/ag-charts-community/src/chart/interaction/consumableEvent.ts
@@ -12,12 +12,17 @@ type TypedListener<TType extends string, TEvent extends TypedConsumableEvent<TTy
     (event: TEvent) => void
 >;
 
-export function buildConsumable<T>(obj: T): T & ConsumableEvent {
+export function buildConsumable<T>(obj: T & { sourceEvent?: Event | ConsumableEvent }): T & ConsumableEvent {
     const builtEvent = {
         ...obj,
         consumed: false,
         consume() {
             builtEvent.consumed = true;
+            if (obj.sourceEvent instanceof Event) {
+                obj.sourceEvent?.preventDefault();
+            } else {
+                obj.sourceEvent?.consume();
+            }
         },
     };
     return builtEvent;

--- a/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
@@ -14,7 +14,7 @@ export type KeyNavEventType = 'blur' | 'browserfocus' | 'tab' | 'tab-start' | 'n
 export type KeyNavEvent<T extends KeyNavEventType = KeyNavEventType> = ConsumableEvent & {
     type: T;
     delta: number;
-    interactionEvent: InteractionEvent;
+    sourceEvent: InteractionEvent;
 };
 
 // The purpose of this class is to decouple keyboard input events configuration with
@@ -106,7 +106,7 @@ export class KeyNavManager extends BaseManager<KeyNavEventType, KeyNavEvent> {
     }
 
     private dispatch(type: KeyNavEventType, delta: number, interactionEvent: InteractionEvent) {
-        const event = buildConsumable({ type, delta, interactionEvent });
+        const event = buildConsumable({ type, delta, sourceEvent: interactionEvent });
         dispatchTypedConsumable(this.listeners, type, event);
     }
 }

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -245,8 +245,12 @@ export class RegionManager {
     }
 
     private dispatchTabStart(event: KeyNavEvent<'tab'>): boolean {
-        const { delta, interactionEvent } = event;
-        const startEvent: KeyNavEvent<'tab-start'> = buildConsumable({ type: 'tab-start', delta, interactionEvent });
+        const { delta, sourceEvent } = event;
+        const startEvent: KeyNavEvent<'tab-start'> = buildConsumable({
+            type: 'tab-start',
+            delta,
+            sourceEvent,
+        });
         const focusedRegion = this.getTabRegion(this.currentTabIndex);
 
         this.dispatch(focusedRegion, startEvent);
@@ -278,7 +282,7 @@ export class RegionManager {
     }
 
     private onFocus(event: KeyNavEvent<'browserfocus'>) {
-        const { delta, interactionEvent } = event;
+        const { delta, sourceEvent } = event;
         const newIndex =
             delta > 0
                 ? this.getNextInteractableTabIndex(-1, 1)
@@ -286,7 +290,7 @@ export class RegionManager {
         this.currentTabIndex = newIndex ?? 0;
         const focusedRegion = this.getTabRegion(this.currentTabIndex);
         if (focusedRegion) {
-            this.dispatch(focusedRegion, buildConsumable({ type: 'tab', delta, interactionEvent }));
+            this.dispatch(focusedRegion, buildConsumable({ type: 'tab', delta, sourceEvent }));
         }
     }
 
@@ -307,7 +311,7 @@ export class RegionManager {
             if (newRegion === undefined || !newRegion.properties.canInteraction()) {
                 this.updateFocusIndicatorRect(undefined);
             } else {
-                event.interactionEvent.sourceEvent.preventDefault();
+                event.sourceEvent.consume();
                 this.dispatch(newRegion, event);
             }
         }

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -969,8 +969,9 @@ export class Legend extends BaseProperties {
         this.ctx.regionManager.updateFocusIndicatorRect(undefined);
     }
 
-    private onTab(_event: KeyNavEvent<'tab'>) {
+    private onTab(event: KeyNavEvent<'tab'>) {
         this.updateFocus();
+        event.consume();
     }
 
     private onTabStart(event: KeyNavEvent<'tab-start'>) {
@@ -982,8 +983,6 @@ export class Legend extends BaseProperties {
             this.focus.mode = newMode;
             this.updateFocus();
             event.consume();
-            event.interactionEvent.consume();
-            event.interactionEvent.sourceEvent.preventDefault();
         };
         if (this.focus.mode === 'item' && event.delta === 1) {
             // If the user is on the first page then put the initial focus on the next button (index: 1),
@@ -1002,10 +1001,12 @@ export class Legend extends BaseProperties {
             const newIndex = this.focus.index + event.delta;
             this.focus.index = clamp(0, newIndex, this.data.length - 1);
             this.updateFocus();
+            event.consume();
         } else if (this.focus.mode === 'page') {
             if (event.delta < 0) this.focus.index = 0;
             if (event.delta > 0) this.focus.index = 1;
             this.updateFocus();
+            event.consume();
         }
     }
 


### PR DESCRIPTION
Fixes containing page scrolling when using up/down arrows to navigate a chart, for in-line docs examples.

The core of the change is to ensure that `ConsumableEvent`s percolate back a `Event.preventDefault()` on consumption.