### PR TITLE
AG-11362 - Aligns tooltip renderer callback parameters with options contract.

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -590,7 +590,7 @@ export class AreaSeries extends CartesianSeries<
     getTooltipHtml(nodeDatum: MarkerSelectionDatum): TooltipContent {
         const { id: seriesId, axes, dataModel } = this;
         const { xKey, xName, yName, tooltip, marker } = this.properties;
-        const { yKey, xValue, yValue, datum } = nodeDatum;
+        const { yKey, xValue, yValue, datum, itemId } = nodeDatum;
 
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
@@ -618,6 +618,7 @@ export class AreaSeries extends CartesianSeries<
             { title, content, backgroundColor: color },
             {
                 datum,
+                itemId,
                 xKey,
                 xName,
                 yKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -1,6 +1,11 @@
 import type { ModuleContext } from '../../../module/moduleContext';
 import { fromToMotion } from '../../../motion/fromToMotion';
-import type { AgBarSeriesStyle, FontStyle, FontWeight } from '../../../options/agChartOptions';
+import type {
+    AgBarSeriesStyle,
+    AgErrorBoundSeriesTooltipRendererParams,
+    FontStyle,
+    FontWeight,
+} from '../../../options/agChartOptions';
 import { ContinuousScale } from '../../../scale/continuousScale';
 import { OrdinalTimeScale } from '../../../scale/ordinalTimeScale';
 import { BBox } from '../../../scene/bbox';
@@ -12,6 +17,7 @@ import type { Text } from '../../../scene/shape/text';
 import { extent } from '../../../util/array';
 import { sanitizeHtml } from '../../../util/sanitize';
 import { isFiniteNumber } from '../../../util/type-guards';
+import type { RequireOptional } from '../../../util/types';
 import { LogAxis } from '../../axis/logAxis';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
@@ -476,8 +482,9 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
             return EMPTY_TOOLTIP_CONTENT;
         }
 
-        const { xKey, yKey, xName, yName, fill, stroke, strokeWidth, tooltip, formatter, stackGroup } = this.properties;
-        const { xValue, yValue, datum } = nodeDatum;
+        const { xKey, yKey, xName, yName, fill, stroke, strokeWidth, tooltip, formatter, stackGroup, legendItemName } =
+            this.properties;
+        const { xValue, yValue, datum, itemId } = nodeDatum;
 
         const xString = xAxis.formatDatum(xValue);
         const yString = yAxis.formatDatum(yValue);
@@ -506,6 +513,7 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
             { title, content, backgroundColor: color },
             {
                 seriesId,
+                itemId,
                 datum,
                 xKey,
                 yKey,
@@ -514,7 +522,8 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
                 stackGroup,
                 title,
                 color,
-                ...this.getModuleTooltipParams(),
+                legendItemName,
+                ...(this.getModuleTooltipParams() as RequireOptional<AgErrorBoundSeriesTooltipRendererParams>),
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -310,6 +310,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleSeriesProperties,
             yValue,
             sizeValue,
             label: { text: labelText },
+            itemId,
         } = nodeDatum;
         const xString = sanitizeHtml(xAxis.formatDatum(xValue));
         const yString = sanitizeHtml(yAxis.formatDatum(yValue));
@@ -330,6 +331,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleSeriesProperties,
             { title, content, backgroundColor: color },
             {
                 datum,
+                itemId,
                 xKey,
                 xName,
                 yKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -470,6 +470,7 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramSeriesProper
             aggregatedValue,
             frequency,
             domain: [rangeMin, rangeMax],
+            itemId,
         } = nodeDatum;
         const title = `${sanitizeHtml(xName ?? xKey)}: ${xAxis.formatDatum(rangeMin)} - ${xAxis.formatDatum(rangeMax)}`;
         let content = yKey
@@ -491,6 +492,7 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramSeriesProper
                 domain: nodeDatum.domain,
                 frequency: nodeDatum.frequency,
             },
