### PR TITLE
Remove redundant Chart.processedOptions, fix stale options state bugs.

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -155,7 +155,7 @@ class AgChartsInternal {
         });
 
         let chart = proxy?.chart;
-        if (chart == null || chartType(userOptions) !== chartType(chart.processedOptions)) {
+        if (chart == null || chartType(userOptions) !== chartType(chart?.chartOptions.processedOptions)) {
             chart = AgChartsInternal.createChartInstance(chartOptions, chart);
         }
 

--- a/packages/ag-charts-community/src/chart/mapping/themes.test.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.test.ts
@@ -31,7 +31,7 @@ describe('themes module', () => {
 
     const getActualPalette = (chart: AgChartInstance) => {
         let result = undefined;
-        for (const series of deproxy(chart).processedOptions.series ?? []) {
+        for (const series of deproxy(chart).chartOptions.processedOptions.series ?? []) {
             result ??= { fills: [] as string[], strokes: [] as string[] };
 
             expect(series.type).toEqual('bar');


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11506

Removes redundant copy of options kept in `Chart.processedOptions`, and consequently tries to straighten out the set of options used in `Chart.applyOptions()` to reduce complexity and fix a couple of bugs due to mixed up options.