### PR TITLE
AG-11879 Partial fix of imports getting replaced in strings

### DIFF
--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/simple-range-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/simple-range-area/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts, time } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
@@ -97,7 +97,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         );
         if (chartImports) {
             const allImports = `(${chartImports.imports.join('|')})`;
-            const toReplace = `(?<=['"])\\b${allImports}\\b`;
+            const toReplace = `(?<!['"])\\b${allImports}\\b`;
             const reg = new RegExp(toReplace, 'g');
             mainJs = mainJs.replace(reg, `agCharts.$1`);
         }

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
@@ -97,7 +97,7 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         );
         if (chartImports) {
             const allImports = `(${chartImports.imports.join('|')})`;
-            const toReplace = `\\b${allImports}\\b`;
+            const toReplace = `(?<=['"])\\b${allImports}\\b`;
             const reg = new RegExp(toReplace, 'g');
             mainJs = mainJs.replace(reg, `agCharts.$1`);
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11879

Partial fix - we should do this at the AST level. E.g. if you import `time`, it'll get replaced in `text: 'something time something'`. We don't have anything that operates like this at the moment, so we'd need to add it