### PR TITLE
AG-9528 Add sankey chart type

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.ts
@@ -20,15 +20,17 @@ import {
     isAgCartesianChartOptions,
     isAgHierarchyChartOptions,
     isAgPolarChartOptions,
+    isAgSankeyChartOptions,
     isAgTopologyChartOptions,
 } from './mapping/types';
 import { MementoCaretaker } from './memento';
 import { PolarChart } from './polarChart';
+import { SankeyChart } from './sankeyChart';
 import { TopologyChart } from './topologyChart';
 
 const debug = Debug.create(true, 'opts');
 
-function chartType(options: any): 'cartesian' | 'polar' | 'hierarchy' | 'topology' {
+function chartType(options: any): 'cartesian' | 'polar' | 'hierarchy' | 'topology' | 'sankey' {
     if (isAgCartesianChartOptions(options)) {
         return 'cartesian';
     } else if (isAgPolarChartOptions(options)) {
@@ -311,6 +313,8 @@ class AgChartsInternal {
             return PolarChart;
         } else if (isAgTopologyChartOptions(options)) {
             return TopologyChart;
+        } else if (isAgSankeyChartOptions(options)) {
+            return SankeyChart;
         }
 
         throw new Error(

--- a/packages/ag-charts-community/src/chart/background/backgroundModule.ts
+++ b/packages/ag-charts-community/src/chart/background/backgroundModule.ts
@@ -5,6 +5,6 @@ export const BackgroundModule: Module = {
     type: 'root',
     optionsKey: 'background',
     packageType: 'community',
-    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'],
+    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'],
     instanceConstructor: Background,
 };

--- a/packages/ag-charts-community/src/chart/factory/chartTypes.ts
+++ b/packages/ag-charts-community/src/chart/factory/chartTypes.ts
@@ -1,6 +1,6 @@
 import { mergeDefaults } from '../../util/object';
 
-export type ChartType = 'cartesian' | 'polar' | 'hierarchy' | 'topology';
+export type ChartType = 'cartesian' | 'polar' | 'hierarchy' | 'topology' | 'sankey';
 
 class ChartTypes extends Map<string, ChartType | 'unknown'> {
     override get(seriesType: string) {
@@ -18,6 +18,9 @@ class ChartTypes extends Map<string, ChartType | 'unknown'> {
     isTopology(seriesType: string) {
         return this.get(seriesType) === 'topology';
     }
+    isSankey(seriesType: string) {
+        return this.get(seriesType) === 'sankey';
+    }
     get seriesTypes() {
         return Array.from(this.keys());
     }
@@ -32,6 +35,9 @@ class ChartTypes extends Map<string, ChartType | 'unknown'> {
     }
     get topologyTypes() {
         return this.seriesTypes.filter((t) => this.isTopology(t));
+    }
+    get sankeyTypes() {
+        return this.seriesTypes.filter((t) => this.isSankey(t));
     }
 }
 

--- a/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/expectedEnterpriseModules.ts
@@ -4,22 +4,22 @@ type EnterpriseModuleStub = {
     packageType?: 'enterprise';
     identifier?: string;
     optionsKey: string;
-    chartTypes: ('cartesian' | 'polar' | 'hierarchy' | 'topology')[];
+    chartTypes: ('cartesian' | 'polar' | 'hierarchy' | 'topology' | 'sankey')[];
     useCount?: number;
     optionsInnerKey?: string;
 };
 
 export const EXPECTED_ENTERPRISE_MODULES: EnterpriseModuleStub[] = [
-    { type: 'root', optionsKey: 'animation', chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'] },
+    { type: 'root', optionsKey: 'animation', chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'] },
     { type: 'root', optionsKey: 'annotations', chartTypes: ['cartesian'] },
     {
         type: 'root',
         optionsKey: 'background',
-        chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'],
+        chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'],
         optionsInnerKey: 'image',
     },
-    { type: 'root', optionsKey: 'contextMenu', chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'] },
-    { type: 'root', optionsKey: 'dataSource', chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'] },
+    { type: 'root', optionsKey: 'contextMenu', chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'] },
+    { type: 'root', optionsKey: 'dataSource', chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'] },
     { type: 'root', optionsKey: 'sync', chartTypes: ['cartesian'] },
     { type: 'root', optionsKey: 'zoom', chartTypes: ['cartesian', 'topology'] },
     {

--- a/packages/ag-charts-community/src/chart/factory/registerInbuiltModules.ts
+++ b/packages/ag-charts-community/src/chart/factory/registerInbuiltModules.ts
@@ -15,6 +15,7 @@ import { LineSeriesModule } from '../series/cartesian/lineSeriesModule';
 import { ScatterSeriesModule } from '../series/cartesian/scatterSeriesModule';
 import { DonutSeriesModule } from '../series/polar/donutSeriesModule';
 import { PieSeriesModule } from '../series/polar/pieSeriesModule';
+import { SankeySeriesModule } from '../series/sankey/sankeySeriesModule';
 import { ToolbarModule } from '../toolbar/toolbarModule';
 import { axisRegistry } from './axisRegistry';
 
@@ -31,7 +32,8 @@ export function registerInbuiltModules() {
         ScatterSeriesModule,
         DonutSeriesModule,
         PieSeriesModule,
-        HistogramSeriesModule
+        HistogramSeriesModule,
+        SankeySeriesModule
     );
 
     for (const AxisConstructor of [NumberAxis, CategoryAxis, TimeAxis, GroupedCategoryAxis, LogAxis]) {

--- a/packages/ag-charts-community/src/chart/factory/seriesRegistry.ts
+++ b/packages/ag-charts-community/src/chart/factory/seriesRegistry.ts
@@ -6,6 +6,7 @@ import type {
     AgCartesianSeriesOptions,
     AgHierarchySeriesOptions,
     AgPolarSeriesOptions,
+    AgSankeySeriesOptions,
 } from '../../options/agChartOptions';
 import type { AgChartOptions } from '../../options/chart/chartBuilderOptions';
 import type { AgTopologySeriesOptions } from '../../options/series/topology/topologyOptions';
@@ -19,7 +20,8 @@ export type SeriesOptions =
     | AgCartesianSeriesOptions
     | AgPolarSeriesOptions
     | AgHierarchySeriesOptions
-    | AgTopologySeriesOptions;
+    | AgTopologySeriesOptions
+    | AgSankeySeriesOptions;
 
 interface SeriesRegistryRecord {
     instanceConstructor?: SeriesConstructor;

--- a/packages/ag-charts-community/src/chart/legendModule.ts
+++ b/packages/ag-charts-community/src/chart/legendModule.ts
@@ -5,7 +5,7 @@ export const CommunityLegendModule: LegendModule = {
     type: 'legend',
     optionsKey: 'legend',
     identifier: 'category',
-    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'],
+    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'],
     instanceConstructor: Legend,
     packageType: 'community',
 };

--- a/packages/ag-charts-community/src/chart/mapping/types.ts
+++ b/packages/ag-charts-community/src/chart/mapping/types.ts
@@ -2,8 +2,10 @@ import type {
     AgCartesianChartOptions,
     AgHierarchyChartOptions,
     AgPolarChartOptions,
+    AgSankeyChartOptions,
+    AgTopologyChartOptions,
 } from '../../options/agChartOptions';
-import type { AgChartOptions, AgTopologyChartOptions } from '../../options/chart/chartBuilderOptions';
+import type { AgChartOptions } from '../../options/chart/chartBuilderOptions';
 import { Logger } from '../../util/logger';
 import { axisRegistry } from '../factory/axisRegistry';
 import { chartTypes } from '../factory/chartTypes';
@@ -76,6 +78,15 @@ export function isAgTopologyChartOptions(input: AgChartOptions): input is AgTopo
     }
 
     return chartTypes.isTopology(specifiedType) || isEnterpriseTopology(specifiedType);
+}
+
+export function isAgSankeyChartOptions(input: AgChartOptions): input is AgSankeyChartOptions {
+    const specifiedType = optionsType(input);
+    if (specifiedType == null) {
+        return false;
+    }
+
+    return chartTypes.isSankey(specifiedType) || isEnterpriseTopology(specifiedType);
 }
 
 export function isAgPolarChartOptionsWithSeriesBasedLegend(input: AgChartOptions): input is AgPolarChartOptions {

--- a/packages/ag-charts-community/src/chart/sankeyChart.ts
+++ b/packages/ag-charts-community/src/chart/sankeyChart.ts
@@ -1,0 +1,6 @@
+import { Chart } from './chart';
+
+export class SankeyChart extends Chart {
+    static readonly className = 'SankeyChart';
+    static readonly type = 'sankey' as const;
+}

--- a/packages/ag-charts-community/src/chart/series/sankey/sankeySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/sankey/sankeySeries.ts
@@ -1,0 +1,45 @@
+import type { ModuleContext } from '../../../module/moduleContext';
+import type { BBox } from '../../../scene/bbox';
+import type { PointLabelDatum } from '../../../scene/util/labelPlacement';
+import type { ChartAnimationPhase } from '../../chartAnimationPhase';
+import type { ChartAxisDirection } from '../../chartAxisDirection';
+import type { DataController } from '../../data/dataController';
+import type { TooltipContent } from '../../tooltip/tooltip';
+import { Series, type SeriesNodeDataContext } from '../series';
+import { SankeySeriesProperties } from './sankeySeriesProperties';
+
+export class SankeySeries extends Series<any, any> {
+    override properties = new SankeySeriesProperties();
+
+    constructor(moduleCtx: ModuleContext) {
+        super({
+            moduleCtx,
+        });
+    }
+
+    override async processData(_dataController: DataController): Promise<void> {}
+
+    override async createNodeData(): Promise<SeriesNodeDataContext<any, any> | undefined> {
+        return;
+    }
+
+    override async update(_opts: { seriesRect?: BBox | undefined }): Promise<void> {}
+
+    override resetAnimation(_chartAnimationPhase: ChartAnimationPhase): void {}
+
+    override getTooltipHtml(_seriesDatum: any): TooltipContent {
+        return { html: '', ariaLabel: '' };
+    }
+
+    override getSeriesDomain(_direction: ChartAxisDirection): any[] {
+        return [];
+    }
+
+    override getLabelData(): PointLabelDatum[] {
+        return [];
+    }
+
+    override getLegendData(_legendType: unknown) {
+        return [];
+    }
+}

--- a/packages/ag-charts-community/src/chart/series/sankey/sankeySeriesModule.ts
+++ b/packages/ag-charts-community/src/chart/series/sankey/sankeySeriesModule.ts
@@ -1,0 +1,19 @@
+import type { SeriesModule } from '../../../module/coreModules';
+import { EXTENDS_SERIES_DEFAULTS } from '../../themes/symbols';
+import { SankeySeries } from './sankeySeries';
+
+export const SankeySeriesModule: SeriesModule<'sankey'> = {
+    type: 'series',
+    optionsKey: 'series[]',
+    packageType: 'community',
+    chartTypes: ['sankey'],
+
+    identifier: 'sankey',
+    instanceConstructor: SankeySeries,
+
+    themeTemplate: {
+        series: {
+            __extends__: EXTENDS_SERIES_DEFAULTS,
+        },
+    },
+};

--- a/packages/ag-charts-community/src/chart/series/sankey/sankeySeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/sankey/sankeySeriesProperties.ts
@@ -1,0 +1,12 @@
+import type {
+    AgSankeySeriesOptions,
+    AgSankeySeriesTooltipRendererParams,
+} from '../../../options/series/sankey/sankeyOptions';
+import { OBJECT, Validate } from '../../../util/validation';
+import { SeriesProperties } from '../seriesProperties';
+import { SeriesTooltip } from '../seriesTooltip';
+
+export class SankeySeriesProperties extends SeriesProperties<AgSankeySeriesOptions> {
+    @Validate(OBJECT)
+    readonly tooltip = new SeriesTooltip<AgSankeySeriesTooltipRendererParams>();
+}

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -249,6 +249,17 @@ export function topologyChartAssertions(params?: { seriesTypes?: string[] }) {
     };
 }
 
+export function sankeyChartAssertions(params?: { seriesTypes?: string[] }) {
+    const { seriesTypes = ['map-shape'] } = params ?? {};
+
+    return async (chartOrProxy: Chart | AgChartProxy) => {
+        const chart = deproxy(chartOrProxy);
+        expect(chart?.constructor?.name).toEqual('SankeyChart');
+        expect(chart.axes).toHaveLength(0);
+        expect(chart.series.map((s) => s.type)).toEqual(seriesTypes);
+    };
+}
+
 const checkTargetValid = (target: HTMLElement) => {
     if (!target.isConnected) throw new Error('Chart must be configured with a container for event testing to work');
 };

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -73,6 +73,9 @@ const CHART_TYPE_CONFIG: { [k in ChartType]: ChartTypeConfig } = {
     get topology(): ChartTypeConfig {
         return { seriesTypes: chartTypes.topologyTypes, commonOptions: [] };
     },
+    get sankey(): ChartTypeConfig {
+        return { seriesTypes: chartTypes.topologyTypes, commonOptions: [] };
+    },
 };
 
 const CHART_TYPE_SPECIFIC_COMMON_OPTIONS = Object.values(CHART_TYPE_CONFIG).reduce<
@@ -315,7 +318,8 @@ export class ChartTheme {
             getOverridesByType('cartesian', chartTypes.cartesianTypes),
             getOverridesByType('polar', chartTypes.polarTypes),
             getOverridesByType('hierarchy', chartTypes.hierarchyTypes),
-            getOverridesByType('topology', chartTypes.topologyTypes)
+            getOverridesByType('topology', chartTypes.topologyTypes),
+            getOverridesByType('sankey', chartTypes.sankeyTypes)
         );
     }
 

--- a/packages/ag-charts-community/src/module/baseModule.ts
+++ b/packages/ag-charts-community/src/module/baseModule.ts
@@ -9,7 +9,7 @@ export interface ModuleInstance {
     destroy(): void;
 }
 
-export type ChartTypes = 'cartesian' | 'polar' | 'hierarchy' | 'topology';
+export type ChartTypes = 'cartesian' | 'polar' | 'hierarchy' | 'topology' | 'sankey';
 
 export interface BaseModule<T extends ChartTypes = ChartTypes> {
     optionsKey: string;

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -9,6 +9,7 @@ import {
     isAgHierarchyChartOptions,
     isAgPolarChartOptions,
     isAgPolarChartOptionsWithSeriesBasedLegend,
+    isAgSankeyChartOptions,
     isAgTopologyChartOptions,
     isAxisOptionType,
     isSeriesOptionType,
@@ -407,6 +408,8 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             return 'treemap';
         } else if (isAgTopologyChartOptions(options)) {
             return 'map-shape';
+        } else if (isAgSankeyChartOptions(options)) {
+            return 'sankey';
         }
         throw new Error('Invalid chart options type detected.');
     }

--- a/packages/ag-charts-community/src/module/optionsModuleTypes.ts
+++ b/packages/ag-charts-community/src/module/optionsModuleTypes.ts
@@ -4,6 +4,7 @@ import type { SeriesNodeDatum } from '../chart/series/seriesTypes';
 import type { AgCartesianSeriesOptions } from '../options/series/cartesian/cartesianSeriesTypes';
 import type { AgHierarchySeriesOptions } from '../options/series/hierarchy/hierarchyOptions';
 import type { AgPolarSeriesOptions } from '../options/series/polar/polarOptions';
+import type { AgSankeySeriesOptions } from '../options/series/sankey/sankeyOptions';
 import type { AgTopologySeriesOptions } from '../options/series/topology/topologyOptions';
 import type { ScaleType } from '../scale/scale';
 import type { Point } from '../scene/point';
@@ -17,6 +18,7 @@ export type SeriesType = NonNullable<
     | AgPolarSeriesOptions['type']
     | AgHierarchySeriesOptions['type']
     | AgTopologySeriesOptions['type']
+    | AgSankeySeriesOptions['type']
 >;
 
 export interface SeriesOptionInstance extends ModuleInstance {

--- a/packages/ag-charts-community/src/options/agChartOptions.ts
+++ b/packages/ag-charts-community/src/options/agChartOptions.ts
@@ -54,6 +54,7 @@ export * from './series/topology/mapLineOptions';
 export * from './series/topology/mapMarkerOptions';
 export * from './series/topology/mapShapeBackgroundOptions';
 export * from './series/topology/mapLineBackgroundOptions';
+export * from './series/sankey/sankeyOptions';
 export * from './series/markerOptions';
 
 /**

--- a/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
@@ -1,6 +1,7 @@
 import type { AgBaseCartesianChartOptions } from '../series/cartesian/cartesianOptions';
 import type { AgBaseHierarchyChartOptions } from '../series/hierarchy/hierarchyOptions';
 import type { AgBasePolarChartOptions } from '../series/polar/polarOptions';
+import type { AgBaseSankeyChartOptions } from '../series/sankey/sankeyOptions';
 import type { AgBaseTopologyChartOptions } from '../series/topology/topologyOptions';
 import type { AgBaseChartOptions } from './chartOptions';
 import type { AgBaseChartThemeOptions, AgChartTheme, AgChartThemeName } from './themeOptions';
@@ -25,11 +26,15 @@ export interface AgHierarchyChartOptions extends AgBaseHierarchyChartOptions, Ag
 export interface AgTopologyChartOptions extends AgBaseTopologyChartOptions, AgBaseChartOptions {
     theme?: AgChartTheme | AgChartThemeName;
 }
+export interface AgSankeyChartOptions extends AgBaseSankeyChartOptions, AgBaseChartOptions {
+    theme?: AgChartTheme | AgChartThemeName;
+}
 export type AgChartOptions =
     | AgCartesianChartOptions
     | AgPolarChartOptions
     | AgHierarchyChartOptions
-    | AgTopologyChartOptions;
+    | AgTopologyChartOptions
+    | AgSankeyChartOptions;
 
 export interface AgChartInstance {
     /** Get the `AgChartOptions` representing the current chart configuration. */

--- a/packages/ag-charts-community/src/options/chart/themeOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/themeOptions.ts
@@ -25,6 +25,11 @@ import type { AgRadarAreaSeriesThemeableOptions } from '../series/polar/radarAre
 import type { AgRadarSeriesThemeableOptions } from '../series/polar/radarOptions';
 import type { AgRadialBarSeriesThemeableOptions } from '../series/polar/radialBarOptions';
 import type { AgRadialColumnSeriesThemeableOptions } from '../series/polar/radialColumnOptions';
+import type {
+    AgBaseSankeyThemeOptions,
+    AgSankeySeriesOptions,
+    AgSankeySeriesThemeableOptions,
+} from '../series/sankey/sankeyOptions';
 import type { AgMapLineBackgroundThemeableOptions } from '../series/topology/mapLineBackgroundOptions';
 import type { AgMapLineSeriesThemeableOptions } from '../series/topology/mapLineOptions';
 import type { AgMapMarkerSeriesThemeableOptions } from '../series/topology/mapMarkerOptions';
@@ -156,6 +161,9 @@ export interface AgMapShapeBackgroundThemeOverrides extends AgBaseTopologyThemeO
 export interface AgMapLineBackgroundThemeOverrides extends AgBaseTopologyThemeOptions {
     series?: AgMapLineBackgroundThemeableOptions;
 }
+export interface AgSankeyThemeOverrides extends AgBaseSankeyThemeOptions {
+    series?: AgSankeySeriesThemeableOptions;
+}
 
 export interface AgCommonThemeableAxisOptions extends AgCartesianAxesTheme, AgPolarAxesTheme {}
 
@@ -224,6 +232,8 @@ export interface AgChartThemeOverrides {
     'map-shape-background'?: AgMapShapeBackgroundThemeOverrides;
     /** map-line-background series theme overrides. */
     'map-line-background'?: AgMapLineBackgroundThemeOverrides;
+    /** sankey series theme overrides. */
+    sankey?: AgSankeyThemeOverrides;
 }
 
 // Use Typescript function types to verify that all series types are present in the manually
@@ -234,6 +244,8 @@ type VerifyAgBaseChartThemeOverrides<T = AgBaseChartOptions> = {
     [K in NonNullable<AgPolarSeriesOptions['type']>]?: T;
 } & {
     [K in NonNullable<AgHierarchySeriesOptions['type']>]?: T;
+} & {
+    [K in NonNullable<AgSankeySeriesOptions['type']>]?: T;
 } & {
     common?: Partial<T>;
 };

--- a/packages/ag-charts-community/src/options/series/sankey/sankeyOptions.ts
+++ b/packages/ag-charts-community/src/options/series/sankey/sankeyOptions.ts
@@ -1,0 +1,52 @@
+import type { AgBaseThemeableChartOptions } from '../../chart/chartOptions';
+import type { AgSeriesTooltipRendererParams } from '../../chart/tooltipOptions';
+import type { AgBaseSeriesOptions } from '../seriesOptions';
+
+export interface AgSankeySeriesOptions<TDatum = any>
+    extends AgBaseSeriesOptions<TDatum>,
+        AgSankeySeriesOptionsKeys,
+        AgSankeySeriesThemeableOptions<TDatum> {
+    /** Configuration for the Sankey Series. */
+    type: 'sankey';
+}
+
+export interface AgSankeySeriesThemeableOptions<_TDatum = any> {}
+
+export interface AgSankeySeriesOptionsKeys {
+    /** The name of the node key containing the from id. */
+    fromIdKey?: string;
+    /** The name of the node key containing the to id. */
+    toIdKey?: string;
+    /** The name of the node key containing the size. */
+    sizeKey?: string;
+}
+
+export interface AgSankeySeriesOptionsNames {
+    /** The name of the node key containing the from id. */
+    fromIdName?: string;
+    /** The name of the node key containing the to id. */
+    toIdName?: string;
+    /** The name of the node key containing the size. */
+    sizeName?: string;
+}
+
+export interface AgSankeyNodeOptions {
+    /** The name of the node key containing the id. */
+    idKey?: string;
+    /** The name of the node key containing the id. */
+    labelKey?: string;
+}
+
+export interface AgSankeySeriesTooltipRendererParams
+    extends AgSeriesTooltipRendererParams,
+        AgSankeySeriesOptionsKeys,
+        AgSankeySeriesOptionsNames {}
+
+export interface AgBaseSankeyChartOptions {
+    /** Series configurations. */
+    series?: AgSankeySeriesOptions[];
+    /** Node options */
+    nodes?: AgSankeyNodeOptions[];
+}
+
+export interface AgBaseSankeyThemeOptions extends AgBaseThemeableChartOptions {}

--- a/packages/ag-charts-enterprise/src/features/animation/animationModule.ts
+++ b/packages/ag-charts-enterprise/src/features/animation/animationModule.ts
@@ -6,7 +6,7 @@ export const AnimationModule: _ModuleSupport.Module = {
     type: 'root',
     optionsKey: 'animation',
     packageType: 'enterprise',
-    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'],
+    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'],
     instanceConstructor: Animation,
     themeTemplate: {
         animation: {

--- a/packages/ag-charts-enterprise/src/features/background/backgroundModule.ts
+++ b/packages/ag-charts-enterprise/src/features/background/backgroundModule.ts
@@ -6,6 +6,6 @@ export const BackgroundModule: _ModuleSupport.RootModule = {
     type: 'root',
     optionsKey: 'background',
     packageType: 'enterprise',
-    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'],
+    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'],
     instanceConstructor: Background,
 };

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
@@ -6,7 +6,7 @@ import { ContextMenu } from './contextMenu';
 export const ContextMenuModule: _ModuleSupport.Module = {
     type: 'root',
     packageType: 'enterprise',
-    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology'],
+    chartTypes: ['cartesian', 'polar', 'hierarchy', 'topology', 'sankey'],
     optionsKey: 'contextMenu',
     instanceConstructor: ContextMenu,
     themeTemplate: {

--- a/packages/ag-charts-enterprise/src/features/data-source/dataSourceModule.ts
+++ b/packages/ag-charts-enterprise/src/features/data-source/dataSourceModule.ts
@@ -6,7 +6,7 @@ export const DataSourceModule: _ModuleSupport.Module = {
     type: 'root',
     optionsKey: 'dataSource',
     packageType: 'enterprise',
-    chartTypes: ['cartesian', 'hierarchy', 'polar', 'topology'],
+    chartTypes: ['cartesian', 'hierarchy', 'polar', 'topology', 'sankey'],
     instanceConstructor: DataSource,
     themeTemplate: {
         dataSource: { enabled: false },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9528

The minimal code to get a Sankey chart registered so I can avoid merge conflicts going forward

Only thing to note is this is the first series type that has the same name as a chart. This will change if we're able to merge the Sankey and chord charts - I'm not certain on that yet