### PR TITLE
AG-11450 - Introduce DOMManager, and factor out DOM uses.

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -88,7 +88,7 @@ export abstract class AgCharts {
         const chart = AgChartsInternal.createOrUpdate(options);
 
         if (this.licenseManager?.isDisplayWatermark()) {
-            enterpriseModule.injectWatermark?.(chart.chart.wrapper.element, this.licenseManager.getWatermarkMessage());
+            enterpriseModule.injectWatermark?.(chart.chart.ctx.domManager, this.licenseManager.getWatermarkMessage());
         }
         return chart;
     }

--- a/packages/ag-charts-community/src/chart/baseManager.ts
+++ b/packages/ag-charts-community/src/chart/baseManager.ts
@@ -1,4 +1,4 @@
-import { Listeners } from '../../util/listeners';
+import { Listeners } from '../util/listeners';
 
 export abstract class BaseManager<EventType extends string = never, Event extends { type: any } = never> {
     protected readonly listeners = new Listeners<EventType, (event: Event) => void>();

--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -561,8 +561,7 @@ describe('Chart', () => {
             expect(elements.length).toEqual(1);
 
             expect(elements[0].querySelectorAll('canvas')).toHaveLength(1);
-            expect(elements[0].querySelectorAll('.ag-charts-focus')).toHaveLength(2);
-            expect(elements[0].querySelectorAll('.ag-charts-focus__wrapper')).toHaveLength(1);
+            expect(elements[0].querySelectorAll('.ag-charts-focus')).toHaveLength(1);
         });
 
         it('should cleanup DOM on destroy()', async () => {
@@ -573,7 +572,6 @@ describe('Chart', () => {
 
             expect(document.querySelectorAll('canvas')).toHaveLength(0);
             expect(document.querySelectorAll('.ag-charts-focus')).toHaveLength(0);
-            expect(document.querySelectorAll('.ag-charts-focus__wrapper')).toHaveLength(0);
             expect(document.querySelectorAll('div')).toHaveLength(0);
         });
 
@@ -597,7 +595,7 @@ describe('Chart', () => {
             expect(elements).toHaveLength(1);
 
             expect(elements[0].querySelectorAll('canvas')).toHaveLength(1);
-            expect(elements[0].querySelectorAll('.ag-charts-focus__wrapper')).toHaveLength(1);
+            expect(elements[0].querySelectorAll('.ag-charts-focus')).toHaveLength(1);
             expect(elements[0].querySelectorAll('.ag-charts-toolbar')).toHaveLength(0);
         });
     });

--- a/packages/ag-charts-community/src/chart/chartContext.ts
+++ b/packages/ag-charts-community/src/chart/chartContext.ts
@@ -1,12 +1,12 @@
 import type { ModuleContext } from '../module/moduleContext';
 import type { Group } from '../scene/group';
-import type { Scene } from '../scene/scene';
+import { Scene } from '../scene/scene';
 import { CallbackCache } from '../util/callbackCache';
-import type { GuardedElement } from '../util/guardedElement';
 import type { Mutex } from '../util/mutex';
 import { AnnotationManager } from './annotation/annotationManager';
 import type { ChartService } from './chartService';
 import { DataService } from './data/dataService';
+import { DOMManager } from './dom/domManager';
 import { AnimationManager } from './interaction/animationManager';
 import { AriaAnnouncementService } from './interaction/ariaAnnouncementServices';
 import { ChartEventManager } from './interaction/chartEventManager';
@@ -44,6 +44,7 @@ export class ChartContext implements ModuleContext {
     chartEventManager: ChartEventManager;
     contextMenuRegistry: ContextMenuRegistry;
     cursorManager: CursorManager;
+    domManager: DOMManager;
     highlightManager: HighlightManager;
     interactionManager: InteractionManager;
     keyNavManager: KeyNavManager;
@@ -57,36 +58,33 @@ export class ChartContext implements ModuleContext {
     constructor(
         chart: ChartService & { zoomManager: ZoomManager; annotationRoot: Group; keyboard: Keyboard; tooltip: Tooltip },
         vars: {
-            scene: Scene;
+            scene?: Scene;
             syncManager: SyncManager;
-            wrapper: GuardedElement;
+            container?: HTMLElement;
             updateCallback: UpdateCallback;
             updateMutex: Mutex;
+            overrideDevicePixelRatio?: number;
         }
     ) {
-        const { scene, syncManager, wrapper, updateCallback, updateMutex } = vars;
-        const { element } = wrapper;
+        const { scene, syncManager, container, updateCallback, updateMutex, overrideDevicePixelRatio } = vars;
         this.chartService = chart;
-        this.scene = scene;
         this.syncManager = syncManager;
         this.zoomManager = chart.zoomManager;
+        this.domManager = new DOMManager(container);
+        scene?.setContainer(this.domManager);
+        this.scene = scene ?? new Scene({ pixelRatio: overrideDevicePixelRatio, domManager: this.domManager });
 
         this.annotationManager = new AnnotationManager(chart.annotationRoot);
-        this.ariaAnnouncementService = new AriaAnnouncementService(scene.canvas.element);
+        this.ariaAnnouncementService = new AriaAnnouncementService(this.scene.canvas.element);
         this.chartEventManager = new ChartEventManager();
         this.contextMenuRegistry = new ContextMenuRegistry();
-        this.cursorManager = new CursorManager(element);
+        this.cursorManager = new CursorManager(this.domManager);
         this.highlightManager = new HighlightManager();
-        this.interactionManager = new InteractionManager(chart.keyboard, element);
-        this.keyNavManager = new KeyNavManager(this.interactionManager, wrapper);
-        this.regionManager = new RegionManager(
-            this.interactionManager,
-            this.keyNavManager,
-            this.scene.canvas.element,
-            element
-        );
-        this.toolbarManager = new ToolbarManager(element);
-        this.gestureDetector = new GestureDetector(element);
+        this.interactionManager = new InteractionManager(chart.keyboard, this.domManager);
+        this.keyNavManager = new KeyNavManager(this.interactionManager, this.domManager);
+        this.regionManager = new RegionManager(this.interactionManager, this.keyNavManager, this.domManager);
+        this.toolbarManager = new ToolbarManager();
+        this.gestureDetector = new GestureDetector(this.domManager);
         this.layoutService = new LayoutService();
         this.updateService = new UpdateService(updateCallback);
         this.seriesStateManager = new SeriesStateManager();
@@ -97,7 +95,7 @@ export class ChartContext implements ModuleContext {
         this.animationManager.play();
 
         this.dataService = new DataService<any>(this.animationManager);
-        this.tooltipManager = new TooltipManager(this.scene.canvas.element, chart.tooltip);
+        this.tooltipManager = new TooltipManager(this.domManager, chart.tooltip);
     }
 
     destroy() {
@@ -114,5 +112,6 @@ export class ChartContext implements ModuleContext {
         this.callbackCache.invalidateCache();
         this.animationManager.reset();
         this.syncManager.destroy();
+        this.domManager.destroy();
     }
 }

--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -1,0 +1,256 @@
+import { createElement, getDocument } from '../../util/dom';
+import { GuardedElement } from '../../util/guardedElement';
+import { Size, SizeMonitor } from '../../util/sizeMonitor';
+import { BaseManager } from '../baseManager';
+
+const domElementClasses = ['styles', 'canvas', 'canvas-overlay', 'hidden'] as const;
+export type DOMElementClass = (typeof domElementClasses)[number];
+
+const domElementConfig: Record<
+    DOMElementClass,
+    { childElementType: 'style' | 'canvas' | 'div'; style?: Partial<CSSStyleDeclaration> }
+> = {
+    styles: { childElementType: 'style' },
+    canvas: { childElementType: 'canvas' },
+    'canvas-overlay': { childElementType: 'div' },
+    hidden: { childElementType: 'div' },
+};
+
+const STYLES = `
+.ag-charts-style {
+    display: none;
+}
+
+.ag-charts-hidden {
+    visibility: none;
+}
+
+.ag-charts-canvas, .ag-charts-canvas-overlay {
+    position: absolute;
+    display: block;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}
+ 
+.ag-charts-canvas-overlay > * {
+    position: absolute;
+}
+`;
+
+function setupObserver(element: HTMLElement, cb: (intersectionRatio: number) => void) {
+    // Detect when the chart becomes invisible and hide the tooltip as well.
+    if (typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            for (const entry of entries) {
+                if (entry.target === element) {
+                    cb(entry.intersectionRatio);
+                }
+            }
+        },
+        { root: element }
+    );
+    observer.observe(element);
+    return observer;
+}
+
+export class GuardedAgChartsWrapperElement extends GuardedElement {
+    constructor() {
+        super(
+            createElement('div', 'ag-chart-wrapper', { position: 'relative', userSelect: 'none' }),
+            getDocument().createElement('div'),
+            getDocument().createElement('div')
+        );
+    }
+
+    override destroy(): void {
+        super.destroy();
+
+        this.topTabGuard.remove();
+        this.bottomTabGuard.remove();
+        this.element.remove();
+    }
+}
+
+type Events = { type: 'hidden' } | { type: 'resize'; size: Size };
+
+export class DOMManager extends BaseManager<Events['type'], Events> {
+    private rootElements: Map<DOMElementClass, { element: HTMLElement; children: Map<string, HTMLElement> }>;
+    private readonly parentElement: GuardedElement;
+    private container?: HTMLElement;
+
+    private readonly observer?: IntersectionObserver;
+    private readonly sizeMonitor: SizeMonitor;
+
+    constructor(container?: HTMLElement) {
+        super();
+
+        this.parentElement = new GuardedAgChartsWrapperElement();
+        const { element } = this.parentElement;
+        if (container) {
+            this.setContainer(container);
+        }
+
+        this.rootElements = new Map(
+            domElementClasses.map((c) => {
+                const el = createElement('div', `ag-charts-${c}`, domElementConfig[c].style);
+
+                return [c, { element: el, children: new Map<string, HTMLElement>() }];
+            })
+        );
+
+        this.rootElements.forEach((el) => element.appendChild(el.element));
+
+        let hidden = false;
+        this.observer = setupObserver(element, (intersectionRatio) => {
+            if (intersectionRatio === 0 && !hidden) {
+                this.listeners.dispatch('hidden', { type: 'hidden' });
+            }
+            hidden = intersectionRatio === 0;
+        });
+
+        this.sizeMonitor = new SizeMonitor();
+        this.sizeMonitor.observe(element, (size) => this.listeners.dispatch('resize', { type: 'resize', size }));
+
+        this.addStyles('dom-manager', STYLES);
+    }
+
+    override destroy() {
+        super.destroy();
+
+        const { element } = this.parentElement;
+        this.observer?.unobserve(element);
+        this.sizeMonitor.unobserve(element);
+
+        this.rootElements.forEach((el) => {
+            el.children.forEach((c) => c.remove());
+            el.element.remove();
+        });
+
+        this.parentElement.destroy();
+    }
+
+    get parent() {
+        return this.parentElement;
+    }
+
+    setAutoSizeStyle(autoSize: boolean) {
+        const { style } = this.parentElement.element;
+        if (autoSize) {
+            style.display = 'block';
+            style.width = '100%';
+            style.height = '100%';
+        } else {
+            style.display = 'inline-block';
+            style.width = 'auto';
+            style.height = 'auto';
+        }
+    }
+
+    setContainer(newContainer: HTMLElement) {
+        if (newContainer === this.container) return;
+
+        this.container?.removeChild(this.parentElement.topTabGuard);
+        this.container?.removeChild(this.parentElement.element);
+        this.container?.removeChild(this.parentElement.bottomTabGuard);
+        newContainer.appendChild(this.parentElement.topTabGuard);
+        newContainer.appendChild(this.parentElement.element);
+        newContainer.appendChild(this.parentElement.bottomTabGuard);
+
+        this.container = newContainer;
+    }
+
+    setThemeClass(themeClassName: string) {
+        const themeClassNamePrefix = 'ag-charts-theme-';
+
+        const { element } = this.parentElement;
+        element.classList.forEach((className) => {
+            if (className.startsWith(themeClassNamePrefix) && className !== themeClassName) {
+                element.classList.remove(className);
+            }
+        });
+
+        element.classList.add(themeClassName);
+    }
+
+    setTabIndex(tabIndex: number) {
+        this.parentElement.tabIndex = tabIndex;
+    }
+
+    addEventListener<K extends keyof HTMLElementEventMap>(
+        type: K,
+        listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions
+    ) {
+        this.parentElement.element.addEventListener(type, listener, options);
+    }
+
+    removeEventListener<K extends keyof HTMLElementEventMap>(
+        type: K,
+        listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+        options?: boolean | EventListenerOptions
+    ) {
+        this.parentElement.element.removeEventListener(type, listener, options);
+    }
+
+    getBoundingClientRect() {
+        return this.parent.element.getBoundingClientRect();
+    }
+
+    isEventOverElement(event: Event | MouseEvent | TouchEvent) {
+        return (
+            event.target === this.parentElement.element ||
+            (event.target as any)?.parentElement === this.parentElement.element ||
+            (event.target as any)?.parentElement?.parentElement === this.parentElement.element
+        );
+    }
+
+    addStyles(id: string, styles: string) {
+        const styleElement = this.addChild('styles', id);
+        styleElement.innerHTML = styles;
+    }
+
+    removeStyles(id: string) {
+        this.removeChild('styles', id);
+    }
+
+    updateCursor(style: string) {
+        this.parentElement.element.style.cursor = style;
+    }
+
+    getCursor() {
+        return this.parentElement.element.style.cursor;
+    }
+
+    addChild(domElementClass: DOMElementClass, id: string, child?: HTMLElement) {
+        const { element, children } = this.rootElements.get(domElementClass) ?? {};
+        if (!children) {
+            throw new Error('AG Charts - unable to create DOM elements after destroy()');
+        }
+
+        if (children.has(id)) return children.get(id)!;
+
+        const { childElementType } = domElementConfig[domElementClass];
+        if (child && child.tagName.toLowerCase() !== childElementType.toLowerCase()) {
+            throw new Error('AG Charts - mismatching DOM element type');
+        }
+
+        const newChild = child ?? createElement(childElementType);
+        children.set(id, newChild);
+        element?.appendChild(newChild);
+        return newChild;
+    }
+
+    removeChild(domElementClass: DOMElementClass, id: string) {
+        const { children } = this.rootElements.get(domElementClass) ?? {};
+        if (!children) return;
+
+        if (!children.has(id)) return;
+
+        children.get(id)?.remove();
+        children.delete(id);
+    }
+}

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -3,8 +3,8 @@ import { Animation } from '../../motion/animation';
 import { Debug } from '../../util/debug';
 import { Logger } from '../../util/logger';
 import type { Mutex } from '../../util/mutex';
+import { BaseManager } from '../baseManager';
 import { AnimationBatch } from './animationBatch';
-import { BaseManager } from './baseManager';
 import { InteractionManager, InteractionState } from './interactionManager';
 
 type AnimationEventType = 'animation-frame' | 'animation-start' | 'animation-stop';

--- a/packages/ag-charts-community/src/chart/interaction/chartEventManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/chartEventManager.ts
@@ -1,5 +1,5 @@
+import { BaseManager } from '../baseManager';
 import type { ChartAxisDirection } from '../chartAxisDirection';
-import { BaseManager } from './baseManager';
 
 type ChartEventType = 'legend-item-click' | 'legend-item-double-click' | 'axis-hover';
 type ChartEvents = LegendItemClickChartEvent | LegendItemDoubleClickChartEvent | AxisHoverChartEvent;

--- a/packages/ag-charts-community/src/chart/interaction/cursorManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/cursorManager.ts
@@ -1,4 +1,5 @@
 import { StateTracker } from '../../util/stateTracker';
+import type { DOMManager } from '../dom/domManager';
 
 /**
  * Manages the cursor styling for an element. Tracks the requested styling from distinct
@@ -7,14 +8,14 @@ import { StateTracker } from '../../util/stateTracker';
 export class CursorManager {
     private readonly stateTracker = new StateTracker('default');
 
-    constructor(private readonly element: HTMLElement) {}
+    constructor(private readonly domManager: DOMManager) {}
 
     public updateCursor(callerId: string, style?: string) {
         this.stateTracker.set(callerId, style);
-        this.element.style.cursor = this.stateTracker.stateValue()!;
+        this.domManager.updateCursor(this.stateTracker.stateValue()!);
     }
 
     public getCursor(): string {
-        return this.element.style.cursor;
+        return this.domManager.getCursor();
     }
 }

--- a/packages/ag-charts-community/src/chart/interaction/gestureDetector.ts
+++ b/packages/ag-charts-community/src/chart/interaction/gestureDetector.ts
@@ -1,6 +1,7 @@
 import { Logger } from '../../util/logger';
 import { partialAssign } from '../../util/object';
-import { BaseManager } from './baseManager';
+import { BaseManager } from '../baseManager';
+import type { DOMManager } from '../dom/domManager';
 
 type PinchEventTypes = 'pinch-start' | 'pinch-move' | 'pinch-end';
 type GestureEventTypes = PinchEventTypes;
@@ -44,8 +45,6 @@ function distance(finger1: Finger, finger2: Finger): number {
 const MIN_DISTANCE_TO_START_PINCH = 1;
 
 export class GestureDetector extends BaseManager<GestureEventTypes, GestureEvent> {
-    private readonly element: HTMLElement;
-
     private touchstart = (event: TouchEvent) => this.onTouchStart(event);
     private touchmove = (event: TouchEvent) => this.onTouchMove(event);
     private touchend = (event: TouchEvent) => this.onTouchEnd(event);
@@ -59,21 +58,19 @@ export class GestureDetector extends BaseManager<GestureEventTypes, GestureEvent
         status: PinchTrackingStatus.Off,
     };
 
-    public constructor(element: HTMLElement) {
+    public constructor(private readonly domManager: DOMManager) {
         super();
-        this.element = element;
-        element.addEventListener('touchstart', this.touchstart, { passive: true });
-        element.addEventListener('touchmove', this.touchmove, { passive: true });
-        element.addEventListener('touchend', this.touchend);
-        element.addEventListener('touchcancel', this.touchcancel);
+        this.domManager.addEventListener('touchstart', this.touchstart, { passive: true });
+        this.domManager.addEventListener('touchmove', this.touchmove, { passive: true });
+        this.domManager.addEventListener('touchend', this.touchend);
+        this.domManager.addEventListener('touchcancel', this.touchcancel);
     }
 
     override destroy() {
-        const { element } = this;
-        element.removeEventListener('touchstart', this.touchstart);
-        element.removeEventListener('touchmove', this.touchmove);
-        element.removeEventListener('touchend', this.touchend);
-        element.removeEventListener('touchcancel', this.touchcancel);
+        this.domManager.removeEventListener('touchstart', this.touchstart);
+        this.domManager.removeEventListener('touchmove', this.touchmove);
+        this.domManager.removeEventListener('touchend', this.touchend);
+        this.domManager.removeEventListener('touchcancel', this.touchcancel);
     }
 
     private findPinchTouches(moveEvent: TouchEvent): undefined | [Touch, Touch] {

--- a/packages/ag-charts-community/src/chart/interaction/highlightManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/highlightManager.ts
@@ -1,6 +1,6 @@
 import { StateTracker } from '../../util/stateTracker';
+import { BaseManager } from '../baseManager';
 import type { SeriesNodeDatum } from '../series/seriesTypes';
-import { BaseManager } from './baseManager';
 
 export interface HighlightNodeDatum extends SeriesNodeDatum {
     readonly xKey?: string;

--- a/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/keyNavManager.ts
@@ -1,5 +1,5 @@
-import type { GuardedElement } from '../../util/guardedElement';
-import { BaseManager } from './baseManager';
+import { BaseManager } from '../baseManager';
+import type { DOMManager } from '../dom/domManager';
 import { ConsumableEvent, buildConsumable, dispatchTypedConsumable } from './consumableEvent';
 import type {
     FocusInteractionEvent,
@@ -28,7 +28,7 @@ export class KeyNavManager extends BaseManager<KeyNavEventType, KeyNavEvent> {
 
     constructor(
         interactionManager: InteractionManager,
-        private readonly wrapper: GuardedElement
+        private readonly domManager: DOMManager
     ) {
         super();
         this.destroyFns.push(
@@ -79,7 +79,7 @@ export class KeyNavManager extends BaseManager<KeyNavEventType, KeyNavEvent> {
         if (this.isClicking) {
             this.isMouseBlurred = true;
         } else {
-            const delta = this.wrapper.getBrowserFocusDelta();
+            const delta = this.domManager.parent.getBrowserFocusDelta();
             this.dispatch('browserfocus', delta, event);
             this.dispatch('tab', delta, event);
         }

--- a/packages/ag-charts-community/src/chart/interaction/syncManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/syncManager.ts
@@ -1,7 +1,7 @@
+import { BaseManager } from '../baseManager';
 import type { ChartAxisDirection } from '../chartAxisDirection';
 import type { ISeries } from '../series/seriesTypes';
 import type { UpdateService } from '../updateService';
-import { BaseManager } from './baseManager';
 import type { HighlightManager } from './highlightManager';
 import type { TooltipManager } from './tooltipManager';
 import type { ZoomManager } from './zoomManager';

--- a/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
@@ -1,6 +1,6 @@
 import type { AgToolbarOptions } from '../../options/chart/toolbarOptions';
+import { BaseManager } from '../baseManager';
 import type { ToolbarGroup } from '../toolbar/toolbarTypes';
-import { BaseManager } from './baseManager';
 
 type EventTypes = ToolbarButtonPressed | ToolbarButtonToggled | ToolbarGroupToggled | ToolbarProxyGroupOptions;
 type ToolbarButtonPressed = 'button-pressed';
@@ -48,10 +48,6 @@ export class ToolbarManager extends BaseManager<EventTypes, ToolbarEvent> {
         event: ToolbarEvent
     ): event is ToolbarButtonPressedEvent<ToolbarEventButtonValue<T>> {
         return event.group === group;
-    }
-
-    constructor(readonly element: HTMLElement) {
-        super();
     }
 
     pressButton(group: ToolbarGroup, value: any) {

--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -1,5 +1,5 @@
-import { injectStyle } from '../../util/dom';
 import { StateTracker } from '../../util/stateTracker';
+import type { DOMManager } from '../dom/domManager';
 import type { ErrorBoundSeriesNodeDatum, SeriesNodeDatum } from '../series/seriesTypes';
 import type { Tooltip, TooltipContent, TooltipMeta } from '../tooltip/tooltip';
 import { DEFAULT_TOOLTIP_CLASS, TooltipPointerEvent } from '../tooltip/tooltip';
@@ -13,9 +13,6 @@ const defaultTooltipCss = `
 .${DEFAULT_TOOLTIP_CLASS} {
     transition: transform 0.1s ease;
     max-width: 100%;
-    position: fixed;
-    left: 0px;
-    top: 0px;
     z-index: 99999;
     font: 12px Verdana, sans-serif;
     color: rgb(70, 70, 70);
@@ -138,30 +135,16 @@ const defaultTooltipCss = `
  */
 export class TooltipManager {
     private readonly stateTracker = new StateTracker<TooltipState>();
-    private readonly observer?: IntersectionObserver;
     private appliedState: TooltipState | null = null;
 
     public constructor(
-        private readonly canvasElement: HTMLCanvasElement,
+        private readonly domManager: DOMManager,
         private readonly tooltip: Tooltip
     ) {
-        // Detect when the chart becomes invisible and hide the tooltip as well.
-        if (typeof IntersectionObserver !== 'undefined') {
-            const observer = new IntersectionObserver(
-                (entries) => {
-                    for (const entry of entries) {
-                        if (entry.target === this.canvasElement && entry.intersectionRatio === 0) {
-                            this.tooltip.toggle(false);
-                        }
-                    }
-                },
-                { root: this.tooltip.root }
-            );
-            observer.observe(this.canvasElement);
-            this.observer = observer;
-        }
+        tooltip.setup(domManager);
 
-        injectStyle(defaultTooltipCss, 'tooltip');
+        domManager.addListener('hidden', () => this.tooltip.toggle(false));
+        domManager.addStyles('tooltip', defaultTooltipCss);
     }
 
     public updateTooltip(callerId: string, meta?: TooltipMeta, content?: TooltipContent) {
@@ -182,7 +165,7 @@ export class TooltipManager {
     }
 
     public destroy() {
-        this.observer?.unobserve(this.canvasElement);
+        this.domManager.removeStyles('tooltip');
     }
 
     private applyStates() {
@@ -195,7 +178,7 @@ export class TooltipManager {
             return;
         }
 
-        const canvasRect = this.canvasElement.getBoundingClientRect();
+        const canvasRect = this.domManager.getBoundingClientRect();
 
         if (this.appliedState?.content === state?.content) {
             const renderInstantly = this.tooltip.isVisible();

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,7 +1,7 @@
 import { deepClone } from '../../util/json';
 import { StateTracker } from '../../util/stateTracker';
+import { BaseManager } from '../baseManager';
 import { ChartAxisDirection } from '../chartAxisDirection';
-import { BaseManager } from './baseManager';
 
 export interface ZoomState {
     min: number;

--- a/packages/ag-charts-community/src/chart/overlay/loadingSpinner.ts
+++ b/packages/ag-charts-community/src/chart/overlay/loadingSpinner.ts
@@ -1,28 +1,6 @@
 import { PHASE_METADATA } from '../../motion/animation';
-import { createElement, injectStyle } from '../../util/dom';
-import { DEFAULT_OVERLAY_CLASS, DEFAULT_OVERLAY_DARK_CLASS } from './overlay';
-
-const defaultOverlayCss = `
-.${DEFAULT_OVERLAY_CLASS} {
-    color: #181d1f;
-}
-
-.${DEFAULT_OVERLAY_CLASS}.${DEFAULT_OVERLAY_DARK_CLASS} {
-    color: #ffffff;
-}
-
-.${DEFAULT_OVERLAY_CLASS}--loading {
-    color: rgb(140, 140, 140); /* DEFAULT_MUTED_LABEL_COLOUR */
-}
-
-.${DEFAULT_OVERLAY_CLASS}__loading-background {
-    background: white; /* DEFAULT_BACKGROUND_FILL */
-}
-
-.${DEFAULT_OVERLAY_CLASS}.${DEFAULT_OVERLAY_DARK_CLASS} .${DEFAULT_OVERLAY_CLASS}__loading-background {
-    background: #192232; /* DEFAULT_DARK_BACKGROUND_FILL */
-}
-`;
+import { createElement } from '../../util/dom';
+import { DEFAULT_OVERLAY_CLASS } from './overlay';
 
 export function getLoadingSpinner(text: string, defaultDuration: number) {
     const { animationDuration } = PHASE_METADATA['add'];
@@ -73,8 +51,6 @@ export function getLoadingSpinner(text: string, defaultDuration: number) {
     ].join(' ');
 
     container.replaceChildren(animationStyles, matrix, label, background);
-
-    injectStyle(defaultOverlayCss, 'chartOverlays');
 
     return container;
 }

--- a/packages/ag-charts-community/src/chart/overlay/overlay.ts
+++ b/packages/ag-charts-community/src/chart/overlay/overlay.ts
@@ -82,7 +82,7 @@ export class Overlay extends BaseProperties {
         return this.element;
     }
 
-    removeElement(animationManager?: AnimationManager) {
+    removeElement(cleanup = () => this.element?.remove(), animationManager?: AnimationManager) {
         if (!this.element) return;
 
         if (animationManager) {
@@ -97,11 +97,11 @@ export class Overlay extends BaseProperties {
                     element.style.opacity = String(value);
                 },
                 onStop() {
-                    element.remove();
+                    cleanup?.();
                 },
             });
         } else {
-            this.element.remove();
+            cleanup?.();
         }
 
         this.element = undefined;

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -3,7 +3,7 @@ import { BaseModuleInstance } from '../../module/module';
 import type { ModuleContext } from '../../module/moduleContext';
 import type { AgToolbarGroupPosition } from '../../options/agChartOptions';
 import type { BBox } from '../../scene/bbox';
-import { createElement, injectStyle } from '../../util/dom';
+import { createElement } from '../../util/dom';
 import { ObserveChanges } from '../../util/proxy';
 import { BOOLEAN, Validate } from '../../util/validation';
 import { InteractionState, type PointerInteractionEvent } from '../interaction/interactionManager';
@@ -47,7 +47,6 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
 
     private margin = 10;
     private floatingDetectionRange = 28;
-    private readonly container: HTMLElement;
 
     private elements: Record<ToolbarPosition, HTMLElement>;
 
@@ -88,17 +87,16 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     constructor(private readonly ctx: ModuleContext) {
         super();
 
-        this.container = ctx.toolbarManager.element;
-        this.elements = {
-            [ToolbarPosition.Top]: this.container.appendChild(createElement('div')),
-            [ToolbarPosition.Right]: this.container.appendChild(createElement('div')),
-            [ToolbarPosition.Bottom]: this.container.appendChild(createElement('div')),
-            [ToolbarPosition.Left]: this.container.appendChild(createElement('div')),
-            [ToolbarPosition.FloatingTop]: this.container.appendChild(createElement('div')),
-            [ToolbarPosition.FloatingBottom]: this.container.appendChild(createElement('div')),
-        };
-
-        injectStyle(styles.css, styles.block);
+        ctx.domManager.addStyles(styles.block, styles.css);
+        this.elements = Object.values(ToolbarPosition)
+            .filter((v) => typeof v === 'string')
+            .reduce(
+                (r, n) => {
+                    r[n] = ctx.domManager.addChild('canvas-overlay', `toolbar-${n}`);
+                    return r;
+                },
+                {} as Record<ToolbarPosition, HTMLElement>
+            );
 
         this.renderToolbar(ToolbarPosition.Top);
         this.renderToolbar(ToolbarPosition.Right);
@@ -121,8 +119,9 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
     }
 
     private destroyElements() {
-        for (const element of Object.values(this.elements)) {
-            element.remove();
+        this.ctx.domManager.removeStyles(styles.block);
+        for (const element of Object.keys(this.elements)) {
+            this.ctx.domManager.removeChild('canvas-overlay', `toolbar-${element}`);
         }
     }
 

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -1,6 +1,6 @@
 import type { AgTooltipRendererResult, InteractionRange, TextWrap } from '../../options/agChartOptions';
 import { setAttribute } from '../../util/attributeUtil';
-import { createElement, getDocument, getWindow } from '../../util/dom';
+import { getWindow } from '../../util/dom';
 import { clamp } from '../../util/number';
 import { Bounds, calculatePlacement } from '../../util/placement';
 import { BaseProperties } from '../../util/properties';
@@ -16,6 +16,7 @@ import {
     UNION,
     Validate,
 } from '../../util/validation';
+import type { DOMManager } from '../dom/domManager';
 import type { PointerInteractionEvent, PointerOffsets } from '../interaction/interactionManager';
 
 export const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
@@ -139,10 +140,10 @@ export class Tooltip extends BaseProperties {
 
     @ObserveChanges<Tooltip>((target, newValue, oldValue) => {
         if (newValue) {
-            target.element.classList.add(newValue);
+            target.element?.classList.add(newValue);
         }
         if (oldValue) {
-            target.element.classList.remove(oldValue);
+            target.element?.classList.remove(oldValue);
         }
     })
     @Validate(STRING, { optional: true })
@@ -167,28 +168,27 @@ export class Tooltip extends BaseProperties {
     private lastVisibilityChange: number = Date.now();
     private readonly wrapTypes = ['always', 'hyphenate', 'on-space', 'never'];
 
-    private readonly element: HTMLDivElement;
-    readonly root: HTMLElement;
+    private element?: HTMLElement;
 
     private showTimeout: NodeJS.Timeout | number = 0;
     private _showArrow = true;
 
     constructor() {
         super();
-
-        this.element = createElement('div', DEFAULT_TOOLTIP_CLASS);
-        setAttribute(this.element, 'aria-hidden', true);
-
-        this.root = getDocument('body');
-        this.root.appendChild(this.element);
     }
 
-    destroy() {
-        this.element.remove();
+    setup(domManager: DOMManager) {
+        this.element = domManager.addChild('canvas-overlay', DEFAULT_TOOLTIP_CLASS);
+        this.element.classList.add(DEFAULT_TOOLTIP_CLASS);
+        setAttribute(this.element, 'aria-hidden', true);
+    }
+
+    destroy(domManager: DOMManager) {
+        domManager.removeChild('canvas-overlay', DEFAULT_TOOLTIP_CLASS);
     }
 
     isVisible(): boolean {
-        return !this.element.classList.contains(DEFAULT_TOOLTIP_CLASS + '-hidden');
+        return !this.element?.classList.contains(DEFAULT_TOOLTIP_CLASS + '-hidden');
     }
 
     /**
@@ -198,9 +198,9 @@ export class Tooltip extends BaseProperties {
     show(canvasRect: DOMRect, meta: TooltipMeta, content?: TooltipContent | null, instantly = false) {
         const { element } = this;
 
-        if (content != null) {
+        if (content != null && element != null) {
             element.innerHTML = content.html;
-        } else if (!element.innerHTML) {
+        } else if (!element?.innerHTML) {
             this.toggle(false);
             return;
         }
@@ -219,9 +219,6 @@ export class Tooltip extends BaseProperties {
             canvasRect.height,
             tooltipBounds
         );
-
-        position.x += canvasRect.x;
-        position.y += canvasRect.y;
 
         const left = clamp(0, position.x, windowBounds.width - element.clientWidth - 1);
         const top = clamp(0, position.y, windowBounds.height - element.clientHeight);
@@ -252,6 +249,8 @@ export class Tooltip extends BaseProperties {
     }
 
     toggle(visible: boolean) {
+        if (!this.element) return;
+
         const { classList } = this.element;
         const toggleClass = (name: string, include: boolean) =>
             classList.toggle(`${DEFAULT_TOOLTIP_CLASS}-${name}`, include);
@@ -320,6 +319,8 @@ export class Tooltip extends BaseProperties {
         xOffset: number;
         canvasRect: DOMRect;
     }): Bounds {
+        if (!this.element) return {};
+
         const { clientWidth: tooltipWidth, clientHeight: tooltipHeight } = this.element;
         const bounds: Bounds = { width: tooltipWidth, height: tooltipHeight };
 

--- a/packages/ag-charts-community/src/chart/update/overlaysProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/overlaysProcessor.ts
@@ -1,10 +1,33 @@
 import type { BBox } from '../../scene/bbox';
 import type { DataService } from '../data/dataService';
+import type { DOMManager } from '../dom/domManager';
 import type { AnimationManager } from '../interaction/animationManager';
 import type { LayoutCompleteEvent, LayoutService } from '../layout/layoutService';
 import type { ChartOverlays } from '../overlay/chartOverlays';
-import type { Overlay } from '../overlay/overlay';
+import { DEFAULT_OVERLAY_CLASS, DEFAULT_OVERLAY_DARK_CLASS, type Overlay } from '../overlay/overlay';
 import type { ChartLike, UpdateProcessor } from './processor';
+
+const defaultOverlayCss = `
+.${DEFAULT_OVERLAY_CLASS} {
+    color: #181d1f;
+}
+
+.${DEFAULT_OVERLAY_CLASS}.${DEFAULT_OVERLAY_DARK_CLASS} {
+    color: #ffffff;
+}
+
+.${DEFAULT_OVERLAY_CLASS}--loading {
+    color: rgb(140, 140, 140); /* DEFAULT_MUTED_LABEL_COLOUR */
+}
+
+.${DEFAULT_OVERLAY_CLASS}__loading-background {
+    background: white; /* DEFAULT_BACKGROUND_FILL */
+}
+
+.${DEFAULT_OVERLAY_CLASS}.${DEFAULT_OVERLAY_DARK_CLASS} .${DEFAULT_OVERLAY_CLASS}__loading-background {
+    background: #192232; /* DEFAULT_DARK_BACKGROUND_FILL */
+}
+`;
 
 export class OverlaysProcessor<D extends object> implements UpdateProcessor {
     private destroyFns: (() => void)[] = [];
@@ -14,7 +37,8 @@ export class OverlaysProcessor<D extends object> implements UpdateProcessor {
         private readonly overlays: ChartOverlays,
         private readonly dataService: DataService<D>,
         private readonly layoutService: LayoutService,
-        private readonly animationManager: AnimationManager
+        private readonly animationManager: AnimationManager,
+        private readonly domManager: DOMManager
     ) {
         this.destroyFns.push(this.layoutService.addListener('layout-complete', (e) => this.onLayoutComplete(e)));
     }
@@ -35,10 +59,15 @@ export class OverlaysProcessor<D extends object> implements UpdateProcessor {
 
     private toggleOverlay(overlay: Overlay, seriesRect: BBox, visible: boolean) {
         if (visible) {
+            this.domManager.addStyles('overlays', defaultOverlayCss);
             const element = overlay.getElement(this.animationManager, seriesRect);
-            this.chartLike.wrapper.element.append(element);
+            this.domManager.addChild('canvas-overlay', 'overlay').appendChild(element);
         } else {
-            overlay.removeElement(this.animationManager);
+            overlay.removeElement(
+                () => this.domManager.removeChild('canvas-overlay', 'overlay'),
+                this.animationManager
+            );
+            this.domManager.removeStyles('overlays');
         }
     }
 }

--- a/packages/ag-charts-community/src/chart/update/processor.ts
+++ b/packages/ag-charts-community/src/chart/update/processor.ts
@@ -13,7 +13,6 @@ export interface ChartLike {
     title: Caption;
     subtitle: Caption;
     footnote: Caption;
-    wrapper: { element: HTMLElement };
 }
 
 export interface AxisLike {

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -91,6 +91,7 @@ export * as Motion from './motion/easing';
 export * from './motion/states';
 export * from './motion/resetMotion';
 export * from './motion/fromToMotion';
+export * from './chart/dom/domManager';
 export { resetIds } from './util/id';
 export { DefaultColors } from './chart/themes/defaultColors';
 

--- a/packages/ag-charts-community/src/module/enterpriseModule.ts
+++ b/packages/ag-charts-community/src/module/enterpriseModule.ts
@@ -1,3 +1,4 @@
+import type { DOMManager } from '../chart/dom/domManager';
 import type { AgChartOptions } from '../options/chart/chartBuilderOptions';
 
 export interface LicenseManager {
@@ -11,7 +12,7 @@ export interface LicenseManager {
 interface EnterpriseModuleOptions {
     isEnterprise: boolean;
     licenseManager?: (options: AgChartOptions) => LicenseManager;
-    injectWatermark?: (parentElement: HTMLElement, text: string) => void;
+    injectWatermark?: (domManager: DOMManager, text: string) => void;
 }
 
 export const enterpriseModule: EnterpriseModuleOptions = {

--- a/packages/ag-charts-community/src/module/moduleContext.ts
+++ b/packages/ag-charts-community/src/module/moduleContext.ts
@@ -2,6 +2,7 @@ import type { AnnotationManager } from '../chart/annotation/annotationManager';
 import type { ChartAxisDirection } from '../chart/chartAxisDirection';
 import type { ChartService } from '../chart/chartService';
 import type { DataService } from '../chart/data/dataService';
+import type { DOMManager } from '../chart/dom/domManager';
 import type { AnimationManager } from '../chart/interaction/animationManager';
 import type { AriaAnnouncementService } from '../chart/interaction/ariaAnnouncementServices';
 import type { ChartEventManager } from '../chart/interaction/chartEventManager';
@@ -39,6 +40,7 @@ export interface ModuleContext {
     readonly chartEventManager: ChartEventManager;
     readonly contextMenuRegistry: ContextMenuRegistry;
     readonly cursorManager: CursorManager;
+    readonly domManager: DOMManager;
     readonly highlightManager: HighlightManager;
     readonly interactionManager: InteractionManager;
     readonly regionManager: RegionManager;

--- a/packages/ag-charts-community/src/scene/layersManager.ts
+++ b/packages/ag-charts-community/src/scene/layersManager.ts
@@ -57,7 +57,7 @@ export class LayersManager {
     }) {
         const { width, height, pixelRatio } = this.canvas;
         const { zIndex = this.nextZIndex++, name, zIndexSubOrder, getComputedOpacity, getVisibility } = opts;
-        const canvas = new HdpiCanvas({ width, height, pixelRatio, position: 'absolute' });
+        const canvas = new HdpiCanvas({ width, height, pixelRatio });
 
         const newLayer: SceneLayer = {
             id: this.nextLayerId++,

--- a/packages/ag-charts-community/src/util/dom.ts
+++ b/packages/ag-charts-community/src/util/dom.ts
@@ -1,5 +1,4 @@
 const verifiedGlobals = {} as { document: Document; window: Window };
-const injectCache = new WeakMap<Document, Set<string>>();
 
 if (typeof window !== 'undefined') {
     verifiedGlobals.window = window;
@@ -62,23 +61,6 @@ export function downloadUrl(dataUrl: string, fileName: string) {
     body.appendChild(element);
     element.click();
     setTimeout(() => body.removeChild(element));
-}
-
-export function injectStyle(cssStyle: string, uniqueId?: string) {
-    const document = getDocument();
-
-    if (uniqueId && injectCache.get(document)?.has(uniqueId)) return;
-
-    const styleElement = createElement('style');
-    styleElement.innerHTML = cssStyle;
-    // Make sure these styles are injected before other styles, so it can be overridden.
-    document.head.insertBefore(styleElement, document.head.querySelector('style'));
-
-    if (uniqueId && !injectCache.has(document)) {
-        injectCache.set(document, new Set([uniqueId]));
-    } else if (uniqueId) {
-        injectCache.get(document)?.add(uniqueId);
-    }
 }
 
 export function setDocument(document: Document) {

--- a/packages/ag-charts-community/src/util/guardedElement.ts
+++ b/packages/ag-charts-community/src/util/guardedElement.ts
@@ -1,7 +1,7 @@
 export type GuardedElementProperties = {
     element: HTMLElement;
     topTabGuard: HTMLElement;
-    botTabGuard: HTMLElement;
+    bottomTabGuard: HTMLElement;
 };
 
 export class GuardedElement implements GuardedElementProperties {
@@ -15,13 +15,13 @@ export class GuardedElement implements GuardedElementProperties {
     constructor(
         public readonly element: HTMLElement,
         public readonly topTabGuard: HTMLElement,
-        public readonly botTabGuard: HTMLElement
+        public readonly bottomTabGuard: HTMLElement
     ) {
         this.element.tabIndex = -1;
         this.initEventListener(this.element, 'blur', () => this.onBlur());
         this.initEventListener(this.element, 'focus', () => this.onFocus());
         this.initEventListener(this.topTabGuard, 'focus', (ev) => this.onTabStart(ev, this.topTabGuard));
-        this.initEventListener(this.botTabGuard, 'focus', (ev) => this.onTabStart(ev, this.botTabGuard));
+        this.initEventListener(this.bottomTabGuard, 'focus', (ev) => this.onTabStart(ev, this.bottomTabGuard));
     }
 
     set tabIndex(index: number) {
@@ -35,10 +35,10 @@ export class GuardedElement implements GuardedElementProperties {
         // to treat TAB and Shift+TAB the same way.
         if (index > 0) {
             this.topTabGuard.tabIndex = index;
-            this.botTabGuard.style.display = 'none';
+            this.bottomTabGuard.style.display = 'none';
         } else {
             this.topTabGuard.tabIndex = index;
-            this.botTabGuard.tabIndex = index;
+            this.bottomTabGuard.tabIndex = index;
         }
     }
 
@@ -88,7 +88,7 @@ export class GuardedElement implements GuardedElementProperties {
     }
 
     public getBrowserFocusDelta(): -1 | 0 | 1 {
-        const { guessedDelta, guardTarget, topTabGuard, botTabGuard } = this;
+        const { guessedDelta, guardTarget, topTabGuard, bottomTabGuard: botTabGuard } = this;
         if (guessedDelta !== undefined) return guessedDelta;
         if (guardTarget === topTabGuard) return 1;
         if (guardTarget === botTabGuard) return -1;

--- a/packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -1,6 +1,6 @@
 import { getDocument, getWindow } from './dom';
 
-type Size = {
+export type Size = {
     width: number;
     height: number;
 };

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -7,8 +7,7 @@ type AgCrosshairLabelRendererResult = any;
 
 const { Group, Line, BBox } = _Scene;
 const { createId } = _Util;
-const { POSITIVE_NUMBER, RATIO, BOOLEAN, COLOR_STRING, LINE_DASH, OBJECT, Validate, Layers, getDocument } =
-    _ModuleSupport;
+const { POSITIVE_NUMBER, RATIO, BOOLEAN, COLOR_STRING, LINE_DASH, OBJECT, Validate, Layers } = _ModuleSupport;
 
 export class Crosshair extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     readonly id = createId(this);
@@ -130,7 +129,7 @@ export class Crosshair extends _ModuleSupport.BaseModuleInstance implements _Mod
     private updateLabels(keys: string[]) {
         const { labels, ctx, axisLayout } = this;
         keys.forEach((key) => {
-            labels[key] ??= new CrosshairLabel(ctx.scene.canvas.container ?? getDocument('body'));
+            labels[key] ??= new CrosshairLabel(ctx.domManager);
 
             this.updateLabel(labels[key]);
         });

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
@@ -1,8 +1,7 @@
 import type { AgCrosshairLabelRendererParams, AgCrosshairLabelRendererResult } from 'ag-charts-community';
 import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
-const { ActionOnSet, BaseProperties, BOOLEAN, FUNCTION, NUMBER, STRING, Validate, createElement, injectStyle } =
-    _ModuleSupport;
+const { ActionOnSet, BaseProperties, BOOLEAN, FUNCTION, NUMBER, STRING, Validate } = _ModuleSupport;
 const { setAttribute } = _Util;
 const { BBox } = _Scene;
 
@@ -61,6 +60,8 @@ export class CrosshairLabelProperties extends _Scene.ChangeDetectableProperties 
 }
 
 export class CrosshairLabel extends BaseProperties {
+    private id = _Util.createId(this);
+
     @Validate(BOOLEAN)
     enabled: boolean = true;
 
@@ -93,15 +94,14 @@ export class CrosshairLabel extends BaseProperties {
 
     private readonly element: HTMLElement;
 
-    constructor(private readonly labelRoot: HTMLElement) {
+    constructor(private readonly domManager: _ModuleSupport.DOMManager) {
         super();
 
-        this.element = createElement('div');
+        this.element = domManager.addChild('canvas-overlay', `crosshair-label-${this.id}`);
         this.element.classList.add(DEFAULT_LABEL_CLASS);
         setAttribute(this.element, 'aria-hidden', true);
-        labelRoot.appendChild(this.element);
 
-        injectStyle(defaultLabelCss, 'crosshairLabel');
+        this.domManager.addStyles('crosshair-labels', defaultLabelCss);
     }
 
     show(meta: LabelMeta) {
@@ -139,7 +139,7 @@ export class CrosshairLabel extends BaseProperties {
     }
 
     private getContainerBoundingBox(): _Scene.BBox {
-        const { width, height } = this.labelRoot.getBoundingClientRect();
+        const { width, height } = this.domManager.getBoundingClientRect();
         return new BBox(0, 0, width, height);
     }
 
@@ -148,11 +148,7 @@ export class CrosshairLabel extends BaseProperties {
     }
 
     destroy() {
-        const { parentNode } = this.element;
-
-        if (parentNode) {
-            parentNode.removeChild(this.element);
-        }
+        this.domManager.removeChild('canvas-overlay', `crosshair-label-${this.id}`);
     }
 
     toLabelHtml(input: string | AgCrosshairLabelRendererResult, defaults?: AgCrosshairLabelRendererResult): string {

--- a/packages/ag-charts-enterprise/src/features/error-bar/__snapshots__/errorBar.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/features/error-bar/__snapshots__/errorBar.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ErrorBars AG-10525 should render tooltips with no errorbars 1`] = `
-HTMLCollection [
+NodeList [
   <div
     aria-hidden="true"
     class="ag-chart-tooltip ag-chart-tooltip-no-interaction ag-chart-tooltip-arrow ag-chart-tooltip-wrap-hyphenate"
@@ -17,7 +17,7 @@ HTMLCollection [
 `;
 
 exports[`ErrorBars should render default tooltips 1`] = `
-HTMLCollection [
+NodeList [
   <div
     aria-hidden="true"
     class="ag-chart-tooltip ag-chart-tooltip-no-interaction ag-chart-tooltip-arrow ag-chart-tooltip-wrap-hyphenate"

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.test.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.test.ts
@@ -597,7 +597,7 @@ describe('ErrorBars', () => {
         await hoverAction(x, y)(chart);
         await waitForChartStability(chart);
 
-        expect(document.body.getElementsByClassName('ag-chart-tooltip')).toMatchSnapshot();
+        expect(document.querySelectorAll('.ag-chart-tooltip')).toMatchSnapshot();
     });
 
     it('AG-10525 should render tooltips with no errorbars', async () => {
@@ -608,7 +608,7 @@ describe('ErrorBars', () => {
         await hoverAction(x, y)(chart);
         await waitForChartStability(chart);
 
-        expect(document.body.getElementsByClassName('ag-chart-tooltip')).toMatchSnapshot();
+        expect(document.querySelectorAll('.ag-chart-tooltip')).toMatchSnapshot();
     });
 
     it('should provide tooltip params', async () => {

--- a/packages/ag-charts-enterprise/src/license/watermark.ts
+++ b/packages/ag-charts-enterprise/src/license/watermark.ts
@@ -1,6 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
 
-const { createElement, injectStyle } = _ModuleSupport;
+const { createElement } = _ModuleSupport;
 
 const watermarkStyles = `
 .ag-watermark {
@@ -36,13 +36,15 @@ const watermarkStyles = `
 }
 `;
 
-export function injectWatermark(parentElement: HTMLElement, text: string) {
-    injectStyle(watermarkStyles, 'watermark');
-    const element = createElement('div');
+export function injectWatermark(domManager: _ModuleSupport.DOMManager, text: string) {
+    domManager.addStyles('watermark', watermarkStyles);
+    const element = domManager.addChild('canvas-overlay', 'watermark');
     const textElement = createElement('span');
     textElement.innerText = text;
-    element.addEventListener('animationend', () => parentElement.removeChild(element));
+    element.addEventListener('animationend', () => {
+        domManager.removeChild('canvas-overlay', 'watermark');
+        domManager.removeStyles('watermark');
+    });
     element.classList.add('ag-watermark');
     element.appendChild(textElement);
-    parentElement.appendChild(element);
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11450

Multiple improvements:
- Reworks all Chart DOM elements so they are managed by a new manager, `DOMManager`.
- All `container`, `wrapper` and child related DOM actions are now centralised.
- All DOM elements added now live under the specified `container`.

This opens the door to use of shadow-DOM scenarios in the future, as well as simplifying positioning of overlaying HTML elements.

Before:
![Screenshot 2024-05-03 at 15 55 50](https://github.com/ag-grid/ag-charts/assets/17544187/a8cc2487-0633-4845-9e07-b77e4e6532ff)

After:
![Screenshot 2024-05-03 at 15 54 47](https://github.com/ag-grid/ag-charts/assets/17544187/273cfecc-b93a-4f4f-bd0f-462da78657d1)
