### PR TITLE
AG-11917 AG-11899 Set pointer-events: none on overlay

### DIFF
--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -53,6 +53,7 @@ const STYLES = `
 }
 
 .ag-charts-canvas-overlay {
+    pointer-events: none;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11917
https://ag-grid.atlassian.net/browse/AG-11899

There is a recent bug regression where the KeyNavManager is not correctly receiving keyboard events.

This happening because we’ve swapped the DOM ordering of the canvas and overlay elements. This was done because we need keep the correct tab-ordering (the canvas, i.e. series, is the first region when pressing TAB).

Setting `pointer-events: none` on the .ag-charts-canvas-overlay element allow mouse event to pass-through and hit the <canvas> element, which ensures that it also receives keyboard input.