### PR TITLE
AG-11917 Remove defaultPrevent() on drag event

### DIFF
--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -272,7 +272,6 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const { enabled, enableDoubleClickToReset, hoveredAxis, paddedRect } = this;
 
         if (!enabled || !enableDoubleClickToReset) return;
-        event.preventDefault();
 
         const { x, y } = this.getResetZoom();
 
@@ -298,7 +297,6 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
 
         if (!enabled || !paddedRect) return;
 
-        event.preventDefault();
         this.panner.stopInteractions();
 
         // Determine which ZoomDrag behaviour to use.
@@ -357,17 +355,14 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
                 const axisZoom = zoomManager.getAxisZoom(axisId);
                 const newZoom = axisDragger.update(event, direction, anchor, seriesRect, zoom, axisZoom);
                 this.updateAxisZoom(axisId, direction, newZoom);
-                event.preventDefault();
                 break;
 
             case DragState.Pan:
                 panner.update(event);
-                event.preventDefault();
                 break;
 
             case DragState.Select:
                 selector.update(event, this.getModuleProperties(), paddedRect, zoom);
-                event.preventDefault();
                 break;
 
             case DragState.None:
@@ -378,7 +373,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         updateService.update(ChartUpdateType.PERFORM_LAYOUT, { skipAnimations: true });
     }
 
-    private onDragEnd(event: _ModuleSupport.PointerInteractionEvent<'drag-end'>) {
+    private onDragEnd(_event: _ModuleSupport.PointerInteractionEvent<'drag-end'>) {
         const {
             axisDragger,
             dragState,
@@ -396,12 +391,10 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         switch (dragState) {
             case DragState.Axis:
                 axisDragger.stop();
-                event.preventDefault();
                 break;
 
             case DragState.Pan:
                 panner.stop();
-                event.preventDefault();
                 break;
 
             case DragState.Select:
@@ -410,7 +403,6 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
                 if (this.isMinZoom(zoom)) break;
                 const newZoom = selector.stop(this.seriesRect, this.paddedRect, zoom);
                 this.updateZoom(newZoom);
-                event.preventDefault();
                 break;
         }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11917

This ensures that the canvas receives focus when it is clicked on.

Also, the defaultPrevent() call no longer seems necessary, is might be because the canvas is receiving the MouseEvents, and therefore nothing happens if defaultPrevent() isn't called.

The defaultPrevent() call is still necessary for the wheel event. I'm not sure whether it's necessray for the +/- keyboard presses, but I would assume yes.