### PR TITLE
AG-11385 Use aria-disabled="true" instead of disabled

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -244,6 +244,13 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
     private processEvent(event: SupportedEvent) {
         const types: InteractionTypes[] = this.decideInteractionEventTypes(event);
 
+        // AG-11385 Ignore clicks on focusable & disabled elements.
+        const target: EventTarget & { ariaDisabled?: string} | null = event.target;
+        if (event.type === 'click' && target?.ariaDisabled === 'true') {
+            event.preventDefault();
+            return;
+        }
+
         if (types.length > 0) {
             // Async dispatch to avoid blocking the event-processing thread.
             this.dispatchEvent(event, types).catch((e) => Logger.errorOnce(e));

--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -335,7 +335,7 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
                 return [event.type];
 
             case 'mousedown':
-                if (!this.isEventOverElement(event)) {
+                if (!this.isEventOverElement(event) || ! ('button' in event) || event.button !== 0) {
                     return [];
                 }
                 this.mouseDown = true;

--- a/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/interactionManager.ts
@@ -245,7 +245,7 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
         const types: InteractionTypes[] = this.decideInteractionEventTypes(event);
 
         // AG-11385 Ignore clicks on focusable & disabled elements.
-        const target: EventTarget & { ariaDisabled?: string} | null = event.target;
+        const target: (EventTarget & { ariaDisabled?: string }) | null = event.target;
         if (event.type === 'click' && target?.ariaDisabled === 'true') {
             event.preventDefault();
             return;
@@ -335,7 +335,7 @@ export class InteractionManager extends BaseManager<InteractionTypes, Interactio
                 return [event.type];
 
             case 'mousedown':
-                if (!this.isEventOverElement(event) || ! ('button' in event) || event.button !== 0) {
+                if (!this.isEventOverElement(event) || !('button' in event) || event.button !== 0) {
                     return [];
                 }
                 this.mouseDown = true;

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -4,7 +4,7 @@ import type { ModuleContext } from '../../module/moduleContext';
 import type { AgToolbarGroupPosition } from '../../options/agChartOptions';
 import type { BBox } from '../../scene/bbox';
 import { createElement } from '../../util/dom';
-import { initToolbarKeyNav } from '../../util/keynavUtil';
+import { initToolbarKeyNav, makeAccessibleClickListener } from '../../util/keynavUtil';
 import { ObserveChanges } from '../../util/proxy';
 import { BOOLEAN, Validate } from '../../util/validation';
 import { InteractionState, type PointerInteractionEvent } from '../interaction/interactionManager';
@@ -452,7 +452,7 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         if (typeof options.value === 'string' || typeof options.value === 'number') {
             button.dataset.toolbarValue = `${options.value}`;
         }
-        button.onclick = this.onButtonPress.bind(this, group, options.value);
+        button.onclick = makeAccessibleClickListener(button, this.onButtonPress.bind(this, group, options.value));
         this.updateButtonText(button, options);
 
         this.destroyFns.push(() => button.remove());

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -215,7 +215,7 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
 
         for (const button of this.groupButtons[group]) {
             if (button.dataset.toolbarValue !== `${value}`) continue;
-            button.disabled = !enabled;
+            button.ariaDisabled = `${!enabled}`;
             button.classList.toggle(styles.modifiers.button.hiddenToggled, !visible);
             button.classList.toggle(styles.modifiers.button.active, active);
         }

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
@@ -173,12 +173,12 @@ export const css = `
     background: var(--ag-charts-toolbar-active-color);
 }
 
-.${elements.button}:disabled {
+.${elements.button}[aria-disabled="true"] {
     background: var(--ag-charts-toolbar-disabled-background-color);
     color: var(--ag-charts-toolbar-disabled-foreground-color);
 }
 
-.${elements.button}:not([disabled]) {
+.${elements.button}:not([aria-disabled="true"]) {
     cursor: pointer;
 }
 

--- a/packages/ag-charts-community/src/util/keynavUtil.ts
+++ b/packages/ag-charts-community/src/util/keynavUtil.ts
@@ -118,3 +118,12 @@ export function initMenuKeyNav(opts: {
 
     return destroyFns;
 }
+
+export function makeAccessibleClickListener(element: HTMLElement, onclick: (event: MouseEvent) => unknown) {
+    return (event: MouseEvent) => {
+        if (element.ariaDisabled === 'true') {
+            return event.preventDefault();
+        }
+        onclick(event);
+    };
+}

--- a/packages/ag-charts-enterprise/src/features/__snapshots__/features.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/features/__snapshots__/features.test.ts.snap
@@ -17,7 +17,6 @@ HTMLCollection [
       </button>
       <button
         class="ag-chart-context-menu__item"
-        disabled=""
         tabindex="-1"
       >
         Zoom to here
@@ -56,7 +55,6 @@ HTMLCollection [
       </button>
       <button
         class="ag-chart-context-menu__item"
-        disabled=""
         tabindex="-1"
       >
         Pan to here

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -18,7 +18,8 @@ type ContextMenuEvent = _ModuleSupport.ContextMenuEvent;
 type ContextMenuAction<T extends ContextType = ContextType> = _ModuleSupport.ContextMenuAction<T>;
 type ContextMenuCallback<T extends ContextType> = _ModuleSupport.ContextMenuCallback<T>;
 
-const { BOOLEAN, Validate, createElement, initMenuKeyNav, ContextMenuRegistry } = _ModuleSupport;
+const { BOOLEAN, Validate, createElement, initMenuKeyNav, makeAccessibleClickListener, ContextMenuRegistry } =
+    _ModuleSupport;
 
 const moduleId = 'context-menu';
 
@@ -276,10 +277,14 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private createActionElement({ id, label, type, action }: ContextMenuAction): HTMLElement {
+        let button: HTMLElement;
         if (id && this.registry.isDisabled(id)) {
-            return this.createDisabledElement(label);
+            button = this.createDisabledElement(label);
+        } else {
+            button = this.createButtonElement(label);
         }
-        return this.createButtonElement(type, label, action);
+        button.onclick = makeAccessibleClickListener(button, this.createButtonOnClick(type, action));
+        return button;
     }
 
     private createButtonOnClick<T extends ContextType>(type: T, callback: ContextMenuCallback<T>) {
@@ -310,16 +315,11 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         };
     }
 
-    private createButtonElement<T extends ContextType>(
-        type: T,
-        label: string,
-        callback: ContextMenuCallback<T>
-    ): HTMLElement {
+    private createButtonElement(label: string): HTMLElement {
         const el = createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
         el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
         el.textContent = this.ctx.localeManager.t(label);
-        el.onclick = this.createButtonOnClick(type, callback);
         el.role = 'menuitem';
         return el;
     }

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -328,7 +328,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         const el = createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
         el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
-        el.disabled = true;
+        el.ariaDisabled = true.toString();
         el.textContent = this.ctx.localeManager.t(label);
         el.role = 'menuitem';
         return el;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -277,14 +277,8 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private createActionElement({ id, label, type, action }: ContextMenuAction): HTMLElement {
-        let button: HTMLElement;
-        if (id && this.registry.isDisabled(id)) {
-            button = this.createDisabledElement(label);
-        } else {
-            button = this.createButtonElement(label);
-        }
-        button.onclick = makeAccessibleClickListener(button, this.createButtonOnClick(type, action));
-        return button;
+        const disabled = !!(id && this.registry.isDisabled(id));
+        return this.createButtonElement(type, label, action, disabled);
     }
 
     private createButtonOnClick<T extends ContextType>(type: T, callback: ContextMenuCallback<T>) {
@@ -315,22 +309,19 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         };
     }
 
-    private createButtonElement(label: string): HTMLElement {
+    private createButtonElement<T extends ContextType>(
+        type: T,
+        label: string,
+        callback: ContextMenuCallback<T>,
+        disabled: boolean
+    ): HTMLElement {
         const el = createElement('button');
         el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
         el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
+        el.ariaDisabled = disabled.toString();
         el.textContent = this.ctx.localeManager.t(label);
         el.role = 'menuitem';
-        return el;
-    }
-
-    private createDisabledElement(label: string): HTMLElement {
-        const el = createElement('button');
-        el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
-        el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
-        el.ariaDisabled = true.toString();
-        el.textContent = this.ctx.localeManager.t(label);
-        el.role = 'menuitem';
+        el.onclick = makeAccessibleClickListener(el, this.createButtonOnClick(type, callback));
         return el;
     }
 

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.css
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.css
@@ -60,13 +60,13 @@
     background: rgb(33, 150, 243, 0.1);
 }
 
-.ag-chart-context-menu__item[disabled] {
+.ag-chart-context-menu__item[aria-disabled="true"] {
     border: none;
     opacity: 0.5;
     text-align: left;
 }
 
-.ag-chart-context-menu__item[disabled]:hover {
+.ag-chart-context-menu__item[aria-disabled="true"]:hover {
     background: inherit;
     cursor: inherit;
 }

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.css
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuStyles.css
@@ -60,13 +60,13 @@
     background: rgb(33, 150, 243, 0.1);
 }
 
-.ag-chart-context-menu__item[aria-disabled="true"] {
+.ag-chart-context-menu__item[aria-disabled='true'] {
     border: none;
     opacity: 0.5;
     text-align: left;
 }
 
-.ag-chart-context-menu__item[aria-disabled="true"]:hover {
+.ag-chart-context-menu__item[aria-disabled='true']:hover {
     background: inherit;
     cursor: inherit;
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11385

The guideline is to make buttons of toolbars/menus focusable even when they are disabled. This is so that the buttons are discoverable to screenreader users.

Reference:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/roles/toolbar_role