+            itemId,
             xKey,
             xName,
             yKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -2,6 +2,7 @@ import type { ModuleContext } from '../../../module/moduleContext';
 import { fromToMotion } from '../../../motion/fromToMotion';
 import { pathMotion } from '../../../motion/pathMotion';
 import { resetMotion } from '../../../motion/resetMotion';
+import type { AgErrorBoundSeriesTooltipRendererParams } from '../../../options/agChartOptions';
 import { ContinuousScale } from '../../../scale/continuousScale';
 import type { BBox } from '../../../scene/bbox';
 import { Group } from '../../../scene/group';
@@ -13,6 +14,7 @@ import { extent } from '../../../util/array';
 import { mergeDefaults } from '../../../util/object';
 import { sanitizeHtml } from '../../../util/sanitize';
 import { isFiniteNumber } from '../../../util/type-guards';
+import type { RequireOptional } from '../../../util/types';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import type { DataModelOptions, UngroupedDataItem } from '../../data/dataModel';
@@ -336,7 +338,7 @@ export class LineSeries extends CartesianSeries<Group, LineSeriesProperties, Lin
         }
 
         const { xKey, yKey, xName, yName, strokeWidth, marker, tooltip } = this.properties;
-        const { datum, xValue, yValue } = nodeDatum;
+        const { datum, xValue, yValue, itemId } = nodeDatum;
         const xString = xAxis.formatDatum(xValue);
         const yString = yAxis.formatDatum(yValue);
         const title = sanitizeHtml(this.properties.title ?? yName);
@@ -353,6 +355,7 @@ export class LineSeries extends CartesianSeries<Group, LineSeriesProperties, Lin
             { title, content, backgroundColor: color },
             {
                 datum,
+                itemId,
                 xKey,
                 xName,
                 yKey,
@@ -360,7 +363,7 @@ export class LineSeries extends CartesianSeries<Group, LineSeriesProperties, Lin
                 title,
                 color,
                 seriesId: this.id,
-                ...this.getModuleTooltipParams(),
+                ...(this.getModuleTooltipParams() as RequireOptional<AgErrorBoundSeriesTooltipRendererParams>),
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -1,4 +1,5 @@
 import type { ModuleContext } from '../../../module/moduleContext';
+import type { AgErrorBoundSeriesTooltipRendererParams } from '../../../options/agChartOptions';
 import { ColorScale } from '../../../scale/colorScale';
 import type { BBox } from '../../../scene/bbox';
 import { Group } from '../../../scene/group';
@@ -9,6 +10,7 @@ import type { PointLabelDatum } from '../../../scene/util/labelPlacement';
 import { extent } from '../../../util/array';
 import { mergeDefaults } from '../../../util/object';
 import { sanitizeHtml } from '../../../util/sanitize';
+import type { RequireOptional } from '../../../util/types';
 import { ChartAxisDirection } from '../../chartAxisDirection';
 import type { DataController } from '../../data/dataController';
 import { fixNumericExtent } from '../../data/dataModel';
@@ -259,7 +261,7 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesPropertie
         }
 
         const { xKey, yKey, labelKey, xName, yName, labelName, title = yName, marker, tooltip } = this.properties;
