### PR TITLE
AG-11297 Make the navigator a vertical toolbar

### DIFF
--- a/packages/ag-charts-community/src/chart/dom/proxyInteractionService.ts
+++ b/packages/ag-charts-community/src/chart/dom/proxyInteractionService.ts
@@ -1,3 +1,4 @@
+import type { Direction } from '../../options/agChartOptions';
 import type { BBoxProvider, BBoxValues } from '../../util/bboxinterface';
 import { Debug } from '../../util/debug';
 import { createElement } from '../../util/dom';
@@ -15,11 +16,11 @@ type ElemParams<T extends ProxyElementType> = {
 };
 
 type ContainerParams<T extends ProxyContainerType> = {
-    type: T;
-    id: string;
-    classList: string[];
-    ariaLabel: string;
-    ariaOrientation?: 'horizontal' | 'vertical';
+    readonly type: T;
+    readonly id: string;
+    readonly classList: string[];
+    readonly ariaLabel: string;
+    readonly ariaOrientation: Direction;
 };
 
 type ProxyMeta = {
@@ -28,21 +29,17 @@ type ProxyMeta = {
         result: HTMLButtonElement;
     };
     slider: {
-        params: ElemParams<'slider'> & { readonly ariaLabel: string };
+        params: ElemParams<'slider'> & { readonly ariaLabel: string; readonly ariaOrientation: Direction };
         result: HTMLInputElement;
     };
     toolbar: {
         params: ContainerParams<'toolbar'>;
         result: HTMLDivElement;
     };
-    scrollbar: {
-        params: ContainerParams<'scrollbar'>;
-        result: HTMLDivElement;
-    };
 };
 
 type ProxyElementType = 'button' | 'slider';
-type ProxyContainerType = 'toolbar' | 'scrollbar';
+type ProxyContainerType = 'toolbar';
 
 function checkType<T extends keyof ProxyMeta>(
     type: T,
@@ -52,7 +49,7 @@ function checkType<T extends keyof ProxyMeta>(
 }
 
 function allocateMeta<T extends keyof ProxyMeta>(params: ProxyMeta[T]['params']) {
-    const map = { button: 'button', slider: 'input', toolbar: 'div', scrollbar: 'div' } as const;
+    const map = { button: 'button', slider: 'input', toolbar: 'div' } as const;
     return { params, result: createElement(map[params.type]) } as ProxyMeta[T];
 }
 
@@ -87,7 +84,7 @@ export class ProxyInteractionService {
         div.style.pointerEvents = 'none';
         div.role = params.type;
         div.ariaLabel = params.ariaLabel;
-        div.ariaOrientation = params.ariaOrientation ?? null;
+        div.ariaOrientation = params.ariaOrientation;
         return div;
     }
 
@@ -104,8 +101,10 @@ export class ProxyInteractionService {
             const { params, result: slider } = meta;
             this.initElement(params, slider);
             slider.type = 'range';
+            slider.role = 'presentation';
             slider.style.margin = '0px';
             slider.ariaLabel = params.ariaLabel;
+            slider.ariaOrientation = params.ariaOrientation;
         }
 
         return meta.result;

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -270,6 +270,7 @@ export class Legend extends BaseProperties {
             id: `${this.id}-toolbar`,
             classList: ['ag-charts-proxy-legend-toolbar'],
             ariaLabel: 'Legend',
+            ariaOrientation: 'horizontal',
         });
     }
 

--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -10,6 +10,7 @@ import { ActionOnSet, ObserveChanges } from '../../util/proxy';
 import { AND, BOOLEAN, GREATER_THAN, LESS_THAN, OBJECT, POSITIVE_NUMBER, RATIO, Validate } from '../../util/validation';
 import { InteractionState, type PointerInteractionEvent } from '../interaction/interactionManager';
 import type { ZoomChangeEvent } from '../interaction/zoomManager';
+import { initToolbarKeyNav } from '../toolbar/toolbarUtil';
 import { RangeHandle } from './shapes/rangeHandle';
 import { RangeMask } from './shapes/rangeMask';
 import { RangeSelector } from './shapes/rangeSelector';
@@ -92,10 +93,10 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
         );
 
         this.proxyNavigatorToolbar = this.ctx.proxyInteractionService.createProxyContainer({
-            type: 'scrollbar',
+            type: 'toolbar',
             id: `navigator-toolbar`,
             classList: ['ag-charts-proxy-navigator-toolbar'],
-            ariaOrientation: 'horizontal',
+            ariaOrientation: 'vertical',
             ariaLabel: 'Navigator',
         });
         this.updateGroupVisibility();
