### PR TITLE
AG-11450 - Fix tooltip hover events.

### DIFF
--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -17,6 +17,12 @@ const domElementConfig: Record<
 };
 
 const STYLES = `
+.ag-chart-wrapper {
+    touch-action: none;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
 .ag-charts-style {
     display: none;
 }
@@ -198,6 +204,34 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
 
     getBoundingClientRect() {
         return this.parent.element.getBoundingClientRect();
+    }
+
+    calculateCanvasPosition(el: HTMLElement) {
+        let x = 0;
+        let y = 0;
+
+        const parentRect = this.getBoundingClientRect();
+        const elRect = el.getBoundingClientRect();
+        x = elRect.x - parentRect.x;
+        y = elRect.y - parentRect.y;
+
+        return { x, y };
+    }
+
+    isManagedDOMElement(el: HTMLElement, container = this.parentElement.element) {
+        while (el && el !== container) {
+            if (el.parentElement == null) return false;
+            el = el.parentElement;
+        }
+
+        return true;
+    }
+
+    isManagedChildDOMElement(el: HTMLElement, domElementClass: DOMElementClass, id: string) {
+        const { children } = this.rootElements.get(domElementClass) ?? {};
+
+        const search = children?.get(id);
+        return search != null && this.isManagedDOMElement(el, search);
     }
 
     isEventOverElement(event: Event | MouseEvent | TouchEvent) {

--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -122,11 +122,6 @@ const defaultTooltipCss = `
 
     margin: 0 auto;
 }
-
-.ag-chart-wrapper {
-    box-sizing: border-box;
-    overflow: hidden;
-}
 `;
 
 /**

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -163,13 +163,13 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
             elements,
             ctx: { scene },
         } = this;
-        const { relatedTarget, target } = event.sourceEvent as MouseEvent;
+        const { relatedElement, targetElement } = event;
         const { FloatingBottom, FloatingTop } = ToolbarPosition;
 
-        if (!enabled || target !== scene.canvas.element) return;
+        if (!enabled || targetElement !== scene.canvas.element) return;
 
         const isTargetButton = TOOLBAR_GROUPS.some((group) =>
-            this.groupButtons[group].some((button) => button === relatedTarget)
+            this.groupButtons[group].some((button) => button === relatedElement)
         );
         if (isTargetButton) return;
 

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -17,7 +17,7 @@ import {
     Validate,
 } from '../../util/validation';
 import type { DOMManager } from '../dom/domManager';
-import type { PointerInteractionEvent, PointerOffsets } from '../interaction/interactionManager';
+import type { PointerOffsets } from '../interaction/interactionManager';
 
 export const DEFAULT_TOOLTIP_CLASS = 'ag-chart-tooltip';
 export const DEFAULT_TOOLTIP_DARK_CLASS = 'ag-chart-dark-tooltip';
@@ -37,6 +37,8 @@ type TooltipPositionType =
 export type TooltipEventType = 'hover' | 'keyboard';
 export type TooltipPointerEvent<T extends TooltipEventType> = PointerOffsets & {
     type: T;
+    relatedElement?: HTMLElement;
+    targetElement?: HTMLElement;
 };
 
 export type TooltipMeta = PointerOffsets & {
@@ -173,6 +175,10 @@ export class Tooltip extends BaseProperties {
     private showTimeout: NodeJS.Timeout | number = 0;
     private _showArrow = true;
 
+    get interactive() {
+        return this.enableInteraction;
+    }
+
     constructor() {
         super();
     }
@@ -290,16 +296,6 @@ export class Tooltip extends BaseProperties {
         for (const wrapType of this.wrapTypes) {
             classList.toggle(`${DEFAULT_TOOLTIP_CLASS}-wrap-${wrapType}`, wrapType === this.wrapping);
         }
-    }
-
-    pointerLeftOntoTooltip(event: PointerInteractionEvent<'leave'>): boolean {
-        if (!this.enableInteraction) return false;
-
-        const classList = ((event.sourceEvent as MouseEvent).relatedTarget as any)?.classList as DOMTokenList;
-        const classes = ['', '-title', '-content'];
-        const classListContains = Boolean(classes.filter((c) => classList?.contains(`${DEFAULT_TOOLTIP_CLASS}${c}`)));
-
-        return classList !== undefined && classListContains;
     }
 
     private updateShowArrow(show: boolean) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11450

Fixes hover of interactive tooltips; as a bonus, cleans up some of the digging through `sourceEvent` to find related `HTMLElement` instances.