-        const { datum, xValue, yValue, label } = nodeDatum;
+        const { datum, xValue, yValue, label, itemId } = nodeDatum;
 
         const baseStyle = mergeDefaults(
             { fill: nodeDatum.fill, strokeWidth: this.getStrokeWidth(marker.strokeWidth) },
@@ -287,6 +289,7 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesPropertie
             { title, content, backgroundColor: color },
             {
                 datum,
+                itemId,
                 xKey,
                 xName,
                 yKey,
@@ -296,7 +299,7 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesPropertie
                 title,
                 color,
                 seriesId: this.id,
-                ...this.getModuleTooltipParams(),
+                ...(this.getModuleTooltipParams() as RequireOptional<AgErrorBoundSeriesTooltipRendererParams>),
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -1256,6 +1256,7 @@ export class DonutSeries extends PolarSeries<DonutNodeDatum, DonutSeriesProperti
             datum,
             angleValue,
             sectorFormat: { fill: color },
+            itemId,
         } = nodeDatum;
 
         const title = sanitizeHtml(this.properties.title?.text);
@@ -1270,6 +1271,7 @@ export class DonutSeries extends PolarSeries<DonutNodeDatum, DonutSeriesProperti
             },
             {
                 datum,
+                itemId,
                 title,
                 color,
                 seriesId: this.id,
@@ -1281,6 +1283,7 @@ export class DonutSeries extends PolarSeries<DonutNodeDatum, DonutSeriesProperti
                 calloutLabelName: this.properties.calloutLabelName,
                 sectorLabelKey: this.properties.sectorLabelKey,
                 sectorLabelName: this.properties.sectorLabelName,
+                legendItemKey: this.properties.legendItemKey,
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1254,6 +1254,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, PieSeriesProperties, Se
             datum,
             angleValue,
             sectorFormat: { fill: color },
+            itemId,
         } = nodeDatum;
 
         const title = sanitizeHtml(this.properties.title?.text);
@@ -1268,6 +1269,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, PieSeriesProperties, Se
             },
             {
                 datum,
+                itemId,
                 title,
                 color,
                 seriesId: this.id,
@@ -1279,6 +1281,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, PieSeriesProperties, Se
                 calloutLabelName: this.properties.calloutLabelName,
                 sectorLabelKey: this.properties.sectorLabelKey,
                 sectorLabelName: this.properties.sectorLabelName,
+                legendItemKey: this.properties.legendItemKey,
             }
         );
     }

--- a/packages/ag-charts-community/src/chart/series/seriesTooltip.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTooltip.ts
@@ -1,5 +1,6 @@
 import type { AgSeriesTooltipRendererParams, AgTooltipRendererResult } from '../../options/chart/tooltipOptions';
 import { BaseProperties } from '../../util/properties';
+import type { RequireOptional } from '../../util/types';
 import { BOOLEAN, FUNCTION, OBJECT, Validate } from '../../util/validation';
 import { TooltipPosition, toTooltipHtml } from '../tooltip/tooltip';
 
@@ -26,9 +27,9 @@ export class SeriesTooltip<P extends AgSeriesTooltipRendererParams> extends Base
     @Validate(OBJECT)
     readonly position = new TooltipPosition();
 
-    toTooltipHtml(defaults: AgTooltipRendererResult, params: P) {
+    toTooltipHtml(defaults: AgTooltipRendererResult, params: RequireOptional<P>) {
         if (this.renderer) {
-            return toTooltipHtml(this.renderer(params), defaults);
+            return toTooltipHtml(this.renderer(params as P), defaults);
         }
         return toTooltipHtml(defaults);
     }

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -277,8 +277,9 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
             q3Name,
             maxName,
             tooltip,
+            fill,
         } = this.properties;
-        const { datum } = nodeDatum as { datum: any };
+        const { datum, itemId } = nodeDatum;
 
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
@@ -298,12 +299,13 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
             .map(([key, name, axis]) => _Util.sanitizeHtml(`${name ?? key}: ${axis.formatDatum(datum[key])}`))
             .join(title ? '<br/>' : ', ');
 
-        const { fill } = this.getFormattedStyles(nodeDatum);
+        const { fill: formatFill } = this.getFormattedStyles(nodeDatum);
 
         return tooltip.toTooltipHtml(
             { title, content, backgroundColor: fill },
             {
                 seriesId: this.id,
+                itemId,
                 datum,
                 fill,
                 xKey,
@@ -318,6 +320,9 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
                 medianName,
                 q3Name,
                 maxName,
+                yName,
+                title,
+                color: fill ?? formatFill,
             }
         );
     }

