### PR TITLE
AG-11290 - Stop showing tooltip for invalid BarSeries datums.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
@@ -1,6 +1,6 @@
 import type { NodeUpdateState } from '../../../motion/fromToMotion';
 import type { FontStyle, FontWeight } from '../../../options/agChartOptions';
-import type { Point } from '../../../scene/point';
+import type { Point, SizedPoint } from '../../../scene/point';
 import type { ProcessedOutputDiff } from '../../data/dataModel';
 import type { SeriesNodeDatum } from '../seriesTypes';
 import type { CartesianSeriesNodeDataContext, CartesianSeriesNodeDatum } from './cartesianSeries';
@@ -33,7 +33,9 @@ export type AreaPathDatum = {
     readonly itemId: string;
 };
 
-export interface MarkerSelectionDatum extends Required<CartesianSeriesNodeDatum> {
+export interface MarkerSelectionDatum extends CartesianSeriesNodeDatum {
+    readonly point: Readonly<SizedPoint>;
+    readonly yKey: string;
     readonly index: number;
     readonly fill?: string;
     readonly stroke?: string;

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -355,7 +355,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
                     bottomLeftCornerRadius: !isUpward,
                     clipBBox,
                     label: labelDatum,
-                    valid: yRawValue != null,
+                    missing: yRawValue == null,
                 };
                 context.nodeData.push(nodeData);
                 context.labelData.push(nodeData);

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -355,6 +355,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
                     bottomLeftCornerRadius: !isUpward,
                     clipBBox,
                     label: labelDatum,
+                    valid: yRawValue != null,
                 };
                 context.nodeData.push(nodeData);
                 context.labelData.push(nodeData);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesProperties.ts
@@ -6,6 +6,7 @@ import type {
     LabelPlacement,
 } from '../../../options/agChartOptions';
 import { RedrawType, SceneChangeDetection } from '../../../scene/changeDetectable';
