### PR TITLE
AG-11527 - Spike first Financial Charts preset.

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -18,7 +18,7 @@ import { TopologyChart } from '../chart/topologyChart';
 import type { LicenseManager } from '../module/enterpriseModule';
 import { enterpriseModule } from '../module/enterpriseModule';
 import { ChartOptions } from '../module/optionsModule';
-import type { AgChartInstance, AgChartOptions } from '../options/agChartOptions';
+import type { AgChartInstance, AgChartOptions, AgFinancialChartOptions } from '../options/agChartOptions';
 import { Debug } from '../util/debug';
 import { deepClone, jsonWalk } from '../util/json';
 import { mergeDefaults } from '../util/object';
@@ -88,14 +88,18 @@ export abstract class AgCharts {
     /**
      * Create a new `AgChartInstance` based upon the given configuration options.
      */
-    public static create(options: AgChartOptions): AgChartInstance {
+    public static create<O extends AgChartOptions = AgChartOptions>(options: O): AgChartInstance<O> {
         this.licenseCheck(options);
         const chart = AgChartsInternal.createOrUpdate(options);
 
         if (this.licenseManager?.isDisplayWatermark()) {
             enterpriseModule.injectWatermark?.(chart.chart.ctx.domManager, this.licenseManager.getWatermarkMessage());
         }
-        return chart;
+        return chart as unknown as AgChartInstance<O>;
+    }
+
+    public static createFinancialChart(opts: AgFinancialChartOptions) {
+        return this.create<AgFinancialChartOptions>(opts);
     }
 }
 

--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -88,7 +88,7 @@ export abstract class AgCharts {
     /**
      * Create a new `AgChartInstance` based upon the given configuration options.
      */
-    public static create<O extends AgChartOptions = AgChartOptions>(options: O): AgChartInstance<O> {
+    public static create<O extends AgChartOptions>(options: O): AgChartInstance<O> {
         this.licenseCheck(options);
         const chart = AgChartsInternal.createOrUpdate(options);
 

--- a/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
+++ b/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
@@ -1,0 +1,141 @@
+import type {
+    AgAxisLabelFormatterParams,
+    AgBarSeriesFormatterParams,
+    AgCartesianChartOptions,
+    AgCartesianSeriesTooltipRendererParams,
+    AgCrosshairLabelRendererParams,
+    AgSeriesTooltip,
+    CandlestickVolumePreset,
+} from '../../options/agChartOptions';
+
+function dateFormat(dateString: string, format: string) {
+    const dateObject = new Date(dateString);
+    return format == 'd-m'
+        ? dateObject.toLocaleString('en-GB', { day: 'numeric', month: 'short' })
+        : dateObject.toLocaleString('en-GB', { month: 'short', year: '2-digit' });
+}
+
+const tooltipOptions: AgSeriesTooltip<any> = {
+    position: {
+        type: 'top-left',
+        xOffset: 70,
+        yOffset: 20,
+    },
+    renderer: ({ datum }: AgCartesianSeriesTooltipRendererParams) => {
+        const fill = datum.open < datum.close ? '#089981' : '#F23645';
+        return `
+           <div>
+           O<span style="color: ${fill}">${datum.open}</span>
+           H<span style="color: ${fill}">${datum.high}</span>
+           L<span style="color: ${fill}">${datum.low}</span>
+           C<span style="color: ${fill}">${datum.close}</span>
+           Vol <span style="color: ${fill}">${Intl.NumberFormat('en', {
+               notation: 'compact',
+               maximumSignificantDigits: 3,
+           }).format(datum.volume)}</span></div>`;
+    },
+};
+
+export function candlestickVolumePreset(opts: CandlestickVolumePreset): AgCartesianChartOptions {
+    const {
+        xKey = 'date',
+        highKey = 'high',
+        openKey = 'open',
+        lowKey = 'low',
+        closeKey = 'close',
+        volumeKey = 'volume',
+    } = opts;
+    return {
+        zoom: {
+            enabled: true,
+        },
+        toolbar: {
+            ranges: {
+                enabled: true,
+            },
+        },
+        series: [
+            {
+                type: 'bar',
+                xKey: 'date',
+                yKey: volumeKey,
+                showInLegend: false,
+                formatter: (params: AgBarSeriesFormatterParams<any>) => {
+                    const { datum } = params;
+                    const fill = datum[openKey] < datum[closeKey] ? '#92D2CC' : '#F7A9A7';
+                    return { fill };
+                },
+                tooltip: tooltipOptions,
+            },
+            {
+                type: 'candlestick',
+                xKey,
+                openKey,
+                closeKey,
+                highKey,
+                lowKey,
+                item: {
+                    up: {
+                        fill: '#089981',
+                        stroke: '#089981',
+                    },
+                    down: {
+                        fill: '#F23645',
+                        stroke: '#F23645',
+                    },
+                },
+                tooltip: tooltipOptions,
+            },
+        ],
+        axes: [
+            {
+                type: 'number',
+                position: 'right',
+                keys: ['open', 'close', 'high', 'low'],
+                max: 210,
+                tick: {
+                    size: 0,
+                    maxSpacing: 50,
+                },
+                label: {
+                    padding: 0,
+                    fontSize: 10,
+                    format: '.2f',
+                },
+                thickness: 25,
+                crosshair: {
+                    enabled: true,
+                    snap: false,
+                },
+            },
+            {
+                type: 'number',
+                position: 'left',
+                keys: ['volume'],
+                max: 1000000000,
+                label: { enabled: false },
+                crosshair: { enabled: false },
+            },
+            {
+                type: 'category',
+                position: 'bottom',
+                label: {
+                    enabled: true,
+                    autoRotate: false,
+                    formatter: ({ value }: AgAxisLabelFormatterParams) => dateFormat(value, 'd-m'),
+                },
+                crosshair: {
+                    enabled: true,
+                    label: {
+                        renderer: ({ value }: AgCrosshairLabelRendererParams) => {
+                            return { text: dateFormat(value, 'd-m') };
+                        },
+                    },
+                },
+            },
+        ],
+        annotations: {
+            enabled: true,
+        },
+    };
+}

--- a/packages/ag-charts-community/src/api/preset/presets.ts
+++ b/packages/ag-charts-community/src/api/preset/presets.ts
@@ -1,0 +1,6 @@
+import type { AgChartOptions, Preset } from '../../options/agChartOptions';
+import { candlestickVolumePreset } from './candlestickVolumePreset';
+
+export const PRESETS: { [K in Preset['type']]: (p: Preset & { type: K }) => AgChartOptions } = {
+    'candlestick-volume': candlestickVolumePreset,
+};

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1601,6 +1601,7 @@ export abstract class Chart extends Observable {
             'data',
             'series',
             'listeners',
+            'preset',
             'theme',
             'legend.listeners',
             'navigator.miniChart.series',

--- a/packages/ag-charts-community/src/chart/chartProxy.ts
+++ b/packages/ag-charts-community/src/chart/chartProxy.ts
@@ -149,7 +149,7 @@ export class AgChartInstanceProxy implements AgChartProxy {
             }
         });
         chart.update(ChartUpdateType.FULL, { forceNodeDataRefresh: true });
-        await cloneProxy.chart.waitForUpdate();
+        await cloneProxy.waitForUpdate();
         return cloneProxy;
     }
 }

--- a/packages/ag-charts-community/src/options/agChartOptions.ts
+++ b/packages/ag-charts-community/src/options/agChartOptions.ts
@@ -1,3 +1,4 @@
+export * from './api/presetOptions';
 export * from './chart/axisOptions';
 export * from './chart/crosshairOptions';
 export * from './chart/chartOptions';

--- a/packages/ag-charts-community/src/options/api/presetOptions.ts
+++ b/packages/ag-charts-community/src/options/api/presetOptions.ts
@@ -1,0 +1,12 @@
+export type CandlestickVolumePreset = {
+    type: 'candlestick-volume';
+
+    xKey?: string;
+    openKey?: string;
+    highKey?: string;
+    lowKey?: string;
+    closeKey?: string;
+    volumeKey?: string;
+};
+
+export type Preset = CandlestickVolumePreset;

--- a/packages/ag-charts-community/src/options/chart/chartOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartOptions.ts
@@ -1,3 +1,4 @@
+import type { CandlestickVolumePreset, Preset } from '../api/presetOptions';
 import type { AgAnimationOptions } from './animationOptions';
 import type { AgChartBackgroundImage } from './backgroundOptions';
 import type { AgContextMenuOptions } from './contextMenuOptions';
@@ -202,8 +203,15 @@ export interface AgBaseThemeableChartOptions<TDatum = any> {
 
 /** Configuration common to all charts.  */
 export interface AgBaseChartOptions<TDatum = any> extends AgBaseThemeableChartOptions<TDatum> {
+    preset?: Preset | Preset['type'];
     /** The data to render the chart from. If this is not specified, it must be set on individual series instead. */
     data?: TDatum[];
     /** The element to place the rendered chart into. */
     container?: HTMLElement | null;
 }
+
+type AgPresetOptions<P extends Preset> = AgBaseChartOptions & {
+    preset: P | P['type'];
+};
+
+export type AgFinancialChartOptions = AgPresetOptions<CandlestickVolumePreset>;

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
@@ -1,4 +1,10 @@
-import { AgCartesianChartOptions, AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgChartInstance,
+    AgChartOptions,
+    AgCharts,
+    AgPolarChartOptions,
+} from 'ag-charts-enterprise';
 
 import { getData, random } from './data';
 
@@ -204,7 +210,7 @@ let options: AgCartesianChartOptions | AgPolarChartOptions = {
 };
 
 // Create chart
-const chart = AgCharts.create(options);
+const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
 
 // Elements
 const tickingButton = document.getElementsByClassName('animation-data-updates__toggle-ticking')[0];

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
@@ -210,7 +210,7 @@ let options: AgCartesianChartOptions | AgPolarChartOptions = {
 };
 
 // Create chart
-const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
+const chart = AgCharts.create(options as AgChartOptions);
 
 // Elements
 const tickingButton = document.getElementsByClassName('animation-data-updates__toggle-ticking')[0];

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
@@ -229,7 +229,7 @@ let options: AgCartesianChartOptions | AgPolarChartOptions = {
     ...barOptions,
 };
 
-const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
+const chart = AgCharts.create(options as AgChartOptions);
 
 function changeSeriesBar() {
     options.series = barOptions.series;

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
@@ -1,6 +1,7 @@
 import {
     AgCartesianChartOptions,
     AgCartesianSeriesTooltipRendererParams,
+    AgChartInstance,
     AgChartOptions,
     AgCharts,
     AgPolarChartOptions,
@@ -228,7 +229,7 @@ let options: AgCartesianChartOptions | AgPolarChartOptions = {
     ...barOptions,
 };
 
-const chart = AgCharts.create(options);
+const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
 
 function changeSeriesBar() {
     options.series = barOptions.series;

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
@@ -1,6 +1,8 @@
 import {
     AgCartesianChartOptions,
     AgCartesianSeriesTooltipRendererParams,
+    AgChartInstance,
+    AgChartOptions,
     AgCharts,
     AgPolarChartOptions,
     AgTooltipRendererResult,
@@ -227,7 +229,7 @@ let options: AgCartesianChartOptions | AgPolarChartOptions = {
     ...barOptions,
 };
 
-const chart = AgCharts.create(options);
+const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
 
 function changeSeriesBar() {
     options.series = barOptions.series;

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
@@ -229,7 +229,7 @@ let options: AgCartesianChartOptions | AgPolarChartOptions = {
     ...barOptions,
 };
 
-const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
+const chart = AgCharts.create(options as AgChartOptions);
 
 function changeSeriesBar() {
     options.series = barOptions.series;

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/main.ts
@@ -1,4 +1,10 @@
-import { AgAreaSeriesOptions, AgChartLegendPosition, AgChartOptions, AgCharts } from 'ag-charts-community';
+import {
+    AgAreaSeriesOptions,
+    AgChartInstance,
+    AgChartLegendPosition,
+    AgChartOptions,
+    AgCharts,
+} from 'ag-charts-community';
 
 import { getData } from './data';
 
@@ -32,7 +38,7 @@ const options: AgChartOptions = {
     legend,
 };
 
-const chart = AgCharts.create(options);
+const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
 
 function reverseSeries() {
     options.series = series.reverse();

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/create-update/main.ts
@@ -38,7 +38,7 @@ const options: AgChartOptions = {
     legend,
 };
 
-const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
+const chart = AgCharts.create(options as AgChartOptions);
 
 function reverseSeries() {
     options.series = series.reverse();

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
@@ -40,7 +40,7 @@ const options: AgChartOptions = {
     ],
 };
 
-const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
+const chart = AgCharts.create(options as AgChartOptions);
 
 function actionReset() {
     options.data = [...data];

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartInstance, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 const data = [
     { quarter: 'week 3', week: 3, iphone: 60 },
@@ -40,7 +40,7 @@ const options: AgChartOptions = {
     ],
 };
 
-const chart = AgCharts.create(options);
+const chart = AgCharts.create(options) as AgChartInstance<AgChartOptions>;
 
 function actionReset() {
     options.data = [...data];

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts, time } from 'ag-charts-enterprise';
+import { AgChartInstance, AgChartOptions, AgCharts, time } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -54,7 +54,7 @@ const options: AgChartOptions = {
     ],
 };
 
-const chart = AgCharts.create(options);
+const chart = AgCharts.create(options as AgChartOptions);
 
 function genDataPoint(ref: Date | { date: Date; petrol: number; diesel: number }, offsetDays: number) {
     const { date, petrol = 120, diesel = 125 } = ref instanceof Date ? { date: ref } : ref;

--- a/packages/ag-charts-website/src/content/docs/area-series/_examples/missing-data-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series/_examples/missing-data-area/main.ts
@@ -1,8 +1,8 @@
-import { AgAreaSeriesOptions, AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgAreaSeriesOptions, AgCartesianChartOptions, AgChartOptions, AgCharts } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     title: {
         text: 'Sales by Month',

--- a/packages/ag-charts-website/src/content/docs/background/_examples/background-fill/main.ts
+++ b/packages/ag-charts-website/src/content/docs/background/_examples/background-fill/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgChartOptions, AgCharts, AgPolarChartOptions } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     series: [

--- a/packages/ag-charts-website/src/content/docs/bubble-series/_examples/bubble-chart-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bubble-series/_examples/bubble-chart-labels/main.ts
@@ -1,8 +1,8 @@
-import { AgBubbleSeriesOptions, AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgBubbleSeriesOptions, AgCartesianChartOptions, AgChartOptions, AgCharts } from 'ag-charts-community';
 
 import { femaleHeightWeight, maleHeightWeight } from './height-weight-data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     title: {
         text: 'Weight vs Height)',

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-add-data/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: {

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-remove-data/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: {

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-update-value/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-update-value/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: {

--- a/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
@@ -30,4 +30,3 @@ const options: AgFinancialChartOptions = {
 };
 
 const chart = AgCharts.createFinancialChart(options);
-

--- a/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
@@ -1,162 +1,33 @@
-import {
-    AgCartesianChartOptions,
-    AgCartesianSeriesTooltipRendererParams,
-    AgCharts,
-    AgSeriesTooltip,
-} from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-function dateFormat(dateString: string, format: string) {
-    const dateObject = new Date(dateString);
-    const formattedDate =
-        format == 'd-m'
-            ? dateObject.toLocaleString('en-GB', { day: 'numeric', month: 'short' })
-            : dateObject.toLocaleString('en-GB', { month: 'short', year: '2-digit' });
-
-    return formattedDate;
-}
-
-const tooltipOptions: AgSeriesTooltip<any> = {
-    position: {
-        type: 'top-left',
-        xOffset: 70,
-        yOffset: 20,
-    },
-    renderer: ({ datum }: AgCartesianSeriesTooltipRendererParams) => {
-        var fill = datum.open < datum.close ? '#089981' : '#F23645';
-        return `
-           <div>
-           O<span style="color: ${fill}">${datum.open}</span>
-           H<span style="color: ${fill}">${datum.high}</span>
-           L<span style="color: ${fill}">${datum.low}</span>
-           C<span style="color: ${fill}">${datum.close}</span>
-           Vol <span style="color: ${fill}">${Intl.NumberFormat('en', {
-               notation: 'compact',
-               maximumSignificantDigits: 3,
-           }).format(datum.volume)}</span></div>`;
-    },
-};
-
-const options: AgCartesianChartOptions = {
+const options: AgFinancialChartOptions = {
+    preset: 'candlestick-volume',
     container: document.getElementById('myChart'),
     data: getData(),
-    zoom: {
-        enabled: true,
-        rangeX: {
-            start: new Date(2023, 10, 26),
-        },
-    },
-    toolbar: {
-        ranges: {
-            enabled: true,
-        },
-    },
-    title: {
-        text: 'AAPL',
-        textAlign: 'left',
-    },
-    series: [
-        {
-            type: 'bar',
-            xKey: 'date',
-            yKey: 'volume',
-            showInLegend: false,
-            formatter: ({ datum }) => {
-                var fill = datum.open < datum.close ? '#92D2CC' : '#F7A9A7';
-                return { fill: fill };
-            },
-            tooltip: tooltipOptions,
-        },
-        {
-            type: 'candlestick',
-            xKey: 'date',
-            openKey: 'open',
-            closeKey: 'close',
-            highKey: 'high',
-            lowKey: 'low',
-            item: {
-                up: {
-                    fill: '#089981',
-                    stroke: '#089981',
-                },
-                down: {
-                    fill: '#F23645',
-                    stroke: '#F23645',
-                },
-            },
-            tooltip: tooltipOptions,
-        },
-    ],
-
-    axes: [
-        {
-            type: 'number',
-            position: 'right',
-            keys: ['open', 'close', 'high', 'low'],
-            max: 210,
-            tick: {
-                size: 0,
-                maxSpacing: 50,
-            },
-            label: {
-                padding: 0,
-                fontSize: 10,
-                format: '.2f',
-            },
-            thickness: 25,
-            crosshair: {
-                enabled: true,
-                snap: false,
-            },
-        },
-        {
-            type: 'number',
-            position: 'left',
-            keys: ['volume'],
-            max: 1000000000,
-            label: { enabled: false },
-            crosshair: { enabled: false },
-        },
-        {
-            type: 'category',
-            position: 'bottom',
-            label: {
-                enabled: true,
-                autoRotate: false,
-                formatter: ({ value }) => dateFormat(value, 'd-m'),
-            },
-            crosshair: {
-                enabled: true,
-                label: {
-                    renderer: ({ value }) => {
-                        return { text: dateFormat(value, 'd-m') };
-                    },
-                },
-            },
-        },
-    ],
-    annotations: {
-        enabled: true,
-        initial: [
-            {
-                type: 'parallel-channel',
-                start: { x: new Date(1672756200000), y: 130.28 + 6 },
-                end: { x: new Date(1689773400000), y: 195.1 + 6 },
-                size: 12,
-            },
-            {
-                type: 'line',
-                start: { x: new Date(1701959400000), y: 193.63 },
-                end: { x: new Date(1707489000000), y: 188.85 },
-            },
-            {
-                type: 'line',
-                start: { x: new Date(1691155800000), y: 185.52 },
-                end: { x: new Date(1698413400000), y: 166.91 },
-            },
-        ],
-    },
+    // annotations: {
+    //     enabled: true,
+    //     initial: [
+    //         {
+    //             type: 'parallel-channel',
+    //             start: { x: new Date(1672756200000), y: 130.28 + 6 },
+    //             end: { x: new Date(1689773400000), y: 195.1 + 6 },
+    //             size: 12,
+    //         },
+    //         {
+    //             type: 'line',
+    //             start: { x: new Date(1701959400000), y: 193.63 },
+    //             end: { x: new Date(1707489000000), y: 188.85 },
+    //         },
+    //         {
+    //             type: 'line',
+    //             start: { x: new Date(1691155800000), y: 185.52 },
+    //             end: { x: new Date(1698413400000), y: 166.91 },
+    //         },
+    //     ],
+    // },
 };
 
-AgCharts.create(options);
+const chart = AgCharts.createFinancialChart(options);
+

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-horizontal/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-horizontal/main.ts
@@ -1,6 +1,6 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCharts, AgPolarChartOptions } from 'ag-charts-community';
 
-const options: AgChartOptions = {
+const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
     width: 600,
     data: [

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-vertical/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-layout-vertical/main.ts
@@ -1,6 +1,6 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCharts, AgPolarChartOptions } from 'ag-charts-community';
 
-const options: AgChartOptions = {
+const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
     height: 300,
     data: [

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/main.ts
@@ -1,8 +1,8 @@
-import { AgChartLegendPosition, AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgChartLegendPosition, AgCharts } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     title: {
         text: `Renewable sources used to generate electricity for transport fuels`,

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-constraints/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-constraints/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCharts, AgPolarChartOptions } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     series: [

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-customisation/main.ts
@@ -1,8 +1,8 @@
-import { AgChartLegendPosition, AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgChartLegendPosition, AgCharts } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
 
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-position/main.ts
@@ -1,8 +1,8 @@
-import { AgChartLegendPosition, AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgChartLegendPosition, AgCharts } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
 
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-seriesStroke/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-seriesStroke/main.ts
@@ -1,6 +1,6 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-community';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: [
         { month: 'Jan', price: 148.9, volume: 2.5 },

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 const data = [
     { quarter: 'week 3', week: 3, iphone: 60 },
@@ -10,7 +10,7 @@ const data = [
     { quarter: 'week 11', week: 11, iphone: 121 },
 ];
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     animation: {
         enabled: true,

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +18,7 @@ const series: NonNullable<AgChartOptions['series']> = [
         label: {},
     },
 ];
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     animation: {
         enabled: true,

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/easeOut-very-slow/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/easeOut-very-slow/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 const STATIONS = [
     'Finsbury\nPark',
@@ -12,7 +12,7 @@ const STATIONS = [
 // Make the maker scale-in animation duration = 0.
 (window as any).agChartsDebug = ['animationImmediateMarkerSwipeScaleIn'];
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: STATIONS.map((station) => {
         return { station, early: 4000 };

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/gap-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/gap-line/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts, AgLineSeriesOptions } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgCharts, AgLineSeriesOptions } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: {

--- a/packages/ag-charts-website/src/content/docs/line-series/_examples/line-style/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series/_examples/line-style/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts, AgLineSeriesOptions } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgCharts, AgLineSeriesOptions } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     title: {
         text: '2023 Average Temperatures',

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
 
 const data = [
     { label: 'Android', value: 56.9 },
@@ -15,7 +15,7 @@ const filter = (...labels: string[]) => {
     return (d: (typeof data)[number]) => labels.includes(d.label);
 };
 
-const options: AgChartOptions = {
+const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
     animation: {
         enabled: true,

--- a/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/animation/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
 
 import { getData1, getData2 } from './data';
 
-const options: AgChartOptions = {
+const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
 
     data: getData1(),

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-missing-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-missing-data/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts, AgRangeAreaSeriesOptions } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AgRangeAreaSeriesOptions } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: data.slice(0, 1),
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: data.slice(0, 1),
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/main.ts
@@ -1,10 +1,10 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
 const data = getData();
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data,
     title: {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-missing-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-missing-data/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/alignment/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/alignment/main.ts
@@ -1,7 +1,7 @@
 // Fictitious data used for demonstration purposes
-import { AgChartOptions, AgCharts, AgSankeySeriesOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgFlowProportionChartOptions, AgSankeySeriesOptions } from 'ag-charts-enterprise';
 
-const options: AgChartOptions = {
+const options: AgFlowProportionChartOptions = {
     container: document.getElementById('myChart'),
     data: [
         { from: 'Employees', to: 'Sales', size: 2 },

--- a/packages/ag-charts-website/src/content/docs/scatter-series/_examples/scatter-chart-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scatter-series/_examples/scatter-chart-labels/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts, AgScatterSeriesOptions } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgCharts, AgScatterSeriesOptions } from 'ag-charts-community';
 
 import { femaleHeightWeight, maleHeightWeight } from './height-weight-data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     title: {
         text: 'Weight vs Height)',

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
@@ -71,7 +71,7 @@ var myTheme: AgChartTheme = {
     },
 };
 
-var options: AgChartOptions = {
+const options: AgChartOptions = {
     theme: myTheme,
     container: document.getElementById('myChart'),
     title: {
@@ -109,7 +109,7 @@ var options: AgChartOptions = {
     ],
 };
 
-const chart = AgCharts.create(options);
+const chart = AgCharts.create(options as AgChartOptions);
 
 function applyOptions(type: 'bar' | 'pie') {
     if (type === 'pie') {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/stock-themes/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgChartThemeName, AgCharts } from 'ag-charts-community';
+import { AgCharts, AgPolarChartOptions } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
     theme: 'ag-default',
     title: {

--- a/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/tooltips/_examples/tooltip-position/main.ts
@@ -1,8 +1,8 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-community';
 
 import { getData } from './data';
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     series: [


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11527

Adds support for the `preset: 'candlestick-volume'` use-case.

The intent is to flesh out the preset registration distinctly, and move some of the definitions to enterprise modules. This PR unlocks the ability for relevant team members to start exercising and improving the presets in parallel.