--- a/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bullet/bulletSeries.ts
@@ -278,7 +278,7 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<
     override getTooltipHtml(nodeDatum: BulletNodeDatum): _ModuleSupport.TooltipContent {
         const { valueKey, valueName, targetKey, targetName } = this.properties;
         const axis = this.getValueAxis();
-        const { yValue: valueValue, target: { value: targetValue } = { value: undefined }, datum } = nodeDatum;
+        const { yValue: valueValue, target: { value: targetValue } = { value: undefined }, datum, itemId } = nodeDatum;
 
         if (valueKey === undefined || valueValue === undefined || axis === undefined) {
             return _ModuleSupport.EMPTY_TOOLTIP_CONTENT;
@@ -297,7 +297,7 @@ export class BulletSeries extends _ModuleSupport.AbstractBarSeries<
 
         return this.properties.tooltip.toTooltipHtml(
             { title, content, backgroundColor: this.properties.fill },
-            { datum, title, seriesId: this.id, valueKey, valueName, targetKey, targetName }
+            { datum, itemId, title, seriesId: this.id, valueKey, valueName, targetKey, targetName, color: undefined }
         );
     }
 

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeriesBase.ts
@@ -341,7 +341,7 @@ export abstract class CandlestickSeriesBase<
             lowName,
             tooltip,
         } = this.properties;
-        const { datum } = nodeDatum;
+        const { datum, itemId } = nodeDatum;
 
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
@@ -385,6 +385,10 @@ export abstract class CandlestickSeriesBase<
                 closeName,
                 highName,
                 lowName,
+                title,
+                color: styles.fill,
+                fill: styles.fill,
+                itemId,
             }
         );
     }

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -421,7 +421,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
             ctx: { callbackCache },
         } = this;
 
-        const { datum, xValue, yValue, colorValue } = nodeDatum;
+        const { datum, xValue, yValue, colorValue, itemId } = nodeDatum;
         const fill = this.isColorScaleValid() ? colorScale.convert(colorValue) : colorRange[0];
 
         let format: AgHeatmapSeriesFormat | undefined;
@@ -465,6 +465,8 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
                 title,
                 color,
                 colorKey,
+                colorName,
+                itemId,
             }
         );
     }

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -592,7 +592,7 @@ export class MapLineSeries
             formatter,
             tooltip,
         } = properties;
-        const { datum, stroke, idValue, colorValue, sizeValue, labelValue } = nodeDatum;
+        const { datum, stroke, idValue, colorValue, sizeValue, labelValue, itemId } = nodeDatum;
 
         const title = sanitizeHtml(properties.title ?? legendItemName) ?? '';
         const contentLines: string[] = [];
@@ -631,6 +631,14 @@ export class MapLineSeries
                 idKey,
                 title,
                 color,
+                itemId,
+                sizeKey,
+                colorKey,
+                colorName,
+                idName,
+                labelKey,
+                labelName,
+                sizeName,
                 ...this.getModuleTooltipParams(),
             }
         );

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -770,8 +770,10 @@ export class MapMarkerSeries
             labelName,
             formatter,
             tooltip,
+            latitudeName,
+            longitudeName,
         } = properties;
-        const { datum, fill, idValue, latValue, lonValue, sizeValue, colorValue, labelValue } = nodeDatum;
+        const { datum, fill, idValue, latValue, lonValue, sizeValue, colorValue, labelValue, itemId } = nodeDatum;
 
         const title = sanitizeHtml(properties.title ?? legendItemName) ?? '';
         const contentLines: string[] = [];
@@ -821,6 +823,16 @@ export class MapMarkerSeries
                 longitudeKey,
                 title,
                 color,
