### PR TITLE
AG-11527 - Move static AgCharts functions to AgChartInstance.

### DIFF
--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-angular.component.ts
@@ -63,7 +63,7 @@ export class AgChartsAngular implements AfterViewInit, OnChanges, OnDestroy {
             if (!this._initialised || !this.chart) {
                 return;
             }
-            AgCharts.update(this.chart, this.patchChartOptions(this.options));
+            this.chart.update(this.patchChartOptions(this.options));
         });
     }
 

--- a/packages/ag-charts-community-examples/src/charts-overview/examples/log-axis/main.ts
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/log-axis/main.ts
@@ -83,7 +83,7 @@ function setNumberAxis() {
     text: "linear scale",
   }
   options.axes = linearAxes
-  AgCharts.update(chart, options)
+  chart.update(options)
 }
 
 function setLogAxis() {
@@ -91,5 +91,5 @@ function setLogAxis() {
     text: "log scale",
   }
   options.axes = logAxes
-  AgCharts.update(chart, options)
+  chart.update(options)
 }

--- a/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/main.ts
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/main.ts
@@ -88,7 +88,7 @@ const chart = AgCharts.create(options)
 function updateData() {
   const now = Date.now()
   options.data = getData()
-  AgCharts.update(chart, options)
+  chart.update(options)
 }
 //@ts-ignore
 setInterval(this.updateData, refreshRateInMilliseconds)

--- a/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/provided/modules/typescript/main.ts
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/real-time-data-updates/provided/modules/typescript/main.ts
@@ -92,6 +92,6 @@ const chart = AgCharts.create(options)
 
 function updateData() {
   options.data = getData()
-  AgCharts.update(chart, options)
+  chart.update(options)
 }
 setInterval(updateData, refreshRateInMilliseconds)

