### PR TITLE
AG-11527 - Rework presets into AgFinancialChartOptions.

### DIFF
--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-financial-charts.component.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-financial-charts.component.ts
@@ -13,7 +13,7 @@ import { AgChartsBase } from './ag-charts-base';
 })
 export class AgFinancialCharts extends AgChartsBase<AgFinancialChartOptions> {
     @Input()
-    public options: AgFinancialChartOptions = { preset: 'candlestick-volume' };
+    public options: AgFinancialChartOptions = { type: 'candlestick-volume' };
 
     @Output()
     public onChartReady: EventEmitter<AgChartInstance> = new EventEmitter();

--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -1,4 +1,4 @@
-import type { AgChartInstance, AgChartOptions, AgFinancialChartOptions } from 'ag-charts-types';
+import type { AgChartInstance, AgChartOptions, AgFinancialChartOptions, Preset } from 'ag-charts-types';
 
 import { CartesianChart } from '../chart/cartesianChart';
 import { Chart, type ChartExtendedOptions } from '../chart/chart';
@@ -24,6 +24,7 @@ import { deepClone, jsonWalk } from '../util/json';
 import { mergeDefaults } from '../util/object';
 import type { DeepPartial } from '../util/types';
 import { VERSION } from '../version';
+import { PRESETS, isAgFinancialChartOptions } from './preset/presets';
 import { MementoCaretaker } from './state/memento';
 
 const debug = Debug.create(true, 'opts');
@@ -99,9 +100,19 @@ export abstract class AgCharts {
         return chart as unknown as AgChartInstance<O>;
     }
 
-    public static createFinancialChart(opts: AgFinancialChartOptions) {
-        return this.create<AgFinancialChartOptions>(opts);
+    public static createFinancialChart(options: AgFinancialChartOptions) {
+        if (!isAgFinancialChartOptions(options)) throw new Error('AG Charts - unrecognized financial options type');
+
+        return this.create(processPreset(options)) as unknown as AgChartInstance<AgFinancialChartOptions>;
     }
+}
+
+function processPreset(preset: Preset) {
+    const result = PRESETS[preset.type](preset);
+
+    debug('>>> AgCharts.processPreset() - applying preset', preset, result);
+
+    return result;
 }
 
 class AgChartsInternal {

--- a/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
+++ b/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
@@ -1,11 +1,11 @@
 import type {
     AgAxisLabelFormatterParams,
     AgBarSeriesFormatterParams,
+    AgCandlestickVolumePreset,
     AgCartesianChartOptions,
     AgCartesianSeriesTooltipRendererParams,
     AgCrosshairLabelRendererParams,
     AgSeriesTooltip,
-    CandlestickVolumePreset,
 } from 'ag-charts-types';
 
 function dateFormat(dateString: string, format: string) {
@@ -36,14 +36,16 @@ const tooltipOptions: AgSeriesTooltip<any> = {
     },
 };
 
-export function candlestickVolumePreset(opts: CandlestickVolumePreset): AgCartesianChartOptions {
+export function candlestickVolumePreset(opts: AgCandlestickVolumePreset): AgCartesianChartOptions {
     const {
+        type: _type,
         xKey = 'date',
         highKey = 'high',
         openKey = 'open',
         lowKey = 'low',
         closeKey = 'close',
         volumeKey = 'volume',
+        ...unusedOpts
     } = opts;
     return {
         zoom: {
@@ -154,5 +156,6 @@ export function candlestickVolumePreset(opts: CandlestickVolumePreset): AgCartes
         annotations: {
             enabled: true,
         },
+        ...unusedOpts,
     };
 }

--- a/packages/ag-charts-community/src/api/preset/presets.ts
+++ b/packages/ag-charts-community/src/api/preset/presets.ts
@@ -7,5 +7,6 @@ export const PRESETS: { [K in Preset['type']]: (p: Preset & { type: K }) => AgCh
 };
 
 export function isAgFinancialChartOptions(x: any): x is AgFinancialChartOptions {
-    return x.type != null && PRESETS[x.type] != null;
+    const { type } = x;
+    return type != null && typeof type === 'string' && PRESETS[type as Preset['type']] != null;
 }

--- a/packages/ag-charts-community/src/api/preset/presets.ts
+++ b/packages/ag-charts-community/src/api/preset/presets.ts
@@ -7,5 +7,5 @@ export const PRESETS: { [K in Preset['type']]: (p: Preset & { type: K }) => AgCh
 };
 
 export function isAgFinancialChartOptions(x: any): x is AgFinancialChartOptions {
-    return x.type != null && Object.keys(PRESETS).includes(x.type);
+    return x.type != null && PRESETS[x.type] != null;
 }

--- a/packages/ag-charts-community/src/api/preset/presets.ts
+++ b/packages/ag-charts-community/src/api/preset/presets.ts
@@ -1,7 +1,11 @@
-import type { AgChartOptions, Preset } from 'ag-charts-types';
+import type { AgChartOptions, AgFinancialChartOptions, Preset } from 'ag-charts-types';
 
 import { candlestickVolumePreset } from './candlestickVolumePreset';
 
 export const PRESETS: { [K in Preset['type']]: (p: Preset & { type: K }) => AgChartOptions } = {
     'candlestick-volume': candlestickVolumePreset,
 };
+
+export function isAgFinancialChartOptions(x: any): x is AgFinancialChartOptions {
+    return x.type != null && Object.keys(PRESETS).includes(x.type);
+}

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -7,7 +7,6 @@ import {
     AgTooltipPositionType,
 } from 'ag-charts-types';
 
-import { PRESETS } from '../api/preset/presets';
 import { axisRegistry } from '../chart/factory/axisRegistry';
 import { publicChartTypes } from '../chart/factory/chartTypes';
 import { isEnterpriseSeriesType } from '../chart/factory/expectedEnterpriseModules';
@@ -76,8 +75,6 @@ enum GroupingType {
 
 const unthemedSeries = new Set<SeriesType>(['map-shape-background', 'map-line-background']);
 
-const debug = Debug.create(true, 'opts');
-
 export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     activeTheme: ChartTheme;
     processedOptions: T;
@@ -105,12 +102,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             ...themeDefaults
         } = this.getSeriesThemeConfig(chartType);
 
-        const presetOptions = this.processPreset(options);
-
-        this.processedOptions = deepClone(
-            mergeDefaults(options, presetOptions, themeDefaults, this.defaultAxes),
-            cloneOptions
-        ) as T;
+        this.processedOptions = deepClone(mergeDefaults(options, themeDefaults, this.defaultAxes), cloneOptions) as T;
 
         this.processAxesOptions(this.processedOptions, axesThemes);
         this.processSeriesOptions(this.processedOptions);
@@ -178,22 +170,6 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             Logger.warnOnce('bullet series cannot be synced, disabling synchronization.');
             delete options.sync;
         }
-    }
-
-    protected processPreset(options: T) {
-        const { preset } = options;
-        if (preset == null) return {};
-
-        let presetInput = preset;
-        if (typeof presetInput === 'string') {
-            presetInput = { type: presetInput };
-        }
-
-        const result = PRESETS[presetInput.type](presetInput);
-
-        debug('>>> AgCharts.processPreset() - applying preset', presetInput, result);
-
-        return result;
     }
 
     protected swapAxesPosition(options: T) {

--- a/packages/ag-charts-react/src/index.ts
+++ b/packages/ag-charts-react/src/index.ts
@@ -26,7 +26,7 @@ interface BaseChartProps {
 function getOptions(options: AgChartOptions, containerRef: RefObject<HTMLElement | null>): AgChartOptions {
     return {
         ...options,
-        container: containerRef.current ?? undefined,
+        container: containerRef.current,
     };
 }
 

--- a/packages/ag-charts-react/src/index.ts
+++ b/packages/ag-charts-react/src/index.ts
@@ -26,7 +26,7 @@ interface BaseChartProps {
 function getOptions(options: AgChartOptions, containerRef: RefObject<HTMLElement | null>): AgChartOptions {
     return {
         ...options,
-        container: containerRef.current,
+        container: containerRef.current ?? undefined,
     };
 }
 

--- a/packages/ag-charts-types/src/api/presetOptions.ts
+++ b/packages/ag-charts-types/src/api/presetOptions.ts
@@ -1,4 +1,4 @@
-export type CandlestickVolumePreset = {
+export type AgCandlestickVolumePreset = {
     type: 'candlestick-volume';
 
     xKey?: string;
@@ -9,4 +9,4 @@ export type CandlestickVolumePreset = {
     volumeKey?: string;
 };
 
-export type Preset = CandlestickVolumePreset;
+export type Preset = AgCandlestickVolumePreset;

--- a/packages/ag-charts-types/src/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartBuilderOptions.ts
@@ -1,3 +1,4 @@
+import type { AgCandlestickVolumePreset } from '../api/presetOptions';
 import type { AgBaseCartesianChartOptions } from '../series/cartesian/cartesianOptions';
 import type { AgBaseFlowProportionChartOptions } from '../series/flow-proportion/flowProportionOptions';
 import type { AgBaseHierarchyChartOptions } from '../series/hierarchy/hierarchyOptions';
@@ -36,9 +37,29 @@ export type AgChartOptions =
     | AgTopologyChartOptions
     | AgFlowProportionChartOptions;
 
+type AgFinancialChartPresets = AgCandlestickVolumePreset;
+
+export type AgFinancialChartOptions = AgFinancialChartPresets &
+    Pick<
+        AgCartesianChartOptions,
+        | 'data'
+        | 'container'
+        | 'width'
+        | 'height'
+        | 'minWidth'
+        | 'minHeight'
+        | 'theme'
+        | 'dataSource'
+        | 'title'
+        | 'subtitle'
+        | 'footnote'
+    >;
+
+export type AgChartInstanceOptions = AgChartOptions | AgFinancialChartOptions;
+
 type DeepPartial<T> = T extends Array<unknown> ? T : T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T;
 
-export interface AgChartInstance<O extends AgChartOptions = AgChartOptions> {
+export interface AgChartInstance<O extends AgChartInstanceOptions = AgChartOptions> {
     /**
      * Update an existing `AgChartInstance`. Options provided should be complete and not
      * partial.

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -1,4 +1,3 @@
-import type { CandlestickVolumePreset, Preset } from '../api/presetOptions';
 import type { AgAnimationOptions } from './animationOptions';
 import type { AgChartBackgroundImage } from './backgroundOptions';
 import type { AgContextMenuOptions } from './contextMenuOptions';
@@ -206,15 +205,8 @@ export interface AgBaseThemeableChartOptions<TDatum = any> {
 
 /** Configuration common to all charts.  */
 export interface AgBaseChartOptions<TDatum = any> extends AgBaseThemeableChartOptions<TDatum> {
-    preset?: Preset | Preset['type'];
     /** The data to render the chart from. If this is not specified, it must be set on individual series instead. */
     data?: TDatum[];
     /** The element to place the rendered chart into. */
     container?: HTMLElement | null;
 }
-
-type AgPresetOptions<P extends Preset> = AgBaseChartOptions & {
-    preset: P | P['type'];
-};
-
-export type AgFinancialChartOptions = AgPresetOptions<CandlestickVolumePreset>;

--- a/packages/ag-charts-vue3/src/index.ts
+++ b/packages/ag-charts-vue3/src/index.ts
@@ -36,7 +36,7 @@ export const AgFinancialCharts = /*#__PURE__*/ defineComponent({
     props: {
         options: {
             type: Object as PropType<AgFinancialChartOptions>,
-            default: (): AgFinancialChartOptions => ({ preset: 'candlestick-volume' }),
+            default: (): AgFinancialChartOptions => ({ type: 'candlestick-volume' }),
         },
     },
     data(): { chart: AgChartInstance | undefined } {

--- a/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
 import { getData } from './data';
 
 const options: AgFinancialChartOptions = {
-    preset: 'candlestick-volume',
+    type: 'candlestick-volume',
     container: document.getElementById('myChart'),
     data: getData(),
     // annotations: {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11527

Based upon feedback earlier this week, breaks the inheritance between `AgFinancialChartOptions` and `AgChartOptions` and moves `preset` up a level in the option heirarchy.