### PR TITLE
AG-11367 Add zoom toolbar buttons proxy in zoom module

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
@@ -67,6 +67,6 @@ export class ToolbarManager extends BaseManager<EventTypes, ToolbarEvent> {
     }
 
     proxyGroupOptions<T extends ToolbarGroup>(group: T, options: Partial<AgToolbarOptions[T]>) {
-        this.listeners.dispatchAlwaysResolve('proxy-group-options', { type: 'proxy-group-options', group, options });
+        this.listeners.dispatch('proxy-group-options', { type: 'proxy-group-options', group, options });
     }
 }

--- a/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
@@ -2,12 +2,17 @@ import type { AgToolbarOptions } from '../../options/chart/toolbarOptions';
 import type { ToolbarGroup } from '../toolbar/toolbarTypes';
 import { BaseManager } from './baseManager';
 
-type EventTypes = ToolbarButtonPressed | ToolbarButtonToggled | ToolbarGroupToggled;
+type EventTypes = ToolbarButtonPressed | ToolbarButtonToggled | ToolbarGroupToggled | ToolbarProxyGroupOptions;
 type ToolbarButtonPressed = 'button-pressed';
 type ToolbarButtonToggled = 'button-toggled';
 type ToolbarGroupToggled = 'group-toggled';
+type ToolbarProxyGroupOptions = 'proxy-group-options';
 
-type ToolbarEvent = ToolbarButtonPressedEvent | ToolbarButtonToggledEvent | ToolbarGroupToggledEvent;
+type ToolbarEvent =
+    | ToolbarButtonPressedEvent
+    | ToolbarButtonToggledEvent
+    | ToolbarGroupToggledEvent
+    | ToolbarProxyGroupOptionsEvent;
 type ToolbarEventButtonValue<T extends ToolbarGroup> = NonNullable<
     NonNullable<AgToolbarOptions[T]>['buttons']
 >[number]['value'];
@@ -32,6 +37,11 @@ export interface ToolbarButtonToggledEvent<T = any> extends Event<ToolbarButtonT
     enabled: boolean;
 }
 
+export interface ToolbarProxyGroupOptionsEvent extends Event<ToolbarProxyGroupOptions> {
+    group: ToolbarGroup;
+    options: Partial<NonNullable<AgToolbarOptions[ToolbarGroup]>>;
+}
+
 export class ToolbarManager extends BaseManager<EventTypes, ToolbarEvent> {
     static isGroup<T extends ToolbarGroup>(
         group: T,
@@ -54,5 +64,9 @@ export class ToolbarManager extends BaseManager<EventTypes, ToolbarEvent> {
 
     toggleButton<T extends ToolbarGroup>(group: T, value: ToolbarEventButtonValue<T>, enabled: boolean) {
         this.listeners.dispatch('button-toggled', { type: 'button-toggled', group, value, enabled });
+    }
+
+    proxyGroupOptions<T extends ToolbarGroup>(group: T, options: Partial<AgToolbarOptions[T]>) {
+        this.listeners.dispatchAlwaysResolve('proxy-group-options', { type: 'proxy-group-options', group, options });
     }
 }

--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -483,7 +483,6 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -1023,7 +1022,6 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -1713,7 +1711,6 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -2459,7 +2456,6 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -2819,7 +2815,6 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -3349,7 +3344,6 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -3979,7 +3973,6 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -4349,7 +4342,6 @@ by Occupation",
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -4711,7 +4703,6 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -5070,7 +5061,6 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -5431,7 +5421,6 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -5867,7 +5856,6 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -6307,7 +6295,6 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -6999,7 +6986,6 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -8151,7 +8137,6 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -8506,7 +8491,6 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -9285,7 +9269,6 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -9785,7 +9768,6 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -10445,7 +10427,6 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -11002,7 +10983,6 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -11365,7 +11345,6 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -12016,7 +11995,6 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -12566,7 +12544,6 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -13302,7 +13279,6 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -13837,7 +13813,6 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },
@@ -14448,7 +14423,6 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
         },
         {
           "icon": "arrows",
-          "label": "Reset",
           "tooltip": "Reset the zoom",
           "value": "reset-zoom",
         },

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -5,7 +5,12 @@ import type { BBox } from '../../scene/bbox';
 import { createElement, injectStyle } from '../../util/dom';
 import { ObserveChanges } from '../../util/proxy';
 import { BOOLEAN, Validate } from '../../util/validation';
