### PR TITLE
AG-NONE Do not use getComputedStyle()

### DIFF
--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -332,14 +332,7 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
             onBlur = () => this.translateFloatingElements(position, false);
         }
 
-        // Our styles only use 'row' and 'column'. Unit tests use 'inherit' and ''.
-        // Ignore other flex-direction values with `!`.
-        const { flexDirection } = getComputedStyle(alignElement);
-        const orientation = (
-            { '': 'horizontal', inherit: 'horizontal', row: 'horizontal', column: 'vertical' } as const
-        )[flexDirection];
-        if (!orientation) throw TypeError(`AG Charts - unexpected flex-direction [${flexDirection}]`);
-
+        const orientation = this.computeAriaOrientation(alignElement);
         this.groupDestroyFns[group] = initToolbarKeyNav({
             orientation,
             toolbar: alignElement,
@@ -348,6 +341,25 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
             onFocus,
             onBlur,
         });
+    }
+
+    private computeAriaOrientation(elem: HTMLElement): 'horizontal' | 'vertical' {
+        // Our styles only use 'row' and 'column'. Unit tests use ''.
+        const flexDirection = this.computedStyle(elem, 'flex-direction', 'row');
+        const orientation = ({ row: 'horizontal', column: 'vertical' } as const)[flexDirection];
+        if (!orientation) throw TypeError(`AG Charts - unexpected flex-direction [${flexDirection}]`);
+        return orientation;
+    }
+
+    private computedStyle(elem: HTMLElement, property: string, defaultValue: string): string {
+        // We could use the global getComputedStyle function, but it doesn't always work as intended in tests.
+        let value: string;
+        let current: HTMLElement | null = elem;
+        do {
+            value = current!.style.getPropertyValue(property);
+            current = current!.parentElement;
+        } while (current != null && value !== '');
+        return value === '' ? defaultValue : value;
     }
 
     private toggleGroup(caller: string, group: ToolbarGroup, enabled?: boolean) {


### PR DESCRIPTION
This is because the function is causing errors in our utilities (thumbnail generator). We cannot use alignElement.style.flexDirection directly either though, because that value expands to ''. So just create a simple ancestor traversor to find the nearest none-empty `flex-direction` property.

This is not a perfect solution, because it does not properly compute some cases (e.g. if an ancestor has an !important flex-direction set), but it is good enough for our use case.