### PR TITLE
AG-11192 Find enable datum in reverse when changing series focus

### DIFF
--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -126,7 +126,7 @@ export abstract class DataModelSeries<
             while (datumIndex >= 0 && !isDatumEnabled(datumIndex)) {
                 datumIndex--;
             }
-        }else {
+        } else {
             while (datumIndex < nodeData.length && !isDatumEnabled(datumIndex)) {
                 datumIndex++;
             }

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -122,13 +122,13 @@ export abstract class DataModelSeries<
 
         // Search forward or backwards depending on the delta direction.
         let datumIndex: number = clamp(0, opts.datumIndex, nodeData.length - 1);
-        if (opts.datumIndexDelta >= 0) {
-            while (datumIndex < nodeData.length && !isDatumEnabled(datumIndex)) {
-                datumIndex++;
-            }
-        } else {
+        if (opts.datumIndexDelta <= 0) {
             while (datumIndex >= 0 && !isDatumEnabled(datumIndex)) {
                 datumIndex--;
+            }
+        }else {
+            while (datumIndex < nodeData.length && !isDatumEnabled(datumIndex)) {
+                datumIndex++;
             }
         }
 

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -62,6 +62,7 @@ export type SeriesNodePickMatch = {
 
 export type PickFocusInputs = {
     readonly datumIndex: number;
+    // datum delta is stricly +ve/-ve when changing datum focus, or 0 when changing series focus.
     readonly datumIndexDelta: number;
     readonly seriesRect?: Readonly<BBox>;
 };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11192

This fixed a bug where the tooltip can show an undefined datum tooltip when switching the focus from one bar series (with more data) to another bar series (with less data).