### PR TITLE
AG-11370 Fix CSS bounding rects of legend pagination buttons

### DIFF
--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -707,7 +707,6 @@ export class Legend extends BaseProperties {
             this.proxyPrevButton?.remove();
             [this.proxyNextButton, this.proxyPrevButton] = [undefined, undefined];
         }
-
     }
 
     private calculatePagination(bboxes: BBox[], width: number, height: number) {

--- a/packages/ag-charts-community/src/chart/pagination/pagination.ts
+++ b/packages/ag-charts-community/src/chart/pagination/pagination.ts
@@ -391,4 +391,15 @@ export class Pagination extends BaseProperties {
     computeBBox() {
         return this.group.computeBBox();
     }
+
+    computeCSSBounds() {
+        const group = this.group.computeTransformedBBox();
+        const prev = this._previousButton.computeTransformedBBox();
+        const next = this._nextButton.computeTransformedBBox();
+        prev.x -= group.x;
+        prev.y -= group.y;
+        next.x -= group.x;
+        next.y -= group.y;
+        return { group, prev, next };
+    }
 }


### PR DESCRIPTION
This change set the CSS bounds on the proxyLegendPagination container and then sets the CSS bounds on the proxy buttons to be relative to that container.

This is necessary, because I've tried rearranging the 'ag-charts-canvas' and 'ag-charts-canvas-overlay' elements in the DOMManager's BASE_DOM, but weird things start to happen when the legend pagination buttons come into focus.