### PR TITLE
AG-11133 Add annotation toolbar tooltip suppression

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -130,6 +130,7 @@ const defaultTooltipCss = `
  */
 export class TooltipManager {
     private readonly stateTracker = new StateTracker<TooltipState>();
+    private readonly suppressState = new StateTracker(false);
     private appliedState: TooltipState | null = null;
 
     public constructor(
@@ -155,6 +156,14 @@ export class TooltipManager {
         this.applyStates();
     }
 
+    public suppressTooltip(callerId: string) {
+        this.suppressState.set(callerId, true);
+    }
+
+    public unsuppressTooltip(callerId: string) {
+        this.suppressState.delete(callerId);
+    }
+
     public getTooltipMeta(callerId: string): TooltipMeta | undefined {
         return this.stateTracker.get(callerId)?.meta;
     }
@@ -167,7 +176,7 @@ export class TooltipManager {
         const id = this.stateTracker.stateId();
         const state = id ? this.stateTracker.get(id) : null;
 
-        if (state?.meta == null || state?.content == null) {
+        if (this.suppressState.stateValue() || state?.meta == null || state?.content == null) {
             this.appliedState = null;
             this.tooltip.toggle(false);
             return;

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -479,10 +479,13 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         this.active = hovered;
         toolbarManager.toggleGroup('annotations', 'annotationOptions', this.active != null);
 
-        if (this.active != null) {
+        if (this.active == null) {
+            this.ctx.tooltipManager.unsuppressTooltip('annotations');
+        } else {
             const node = annotations.nodes()[this.active];
             node.toggleActive(true);
             this.ctx.toolbarManager.changeFloatingAnchor('annotationOptions', node.getAnchor());
+            this.ctx.tooltipManager.suppressTooltip('annotations');
         }
 
         updateService.update(ChartUpdateType.PERFORM_LAYOUT, { skipAnimations: true });


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11133

Prevents the tooltip from showing while an annotation is selected.