-import type { ToolbarButtonToggledEvent, ToolbarGroupToggledEvent } from '../interaction/toolbarManager';
+import type { PointerInteractionEvent } from '../interaction/interactionManager';
+import type {
+    ToolbarButtonToggledEvent,
+    ToolbarGroupToggledEvent,
+    ToolbarProxyGroupOptionsEvent,
+} from '../interaction/toolbarManager';
 import { ToolbarGroupProperties } from './toolbarProperties';
 import * as styles from './toolbarStyles';
 import {
@@ -14,7 +19,7 @@ import {
     TOOLBAR_POSITIONS,
     type ToolbarButton,
     type ToolbarGroup,
-    type ToolbarPosition,
+    ToolbarPosition,
 } from './toolbarTypes';
 
 export class Toolbar extends BaseModuleInstance implements ModuleInstance {
@@ -39,15 +44,18 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     );
 
     private margin = 10;
+    private floatingDetectionRange = 50;
     private readonly container: HTMLElement;
 
-    private fixed: Record<ToolbarPosition, HTMLElement>;
+    private elements: Record<ToolbarPosition, HTMLElement>;
 
     private positions: Record<ToolbarPosition, Set<ToolbarGroup>> = {
-        top: new Set(),
-        right: new Set(),
-        bottom: new Set(),
-        left: new Set(),
+        [ToolbarPosition.Top]: new Set(),
+        [ToolbarPosition.Right]: new Set(),
+        [ToolbarPosition.Bottom]: new Set(),
+        [ToolbarPosition.Left]: new Set(),
+        [ToolbarPosition.FloatingTop]: new Set(),
+        [ToolbarPosition.FloatingBottom]: new Set(),
     };
 
     private groupCallers: Record<ToolbarGroup, number> = {
@@ -64,67 +72,77 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
 
     private pendingButtonToggledEvents: Array<ToolbarButtonToggledEvent> = [];
 
+    private groupProxied = new Set<ToolbarGroup>();
+
     constructor(private readonly ctx: ModuleContext) {
         super();
 
         this.container = ctx.toolbarManager.element;
-        this.fixed = {
-            top: this.container.appendChild(createElement('div')),
-            right: this.container.appendChild(createElement('div')),
-            bottom: this.container.appendChild(createElement('div')),
-            left: this.container.appendChild(createElement('div')),
+        this.elements = {
+            [ToolbarPosition.Top]: this.container.appendChild(createElement('div')),
+            [ToolbarPosition.Right]: this.container.appendChild(createElement('div')),
+            [ToolbarPosition.Bottom]: this.container.appendChild(createElement('div')),
+            [ToolbarPosition.Left]: this.container.appendChild(createElement('div')),
+            [ToolbarPosition.FloatingTop]: this.container.appendChild(createElement('div')),
+            [ToolbarPosition.FloatingBottom]: this.container.appendChild(createElement('div')),
         };
 
         injectStyle(styles.css, styles.block);
 
-        this.renderToolbar('top');
-        this.renderToolbar('right');
-        this.renderToolbar('bottom');
-        this.renderToolbar('left');
+        this.renderToolbar(ToolbarPosition.Top);
+        this.renderToolbar(ToolbarPosition.Right);
+        this.renderToolbar(ToolbarPosition.Bottom);
+        this.renderToolbar(ToolbarPosition.Left);
+        this.renderToolbar(ToolbarPosition.FloatingTop);
+        this.renderToolbar(ToolbarPosition.FloatingBottom);
 
         this.toggleVisibilities();
 
         this.destroyFns.push(
+            ctx.interactionManager.addListener('hover', this.onHover.bind(this)),
             ctx.toolbarManager.addListener('button-toggled', this.onButtonToggled.bind(this)),
             ctx.toolbarManager.addListener('group-toggled', this.onGroupToggled.bind(this)),
+            ctx.toolbarManager.addListener('proxy-group-options', this.onProxyGroupOptions.bind(this)),
             ctx.layoutService.addListener('layout-complete', this.onLayoutComplete.bind(this))
         );
     }
 
+    private onHover(event: PointerInteractionEvent<'hover'>) {
+        if (!this.enabled) return;
+
+        const { elements, floatingDetectionRange } = this;
+        const { offsetY, sourceEvent } = event;
+
+        const bottomDetectionY = elements[ToolbarPosition.FloatingBottom].offsetTop - floatingDetectionRange;
+        const bottomVisible =
+            offsetY > bottomDetectionY || sourceEvent.target === elements[ToolbarPosition.FloatingBottom];
+        elements[ToolbarPosition.FloatingBottom].classList.toggle(styles.modifiers.floatingHidden, !bottomVisible);
+
+        const topDetectionY =
+            elements[ToolbarPosition.FloatingTop].offsetTop +
+            elements[ToolbarPosition.FloatingTop].offsetHeight +
+            floatingDetectionRange;
+        const topVisible = offsetY < topDetectionY || sourceEvent.target === elements[ToolbarPosition.FloatingTop];
+        elements[ToolbarPosition.FloatingTop].classList.toggle(styles.modifiers.floatingHidden, !topVisible);
+    }
+
     private onGroupChanged(group: ToolbarGroup) {
-        if (this[group] == null) return;
+        if (this[group] == null || this.groupProxied.has(group)) return;
 
-        for (const position of TOOLBAR_POSITIONS) {
-            if (this[group].enabled && this[group].position === position) {
-                this.positions[position].add(group);
-            } else {
-                this.positions[position].delete(group);
-            }
-        }
-
+        this.createGroup(group);
         this.toggleVisibilities();
     }
 
     private onGroupButtonsChanged(group: ToolbarGroup, buttons?: Array<ToolbarButton>) {
-        if (!this.enabled) return;
+        if (!this.enabled || this.groupProxied.has(group)) return;
 
-        const align = this[group].align ?? 'start';
-        const position = this[group].position ?? 'top';
-        const toolbar = this.fixed[position as ToolbarPosition];
-
-        for (const options of buttons ?? []) {
-            const button = this.createButtonElement(group, options);
-            const parent = toolbar.getElementsByClassName(styles.elements[align]).item(0);
-            parent?.appendChild(button);
-            this.groupButtons[group].push(button);
-        }
-
+        this.createGroupButtons(group, buttons);
         this.toggleVisibilities();
     }
 
     private onLayoutComplete() {
         for (const position of TOOLBAR_POSITIONS) {
-            this.fixed[position].classList.remove(styles.modifiers.preventFlash);
+            this.elements[position].classList.remove(styles.modifiers.preventFlash);
         }
     }
 
@@ -145,13 +163,56 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     private onGroupToggled(event: ToolbarGroupToggledEvent) {
         const { group, visible } = event;
 
-        if (visible) {
+        this.toggleGroup(group, visible);
+        this.toggleVisibilities();
+    }
+
+    private onProxyGroupOptions(event: ToolbarProxyGroupOptionsEvent) {
+        const { group, options } = event;
+
+        this.groupProxied.add(group);
+
+        this.createGroup(group);
+        this.createGroupButtons(group, options.buttons);
+        this.toggleGroup(group, options.enabled);
+
+        this[group].set(options);
+    }
+
+    private createGroup(group: ToolbarGroup) {
+        for (const position of TOOLBAR_POSITIONS) {
+            if (this[group].enabled && this[group].position === position) {
+                this.positions[position].add(group);
+            } else {
+                this.positions[position].delete(group);
+            }
+        }
+    }
+
+    private createGroupButtons(group: ToolbarGroup, buttons?: Array<ToolbarButton>) {
+        for (const button of this.groupButtons[group]) {
+            button.remove();
+        }
+        this.groupButtons[group] = [];
+
+        const align = this[group].align ?? 'start';
+        const position = this[group].position ?? 'top';
+        const toolbar = this.elements[position as ToolbarPosition];
+
+        for (const options of buttons ?? []) {
+            const button = this.createButtonElement(group, options);
+            const parent = toolbar.getElementsByClassName(styles.modifiers.group[align]).item(0);
+            parent?.appendChild(button);
+            this.groupButtons[group].push(button);
+        }
+    }
+
+    private toggleGroup(group: ToolbarGroup, enabled?: boolean) {
+        if (enabled) {
             this.groupCallers[group] += 1;
         } else {
             this.groupCallers[group] = Math.max(0, this.groupCallers[group] - 1);
         }
-
-        this.toggleVisibilities();
     }
 
     private processPendingEvents() {
@@ -165,56 +226,63 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     }
 
     async performLayout({ shrinkRect }: { shrinkRect: BBox }): Promise<{ shrinkRect: BBox }> {
-        const { fixed, margin } = this;
+        const { elements, margin } = this;
 
-        if (!fixed.top.classList.contains(styles.modifiers.hidden)) {
-            shrinkRect.shrink(fixed.top.offsetHeight + margin * 2, 'top');
+        if (!elements.top.classList.contains(styles.modifiers.hidden)) {
+            shrinkRect.shrink(elements.top.offsetHeight + margin * 2, 'top');
         }
 
-        if (!fixed.right.classList.contains(styles.modifiers.hidden)) {
-            shrinkRect.shrink(fixed.right.offsetWidth + margin, 'right');
+        if (!elements.right.classList.contains(styles.modifiers.hidden)) {
+            shrinkRect.shrink(elements.right.offsetWidth + margin, 'right');
         }
 
-        if (!fixed.bottom.classList.contains(styles.modifiers.hidden)) {
-            shrinkRect.shrink(fixed.bottom.offsetHeight + margin * 2, 'bottom');
+        if (!elements.bottom.classList.contains(styles.modifiers.hidden)) {
+            shrinkRect.shrink(elements.bottom.offsetHeight + margin * 2, 'bottom');
         }
 
-        if (!fixed.left.classList.contains(styles.modifiers.hidden)) {
-            shrinkRect.shrink(fixed.left.offsetWidth + margin, 'left');
+        if (!elements.left.classList.contains(styles.modifiers.hidden)) {
+            shrinkRect.shrink(elements.left.offsetWidth + margin, 'left');
         }
 
         return { shrinkRect };
     }
 
     async performCartesianLayout(opts: { seriesRect: BBox }): Promise<void> {
-        const { fixed, margin } = this;
+        const { elements, margin } = this;
         const { seriesRect } = opts;
 
-        fixed.top.style.top = `${seriesRect.y - fixed.top.offsetHeight - margin * 2}px`;
-        fixed.top.style.left = `${margin}px`;
-        fixed.top.style.width = `calc(100% - ${margin * 2}px)`;
+        elements.top.style.top = `${seriesRect.y - elements.top.offsetHeight - margin * 2}px`;
+        elements.top.style.left = `${margin}px`;
+        elements.top.style.width = `calc(100% - ${margin * 2}px)`;
 
-        fixed.right.style.top = `${seriesRect.y + margin}px`;
-        fixed.right.style.right = `${margin}px`;
-        fixed.right.style.height = `calc(100% - ${seriesRect.y + margin * 2}px)`;
+        elements.right.style.top = `${seriesRect.y + margin}px`;
+        elements.right.style.right = `${margin}px`;
+        elements.right.style.height = `calc(100% - ${seriesRect.y + margin * 2}px)`;
 
-        fixed.bottom.style.bottom = `${margin}px`;
-        fixed.bottom.style.left = `${margin}px`;
-        fixed.bottom.style.width = `calc(100% - ${margin * 2}px)`;
+        elements.bottom.style.bottom = `${margin}px`;
+        elements.bottom.style.left = `${margin}px`;
+        elements.bottom.style.width = `calc(100% - ${margin * 2}px)`;
 
-        fixed.left.style.top = `${seriesRect.y}px`;
-        fixed.left.style.left = `${margin}px`;
-        fixed.left.style.height = `calc(100% - ${seriesRect.y + margin * 2}px)`;
+        elements.left.style.top = `${seriesRect.y}px`;
+        elements.left.style.left = `${margin}px`;
+        elements.left.style.height = `calc(100% - ${seriesRect.y + margin * 2}px)`;
+
+        elements[ToolbarPosition.FloatingTop].style.top = `${seriesRect.y + margin * 4}px`;
+        elements[ToolbarPosition.FloatingBottom].style.top =
+            `${seriesRect.y + seriesRect.height - elements.top.offsetHeight - margin * 4}px`;
     }
 
     private toggleVisibilities() {
-        if (this.fixed == null) return;
+        if (this.elements == null) return;
 
         const isGroupVisible = (group: ToolbarGroup) => this[group].enabled && this.groupCallers[group] > 0;
+        const isButtonVisible = (element: HTMLButtonElement) => (button: ToolbarButton) =>
+            (typeof button.value !== 'string' && typeof button.value !== 'number') ||
+            `${button.value}` === element.dataset.toolbarValue;
 
         for (const position of TOOLBAR_POSITIONS) {
             const visible = this.enabled && Array.from(this.positions[position].values()).some(isGroupVisible);
-            this.fixed[position].classList.toggle(styles.modifiers.hidden, !visible);
+            this.elements[position].classList.toggle(styles.modifiers.hidden, !visible);
         }
 
         for (const group of TOOLBAR_GROUPS) {
@@ -222,18 +290,23 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
 
             const visible = isGroupVisible(group);
             for (const button of this.groupButtons[group]) {
-                button.classList.toggle(styles.modifiers.button.hidden, !visible);
+                const buttonVisible = visible && this[group].buttons?.some(isButtonVisible(button));
+                button.classList.toggle(styles.modifiers.button.hidden, !buttonVisible);
             }
         }
     }
 
-    private renderToolbar(position: ToolbarPosition = 'top') {
-        const element = this.fixed[position];
+    private renderToolbar(position = ToolbarPosition.Top) {
+        const element = this.elements[position];
         element.classList.add(styles.block, styles.modifiers[position], styles.modifiers.preventFlash);
+
+        if (position === ToolbarPosition.FloatingTop || position === ToolbarPosition.FloatingBottom) {
+            element.classList.add(styles.modifiers.floatingHidden);
+        }
 
         for (const align of TOOLBAR_ALIGNMENTS) {
             const alignmentElement = createElement('div');
-            alignmentElement.classList.add(styles.elements[align]);
+            alignmentElement.classList.add(styles.elements.group, styles.modifiers.group[align]);
             element.appendChild(alignmentElement);
         }
     }

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
@@ -67,7 +67,6 @@ const zoom: AgToolbarOptions['zoom'] = {
         },
         {
             icon: 'arrows',
-            label: 'Reset',
             tooltip: 'Reset the zoom',
             value: 'reset-zoom',
         },

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarProperties.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarProperties.ts
@@ -1,7 +1,7 @@
 import { BaseProperties } from '../../util/properties';
 import { ObserveChanges } from '../../util/proxy';
 import { ARRAY, BOOLEAN, UNION, Validate } from '../../util/validation';
-import type { ToolbarAlignment, ToolbarButton, ToolbarPosition } from './toolbarTypes';
+import { type ToolbarAlignment, type ToolbarButton, ToolbarPosition } from './toolbarTypes';
 
 export class ToolbarGroupProperties extends BaseProperties {
     @ObserveChanges<ToolbarGroupProperties>((target) => {
@@ -19,8 +19,8 @@ export class ToolbarGroupProperties extends BaseProperties {
     @ObserveChanges<ToolbarGroupProperties>((target) => {
         target.onChange(target.enabled);
     })
-    @Validate(UNION(['top', 'right', 'bottom', 'left']), { optional: true })
-    position: ToolbarPosition = 'top';
+    @Validate(UNION(['top', 'right', 'bottom', 'left', 'floating-top', 'floating-bottom']), { optional: true })
+    position: ToolbarPosition = ToolbarPosition.Top;
 
     @ObserveChanges<ToolbarGroupProperties>((target) => {
         target.onButtonsChange(target.buttons);

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
@@ -1,19 +1,27 @@
+import { ToolbarPosition } from './toolbarTypes';
+
 export const block = 'ag-charts-toolbar';
 export const elements = {
+    group: `${block}__group`,
     button: `${block}__button`,
-    start: `${block}__start`,
-    center: `${block}__center`,
-    end: `${block}__end`,
     icon: `${block}__icon`,
     label: `${block}__label`,
 };
 export const modifiers = {
-    top: `${block}--top`,
-    right: `${block}--right`,
-    bottom: `${block}--bottom`,
-    left: `${block}--left`,
+    [ToolbarPosition.Top]: `${block}--top`,
+    [ToolbarPosition.Right]: `${block}--right`,
+    [ToolbarPosition.Bottom]: `${block}--bottom`,
+    [ToolbarPosition.Left]: `${block}--left`,
+    [ToolbarPosition.FloatingTop]: `${block}--floating-top`,
+    [ToolbarPosition.FloatingBottom]: `${block}--floating-bottom`,
     hidden: `${block}--hidden`,
     preventFlash: `${block}--prevent-flash`,
+    floatingHidden: `${block}--floating-hidden`,
+    group: {
+        start: `${elements.group}--start`,
+        center: `${elements.group}--center`,
+        end: `${elements.group}--end`,
+    },
     button: {
         hidden: `${elements.button}--hidden`,
     },
@@ -32,41 +40,57 @@ export const css = `
 }
 
 .${modifiers.hidden},
-.${modifiers.preventFlash} {
+.${modifiers.preventFlash},
+.${modifiers.floatingHidden} {
     visibility: hidden;
 }
 
-.${modifiers.top}, .${modifiers.bottom} {
+.${modifiers[ToolbarPosition.Top]},
+.${modifiers[ToolbarPosition.Bottom]} {
     flex-direction: row;
     height: var(--ag-charts-toolbar-size);
     padding: 0 var(--ag-charts-toolbar-padding);
 }
 
-.${modifiers.left}, .${modifiers.right} {
+.${modifiers[ToolbarPosition.Left]},
+.${modifiers[ToolbarPosition.Right]} {
     flex-direction: column;
     padding: var(--ag-charts-toolbar-padding) 0;
     width: var(--ag-charts-toolbar-size);
 }
 
-.${elements.start}, .${elements.center}, .${elements.end} {
+.${modifiers[ToolbarPosition.FloatingTop]},
+.${modifiers[ToolbarPosition.FloatingBottom]} {
+    background: none;
+    border: none;
+    flex-direction: row;
+    height: var(--ag-charts-toolbar-size);
+    padding: 0 var(--ag-charts-toolbar-padding);
+}
+
+.${elements.group} {
     display: flex;
     flex-direction: inherit;
     flex-wrap: inherit;
     max-width: 100%;
 }
 
-.${modifiers.top} .${elements.center},
-.${modifiers.top} .${elements.end},
-.${modifiers.bottom} .${elements.center},
-.${modifiers.bottom} .${elements.end} {
+.${modifiers.group.center},
+.${modifiers.group.end} {
     margin-left: auto;
 }
 
-.${modifiers.left} .${elements.center},
-.${modifiers.left} .${elements.end},
-.${modifiers.right} .${elements.center},
-.${modifiers.right} .${elements.end} {
+.${modifiers[ToolbarPosition.Left]} .${modifiers.group.center},
+.${modifiers[ToolbarPosition.Left]} .${modifiers.group.end},
+.${modifiers[ToolbarPosition.Right]} .${modifiers.group.center},
+.${modifiers[ToolbarPosition.Right]} .${modifiers.group.end} {
+    margin-left: 0;
     margin-top: auto;
+}
+
+.${modifiers[ToolbarPosition.FloatingTop]} .${elements.group},
+.${modifiers[ToolbarPosition.FloatingBottom]} .${elements.group} {
+    gap: 1em;
 }
 
 .${elements.button} {
@@ -80,17 +104,25 @@ export const css = `
     padding: 0;
 }
 
-.${modifiers.top} .${elements.button},
-.${modifiers.bottom} .${elements.button} {
+.${modifiers[ToolbarPosition.Top]} .${elements.button},
+.${modifiers[ToolbarPosition.Bottom]} .${elements.button},
+.${modifiers[ToolbarPosition.FloatingTop]} .${elements.button},
+.${modifiers[ToolbarPosition.FloatingBottom]} .${elements.button} {
     min-width: var(--ag-charts-toolbar-size);
     padding: 0 var(--ag-charts-toolbar-padding);
 }
 
-.${modifiers.left} .${elements.button},
-.${modifiers.right} .${elements.button} {
+.${modifiers[ToolbarPosition.Left]} .${elements.button},
+.${modifiers[ToolbarPosition.Right]} .${elements.button} {
     height: var(--ag-charts-toolbar-size);
     max-width: 100%;
     overflow: hidden;
+}
+
+.${modifiers[ToolbarPosition.FloatingTop]} .${elements.button},
+.${modifiers[ToolbarPosition.FloatingBottom]} .${elements.button} {
+    background: var(--ag-charts-toolbar-background-color);
+    border: var(--ag-charts-toolbar-border-critical);
 }
 
 .${modifiers.button.hidden} {

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarTypes.ts
@@ -4,8 +4,16 @@ export const TOOLBAR_ALIGNMENTS: ToolbarAlignment[] = ['start', 'center', 'end']
 export type ToolbarGroup = 'annotations' | 'ranges' | 'zoom';
 export const TOOLBAR_GROUPS: ToolbarGroup[] = ['annotations', 'ranges', 'zoom'];
 
-export type ToolbarPosition = 'top' | 'right' | 'bottom' | 'left';
-export const TOOLBAR_POSITIONS: ToolbarPosition[] = ['top', 'right', 'bottom', 'left'];
+export enum ToolbarPosition {
+    Top = 'top',
+    Right = 'right',
+    Bottom = 'bottom',
+    Left = 'left',
+    FloatingTop = 'floating-top',
+    FloatingBottom = 'floating-bottom',
+}
+
+export const TOOLBAR_POSITIONS: ToolbarPosition[] = Object.values(ToolbarPosition);
 
 export interface ToolbarButton {
     icon?: string;

--- a/packages/ag-charts-community/src/module/baseModule.ts
+++ b/packages/ag-charts-community/src/module/baseModule.ts
@@ -16,4 +16,5 @@ export interface BaseModule<T extends ChartTypes = ChartTypes> {
     packageType: 'community' | 'enterprise';
     chartTypes: T[];
     identifier?: string;
+    dependencies?: string[];
 }

--- a/packages/ag-charts-community/src/module/module.ts
+++ b/packages/ag-charts-community/src/module/module.ts
@@ -25,8 +25,13 @@ export abstract class BaseModuleInstance {
 class ModuleRegistry {
     readonly modules: Module[] = [];
 
+    private readonly dependencies: Set<string> = new Set();
+    private readonly dependents: Set<string> = new Set();
+
     register(...modules: Module[]) {
         for (const module of modules) {
+            this.registerDependencies(module);
+
             const otherModule = this.modules.find(
                 (other) =>
                     module.type === other.type &&
@@ -52,10 +57,47 @@ class ModuleRegistry {
 
     *byType<T extends Module>(...types: Module['type'][]): Generator<T> {
         for (const module of this.modules) {
-            if (types.includes(module.type)) {
+            if (types.includes(module.type) && this.dependencies.has(module.optionsKey)) {
                 yield module as T;
             }
         }
+
+        for (const module of this.modules) {
+            if (
+                types.includes(module.type) &&
+                !this.dependencies.has(module.optionsKey) &&
+                !this.dependents.has(module.optionsKey)
+            ) {
+                yield module as T;
+            }
+        }
+
+        for (const module of this.modules) {
+            if (types.includes(module.type) && this.dependents.has(module.optionsKey)) {
+                yield module as T;
+            }
+        }
+    }
+
+    private registerDependencies(module: Module) {
+        if (module.dependencies == null || module.dependencies.length === 0) return;
+
+        if (this.dependencies.has(module.optionsKey)) {
+            throw new Error(
+                `Module [${module.optionsKey}] can not both be depended upon by any module and have dependencies of [${module.dependencies}].`
+            );
+        }
+
+        for (const dep of module.dependencies) {
+            if (this.dependents.has(dep)) {
+                throw new Error(
+                    `Module [${dep}] can not both be depended upon by any module and have dependencies of [${module.optionsKey}].`
+                );
+            }
+            this.dependencies.add(dep);
+        }
+
+        this.dependents.add(module.optionsKey);
     }
 }
 

--- a/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/toolbarOptions.ts
@@ -15,7 +15,7 @@ export interface AgToolbarGroup extends Toggleable {
 }
 
 export type AgToolbarGroupAlignment = 'start' | 'center' | 'end';
-export type AgToolbarGroupPosition = 'top' | 'left' | 'right' | 'bottom';
+export type AgToolbarGroupPosition = 'top' | 'left' | 'right' | 'bottom' | 'floating-top' | 'floating-bottom';
 
 export interface AgToolbarButton {
     /** Icon to display on the button. */

--- a/packages/ag-charts-community/src/options/chart/zoomOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/zoomOptions.ts
@@ -1,3 +1,4 @@
+import type { AgToolbarZoomGroup } from './toolbarOptions';
 import type { Ratio } from './types';
 
 export type AgZoomAnchorPoint = 'pointer' | 'start' | 'middle' | 'end';
@@ -22,6 +23,8 @@ export interface AgZoomRatio {
     end?: number;
 }
 
+export interface AgZoomButtons extends Omit<AgToolbarZoomGroup, 'align' | 'position'> {}
+
 export interface AgZoomOptions {
     /**
      * The anchor point for the x-axis about which to zoom into when scrolling.
@@ -38,8 +41,16 @@ export interface AgZoomOptions {
      * Default: `x`
      */
     axes?: AgZoomAxes;
+    /** A set of buttons to perform common zoom actions. */
+    buttons?: AgZoomButtons;
     /**
-     *  Set to `true` to enable the zoom module.
+     * Rate of deceleration of panning when dragging and releasing a zoomed chart. A value of 1 will cause the panning to stop immediately when released.
+     * Typical values are between 0.01 for a short pan duration, and 0.002 for a long pan duration.
+     * Default: `1`
+     */
+    deceleration?: Ratio;
+    /**
+     * Set to `true` to enable the zoom module.
      * Default: `false`
      */
     enabled?: boolean;
@@ -96,10 +107,4 @@ export interface AgZoomOptions {
      * Default: `0.1`
      */
     scrollingStep?: Ratio;
-    /**
-     * Rate of deceleration of panning when dragging and releasing a zoomed chart. A value of 1 will cause the panning to stop immediately when released.
-     * Typical values are between 0.01 for a short pan duration, and 0.002 for a long pan duration.
-     * Default: `1`
-     */
-    deceleration?: Ratio;
 }

--- a/packages/ag-charts-community/src/styles/theme-default.ts
+++ b/packages/ag-charts-community/src/styles/theme-default.ts
@@ -27,7 +27,7 @@ export default `
     --ag-charts-toolbar-border-critical: var(--ag-charts-border-critical, solid 1px) var(--ag-charts-border-color);
     --ag-charts-toolbar-hover-color: var(
         --ag-row-hover-color,
-        color-mix(in srgb, transparent, var(--ag-charts-active-color) 12%)
+        color-mix(in srgb, var(--ag-charts-background-color), var(--ag-charts-active-color) 12%)
     );
     --ag-charts-toolbar-disabled-foreground-color: var(
         --ag-disabled-foreground-color,

--- a/packages/ag-charts-community/src/util/listeners.ts
+++ b/packages/ag-charts-community/src/util/listeners.ts
@@ -9,6 +9,7 @@ export type Listener<H extends Handler> = {
 
 export class Listeners<EventType extends string, EventHandler extends Handler> {
     protected readonly registeredListeners: Map<EventType, Listener<EventHandler>[]> = new Map();
+    protected pendingDispatches: Array<{ eventType: EventType; params: Parameters<EventHandler> }> = [];
 
     public addListener(eventType: EventType, handler: EventHandler) {
         const record = { symbol: Symbol(eventType), handler };
@@ -17,6 +18,12 @@ export class Listeners<EventType extends string, EventHandler extends Handler> {
             this.registeredListeners.get(eventType)!.push(record);
         } else {
             this.registeredListeners.set(eventType, [record]);
+        }
+
+        for (const pending of this.pendingDispatches) {
+            if (pending.eventType === eventType) {
+                this.dispatch(eventType, ...pending.params);
+            }
         }
 
         return () => this.removeListener(record.symbol);
@@ -43,6 +50,21 @@ export class Listeners<EventType extends string, EventHandler extends Handler> {
                 Logger.errorOnce(e);
             }
         }
+    }
+
+    /**
+     * Ensure the event is always dispatched. If there are no listeners ready, save the event as pending and dispatch
+     * to listeners as soon as they are added.
+     */
+    public dispatchAlwaysResolve(eventType: EventType, ...params: Parameters<EventHandler>): void {
+        if (this.getListenersByType(eventType).length === 0) {
+            this.pendingDispatches.push({ eventType, params });
+            return;
+        }
+
+        this.pendingDispatches = this.pendingDispatches.filter((pending) => pending.eventType !== eventType);
+
+        this.dispatch(eventType, ...params);
     }
 
     public dispatchWrapHandlers(

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsModule.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsModule.ts
@@ -7,6 +7,7 @@ export const AnnotationsModule: _ModuleSupport.Module = {
     optionsKey: 'annotations',
     packageType: 'enterprise',
     chartTypes: ['cartesian'],
+    dependencies: ['toolbar'],
     instanceConstructor: Annotations,
     themeTemplate: {
         annotations: {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
@@ -1,0 +1,121 @@
+import type { _ModuleSupport, _Scene } from 'ag-charts-community';
+
+import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
+import {
+    UNIT,
+    constrainZoom,
+    definedZoomState,
+    dx,
+    dy,
+    isZoomEqual,
+    isZoomLess,
+    pointToRatio,
+    scaleZoomCenter,
+    translateZoom,
+    unitZoomState,
+} from './zoomUtils';
+
+type ContextMenuActionParams = _ModuleSupport.ContextMenuActionParams;
+
+const CONTEXT_ZOOM_ACTION_ID = 'zoom-action';
+const CONTEXT_PAN_ACTION_ID = 'pan-action';
+
+export class ZoomContextMenu {
+    constructor(
+        private readonly contextMenuRegistry: _ModuleSupport.ContextMenuRegistry,
+        private readonly zoomManager: _ModuleSupport.ZoomManager,
+        private readonly updateZoom: (zoom: DefinedZoomState) => void
+    ) {}
+
+    public registerActions(
+        enabled: boolean | undefined,
+        zoom: DefinedZoomState,
+        props: ZoomProperties,
+        rect?: _Scene.BBox
+    ) {
+        if (!enabled) return;
+
+        const { contextMenuRegistry } = this;
+
+        contextMenuRegistry.registerDefaultAction({
+            id: CONTEXT_ZOOM_ACTION_ID,
+            label: 'Zoom to here',
+            action: (params) => this.onZoomToHere(params, props, rect),
+        });
+        contextMenuRegistry.registerDefaultAction({
+            id: CONTEXT_PAN_ACTION_ID,
+            label: 'Pan to here',
+            action: (params) => this.onPanToHere(params, props, rect),
+        });
+
+        this.toggleActions(zoom, props);
+    }
+
+    public toggleActions(zoom: DefinedZoomState, props: ZoomProperties) {
+        const { contextMenuRegistry } = this;
+
+        if (isZoomLess(zoom, props.minRatioX, props.minRatioY)) {
+            contextMenuRegistry.disableAction(CONTEXT_ZOOM_ACTION_ID);
+        } else {
+            contextMenuRegistry.enableAction(CONTEXT_ZOOM_ACTION_ID);
+        }
+
+        if (isZoomEqual(zoom, unitZoomState())) {
+            contextMenuRegistry.disableAction(CONTEXT_PAN_ACTION_ID);
+        } else {
+            contextMenuRegistry.enableAction(CONTEXT_PAN_ACTION_ID);
+        }
+    }
+
+    private onZoomToHere({ event }: ContextMenuActionParams, props: ZoomProperties, rect?: _Scene.BBox) {
+        const { enabled, isScalingX, isScalingY, minRatioX, minRatioY } = props;
+
+        if (!enabled || !rect || !event || !event.target) return;
+
+        const zoom = definedZoomState(this.zoomManager.getZoom());
+        const origin = pointToRatio(rect, event.clientX, event.clientY);
+
+        const scaledOriginX = origin.x * dx(zoom);
+        const scaledOriginY = origin.y * dy(zoom);
+
+        const size = UNIT.max - UNIT.min;
+        const halfSize = size / 2;
+
+        let newZoom = {
+            x: { min: origin.x - halfSize, max: origin.x + halfSize },
+            y: { min: origin.y - halfSize, max: origin.y + halfSize },
+        };
+
+        newZoom = scaleZoomCenter(newZoom, isScalingX ? minRatioX : size, isScalingY ? minRatioY : size);
+        newZoom = translateZoom(newZoom, zoom.x.min - origin.x + scaledOriginX, zoom.y.min - origin.y + scaledOriginY);
+
+        this.updateZoom(constrainZoom(newZoom));
+    }
+
+    private onPanToHere({ event }: ContextMenuActionParams, props: ZoomProperties, rect?: _Scene.BBox) {
+        const { enabled } = props;
+
+        if (!enabled || !rect || !event || !event.target) return;
+
+        const zoom = definedZoomState(this.zoomManager.getZoom());
+        const origin = pointToRatio(rect, event.clientX, event.clientY);
+
+        const scaleX = dx(zoom);
+        const scaleY = dy(zoom);
+
+        const scaledOriginX = origin.x * scaleX;
+        const scaledOriginY = origin.y * scaleY;
+
+        const halfSize = (UNIT.max - UNIT.min) / 2;
+
+        let newZoom = {
+            x: { min: origin.x - halfSize, max: origin.x + halfSize },
+            y: { min: origin.y - halfSize, max: origin.y + halfSize },
+        };
+
+        newZoom = scaleZoomCenter(newZoom, scaleX, scaleY);
+        newZoom = translateZoom(newZoom, zoom.x.min - origin.x + scaledOriginX, zoom.y.min - origin.y + scaledOriginY);
+
+        this.updateZoom(constrainZoom(newZoom));
+    }
+}

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomModule.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomModule.ts
@@ -7,6 +7,7 @@ export const ZoomModule: _ModuleSupport.Module = {
     optionsKey: 'zoom',
     packageType: 'enterprise',
     chartTypes: ['cartesian', 'topology'],
+    dependencies: ['toolbar'],
     instanceConstructor: Zoom,
     themeTemplate: {
         zoom: {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomModule.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomModule.ts
@@ -13,6 +13,36 @@ export const ZoomModule: _ModuleSupport.Module = {
             anchorPointX: 'end',
             anchorPointY: 'middle',
             axes: 'x',
+            buttons: {
+                enabled: true,
+                buttons: [
+                    {
+                        icon: 'desc',
+                        tooltip: 'Zoom out',
+                        value: 'zoom-out',
+                    },
+                    {
+                        icon: 'asc',
+                        tooltip: 'Zoom in',
+                        value: 'zoom-in',
+                    },
+                    {
+                        icon: 'left',
+                        tooltip: 'Pan left',
+                        value: 'pan-left',
+                    },
+                    {
+                        icon: 'right',
+                        tooltip: 'Pan right',
+                        value: 'pan-right',
+                    },
+                    {
+                        icon: 'arrows',
+                        tooltip: 'Reset the zoom',
+                        value: 'reset-zoom',
+                    },
+                ],
+            },
             enabled: false,
             enableAxisDragging: true,
             enableDoubleClickToReset: true,

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
@@ -1,6 +1,6 @@
-import type { AgZoomAnchorPoint, _ModuleSupport, _Scene } from 'ag-charts-community';
+import type { _ModuleSupport, _Scene } from 'ag-charts-community';
 
-import type { DefinedZoomState } from './zoomTypes';
+import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
 import {
     constrainZoom,
     definedZoomState,
@@ -14,22 +14,19 @@ import {
 export class ZoomScroller {
     update(
         event: _ModuleSupport.PointerInteractionEvent<'wheel'>,
-        step: number,
-        anchorPointX: AgZoomAnchorPoint,
-        anchorPointY: AgZoomAnchorPoint,
-        isScalingX: boolean,
-        isScalingY: boolean,
+        props: ZoomProperties,
         bbox: _Scene.BBox,
-        currentZoom?: _ModuleSupport.AxisZoomState
+        oldZoom: DefinedZoomState
     ): DefinedZoomState {
-        const oldZoom = definedZoomState(currentZoom);
         const sourceEvent = event.sourceEvent as WheelEvent;
+
+        const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
 
         // Scale the zoom bounding box
         const dir = event.deltaY;
         let newZoom = definedZoomState(oldZoom);
-        newZoom.x.max += isScalingX ? step * dir * dx(oldZoom) : 0;
-        newZoom.y.max += isScalingY ? step * dir * dy(oldZoom) : 0;
+        newZoom.x.max += isScalingX ? scrollingStep * dir * dx(oldZoom) : 0;
+        newZoom.y.max += isScalingY ? scrollingStep * dir * dy(oldZoom) : 0;
 
         if ((anchorPointX === 'pointer' && isScalingX) || (anchorPointY === 'pointer' && isScalingY)) {
             newZoom = this.scaleZoomToPointer(sourceEvent, isScalingX, isScalingY, bbox, oldZoom, newZoom);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
@@ -1,7 +1,7 @@
 import type { _ModuleSupport, _Scene } from 'ag-charts-community';
 
 import type { ZoomRect } from './scenes/zoomRect';
-import type { DefinedZoomState, ZoomCoords } from './zoomTypes';
+import type { DefinedZoomState, ZoomCoords, ZoomProperties } from './zoomTypes';
 import { constrainZoom, definedZoomState, multiplyZoom, pointToRatio, scaleZoom, translateZoom } from './zoomUtils';
 
 // "Re-rewind, when the crowd say..."
@@ -16,25 +16,13 @@ export class ZoomSelector {
 
     update(
         event: _ModuleSupport.PointerInteractionEvent<'drag' | 'hover'>,
-        minRatioX: number,
-        minRatioY: number,
-        isScalingX: boolean,
-        isScalingY: boolean,
+        props: ZoomProperties,
         bbox?: _Scene.BBox,
         currentZoom?: _ModuleSupport.AxisZoomState
     ): void {
         this.rect.visible = true;
 
-        this.updateCoords(
-            event.offsetX,
-            event.offsetY,
-            minRatioX,
-            minRatioY,
-            isScalingX,
-            isScalingY,
-            bbox,
-            currentZoom
-        );
+        this.updateCoords(event.offsetX, event.offsetY, props, bbox, currentZoom);
         this.updateRect(bbox);
     }
 
@@ -71,10 +59,7 @@ export class ZoomSelector {
     private updateCoords(
         x: number,
         y: number,
-        minRatioX: number,
-        minRatioY: number,
-        isScalingX: boolean,
-        isScalingY: boolean,
+        props: ZoomProperties,
         bbox?: _Scene.BBox,
         currentZoom?: _ModuleSupport.AxisZoomState
     ): void {
@@ -87,6 +72,8 @@ export class ZoomSelector {
         this.coords.y2 = y;
 
         if (!bbox) return;
+
+        const { isScalingX, isScalingY, minRatioX, minRatioY } = props;
 
         // Ensure the selection is always at the same aspect ratio, using the width as the source of truth for the size
         // of the selection and limit it to the minimum dimensions.

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -1,0 +1,120 @@
+import { _ModuleSupport } from 'ag-charts-community';
+
+import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
+import {
+    DEFAULT_ANCHOR_POINT_X,
+    DEFAULT_ANCHOR_POINT_Y,
+    UNIT,
+    constrainZoom,
+    definedZoomState,
+    dx,
+    isZoomEqual,
+    isZoomLess,
+    scaleZoom,
+    scaleZoomAxisWithAnchor,
+    translateZoom,
+    unitZoomState,
+} from './zoomUtils';
+
+const { ToolbarManager } = _ModuleSupport;
+
+export class ZoomToolbar {
+    constructor(
+        private readonly toolbarManager: _ModuleSupport.ToolbarManager,
+        private readonly zoomManager: _ModuleSupport.ZoomManager,
+        private readonly getResetZoom: () => DefinedZoomState,
+        private readonly updateZoom: (zoom: DefinedZoomState) => void
+    ) {}
+
+    public toggle(enabled: boolean | undefined, zoom: DefinedZoomState, props: ZoomProperties) {
+        this.toggleGroups(enabled);
+        if (enabled) {
+            this.toggleButtons(zoom, props);
+        }
+    }
+
+    public toggleButtons(zoom: DefinedZoomState, props: ZoomProperties) {
+        const { toolbarManager } = this;
+
+        const isMaxZoom = isZoomEqual(zoom, unitZoomState());
+        const isMinZoom = isZoomLess(zoom, props.minRatioX, props.minRatioY);
+        const isResetZoom = isZoomEqual(zoom, this.getResetZoom());
+
+        toolbarManager.toggleButton('zoom', 'pan-start', zoom.x.min > UNIT.min);
+        toolbarManager.toggleButton('zoom', 'pan-end', zoom.x.max < UNIT.max);
+        toolbarManager.toggleButton('zoom', 'pan-left', zoom.x.min > UNIT.min);
+        toolbarManager.toggleButton('zoom', 'pan-right', zoom.x.max < UNIT.max);
+        toolbarManager.toggleButton('zoom', 'zoom-out', !isMaxZoom);
+        toolbarManager.toggleButton('zoom', 'zoom-in', !isMinZoom);
+        toolbarManager.toggleButton('zoom', 'reset-zoom', !isResetZoom);
+    }
+
+    public onButtonPress(event: _ModuleSupport.ToolbarButtonPressedEvent, props: ZoomProperties) {
+        this.onButtonPressRanges(event, props);
+        this.onButtonPressZoom(event, props);
+    }
+
+    private toggleGroups(enabled?: boolean) {
+        this.toolbarManager?.toggleGroup('ranges', Boolean(enabled));
+        this.toolbarManager?.toggleGroup('zoom', Boolean(enabled));
+    }
+
+    private onButtonPressRanges(event: _ModuleSupport.ToolbarButtonPressedEvent, props: ZoomProperties) {
+        if (!ToolbarManager.isGroup('ranges', event)) return;
+
+        const { rangeX } = props;
+
+        const time = event.value;
+        if (typeof time === 'number') {
+            rangeX.extendToEnd(time);
+        } else if (Array.isArray(time)) {
+            rangeX.updateWith(() => time);
+        } else if (typeof time === 'function') {
+            rangeX.updateWith(time);
+        }
+    }
+
+    private onButtonPressZoom(event: _ModuleSupport.ToolbarButtonPressedEvent, props: ZoomProperties) {
+        if (!ToolbarManager.isGroup('zoom', event)) return;
+
+        const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
+
+        const oldZoom = definedZoomState(this.zoomManager.getZoom());
+        let zoom = definedZoomState(oldZoom);
+
+        switch (event.value) {
+            case 'reset-zoom':
+                zoom = this.getResetZoom();
+                break;
+
+            case 'pan-start':
+                zoom.x.max = dx(zoom);
+                zoom.x.min = 0;
+                break;
+
+            case 'pan-end':
+                zoom.x.min = UNIT.max - dx(zoom);
+                zoom.x.max = UNIT.max;
+                break;
+
+            case 'pan-left':
+            case 'pan-right':
+                zoom = translateZoom(zoom, event.value === 'pan-left' ? -dx(zoom) : dx(zoom), 0);
+                break;
+
+            case 'zoom-in':
+            case 'zoom-out':
+                const scale = event.value === 'zoom-in' ? 1 - scrollingStep : 1 + scrollingStep;
+
+                const useAnchorPointX = anchorPointX === 'pointer' ? DEFAULT_ANCHOR_POINT_X : anchorPointX;
+                const useAnchorPointY = anchorPointY === 'pointer' ? DEFAULT_ANCHOR_POINT_Y : anchorPointY;
+
+                zoom = scaleZoom(zoom, isScalingX ? scale : 1, isScalingY ? scale : 1);
+                zoom.x = scaleZoomAxisWithAnchor(zoom.x, oldZoom.x, useAnchorPointX);
+                zoom.y = scaleZoomAxisWithAnchor(zoom.y, oldZoom.y, useAnchorPointY);
+                break;
+        }
+
+        this.updateZoom(constrainZoom(zoom));
+    }
+}

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
@@ -1,4 +1,6 @@
-import type { _ModuleSupport } from 'ag-charts-community';
+import type { AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
+
+import type { ZoomRange } from './zoomRange';
 
 export interface DefinedZoomState extends _ModuleSupport.AxisZoomState {
     x: _ModuleSupport.ZoomState;
@@ -16,3 +18,15 @@ export type AxisZoomStates = Record<
     string,
     { direction: _ModuleSupport.ChartAxisDirection; zoom: _ModuleSupport.ZoomState | undefined }
 >;
+
+export interface ZoomProperties {
+    anchorPointX: AgZoomAnchorPoint;
+    anchorPointY: AgZoomAnchorPoint;
+    enabled: boolean;
+    isScalingX: boolean;
+    isScalingY: boolean;
+    minRatioX: number;
+    minRatioY: number;
+    rangeX: ZoomRange;
+    scrollingStep: number;
+}

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -2,9 +2,11 @@ import { AgZoomAnchorPoint, _ModuleSupport, _Scene } from 'ag-charts-community';
 
 import type { DefinedZoomState } from './zoomTypes';
 
-const { clamp, isEqual } = _ModuleSupport;
+const { clamp, isEqual, round } = _ModuleSupport;
 
 export const UNIT = { min: 0, max: 1 };
+export const DEFAULT_ANCHOR_POINT_X: AgZoomAnchorPoint = 'end';
+export const DEFAULT_ANCHOR_POINT_Y: AgZoomAnchorPoint = 'middle';
 
 const constrain = (value: number, min = UNIT.min, max = UNIT.max) => clamp(min, value, max);
 
@@ -27,6 +29,13 @@ export function isZoomEqual(left: DefinedZoomState, right: DefinedZoomState, eps
         isEqual(left.y.min, right.y.min, epsilon) &&
         isEqual(left.y.max, right.y.max, epsilon)
     );
+}
+
+export function isZoomLess(zoom: DefinedZoomState, minRatioX: number, minRatioY: number) {
+    const isMinXZoom = round(dx(zoom), 10) <= minRatioX;
+    const isMinYZoom = round(dy(zoom), 10) <= minRatioY;
+
+    return isMinXZoom || isMinYZoom;
 }
 
 export function definedZoomState(zoom?: _ModuleSupport.AxisZoomState): DefinedZoomState {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11367

Includes some refactoring of the zoom module to separate out context menu and toolbar actions.

See [17358ad](https://github.com/ag-grid/ag-charts/pull/1457/commits/17358adffaa564cf1a2aee04dcbaaab76bd36890) for just this ticket.