@@ -105,6 +106,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
                 type: 'slider',
                 id: 'ag-charts-navigator-pan',
                 ariaLabel: 'Panning',
+                ariaOrientation: 'horizontal',
                 parent: this.proxyNavigatorToolbar,
                 focusable: this.maskVisibleRange,
                 onchange: (ev) => this.onPanSliderChange(ev),
@@ -113,6 +115,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
                 type: 'slider',
                 id: 'ag-charts-navigator-min',
                 ariaLabel: 'Minimum',
+                ariaOrientation: 'horizontal',
                 parent: this.proxyNavigatorToolbar,
                 focusable: this.minHandle,
                 onchange: (ev) => this.onMinSliderChange(ev),
@@ -121,11 +124,17 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
                 type: 'slider',
                 id: 'ag-charts-navigator-max',
                 ariaLabel: 'Maximum',
+                ariaOrientation: 'horizontal',
                 parent: this.proxyNavigatorToolbar,
                 focusable: this.maxHandle,
                 onchange: (ev) => this.onMaxSliderChange(ev),
             }),
         ];
+        initToolbarKeyNav({
+            orientation: 'vertical',
+            toolbar: this.proxyNavigatorToolbar,
+            buttons: this.proxyNavigatorElements,
+        });
         this.destroyFns.push(() => {
             this.proxyNavigatorElements.forEach((e) => e.remove());
             this.proxyNavigatorToolbar.remove();

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarUtil.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarUtil.ts
@@ -1,8 +1,8 @@
 function addRemovableEventListener<K extends keyof HTMLElementEventMap>(
     destroyFns: (() => void)[],
-    button: HTMLButtonElement,
+    button: HTMLElement,
     type: K,
-    listener?: (this: HTMLButtonElement, ev: HTMLElementEventMap[K]) => any
+    listener?: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any
 ): void {
     if (listener) {
         button.addEventListener(type, listener);
@@ -14,21 +14,21 @@ function addRemovableEventListener<K extends keyof HTMLElementEventMap>(
 export function initToolbarKeyNav(opts: {
     orientation: 'horizontal' | 'vertical';
     toolbar: HTMLElement;
-    buttons: HTMLButtonElement[];
+    buttons: HTMLElement[];
     onfocus?: (ev: FocusEvent) => void;
     onblur?: (ev: FocusEvent) => void;
 }): (() => void)[] {
     const { orientation, toolbar, buttons, onfocus, onblur } = opts;
     const { nextKey, prevKey } = {
         horizontal: { nextKey: 'ArrowRight', prevKey: 'ArrowLeft' },
-        vertical: { nextKey: 'ArrowUp', prevKey: 'ArrowDown' },
+        vertical: { nextKey: 'ArrowDown', prevKey: 'ArrowUp' },
     }[orientation];
 
     toolbar.role = 'toolbar';
     toolbar.ariaOrientation = orientation;
 
     const destroyFns: (() => void)[] = [];
-    const linkButtons = (src: HTMLButtonElement, dst: HTMLButtonElement | undefined, key: string) => {
+    const linkButtons = (src: HTMLElement, dst: HTMLElement | undefined, key: string) => {
         if (dst) {
             addRemovableEventListener(destroyFns, src, 'keydown', (ev: KeyboardEvent) => {
                 if (ev.key === key) {
@@ -47,6 +47,11 @@ export function initToolbarKeyNav(opts: {
         const next = buttons[i + 1];
         linkButtons(curr, prev, prevKey);
         linkButtons(curr, next, nextKey);
+        addRemovableEventListener(destroyFns, curr, 'keydown', (ev: KeyboardEvent) => {
+            if (ev.key === nextKey || ev.key === prevKey) {
+                ev.preventDefault();
+            }
+        });
         curr.tabIndex = i === 0 ? 0 : -1;
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11297

Every browser seems to treat a role="scrollbar" element differently. But more importantly, not of them announce changes to the scrollbar when moving back and forth. Also, most examples of role="scrollbar" that I've seen online assume that there's just a single thumb on track (which isn't the case for use, because we've also got min/max handles). The recommendation is to use native scrollbars, which won't work in our use case.