### PR TITLE
CRT-305 CRT-315 Fix react examples with clone local var of options

### DIFF
--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.ts
@@ -11,7 +11,7 @@ export function wrapOptionsUpdateCode(
     }
 
     return code
-        .replace(/(?<!= )options\./g, localVar + '.')
+        .replace(/(?<!\w)options\./g, localVar + '.')
         .replace(/(.*?)\{(.*)\}/s, `$1{\n${before}\n$2\n${after}\n}`);
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-305
https://ag-grid.atlassian.net/browse/CRT-315

This was caused by the `const clone = deepClone(options)` in the example generation. React is the only FW that renames it from `options`. It has to be a unique name different from `options` (unless we rename `const [options, ...] = useState(...)`, which would not be idiomatic).

The wrapping code here previously had a negative lookbehind to _not_ rename the variable when it preceeded by an equals sign, `= options`, which seems wrong.

I've replaced this with a negative lookbehind for any word character which fixes the issue, and matches current behaviour in the grid. See https://regex101.com/r/KmRnsr/1