+import type { SizedPoint } from '../../../scene/point';
 import type { MeasuredLabel } from '../../../scene/util/labelPlacement';
 import {
     COLOR_STRING_ARRAY,
@@ -22,7 +23,8 @@ import { SeriesMarker } from '../seriesMarker';
 import { SeriesTooltip } from '../seriesTooltip';
 import { CartesianSeriesNodeDatum, CartesianSeriesProperties } from './cartesianSeries';
 
-export interface BubbleNodeDatum extends Required<CartesianSeriesNodeDatum> {
+export interface BubbleNodeDatum extends CartesianSeriesNodeDatum {
+    readonly point: Readonly<SizedPoint>;
     readonly sizeValue: any;
     readonly label: MeasuredLabel;
     readonly placement: LabelPlacement;

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -535,6 +535,8 @@ export abstract class CartesianSeries<
 
     protected *datumNodesIter(): Iterable<TNode> {
         for (const { node } of this.datumSelection) {
+            if (node.datum.valid === false) continue;
+
             yield node;
         }
     }
@@ -573,14 +575,14 @@ export abstract class CartesianSeries<
             match = markerGroup?.pickNode(x, y);
         }
 
-        if (match) {
+        if (match && match.datum.valid !== false) {
             return { datum: match.datum, distance: 0 };
-        } else {
-            for (const mod of this.moduleMap.modules()) {
-                const { datum } = mod.pickNodeExact(point) ?? {};
-                if (datum !== undefined) {
-                    return { datum, distance: 0 };
-                }
+        }
+
+        for (const mod of this.moduleMap.modules()) {
+            const { datum } = mod.pickNodeExact(point) ?? {};
+            if (datum !== undefined && datum.valid !== false) {
+                return { datum, distance: 0 };
             }
         }
     }
@@ -662,8 +664,8 @@ export abstract class CartesianSeries<
         let closestDatum: SeriesNodeDatum | undefined;
 
         for (const datum of contextNodeData.nodeData) {
-            const { point: { x: datumX = NaN, y: datumY = NaN } = {} } = datum;
-            if (isNaN(datumX) || isNaN(datumY)) {
+            const { point: { x: datumX = NaN, y: datumY = NaN } = {}, valid } = datum;
+            if (isNaN(datumX) || isNaN(datumY) || valid === false) {
                 continue;
             }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -535,7 +535,7 @@ export abstract class CartesianSeries<
 
     protected *datumNodesIter(): Iterable<TNode> {
         for (const { node } of this.datumSelection) {
-            if (node.datum.valid === false) continue;
+            if (node.datum.missing === true) continue;
 
             yield node;
         }
@@ -575,15 +575,16 @@ export abstract class CartesianSeries<
             match = markerGroup?.pickNode(x, y);
         }
 
-        if (match && match.datum.valid !== false) {
+        if (match && match.datum.missing !== true) {
             return { datum: match.datum, distance: 0 };
         }
 
         for (const mod of this.moduleMap.modules()) {
             const { datum } = mod.pickNodeExact(point) ?? {};
-            if (datum !== undefined && datum.valid !== false) {
-                return { datum, distance: 0 };
-            }
+            if (datum == null) continue;
+            if (datum?.missing === true) continue;
+
+            return { datum, distance: 0 };
         }
     }
 
@@ -664,7 +665,7 @@ export abstract class CartesianSeries<
         let closestDatum: SeriesNodeDatum | undefined;
 
         for (const datum of contextNodeData.nodeData) {
-            const { point: { x: datumX = NaN, y: datumY = NaN } = {}, valid } = datum;
+            const { point: { x: datumX = NaN, y: datumY = NaN } = {}, missing: valid } = datum;
             if (isNaN(datumX) || isNaN(datumY) || valid === false) {
                 continue;
             }

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesProperties.ts
@@ -4,6 +4,7 @@ import type {
     AgScatterSeriesOptionsKeys,
     AgScatterSeriesTooltipRendererParams,
 } from '../../../options/agChartOptions';
+import type { SizedPoint } from '../../../scene/point';
 import type { LabelPlacement, MeasuredLabel } from '../../../scene/util/labelPlacement';
 import { COLOR_STRING_ARRAY, LABEL_PLACEMENT, NUMBER_ARRAY, OBJECT, STRING, Validate } from '../../../util/validation';
 import { Label } from '../../label';
@@ -13,7 +14,8 @@ import { SeriesTooltip } from '../seriesTooltip';
 import type { ErrorBoundSeriesNodeDatum } from '../seriesTypes';
 import { CartesianSeriesNodeDatum, CartesianSeriesProperties } from './cartesianSeries';
 
-export interface ScatterNodeDatum extends Required<CartesianSeriesNodeDatum>, ErrorBoundSeriesNodeDatum {
+export interface ScatterNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDatum {
+    readonly point: Readonly<SizedPoint>;
     readonly label: MeasuredLabel;
     readonly placement: LabelPlacement;
     readonly marker: MarkerConstructor;

--- a/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
@@ -142,7 +142,7 @@ export function pickByMatchingAngle(series: SectorSeries, point: Point): SeriesN
     const angle = Math.atan2(dy, dx);
     const sectors: SectorSceneNode[] = series.getItemNodes();
     for (const sector of sectors) {
-        if (sector.datum.valid === false) continue;
+        if (sector.datum.missing === true) continue;
 
         if (isBetweenAngles(angle, sector.startAngle, sector.endAngle)) {
             const radius = Math.sqrt(dx * dx + dy * dy);

--- a/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
@@ -142,6 +142,8 @@ export function pickByMatchingAngle(series: SectorSeries, point: Point): SeriesN
     const angle = Math.atan2(dy, dx);
     const sectors: SectorSceneNode[] = series.getItemNodes();
     for (const sector of sectors) {
+        if (sector.datum.valid === false) continue;
+
         if (isBetweenAngles(angle, sector.startAngle, sector.endAngle)) {
             const radius = Math.sqrt(dx * dx + dy * dy);
             let distance = 0;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -631,7 +631,7 @@ export abstract class Series<
 
     protected pickNodeExactShape(point: Point): SeriesNodePickMatch | undefined {
         const match = this.contentGroup.pickNode(point.x, point.y);
-        if (match && match.datum.valid !== false) {
+        if (match && match.datum.missing !== true) {
             return { datum: match.datum, distance: 0 };
         }
 
@@ -646,7 +646,7 @@ export abstract class Series<
 
     protected pickNodeNearestDistantObject<T extends Node & DistantObject>(point: Point, items: Iterable<T>) {
         const match = nearestSquared(point.x, point.y, items);
-        if (match.nearest !== undefined && match.nearest.datum.valid !== false) {
+        if (match.nearest !== undefined && match.nearest.datum.missing !== true) {
             return { datum: match.nearest.datum, distance: Math.sqrt(match.distanceSquared) };
         }
         return undefined;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -631,7 +631,11 @@ export abstract class Series<
 
     protected pickNodeExactShape(point: Point): SeriesNodePickMatch | undefined {
         const match = this.contentGroup.pickNode(point.x, point.y);
-        return match && { datum: match.datum, distance: 0 };
+        if (match && match.datum.valid !== false) {
+            return { datum: match.datum, distance: 0 };
+        }
+
+        return undefined;
     }
 
     protected pickNodeClosestDatum(_point: Point): SeriesNodePickMatch | undefined {
@@ -642,7 +646,7 @@ export abstract class Series<
 
     protected pickNodeNearestDistantObject<T extends Node & DistantObject>(point: Point, items: Iterable<T>) {
         const match = nearestSquared(point.x, point.y, items);
-        if (match.nearest !== undefined) {
+        if (match.nearest !== undefined && match.nearest.datum.valid !== false) {
             return { datum: match.nearest.datum, distance: Math.sqrt(match.distanceSquared) };
         }
         return undefined;

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -45,6 +45,7 @@ export interface SeriesNodeDatum {
     readonly itemId?: any;
     readonly datum: any;
     readonly point?: Readonly<SizedPoint>;
+    readonly valid?: boolean;
     midPoint?: Readonly<Point>;
 }
 

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -45,7 +45,7 @@ export interface SeriesNodeDatum {
     readonly itemId?: any;
     readonly datum: any;
     readonly point?: Readonly<SizedPoint>;
-    readonly valid?: boolean;
+    readonly missing?: boolean;
     midPoint?: Readonly<Point>;
 }
 

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -17,7 +17,9 @@ const { Rect, PointerEvents } = _Scene;
 const { ColorScale } = _Scale;
 const { sanitizeHtml, Color, Logger } = _Util;
 
-interface HeatmapNodeDatum extends Required<_ModuleSupport.CartesianSeriesNodeDatum> {
+interface HeatmapNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum {
+    readonly point: Readonly<_Scene.SizedPoint>;
+    midPoint: Readonly<_Scene.Point>;
     readonly width: number;
     readonly height: number;
     readonly fill: string;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeAreaProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeAreaProperties.ts
@@ -7,8 +7,7 @@ import type {
 } from 'ag-charts-community';
 import { _ModuleSupport, _Scene } from 'ag-charts-community';
 
-export interface RangeAreaMarkerDatum
-    extends Required<Omit<_ModuleSupport.CartesianSeriesNodeDatum, 'yKey' | 'yValue'>> {
+export interface RangeAreaMarkerDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDatum, 'yKey' | 'yValue'> {
     readonly index: number;
     readonly yLowKey: string;
     readonly yHighKey: string;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11290

Fixes display of invalid BarSeries datums, and plumbs in support generally for handling of invalid datums in all node search mechanisms.

Side-note: There seemed to be several spots where we were unnecessarily using a `Required<>` wrapper around `CartesianSeriesNodeDatum` when only `point` or `midPoint` were actually needing to be made required - I've removed that where necessary to avoid needing to always add a `valid` property to all cartesian series datums.