### PR TITLE
CRT-322 Trigger mouseBlur when clicking on the overlay

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -362,7 +362,11 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
     }
 
     private isEventOverElement(event: SupportedEvent) {
-        return event.target === this.element || (event.target as any)?.parentElement === this.element;
+        return (
+            event.target === this.element ||
+            (event.target as any)?.parentElement === this.element ||
+            (event.target as any)?.parentElement?.parentElement === this.element
+        );
     }
 
     private static readonly NULL_COORDS: Coords = {

--- a/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
@@ -45,8 +45,9 @@ export class KeyNavManager extends BaseManager<KeyNavEventType, KeyNavEvent> {
         super.destroy();
     }
 
-    private onClickStart(_event: PointerInteractionEvent<'drag-start'>) {
+    private onClickStart(event: PointerInteractionEvent<'drag-start'>) {
         this.isClicking = true;
+        this.mouseBlur(event);
     }
 
     private onClickStop(event: PointerInteractionEvent<'drag-end' | 'click'>) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-322

There was also a bug when the InteractionManager wouldn't dispatch a 'drag-start' event when clicking the overlay.