### PR TITLE
AG-8192 - Update API Docs with new AgChartsInstance + Promise-based APIs

### DIFF
--- a/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-community/src/options/chart/chartBuilderOptions.ts
@@ -96,26 +96,6 @@ export interface AgChartInterface {
      * Create a new `AgChartInstance` based upon the given configuration options.
      */
     create(options: AgChartOptions): AgChartInstance;
-
-    /**
-     * Update an existing `AgChartInstance`. Options provided should be complete and not partial.
-     *
-     * __NOTE__ As each call could trigger a chart redraw, multiple calls to update options in quick succession could result in undesirable flickering, so callers should batch up and/or debounce changes to avoid unintended partial update renderings.
-     */
-    update(chart: AgChartInstance, options: AgChartOptions): void;
-
-    /**
-     * Update an existing `AgChartInstance` by applying a partial set of option changes.
-     *
-     * __NOTE__: As each call could trigger a chart redraw, each individual delta options update should leave the chart in a valid options state. Also, multiple calls to update options in quick succession could result in undesirable flickering, so callers should batch up and/or debounce changes to avoid unintended partial update renderings.
-     */
-    updateDelta(chart: AgChartInstance, deltaOptions: AgChartOptions): void;
-
-    /** Starts a browser-based image download for the given `AgChartInstance`. */
-    download(chart: AgChartInstance, options?: DownloadOptions): void;
-
-    /** Returns a base64-encoded image data URL for the given `AgChartInstance`. */
-    getImageDataURL(chart: AgChartInstance, options?: ImageDataUrlOptions): Promise<string>;
 }
 
 export interface DownloadOptions extends ImageDataUrlOptions {

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/data.ts
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/data.ts
@@ -1,0 +1,13 @@
+let count = 0;
+
+export function generateDatum() {
+    return { count: count++, value: Math.random() * 100 };
+}
+
+export function getData() {
+    const result: { count: number; value: number }[] = [];
+    for (let i = 0; i < 100; i++) {
+        result[i] = generateDatum();
+    }
+    return result;
+}

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/index.html
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/index.html
@@ -1,0 +1,8 @@
+<div class="wrapper">
+    <div class="toolPanel">
+        <button onclick="start()">Start</button>
+        <span class="spacer"></span>
+        <button onclick="stop()">Stop</button>
+    </div>
+    <div id="myChart" class="chart"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/main.ts
@@ -22,6 +22,7 @@ const chart = AgCharts.create(options as AgChartOptions);
 
 let running = false;
 async function start() {
+    if (running) return;
     running = true;
 
     while (running) {

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/main.ts
@@ -1,0 +1,35 @@
+// @ag-skip-fws
+import { AgChartOptions, AgCharts } from 'ag-charts-community';
+
+import { generateDatum, getData } from './data';
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Simple Promise-base example',
+    },
+    data: getData(),
+    series: [
+        {
+            type: 'line',
+            xKey: 'count',
+            yKey: 'value',
+        },
+    ],
+};
+
+const chart = AgCharts.create(options as AgChartOptions);
+
+let running = false;
+async function start() {
+    running = true;
+
+    while (running) {
+        options.data = [...options.data!, generateDatum()];
+        await chart.update(options);
+    }
+}
+
+function stop() {
+    running = false;
+}

--- a/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/styles.css
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/_examples/wait-for-update/styles.css
@@ -1,0 +1,18 @@
+.wrapper {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.toolPanel {
+    text-align: center;
+}
+
+.spacer {
+    display: inline-block;
+    min-width: 20px;
+}
+
+.chart {
+    height: 100%;
+}

--- a/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
@@ -8,15 +8,15 @@ Learn about creating and updating charts in more detail.
 ## Creating and Updating Charts
 
 {% if isFramework("javascript") %}
-`AgCharts` exposes `create()` and `update()` static methods to perform chart initialisation and update based upon
-the `AgChartOptions` configuration structure.
+`AgCharts` exposes `create()` static methods to perform chart initialisation, and the resulting `AgChartInstance` has methods
+such as `AgChartInstance.update()` to allow updating configuration. The `AgChartOptions` type defines the configuration structure.
 
 Mutations to the previously used options object are not automatically picked up by the chart implementation,
-`AgCharts.update()` should be called for changes to be applied.
+`AgChartInstance.update()` should be called for changes to be applied.
 
 {% note %}
-We expect the options supplied to `AgCharts.update()` to be the full configuration state to update
-to, not a partial configuration. Use `AgCharts.updateDelta()` to apply partial updates.
+We expect the options supplied to `AgChartInstance.update()` to be the full configuration state to update
+to, not a partial configuration. Use `AgChartInstance.updateDelta()` to apply partial updates.
 {% /note %}
 
 {% warning %}
@@ -24,9 +24,17 @@ We expect immutable data for `data` elements, as this enables efficient change d
 elements are mutated in-place, we cannot guarantee to detect the changes.
 {% /warning %}
 
-`AgCharts` has the following API:
+{% tabs %}
 
-{% apiReference id="AgChartInterface" include=["create", "update"] hideHeader=true hideRequired=true /%}
+{% tabItem id="AgCharts" label="AgCharts" %}
+{% apiReference id="AgChartInterface" include=["create"] hideHeader=true hideRequired=true /%}
+{% /tabItem %}
+
+{% tabItem id="AgChartInstance" label="AgChartInstance" %}
+{% apiReference id="AgChartInstance" hideHeader=true /%}
+{% /tabItem %}
+
+{% /tabs %}
 
 {% /if %}
 
@@ -47,13 +55,11 @@ The following example demonstrates both create and update cases:
 
 ## Delta Options Update
 
-`AgCharts` exposes an `updateDelta()` static method to allow partial updates to a charts options.
+`AgChartInstance` exposes `updateDelta()` and `getOptions()` method to allow partial updates to a charts options.
 
-{% apiReference id="AgChartInterface" include=["updateDelta"] hideHeader=true hideRequired=true /%}
+To assist with state management, the complete applied options state can be retrieved by calling `getOptions()`:
 
-To assist with state management, the complete applied options state can be retrieved by calling `getOptions()` on `AgChartInstance`:
-
-{% apiReference id="AgChartInstance" include=["getOptions"] hideHeader=true hideRequired=true /%}
+{% apiReference id="AgChartInstance" include=["updateDelta", "getOptions"] hideHeader=true hideRequired=true /%}
 
 The following example demonstrates:
 
@@ -61,8 +67,6 @@ The following example demonstrates:
 -   Mutation of the Chart configuration via `updateDelta()`.
 
 {% chartExampleRunner title="Update with Partial AgChartOptions" name="update-partial" type="generated" /%}
-
-{% apiReference id="AgChartInterface" include=["updateDelta"] hideHeader=true hideRequired=true /%}
 
 {% /if %}
 

--- a/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
@@ -68,6 +68,23 @@ The following example demonstrates:
 
 {% chartExampleRunner title="Update with Partial AgChartOptions" name="update-partial" type="generated" /%}
 
+## Waiting for Options Update
+
+Creation and updates happen asynchronously, but in some situations it maybe useful to know when an update is
+rendered.
+
+To assist with this, `AgChartInstance.update()` and `AgChartInstance.updateDelta()` return `Promise`s that resolve once
+rendering is complete. Additionally `AgChartsInstance.waitForUpdate()` can be used after initial creation to understand
+when the next pending render cycle has happened.
+
+{% note %}
+`Promise`s do not take animations into account, they resolve after the first rendering in an animation sequence.
+{% /note %}
+
+This example demonstrates how this can be used to create trivial loops to continuously update a chart:
+
+{% chartExampleRunner title="Wait for Options Update" name="wait-for-update" type="generated" /%}
+
 {% /if %}
 
 ## Destroying Charts

--- a/packages/ag-charts-website/src/content/docs/api-download/_examples/download/index.html
+++ b/packages/ag-charts-website/src/content/docs/api-download/_examples/download/index.html
@@ -2,7 +2,7 @@
     <div class="toolPanel">
         <button onclick="download()">Download</button>
         <span class="spacer"></span>
-        <button onclick="downloadFixedSize()">Download @ 600x300</button>
+        <button onclick="downloadFixedSize()">Download at 600x300</button>
         <span class="spacer"></span>
         <button onclick="openImage()">Open</button>
     </div>

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/examplesGenerator.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/examplesGenerator.ts
@@ -94,10 +94,14 @@ export const getGeneratedContents = async (params: GeneratedContentParams): Prom
     let indexHtml = await readFile(path.join(folderPath, 'index.html'));
     extractOptions ||= entryFile.includes('@ag-options-extract');
 
-    if (entryFile.includes('@ag-skip-fws') && internalFramework !== 'vanilla') {
-        entryFile = PLACEHOLDER_MAIN_TS;
-        indexHtml = `<div id="myChart"></div>`;
-        extractOptions = false;
+    if (entryFile.includes('@ag-skip-fws')) {
+        if (['vanilla', 'typescript'].includes(internalFramework)) {
+            entryFile = entryFile.replace(/^\s*\/\/ @ag-skip-fws\s*\n*$/g, '');
+        } else {
+            entryFile = PLACEHOLDER_MAIN_TS;
+            indexHtml = `<div id="myChart"></div>`;
+            extractOptions = false;
+        }
     }
 
     const otherScriptFiles = await getOtherScriptFiles({

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
@@ -182,7 +182,8 @@ export async function vanillaToAngular(bindings: any, componentFileNames: string
 
     if (bindings.usesChartApi) {
         indexFile = indexFile.replace(/AgCharts.(\w*)\((\w*)(,|\))/g, 'AgCharts.$1(this.agCharts.chart!$3');
-        indexFile = indexFile.replace(/\(this.agCharts.chart!, options/g, '(this.agCharts.chart!, this.options');
+        indexFile = indexFile.replace(/chart.(\w*)\(/g, 'this.agCharts.chart!.$1(');
+        indexFile = indexFile.replace(/this.agCharts.chart!.(\w*)\(options/g, 'this.agCharts.chart!.$1(this.options');
     }
 
     return indexFile;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
@@ -1,6 +1,6 @@
 import { wrapOptionsUpdateCode } from './chart-utils';
 import { addBindingImports, convertFunctionToProperty } from './parser-utils';
-import { convertFunctionToCallback, convertFunctionalTemplate, getImport, styleAsObject } from './react-utils';
+import { convertFunctionalTemplate, getImport, styleAsObject } from './react-utils';
 import { toTitleCase } from './string-utils';
 
 export function processFunction(code: string): string {
@@ -116,9 +116,9 @@ export async function vanillaToReactFunctionalTs(bindings: any, componentFilenam
         const template = getTemplate(bindings, componentAttributes);
 
         const externalEventHandlers = bindings.externalEventHandlers.map((handler) =>
-            processFunction(convertFunctionToCallback(handler.body))
+            processFunction(convertFunctionToProperty(handler.body))
         );
-        const instanceMethods = bindings.instanceMethods.map((m) => processFunction(convertFunctionToCallback(m)));
+        const instanceMethods = bindings.instanceMethods.map((m) => processFunction(convertFunctionToProperty(m)));
 
         indexFile = `
             ${imports.join(`

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
@@ -193,7 +193,8 @@ export async function vanillaToReactFunctionalTs(bindings: any, componentFilenam
 
     if (bindings.usesChartApi) {
         indexFile = indexFile.replace(/AgCharts.(\w*)\((\w*)(,|\))/g, 'AgCharts.$1(chartRef.current!.chart$3');
-        indexFile = indexFile.replace(/\(this.chartRef.current.chart, options/g, '(chartRef.current!.chart, options');
+        indexFile = indexFile.replace(/chart.(\w*)\(/g, 'chartRef.current!.chart.$1(');
+        indexFile = indexFile.replace(/this.chartRef.current.chart/g, 'chartRef.current!.chart');
     }
 
     return indexFile;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
@@ -1,6 +1,6 @@
 import { getChartImports, wrapOptionsUpdateCode } from './chart-utils';
 import { convertFunctionToProperty } from './parser-utils';
-import { convertFunctionToCallback, convertFunctionalTemplate, getImport, styleAsObject } from './react-utils';
+import { convertFunctionalTemplate, getImport, styleAsObject } from './react-utils';
 import { toTitleCase } from './string-utils';
 
 export function processFunction(code: string): string {
@@ -106,9 +106,9 @@ export async function vanillaToReactFunctional(bindings: any, componentFilenames
         const template = getTemplate(bindings, componentAttributes);
 
         const externalEventHandlers = bindings.externalEventHandlers.map((handler) =>
-            processFunction(convertFunctionToCallback(handler.body))
+            processFunction(convertFunctionToProperty(handler.body))
         );
-        const instanceMethods = bindings.instanceMethods.map((m) => processFunction(convertFunctionToCallback(m)));
+        const instanceMethods = bindings.instanceMethods.map((m) => processFunction(convertFunctionToProperty(m)));
 
         indexFile = `
             ${imports.join(`

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
@@ -183,7 +183,8 @@ export async function vanillaToReactFunctional(bindings: any, componentFilenames
 
     if (bindings.usesChartApi) {
         indexFile = indexFile.replace(/AgCharts.(\w*)\((\w*)(,|\))/g, 'AgCharts.$1(chartRef.current.chart$3');
-        indexFile = indexFile.replace(/\(this.chartRef.current.chart, options/g, '(chartRef.current.chart, options');
+        indexFile = indexFile.replace(/chart.(\w*)\(/g, 'chartRef.current.chart.$1(');
+        indexFile = indexFile.replace(/this.chartRef.current.chart/g, 'chartRef.current.chart');
     }
 
     return indexFile;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-vue3.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-vue3.ts
@@ -196,9 +196,10 @@ export async function vanillaToVue3(bindings: any, componentFileNames: string[])
 
     if (bindings.usesChartApi) {
         mainFile = mainFile.replace(/AgCharts.(\w*)\((\w*)(,|\))/g, 'AgCharts.$1(this.$refs.agCharts.chart$3');
+        mainFile = mainFile.replace(/chart.(\w*)\(/g, 'this.$refs.agCharts.chart.$1(');
         mainFile = mainFile.replace(
-            /\(this.\$refs.agCharts.chart, options/g,
-            '(this.$refs.agCharts.chart, this.options'
+            /this.\$refs.agCharts.chart.(\w*)\(options/g,
+            'this.$refs.agCharts.chart.$1(this.options'
         );
     }
 

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -90,7 +90,7 @@ export function getFunctionName(code: string): string {
 }
 
 export const convertFunctionToProperty = (code: string) =>
-    code.replace(/(async ){0,1}function\s+([^(\s]+)\s*\(([^)]*)\)/, '$2 = $1($3) =>');
+    code.replace(/(async )?function\s+([^(\s]+)\s*\(([^)]*)\)/, '$2 = $1($3) =>');
 
 export const convertFunctionToConstProperty = (code: string) =>
     code.replace(/(async ){0,1}function\s+([^(\s]+)\s*\(([^)]*)\)/, 'const $2 = $1($3) =>');

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -343,9 +343,13 @@ export function getTypes(node: ts.Node) {
     return typesToInclude;
 }
 
+const CHART_API_EXPRESSIONS = [/AgCharts.(?!create)/, /chart.(?!(update))/];
 export function usesChartApi(node: ts.Node) {
-    if (ts.isCallExpression(node) && node.getText()?.match(/AgCharts.(?!create)/)) {
-        return true;
+    if (ts.isCallExpression(node)) {
+        const nodeText = node.getText();
+        if (CHART_API_EXPRESSIONS.some((e) => e.test(nodeText))) {
+            return true;
+        }
     }
 
     let usesApi = false;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -81,7 +81,7 @@ export function modulesProcessor(modules: string[]) {
 }
 
 export function removeFunctionKeyword(code: string): string {
-    return code.replace(/^function /, '').replace(/\n\s?function /, '\n ');
+    return code.replace(/^(async ){0,1}function /, '$1').replace(/\n\s?function /, '\n ');
 }
 
 export function getFunctionName(code: string): string {
@@ -90,12 +90,12 @@ export function getFunctionName(code: string): string {
 }
 
 export const convertFunctionToProperty = (code: string) =>
-    code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\)/, '$1 = ($2) =>');
+    code.replace(/(async ){0,1}function\s+([^(\s]+)\s*\(([^)]*)\)/, '$2 = $1($3) =>');
 
 export const convertFunctionToConstProperty = (code: string) =>
-    code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\)/, 'const $1 = ($2) =>');
+    code.replace(/(async ){0,1}function\s+([^(\s]+)\s*\(([^)]*)\)/, 'const $2 = $1($3) =>');
 export const convertFunctionToConstPropertyTs = (code: string) => {
-    return code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\):(\s+[^{]*)/, 'const $1: ($2) => $3 = ($2) =>');
+    return code.replace(/(async ){0,1}function\s+([^(\s]+)\s*\(([^)]*)\)(:?\s+[^{]*)/, 'const $2 = $1($3) $4 =>');
 };
 
 export function isInstanceMethod(methods: string[], property: any): boolean {

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -81,7 +81,7 @@ export function modulesProcessor(modules: string[]) {
 }
 
 export function removeFunctionKeyword(code: string): string {
-    return code.replace(/^(async ){0,1}function /, '$1').replace(/\n\s?function /, '\n ');
+    return code.replace(/^(async )?function /, '$1').replace(/\n\s?function /, '\n ');
 }
 
 export function getFunctionName(code: string): string {

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/react-utils.ts
@@ -108,10 +108,3 @@ export const getValueType = (value: string) => {
     }
     return type;
 };
-
-export const convertFunctionToCallback = (code: string) => {
-    return code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\)/, 'const $1 = ($2) =>');
-};
-export const convertFunctionToCallbackTs = (code: string) => {
-    return code.replace(/function\s+([^(\s]+)\s*\(([^)]*)\)(:?\s+[^{]*)/, 'const $1 = ($2) $3 =>');
-};


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8192

Updates docs and examples to allow us to demonstrate the new APIs recently added:
- Move of `AgCharts` static methods into `AgChartsInstance`.
- Addition of `Promise`-based returns for update and other async APIs.

Bonus:
- Adds support for handling of `async` functions to all FW variants, although we're not using them yet.