### PR TITLE
Fix zoom button locale updates to apply to correct button

### DIFF
--- a/packages/ag-charts-community/src/chart/locale/en.ts
+++ b/packages/ag-charts-community/src/chart/locale/en.ts
@@ -76,7 +76,7 @@ export const en: Record<string, string> = {
     // Text for the zoom toolbar's pan to the end button
     'toolbar-zoom.pan-end': 'Pan to the end',
     // Text for the zoom toolbar's pan reset button
-    'toolbar-zoom.zoom': 'Reset the zoom',
+    'toolbar-zoom.reset': 'Reset the zoom',
     // Text for the context menu's download button
     'context-menu.download': 'Download',
     // Text for the context menu's toggle series visibility button

--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -338,18 +338,13 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         }
 
         if (this.hasNewLocale) {
-            this.groupButtons.annotations.forEach((button, index) => {
-                this.updateButtonText(button, this.annotations.buttons![index]);
-            });
-            this.groupButtons.annotationOptions.forEach((button, index) => {
-                this.updateButtonText(button, this.annotationOptions.buttons![index]);
-            });
-            this.groupButtons.ranges.forEach((button, index) => {
-                this.updateButtonText(button, this.ranges.buttons![index]);
-            });
-            this.groupButtons.zoom.forEach((button, index) => {
-                this.updateButtonText(button, this.zoom.buttons![index]);
-            });
+            for (const group of TOOLBAR_GROUPS) {
+                this.groupButtons[group].forEach((element) => {
+                    const button = this[group].buttons?.find(({ value }) => value === element.dataset.toolbarValue);
+                    if (!button) return;
+                    this.updateButtonText(element, button);
+                });
+            }
             this.hasNewLocale = false;
         }
 

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarModule.ts
@@ -126,7 +126,7 @@ const zoom: AgToolbarOptions['zoom'] = {
         },
         {
             icon: 'reset',
-            tooltip: 'toolbar-zoom.zoom',
+            tooltip: 'toolbar-zoom.reset',
             value: 'reset',
         },
     ],

--- a/packages/ag-charts-community/src/module/__snapshots__/optionsModule.test.ts.snap
+++ b/packages/ag-charts-community/src/module/__snapshots__/optionsModule.test.ts.snap
@@ -488,7 +488,7 @@ exports[`ChartOptions #prepareOptions for ADV_CHART_CUSTOMISATION it should prep
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -1022,7 +1022,7 @@ exports[`ChartOptions #prepareOptions for ADV_COMBINATION_SERIES_CHART_EXAMPLE i
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -1704,7 +1704,7 @@ exports[`ChartOptions #prepareOptions for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE it sh
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -2380,7 +2380,7 @@ exports[`ChartOptions #prepareOptions for ADV_CUSTOM_TOOLTIPS_EXAMPLE it should 
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -2758,7 +2758,7 @@ exports[`ChartOptions #prepareOptions for ADV_PER_MARKER_CUSTOMISATION_EXAMPLE i
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -3282,7 +3282,7 @@ exports[`ChartOptions #prepareOptions for ADV_TIME_AXIS_WITH_IRREGULAR_INTERVALS
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -3926,7 +3926,7 @@ exports[`ChartOptions #prepareOptions for AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPL
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -4315,7 +4315,7 @@ by Occupation",
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -4701,7 +4701,7 @@ exports[`ChartOptions #prepareOptions for BAR_CHART_WITH_LABELS_EXAMPLE it shoul
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -5077,7 +5077,7 @@ exports[`ChartOptions #prepareOptions for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMPLE i
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -5455,7 +5455,7 @@ exports[`ChartOptions #prepareOptions for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_EXAM
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -5905,7 +5905,7 @@ exports[`ChartOptions #prepareOptions for COLUMN_CHART_WITH_NEGATIVE_VALUES_EXAM
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -6359,7 +6359,7 @@ exports[`ChartOptions #prepareOptions for GROUPED_BAR_CHART_EXAMPLE it should pr
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -7036,7 +7036,7 @@ exports[`ChartOptions #prepareOptions for GROUPED_COLUMN_EXAMPLE it should prepa
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -8142,7 +8142,7 @@ exports[`ChartOptions #prepareOptions for LINE_GRAPH_WITH_GAPS_EXAMPLE it should
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -8521,7 +8521,7 @@ exports[`ChartOptions #prepareOptions for LOG_AXIS_EXAMPLE it should prepare opt
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -9306,7 +9306,7 @@ exports[`ChartOptions #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_AREA_GRAPH
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -9810,7 +9810,7 @@ exports[`ChartOptions #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_BAR_EXAMPL
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -10444,7 +10444,7 @@ exports[`ChartOptions #prepareOptions for ONE_HUNDRED_PERCENT_STACKED_COLUMNS_EX
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -10999,7 +10999,7 @@ exports[`ChartOptions #prepareOptions for SIMPLE_AREA_GRAPH_EXAMPLE it should pr
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -11383,7 +11383,7 @@ exports[`ChartOptions #prepareOptions for SIMPLE_COLUMN_CHART_EXAMPLE it should 
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -12061,7 +12061,7 @@ exports[`ChartOptions #prepareOptions for SIMPLE_LINE_CHART_EXAMPLE it should pr
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -12633,7 +12633,7 @@ exports[`ChartOptions #prepareOptions for SIMPLE_SCATTER_CHART_EXAMPLE it should
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -13379,7 +13379,7 @@ exports[`ChartOptions #prepareOptions for STACKED_AREA_GRAPH_EXAMPLE it should p
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -13908,7 +13908,7 @@ exports[`ChartOptions #prepareOptions for STACKED_BAR_CHART_EXAMPLE it should pr
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],
@@ -14513,7 +14513,7 @@ exports[`ChartOptions #prepareOptions for STACKED_COLUMN_GRAPH_EXAMPLE it should
         },
         {
           "icon": "reset",
-          "tooltip": "toolbar-zoom.zoom",
+          "tooltip": "toolbar-zoom.reset",
           "value": "reset",
         },
       ],

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomModule.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomModule.ts
@@ -19,27 +19,27 @@ export const ZoomModule: _ModuleSupport.Module = {
                 buttons: [
                     {
                         icon: 'zoom-out',
-                        tooltip: 'Zoom out',
+                        tooltip: 'toolbar-zoom.zoom-out',
                         value: 'zoom-out',
                     },
                     {
                         icon: 'zoom-in',
-                        tooltip: 'Zoom in',
+                        tooltip: 'toolbar-zoom.zoom-in',
                         value: 'zoom-in',
                     },
                     {
                         icon: 'pan-left',
-                        tooltip: 'Pan left',
+                        tooltip: 'toolbar-zoom.pan-left',
                         value: 'pan-left',
                     },
                     {
                         icon: 'pan-right',
-                        tooltip: 'Pan right',
+                        tooltip: 'toolbar-zoom.pan-right',
                         value: 'pan-right',
                     },
                     {
                         icon: 'reset',
-                        tooltip: 'Reset the zoom',
+                        tooltip: 'toolbar-zoom.reset',
                         value: 'reset',
                     },
                 ],


### PR DESCRIPTION
Fixes a bug with locale updates being applied to the wrong zoom buttons. For example, the last button here is the wrong one, should be reset not pan-start (due to mistmatching indices from the proxied zoom options).

<img width="280" alt="Screenshot 2024-06-10 at 11 03 33" src="https://github.com/ag-grid/ag-charts/assets/3817697/187a77b1-28dd-40ea-8827-32fcb1fbcab0">
