### PR TITLE
AG-11360 Fix keyboard node clicks on all series

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -3,12 +3,7 @@ import { getDocument, injectStyle } from '../../util/dom';
 import { Listeners } from '../../util/listeners';
 import { buildConsumable } from './consumableEvent';
 import * as focusStyles from './focusStyles';
-import type {
-    InteractionManager,
-    PointerInteractionEvent,
-    PointerInteractionTypes,
-    PointerOffsets,
-} from './interactionManager';
+import type { InteractionManager, PointerInteractionEvent, PointerInteractionTypes } from './interactionManager';
 import { InteractionState, POINTER_INTERACTION_TYPES } from './interactionManager';
 import { KeyNavEvent, KeyNavEventType, KeyNavManager } from './keyNavManager';
 
@@ -56,7 +51,6 @@ export class RegionManager {
     public readonly keyNavManager: KeyNavManager;
     private readonly focusWrapper: HTMLDivElement;
     private readonly focusIndicator: HTMLDivElement;
-    private readonly focusClickOffsets: PointerOffsets = { offsetX: 0, offsetY: 0 };
 
     private currentRegion?: Region;
     private isDragging = false;
@@ -352,12 +346,5 @@ export class RegionManager {
         this.focusIndicator.style.height = `${rect.height}px`;
         this.focusIndicator.style.left = `${rect.x}px`;
         this.focusIndicator.style.top = `${rect.y}px`;
-
-        this.focusClickOffsets.offsetX = rect.x + rect.width / 2;
-        this.focusClickOffsets.offsetY = rect.y + rect.height / 2;
-    }
-
-    public getKeyboardPointer(): PointerOffsets {
-        return this.focusClickOffsets;
     }
 }

--- a/packages/ag-charts-community/src/chart/keyboardUtil.ts
+++ b/packages/ag-charts-community/src/chart/keyboardUtil.ts
@@ -1,5 +1,4 @@
 import type { BBox } from '../scene/bbox';
-import type { KeyNavEvent } from './interaction/keyNavManager';
 import type { RegionManager } from './interaction/regionManager';
 import type { TooltipPointerEvent } from './tooltip/tooltip';
 
@@ -13,10 +12,4 @@ export function makeKeyboardPointerEvent(
         return { type: 'keyboard', offsetX, offsetY };
     }
     return undefined;
