### PR TITLE
Add native dependency version check.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "run-s postinstall:*",
     "postinstall:patch": "patch-package",
     "postinstall:verify-canvas-binary-present": "test -f node_modules/canvas/build/Release/canvas.node",
+    "postinstall:verify-native-dep-versions": "./tools/dependencies/check-versions.sh",
     "postinstall:nx-plugin-build": "nx run-many -p ag-charts-generate-chart-thumbnail,ag-charts-generate-code-reference-files,ag-charts-generate-example-files,ag-charts-task-autogen -t build && nx daemon --stop"
   },
   "private": true,

--- a/tools/dependencies/check-versions.sh
+++ b/tools/dependencies/check-versions.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -eu
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+PASS=true
+
+checkVersion() {
+    local brewPkg=$1
+    local aptPkg=$2
+    local expectedBrew=$3
+    local expectedApt=${4:-3}
+
+    local expected
+    local actual
+    local pkg
+    if (which brew >/dev/null) ; then
+        pkg=$brewPkg
+        expected=$expectedBrew
+        actual=$(brew list --versions $brewPkg)
+    elif (which apt-cache >/dev/null) ; then
+        pkg=$aptPkg
+        expected=$expectedApt
+        actual=$(apt-cache policy $aptPkg | grep "Installed" | awk '{ print $2 }')
+    fi
+
+    if [[ "${actual}" =~ "${expected}" ]] ; then
+        PASS=fail
+        echo "${RED}Installed version of ${pkg} !== ${expected}, found ${actual}${RESET}"
+    else
+        echo "${GREEN}Installed version of ${pkg} matched ${expected}${RESET}"
+    fi
+}
+
+checkVersion cairo libcairo2 1.18.0 "1.18.0-ubuntu.*"
+
+if [[ $PASS == "fail" ]] ; then
+    exit 1
+fi

--- a/tools/dependencies/check-versions.sh
+++ b/tools/dependencies/check-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -28,14 +28,14 @@ checkVersion() {
     fi
 
     if [[ "${actual}" =~ "${expected}" ]] ; then
-        echo "${GREEN}Installed version of ${pkg} matched ${actual}${RESET}"
+        echo -e "${GREEN}Installed version of ${pkg} matched ${actual}${RESET}"
     else
         PASS=false
-        echo "${RED}Installed version of ${pkg} !== ${expected}, found ${actual}${RESET}"
+        echo -e "${RED}Installed version of ${pkg} !== ${expected}, found ${actual}${RESET}"
     fi
 }
 
-checkVersion cairo libcairo2 1.18.0 "1.18.0-ubuntu.*"
+checkVersion cairo libcairo2 1.18.0 "1.18.0-.*"
 
 if [[ $PASS == "false" ]] ; then
     exit 1

--- a/tools/dependencies/check-versions.sh
+++ b/tools/dependencies/check-versions.sh
@@ -28,15 +28,15 @@ checkVersion() {
     fi
 
     if [[ "${actual}" =~ "${expected}" ]] ; then
-        PASS=fail
-        echo "${RED}Installed version of ${pkg} !== ${expected}, found ${actual}${RESET}"
+        echo "${GREEN}Installed version of ${pkg} matched ${actual}${RESET}"
     else
-        echo "${GREEN}Installed version of ${pkg} matched ${expected}${RESET}"
+        PASS=false
+        echo "${RED}Installed version of ${pkg} !== ${expected}, found ${actual}${RESET}"
     fi
 }
 
 checkVersion cairo libcairo2 1.18.0 "1.18.0-ubuntu.*"
 
-if [[ $PASS == "fail" ]] ; then
+if [[ $PASS == "false" ]] ; then
     exit 1
 fi

--- a/tools/dependencies/check-versions.sh
+++ b/tools/dependencies/check-versions.sh
@@ -27,7 +27,7 @@ checkVersion() {
         actual=$(apt-cache policy $aptPkg | grep "Installed" | awk '{ print $2 }')
     fi
 
-    if [[ "${actual}" =~ "${expected}" ]] ; then
+    if [[ ${actual} =~ ${expected} ]] ; then
         echo -e "${GREEN}Installed version of ${pkg} matched ${actual}${RESET}"
     else
         PASS=false


### PR DESCRIPTION
As we know that Cairo 1.18.0 is a requirement for consistent visual regression test output, adds a `postinstall` script to sanity check this.