### PR TITLE
AG-11450 - Fix flexbox layout case + chart-type switching.

### DIFF
--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -120,10 +120,6 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
 
         this.parentElement = new GuardedAgChartsWrapperElement();
         const { element } = this.parentElement;
-        if (container) {
-            this.setContainer(container);
-        }
-
         this.rootElements = domElementClasses.reduce(
             (r, c) => {
                 const cssClass = `ag-charts-${c}`;
@@ -150,6 +146,10 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
         this.setSizeOptions();
 
         this.addStyles('dom-manager', STYLES);
+
+        if (container) {
+            this.setContainer(container);
+        }
     }
 
     override destroy() {
@@ -157,7 +157,9 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
 
         const { element } = this.parentElement;
         this.observer?.unobserve(element);
-        this.sizeMonitor.unobserve(element);
+        if (this.container) {
+            this.sizeMonitor.unobserve(this.container);
+        }
 
         Object.values(this.rootElements).forEach((el) => {
             el.children.forEach((c) => c.remove());

--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -171,7 +171,7 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
         return this.parentElement;
     }
 
-    setSizeOptions(minWidth: number = 0, minHeight: number = 300, optionsWidth?: number, optionsHeight?: number) {
+    setSizeOptions(minWidth: number = 300, minHeight: number = 300, optionsWidth?: number, optionsHeight?: number) {
         const { style } = this.parentElement.element;
 
         style.width = `${optionsWidth ?? minWidth}px`;

--- a/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/mapping/__snapshots__/prepare.test.ts.snap
@@ -166,6 +166,7 @@ exports[`prepare #prepareOptions for ADV_CHART_CUSTOMISATION it should prepare o
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -699,6 +700,7 @@ exports[`prepare #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE it sho
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -1197,6 +1199,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it should 
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -1892,6 +1895,7 @@ exports[`prepare #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should prepa
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -2642,6 +2646,7 @@ exports[`prepare #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE it sho
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -3008,6 +3013,7 @@ exports[`prepare #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS it s
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -3545,6 +3551,7 @@ exports[`prepare #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE it 
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -4181,6 +4188,7 @@ exports[`prepare #prepareOptions for BAR_CHART_EXAMPLE it should prepare options
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -4557,6 +4565,7 @@ exports[`prepare #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it should pre
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -4930,6 +4939,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE it sho
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -5294,6 +5304,7 @@ exports[`prepare #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE i
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -5657,6 +5668,7 @@ exports[`prepare #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAMPLE i
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -6099,6 +6111,7 @@ exports[`prepare #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should prepare
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -6546,6 +6559,7 @@ exports[`prepare #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepare op
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -7247,6 +7261,7 @@ exports[`prepare #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should prep
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -8401,6 +8416,7 @@ exports[`prepare #prepareOptions for LOG_AXIS_EXAMPLE it should prepare options 
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -8764,6 +8780,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH_EXAM
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -9550,6 +9567,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPLE it 
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -10055,6 +10073,7 @@ exports[`prepare #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EXAMPLE
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -10724,6 +10743,7 @@ exports[`prepare #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should prepare
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -11284,6 +11304,7 @@ exports[`prepare #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should prepa
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -11569,6 +11590,7 @@ exports[`prepare #prepareOptions for SIMPLE_DONUT_CHART_EXAMPLE it should prepar
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "overlays": {
     "loading": {
       "darkTheme": false,
@@ -11893,6 +11915,7 @@ exports[`prepare #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should prepare
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -12237,6 +12260,7 @@ exports[`prepare #prepareOptions for SIMPLE_PIE_CHART_EXAMPLE it should prepare 
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "overlays": {
     "loading": {
       "darkTheme": false,
@@ -12532,6 +12556,7 @@ exports[`prepare #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should prep
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -12893,6 +12918,7 @@ exports[`prepare #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should prepar
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -13630,6 +13656,7 @@ exports[`prepare #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should prepare
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,
@@ -14172,6 +14199,7 @@ exports[`prepare #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should prep
   },
   "listeners": {},
   "minHeight": 300,
+  "minWidth": 300,
   "navigator": {
     "enabled": false,
     "height": 30,

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.ts
@@ -160,6 +160,7 @@ export class ChartTheme {
     private static getChartDefaults() {
         return {
             minHeight: 300,
+            minWidth: 300,
             background: { visible: true, fill: DEFAULT_BACKGROUND_COLOUR },
             padding: { top: 20, right: 20, bottom: 20, left: 20 },
             keyboard: { enabled: true },

--- a/packages/ag-charts-community/src/options/chart/chartOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartOptions.ts
@@ -153,7 +153,7 @@ export interface AgBaseThemeableChartOptions<TDatum = any> {
     minHeight?: PixelSize;
     /**
      * Sets the minimum width of the chart. Ignored if `width` is specified.
-     * Default: `0`
+     * Default: `300`
      */
     minWidth?: PixelSize;
     /** Configuration for the padding shown around the chart. */

--- a/packages/ag-charts-website/src/content/docs/layout-test/_examples/layout-inline/main.ts
+++ b/packages/ag-charts-website/src/content/docs/layout-test/_examples/layout-inline/main.ts
@@ -51,10 +51,14 @@ doc?.write(`
         <div style="display: flex; aspect-ratio: 2 / 1; border: 1px solid black">
             <textarea style="width: 200px; resize: both">Resize me</textarea>
             <div class="chart" style="flex: 1"></div>
+        </div> 
+        <h1>WebApp Example (Simple Flexbox)</h1>
+        <div style="display: flex">
+            <div class="chart"></div>
         </div>
         <h1>Small Grid Example</h1>
         <div style="display: grid; grid: 'a' 1fr / 1fr; width: 100px; height: 100px; border: 1px solid black">
-            <div class="chart" data-min-height="0"></div>
+            <div class="chart" data-min-height="0" data-min-width="0"></div>
         </div>
         <h1>Small Grid Example Via Min/Max Height</h1>
         <div
@@ -68,7 +72,7 @@ doc?.write(`
                 border: 1px solid black;
             "
         >
-            <div class="chart" data-min-height="0"></div>
+            <div class="chart" data-min-height="0" data-min-width="0"></div>
         </div>
         <h1>Grid with Small Chart Example</h1>
         <div style="display: grid; grid: 'a b' auto 'c d' 1fr / auto 1fr; aspect-ratio: 2 / 1; border: 1px solid black">
@@ -83,10 +87,12 @@ doc?.write(`
                 const width = Number(container.getAttribute('data-width'));
                 const height = Number(container.getAttribute('data-height'));
                 const minHeight = Number(container.getAttribute('data-min-height') ?? -1);
+                const minWidth = Number(container.getAttribute('data-min-width') ?? -1);
                 const chartOptions = { ...options, container };
                 if (width > 0) chartOptions.width = width;
                 if (height > 0) chartOptions.height = height;
-                if (minHeight === 0 || minHeight > 0) chartOptions.minHeight = minHeight;
+                if (minHeight >= 0) chartOptions.minHeight = minHeight;
+                if (minWidth >= 0) chartOptions.minWidth = minWidth;
                 AgCharts.create(chartOptions);
             }
         </script>

--- a/packages/ag-charts-website/src/content/docs/layout/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/layout/index.mdoc
@@ -85,14 +85,14 @@ For determining chart size, we either:
 
 If auto-sizing is used for one or both dimenions:
 
--   by default the chart will assume a minimum height of 300px, and grow with the dimensions of the `container` element.
--   set `minHeight: 0` to remove the minimum height constraint, or set `minWidth` to add a minimum width constraint.
+-   by default the chart will assume a minimum width and height of 300px, and grow with the dimensions of the `container` element.
+-   set `minHeight: 0` and/or `minWidth: 0` to effectively remove the constraints.
 
 {% note %}
 When auto-sizing, our DOM elements do not affect the size of the `container` element to avoid infinite loops between
 chart (re)size and resulting `container` resize.
 
-A `<div>` element is commontly used for the `container`, and it should be noted that the default height for this element
+A `<div>` element is commonly used for the `container`, and it should be noted that the default height for this element
 is `0px`; you should explicitly manage the browser calculated `container` element size to achieve the dynamic size you
 require.
 {% /note %}

--- a/packages/ag-charts-website/src/content/docs/sync/_examples/basic-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync/_examples/basic-sync/main.ts
@@ -3,6 +3,7 @@ import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 import { AAPL, MSFT } from './data';
 
 const commonOptions: AgChartOptions = {
+    minWidth: 0,
     minHeight: 0,
     series: [
         {

--- a/packages/ag-charts-website/src/content/docs/sync/_examples/group-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync/_examples/group-sync/main.ts
@@ -3,6 +3,7 @@ import { AgCartesianChartOptions, AgChartOptions, AgCharts } from 'ag-charts-ent
 import { costsProductA, costsProductB, salesProductA, salesProductB } from './data';
 
 const commonOptions: AgCartesianChartOptions = {
+    minWidth: 0,
     minHeight: 0,
     tooltip: {
         enabled: false,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11450

Fixes the trivial `display: flex` container cases by re-instantiating the `minWidth: 300` default.

Fixes hard error on chart-type switch due to initialisation ordering error.