### PR TITLE
AG-11745 - Switch context menu to canvas-relative positioning.

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
@@ -90,7 +90,7 @@ export class ContextMenuRegistry {
         pointerEvent: PointerInteractionEvent<'contextmenu'>,
         context: ContextTypeMap[T]
     ) {
-        const { pageX: x, pageY: y, sourceEvent } = pointerEvent;
+        const { offsetX: x, offsetY: y, sourceEvent } = pointerEvent;
         this.listeners.dispatch('', this.buildConsumable({ type, x, y, context, sourceEvent }));
     }
 

--- a/packages/ag-charts-enterprise/src/features/__snapshots__/features.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/features/__snapshots__/features.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Feature Combinations Context Menu and Zoom when fully zoomed in it shou
 HTMLCollection [
   <div
     class="ag-chart-context-menu"
-    style="display: block; left: 401px; top: calc(300px - 0.5em);"
+    style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
       class="ag-chart-context-menu__menu"
@@ -34,7 +34,7 @@ exports[`Feature Combinations Context Menu and Zoom when fully zoomed out it sho
 HTMLCollection [
   <div
     class="ag-chart-context-menu"
-    style="display: block; left: 401px; top: calc(300px - 0.5em);"
+    style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
       class="ag-chart-context-menu__menu"
@@ -64,7 +64,7 @@ exports[`Feature Combinations Context Menu and Zoom when zoomed in it should ena
 HTMLCollection [
   <div
     class="ag-chart-context-menu"
-    style="display: block; left: 401px; top: calc(300px - 0.5em);"
+    style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
       class="ag-chart-context-menu__menu"

--- a/packages/ag-charts-enterprise/src/features/context-menu/__snapshots__/contextMenu.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/features/context-menu/__snapshots__/contextMenu.test.ts.snap
@@ -13,7 +13,7 @@ exports[`Context Menu should show the default actions 1`] = `
 HTMLCollection [
   <div
     class="ag-chart-context-menu"
-    style="display: block; left: 401px; top: calc(300px - 0.5em);"
+    style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
       class="ag-chart-context-menu__menu"

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -18,7 +18,7 @@ type ContextMenuEvent = _ModuleSupport.ContextMenuEvent;
 type ContextMenuAction<T extends ContextType = ContextType> = _ModuleSupport.ContextMenuAction<T>;
 type ContextMenuCallback<T extends ContextType> = _ModuleSupport.ContextMenuCallback<T>;
 
-const { BOOLEAN, Validate, createElement, getWindow, ContextMenuRegistry } = _ModuleSupport;
+const { BOOLEAN, Validate, createElement, ContextMenuRegistry } = _ModuleSupport;
 
 const moduleId = 'context-menu';
 
@@ -296,24 +296,19 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private reposition() {
-        const { x, y } = this;
+        let { x, y } = this;
 
         this.element.style.top = 'unset';
         this.element.style.bottom = 'unset';
-        this.element.style.left = 'unset';
-        this.element.style.right = 'unset';
 
-        if (x + this.element.offsetWidth > getWindow('innerWidth')) {
-            this.element.style.right = `calc(100% - ${x - 1}px)`;
-        } else {
-            this.element.style.left = `${x + 1}px`;
-        }
+        const canvasRect = this.ctx.domManager.getBoundingClientRect();
+        const { offsetWidth: width, offsetHeight: height } = this.element;
 
-        if (y + this.element.offsetHeight > getWindow('innerHeight')) {
-            this.element.style.bottom = `calc(100% - ${y}px - 0.5em)`;
-        } else {
-            this.element.style.top = `calc(${y}px - 0.5em)`;
-        }
+        x = _ModuleSupport.clamp(0, x, canvasRect.width - width);
+        y = _ModuleSupport.clamp(0, y, canvasRect.height - height);
+
+        this.element.style.left = `${x}px`;
+        this.element.style.top = `calc(${y}px - 0.5em)`;
     }
 
     public override destroy() {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.ts
@@ -9,7 +9,6 @@ export const defaultContextMenuCss = `
     box-shadow: 0 1px 4px 1px rgba(186, 191, 199, 0.4);
     color: rgb(24, 29, 31);
     font: 13px Verdana, sans-serif;
-    position: fixed;
     transition: transform 0.1s ease;
     white-space: nowrap;
     z-index: 99999;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11745

Switches context-menu positioning from viewport fixed to canvas relative, addressing some layout issues when scrolling the viewport after opening the menu, and aligning with other overlay positioning.