### PR TITLE
AG-10486 QA Feedback for Legend Context Menu

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
@@ -15,9 +15,12 @@ export type ContextMenuActionParams = {
 export class ContextMenuRegistry {
     private readonly defaultActions: Array<ContextMenuAction> = [];
     private readonly disabledActions: Set<string> = new Set();
+    private readonly hiddenActions: Set<string> = new Set();
 
     public filterActions(region: string): ContextMenuAction[] {
-        return this.defaultActions.filter((action) => ['all', region].includes(action.region));
+        return this.defaultActions.filter((action) => {
+            return action.id && !this.hiddenActions.has(action.id) && ['all', region].includes(action.region);
+        });
     }
 
     public registerDefaultAction(action: ContextMenuAction) {
@@ -33,6 +36,14 @@ export class ContextMenuRegistry {
 
     public disableAction(actionId: string) {
         this.disabledActions.add(actionId);
+    }
+
+    public setActionVisiblity(actionId: string, visible: boolean) {
+        if (visible) {
+            this.hiddenActions.delete(actionId);
+        } else {
+            this.hiddenActions.add(actionId);
+        }
     }
 
     public isDisabled(actionId: string): boolean {

--- a/packages/ag-charts-community/src/chart/interaction/highlightManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/highlightManager.ts
@@ -1,5 +1,6 @@
 import { StateTracker } from '../../util/stateTracker';
 import { BaseManager } from '../baseManager';
+import type { CategoryLegendDatum } from '../legendDatum';
 import type { SeriesNodeDatum } from '../series/seriesTypes';
 
 export interface HighlightNodeDatum extends SeriesNodeDatum {
@@ -24,9 +25,11 @@ export interface HighlightChangeEvent {
 export class HighlightManager extends BaseManager<'highlight-change', HighlightChangeEvent> {
     private readonly highlightStates = new StateTracker<HighlightNodeDatum>();
     private readonly pickedStates = new StateTracker<SeriesNodeDatum>();
+    private readonly legendItemStates = new StateTracker<CategoryLegendDatum>();
 
     private activeHighlight?: HighlightNodeDatum;
     private activePicked?: SeriesNodeDatum;
+    private activeLegendItem?: CategoryLegendDatum;
 
     public updateHighlight(callerId: string, highlightedDatum?: HighlightNodeDatum) {
         const { activeHighlight: previousHighlight } = this;
@@ -52,6 +55,15 @@ export class HighlightManager extends BaseManager<'highlight-change', HighlightC
 
     public getActivePicked(): SeriesNodeDatum | undefined {
         return this.activePicked;
+    }
+
+    public updateLegendItem(callerId: string, clickableLegendItem?: CategoryLegendDatum) {
+        this.legendItemStates.set(callerId, clickableLegendItem);
+        this.activeLegendItem = this.legendItemStates.stateValue();
+    }
+
+    public getActiveLegendItem(): CategoryLegendDatum | undefined {
+        return this.activeLegendItem;
     }
 
     private isEqual(a?: SeriesNodeDatum, b?: SeriesNodeDatum) {

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -876,6 +876,7 @@ export class Legend extends BaseProperties {
 
     private checkContextClick(event: PointerInteractionEvent<'contextmenu'>) {
         this.contextMenuDatum = this.getDatumForPoint(event.offsetX, event.offsetY);
+        this.ctx.highlightManager.updateLegendItem(this.id, this.contextMenuDatum);
 
         if (this.preventHidingAll && this.contextMenuDatum?.enabled && this.getVisibleItemCount() <= 1) {
             this.ctx.contextMenuRegistry.disableAction('legend-visibility');
@@ -1062,6 +1063,7 @@ export class Legend extends BaseProperties {
         // is in a state when highlighting is possible.
         if (this.ctx.interactionManager.getState() === InteractionState.Default) {
             this.ctx.highlightManager.updateHighlight(this.id);
+            this.ctx.highlightManager.updateLegendItem(this.id);
         }
     }
 

--- a/packages/ag-charts-community/src/options/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/contextMenuOptions.ts
@@ -1,17 +1,20 @@
 import type { AgNodeContextMenuActionEvent } from './eventOptions';
+import type { AgChartLegendContextMenuEvent } from './legendOptions';
 
 export interface AgContextMenuOptions {
     /**  Whether to show the context menu. */
     enabled?: boolean;
     /**  Custom actions displayed in the context menu when right-clicking anywhere on the chart. */
-    extraActions?: AgContextMenuAction[];
+    extraActions?: AgContextMenuAction<AgNodeContextMenuActionEvent>[];
     /**  Custom actions displayed in the context menu when right-clicking on a series node. */
-    extraNodeActions?: AgContextMenuAction[];
+    extraNodeActions?: AgContextMenuAction<AgNodeContextMenuActionEvent>[];
+    /**  Custom actions displayed in the context menu when right-clicking on a legend item. */
+    extraLegendItemActions?: AgContextMenuAction<AgChartLegendContextMenuEvent>[];
 }
 
-export interface AgContextMenuAction {
+export interface AgContextMenuAction<TEvent = AgNodeContextMenuActionEvent> {
     /** The text to display in the context menu for the custom action. */
     label: string;
     /** Callback function for the custom action. */
-    action: (event: AgNodeContextMenuActionEvent) => void;
+    action: (event: TEvent) => void;
 }

--- a/packages/ag-charts-community/src/options/chart/legendOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/legendOptions.ts
@@ -78,6 +78,8 @@ export interface AgChartLegendClickEvent extends AgChartLegendEvent<'click'> {}
 
 export interface AgChartLegendDoubleClickEvent extends AgChartLegendEvent<'dblclick'> {}
 
+export interface AgChartLegendContextMenuEvent extends AgChartLegendEvent<'contextmenu'> {}
+
 export interface AgChartLegendListeners {
     /** The listener to call when a legend item is clicked. */
     legendItemClick?: (event: AgChartLegendClickEvent) => void;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -271,21 +271,17 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
                     callback(event);
                 }
             };
-        } else {
-            return () => {
-                const event = this.pickedNode?.series.createNodeContextMenuActionEvent(
-                    this.showEvent!,
-                    this.pickedNode
-                );
-                if (event) {
-                    callback(event);
-                } else {
-                    callback({ event: this.showEvent! });
-                }
-
-                this.hide();
-            };
         }
+        return () => {
+            const event = this.pickedNode?.series.createNodeContextMenuActionEvent(this.showEvent!, this.pickedNode);
+            if (event) {
+                callback(event);
+            } else {
+                callback({ event: this.showEvent! });
+            }
+
+            this.hide();
+        };
     }
 
     private createButtonElement(

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -12,6 +12,7 @@ type ContextMenuGroups = {
     node: Array<ContextMenuItem>;
     extra: Array<ContextMenuItem>;
     extraNode: Array<ContextMenuItem>;
+    extraLegendItem: Array<ContextMenuItem>;
 };
 type ContextMenuAction = _ModuleSupport.ContextMenuAction;
 type ContextMenuActionParams = _ModuleSupport.ContextMenuActionParams;
@@ -37,6 +38,11 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
      * Extra menu actions that only appear when clicking on a node.
      */
     public extraNodeActions: Array<ContextMenuAction> = [];
+
+    /**
+     * Extra menu actions that only appear when clicking on a legend item
+     */
+    public extraLegendItemActions: Array<ContextMenuAction> = [];
 
     // Module context
     private readonly scene: _Scene.Scene;
@@ -73,7 +79,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         );
 
         // State
-        this.groups = { default: [], node: [], extra: [], extraNode: [] };
+        this.groups = { default: [], node: [], extra: [], extraNode: [], extraLegendItem: [] };
 
         this.element = ctx.domManager.addChild('canvas-overlay', moduleId);
         this.element.classList.add(DEFAULT_CONTEXT_MENU_CLASS);
@@ -139,8 +145,14 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
             this.groups.extraNode = [...this.extraNodeActions];
         }
 
-        const { default: def, node, extra, extraNode } = this.groups;
-        const groupCount = def.length + node.length + extra.length + extraNode.length;
+        if (this.extraLegendItemActions.length > 0 && event.region === 'legend') {
+            this.groups.extraLegendItem = [...this.extraLegendItemActions];
+        }
+
+        const { default: def, node, extra, extraNode, extraLegendItem } = this.groups;
+        const groupCount = [def, node, extra, extraNode, extraLegendItem].reduce((count, e) => {
+            return e.length + count;
+        }, 0);
 
         if (groupCount === 0) return;
 
@@ -193,6 +205,10 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
         if (this.pickedNode) {
             this.appendMenuGroup(menuElement, this.groups.extraNode);
+        }
+
+        if (event.region === 'legend') {
+            this.appendMenuGroup(menuElement, this.groups.extraLegendItem);
         }
 
         return menuElement;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10486

-   Do not show the legend context menu items when `legend.item.toggleSeriesVisible = false`.

-   Grey out `Toggle Series` when `legend.preventHidingAll = true`.

-   Do not show the legend context menu items in waterfall series.