### PR TITLE
AG-11450 - More new DOM structure fixes.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -557,7 +557,7 @@ describe('Chart', () => {
         });
 
         it('should setup DOM on create', async () => {
-            const elements = document.querySelectorAll('.ag-chart-wrapper');
+            const elements = document.querySelectorAll('.ag-charts-wrapper');
             expect(elements.length).toEqual(1);
 
             expect(elements[0].querySelectorAll('canvas')).toHaveLength(1);
@@ -567,7 +567,7 @@ describe('Chart', () => {
         it('should cleanup DOM on destroy()', async () => {
             agChartInstance.destroy();
 
-            const elements = document.querySelectorAll('.ag-chart-wrapper');
+            const elements = document.querySelectorAll('.ag-charts-wrapper');
             expect(elements.length).toEqual(0);
 
             expect(document.querySelectorAll('canvas')).toHaveLength(0);
@@ -591,7 +591,7 @@ describe('Chart', () => {
             AgCharts.update(agChartInstance, options);
             await waitForChartStability(agChartInstance);
 
-            const elements = document.querySelectorAll('.ag-chart-wrapper');
+            const elements = document.querySelectorAll('.ag-charts-wrapper');
             expect(elements).toHaveLength(1);
 
             expect(elements[0].querySelectorAll('canvas')).toHaveLength(1);

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -172,12 +172,10 @@ export abstract class Chart extends Observable implements AgChartInstance {
         newValue(value: HTMLElement) {
             if (this.destroyed) return;
 
-            value.setAttribute('data-ag-charts', '');
             this.ctx.domManager.setContainer(value);
             Chart.chartsInstances.set(value, this);
         },
         oldValue(value: HTMLElement) {
-            value.removeAttribute('data-ag-charts');
             Chart.chartsInstances.delete(value);
         },
     })

--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -24,10 +24,6 @@ const STYLES = `
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
 }
 
 .ag-charts-canvas {

--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -27,7 +27,7 @@ const STYLES = `
 }
 
 .ag-charts-canvas {
-    position: relative;
+    position: absolute;
 }
 
 .ag-charts-canvas > * {

--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -96,6 +96,7 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
 
         this.parentElement = new GuardedAgChartsWrapperElement();
         const { element } = this.parentElement;
+        element.setAttribute('data-ag-charts', '');
         if (container) {
             this.setContainer(container);
         }

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -226,8 +226,13 @@ export class Tooltip extends BaseProperties {
             tooltipBounds
         );
 
-        const left = clamp(0, position.x, windowBounds.width - element.clientWidth - 1);
-        const top = clamp(0, position.y, windowBounds.height - element.clientHeight);
+        const minX = -canvasRect.left;
+        const maxX = windowBounds.width - element.clientWidth - 1 + minX;
+        const left = clamp(minX, position.x, maxX);
+
+        const minY = -canvasRect.top;
+        const maxY = windowBounds.height - element.clientHeight + minY;
+        const top = clamp(minY, position.y, maxY);
 
         const constrained = left !== position.x || top !== position.y;
         const defaultShowArrow =
@@ -302,13 +307,7 @@ export class Tooltip extends BaseProperties {
         this._showArrow = show;
     }
 
-    private getTooltipBounds({
-        positionType,
-        meta,
-        yOffset,
-        xOffset,
-        canvasRect,
-    }: {
+    private getTooltipBounds(opts: {
         positionType: TooltipPositionType;
         meta: TooltipMeta;
         yOffset: number;
@@ -316,6 +315,8 @@ export class Tooltip extends BaseProperties {
         canvasRect: DOMRect;
     }): Bounds {
         if (!this.element) return {};
+
+        const { positionType, meta, yOffset, xOffset, canvasRect } = opts;
 
         const { clientWidth: tooltipWidth, clientHeight: tooltipHeight } = this.element;
         const bounds: Bounds = { width: tooltipWidth, height: tooltipHeight };

--- a/packages/ag-charts-community/src/scene/bbox.ts
+++ b/packages/ag-charts-community/src/scene/bbox.ts
@@ -36,6 +36,10 @@ export class BBox implements DistantObject, Interpolating<BBox> {
         this.height = height;
     }
 
+    static fromDOMRect({ x, y, width, height }: DOMRect) {
+        return new BBox(x, y, width, height);
+    }
+
     clone() {
         const { x, y, width, height } = this;
         return new BBox(x, y, width, height);

--- a/packages/ag-charts-community/src/scene/canvas/hdpiCanvas.ts
+++ b/packages/ag-charts-community/src/scene/canvas/hdpiCanvas.ts
@@ -99,7 +99,7 @@ export class HdpiCanvas {
 
     private onEnabledChange() {
         if (this.element) {
-            this.element.style.display = this.enabled ? 'block' : 'none';
+            this.element.style.display = this.enabled ? '' : 'none';
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
@@ -17,7 +17,7 @@ export const defaultLabelCss = `
     font: 12px Verdana, sans-serif;
     overflow: hidden;
     white-space: nowrap;
-    z-index: 99999;
+    z-index: 99998; // Needs to be below tooltips!
     box-sizing: border-box;
 }
 

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/styles.css
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/update-partial/styles.css
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/update-partial/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/api-download/_examples/download/styles.css
+++ b/packages/ag-charts-website/src/content/docs/api-download/_examples/download/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-cross-lines/_examples/axis-cross-lines-adding/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-cross-lines/_examples/axis-cross-lines-adding/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 #myChart {

--- a/packages/ag-charts-website/src/content/docs/axes-cross-lines/_examples/axis-cross-lines-customising/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-cross-lines/_examples/axis-cross-lines-customising/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 #myChart {

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-min-max/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-min-max/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .btnPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-nice/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-nice/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .btnPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/styles.css
@@ -19,10 +19,6 @@
 
 #myChart {
     height: 100%;
-}
-
-.ag-chart-wrapper {
     resize: both;
     /* 'auto' has different behaviour on Windows! */
-    overflow: hidden;
 }

--- a/packages/ag-charts-website/src/content/docs/axes-labels/_examples/axis-label-rotation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-labels/_examples/axis-label-rotation/styles.css
@@ -19,10 +19,6 @@
 
 #myChart {
     height: 100%;
-}
-
-.ag-chart-wrapper {
     resize: both;
     /* 'auto' has different behaviour on Windows! */
-    overflow: hidden;
 }

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-interval/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-interval/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .btnPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-min-max-spacing/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-min-max-spacing/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .btnPanel {
@@ -16,10 +15,6 @@
 
 #myChart {
     height: 100%;
-}
-
-.ag-chart-wrapper {
     resize: both;
     /* 'auto' has different behaviour on Windows! */
-    overflow: hidden;
 }

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-values/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-values/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .btnPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/axes-types/_examples/time-vs-ordinal-time/styles.css
+++ b/packages/ag-charts-website/src/content/docs/axes-types/_examples/time-vs-ordinal-time/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/bubble-series/_examples/bubble-chart-labels/styles.css
+++ b/packages/ag-charts-website/src/content/docs/bubble-series/_examples/bubble-chart-labels/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .sliders {

--- a/packages/ag-charts-website/src/content/docs/combination-series/_examples/combination/styles.css
+++ b/packages/ag-charts-website/src/content/docs/combination-series/_examples/combination/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/events/_examples/chart-click-event/styles.css
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/chart-click-event/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/events/_examples/interaction-ranges/styles.css
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/interaction-ranges/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/events/_examples/legend-item-click-event/styles.css
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/legend-item-click-event/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/events/_examples/node-click-event/styles.css
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/node-click-event/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/events/_examples/node-click-select/styles.css
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/node-click-select/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/events/_examples/node-double-click-event/styles.css
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/node-double-click-event/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/events/_examples/series-node-click-event/styles.css
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/series-node-click-event/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-horizontal/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-horizontal/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .sliders {

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-vertical/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-vertical/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .sliders {

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-constraints/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-constraints/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .sliders {

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-customisation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-customisation/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-pagination/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-pagination/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-position/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-position/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-seriesStroke/styles.css
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-seriesStroke/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/easeOut-very-slow/styles.css
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/easeOut-very-slow/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/integrated-category-animation/styles.css
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/integrated-category-animation/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctional/style.css
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctional/style.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctionalTs/style.css
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/reactFunctionalTs/style.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/typescript/style.css
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/provided/modules/typescript/style.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/style.css
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/real-time/style.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator-styling/styles.css
+++ b/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator-styling/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator/styles.css
+++ b/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/scatter-series/_examples/scatter-chart-labels/styles.css
+++ b/packages/ag-charts-website/src/content/docs/scatter-series/_examples/scatter-chart-labels/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .sliders {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/styles.css
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/custom-theme/styles.css
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/custom-theme/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/styles.css
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip-arrow/styles.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip-arrow/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip-styling/styles.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip-styling/styles.css
@@ -10,7 +10,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip/styles.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/interaction-range/style.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/interaction-range/style.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-content-title/styles.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-content-title/styles.css
@@ -6,7 +6,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-interaction/styles.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-interaction/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 #myChart {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/styles.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-renderer/styles.css
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-renderer/styles.css
@@ -6,7 +6,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-time-axis/styles.css
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-time-axis/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/content/gallery/_examples/log-axis/styles.css
+++ b/packages/ag-charts-website/src/content/gallery/_examples/log-axis/styles.css
@@ -2,7 +2,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
 }
 
 .toolPanel {

--- a/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/ExampleStyle.tsx
+++ b/packages/ag-charts-website/src/features/example-runner/framework-templates/lib/ExampleStyle.tsx
@@ -38,17 +38,6 @@ export const ExampleStyle = ({ rootSelector, extraStyles }: { rootSelector?: str
             padding: 1rem;
         }
 
-        [data-ag-charts] {
-            overflow: hidden;
-        }
-
-        /* Center charts with explicit width and heights */
-        .ag-chart-wrapper {
-            display: flex !important;
-            align-items: center !important;
-            justify-content: center !important;
-        }
-
         button:not(#myGrid button, #myChart button, button[class*='ag-'], .ag-chart-context-menu button) {
             --background-color: transparent;
             --text-color: #212529;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -54,7 +54,7 @@ const applyDarkmode = () => {
     document.documentElement.setAttribute('data-dark-mode', darkmode);
     const charts = document.querySelectorAll('[data-ag-charts]');
     charts.forEach((element) => {
-        const chart = __chartAPI.getInstance(element);
+        const chart = __chartAPI.getInstance(element.parentElement);
         if (chart == null) return;
         // .update is monkey-patched to apply theme to options
         // This is just needed to trigger the theme update


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11450

More refinements of the new DOM:
- Tooltips now respect `window` bounds correctly, and are no longer clipped due to removal of redundant `overflow: hidden` in several spots.
- Creating a chart into a DOM with ZERO CSS styles now renders a chart correctly.
- Setting chart `width` and/or `height` now correctly auto-centers the chart in the container DIV.
  - Additionally, tooltips, focus box and other overlaid elements now appear in the correct positions relative to the canvas.
- Reduction of number of inline styles in favour of CSS-based styles when feasible.

Example-runner cleanup:
- Stop polluting the container element:
  - Moved `data-ag-charts` onto `.ag-charts-wrapper` which we manage.

Use-cases tested - configs:
- Zero CSS / auto-sized chart ✅ 
- Zero CSS / fixed-sized chart ✅ 
- Container fixed/% / auto-sized chart ✅ 
- Container fixed/% / fixed-size chart ✅ 

Features tested:
- Tooltips ✅ 
- Keyboard Nav ✅ 
- Crosshairs ✅ 
- Context Menu ✅ 
- Zoom buttons ✅ 