--- a/packages/ag-charts-community/benchmarks/benchmark.ts
+++ b/packages/ag-charts-community/benchmarks/benchmark.ts
@@ -30,8 +30,7 @@ export class BenchmarkContext<T extends AgChartOptions = AgChartOptions> {
     }
 
     async update() {
-        AgCharts.update(this.chart, this.options);
-        await this.waitForUpdate();
+        await this.chart.update(this.options);
     }
 
     async waitForUpdate() {

--- a/packages/ag-charts-community/src/api/agChart.ts
+++ b/packages/ag-charts-community/src/api/agChart.ts
@@ -63,6 +63,9 @@ export abstract class AgCharts {
         this.licenseChecked = true;
     }
 
+    /** @private - for use by Charts website dark-mode support. */
+    static optionsMutationFn?: (opts: AgChartOptions) => AgChartOptions;
+
     public static setLicenseKey(licenseKey: string) {
         this.licenseKey = licenseKey;
     }
@@ -128,6 +131,10 @@ class AgChartsInternal {
         AgChartsInternal.initialiseModules();
 
         debug('>>> AgChartV2.createOrUpdate() user options', options);
+        if (AgCharts.optionsMutationFn) {
+            options = AgCharts.optionsMutationFn(options);
+            debug('>>> AgChartV2.createOrUpdate() MUTATED user options', options);
+        }
 
         const { overrideDevicePixelRatio, document, window: userWindow, ...userOptions } = options;
         const chartOptions = new ChartOptions(userOptions, { overrideDevicePixelRatio, document, window: userWindow });

--- a/packages/ag-charts-community/src/api/agChart.ts
+++ b/packages/ag-charts-community/src/api/agChart.ts
@@ -1,32 +1,29 @@
-import type { LicenseManager } from '../module/enterpriseModule';
-import { enterpriseModule } from '../module/enterpriseModule';
-import { moduleRegistry } from '../module/module';
-import { ChartOptions } from '../module/optionsModule';
-import type { AgChartInstance, AgChartOptions, DownloadOptions, ImageDataUrlOptions } from '../options/agChartOptions';
-import { Debug } from '../util/debug';
-import { deepClone, jsonWalk } from '../util/json';
-import { Logger } from '../util/logger';
-import { mergeDefaults } from '../util/object';
-import type { DeepPartial } from '../util/types';
-import { VERSION } from '../version';
-import { CartesianChart } from './cartesianChart';
-import { Chart, type ChartExtendedOptions } from './chart';
-import { AgChartInstanceProxy } from './chartProxy';
-import { ChartUpdateType } from './chartUpdateType';
-import { registerInbuiltModules } from './factory/registerInbuiltModules';
-import { setupModules } from './factory/setupModules';
-import { FlowProportionChart } from './flowProportionChart';
-import { HierarchyChart } from './hierarchyChart';
+import { CartesianChart } from '../chart/cartesianChart';
+import { Chart, type ChartExtendedOptions } from '../chart/chart';
+import { AgChartInstanceProxy, type FactoryApi } from '../chart/chartProxy';
+import { registerInbuiltModules } from '../chart/factory/registerInbuiltModules';
+import { setupModules } from '../chart/factory/setupModules';
+import { FlowProportionChart } from '../chart/flowProportionChart';
+import { HierarchyChart } from '../chart/hierarchyChart';
 import {
     isAgCartesianChartOptions,
     isAgFlowProportionChartOptions,
     isAgHierarchyChartOptions,
     isAgPolarChartOptions,
     isAgTopologyChartOptions,
-} from './mapping/types';
-import { MementoCaretaker } from './memento';
-import { PolarChart } from './polarChart';
-import { TopologyChart } from './topologyChart';
+} from '../chart/mapping/types';
+import { MementoCaretaker } from '../chart/memento';
+import { PolarChart } from '../chart/polarChart';
+import { TopologyChart } from '../chart/topologyChart';
+import type { LicenseManager } from '../module/enterpriseModule';
+import { enterpriseModule } from '../module/enterpriseModule';
+import { ChartOptions } from '../module/optionsModule';
+import type { AgChartInstance, AgChartOptions } from '../options/agChartOptions';
+import { Debug } from '../util/debug';
+import { deepClone, jsonWalk } from '../util/json';
+import { mergeDefaults } from '../util/object';
+import type { DeepPartial } from '../util/types';
+import { VERSION } from '../version';
 
 const debug = Debug.create(true, 'opts');
 
@@ -52,7 +49,6 @@ function chartType(options: any): 'cartesian' | 'polar' | 'hierarchy' | 'topolog
  * @docsInterface
  */
 export abstract class AgCharts {
-    private static readonly INVALID_CHART_REF_MESSAGE = 'AG Charts - invalid chart reference passed';
     private static licenseManager?: LicenseManager;
     private static licenseChecked = false;
     private static licenseKey?: string;
@@ -98,70 +94,6 @@ export abstract class AgCharts {
         }
         return chart;
     }
-
-    /**
-     * Update an existing `AgChartInstance`. Options provided should be complete and not
-     * partial.
-     *
-     * __NOTE__: As each call could trigger a chart redraw, multiple calls to update options in
-     * quick succession could result in undesirable flickering, so callers should batch up and/or
-     * debounce changes to avoid unintended partial update renderings.
-     */
-    public static update(chart: AgChartInstance, options: AgChartOptions) {
-        if (!AgChartInstanceProxy.isInstance(chart)) {
-            throw new Error(AgCharts.INVALID_CHART_REF_MESSAGE);
-        }
-        AgChartsInternal.createOrUpdate(options, chart);
-    }
-
-    /**
-     * Update an existing `AgChartInstance` by applying a partial set of option changes.
-     *
-     * __NOTE__: As each call could trigger a chart redraw, each individual delta options update
-     * should leave the chart in a valid options state. Also, multiple calls to update options in
-     * quick succession could result in undesirable flickering, so callers should batch up and/or
-     * debounce changes to avoid unintended partial update renderings.
-     */
-    public static updateDelta(chart: AgChartInstance, deltaOptions: DeepPartial<AgChartOptions>) {
-        if (!AgChartInstanceProxy.isInstance(chart)) {
-            throw new Error(AgCharts.INVALID_CHART_REF_MESSAGE);
-        }
-        AgChartsInternal.updateUserDelta(chart, deltaOptions);
-    }
-
-    /**
-     * Starts a browser-based image download for the given `AgChartInstance`.
-     */
-    public static download(chart: AgChartInstance, options?: DownloadOptions) {
-        if (!(chart instanceof AgChartInstanceProxy)) {
-            throw new Error(AgCharts.INVALID_CHART_REF_MESSAGE);
-        }
-        AgChartsInternal.download(chart, options).catch((e) => Logger.errorOnce(e));
-    }
-
-    /**
-     * Returns a base64-encoded image data URL for the given `AgChartInstance`.
-     */
-    public static getImageDataURL(chart: AgChartInstance, options?: ImageDataUrlOptions): Promise<string> {
-        if (!(chart instanceof AgChartInstanceProxy)) {
-            throw new Error(AgCharts.INVALID_CHART_REF_MESSAGE);
-        }
-        return AgChartsInternal.getImageDataURL(chart, options);
-    }
-
-    public static saveAnnotations(chart: AgChartInstance) {
-        if (!(chart instanceof AgChartInstanceProxy)) {
-            throw new Error(AgCharts.INVALID_CHART_REF_MESSAGE);
-        }
-        return AgChartsInternal.saveAnnotations(chart);
-    }
-
-    public static restoreAnnotations(chart: AgChartInstance, blob: unknown) {
-        if (!(chart instanceof AgChartInstanceProxy)) {
-            throw new Error(AgCharts.INVALID_CHART_REF_MESSAGE);
-        }
-        return AgChartsInternal.restoreAnnotations(chart, blob);
-    }
 }
 
 class AgChartsInternal {
@@ -182,6 +114,16 @@ class AgChartsInternal {
         AgChartsInternal.initialised = true;
     }
 
+    static callbackApi: FactoryApi = {
+        caretaker: AgChartsInternal.caretaker,
+        createOrUpdate(opts, chart) {
+            return AgChartsInternal.createOrUpdate(opts, chart as AgChartInstanceProxy);
+        },
+        updateUserDelta(chart, deltaOptions) {
+            return AgChartsInternal.updateUserDelta(chart as AgChartInstanceProxy, deltaOptions);
+        },
+    };
+
     static createOrUpdate(options: ChartExtendedOptions, proxy?: AgChartInstanceProxy) {
         AgChartsInternal.initialiseModules();
 
@@ -196,7 +138,7 @@ class AgChartsInternal {
         }
 
         if (proxy == null) {
-            proxy = new AgChartInstanceProxy(chart);
+            proxy = new AgChartInstanceProxy(chart, AgChartsInternal.callbackApi);
         } else {
             proxy.chart = chart;
         }
@@ -239,64 +181,6 @@ class AgChartsInternal {
         debug('>>> AgChartV2.updateUserDelta() user delta', deltaOptions);
         debug('AgChartV2.updateUserDelta() - base options', lastUpdateOptions);
         AgChartsInternal.createOrUpdate(userOptions, proxy);
-    }
-
-    /**
-     * Returns the content of the current canvas as an image.
-     */
-    static async download(proxy: AgChartInstanceProxy, opts?: DownloadOptions) {
-        try {
-            const clone = await AgChartsInternal.prepareResizedChart(proxy, opts);
-            clone.chart.ctx.scene.download(opts?.fileName, opts?.fileFormat);
-            clone.destroy();
-        } catch (error) {
-            Logger.errorOnce(error);
-        }
-    }
-
-    static async getImageDataURL(proxy: AgChartInstanceProxy, opts?: ImageDataUrlOptions): Promise<string> {
-        const clone = await AgChartsInternal.prepareResizedChart(proxy, opts);
-        const result = clone.chart.ctx.scene.getDataURL(opts?.fileFormat);
-
-        clone.destroy();
-
-        return result;
-    }
-
-    static saveAnnotations(proxy: AgChartInstanceProxy) {
-        return AgChartsInternal.caretaker.save(proxy.chart.ctx.annotationManager);
-    }
-
-    static restoreAnnotations(proxy: AgChartInstanceProxy, blob: unknown) {
-        return AgChartsInternal.caretaker.restore(proxy.chart.ctx.annotationManager, blob);
-    }
-
-    private static async prepareResizedChart({ chart }: AgChartInstanceProxy, opts: DownloadOptions = {}) {
-        const width: number = opts.width ?? chart.width ?? chart.ctx.scene.canvas.width;
-        const height: number = opts.height ?? chart.height ?? chart.ctx.scene.canvas.height;
-
-        const options: ChartExtendedOptions = mergeDefaults(
-            {
-                container: document.createElement('div'),
-                overrideDevicePixelRatio: 1,
-                width,
-                height,
-            },
-            // Disable enterprise features that may interfere with image generation.
-            moduleRegistry.hasEnterpriseModules() && { animation: { enabled: false } },
-            chart.userOptions
-        );
-
-        const cloneProxy = AgChartsInternal.createOrUpdate(options);
-        cloneProxy.chart.ctx.zoomManager.updateZoom('agChartV2', chart.ctx.zoomManager.getZoom()); // sync zoom
-        chart.series.forEach((series, index) => {
-            if (!series.visible) {
-                cloneProxy.chart.series[index].visible = false; // sync series visibility
-            }
-        });
-        chart.update(ChartUpdateType.FULL, { forceNodeDataRefresh: true });
-        await cloneProxy.chart.waitForUpdate();
-        return cloneProxy;
     }
 
     private static createChartInstance(options: ChartOptions, oldChart?: Chart): Chart {

--- a/packages/ag-charts-community/src/chart/agChart.test.ts
+++ b/packages/ag-charts-community/src/chart/agChart.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type { AgChartInstance } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import { NumberAxis } from './axis/numberAxis';
 import { AreaSeries } from './series/cartesian/areaSeries';
 import { BarSeries } from './series/cartesian/barSeries';
@@ -81,7 +81,7 @@ describe('AgChart', () => {
             },
         });
         await waitForChartStability(chartProxy);
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             // chart type is optional because it defaults to `cartesian`
             container: document.body,
             width: 500,
@@ -149,7 +149,7 @@ describe('AgChart', () => {
         expect((chart as any).background.visible).toBe(false);
         expect((chart.series[0] as any).properties.marker.shape).toBe('plus');
 
-        AgCharts.updateDelta(chartProxy, {
+        await chartProxy.updateDelta({
             data: revenueProfitData,
             series: [
                 {
@@ -210,7 +210,7 @@ describe('AgChart', () => {
         const chart = deproxy(chartProxy);
         const createdSeries = chart.series;
 
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             data: revenueProfitData,
             series: [
                 {
@@ -259,7 +259,7 @@ describe('AgChart', () => {
         expect((updatedSeries[3].properties as any).xKey).toEqual('month');
         expect((updatedSeries[3].properties as any).yKey).toEqual('bazqux');
 
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             data: revenueProfitData,
             series: [
                 {
@@ -293,7 +293,7 @@ describe('AgChart', () => {
         expect(updatedSeries2[1].id).toEqual(updatedSeries[1].id);
         expect(updatedSeries2[2].id).toEqual(updatedSeries[2].id);
 
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             data: revenueProfitData,
             series: [
                 {
@@ -338,7 +338,7 @@ describe('AgChart', () => {
 
         const lineSeries = updatedSeries3[1];
 
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             data: revenueProfitData,
             series: [
                 {
@@ -388,7 +388,7 @@ describe('AgChart', () => {
         });
         await waitForChartStability(chartProxy);
 
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             data: revenueProfitData,
             series: [
                 {
@@ -428,7 +428,7 @@ describe('AgChart', () => {
                 lineDash: [],
             },
         ]);
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             data: revenueProfitData,
             series: [
                 {

--- a/packages/ag-charts-community/src/chart/agChartV2.test.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type {
     AgCartesianAxisOptions,
     AgCartesianChartOptions,
     AgChartInstance,
     AgChartOptions,
 } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import type { Chart } from './chart';
 import * as examples from './test/examples';
 import type { TestCase } from './test/utils';
@@ -116,7 +116,7 @@ describe('AgChartV2', () => {
             let previousSnapshot: any = undefined;
             for (let round = 0; round <= 1; round++) {
                 for (let index = 0; index < exampleCycle.length; index++) {
-                    AgCharts.update(chart, exampleCycle[index]);
+                    await chart.update(exampleCycle[index]);
 
                     const exampleSnapshot = await snapshot();
                     if (snapshots[index] != null) {
@@ -165,9 +165,7 @@ describe('AgChartV2', () => {
             // generated.
             for (let round = 0; round <= 1; round++) {
                 for (let index = 0; index < exampleCycle.length; index++) {
-                    AgCharts.update(chart, exampleCycle[index]);
-
-                    await waitForChartStability(chart);
+                    await chart.update(exampleCycle[index]);
                 }
             }
         });

--- a/packages/ag-charts-community/src/chart/axis/axisGridLine.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisGridLine.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect } from '@jest/globals';
 
+import { AgCharts } from '../../api/agChart';
 import type { AgChartOptions } from '../../options/agChartOptions';
-import { AgCharts } from '../agChartV2';
 import type { Chart } from '../chart';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../../api/agChart';
 import type { AgCartesianChartOptions } from '../../options/agChartOptions';
-import { AgCharts } from '../agChartV2';
 import type { ChartAxis } from '../chartAxis';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
@@ -106,7 +106,7 @@ describe('Time Axis Examples', () => {
         for (const [min, max] of ZOOM_LEVELS) {
             it(`for should render as expected as zoom [${min}, ${max}]`, async () => {
                 chart = AgCharts.create(prepareTestOptions({ ...TIME_AXIS_EXAMPLE }));
-                AgCharts.updateDelta(chart, { navigator: { min, max } });
+                chart.updateDelta({ navigator: { min, max } });
                 await axisCompare();
             });
         }

--- a/packages/ag-charts-community/src/chart/cartesianChart.test.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 import { fail } from 'assert';
 
+import { AgCharts } from '../api/agChart';
 import type { AgCartesianChartOptions, AgChartOptions } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import type { CartesianChart } from './cartesianChart';
 import type { Chart } from './chart';
 import type { SeriesNodeDataContext } from './series/series';

--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type { AgCartesianChartOptions, AgPolarChartOptions, InteractionRange } from '../options/agChartOptions';
 import type { Node } from '../scene/node';
 import { Selection } from '../scene/selection';
 import { Rect } from '../scene/shape/rect';
 import { Sector } from '../scene/shape/sector';
-import { AgCharts } from './agChartV2';
 import type { Chart } from './chart';
 import type { AgChartProxy } from './chartProxy';
 import { Circle } from './marker/circle';
@@ -363,19 +363,19 @@ describe('Chart', () => {
             await waitForChartStability(chart);
             expect(testOptions.getNodes(chart).length).toEqual(0);
 
-            AgCharts.updateDelta(chartProxy, {
+            await chartProxy.updateDelta({
                 data: datasets.economy.data,
             });
             await waitForChartStability(chart);
             expect(testOptions.getNodes(chart).length).toEqual(3);
 
-            AgCharts.updateDelta(chartProxy, {
+            await chartProxy.updateDelta({
                 data: datasets.economy.data.slice(0, 2),
             });
             await waitForChartStability(chart);
             expect(testOptions.getNodes(chart).length).toEqual(2);
 
-            AgCharts.updateDelta(chartProxy, {
+            await chartProxy.updateDelta({
                 data: datasets.economy.data,
             });
             await waitForChartStability(chart);
@@ -452,7 +452,7 @@ describe('Chart', () => {
 
         async function updateChart(chartProxy: AgChartProxy, options: object) {
             const chartOptions = prepareTestOptions(options);
-            AgCharts.update(chartProxy, chartOptions);
+            await chartProxy.update(chartOptions);
             await waitForChartStability(deproxy(chartProxy));
         }
 
@@ -576,7 +576,7 @@ describe('Chart', () => {
                     },
                 ],
             });
-            AgCharts.update(agChartInstance, options);
+            await agChartInstance.update(options);
             await waitForChartStability(agChartInstance);
 
             const elements = document.querySelectorAll('.ag-charts-wrapper');

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -5,7 +5,7 @@ import type { ModuleContext } from '../module/moduleContext';
 import type { AxisOptionModule, ChartOptions } from '../module/optionsModule';
 import type { SeriesOptionModule } from '../module/optionsModuleTypes';
 import type { AgBaseAxisOptions } from '../options/chart/axisOptions';
-import type { AgChartInstance, AgChartOptions } from '../options/chart/chartBuilderOptions';
+import type { AgChartOptions } from '../options/chart/chartBuilderOptions';
 import type { AgChartClickEvent, AgChartDoubleClickEvent } from '../options/chart/eventOptions';
 import { BBox } from '../scene/bbox';
 import { Group } from '../scene/group';
@@ -136,7 +136,7 @@ class SeriesArea extends BaseProperties {
     padding = new Padding(0);
 }
 
-export abstract class Chart extends Observable implements AgChartInstance {
+export abstract class Chart extends Observable {
     private static readonly chartsInstances = new WeakMap<HTMLElement, Chart>();
 
     static getInstance(element: HTMLElement): Chart | undefined {
@@ -216,16 +216,14 @@ export abstract class Chart extends Observable implements AgChartInstance {
         return this.ctx.scene.canvas.element;
     }
 
-    /** NOTE: This is exposed for use by Integrated charts only. */
-    getCanvasDataURL(fileFormat?: string) {
-        return this.ctx.scene.getDataURL(fileFormat);
-    }
-
     private _lastAutoSize?: [number, number];
     private _firstAutoSize = true;
 
     download(fileName?: string, fileFormat?: string) {
         this.ctx.scene.download(fileName, fileFormat);
+    }
+    getCanvasDataURL(fileFormat?: string) {
+        return this.ctx.scene.getDataURL(fileFormat);
     }
 
     @Validate(OBJECT)

--- a/packages/ag-charts-community/src/chart/chartHeapMemory.test.ts
+++ b/packages/ag-charts-community/src/chart/chartHeapMemory.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { memoryUsage } from 'process';
 
-import { AgCharts } from './agChartV2';
+import { AgCharts } from '../api/agChart';
 import type { Chart } from './chart';
 import type { AgChartProxy } from './chartProxy';
 import { deproxy, prepareTestOptions, setupMockCanvas, setupMockConsole, waitForChartStability } from './test/utils';
@@ -99,7 +99,7 @@ describe('Chart Heap Memory', () => {
 
         async function updateChart(chartProxy: AgChartProxy, options: object) {
             const chartOptions = prepareTestOptions(options);
-            AgCharts.update(chartProxy, chartOptions);
+            await chartProxy.update(chartOptions);
             await waitForChartStability(deproxy(chartProxy));
         }
 

--- a/packages/ag-charts-community/src/chart/chartProxy.ts
+++ b/packages/ag-charts-community/src/chart/chartProxy.ts
@@ -1,10 +1,27 @@
-import type { AgChartInstance } from '../options/chart/chartBuilderOptions';
+import { moduleRegistry } from '../module/module';
+import type {
+    AgChartInstance,
+    AgChartOptions,
+    DownloadOptions,
+    ImageDataUrlOptions,
+} from '../options/chart/chartBuilderOptions';
 import { deepClone } from '../util/json';
+import { mergeDefaults } from '../util/object';
 import { ActionOnSet } from '../util/proxy';
-import type { Chart } from './chart';
+import type { DeepPartial } from '../util/types';
+import type { Chart, ChartExtendedOptions } from './chart';
+import { ChartUpdateType } from './chartUpdateType';
+import type { MementoCaretaker } from './memento';
 
 export interface AgChartProxy extends AgChartInstance {
-    chart: AgChartInstance;
+    chart: Chart;
+}
+
+export interface FactoryApi {
+    caretaker: MementoCaretaker;
+
+    createOrUpdate(opts: AgChartOptions, chart?: AgChartInstance): AgChartProxy;
+    updateUserDelta(chart: AgChartInstance, deltaOptions: DeepPartial<AgChartOptions>): void;
 }
 
 /**
@@ -44,12 +61,52 @@ export class AgChartInstanceProxy implements AgChartProxy {
     })
     chart: Chart;
 
-    constructor(chart: Chart) {
+    constructor(
+        chart: Chart,
+        private readonly factoryApi: FactoryApi
+    ) {
         this.chart = chart;
+    }
+
+    async update(options: AgChartOptions) {
+        this.factoryApi.createOrUpdate(options, this);
+        await this.chart.waitForUpdate();
+    }
+
+    async updateDelta(deltaOptions: DeepPartial<AgChartOptions>) {
+        this.factoryApi.updateUserDelta(this, deltaOptions);
+        await this.chart.waitForUpdate();
     }
 
     getOptions() {
         return deepClone(this.chart.getOptions());
+    }
+
+    async download(opts?: DownloadOptions) {
+        const clone = await this.prepareResizedChart(this, opts);
+        try {
+            clone.chart.download(opts?.fileName, opts?.fileFormat);
+        } finally {
+            clone.destroy();
+        }
+    }
+
+    async getImageDataURL(opts?: ImageDataUrlOptions) {
+        const clone = await this.prepareResizedChart(this, opts);
+        try {
+            return clone.chart.getCanvasDataURL(opts?.fileFormat);
+        } finally {
+            clone.destroy();
+        }
+    }
+
+    async saveAnnotations() {
+        return this.factoryApi.caretaker.save(this.chart.ctx.annotationManager);
+    }
+
+    async restoreAnnotations(blob: unknown) {
+        this.factoryApi.caretaker.restore(this.chart.ctx.annotationManager, blob);
+        await this.chart.waitForUpdate();
     }
 
     resetAnimations(): void {
@@ -62,5 +119,33 @@ export class AgChartInstanceProxy implements AgChartProxy {
 
     destroy() {
         this.chart.destroy();
+    }
+
+    private async prepareResizedChart({ chart }: AgChartInstanceProxy, opts: DownloadOptions = {}) {
+        const width: number = opts.width ?? chart.width ?? chart.ctx.scene.canvas.width;
+        const height: number = opts.height ?? chart.height ?? chart.ctx.scene.canvas.height;
+
+        const options: ChartExtendedOptions = mergeDefaults(
+            {
+                container: document.createElement('div'),
+                overrideDevicePixelRatio: 1,
+                width,
+                height,
+            },
+            // Disable enterprise features that may interfere with image generation.
+            moduleRegistry.hasEnterpriseModules() && { animation: { enabled: false } },
+            chart.userOptions
+        );
+
+        const cloneProxy = await this.factoryApi.createOrUpdate(options);
+        cloneProxy.chart.ctx.zoomManager.updateZoom('agChartV2', chart.ctx.zoomManager.getZoom()); // sync zoom
+        chart.series.forEach((series, index) => {
+            if (!series.visible) {
+                cloneProxy.chart.series[index].visible = false; // sync series visibility
+            }
+        });
+        chart.update(ChartUpdateType.FULL, { forceNodeDataRefresh: true });
+        await cloneProxy.chart.waitForUpdate();
+        return cloneProxy;
     }
 }

--- a/packages/ag-charts-community/src/chart/chartProxy.ts
+++ b/packages/ag-charts-community/src/chart/chartProxy.ts
@@ -134,7 +134,7 @@ export class AgChartInstanceProxy implements AgChartProxy {
             },
             // Disable enterprise features that may interfere with image generation.
             moduleRegistry.hasEnterpriseModules() && { animation: { enabled: false } },
-            chart.userOptions
+            chart.getOptions()
         );
 
         const cloneProxy = await this.factoryApi.createOrUpdate(options);

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../../api/agChart';
 import type {
     AgCartesianChartOptions,
     AgCartesianCrossLineOptions,
     AgCrossLineLabelPosition,
 } from '../../options/agChartOptions';
-import { AgCharts } from '../agChartV2';
 import type { Chart } from '../chart';
 import type { CartesianTestCase } from '../test/utils';
 import {

--- a/packages/ag-charts-community/src/chart/galleryExamples.test.ts
+++ b/packages/ag-charts-community/src/chart/galleryExamples.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type { AgChartOptions } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import type { Chart } from './chart';
 import { EXAMPLES } from './test/examples-gallery';
 import {
@@ -85,7 +85,7 @@ describe('Gallery Examples', () => {
             });
 
             it(`it should update chart instance as expected`, async () => {
-                AgCharts.update(chart, options);
+                chart.update(options);
                 await waitForChartStability(chart);
 
                 await example.assertions(chart);
@@ -98,10 +98,10 @@ describe('Gallery Examples', () => {
                     return ctx.nodeCanvas.toBuffer('raw');
                 };
 
-                AgCharts.update(chart, options);
+                chart.update(options);
 
                 const before = await snapshot();
-                AgCharts.update(chart, options);
+                chart.update(options);
                 const after = await snapshot();
 
                 expect(after).toMatchImage(before);

--- a/packages/ag-charts-community/src/chart/galleryExamplesUSTimezone.test.ts
+++ b/packages/ag-charts-community/src/chart/galleryExamplesUSTimezone.test.ts
@@ -3,8 +3,8 @@
  */
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type { AgChartOptions } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import type { Chart } from './chart';
 import { isAgCartesianChartOptions } from './mapping/types';
 import { EXAMPLES } from './test/examples-gallery';

--- a/packages/ag-charts-community/src/chart/integratedChartsExamples.test.ts
+++ b/packages/ag-charts-community/src/chart/integratedChartsExamples.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type { AgChartOptions } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import type { Chart } from './chart';
 import { EXAMPLES } from './test/examples-integrated-charts';
 import {
@@ -55,7 +55,7 @@ describe('Integrated Charts Examples', () => {
                 chart = AgCharts.create(startingOptions) as Chart;
                 await waitForChartStability(chart);
 
-                AgCharts.update(chart, options);
+                chart.update(options);
                 await compare();
             });
         }

--- a/packages/ag-charts-community/src/chart/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type { AgCartesianChartOptions, AgChartOptions } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import type { Chart } from './chart';
 import * as examples from './test/examples';
 import { seedRandom } from './test/random';

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -179,7 +179,7 @@ export class Legend extends BaseProperties {
         return this._data;
     }
 
-    private contextMenuDatum?: CategoryLegendDatum;
+    private readonly contextMenuDatum?: CategoryLegendDatum;
 
     @Validate(OBJECT)
     readonly pagination: Pagination;

--- a/packages/ag-charts-community/src/chart/mapping/themes.test.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../../api/agChart';
 import type {
     AgBarSeriesOptions,
     AgChartOptions,
@@ -7,7 +8,6 @@ import type {
     AgChartThemeName,
     AgChartThemePalette,
 } from '../../options/agChartOptions';
-import { AgCharts } from '../agChartV2';
 import type { Chart } from '../chart';
 import {
     deproxy,

--- a/packages/ag-charts-community/src/chart/navigator/navigator.test.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../../api/agChart';
 import type { AgCartesianChartOptions } from '../../options/agChartOptions';
-import { AgCharts } from '../agChartV2';
 import * as CROSSLINE_EXAMPLES from '../crossline/test/examples';
 import {
     type CartesianTestCase,

--- a/packages/ag-charts-community/src/chart/scene.test.ts
+++ b/packages/ag-charts-community/src/chart/scene.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../api/agChart';
 import type { AgCartesianChartOptions, AgChartInstance, AgChartLegendOptions } from '../options/agChartOptions';
-import { AgCharts } from './agChartV2';
 import * as examples from './test/examples';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
@@ -42,7 +42,7 @@ describe('Scene', () => {
             await waitForChartStability(chart);
 
             (options.legend as AgChartLegendOptions).position = 'top';
-            AgCharts.update(chart, options);
+            await chart.update(options);
 
             await compare();
         });
@@ -56,7 +56,7 @@ describe('Scene', () => {
             await waitForChartStability(chart);
 
             (options.legend as AgChartLegendOptions).position = 'top';
-            AgCharts.update(chart, options);
+            await chart.update(options);
 
             await compare();
         });

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgChartOptions } from '../../../options/agChartOptions';
 import { deepClone } from '../../../util/json';
-import { AgCharts } from '../../agChartV2';
 import type { Chart } from '../../chart';
 import {
     DATA_FRACTIONAL_LOG_AXIS,
@@ -254,7 +254,7 @@ describe('AreaSeries', () => {
                     await waitForChartStability(chart);
 
                     animate(1200, ratio);
-                    AgCharts.update(chart, { ...options, data: updatedData });
+                    chart.update({ ...options, data: updatedData });
 
                     await compare();
                 });
@@ -273,7 +273,7 @@ describe('AreaSeries', () => {
                     await waitForChartStability(chart);
 
                     animate(1200, ratio);
-                    AgCharts.update(chart, { ...EXAMPLE });
+                    chart.update({ ...EXAMPLE });
 
                     await compare();
                 });
@@ -297,7 +297,7 @@ describe('AreaSeries', () => {
 
                     animate(1200, ratio);
                     options.series![0].visible = false;
-                    AgCharts.update(chart, { ...options });
+                    chart.update({ ...options });
 
                     await compare();
                 });
@@ -318,7 +318,7 @@ describe('AreaSeries', () => {
 
                     animate(1200, ratio);
                     options.series![1].visible = true;
-                    AgCharts.update(chart, options);
+                    chart.update(options);
 
                     await compare();
                 });

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgChartOptions } from '../../../options/agChartOptions';
-import { AgCharts } from '../../agChartV2';
 import type { Chart } from '../../chart';
 import {
     DATA_FRACTIONAL_LOG_AXIS,
@@ -219,7 +219,7 @@ describe('BarSeries', () => {
                 chart = AgCharts.create(options) as Chart;
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: [...options.data!.slice(2, 4), ...options.data!.slice(6, -2)],
                 });
                 animate(1200, ratio);
@@ -239,7 +239,7 @@ describe('BarSeries', () => {
                 chart = AgCharts.create(options) as Chart;
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.slice(0, options.data!.length / 2),
                 });
                 animate(1200, ratio);
@@ -263,12 +263,12 @@ describe('BarSeries', () => {
                 chart = AgCharts.create(options) as Chart;
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: [...options.data!.slice(2, 4), ...options.data!.slice(6, -2)],
                 });
                 await waitForChartStability(chart);
 
-                AgCharts.update(chart, options);
+                chart.update(options);
                 animate(1200, ratio);
 
                 await waitForChartStability(chart);
@@ -286,12 +286,12 @@ describe('BarSeries', () => {
                 chart = AgCharts.create(options) as Chart;
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.slice(0, options.data!.length / 2),
                 });
                 await waitForChartStability(chart);
 
-                AgCharts.update(chart, options);
+                chart.update(options);
                 animate(1200, ratio);
 
                 await waitForChartStability(chart);
@@ -313,7 +313,7 @@ describe('BarSeries', () => {
                 chart = AgCharts.create(options) as Chart;
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: [...options.data!.map((d, i) => (i % 2 === 0 ? { ...d, value: d.value * 2 } : d))],
                 });
                 animate(1200, ratio);
@@ -333,7 +333,7 @@ describe('BarSeries', () => {
                 chart = AgCharts.create(options) as Chart;
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: [...options.data!.map((d, i) => (i % 2 === 0 ? { ...d, value: d.value * 2 } : d))],
                 });
                 animate(1200, ratio);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgChartOptions } from '../../../options/agChartOptions';
-import { AgCharts } from '../../agChartV2';
 import type { Chart } from '../../chart';
 import * as examples from '../../test/examples';
 import {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgChartOptions } from '../../../options/agChartOptions';
-import { AgCharts } from '../../agChartV2';
 import { COMMUNITY_AND_ENTERPRISE_EXAMPLES as GALLERY_EXAMPLES, type TestCase } from '../../test/examples-gallery';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
@@ -234,7 +234,7 @@ describe('HistogramSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: [
                         ...options.data!.filter(
                             (d: any) => d['engine-size'] > 80 && (d['engine-size'] < 100 || d['engine-size'] > 120)
@@ -262,7 +262,7 @@ describe('HistogramSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: [
                         ...options.data!.filter(
                             (d: any) => d['engine-size'] > 80 && (d['engine-size'] < 100 || d['engine-size'] > 120)
@@ -271,7 +271,7 @@ describe('HistogramSeries', () => {
                 });
                 await waitForChartStability(chart);
 
-                AgCharts.update(chart, options);
+                chart.update(options);
                 animate(1200, ratio);
 
                 await waitForChartStability(chart);
@@ -293,7 +293,7 @@ describe('HistogramSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: [
                         ...options.data!.map((d: any, index: number) => ({
                             ...d,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgChartOptions } from '../../../options/agChartOptions';
 import { deepClone } from '../../../util/json';
-import { AgCharts } from '../../agChartV2';
 import type { Chart } from '../../chart';
 import {
     DATA_FRACTIONAL_LOG_AXIS,
@@ -291,7 +291,7 @@ describe('LineSeries', () => {
                     await waitForChartStability(chart);
 
                     animate(duration, ratio);
-                    AgCharts.updateDelta(chart, { data: changedData });
+                    chart.updateDelta({ data: changedData });
                     await waitForChartStability(chart);
                     await compare();
                 });
@@ -347,7 +347,7 @@ describe('LineSeries', () => {
 
                     animate(1200, ratio);
                     options.series![0].visible = false;
-                    AgCharts.update(chart, { ...options });
+                    chart.update({ ...options });
 
                     await compare();
                 });
@@ -368,7 +368,7 @@ describe('LineSeries', () => {
 
                     animate(1200, ratio);
                     options.series![1].visible = true;
-                    AgCharts.update(chart, options);
+                    chart.update(options);
 
                     await compare();
                 });

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgChartOptions } from '../../../options/agChartOptions';
-import { AgCharts } from '../../agChartV2';
 import type { Chart } from '../../chart';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgChartOptions } from '../../../options/agChartOptions';
-import { AgCharts } from '../../agChartV2';
 import type { Chart } from '../../chart';
 import * as examples from '../../test/examples';
 import {

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
+import { AgCharts } from '../../../api/agChart';
 import type { AgPolarChartOptions } from '../../../options/agChartOptions';
-import { AgCharts } from '../../agChartV2';
 import type { Chart } from '../../chart';
 import { ChartUpdateType } from '../../chartUpdateType';
 import type { PolarTestCase } from '../../test/utils';
@@ -164,7 +164,7 @@ describe('PolarSeries', () => {
                 await waitForChartStability(chart);
 
                 animate(1200, ratio);
-                AgCharts.update(chart, {
+                chart.update({
                     ...options,
                     data: options.data!.slice(0, options.data!.length - 2),
                 });
@@ -190,7 +190,7 @@ describe('PolarSeries', () => {
                 await waitForChartStability(chart);
 
                 animate(1200, ratio);
-                AgCharts.update(chart, { ...options });
+                chart.update({ ...options });
 
                 await compare();
             });
@@ -211,7 +211,7 @@ describe('PolarSeries', () => {
                 await waitForChartStability(chart);
 
                 animate(1200, ratio);
-                AgCharts.update(chart, {
+                chart.update({
                     ...options,
                     data: options.data!.map((d) => (d.os === 'iOS' ? { ...d, share: d.share * 2 } : d)),
                 });

--- a/packages/ag-charts-community/src/chart/series/seriesLabels.test.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesLabels.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../../api/agChart';
 import type { AgChartOptions } from '../../options/agChartOptions';
-import { AgCharts } from '../agChartV2';
 import type { Chart } from '../chart';
 import type { TestCase } from '../test/utils';
 import {

--- a/packages/ag-charts-community/src/chart/test/load-example.ts
+++ b/packages/ag-charts-community/src/chart/test/load-example.ts
@@ -1,7 +1,7 @@
 import * as test from 'ag-charts-test';
 
+import { AgCharts } from '../../api/agChart';
 import * as time from '../../util/time/index';
-import { AgCharts } from '../agChartV2';
 // Undocumented APIs used by examples.
 import { Marker } from '../marker/marker';
 

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, jest } from '@jest/globals';
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 
+import { AgCharts } from '../../api/agChart';
 import { type IAnimation, PHASE_METADATA } from '../../motion/animation';
 import type {
     AgCartesianChartOptions,
@@ -19,7 +20,6 @@ import {
     setupMockCanvas,
     toMatchImage,
 } from '../../util/test/mockCanvas';
-import { AgCharts } from '../agChartV2';
 import type { Chart } from '../chart';
 import type { AgChartProxy } from '../chartProxy';
 import { AnimationManager } from '../interaction/animationManager';
@@ -90,7 +90,7 @@ export function prepareTestOptions<T extends AgChartOptions>(options: T, contain
     return options;
 }
 
-function isChartInstance(chartOrProxy: AgChartInstance): chartOrProxy is Chart {
+function isChartInstance(chartOrProxy: AgChartInstance | Chart): chartOrProxy is Chart {
     return chartOrProxy.constructor.name !== 'AgChartInstanceProxy' || (chartOrProxy as Chart).className != null;
 }
 

--- a/packages/ag-charts-community/src/chart/themes/chartTheme.test.ts
+++ b/packages/ag-charts-community/src/chart/themes/chartTheme.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import { fail } from 'assert';
 
+import { AgCharts } from '../../api/agChart';
 import type {
     AgCartesianChartOptions,
     AgChartInstance,
     AgChartTheme,
     AgPolarChartOptions,
 } from '../../options/agChartOptions';
-import { AgCharts } from '../agChartV2';
 import { CartesianChart } from '../cartesianChart';
 import { PolarChart } from '../polarChart';
 import type { AreaSeries } from '../series/cartesian/areaSeries';

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.test.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 
+import { AgCharts } from '../../api/agChart';
 import type { AgChartOptions } from '../../options/agChartOptions';
 import { getDocument } from '../../util/dom';
-import { AgCharts } from '../agChartV2';
 import {
     AgChartProxy,
     createChart,
@@ -81,7 +81,7 @@ describe('Tooltip', () => {
             const nextValue = async (time: number, voltage: number) => {
                 opts.data!.shift();
                 opts.data!.push({ time, voltage });
-                AgCharts.update(chart, opts);
+                await chart.update(opts);
                 await waitForChartStability(chart);
             };
 

--- a/packages/ag-charts-community/src/main.ts
+++ b/packages/ag-charts-community/src/main.ts
@@ -1,7 +1,7 @@
 // Documented APIs.
 export * from './options/agChartOptions';
 export * as time from './util/time/index';
-export { AgCharts } from './chart/agChartV2';
+export { AgCharts } from './api/agChart';
 export { VERSION } from './version';
 
 // Undocumented APIs used by examples.

--- a/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
@@ -1,3 +1,4 @@
+import type { DeepPartial } from '../../util/types';
 import type { AgBaseCartesianChartOptions } from '../series/cartesian/cartesianOptions';
 import type { AgBaseFlowProportionChartOptions } from '../series/flow-proportion/flowProportionOptions';
 import type { AgBaseHierarchyChartOptions } from '../series/hierarchy/hierarchyOptions';
@@ -36,13 +37,52 @@ export type AgChartOptions =
     | AgTopologyChartOptions
     | AgFlowProportionChartOptions;
 
-export interface AgChartInstance {
+export interface AgChartInstance<O extends AgChartOptions = AgChartOptions> {
+    /**
+     * Update an existing `AgChartInstance`. Options provided should be complete and not
+     * partial.
+     *
+     * __NOTE__: As each call could trigger a chart redraw, multiple calls to update options in
+     * quick succession could result in undesirable flickering, so callers should batch up and/or
+     * debounce changes to avoid unintended partial update renderings.
+     *
+     * @returns a Promise that resolves once the requested change has been rendered
+     */
+    update(options: O): Promise<void>;
+
+    /**
+     * Update an existing `AgChartInstance` by applying a partial set of option changes.
+     *
+     * __NOTE__: As each call could trigger a chart redraw, each individual delta options update
+     * should leave the chart in a valid options state. Also, multiple calls to update options in
+     * quick succession could result in undesirable flickering, so callers should batch up and/or
+     * debounce changes to avoid unintended partial update renderings.
+     *
+     * @returns a Promise that resolves once the requested change has been rendered
+     */
+    updateDelta(deltaOptions: DeepPartial<O>): Promise<void>;
+
     /** Get the `AgChartOptions` representing the current chart configuration. */
-    getOptions(): AgChartOptions;
-    /** Reset animation state; treat the next AgChart.update() as-if the chart is being created from scratch. */
+    getOptions(): O;
+
+    /**
+     * Starts a browser-based image download for the given `AgChartInstance`.
+     *
+     * @returns a Promise that resolves once the download has been initiated
+     */
+    download(options?: DownloadOptions): Promise<void>;
+
+    /** Reset animation state; treat the next AgChartInstance.update() as-if the chart is being created from scratch. */
     resetAnimations(): void;
     /** Skip animations on the next redraw. */
     skipAnimations(): void;
+
+    /** Returns a base64-encoded image data URL for the given `AgChartInstance`.*/
+    getImageDataURL(options?: ImageDataUrlOptions): Promise<string>;
+
+    saveAnnotations(): Promise<unknown>;
+    restoreAnnotations(blob: unknown): Promise<void>;
+
     /** Destroy the chart instance and any allocated resources to support its rendering. */
     destroy(): void;
 }

--- a/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
@@ -1,4 +1,3 @@
-import type { DeepPartial } from '../../util/types';
 import type { AgBaseCartesianChartOptions } from '../series/cartesian/cartesianOptions';
 import type { AgBaseFlowProportionChartOptions } from '../series/flow-proportion/flowProportionOptions';
 import type { AgBaseHierarchyChartOptions } from '../series/hierarchy/hierarchyOptions';
@@ -36,6 +35,8 @@ export type AgChartOptions =
     | AgHierarchyChartOptions
     | AgTopologyChartOptions
     | AgFlowProportionChartOptions;
+
+type DeepPartial<T> = T extends Array<unknown> ? T : T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T;
 
 export interface AgChartInstance<O extends AgChartOptions = AgChartOptions> {
     /**

--- a/packages/ag-charts-enterprise/src/galleryExamples.test.ts
+++ b/packages/ag-charts-enterprise/src/galleryExamples.test.ts
@@ -96,7 +96,7 @@ describe('Gallery Examples', () => {
                 });
 
                 it(`it should update chart instance as expected`, async () => {
-                    AgCharts.update(chart, options);
+                    chart.update(options);
                     await waitForChartStability(chart);
 
                     await example.assertions(chart);
@@ -109,10 +109,10 @@ describe('Gallery Examples', () => {
                         return ctx.nodeCanvas.toBuffer('raw');
                     };
 
-                    AgCharts.update(chart, options);
+                    chart.update(options);
 
                     const before = await snapshot();
-                    AgCharts.update(chart, options);
+                    chart.update(options);
                     const after = await snapshot();
 
                     expect(after).toMatchImage(before);

--- a/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
+++ b/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
@@ -208,7 +208,7 @@ describe('NightingaleSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.slice(0, 4),
                 });
                 animate(1200, ratio);
@@ -233,7 +233,7 @@ describe('NightingaleSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: fullData,
                 });
                 animate(1200, ratio);
@@ -257,7 +257,7 @@ describe('NightingaleSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.map((d: any) => {
                         return Object.entries(d).reduce((obj, [key, value], i) => {
                             return Object.assign(obj, { [key]: typeof value === 'number' ? value * i : value });

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
@@ -204,7 +204,7 @@ describe('RadialBarSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.slice(0, 4),
                 });
                 animate(1200, ratio);
@@ -229,7 +229,7 @@ describe('RadialBarSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: fullData,
                 });
                 animate(1200, ratio);
@@ -253,7 +253,7 @@ describe('RadialBarSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.map((d: any) => {
                         return Object.entries(d).reduce((obj, [key, value], i) => {
                             return Object.assign(obj, { [key]: typeof value === 'number' ? value * i : value });

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
@@ -209,7 +209,7 @@ describe('RadialColumnSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.slice(0, 4),
                 });
                 animate(1200, ratio);
@@ -234,7 +234,7 @@ describe('RadialColumnSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: fullData,
                 });
                 animate(1200, ratio);
@@ -258,7 +258,7 @@ describe('RadialColumnSeries', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
 
-                AgCharts.updateDelta(chart, {
+                chart.updateDelta({
                     data: options.data!.map((d: any) => {
                         return Object.entries(d).reduce((obj, [key, value], i) => {
                             return Object.assign(obj, { [key]: typeof value === 'number' ? value * i : value });

--- a/packages/ag-charts-react/src/agChartsReact.ts
+++ b/packages/ag-charts-react/src/agChartsReact.ts
@@ -44,7 +44,7 @@ export class AgChartsReact extends Component<AgChartProps, AgChartState> {
 
     componentDidUpdate() {
         if (this.chart != null) {
-            AgCharts.update(this.chart, this.applyContainer(this.props.options));
+            this.chart.update(this.applyContainer(this.props.options));
         }
     }
 

--- a/packages/ag-charts-vue3/src/AgChartsVue.ts
+++ b/packages/ag-charts-vue3/src/AgChartsVue.ts
@@ -67,7 +67,7 @@ export class AgChartsVue extends Vue {
 
     public processChanges(currentValue: any, previousValue: any) {
         if (this.isCreated && this.chart) {
-            AgCharts.update(this.chart, toRaw(this.applyContainerIfNotSet(toRaw(this.options))));
+            this.chart.update(toRaw(this.applyContainerIfNotSet(toRaw(this.options))));
         }
     }
 

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
@@ -224,7 +224,7 @@ function changeSeriesBar() {
     options.axes = barOptions.axes;
     options.data = getGeneratedData();
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesLine() {
@@ -237,7 +237,7 @@ function changeSeriesLine() {
     options.axes = lineOptions.axes;
     options.data = getGeneratedData();
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesArea() {
@@ -250,7 +250,7 @@ function changeSeriesArea() {
     options.axes = areaOptions.axes;
     options.data = getGeneratedData();
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesDonut() {
@@ -263,33 +263,33 @@ function changeSeriesDonut() {
     options.axes = donutOptions.axes;
     options.data = getGeneratedData();
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function add() {
     offset++;
     length++;
     options.data = getGeneratedData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function remove() {
     length = Math.max(0, length - 1);
     options.data = getGeneratedData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function update() {
     seed = Math.floor(random() * 1000);
     options.data = getGeneratedData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function addRemoveUpdate() {
     offset++;
     seed = Math.floor(random() * 1000);
     options.data = getGeneratedData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function getGeneratedData() {

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
@@ -233,28 +233,28 @@ const chart = AgCharts.create(options);
 function changeSeriesBar() {
     options.series = barOptions.series;
     options.axes = barOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesLine() {
     options.series = lineOptions.series;
     options.axes = lineOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesArea() {
     options.series = areaOptions.series;
     options.axes = areaOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesDonut() {
     options.series = donutOptions.series;
     options.axes = donutOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeDuration(duration: number) {
     options.animation = { duration };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
@@ -232,23 +232,23 @@ const chart = AgCharts.create(options);
 function changeSeriesBar() {
     options.series = barOptions.series;
     options.axes = barOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesLine() {
     options.series = lineOptions.series;
     options.axes = lineOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesArea() {
     options.series = areaOptions.series;
     options.axes = areaOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeSeriesDonut() {
     options.series = donutOptions.series;
     options.axes = donutOptions.axes;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/annotations/_examples/annotation-save-restore/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations/_examples/annotation-save-restore/main.ts
@@ -58,11 +58,12 @@ let blob =
     'eyJhbm5vdGF0aW9ucyI6W3sidHlwZSI6InBhcmFsbGVsLWNoYW5uZWwiLCJzaXplIjoxMi40NjA3MzI5ODQyOTEwOTksIm1pZGRsZSI6eyJzdHJva2VXaWR0aCI6MSwibGluZURhc2giOls2LDVdfSwiYmFja2dyb3VuZCI6eyJmaWxsIjoiIzUwOTBkYyIsImZpbGxPcGFjaXR5IjowLjJ9LCJzdGFydCI6eyJ4IjoiMjAyNC0wMy0yMVQxODo0NTowMC4wMDBaIiwieSI6Mzk4MjYuNDkyMTQ2NTk2ODZ9LCJlbmQiOnsieCI6IjIwMjQtMDMtMjFUMTg6NTY6MDAuMDAwWiIsInkiOjM5ODQxLjM2MTI1NjU0NDV9LCJoYW5kbGUiOnsiZmlsbCI6IndoaXRlIn0sInN0cm9rZSI6IiMyYjVjOTUiLCJzdHJva2VPcGFjaXR5IjoxLCJzdHJva2VXaWR0aCI6Mn0seyJ0eXBlIjoicGFyYWxsZWwtY2hhbm5lbCIsInNpemUiOjEyLjYxNzgwMTA0NzExOTQyOCwibWlkZGxlIjp7InN0cm9rZVdpZHRoIjoxLCJsaW5lRGFzaCI6WzYsNV19LCJiYWNrZ3JvdW5kIjp7ImZpbGwiOiIjNTA5MGRjIiwiZmlsbE9wYWNpdHkiOjAuMn0sInN0YXJ0Ijp7IngiOnsiX190eXBlIjoiZGF0ZSIsInZhbHVlIjoiVGh1IE1hciAyMSAyMDI0IDE4OjQzOjAwIEdNVCswMDAwIChHcmVlbndpY2ggTWVhbiBUaW1lKSJ9LCJ5IjozOTgyNC44NjkxMDk5NDc2NH0sImVuZCI6eyJ4Ijp7Il9fdHlwZSI6ImRhdGUiLCJ2YWx1ZSI6IlRodSBNYXIgMjEgMjAyNCAxODo1NjowMCBHTVQrMDAwMCAoR3JlZW53aWNoIE1lYW4gVGltZSkifSwieSI6Mzk4NDAuMDUyMzU2MDIwOTR9LCJoYW5kbGUiOnsiZmlsbCI6IndoaXRlIn0sInN0cm9rZSI6IiMyYjVjOTUiLCJzdHJva2VPcGFjaXR5IjoxLCJzdHJva2VXaWR0aCI6Mn1dLCJ0eXBlIjoiYW5ub3RhdGlvbnMiLCJ2ZXJzaW9uIjoiMTAuMCJ9';
 
 function saveAnnotations() {
-    blob = AgCharts.saveAnnotations(chart);
-    console.log(`Saving [${blob}]`);
+    chart.saveAnnotations().then((blob) => {
+        console.log(`Saving [${blob}]`);
+    });
 }
 
 function restoreAnnotations() {
     console.log(`Restoring [${blob}]`);
-    AgCharts.restoreAnnotations(chart, blob);
+    chart.restoreAnnotations(blob);
 }

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/main.ts
@@ -36,7 +36,7 @@ const chart = AgCharts.create(options);
 
 function reverseSeries() {
     options.series = series.reverse();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function swapTitles() {
@@ -44,7 +44,7 @@ function swapTitles() {
     options.title = options.subtitle;
     options.subtitle = oldTitle;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function rotateLegend() {
@@ -52,5 +52,5 @@ function rotateLegend() {
     legend.position = positions[(currentIdx + 1) % positions.length];
 
     options.legend = legend;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/update-partial/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/update-partial/main.ts
@@ -44,13 +44,13 @@ function reverseSeries() {
     const series = chart.getOptions().series as AgAreaSeriesOptions[];
     series!.reverse();
 
-    AgCharts.updateDelta(chart, { series });
+    chart.updateDelta({ series });
 }
 
 function swapTitles() {
     const { title, subtitle } = chart.getOptions();
 
-    AgCharts.updateDelta(chart, { title: subtitle, subtitle: title });
+    chart.updateDelta({ title: subtitle, subtitle: title });
 }
 
 function rotateLegend() {
@@ -59,13 +59,13 @@ function rotateLegend() {
     const currentIdx = positions.indexOf(position ?? 'top');
     const newPosition = positions[(currentIdx + 1) % positions.length];
 
-    AgCharts.updateDelta(chart, { legend: { position: newPosition } });
+    chart.updateDelta({ legend: { position: newPosition } });
 }
 
 function changeTheme() {
     const theme = chart.getOptions()?.theme as AgChartTheme;
     const markersEnabled = theme?.overrides?.area?.series?.marker?.enabled ?? false;
-    AgCharts.updateDelta(chart, {
+    chart.updateDelta({
         theme: { overrides: { area: { series: { marker: { enabled: !markersEnabled } } } } },
     });
 }

--- a/packages/ag-charts-website/src/content/docs/api-download/_examples/download/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-download/_examples/download/main.ts
@@ -28,15 +28,15 @@ const options: AgChartOptions = {
 const chart = AgCharts.create(options);
 
 function download() {
-    AgCharts.download(chart);
+    chart.download();
 }
 
 function downloadFixedSize() {
-    AgCharts.download(chart, { width: 600, height: 300 });
+    chart.download({ width: 600, height: 300 });
 }
 
 function openImage() {
-    AgCharts.getImageDataURL(chart, { width: 600, height: 300 }).then((imageDataURL) => {
+    chart.getImageDataURL({ width: 600, height: 300 }).then((imageDataURL) => {
         const image = new Image();
         image.src = imageDataURL;
 

--- a/packages/ag-charts-website/src/content/docs/api-download/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-download/index.mdoc
@@ -29,8 +29,8 @@ exposes a `chart` property.
 This example demonstrates:
 
 -   How to obtain a reference to an `AgChartInstance`.
--   How to use `AgCharts.download()` to start a chart image download.
--   How to use `AgCharts.getImageDataURL()` to create a base64-encoded image URL, and then open it in
+-   How to use `AgChartInstance.download()` to start a chart image download.
+-   How to use `AgChartInstance.getImageDataURL()` to create a base64-encoded image URL, and then open it in
     a new tab.
 
-{% chartExampleRunner title="Download via AgCharts API" name="download" type="generated" /%}
+{% chartExampleRunner title="Download via AgChartInstance API" name="download" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
@@ -44,7 +44,7 @@ const chart = AgCharts.create(options);
 
 function actionReset() {
     options.data = [...data];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddEndWeek() {
@@ -58,7 +58,7 @@ function actionAddEndWeek() {
             iphone: 78 * (Math.random() - 0.5),
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddStartWeek() {
@@ -72,7 +72,7 @@ function actionAddStartWeek() {
         },
         ...data,
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddWeek12and13() {
@@ -84,7 +84,7 @@ function actionAddWeek12and13() {
     data.sort((a: any, b: any) => a.week - b.week);
     options.data = data;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddWeek7and8() {
@@ -96,7 +96,7 @@ function actionAddWeek7and8() {
     data.sort((a: any, b: any) => a.week - b.week);
     options.data = data;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reorder() {
@@ -104,15 +104,15 @@ function reorder() {
     data.sort((a, b) => a.random - b.random);
     options.data = data;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function rapidUpdate() {
     options.data = [...data, { quarter: 'week 12', iphone: 78 }];
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     (chart as any).chart.waitForUpdate().then(() => {
         options.data = [...data, { quarter: 'week 12', iphone: 78 }, { quarter: 'week 13', iphone: 138 }];
-        AgCharts.update(chart, options);
+        chart.update(options);
     });
 }

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
@@ -76,34 +76,34 @@ function times<T>(cb: () => T, count: number) {
 
 function actionReset() {
     options.data = [...data];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddSeries() {
     options.series = [...options.series!, series[options.series!.length % series.length]] as any;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveSeries() {
     options.series = options.series!.slice(0, options.series!.length - 1);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemovePoints() {
     const data = [...(options.data ?? [])];
     data.splice(data.length / 2 - 5, 10);
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveFirstPoint() {
     options.data = [...(options.data ?? []).slice(1)];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveLastPoint() {
     options.data = [...(options.data ?? []).slice(0, -1)];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveHalf() {
@@ -111,7 +111,7 @@ function actionRemoveHalf() {
     const { length } = data;
     options.data = data.slice(Math.floor((length * 1) / 4), Math.floor((length * 3) / 4));
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddPoints() {
@@ -125,7 +125,7 @@ function actionAddPoints() {
         data.splice(dataIdx + 1, 0, genDataPoint({ ...datum, date }, 0));
     }
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddPointsBefore() {
@@ -134,7 +134,7 @@ function actionAddPointsBefore() {
     const ref = data[0];
     data.splice(0, 0, genDataPoint(ref, -14), genDataPoint(ref, -7));
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddPointsAfter(count = 2) {
@@ -146,7 +146,7 @@ function actionAddPointsAfter(count = 2) {
     }
 
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddDouble() {
@@ -161,7 +161,7 @@ function actionAddDouble() {
         ...data,
         ...times(() => (end = genDataPoint(end, 7)), count),
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionUpdatePoints() {
@@ -170,7 +170,7 @@ function actionUpdatePoints() {
         petrol: d.petrol ? d.petrol + Math.random() * 40 - 20 : d.petrol,
         diesel: d.diesel ? d.diesel + Math.random() * 40 - 20 : d.diesel,
     }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionUpdatePointUndefined() {
@@ -179,7 +179,7 @@ function actionUpdatePointUndefined() {
         petrol: idx % 15 == 0 ? undefined : d.petrol,
         diesel: idx % 20 == 0 ? undefined : d.diesel,
     }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionUpdatePointDefined() {
@@ -188,7 +188,7 @@ function actionUpdatePointDefined() {
         petrol: d.petrol ?? 100 + Math.random() * 40 - 20,
         diesel: d.diesel ?? 100 + Math.random() * 40 - 20,
     }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionShiftLeft() {
@@ -196,7 +196,7 @@ function actionShiftLeft() {
     const [ref] = data.slice(-1);
     options.data = [...data.slice(1), genDataPoint(ref, 7)];
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionShiftRight() {
@@ -204,7 +204,7 @@ function actionShiftRight() {
     const [ref] = data.slice(0);
     options.data = [genDataPoint(ref, -7), ...data.slice(0, -1)];
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 let tick: NodeJS.Timeout;

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/missing-data-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/missing-data-area/main.ts
@@ -60,7 +60,7 @@ function missingYValues() {
 
     options.data = data;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function missingXValues() {
@@ -72,20 +72,20 @@ function missingXValues() {
 
     options.data = data;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function stack() {
     options.series = series.map((s) => ({ ...s, stacked: true }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function group() {
     options.series = series.map((s) => ({ ...s, stacked: false }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reset() {
     options.data = getData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/area-series/_examples/missing-data-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series/_examples/missing-data-area/main.ts
@@ -40,5 +40,5 @@ function toggleConnectMissingData() {
         ...series,
         connectMissingData: !series.connectMissingData,
     }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/main.ts
@@ -75,7 +75,7 @@ function crosshairLabelFormat() {
     crosshair.label = {
         format: `%b %Y`,
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function axisLabelFormat() {
@@ -85,7 +85,7 @@ function axisLabelFormat() {
         delete axes0.crosshair!.label!.format;
     }
     axes0.label = { format: `%Y` };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function defaultFormat() {
@@ -97,5 +97,5 @@ function defaultFormat() {
     if (axes0.label && axes0.label.format) {
         delete axes0.label!.format;
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-min-max/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-min-max/main.ts
@@ -38,7 +38,7 @@ function setAxisMinMax() {
     const numberAxisOptions = options.axes![1] as AgNumberAxisOptions;
     numberAxisOptions.min = -50;
     numberAxisOptions.max = 150;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function resetAxisDomain() {
@@ -49,5 +49,5 @@ function resetAxisDomain() {
     if (numberAxisOptions.max) {
         delete numberAxisOptions.max;
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-nice/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/_examples/axis-nice/main.ts
@@ -36,5 +36,5 @@ const chart = AgCharts.create(options);
 
 function toggleAxisNice() {
     (options.axes![1] as AgNumberAxisOptions).nice = !(options.axes![1] as AgNumberAxisOptions).nice;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-domain/_examples/cartesian-axis-reversed/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/_examples/cartesian-axis-reversed/main.ts
@@ -38,5 +38,5 @@ const chart = AgCharts.create(options);
 function toggleAxisReverse() {
     const numberAxisOptions = options.axes![1];
     numberAxisOptions.reverse = !numberAxisOptions.reverse;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-domain/_examples/polar-axis-reversed/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/_examples/polar-axis-reversed/main.ts
@@ -31,5 +31,5 @@ const chart = AgCharts.create(options);
 function toggleAxisReverse() {
     const radiusNumberAxisOptions = options.axes![1];
     radiusNumberAxisOptions.reverse = !radiusNumberAxisOptions.reverse;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-grid-lines/_examples/axis-grid-lines/main.ts
@@ -66,7 +66,7 @@ function setGridStyle1() {
     ];
     options.axes![0].gridLine!.style = gridStyle;
     options.axes![1].gridLine!.style = gridStyle;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setGridStyle2() {
@@ -84,7 +84,7 @@ function setGridStyle2() {
     ];
     options.axes![0].gridLine!.style = xGridStyle;
     options.axes![1].gridLine!.style = yGridStyle;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setDefaultGridStyle() {
@@ -96,5 +96,5 @@ function setDefaultGridStyle() {
     ];
     options.axes![0].gridLine!.style = gridStyle;
     options.axes![1].gridLine!.style = gridStyle;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/main.ts
@@ -41,7 +41,7 @@ function reset() {
     delete options.axes![1].label!.avoidCollisions;
 
     (options.series![0] as AgBarSeriesOptions).xKey = 'year';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function disableRotation() {
@@ -50,7 +50,7 @@ function disableRotation() {
     options.axes![0].label!.autoRotate = false;
     options.axes![1].label!.autoRotate = false;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function fixedRotation() {
@@ -59,7 +59,7 @@ function fixedRotation() {
     options.axes![0].label!.autoRotate = false;
     options.axes![1].label!.autoRotate = false;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function autoRotation() {
@@ -68,29 +68,29 @@ function autoRotation() {
     options.axes![0].label!.autoRotate = true;
     options.axes![1].label!.autoRotate = true;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function uniformLabels() {
     (options.series![0] as AgBarSeriesOptions).xKey = 'year';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function irregularLabels() {
     (options.series![0] as AgBarSeriesOptions).xKey = 'country';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function noCollisionDetection() {
     options.axes![0].label!.avoidCollisions = false;
     options.axes![1].label!.avoidCollisions = false;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function autoCollisionDetection() {
     options.axes![0].label!.avoidCollisions = true;
     options.axes![1].label!.avoidCollisions = true;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-labels/_examples/axis-label-rotation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-labels/_examples/axis-label-rotation/main.ts
@@ -41,7 +41,7 @@ function reset() {
     delete options.axes![1].label!.avoidCollisions;
 
     (options.series![0] as AgBarSeriesOptions).xKey = 'year';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function disableRotation() {
@@ -50,7 +50,7 @@ function disableRotation() {
     options.axes![0].label!.autoRotate = false;
     options.axes![1].label!.autoRotate = false;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function fixedRotation() {
@@ -59,7 +59,7 @@ function fixedRotation() {
     options.axes![0].label!.autoRotate = false;
     options.axes![1].label!.autoRotate = false;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function autoRotation() {
@@ -68,29 +68,29 @@ function autoRotation() {
     options.axes![0].label!.autoRotate = true;
     options.axes![1].label!.autoRotate = true;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function shortLabels() {
     (options.series![0] as AgBarSeriesOptions).xKey = 'year';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function longLabels() {
     (options.series![0] as AgBarSeriesOptions).xKey = 'country';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function noCollisionDetection() {
     options.axes![0].label!.avoidCollisions = false;
     options.axes![1].label!.avoidCollisions = false;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function autoCollisionDetection() {
     options.axes![0].label!.avoidCollisions = true;
     options.axes![1].label!.avoidCollisions = true;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-interval/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-interval/main.ts
@@ -39,10 +39,10 @@ const chart = AgCharts.create(options);
 
 function setTickInterval(interval: number) {
     options.axes![1].tick = { interval };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function resetInterval() {
     options.axes![1].tick = {};
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-min-max-spacing/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-min-max-spacing/main.ts
@@ -39,10 +39,10 @@ const chart = AgCharts.create(options);
 
 function setMinMaxSpacing(minSpacing: number, maxSpacing: number) {
     options.axes![1].tick = { minSpacing, maxSpacing };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reset() {
     options.axes![1].tick = {};
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/axis-tick-values/main.ts
@@ -39,10 +39,10 @@ const chart = AgCharts.create(options);
 
 function setTickValues(values: number[]) {
     options.axes![1].tick = { values };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reset() {
     options.axes![1].tick = {};
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-ticks/_examples/time-axis-label-format/main.ts
@@ -68,10 +68,10 @@ const chart = AgCharts.create(options);
 
 function setOneMonthInterval() {
     options.axes![0].tick!.interval = time.month;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setTwoMonthInterval() {
     options.axes![0].tick!.interval = time.month.every(2);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types/_examples/number-vs-log/main.ts
@@ -46,7 +46,7 @@ function setNumberAxis() {
             },
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setLogAxis() {
@@ -64,7 +64,7 @@ function setLogAxis() {
             },
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setBaseTwoLogAxis() {
@@ -83,7 +83,7 @@ function setBaseTwoLogAxis() {
             base: 2,
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setLogAxisWithFewerTicks() {
@@ -104,5 +104,5 @@ function setLogAxisWithFewerTicks() {
             },
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/axes-types/_examples/time-vs-ordinal-time/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types/_examples/time-vs-ordinal-time/main.ts
@@ -43,7 +43,7 @@ function setTimeAxis() {
             position: 'left',
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setOrdinalTimeAxis() {
@@ -57,5 +57,5 @@ function setOrdinalTimeAxis() {
             position: 'left',
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/background/_examples/background-fill/main.ts
+++ b/packages/ag-charts-website/src/content/docs/background/_examples/background-fill/main.ts
@@ -27,5 +27,5 @@ function randomColor() {
     options.background = {
         fill: color,
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-vertical/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-vertical/main.ts
@@ -64,7 +64,7 @@ const chart = AgCharts.create(options);
 
 function reset() {
     options.data = getData();
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function randomise() {
@@ -74,7 +74,7 @@ function randomise() {
             iphone: d.iphone + Math.floor(Math.random() * 50 - 25),
         })),
     ];
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function remove() {
@@ -84,5 +84,5 @@ function remove() {
                 !d.quarter.startsWith("Q1'19") && !d.quarter.startsWith("Q3'19") && !d.quarter.startsWith("Q4'18")
         ),
     ];
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
@@ -102,7 +102,7 @@ function reset() {
     data = toIntegratedData('quarter', getData());
     options.data = data;
     options.series = [...series];
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function randomise() {
@@ -112,22 +112,22 @@ function randomise() {
             iphone: d.iphone + Math.floor(Math.random() * 50 - 25),
         })),
     ];
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function removeData() {
     options.data = options.data?.slice(0, options.data.length - 1);
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function removeSeries() {
     options.series = series.slice(0, options.series!.length - 1);
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function addSeries() {
     options.series = series.slice(0, options.series!.length + 1);
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function switchDirection() {
@@ -136,7 +136,7 @@ function switchDirection() {
     if (options.mode === 'integrated') {
         chart.resetAnimations();
     }
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function switchToGrouped() {
@@ -145,7 +145,7 @@ function switchToGrouped() {
     if (options.mode === 'integrated') {
         chart.resetAnimations();
     }
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function switchToStacked() {
@@ -156,7 +156,7 @@ function switchToStacked() {
     if (options.mode === 'integrated') {
         chart.resetAnimations();
     }
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function moveLegend() {
@@ -167,7 +167,7 @@ function moveLegend() {
     if (options.mode === 'integrated') {
         chart.skipAnimations();
     }
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function changeTheme() {
@@ -179,7 +179,7 @@ function changeTheme() {
     if (options.mode === 'integrated') {
         chart.skipAnimations();
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function toggleMode() {
@@ -187,5 +187,5 @@ function toggleMode() {
     options.mode = nextMode;
     modeButton.textContent = `Mode: ${nextMode}`;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/bubble-series/_examples/bubble-chart-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bubble-series/_examples/bubble-chart-labels/main.ts
@@ -86,7 +86,7 @@ function updateFontSize(event: any) {
 
     (options.series![0] as AgBubbleSeriesOptions).label!.fontSize = value;
     (options.series![1] as AgBubbleSeriesOptions).label!.fontSize = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('fontSizeSliderValue')!.innerHTML = String(value);
 }

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-add-data/main.ts
@@ -42,5 +42,5 @@ function updateData() {
     });
     flag *= -1;
     options.data = newData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-remove-data/main.ts
@@ -29,5 +29,5 @@ function removeData() {
     const newData = [...options.data!];
     newData.pop();
     options.data = newData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-update-value/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-update-value/main.ts
@@ -36,5 +36,5 @@ function updateValue() {
 
     flag *= -1;
     options.data = newData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/combination-series/_examples/combination/main.ts
+++ b/packages/ag-charts-website/src/content/docs/combination-series/_examples/combination/main.ts
@@ -95,10 +95,10 @@ const chart = AgCharts.create(options);
 
 function barLine() {
     options.series = BAR_AND_LINE;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function areaBar() {
     options.series = AREA_AND_BAR;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/main.ts
@@ -66,7 +66,7 @@ function scatter() {
             series.type = 'scatter';
         }
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function line() {
@@ -75,7 +75,7 @@ function line() {
             series.type = 'line';
         }
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function resetData() {
@@ -84,7 +84,7 @@ function resetData() {
         options.series[1].data = getHelium();
         options.series[2].data = getArgon();
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function randomDelta(min: number, max: number) {
@@ -113,7 +113,7 @@ function randomiseData() {
         options.series[1].data = options.series[1].data?.map(fn);
         options.series[2].data = options.series[2].data?.map(fn);
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function randomiseErrors() {
@@ -132,7 +132,7 @@ function randomiseErrors() {
         options.series[1].data = options.series[1].data?.map(fn);
         options.series[2].data = options.series[2].data?.map(fn);
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function removeRandomElem() {
@@ -148,5 +148,5 @@ function removeRandomElem() {
         const { seriesIndex, datumIndex } = meta[randomIndex(meta.length)];
         series[seriesIndex].data?.splice(datumIndex, 1);
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/main.ts
@@ -64,7 +64,7 @@ function line() {
             opt.type = 'line';
         }
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function bar() {
@@ -73,7 +73,7 @@ function bar() {
             opt.type = 'bar';
         }
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function resetData() {
@@ -81,7 +81,7 @@ function resetData() {
         options.series[0].data = getData();
         options.series[1].data = getData2();
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function removeOdds() {
@@ -92,7 +92,7 @@ function removeOdds() {
         options.series[0].data = getData().filter(fn);
         options.series[1].data = getData2().filter(fn);
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function removeOddsErrors() {
@@ -108,7 +108,7 @@ function removeOddsErrors() {
         options.series[0].data = getData().map(fn);
         options.series[1].data = getData2().map(fn);
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function randomDelta(min: number, max: number) {
@@ -137,7 +137,7 @@ function randomiseData() {
         options.series[0].data = options.series[0].data?.map(fn);
         options.series[1].data = options.series[1].data?.map(fn);
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function randomiseErrors() {
@@ -157,5 +157,5 @@ function randomiseErrors() {
         options.series[0].data = options.series[0].data?.map(fn);
         options.series[1].data = options.series[1].data?.map(fn);
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/events/_examples/interaction-ranges/main.ts
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/interaction-ranges/main.ts
@@ -56,7 +56,7 @@ function exact() {
         nodeClickRange: 'exact',
     }));
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function nearest() {
@@ -65,7 +65,7 @@ function nearest() {
         nodeClickRange: 'nearest',
     }));
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function distance() {
@@ -74,5 +74,5 @@ function distance() {
         nodeClickRange: 10,
     }));
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/histogram-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/histogram-series-test/_examples/animation/main.ts
@@ -40,7 +40,7 @@ const chart = AgCharts.create(options);
 
 function reset() {
     options.data = getData();
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function randomise() {
@@ -50,10 +50,10 @@ function randomise() {
             age: Math.max(17, Math.min(33, d.age + Math.floor(Math.random() * 4) - 2)),
         })),
     ];
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function remove() {
     options.data = [...getData().filter((d: any) => (d.age < 20 || d.age >= 22) && d.age < 32)];
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-horizontal/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-horizontal/main.ts
@@ -41,7 +41,7 @@ function updateWidth(event: any) {
     var value = +event.target.value;
 
     options.width = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('sliderValue')!.innerHTML = String(value);
 }

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-vertical/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-vertical/main.ts
@@ -44,7 +44,7 @@ function updateHeight(event: any) {
     var value = +event.target.value;
 
     options.height = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('sliderValue')!.innerHTML = String(value);
 }

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/main.ts
@@ -133,5 +133,5 @@ function updateLegendPosition(value: AgChartLegendPosition) {
             break;
     }
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-constraints/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-constraints/main.ts
@@ -31,7 +31,7 @@ function updateLegendItemPaddingX(event: any) {
     var value = +event.target.value;
 
     options.legend!.item!.paddingX = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('xPaddingValue')!.innerHTML = String(value);
 }
@@ -40,7 +40,7 @@ function updateLegendItemPaddingY(event: any) {
     var value = event.target.value;
 
     options.legend!.item!.paddingY = +event.target.value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('yPaddingValue')!.innerHTML = String(value);
 }
@@ -49,7 +49,7 @@ function updateLegendItemSpacing(event: any) {
     var value = +event.target.value;
 
     options.legend!.item!.marker!.padding = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('markerPaddingValue')!.innerHTML = String(value);
 }
@@ -58,7 +58,7 @@ function updateLegendItemMaxWidth(event: any) {
     var value = +event.target.value;
 
     options.legend!.item!.maxWidth = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('maxWidthValue')!.innerHTML = String(value);
 }

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-customisation/main.ts
@@ -67,10 +67,10 @@ const chart = AgCharts.create(options);
 
 function updateLegendPosition(value: AgChartLegendPosition) {
     options.legend!.position = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setLegendEnabled(enabled: boolean) {
     options.legend!.enabled = enabled;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-pagination/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-pagination/main.ts
@@ -110,5 +110,5 @@ function updateLegendPosition(value: AgChartLegendPosition) {
             break;
     }
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-position/main.ts
@@ -48,10 +48,10 @@ const chart = AgCharts.create(options);
 
 function updateLegendPosition(value: AgChartLegendPosition) {
     options.legend!.position = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setLegendEnabled(enabled: boolean) {
     options.legend!.enabled = enabled;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-seriesStroke/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-seriesStroke/main.ts
@@ -67,5 +67,5 @@ const chart = AgCharts.create(options);
 
 function toggleSeriesStroke() {
     options.legend!.item!.showSeriesStroke = !options.legend!.item!.showSeriesStroke;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/main.ts
@@ -44,7 +44,7 @@ const chart = AgCharts.create(options);
 
 function actionReset() {
     options.data = [...data];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddEndWeek() {
@@ -58,7 +58,7 @@ function actionAddEndWeek() {
             iphone: 78 * (Math.random() - 0.5),
         },
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddStartWeek() {
@@ -72,7 +72,7 @@ function actionAddStartWeek() {
         },
         ...data,
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddWeek12and13() {
@@ -82,7 +82,7 @@ function actionAddWeek12and13() {
         { quarter: 'week 13', week: 13, iphone: 138 },
     ];
     options.data.sort((a: any, b: any) => a.week - b.week);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddWeek7and8() {
@@ -92,7 +92,7 @@ function actionAddWeek7and8() {
         { quarter: 'week 8', week: 8, iphone: 87 },
     ];
     options.data.sort((a: any, b: any) => a.week - b.week);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reorder() {
@@ -100,16 +100,16 @@ function reorder() {
     options.data?.forEach((d) => (d.random = Math.random()));
     options.data?.sort((a, b) => a.random - b.random);
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function rapidUpdate() {
-    AgCharts.updateDelta(chart, {
+    chart.updateDelta({
         data: [...data, { quarter: 'week 12', iphone: 78 }],
     });
 
     (chart as any).chart.waitForUpdate().then(() => {
-        AgCharts.updateDelta(chart, {
+        chart.updateDelta({
             data: [...data, { quarter: 'week 12', iphone: 78 }, { quarter: 'week 13', iphone: 138 }],
         });
     });

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
@@ -63,33 +63,33 @@ function times<T>(cb: () => T, count: number) {
 
 function actionReset() {
     options.data = getData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddSeries() {
     options.series = [...options.series!, series[options.series!.length % series.length]] as any;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveSeries() {
     options.series = options.series!.slice(0, options.series!.length - 1);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemovePoints() {
     options.data = [...(options.data ?? [])];
     options.data.splice(options.data.length / 2 - 5, 10);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveFirstPoint() {
     options.data = [...(options.data ?? []).slice(1)];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveLastPoint() {
     options.data = [...(options.data ?? []).slice(0, -1)];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionRemoveHalf() {
@@ -97,7 +97,7 @@ function actionRemoveHalf() {
     const { length } = data;
     options.data = data.slice(Math.floor((length * 1) / 4), Math.floor((length * 3) / 4));
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddPoints() {
@@ -110,7 +110,7 @@ function actionAddPoints() {
         const date = new Date((datum.date.getTime() + nextDatum.date.getTime()) / 2);
         options.data.splice(dataIdx + 1, 0, genDataPoint({ ...datum, date }, 0));
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddPointsBefore() {
@@ -118,7 +118,7 @@ function actionAddPointsBefore() {
 
     const ref = options.data[0];
     options.data.splice(0, 0, genDataPoint(ref, -14), genDataPoint(ref, -7));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddPointsAfter(count = 2) {
@@ -128,7 +128,7 @@ function actionAddPointsAfter(count = 2) {
     for (let idx = 0; idx < count; idx++) {
         options.data.push(genDataPoint(ref, (idx + 1) * 7));
     }
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddDouble() {
@@ -143,7 +143,7 @@ function actionAddDouble() {
         ...data,
         ...times(() => (end = genDataPoint(end, 7)), count),
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionUpdatePoints() {
@@ -152,7 +152,7 @@ function actionUpdatePoints() {
         petrol: d.petrol + Math.random() * 4 - 2,
         diesel: d.diesel + Math.random() * 4 - 2,
     }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionUpdatePointUndefined() {
@@ -161,7 +161,7 @@ function actionUpdatePointUndefined() {
         petrol: Math.random() > 0.9 ? undefined : d.petrol,
         diesel: Math.random() > 0.9 ? undefined : d.diesel,
     }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionShiftLeft() {
@@ -169,7 +169,7 @@ function actionShiftLeft() {
     const [ref] = data.slice(-1);
     options.data = [...data.slice(1), genDataPoint(ref, 7)];
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionShiftRight() {
@@ -177,7 +177,7 @@ function actionShiftRight() {
     const [ref] = data.slice(0);
     options.data = [genDataPoint(ref, -7), ...data.slice(0, -1)];
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 let tick: NodeJS.Timeout;

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/integrated-category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/integrated-category-animation/main.ts
@@ -67,7 +67,7 @@ const chart = AgCharts.create(options);
 
 function actionReset() {
     options.data = [...data].map(toIntegratedKey);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddEndWeek() {
@@ -82,7 +82,7 @@ function actionAddEndWeek() {
             android: 65 * (Math.random() - 0.5),
         },
     ].map(toIntegratedKey);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddStartWeek() {
@@ -97,7 +97,7 @@ function actionAddStartWeek() {
         },
         ...data,
     ].map(toIntegratedKey);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddWeek12and13() {
@@ -107,7 +107,7 @@ function actionAddWeek12and13() {
         { quarter: 'week 13', week: 13, iphone: 138, android: 120 },
     ].map(toIntegratedKey);
     options.data.sort((a: any, b: any) => a.week - b.week);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function actionAddWeek7and8() {
@@ -117,7 +117,7 @@ function actionAddWeek7and8() {
         { quarter: 'week 8', week: 8, iphone: 87, android: 120 },
     ].map(toIntegratedKey);
     options.data.sort((a: any, b: any) => a.week - b.week);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reorder() {
@@ -126,16 +126,16 @@ function reorder() {
     options.data?.sort((a, b) => a.random - b.random);
     options.data = options.data?.map(toIntegratedKey);
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function rapidUpdate() {
-    AgCharts.updateDelta(chart, {
+    chart.updateDelta({
         data: [...data, { quarter: 'week 12', iphone: 78, android: 67 }],
     });
 
     (chart as any).chart.waitForUpdate().then(() => {
-        AgCharts.updateDelta(chart, {
+        chart.updateDelta({
             data: [
                 ...data,
                 { quarter: 'week 12', week: 12, iphone: 78, android: 67 },

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/gap-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/gap-line/main.ts
@@ -27,5 +27,5 @@ function toggleConnectMissingData() {
         ...series,
         connectMissingData: !series.connectMissingData,
     }));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator/main.ts
+++ b/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator/main.ts
@@ -93,5 +93,5 @@ const chart = AgCharts.create(options);
 
 function toggleEnabled(value: boolean) {
     options.navigator!.enabled = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation/main.ts
@@ -41,7 +41,7 @@ const chart = AgCharts.create(options);
 
 function reset() {
     options.data = [...data];
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function randomIndex(array: unknown[]) {
@@ -57,7 +57,7 @@ function randomise() {
             value: (d.originalValue ?? d.value) * (Math.random() * 5 + 0.5),
         })),
     ];
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function addData(position: 'start' | 'mid' | 'end' | number = 'end', inData: any[]) {
@@ -79,7 +79,7 @@ function addData(position: 'start' | 'mid' | 'end' | number = 'end', inData: any
 
 function add(position: 'start' | 'mid' | 'end' = 'end') {
     options.data = addData(position, options.data!);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function removeData(position: 'start' | 'mid' | 'end' | number = 'end', inData: any[]) {
@@ -97,13 +97,13 @@ function removeData(position: 'start' | 'mid' | 'end' | number = 'end', inData: 
 
 function remove(position: 'start' | 'mid' | 'end' = 'end') {
     options.data = removeData(position, options.data!);
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function change() {
     const index = Math.floor(options.data!.length / 2);
     options.data = removeData(index, addData(index + 1, options.data!));
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function shuffle() {
@@ -111,7 +111,7 @@ function shuffle() {
     newData.sort(() => Math.random() - 0.5);
 
     options.data = newData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function rapidUpdates() {

--- a/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/animation/main.ts
@@ -25,10 +25,10 @@ const chart = AgCharts.create(options);
 
 function data1() {
     options.data = getData1();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function data2() {
     options.data = getData2();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-missing-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-missing-data/main.ts
@@ -46,10 +46,10 @@ function toggleConnectMissingData() {
         connectMissingData: !series.connectMissingData,
     }));
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reset() {
     options.data = getData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/main.ts
@@ -35,5 +35,5 @@ function addValue() {
     const randomIndex = Math.floor(Math.random() * optionsData.length);
     optionsData.splice(randomIndex, 0, newDatum);
     options.data = optionsData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/main.ts
@@ -30,5 +30,5 @@ function removeValue() {
     const removeIndex = Math.floor(dataLength * Math.random());
     data.splice(removeIndex, 1);
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/main.ts
@@ -37,5 +37,5 @@ function shuffleValues() {
     }
 
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/main.ts
@@ -32,5 +32,5 @@ function updateValues() {
         high: Math.random() * d.high,
     }));
     options.data = updatedData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/main.ts
@@ -47,7 +47,7 @@ function stopUpdates() {
 
 function update() {
     options.data = getUpdatedData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function getUpdatedData() {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/main.ts
@@ -34,5 +34,5 @@ function addValue() {
     const randomIndex = Math.floor(Math.random() * optionsData.length);
     optionsData.splice(randomIndex, 0, newDatum);
     options.data = optionsData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/main.ts
@@ -29,5 +29,5 @@ function removeValue() {
     const removeIndex = Math.floor(dataLength * Math.random());
     data.splice(removeIndex, 1);
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/main.ts
@@ -36,5 +36,5 @@ function shuffleValues() {
     }
 
     options.data = data;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/main.ts
@@ -31,5 +31,5 @@ function updateValues() {
         high: Math.random() * d.high,
     }));
     options.data = updatedData;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/main.ts
@@ -46,7 +46,7 @@ function stopUpdates() {
 
 function update() {
     options.data = getUpdatedData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function getUpdatedData() {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-missing-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-missing-data/main.ts
@@ -41,7 +41,7 @@ function missingYValues() {
     data[5].low = undefined;
     options.data = data;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function missingXValue() {
@@ -50,10 +50,10 @@ function missingXValue() {
     data[6].date = undefined;
     options.data = data;
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reset() {
     options.data = getData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/justification/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/justification/main.ts
@@ -31,20 +31,20 @@ const chart = AgCharts.create(options);
 
 function justifyLeft() {
     (options.series![0] as AgSankeySeriesOptions).node!.justify = 'left';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function justifyRight() {
     (options.series![0] as AgSankeySeriesOptions).node!.justify = 'right';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function justifyCenter() {
     (options.series![0] as AgSankeySeriesOptions).node!.justify = 'center';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function justifyJustify() {
     (options.series![0] as AgSankeySeriesOptions).node!.justify = 'justify';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/scatter-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scatter-series-test/_examples/animation/main.ts
@@ -66,17 +66,17 @@ const chart = AgCharts.create(options);
 function reset() {
     options.series![0].data = getMaleData();
     options.series![1].data = getFemaleData();
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function randomise() {
     options.series![0].data = getRandomisedMaleData();
     options.series![1].data = getRandomisedFemaleData();
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function remove() {
     options.series![0].data = getRemovedMaleData();
     options.series![1].data = getRemovedFemaleData();
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }

--- a/packages/ag-charts-website/src/content/docs/scatter-series/_examples/scatter-chart-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scatter-series/_examples/scatter-chart-labels/main.ts
@@ -82,7 +82,7 @@ function updateFontSize(event: any) {
 
     (options.series![0] as AgScatterSeriesOptions).label!.fontSize = value;
     (options.series![1] as AgScatterSeriesOptions).label!.fontSize = value;
-    AgCharts.update(chart, options);
+    chart.update(options);
 
     document.getElementById('fontSizeSliderValue')!.innerHTML = String(value);
 }

--- a/packages/ag-charts-website/src/content/docs/sunburst-series-test/_examples/org-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series-test/_examples/org-chart/main.ts
@@ -20,7 +20,7 @@ const chart = AgCharts.create(options);
 
 function reset() {
     options.data = getData();
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function randomise() {
@@ -37,5 +37,5 @@ function randomise() {
 
     options.data = data;
 
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
@@ -133,5 +133,5 @@ function applyOptions(type: 'bar' | 'pie') {
         ];
     }
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/main.ts
@@ -23,29 +23,29 @@ const chart = AgCharts.create(options);
 function setThemeDefault() {
     options.theme = 'ag-default';
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setThemeSheets() {
     options.theme = 'ag-sheets';
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setThemePolychroma() {
     options.theme = 'ag-polychroma';
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setThemeVivid() {
     options.theme = 'ag-vivid';
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setThemeMaterial() {
     options.theme = 'ag-material';
 
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/themes/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/themes/index.mdoc
@@ -33,7 +33,7 @@ type AgChartThemeName =
 
 ### Example: Stock Themes
 
-In the example below, you can click the buttons to change the theme used in the chart. Notice how changing from one theme to another is a simple matter of changing the `theme` property on the original `options` object and passing it to `AgCharts.update(chart, options)` along with the chart instance.
+In the example below, you can click the buttons to change the theme used in the chart. Notice how changing from one theme to another is a simple matter of changing the `theme` property on the original `options` object and passing it to `chart.update(options)` along with the chart instance.
 
 {% chartExampleRunner title="Stock Themes" name="stock-themes" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip-arrow/main.ts
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip-arrow/main.ts
@@ -30,5 +30,5 @@ const chart = AgCharts.create(options);
 
 function toggleTooltipArrow() {
     options.tooltip!.showArrow = !options.tooltip!.showArrow;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip/main.ts
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/default-tooltip/main.ts
@@ -16,11 +16,11 @@ const chart = AgCharts.create(options);
 function removeYNames() {
     (options.series![0] as AgBarSeriesOptions).yName = undefined;
     (options.series![1] as AgBarSeriesOptions).yName = undefined;
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function addYNames() {
     (options.series![0] as AgBarSeriesOptions).yName = 'Sweaters Made';
     (options.series![1] as AgBarSeriesOptions).yName = 'Hats Made';
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/interaction-range/main.ts
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/interaction-range/main.ts
@@ -28,15 +28,15 @@ const chart = AgCharts.create(options);
 
 function nearest() {
     options.tooltip = { range: 'nearest' };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function exact() {
     options.tooltip = { range: 'exact' };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function distance() {
     options.tooltip = { range: 10 };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/main.ts
@@ -28,7 +28,7 @@ function fixTooltipToTopRight() {
             yOffset: 0,
         },
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function fixTooltipToPointer() {
@@ -39,7 +39,7 @@ function fixTooltipToPointer() {
             yOffset: 8,
         },
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function reset() {
@@ -50,5 +50,5 @@ function reset() {
             yOffset: 0,
         },
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/treemap-series-test/_examples/org-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series-test/_examples/org-chart/main.ts
@@ -21,7 +21,7 @@ const chart = AgCharts.create(options);
 
 function reset() {
     options.data = getData();
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }
 
 function randomise() {
@@ -38,5 +38,5 @@ function randomise() {
 
     options.data = data;
 
-    AgCharts.update(chart, options as any);
+    chart.update(options as any);
 }

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-range/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-range/main.ts
@@ -49,7 +49,7 @@ function changeRangeWeek() {
         start: new Date('2024-12-24'),
         end: undefined,
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeRangeMonth() {
@@ -57,7 +57,7 @@ function changeRangeMonth() {
         start: new Date('2024-12-01'),
         end: new Date('2024-12-30 23:59:59'),
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeRangeAugust() {
@@ -65,7 +65,7 @@ function changeRangeAugust() {
         start: new Date('2024-08-01'),
         end: new Date('2024-08-30 23:59:59'),
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function changeRangeAll() {
@@ -73,5 +73,5 @@ function changeRangeAll() {
         start: new Date('2024-01-01'),
         end: new Date('2024-12-30 23:59:59'),
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/gallery/_examples/log-axis/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/log-axis/main.ts
@@ -63,7 +63,7 @@ function setNumberAxis() {
             fontSize: 10,
         },
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 
 function setLogAxis() {
@@ -81,5 +81,5 @@ function setLogAxis() {
             fontSize: 10,
         },
     };
-    AgCharts.update(chart, options);
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/main.ts
@@ -87,7 +87,7 @@ const chart = AgCharts.create(options);
 function updateData() {
     var now = Date.now();
     options.data = getData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 //@ts-ignore
 setInterval(this.updateData, refreshRateInMilliseconds);

--- a/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/provided/modules/typescript/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/real-time-data-updates/provided/modules/typescript/main.ts
@@ -92,6 +92,6 @@ const chart = AgCharts.create(options);
 function updateData() {
     var now = Date.now();
     options.data = getData();
-    AgCharts.update(chart, options);
+    chart.update(options);
 }
 setInterval(updateData, refreshRateInMilliseconds);

--- a/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/thumbnailGenerator.ts
+++ b/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/thumbnailGenerator.ts
@@ -113,7 +113,7 @@ export async function generateThumbnail({ example, theme, outputPath, dpi, mockT
         const x0 = (containerWidth * column + (containerWidth - width) / 2) | 0;
         const y0 = (containerHeight * row + (containerHeight - height) / 2) | 0;
 
-        AgCharts.update(chartProxy, {
+        await chartProxy.update({
             ...options,
             animation: { enabled: false },
             document,
@@ -122,9 +122,6 @@ export async function generateThumbnail({ example, theme, outputPath, dpi, mockT
             height,
             overrideDevicePixelRatio: dpi,
         } as any);
-
-        const chart = (chartProxy as any).chart;
-        await chart.waitForUpdate(5_000);
 
         if (output.multiple === true) {
             output.ctx.drawImage(

--- a/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/types-utils.ts
+++ b/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/types-utils.ts
@@ -393,8 +393,9 @@ export function formatNode(node: ts.Node) {
             return printNode(node);
 
         case ts.SyntaxKind.MappedType:
+        case ts.SyntaxKind.ConditionalType:
             const output = printNode(node);
-            console.warn('Avoid using MappedType in user facing typings.', output);
+            console.warn('Avoid using MappedType/ConditionalType in user facing typings.', output);
             return output;
 
         default:

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-src-parser.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-src-parser.ts
@@ -35,7 +35,7 @@ const chartVariableName = 'chart';
 const optionsVariableName = 'options';
 
 function tsGenerateWithOptionReferences(node, srcFile) {
-    return tsGenerate(node, srcFile).replace(new RegExp(`AgCharts\\.update\\(chart, options\\);?`, 'g'), '');
+    return tsGenerate(node, srcFile).replace(new RegExp(`chart\\.update\\(options\\);?`, 'g'), '');
 }
 
 export function parser({

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-src-parser.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-src-parser.ts
@@ -35,7 +35,7 @@ const chartVariableName = 'chart';
 const optionsVariableName = 'options';
 
 function tsGenerateWithOptionReferences(node, srcFile) {
-    return tsGenerate(node, srcFile).replace(new RegExp(`chart\\.update\\(options\\);?`, 'g'), '');
+    return tsGenerate(node, srcFile).replace(/chart[A-Za-z0-9]*\.update\(options\);?/g, '');
 }
 
 export function parser({

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -21,8 +21,7 @@ const getDarkmodeTheme = (theme = 'ag-default') => {
     return darkmode ? baseTheme + '-dark' : baseTheme;
 };
 
-const defaultUpdate = __chartAPI.update;
-__chartAPI.update = function update(chart, options) {
+__chartAPI.optionsMutationFn = function update(options) {
     const nextOptions = { ...options };
     const theme = options.theme;
     if (isAgThemeOrUndefined(theme)) {
@@ -33,21 +32,7 @@ __chartAPI.update = function update(chart, options) {
             baseTheme: getDarkmodeTheme(theme.baseTheme),
         };
     }
-    defaultUpdate(chart, nextOptions);
-};
-
-const defaultUpdateDelta = __chartAPI.updateDelta;
-__chartAPI.updateDelta = function updateDelta(chart, options) {
-    const nextOptions = { ...options };
-    // Allow setting theme overrides updateDelta (see api-create-update)
-    if (typeof options.theme === 'object') {
-        const theme = options.theme.baseTheme || 'ag-default';
-        nextOptions.theme = {
-            ...options.theme,
-            baseTheme: getDarkmodeTheme(theme),
-        };
-    }
-    defaultUpdateDelta(chart, nextOptions);
+    return nextOptions;
 };
 
 const applyDarkmode = () => {
@@ -56,9 +41,8 @@ const applyDarkmode = () => {
     charts.forEach((element) => {
         const chart = __chartAPI.getInstance(element.parentElement);
         if (chart == null) return;
-        // .update is monkey-patched to apply theme to options
         // This is just needed to trigger the theme update
-        __chartAPI.update(chart, chart.getOptions());
+        chart.update(chart.getOptions());
     });
     return charts.length !== 0;
 };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11506
https://ag-grid.atlassian.net/browse/AG-8192

Major changes for the 10.0.0 to rework `AgCharts` and `AgChartInstance` APIs - this change:
- Moves `static` methods on `AgCharts` to instance methods on `AgChartInstance` - `AgCharts` responsibility reduces to factory creation with this change.
- Makes several API methods `Promise`-based for convenience of being able to track when an update has been rendered.
- Adds private `AgCharts.optionsMutationFn` callback point for integration with website dark-mode processing.
- Updates example generation to take the change to `AgCharts.update()` into account.

Core code changes are in https://github.com/ag-grid/ag-charts/commit/14662d278b64976a095152d9382fd6a79b2c69cd - the rest of the PR is updating uses of `AgCharts` to reflect this change.