+                colorKey,
+                colorName,
+                idName,
+                itemId,
+                labelKey,
+                labelName,
+                latitudeName,
+                longitudeName,
+                sizeKey,
+                sizeName,
                 ...this.getModuleTooltipParams(),
             }
         );

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -661,7 +661,7 @@ export class MapShapeSeries
             formatter,
             tooltip,
         } = properties;
-        const { datum, fill, idValue, colorValue, labelValue } = nodeDatum;
+        const { datum, fill, idValue, colorValue, labelValue, itemId } = nodeDatum;
 
         const title = sanitizeHtml(properties.title ?? legendItemName) ?? '';
         const contentLines: string[] = [];
@@ -698,6 +698,12 @@ export class MapShapeSeries
                 idKey,
                 title,
                 color,
+                colorKey,
+                colorName,
+                idName,
+                itemId,
+                labelKey,
+                labelName,
                 ...this.getModuleTooltipParams(),
             }
         );

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -358,7 +358,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<
 
         const { id: seriesId } = this;
         const { angleKey, radiusKey, angleName, radiusName, marker, tooltip } = this.properties;
-        const { datum, angleValue, radiusValue } = nodeDatum;
+        const { datum, angleValue, radiusValue, itemId } = nodeDatum;
 
         const formattedAngleValue = typeof angleValue === 'number' ? toFixed(angleValue) : String(angleValue);
         const formattedRadiusValue = typeof radiusValue === 'number' ? toFixed(radiusValue) : String(radiusValue);
@@ -383,7 +383,17 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<
 
         return tooltip.toTooltipHtml(
             { title, content, backgroundColor: color },
-            { datum, angleKey, angleName, radiusKey, radiusName, title, color, seriesId }
+            {
+                datum,
+                angleKey,
+                angleName,
+                radiusKey,
+                radiusName,
+                title,
+                color,
+                seriesId,
+                itemId,
+            }
         );
     }
 

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeriesProperties.ts
@@ -1,10 +1,10 @@
 import type {
     AgBaseRadarSeriesOptions,
-    AgPieSeriesFormat,
-    AgPieSeriesFormatterParams,
-    AgPieSeriesTooltipRendererParams,
     AgRadarSeriesLabelFormatterParams,
+    AgRadarSeriesTooltipRendererParams,
     AgRadialSeriesOptionsKeys,
+    FillOptions,
+    StrokeOptions,
 } from 'ag-charts-community';
 import { _ModuleSupport, _Scene } from 'ag-charts-community';
 
@@ -37,6 +37,8 @@ const {
     STRING,
 } = _ModuleSupport;
 
+export type AgRadarSeriesFormat = FillOptions & StrokeOptions;
+
 export class RadarSeriesProperties<T extends AgBaseRadarSeriesOptions> extends SeriesProperties<T> {
     @Validate(STRING)
     angleKey!: string;
@@ -66,7 +68,7 @@ export class RadarSeriesProperties<T extends AgBaseRadarSeriesOptions> extends S
     lineDashOffset: number = 0;
 
     @Validate(FUNCTION, { optional: true })
-    formatter?: (params: AgPieSeriesFormatterParams<any>) => AgPieSeriesFormat;
+    formatter?: (params: AgRadarSeriesTooltipRendererParams) => AgRadarSeriesFormat;
 
     @Validate(DEGREE)
     rotation: number = 0;
@@ -78,7 +80,7 @@ export class RadarSeriesProperties<T extends AgBaseRadarSeriesOptions> extends S
     readonly label = new Label<AgRadarSeriesLabelFormatterParams>();
 
     @Validate(OBJECT)
-    readonly tooltip = new SeriesTooltip<AgPieSeriesTooltipRendererParams>();
+    readonly tooltip = new SeriesTooltip<AgRadarSeriesTooltipRendererParams>();
 
     @Validate(BOOLEAN)
     connectMissingData: boolean = false;

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -454,7 +454,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
         const { id: seriesId, axes, dataModel } = this;
         const { angleKey, angleName, radiusKey, radiusName, fill, stroke, strokeWidth, formatter, tooltip } =
             this.properties;
-        const { angleValue, radiusValue, datum } = nodeDatum;
+        const { angleValue, radiusValue, datum, itemId } = nodeDatum;
 
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
@@ -482,7 +482,19 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
 
         return tooltip.toTooltipHtml(
             { title, backgroundColor: fill, content },
-            { seriesId, datum, color, title, angleKey, radiusKey, angleName, radiusName }
+            {
+                seriesId,
+                datum,
+                color,
+                title,
+                angleKey,
+                radiusKey,
+                angleName,
+                radiusName,
+                angleValue,
+                itemId,
+                radiusValue,
+            }
         );
     }
 

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -467,7 +467,7 @@ export abstract class RadialColumnSeriesBase<
         const { id: seriesId, axes, dataModel } = this;
         const { angleKey, radiusKey, angleName, radiusName, fill, stroke, strokeWidth, formatter, tooltip } =
             this.properties;
