### PR TITLE
AG-11857: Remove `formatter` parameter from Axis[].label.formatter

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1415,7 +1415,6 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
                     value: (fractionDigits ?? 0) > 0 ? datum : String(datum),
                     index,
                     fractionDigits,
-                    formatter: labelFormatter,
                 }) ?? datum;
         } else if (!isTickLabel && datumFormatter) {
             return (datum) => callbackCache.call(datumFormatter, datum) ?? String(datum);

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationProperties.ts
@@ -184,7 +184,6 @@ export function Stroke<T extends Constructor>(Parent: T) {
 
 export interface AnnotationAxisLabelFormatterParams {
     readonly value: any;
-    readonly formatter?: Formatter<any>;
 }
 
 export function Label<T extends Constructor>(Parent: T) {

--- a/packages/ag-charts-types/src/chart/axisOptions.ts
+++ b/packages/ag-charts-types/src/chart/axisOptions.ts
@@ -118,7 +118,6 @@ export interface AgAxisLabelFormatterParams {
     readonly value: any;
     readonly index: number;
     readonly fractionDigits?: number;
-    readonly formatter?: Formatter<any>;
 }
 
 export interface AgBaseAxisLabelOptions {


### PR DESCRIPTION
also from `AnnotationAxisLabelFormatterParams`