### PR TITLE
AG-7538 - Revert crosshair label formatting behaviour

### DIFF
--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -135,7 +135,7 @@ export class Crosshair extends _ModuleSupport.BaseModuleInstance implements _Mod
             this.updateLabel(labels[key]);
         });
         const format = this.label.format ?? axisLayout?.label.format;
-        this.labelFormatter = this.axisCtx.scaleValueFormatter(format);
+        this.labelFormatter = format ? this.axisCtx.scaleValueFormatter(format) : undefined;
     }
 
     private updateLabel(label: CrosshairLabel) {


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/AG-7538, one part was not reverted and was throwing a warning