-        const { angleValue, radiusValue, datum } = nodeDatum;
+        const { angleValue, radiusValue, datum, itemId } = nodeDatum;
 
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
@@ -495,7 +495,19 @@ export abstract class RadialColumnSeriesBase<
 
         return tooltip.toTooltipHtml(
             { title, backgroundColor: fill, content },
-            { seriesId, datum, color, title, angleKey, radiusKey, angleName, radiusName }
+            {
+                seriesId,
+                datum,
+                color,
+                title,
+                angleKey,
+                radiusKey,
+                angleName,
+                radiusName,
+                angleValue,
+                itemId,
+                radiusValue,
+            }
         );
     }
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -549,7 +549,22 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
 
         return tooltip.toTooltipHtml(
             { title, content, backgroundColor: color },
-            { seriesId, itemId, datum, xKey, yLowKey, yHighKey, xName, yLowName, yHighName, yName, color }
+            {
+                seriesId,
+                itemId,
+                datum,
+                xKey,
+                yLowKey,
+                yHighKey,
+                xName,
+                yLowName,
+                yHighName,
+                yName,
+                color,
+                title,
+                yHighValue,
+                yLowValue,
+            }
         );
     }
 

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -530,6 +530,9 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
             color,
             seriesId,
             itemId,
+            title,
+            yHighValue,
+            yLowValue,
         });
     }
 

--- a/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
@@ -505,6 +505,7 @@ export class SunburstSeries extends _ModuleSupport.HierarchySeries<
             secondaryLabelKey,
             sizeKey,
             sizeName = sizeKey,
+            childrenKey,
         } = this.properties;
         const { datum, depth } = node;
         if (datum == null || depth == null) {
@@ -556,6 +557,10 @@ export class SunburstSeries extends _ModuleSupport.HierarchySeries<
             title,
             color,
             seriesId,
+            childrenKey,
+            colorName,
+            itemId: undefined,
+            sizeName,
         });
     }
 

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -718,6 +718,7 @@ export class TreemapSeries<
             secondaryLabelKey,
             sizeKey,
             sizeName = sizeKey,
+            childrenKey,
         } = this.properties;
         const isLeaf = node.children.length === 0;
         const interactive = isLeaf || this.properties.group.interactive;
@@ -770,6 +771,10 @@ export class TreemapSeries<
             title,
             color,
             seriesId,
+            childrenKey,
+            colorName,
+            itemId: undefined,
+            sizeName,
         });
     }
 }

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -663,7 +663,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
 
         return tooltip.toTooltipHtml(
             { title, content, backgroundColor: color },
-            { seriesId, itemId, datum, xKey, yKey, xName, yName, color }
+            { seriesId, itemId, datum, xKey, yKey, xName, yName, color, title }
         );
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11362

The original issue was around treemap tooltip renderer, but on making the tooltip callback parameter typings stricter to flush out other gaps, turns out there were actually quite a few gaps - this PR corrects those gaps.