### PR TITLE
AG-11890 - Show gradient in alpha slider thumb, make alpha gradient s…

### DIFF
--- a/packages/ag-charts-enterprise/src/features/color-picker/colorPickerStyles.css
+++ b/packages/ag-charts-enterprise/src/features/color-picker/colorPickerStyles.css
@@ -112,14 +112,12 @@
 
 .ag-charts-color-picker__alpha-input::before {
     background:
-        linear-gradient(to right, hsla(var(--h), 100%, 50%, 0), hsla(var(--h), 100%, 50%, 1)),
+        linear-gradient(to right, transparent, var(--color)),
         var(--checker) top left / 4px 4px;
 }
 
 .ag-charts-color-picker__alpha-input::-webkit-slider-thumb {
-    /* Linear gradient is required to overlay colour */
-    background: linear-gradient(to bottom, hsla(var(--h), 100%, 50%, var(--a)), hsla(var(--h), 100%, 50%, var(--a)))
-        white;
+    background-color: transparent;
 }
 
 .ag-charts-color-picker__color-field {

--- a/packages/ag-charts-enterprise/src/features/color-picker/colorPickerStyles.css
+++ b/packages/ag-charts-enterprise/src/features/color-picker/colorPickerStyles.css
@@ -117,7 +117,7 @@
 }
 
 .ag-charts-color-picker__alpha-input::-webkit-slider-thumb {
-    background-color: transparent;
+    background: transparent;
 }
 
 .ag-charts-color-picker__color-field {


### PR DESCRIPTION
Colour picker opacity slider should show gradient through the thumb

- Slider thumb shows the patterned “Alpha” gradient that is in the bar underneath.
- Slider track shows ‘complete’ selected colour.