-}
-
-export function makeKeyboardClickEvent(regionManager: RegionManager, event: KeyNavEvent<'submit'>) {
-    const type = 'click' as const;
-    const sourceEvent: Event = event.sourceEvent.sourceEvent;
-    return { type, sourceEvent, ...regionManager.getKeyboardPointer() };
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -35,7 +35,7 @@ type BubbleAnimationData = CartesianAnimationData<Group, BubbleNodeDatum>;
 class BubbleSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends CartesianSeriesNodeEvent<TEvent> {
     readonly sizeKey?: string;
 
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: BubbleNodeDatum, series: BubbleSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: BubbleNodeDatum, series: BubbleSeries) {
         super(type, nativeEvent, datum, series);
         this.sizeKey = series.properties.sizeKey;
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -85,7 +85,7 @@ export class CartesianSeriesNodeEvent<TEvent extends string = SeriesNodeEventTyp
     readonly yKey?: string;
     constructor(
         type: TEvent,
-        nativeEvent: MouseEvent,
+        nativeEvent: Event,
         datum: SeriesNodeDatum,
         series: ISeries<SeriesNodeDatum, { xKey?: string; yKey?: string }>
     ) {

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -50,7 +50,7 @@ class DonutSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends
     readonly radiusKey?: string;
     readonly calloutLabelKey?: string;
     readonly sectorLabelKey?: string;
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: DonutNodeDatum, series: DonutSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: DonutNodeDatum, series: DonutSeries) {
         super(type, nativeEvent, datum, series);
         this.angleKey = series.properties.angleKey;
         this.radiusKey = series.properties.radiusKey;

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -47,7 +47,7 @@ class PieSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends S
     readonly radiusKey?: string;
     readonly calloutLabelKey?: string;
     readonly sectorLabelKey?: string;
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: PieNodeDatum, series: PieSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: PieNodeDatum, series: PieSeries) {
         super(type, nativeEvent, datum, series);
         this.angleKey = series.properties.angleKey;
         this.radiusKey = series.properties.radiusKey;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -180,7 +180,8 @@ export type SeriesNodeEventTypes = 'nodeClick' | 'nodeDoubleClick' | 'nodeContex
 
 interface INodeEvent<TEvent extends string = SeriesNodeEventTypes> extends TypedEvent {
     readonly type: TEvent;
-    readonly event: MouseEvent;
+    // Note: this is typically a MouseEvent, but it can be a TouchEvent or KeyboardEvent too.
+    readonly event: Event;
     readonly datum: unknown;
     readonly seriesId: string;
 }
@@ -190,7 +191,7 @@ export interface INodeEventConstructor<
     TSeries extends Series<TDatum, any>,
     TEvent extends string = SeriesNodeEventTypes,
 > {
-    new (type: TEvent, event: MouseEvent, { datum }: TDatum, series: TSeries): INodeEvent<TEvent>;
+    new (type: TEvent, event: Event, { datum }: TDatum, series: TSeries): INodeEvent<TEvent>;
 }
 
 export class SeriesNodeEvent<TDatum extends SeriesNodeDatum, TEvent extends string = SeriesNodeEventTypes>
@@ -201,7 +202,7 @@ export class SeriesNodeEvent<TDatum extends SeriesNodeDatum, TEvent extends stri
 
     constructor(
         readonly type: TEvent,
-        readonly event: MouseEvent,
+        readonly event: Event,
         { datum }: TDatum,
         series: ISeries<TDatum, unknown>
     ) {
@@ -689,15 +690,15 @@ export abstract class Series<
 
     abstract getLabelData(): PointLabelDatum[];
 
-    fireNodeClickEvent(event: MouseEvent, datum: TDatum): void {
+    fireNodeClickEvent(event: Event, datum: TDatum): void {
         this.fireEvent(new this.NodeEvent('nodeClick', event, datum, this));
     }
 
-    fireNodeDoubleClickEvent(event: MouseEvent, datum: TDatum): void {
+    fireNodeDoubleClickEvent(event: Event, datum: TDatum): void {
         this.fireEvent(new this.NodeEvent('nodeDoubleClick', event, datum, this));
     }
 
-    createNodeContextMenuActionEvent(event: MouseEvent, datum: TDatum): INodeEvent {
+    createNodeContextMenuActionEvent(event: Event, datum: TDatum): INodeEvent {
         return new this.NodeEvent('nodeContextMenuAction', event, datum, this);
     }
 

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -33,7 +33,7 @@ class BoxPlotSeriesNodeEvent<
     readonly q3Key?: string;
     readonly maxKey?: string;
 
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: BoxPlotNodeDatum, series: BoxPlotSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: BoxPlotNodeDatum, series: BoxPlotSeries) {
         super(type, nativeEvent, datum, series);
         this.xKey = series.properties.xKey;
         this.minKey = series.properties.minKey;

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeriesBase.ts
@@ -43,7 +43,7 @@ class CandlestickSeriesNodeEvent<
 
     constructor(
         type: TEvent,
-        nativeEvent: MouseEvent,
+        nativeEvent: Event,
         datum: CandlestickNodeBaseDatum,
         series: CandlestickSeriesBase<
             CandlestickBaseGroup<CandlestickNodeBaseDatum, any>,

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -46,7 +46,7 @@ class HeatmapSeriesNodeEvent<
 > extends _ModuleSupport.CartesianSeriesNodeEvent<TEvent> {
     readonly colorKey?: string;
 
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: HeatmapNodeDatum, series: HeatmapSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: HeatmapNodeDatum, series: HeatmapSeries) {
         super(type, nativeEvent, datum, series);
         this.colorKey = series.properties.colorKey;
     }

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -34,7 +34,7 @@ class RadarSeriesNodeEvent<
 > extends _ModuleSupport.SeriesNodeEvent<RadarNodeDatum, TEvent> {
     readonly angleKey?: string;
     readonly radiusKey?: string;
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: RadarNodeDatum, series: RadarSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: RadarNodeDatum, series: RadarSeries) {
         super(type, nativeEvent, datum, series);
         this.angleKey = series.properties.angleKey;
         this.radiusKey = series.properties.radiusKey;

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -32,7 +32,7 @@ class RadialBarSeriesNodeEvent<
 > extends _ModuleSupport.SeriesNodeEvent<RadialBarNodeDatum, TEvent> {
     readonly angleKey?: string;
     readonly radiusKey?: string;
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: RadialBarNodeDatum, series: RadialBarSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: RadialBarNodeDatum, series: RadialBarSeries) {
         super(type, nativeEvent, datum, series);
         this.angleKey = series.properties.angleKey;
         this.radiusKey = series.properties.radiusKey;

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -32,12 +32,7 @@ class RadialColumnSeriesNodeEvent<
 > extends _ModuleSupport.SeriesNodeEvent<RadialColumnNodeDatum, TEvent> {
     readonly angleKey?: string;
     readonly radiusKey?: string;
-    constructor(
-        type: TEvent,
-        nativeEvent: MouseEvent,
-        datum: RadialColumnNodeDatum,
-        series: RadialColumnSeriesBase<any>
-    ) {
+    constructor(type: TEvent, nativeEvent: Event, datum: RadialColumnNodeDatum, series: RadialColumnSeriesBase<any>) {
         super(type, nativeEvent, datum, series);
         this.angleKey = series.properties.angleKey;
         this.radiusKey = series.properties.radiusKey;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -49,7 +49,7 @@ class RangeAreaSeriesNodeEvent<
     readonly yLowKey?: string;
     readonly yHighKey?: string;
 
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: RangeAreaMarkerDatum, series: RangeAreaSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: RangeAreaMarkerDatum, series: RangeAreaSeries) {
         super(type, nativeEvent, datum, series);
         this.xKey = series.properties.xKey;
         this.yLowKey = series.properties.yLowKey;

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.ts
@@ -80,7 +80,7 @@ class RangeBarSeriesNodeEvent<
     readonly yLowKey?: string;
     readonly yHighKey?: string;
 
-    constructor(type: TEvent, nativeEvent: MouseEvent, datum: RangeBarNodeDatum, series: RangeBarSeries) {
+    constructor(type: TEvent, nativeEvent: Event, datum: RangeBarNodeDatum, series: RangeBarSeries) {
         super(type, nativeEvent, datum, series);
         this.xKey = series.properties.xKey;
         this.yLowKey = series.properties.yLowKey;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11360

Instead, just fire the nodeClicks event directly. We do not need to check whether the keyboard "pointer click" is in range because by we already know with node the use wants to click on.
    
This fixes nodeClicks on series types where the centre of the focus indicator fails the hit-test on the node shape (e.g. radial bars).