### PR TITLE
AG-11527 - Cleanup Financial Charts Preset types.

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -1,4 +1,4 @@
-import type { AgChartInstance, AgChartOptions, AgFinancialChartOptions, Preset } from 'ag-charts-types';
+import type { AgChartInstance, AgChartOptions, AgFinancialChartOptions } from 'ag-charts-types';
 
 import { CartesianChart } from '../chart/cartesianChart';
 import { Chart, type ChartExtendedOptions } from '../chart/chart';
@@ -103,16 +103,11 @@ export abstract class AgCharts {
     public static createFinancialChart(options: AgFinancialChartOptions) {
         if (!isAgFinancialChartOptions(options)) throw new Error('AG Charts - unrecognized financial options type');
 
-        return this.create(processPreset(options)) as unknown as AgChartInstance<AgFinancialChartOptions>;
+        const presetOptions = PRESETS[options.type](options);
+        debug('>>> AgCharts.createFinancialChart() - applying preset', options, presetOptions);
+
+        return this.create(presetOptions) as unknown as AgChartInstance<AgFinancialChartOptions>;
     }
-}
-
-function processPreset(preset: Preset) {
-    const result = PRESETS[preset.type](preset);
-
-    debug('>>> AgCharts.processPreset() - applying preset', preset, result);
-
-    return result;
 }
 
 class AgChartsInternal {

--- a/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
+++ b/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
@@ -4,9 +4,7 @@ import type {
     AgBaseFinancialPresetOptions,
     AgCandlestickVolumePreset,
     AgCartesianChartOptions,
-    AgCartesianSeriesTooltipRendererParams,
     AgCrosshairLabelRendererParams,
-    AgSeriesTooltip,
 } from 'ag-charts-types';
 
 function dateFormat(dateString: string, format: string) {
@@ -15,27 +13,6 @@ function dateFormat(dateString: string, format: string) {
         ? dateObject.toLocaleString('en-GB', { day: 'numeric', month: 'short' })
         : dateObject.toLocaleString('en-GB', { month: 'short', year: '2-digit' });
 }
-
-const tooltipOptions: AgSeriesTooltip<any> = {
-    position: {
-        type: 'top-left',
-        xOffset: 70,
-        yOffset: 20,
-    },
-    renderer: ({ datum }: AgCartesianSeriesTooltipRendererParams) => {
-        const fill = datum.open < datum.close ? '#089981' : '#F23645';
-        return `
-           <div>
-           O<span style="color: ${fill}">${datum.open}</span>
-           H<span style="color: ${fill}">${datum.high}</span>
-           L<span style="color: ${fill}">${datum.low}</span>
-           C<span style="color: ${fill}">${datum.close}</span>
-           Vol <span style="color: ${fill}">${Intl.NumberFormat('en', {
-               notation: 'compact',
-               maximumSignificantDigits: 3,
-           }).format(datum.volume)}</span></div>`;
-    },
-};
 
 export function candlestickVolumePreset(
     opts: AgCandlestickVolumePreset & AgBaseFinancialPresetOptions
@@ -86,7 +63,6 @@ export function candlestickVolumePreset(
                     const fill = datum[openKey] < datum[closeKey] ? '#92D2CC' : '#F7A9A7';
                     return { fill };
                 },
-                tooltip: tooltipOptions,
             },
             {
                 type: 'candlestick',
@@ -105,7 +81,6 @@ export function candlestickVolumePreset(
                         stroke: '#F23645',
                     },
                 },
-                tooltip: tooltipOptions,
             },
         ],
         axes: [
@@ -175,6 +150,7 @@ export function candlestickVolumePreset(
         annotations: {
             enabled: true,
         },
+        tooltip: { enabled: false },
         data,
         ...unusedOpts,
     };

--- a/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
+++ b/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
@@ -1,6 +1,7 @@
 import type {
     AgAxisLabelFormatterParams,
     AgBarSeriesFormatterParams,
+    AgBasePresetOptions,
     AgCandlestickVolumePreset,
     AgCartesianChartOptions,
     AgCartesianSeriesTooltipRendererParams,
@@ -36,7 +37,9 @@ const tooltipOptions: AgSeriesTooltip<any> = {
     },
 };
 
-export function candlestickVolumePreset(opts: AgCandlestickVolumePreset): AgCartesianChartOptions {
+export function candlestickVolumePreset(
+    opts: AgCandlestickVolumePreset & AgBasePresetOptions<'annotations'>
+): AgCartesianChartOptions {
     const {
         type: _type,
         xKey = 'date',
@@ -45,6 +48,7 @@ export function candlestickVolumePreset(opts: AgCandlestickVolumePreset): AgCart
         lowKey = 'low',
         closeKey = 'close',
         volumeKey = 'volume',
+        data,
         ...unusedOpts
     } = opts;
     return {
@@ -59,7 +63,7 @@ export function candlestickVolumePreset(opts: AgCandlestickVolumePreset): AgCart
         legend: { enabled: false },
         statusBar: {
             enabled: true,
-            data: (unusedOpts as any).data ?? [],
+            data: data ?? [],
             highKey,
             openKey,
             lowKey,
@@ -171,6 +175,7 @@ export function candlestickVolumePreset(opts: AgCandlestickVolumePreset): AgCart
         annotations: {
             enabled: true,
         },
+        data,
         ...unusedOpts,
     };
 }

--- a/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
+++ b/packages/ag-charts-community/src/api/preset/candlestickVolumePreset.ts
@@ -1,7 +1,7 @@
 import type {
     AgAxisLabelFormatterParams,
     AgBarSeriesFormatterParams,
-    AgBasePresetOptions,
+    AgBaseFinancialPresetOptions,
     AgCandlestickVolumePreset,
     AgCartesianChartOptions,
     AgCartesianSeriesTooltipRendererParams,
@@ -38,7 +38,7 @@ const tooltipOptions: AgSeriesTooltip<any> = {
 };
 
 export function candlestickVolumePreset(
-    opts: AgCandlestickVolumePreset & AgBasePresetOptions<'annotations'>
+    opts: AgCandlestickVolumePreset & AgBaseFinancialPresetOptions
 ): AgCartesianChartOptions {
     const {
         type: _type,

--- a/packages/ag-charts-community/src/api/preset/presets.ts
+++ b/packages/ag-charts-community/src/api/preset/presets.ts
@@ -1,8 +1,8 @@
-import type { AgChartOptions, AgFinancialChartOptions, Preset } from 'ag-charts-types';
+import type { AgFinancialChartOptions, Preset } from 'ag-charts-types';
 
 import { candlestickVolumePreset } from './candlestickVolumePreset';
 
-export const PRESETS: { [K in Preset['type']]: (p: Preset & { type: K }) => AgChartOptions } = {
+export const PRESETS = {
     'candlestick-volume': candlestickVolumePreset,
 };
 

--- a/packages/ag-charts-types/src/api/presetOptions.ts
+++ b/packages/ag-charts-types/src/api/presetOptions.ts
@@ -9,4 +9,6 @@ export type AgCandlestickVolumePreset = {
     volumeKey?: string;
 };
 
-export type Preset = AgCandlestickVolumePreset;
+export type AgFinancialChartPresets = AgCandlestickVolumePreset;
+
+export type Preset = AgFinancialChartPresets;

--- a/packages/ag-charts-types/src/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartBuilderOptions.ts
@@ -37,23 +37,14 @@ export type AgChartOptions =
     | AgTopologyChartOptions
     | AgFlowProportionChartOptions;
 
-export type AgBasePresetOptions<K extends keyof AgCartesianChartOptions = never> = Pick<
+export type AgBasePresetOptions = Pick<
     AgCartesianChartOptions,
-    | 'data'
-    | 'container'
-    | 'width'
-    | 'height'
-    | 'minWidth'
-    | 'minHeight'
-    | 'theme'
-    | 'dataSource'
-    | 'title'
-    | 'subtitle'
-    | 'footnote'
-    | K
+    'data' | 'container' | 'width' | 'height' | 'minWidth' | 'minHeight' | 'theme' | 'title' | 'subtitle' | 'footnote'
 >;
 
-export type AgFinancialChartOptions = AgFinancialChartPresets & AgBasePresetOptions<'annotations'>;
+export type AgBaseFinancialPresetOptions = AgBasePresetOptions & Pick<AgCartesianChartOptions, 'annotations'>;
+
+export type AgFinancialChartOptions = AgFinancialChartPresets & AgBaseFinancialPresetOptions;
 
 export type AgChartInstanceOptions = AgChartOptions | AgFinancialChartOptions;
 

--- a/packages/ag-charts-types/src/chart/chartBuilderOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartBuilderOptions.ts
@@ -1,4 +1,4 @@
-import type { AgCandlestickVolumePreset } from '../api/presetOptions';
+import type { AgFinancialChartPresets } from '../api/presetOptions';
 import type { AgBaseCartesianChartOptions } from '../series/cartesian/cartesianOptions';
 import type { AgBaseFlowProportionChartOptions } from '../series/flow-proportion/flowProportionOptions';
 import type { AgBaseHierarchyChartOptions } from '../series/hierarchy/hierarchyOptions';
@@ -37,23 +37,23 @@ export type AgChartOptions =
     | AgTopologyChartOptions
     | AgFlowProportionChartOptions;
 
-type AgFinancialChartPresets = AgCandlestickVolumePreset;
+export type AgBasePresetOptions<K extends keyof AgCartesianChartOptions = never> = Pick<
+    AgCartesianChartOptions,
+    | 'data'
+    | 'container'
+    | 'width'
+    | 'height'
+    | 'minWidth'
+    | 'minHeight'
+    | 'theme'
+    | 'dataSource'
+    | 'title'
+    | 'subtitle'
+    | 'footnote'
+    | K
+>;
 
-export type AgFinancialChartOptions = AgFinancialChartPresets &
-    Pick<
-        AgCartesianChartOptions,
-        | 'data'
-        | 'container'
-        | 'width'
-        | 'height'
-        | 'minWidth'
-        | 'minHeight'
-        | 'theme'
-        | 'dataSource'
-        | 'title'
-        | 'subtitle'
-        | 'footnote'
-    >;
+export type AgFinancialChartOptions = AgFinancialChartPresets & AgBasePresetOptions<'annotations'>;
 
 export type AgChartInstanceOptions = AgChartOptions | AgFinancialChartOptions;
 

--- a/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/_examples/candlestick-volume-combo/main.ts
@@ -6,27 +6,27 @@ const options: AgFinancialChartOptions = {
     type: 'candlestick-volume',
     container: document.getElementById('myChart'),
     data: getData(),
-    // annotations: {
-    //     enabled: true,
-    //     initial: [
-    //         {
-    //             type: 'parallel-channel',
-    //             start: { x: new Date(1672756200000), y: 130.28 + 6 },
-    //             end: { x: new Date(1689773400000), y: 195.1 + 6 },
-    //             size: 12,
-    //         },
-    //         {
-    //             type: 'line',
-    //             start: { x: new Date(1701959400000), y: 193.63 },
-    //             end: { x: new Date(1707489000000), y: 188.85 },
-    //         },
-    //         {
-    //             type: 'line',
-    //             start: { x: new Date(1691155800000), y: 185.52 },
-    //             end: { x: new Date(1698413400000), y: 166.91 },
-    //         },
-    //     ],
-    // },
+    annotations: {
+        enabled: true,
+        initial: [
+            {
+                type: 'parallel-channel',
+                start: { x: new Date(1672756200000), y: 130.28 + 6 },
+                end: { x: new Date(1689773400000), y: 195.1 + 6 },
+                height: 12,
+            },
+            {
+                type: 'line',
+                start: { x: new Date(1701959400000), y: 193.63 },
+                end: { x: new Date(1707489000000), y: 188.85 },
+            },
+            {
+                type: 'line',
+                start: { x: new Date(1691155800000), y: 185.52 },
+                end: { x: new Date(1698413400000), y: 166.91 },
+            },
+        ],
+    },
 };
 
 const chart = AgCharts.createFinancialChart(options);

--- a/packages/ag-charts-website/src/content/docs/financial-charts/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/index.mdoc
@@ -1,7 +1,6 @@
 ---
 title: 'Financial Charts - Examples'
 enterprise: true
-hidden: true
 ---
 
 ## Stock Tracking Chart
@@ -17,3 +16,13 @@ Switch between the different time intervals below to see the data at different g
 ## Candlestick Volume Combination
 
 {% chartExampleRunner title="Candlestick Volume Combination" name="candlestick-volume-combo" type="generated" /%}
+
+## API Reference
+
+{% tabs %}
+
+{% tabItem id="AgFinancialChartOptions" label="Options" %}
+{% apiReference id="AgFinancialChartOptions" /%}
+{% /tabItem %}
+
+{% /tabs %}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11527

Improves `AgFinancialChartOptions` definition, use and strictness vs. preset function implementation.