### PR TITLE
Fix annotations dragging on toolbar buttons and color picker

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
@@ -1,6 +1,7 @@
 import type { AgToolbarOptions } from '../../options/chart/toolbarOptions';
 import { BaseManager } from '../baseManager';
-import type { ToolbarGroup } from '../toolbar/toolbarTypes';
+import type { DOMManager } from '../dom/domManager';
+import { TOOLBAR_POSITIONS, type ToolbarGroup } from '../toolbar/toolbarTypes';
 
 type EventTypes =
     | 'button-pressed'
@@ -54,6 +55,15 @@ export class ToolbarManager extends BaseManager<EventTypes, ToolbarEvent> {
         event: ToolbarEvent
     ): event is ToolbarButtonPressedEvent<ToolbarEventButtonValue<T>> {
         return event.group === group;
+    }
+
+    static isManagedChildDOMElement(domManager: DOMManager, element: HTMLElement) {
+        for (const position of TOOLBAR_POSITIONS) {
+            if (domManager.isManagedChildDOMElement(element, 'canvas-overlay', `toolbar-${position}`)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     pressButton(group: ToolbarGroup, value: any) {

--- a/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/toolbarManager.ts
@@ -57,7 +57,7 @@ export class ToolbarManager extends BaseManager<EventTypes, ToolbarEvent> {
         return event.group === group;
     }
 
-    static isManagedChildDOMElement(domManager: DOMManager, element: HTMLElement) {
+    static isChildElement(domManager: DOMManager, element: HTMLElement) {
         for (const position of TOOLBAR_POSITIONS) {
             if (domManager.isManagedChildDOMElement(element, 'canvas-overlay', `toolbar-${position}`)) {
                 return true;

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -531,6 +531,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
 
     private onDrag(event: _ModuleSupport.PointerInteractionEvent<'drag'>) {
         const {
+            colorPicker,
             state,
             ctx: { domManager },
         } = this;
@@ -538,8 +539,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
 
         if (
             targetElement &&
-            (_ModuleSupport.ToolbarManager.isManagedChildDOMElement(domManager, targetElement) ||
-                ColorPicker.isManagedChildDOMElement(domManager, targetElement))
+            (ToolbarManager.isChildElement(domManager, targetElement) || colorPicker.isChildElement(targetElement))
         ) {
             return;
         }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -530,15 +530,26 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private onDrag(event: _ModuleSupport.PointerInteractionEvent<'drag'>) {
-        // TODO: This shouldn't happen. Prevent drags on color picker triggering here.
-        if (this.colorPicker.isVisible()) return;
+        const {
+            state,
+            ctx: { domManager },
+        } = this;
+        const { offsetX, offsetY, targetElement } = event;
 
-        // Only track pointer offset for drag + click prevention when we are placing the first point
-        if (this.state.is('start')) {
-            this.dragOffset = { x: event.offsetX, y: event.offsetY };
+        if (
+            targetElement &&
+            (_ModuleSupport.ToolbarManager.isManagedChildDOMElement(domManager, targetElement) ||
+                ColorPicker.isManagedChildDOMElement(domManager, targetElement))
+        ) {
+            return;
         }
 
-        if (this.state.is('idle')) {
+        // Only track pointer offset for drag + click prevention when we are placing the first point
+        if (state.is('start')) {
+            this.dragOffset = { x: offsetX, y: offsetY };
+        }
+
+        if (state.is('idle')) {
             this.onClickSelecting();
             this.onDragHandle(event);
         } else {

--- a/packages/ag-charts-enterprise/src/features/color-picker/colorPicker.ts
+++ b/packages/ag-charts-enterprise/src/features/color-picker/colorPicker.ts
@@ -8,6 +8,7 @@ const { createElement } = _ModuleSupport;
 const { Color } = _Util;
 
 const moduleId = 'color-picker';
+const canvasOverlay = 'canvas-overlay';
 
 const getHsva = (input: string) => {
     try {
@@ -24,14 +25,18 @@ const getHsva = (input: string) => {
 export class ColorPicker extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     private readonly element: HTMLElement;
 
+    static isManagedChildDOMElement(domManager: _ModuleSupport.DOMManager, element: HTMLElement) {
+        return domManager.isManagedChildDOMElement(element, canvasOverlay, moduleId);
+    }
+
     constructor(readonly ctx: _ModuleSupport.ModuleContext) {
         super();
 
         ctx.domManager.addStyles(moduleId, colorPickerStyles);
 
-        this.element = ctx.domManager.addChild('canvas-overlay', moduleId);
+        this.element = ctx.domManager.addChild(canvasOverlay, moduleId);
 
-        this.destroyFns.push(() => ctx.domManager.removeChild('canvas-overlay', moduleId));
+        this.destroyFns.push(() => ctx.domManager.removeChild(canvasOverlay, moduleId));
     }
 
     show(opts: { anchor?: { x: number; y: number }; color?: string; onChange?: (colorString: string) => void }) {
@@ -121,9 +126,5 @@ export class ColorPicker extends _ModuleSupport.BaseModuleInstance implements _M
 
     hide() {
         this.element.replaceChildren();
-    }
-
-    isVisible() {
-        return this.element.children.length > 0;
     }
 }

--- a/packages/ag-charts-enterprise/src/features/color-picker/colorPicker.ts
+++ b/packages/ag-charts-enterprise/src/features/color-picker/colorPicker.ts
@@ -25,10 +25,6 @@ const getHsva = (input: string) => {
 export class ColorPicker extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     private readonly element: HTMLElement;
 
-    static isManagedChildDOMElement(domManager: _ModuleSupport.DOMManager, element: HTMLElement) {
-        return domManager.isManagedChildDOMElement(element, canvasOverlay, moduleId);
-    }
-
     constructor(readonly ctx: _ModuleSupport.ModuleContext) {
         super();
 
@@ -126,5 +122,9 @@ export class ColorPicker extends _ModuleSupport.BaseModuleInstance implements _M
 
     hide() {
         this.element.replaceChildren();
+    }
+
+    isChildElement(element: HTMLElement) {
+        return this.ctx.domManager.isManagedChildDOMElement(element, canvasOverlay, moduleId);
     }
 }


### PR DESCRIPTION
Fixes issues where clicking and accidentally dragging on the floating toolbar buttons would close the toolbar. Replaces a previous (more hacky) attempt at fixing this for the color picker.