### PR TITLE
AG-11924 Ensure changing chart type preserves container size

### DIFF
--- a/packages/ag-charts-community/src/chart/baseManager.ts
+++ b/packages/ag-charts-community/src/chart/baseManager.ts
@@ -8,10 +8,6 @@ export abstract class BaseManager<EventType extends string = never, Event extend
         return this.listeners.addListener(type, handler);
     }
 
-    public removeListener(listenerSymbol: symbol) {
-        this.listeners.removeListener(listenerSymbol);
-    }
-
     public destroy() {
         this.listeners.destroy();
         this.destroyFns.forEach((fn) => fn());

--- a/packages/ag-charts-community/src/chart/dom/domManager.ts
+++ b/packages/ag-charts-community/src/chart/dom/domManager.ts
@@ -41,7 +41,7 @@ function setupObserver(element: HTMLElement, cb: (intersectionRatio: number) => 
     return observer;
 }
 
-type Events = { type: 'hidden' } | { type: 'resize'; size: Size } | { type: 'container-changed' };
+type Events = { type: 'hidden' } | { type: 'resize' } | { type: 'container-changed' };
 type LiveDOMElement = {
     element: HTMLElement;
     children: Map<string, HTMLElement>;
@@ -52,7 +52,7 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
     private readonly rootElements: Record<DOMElementClass, LiveDOMElement>;
     private readonly element: HTMLElement;
     private container?: HTMLElement;
-    private containerSize?: Size;
+    containerSize?: Size = undefined;
 
     public guardedElement?: GuardedElement;
 
@@ -140,7 +140,7 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
         this.sizeMonitor.observe(newContainer, (size) => {
             this.containerSize = size;
             this.updateContainerSize();
-            this.listeners.dispatch('resize', { type: 'resize', size });
+            this.listeners.dispatch('resize', { type: 'resize' });
         });
 
         this.container = newContainer;

--- a/packages/ag-charts-community/src/util/listeners.ts
+++ b/packages/ag-charts-community/src/util/listeners.ts
@@ -22,7 +22,7 @@ export class Listeners<EventType extends string, EventHandler extends Handler> {
         return () => this.removeListener(record.symbol);
     }
 
-    public removeListener(eventSymbol: symbol) {
+    private removeListener(eventSymbol: symbol) {
         for (const [type, listeners] of this.registeredListeners.entries()) {
             const matchIndex = listeners.findIndex((listener) => listener.symbol === eventSymbol);
             if (matchIndex >= 0) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11924

Issue is when the chart changes, a new dom manager is created, but we don't read the container size