### PR TITLE
AG-11506 - Rework theme colors

### DIFF
--- a/packages/ag-charts-community/src/api/preset/priceVolumePreset.ts
+++ b/packages/ag-charts-community/src/api/preset/priceVolumePreset.ts
@@ -14,7 +14,12 @@ import type {
     AgZoomOptions,
 } from 'ag-charts-types';
 
-export function priceVolume(opts: AgPriceVolumePreset & AgBaseFinancialPresetOptions): AgCartesianChartOptions {
+import type { ChartTheme } from '../../chart/themes/chartTheme';
+
+export function priceVolume(
+    opts: AgPriceVolumePreset & AgBaseFinancialPresetOptions,
+    getTheme: () => ChartTheme
+): AgCartesianChartOptions {
     const {
         xKey = 'date',
         highKey = 'high',
@@ -43,7 +48,8 @@ export function priceVolume(opts: AgPriceVolumePreset & AgBaseFinancialPresetOpt
                   xKey: 'date',
                   yKey: volumeKey,
                   itemStyler: ({ datum }) => {
-                      return { fill: datum[openKey] < datum[closeKey] ? '#92D2CC' : '#F7A9A7' };
+                      const { up, down } = getTheme().palette;
+                      return { fill: datum[openKey] < datum[closeKey] ? up?.fill : down?.fill };
                   },
               } satisfies AgBarSeriesOptions,
           ]
@@ -78,12 +84,6 @@ export function priceVolume(opts: AgPriceVolumePreset & AgBaseFinancialPresetOpt
                   lowKey,
                   closeKey,
                   volumeKey,
-                  positive: {
-                      color: '#089981',
-                  },
-                  negative: {
-                      color: '#F23645',
-                  },
               },
           }
         : null;

--- a/packages/ag-charts-community/src/chart/themes/darkTheme.ts
+++ b/packages/ag-charts-community/src/chart/themes/darkTheme.ts
@@ -8,7 +8,6 @@ import {
     DEFAULT_ANNOTATION_STROKE,
     DEFAULT_AXIS_GRID_COLOUR,
     DEFAULT_BACKGROUND_COLOUR,
-    DEFAULT_COLOURS,
     DEFAULT_CROSS_LINES_COLOUR,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
     DEFAULT_HIERARCHY_FILLS,
@@ -17,10 +16,6 @@ import {
     DEFAULT_LABEL_COLOUR,
     DEFAULT_MUTED_LABEL_COLOUR,
     DEFAULT_POLAR_SERIES_STROKE,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
     IS_DARK_THEME,
 } from './symbols';
 
@@ -59,40 +54,13 @@ const palette: AgChartThemePalette = {
 };
 
 export class DarkTheme extends ChartTheme {
-    protected static override getDefaultColors(): DefaultColors {
+    override getDefaultColors(): DefaultColors {
         return {
             fills: DEFAULT_DARK_FILLS,
             strokes: DEFAULT_DARK_STROKES,
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: DEFAULT_DARK_FILLS.BLUE,
-            stroke: DEFAULT_DARK_STROKES.BLUE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: DEFAULT_DARK_FILLS.ORANGE,
-            stroke: DEFAULT_DARK_STROKES.ORANGE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: DEFAULT_DARK_FILLS.GRAY,
-            stroke: DEFAULT_DARK_STROKES.GRAY,
-            label: {
-                color: 'white',
-            },
+            up: { fill: DEFAULT_DARK_FILLS.BLUE, stroke: DEFAULT_DARK_STROKES.BLUE },
+            down: { fill: DEFAULT_DARK_FILLS.ORANGE, stroke: DEFAULT_DARK_STROKES.ORANGE },
+            neutral: { fill: DEFAULT_DARK_FILLS.GRAY, stroke: DEFAULT_DARK_STROKES.GRAY },
         };
     }
 
@@ -100,15 +68,6 @@ export class DarkTheme extends ChartTheme {
         const params = super.getTemplateParameters();
 
         params.set(IS_DARK_THEME, true);
-        params.set(DEFAULT_COLOURS, DarkTheme.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, DarkTheme.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, DarkTheme.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, DarkTheme.getWaterfallSeriesDefaultTotalColors());
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            DarkTheme.getWaterfallSeriesDefaultTotalColors().stroke
-        );
         params.set(DEFAULT_POLAR_SERIES_STROKE, DEFAULT_DARK_BACKGROUND_FILL);
 
         params.set(DEFAULT_LABEL_COLOUR, 'white');

--- a/packages/ag-charts-community/src/chart/themes/defaultColors.ts
+++ b/packages/ag-charts-community/src/chart/themes/defaultColors.ts
@@ -24,4 +24,10 @@ export const DEFAULT_STROKES = {
     RED: '#a82529',
 };
 
-export type DefaultColors = { fills: { [key: string]: string }; strokes: { [key: string]: string } };
+export type DefaultColors = {
+    fills: { [key: string]: string };
+    strokes: { [key: string]: string };
+    up: { stroke: string; fill: string };
+    down: { stroke: string; fill: string };
+    neutral: { stroke: string; fill: string };
+};

--- a/packages/ag-charts-community/src/chart/themes/financialDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/financialDark.ts
@@ -4,12 +4,7 @@ import { DarkTheme } from './darkTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const FINANCIAL_DARK_FILLS = {
@@ -30,61 +25,24 @@ const palette: AgChartThemePalette = {
 };
 
 export class FinancialDark extends DarkTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: { ...FINANCIAL_DARK_FILLS },
             strokes: { ...FINANCIAL_DARK_STROKES },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: FINANCIAL_DARK_FILLS.GREEN,
-            stroke: FINANCIAL_DARK_STROKES.GREEN,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: FINANCIAL_DARK_FILLS.RED,
-            stroke: FINANCIAL_DARK_STROKES.RED,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: FINANCIAL_DARK_FILLS.BLUE,
-            stroke: FINANCIAL_DARK_STROKES.BLUE,
-            label: {
-                color: 'white',
-            },
+            up: { fill: FINANCIAL_DARK_FILLS.GREEN, stroke: FINANCIAL_DARK_STROKES.GREEN },
+            down: { fill: FINANCIAL_DARK_FILLS.RED, stroke: FINANCIAL_DARK_STROKES.RED },
+            neutral: { fill: FINANCIAL_DARK_FILLS.BLUE, stroke: FINANCIAL_DARK_STROKES.BLUE },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, FinancialDark.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, FinancialDark.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, FinancialDark.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, FinancialDark.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
             FINANCIAL_DARK_FILLS.GREEN,
             FINANCIAL_DARK_FILLS.BLUE,
             FINANCIAL_DARK_FILLS.RED,
         ]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            FinancialDark.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, FINANCIAL_DARK_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, FINANCIAL_DARK_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/financialLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/financialLight.ts
@@ -4,13 +4,7 @@ import { ChartTheme } from './chartTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_LABEL_COLOUR,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const FINANCIAL_LIGHT_FILLS = {
@@ -31,61 +25,24 @@ const palette: AgChartThemePalette = {
 };
 
 export class FinancialLight extends ChartTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: { ...FINANCIAL_LIGHT_FILLS },
             strokes: { ...FINANCIAL_LIGHT_STROKES },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: FINANCIAL_LIGHT_FILLS.GREEN,
-            stroke: FINANCIAL_LIGHT_STROKES.GREEN,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: FINANCIAL_LIGHT_FILLS.RED,
-            stroke: FINANCIAL_LIGHT_STROKES.RED,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: FINANCIAL_LIGHT_FILLS.BLUE,
-            stroke: FINANCIAL_LIGHT_STROKES.BLUE,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
+            up: { fill: FINANCIAL_LIGHT_FILLS.GREEN, stroke: FINANCIAL_LIGHT_STROKES.GREEN },
+            down: { fill: FINANCIAL_LIGHT_FILLS.RED, stroke: FINANCIAL_LIGHT_STROKES.RED },
+            neutral: { fill: FINANCIAL_LIGHT_FILLS.BLUE, stroke: FINANCIAL_LIGHT_STROKES.BLUE },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, FinancialLight.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, FinancialLight.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, FinancialLight.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, FinancialLight.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
             FINANCIAL_LIGHT_FILLS.GREEN,
             FINANCIAL_LIGHT_FILLS.BLUE,
             FINANCIAL_LIGHT_FILLS.RED,
         ]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            FinancialLight.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, FINANCIAL_LIGHT_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, FINANCIAL_LIGHT_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/materialDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/materialDark.ts
@@ -4,12 +4,7 @@ import { DarkTheme } from './darkTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const MATERIAL_DARK_FILLS = {
@@ -44,61 +39,24 @@ const palette: AgChartThemePalette = {
 };
 
 export class MaterialDark extends DarkTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: MATERIAL_DARK_FILLS,
             strokes: MATERIAL_DARK_STROKES,
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: MATERIAL_DARK_FILLS.BLUE,
-            stroke: MATERIAL_DARK_STROKES.BLUE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: MATERIAL_DARK_FILLS.RED,
-            stroke: MATERIAL_DARK_STROKES.RED,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: MATERIAL_DARK_FILLS.GRAY,
-            stroke: MATERIAL_DARK_STROKES.GRAY,
-            label: {
-                color: 'white',
-            },
+            up: { fill: MATERIAL_DARK_FILLS.BLUE, stroke: MATERIAL_DARK_STROKES.BLUE },
+            down: { fill: MATERIAL_DARK_FILLS.RED, stroke: MATERIAL_DARK_STROKES.RED },
+            neutral: { fill: MATERIAL_DARK_FILLS.GRAY, stroke: MATERIAL_DARK_STROKES.GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, MaterialDark.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, MaterialDark.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, MaterialDark.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, MaterialDark.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
             MATERIAL_DARK_FILLS.ORANGE,
             MATERIAL_DARK_FILLS.YELLOW,
             MATERIAL_DARK_FILLS.GREEN,
         ]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            MaterialDark.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, MATERIAL_DARK_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, MATERIAL_DARK_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/materialLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/materialLight.ts
@@ -4,13 +4,7 @@ import { ChartTheme } from './chartTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_LABEL_COLOUR,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const MATERIAL_LIGHT_FILLS = {
@@ -45,61 +39,24 @@ const palette: AgChartThemePalette = {
 };
 
 export class MaterialLight extends ChartTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: MATERIAL_LIGHT_FILLS,
             strokes: MATERIAL_LIGHT_STROKES,
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: MATERIAL_LIGHT_FILLS.BLUE,
-            stroke: MATERIAL_LIGHT_STROKES.BLUE,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: MATERIAL_LIGHT_FILLS.RED,
-            stroke: MATERIAL_LIGHT_STROKES.RED,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: MATERIAL_LIGHT_FILLS.GRAY,
-            stroke: MATERIAL_LIGHT_STROKES.GRAY,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
+            up: { fill: MATERIAL_LIGHT_FILLS.BLUE, stroke: MATERIAL_LIGHT_STROKES.BLUE },
+            down: { fill: MATERIAL_LIGHT_FILLS.RED, stroke: MATERIAL_LIGHT_STROKES.RED },
+            neutral: { fill: MATERIAL_LIGHT_FILLS.GRAY, stroke: MATERIAL_LIGHT_STROKES.GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, MaterialLight.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, MaterialLight.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, MaterialLight.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, MaterialLight.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
             MATERIAL_LIGHT_FILLS.ORANGE,
             MATERIAL_LIGHT_FILLS.YELLOW,
             MATERIAL_LIGHT_FILLS.GREEN,
         ]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            MaterialLight.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, MATERIAL_LIGHT_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, MATERIAL_LIGHT_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/polychromaDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/polychromaDark.ts
@@ -4,12 +4,7 @@ import { DarkTheme } from './darkTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const POLYCHROMA_DARK_FILLS = {
@@ -47,57 +42,20 @@ const palette: AgChartThemePalette = {
 };
 
 export class PolychromaDark extends DarkTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: POLYCHROMA_DARK_FILLS,
             strokes: POLYCHROMA_DARK_STROKES,
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: POLYCHROMA_DARK_FILLS.BLUE,
-            stroke: POLYCHROMA_DARK_STROKES.BLUE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: POLYCHROMA_DARK_FILLS.RED,
-            stroke: POLYCHROMA_DARK_STROKES.RED,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: POLYCHROMA_DARK_FILL_GRAY,
-            stroke: POLYCHROMA_DARK_STROKE_GRAY,
-            label: {
-                color: 'white',
-            },
+            up: { fill: POLYCHROMA_DARK_FILLS.BLUE, stroke: POLYCHROMA_DARK_STROKES.BLUE },
+            down: { fill: POLYCHROMA_DARK_FILLS.RED, stroke: POLYCHROMA_DARK_STROKES.RED },
+            neutral: { fill: POLYCHROMA_DARK_FILL_GRAY, stroke: POLYCHROMA_DARK_STROKE_GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, PolychromaDark.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, PolychromaDark.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, PolychromaDark.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, PolychromaDark.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [POLYCHROMA_DARK_FILLS.BLUE, POLYCHROMA_DARK_FILLS.RED]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            PolychromaDark.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, POLYCHROMA_DARK_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, POLYCHROMA_DARK_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/polychromaLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/polychromaLight.ts
@@ -4,13 +4,7 @@ import { ChartTheme } from './chartTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_LABEL_COLOUR,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const POLYCHROMA_LIGHT_FILLS = {
@@ -48,62 +42,20 @@ const palette: AgChartThemePalette = {
 };
 
 export class PolychromaLight extends ChartTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: POLYCHROMA_LIGHT_FILLS,
             strokes: POLYCHROMA_LIGHT_STROKES,
-        };
-    }
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: POLYCHROMA_LIGHT_FILLS.BLUE,
-            stroke: POLYCHROMA_LIGHT_STROKES.BLUE,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: POLYCHROMA_LIGHT_FILLS.RED,
-            stroke: POLYCHROMA_LIGHT_STROKES.RED,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: POLYCHROMA_LIGHT_FILL_GRAY,
-            stroke: POLYCHROMA_LIGHT_STROKE_GRAY,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
+            up: { fill: POLYCHROMA_LIGHT_FILLS.BLUE, stroke: POLYCHROMA_LIGHT_STROKES.BLUE },
+            down: { fill: POLYCHROMA_LIGHT_FILLS.RED, stroke: POLYCHROMA_LIGHT_STROKES.RED },
+            neutral: { fill: POLYCHROMA_LIGHT_FILL_GRAY, stroke: POLYCHROMA_LIGHT_STROKE_GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, PolychromaLight.getDefaultColors());
-        params.set(
-            DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-            PolychromaLight.getWaterfallSeriesDefaultPositiveColors()
-        );
-        params.set(
-            DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-            PolychromaLight.getWaterfallSeriesDefaultNegativeColors()
-        );
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, PolychromaLight.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [POLYCHROMA_LIGHT_FILLS.BLUE, POLYCHROMA_LIGHT_FILLS.RED]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            PolychromaLight.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, POLYCHROMA_LIGHT_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, POLYCHROMA_LIGHT_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/sheetsDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/sheetsDark.ts
@@ -4,12 +4,7 @@ import { DarkTheme } from './darkTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const SHEETS_DARK_FILLS = {
@@ -44,61 +39,24 @@ const palette: AgChartThemePalette = {
 };
 
 export class SheetsDark extends DarkTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: { ...SHEETS_DARK_FILLS, RED: SHEETS_DARK_FILLS.ORANGE },
             strokes: { ...SHEETS_DARK_STROKES, RED: SHEETS_DARK_STROKES.ORANGE },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: SHEETS_DARK_FILLS.BLUE,
-            stroke: SHEETS_DARK_STROKES.BLUE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: SHEETS_DARK_FILLS.ORANGE,
-            stroke: SHEETS_DARK_STROKES.ORANGE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: SHEETS_DARK_FILLS.GRAY,
-            stroke: SHEETS_DARK_STROKES.GRAY,
-            label: {
-                color: 'white',
-            },
+            up: { fill: SHEETS_DARK_FILLS.BLUE, stroke: SHEETS_DARK_STROKES.BLUE },
+            down: { fill: SHEETS_DARK_FILLS.ORANGE, stroke: SHEETS_DARK_STROKES.ORANGE },
+            neutral: { fill: SHEETS_DARK_FILLS.GRAY, stroke: SHEETS_DARK_STROKES.GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, SheetsDark.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, SheetsDark.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, SheetsDark.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, SheetsDark.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
             SHEETS_DARK_FILLS.ORANGE,
             SHEETS_DARK_FILLS.YELLOW,
             SHEETS_DARK_FILLS.GREEN,
         ]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            SheetsDark.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, SHEETS_DARK_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, SHEETS_DARK_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/sheetsLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/sheetsLight.ts
@@ -4,13 +4,7 @@ import { ChartTheme } from './chartTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_LABEL_COLOUR,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const SHEETS_LIGHT_FILLS = {
@@ -45,61 +39,24 @@ const palette: AgChartThemePalette = {
 };
 
 export class SheetsLight extends ChartTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: { ...SHEETS_LIGHT_FILLS, RED: SHEETS_LIGHT_FILLS.ORANGE },
             strokes: { ...SHEETS_LIGHT_STROKES, RED: SHEETS_LIGHT_STROKES.ORANGE },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: SHEETS_LIGHT_FILLS.BLUE,
-            stroke: SHEETS_LIGHT_STROKES.BLUE,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: SHEETS_LIGHT_FILLS.ORANGE,
-            stroke: SHEETS_LIGHT_STROKES.ORANGE,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: SHEETS_LIGHT_FILLS.GRAY,
-            stroke: SHEETS_LIGHT_STROKES.GRAY,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
+            up: { fill: SHEETS_LIGHT_STROKES.BLUE, stroke: SHEETS_LIGHT_FILLS.BLUE },
+            down: { fill: SHEETS_LIGHT_STROKES.ORANGE, stroke: SHEETS_LIGHT_FILLS.ORANGE },
+            neutral: { fill: SHEETS_LIGHT_STROKES.GRAY, stroke: SHEETS_LIGHT_FILLS.GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, SheetsLight.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, SheetsLight.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, SheetsLight.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, SheetsLight.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
             SHEETS_LIGHT_FILLS.ORANGE,
             SHEETS_LIGHT_FILLS.YELLOW,
             SHEETS_LIGHT_FILLS.GREEN,
         ]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            SheetsLight.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, SHEETS_LIGHT_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, SHEETS_LIGHT_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/symbols.ts
+++ b/packages/ag-charts-community/src/chart/themes/symbols.ts
@@ -10,18 +10,9 @@ export const DEFAULT_CROSS_LINES_COLOUR = Symbol('default-cross-lines-colour') a
 export const DEFAULT_BACKGROUND_COLOUR = Symbol('default-background-colour') as unknown as string;
 export const DEFAULT_SHADOW_COLOUR = Symbol('default-shadow-colour') as unknown as string;
 export const DEFAULT_COLOURS = Symbol('default-colours') as unknown as string;
-export const DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS = Symbol(
-    'default-waterfall-series-positive-colors'
-) as unknown as string;
-export const DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS = Symbol(
-    'default-waterfall-series-negative-colors'
-) as unknown as string;
-export const DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS = Symbol(
-    'default-waterfall-series-total-colors'
-) as unknown as string;
-export const DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE = Symbol(
-    'default-waterfall-series-connector-line-stroke'
-) as unknown as string;
+export const PALETTE_UP_STROKE = Symbol('palette-up-stroke') as unknown as string;
+export const PALETTE_DOWN_STROKE = Symbol('palette-down-stroke') as unknown as string;
+export const PALETTE_NEUTRAL_STROKE = Symbol('palette-neutral-stroke') as unknown as string;
 
 export const DEFAULT_POLAR_SERIES_STROKE = Symbol('default-polar-series-stroke') as unknown as string;
 export const DEFAULT_DIVERGING_SERIES_COLOUR_RANGE = Symbol(

--- a/packages/ag-charts-community/src/chart/themes/vividDark.ts
+++ b/packages/ag-charts-community/src/chart/themes/vividDark.ts
@@ -4,12 +4,7 @@ import { DarkTheme } from './darkTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const VIVID_DARK_FILLS = {
@@ -44,61 +39,24 @@ const palette: AgChartThemePalette = {
 };
 
 export class VividDark extends DarkTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: VIVID_DARK_FILLS,
             strokes: VIVID_DARK_STROKES,
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: VIVID_DARK_FILLS.BLUE,
-            stroke: VIVID_DARK_STROKES.BLUE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: VIVID_DARK_FILLS.ORANGE,
-            stroke: VIVID_DARK_STROKES.ORANGE,
-            label: {
-                color: 'white',
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: VIVID_DARK_FILLS.GRAY,
-            stroke: VIVID_DARK_STROKES.GRAY,
-            label: {
-                color: 'white',
-            },
+            up: { fill: VIVID_DARK_FILLS.BLUE, stroke: VIVID_DARK_STROKES.BLUE },
+            down: { fill: VIVID_DARK_FILLS.ORANGE, stroke: VIVID_DARK_STROKES.ORANGE },
+            neutral: { fill: VIVID_DARK_FILLS.GRAY, stroke: VIVID_DARK_STROKES.GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, VividDark.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, VividDark.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, VividDark.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, VividDark.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [
             VIVID_DARK_FILLS.ORANGE,
             VIVID_DARK_FILLS.YELLOW,
             VIVID_DARK_FILLS.GREEN,
         ]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            VividDark.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, VIVID_DARK_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, VIVID_DARK_FILLS.BLUE);

--- a/packages/ag-charts-community/src/chart/themes/vividLight.ts
+++ b/packages/ag-charts-community/src/chart/themes/vividLight.ts
@@ -4,13 +4,7 @@ import { ChartTheme } from './chartTheme';
 import {
     DEFAULT_ANNOTATION_BACKGROUND_FILL,
     DEFAULT_ANNOTATION_STROKE,
-    DEFAULT_COLOURS,
     DEFAULT_DIVERGING_SERIES_COLOUR_RANGE,
-    DEFAULT_LABEL_COLOUR,
-    DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-    DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS,
-    DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS,
 } from './symbols';
 
 const VIVID_FILLS = {
@@ -45,57 +39,20 @@ const palette: AgChartThemePalette = {
 };
 
 export class VividLight extends ChartTheme {
-    protected static override getDefaultColors() {
+    override getDefaultColors() {
         return {
             fills: VIVID_FILLS,
             strokes: VIVID_STROKES,
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultPositiveColors() {
-        return {
-            fill: VIVID_FILLS.BLUE,
-            stroke: VIVID_STROKES.BLUE,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultNegativeColors() {
-        return {
-            fill: VIVID_FILLS.ORANGE,
-            stroke: VIVID_STROKES.ORANGE,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
-        };
-    }
-
-    protected static override getWaterfallSeriesDefaultTotalColors() {
-        return {
-            fill: VIVID_FILLS.GRAY,
-            stroke: VIVID_STROKES.GRAY,
-            label: {
-                color: DEFAULT_LABEL_COLOUR,
-            },
+            up: { fill: VIVID_FILLS.BLUE, stroke: VIVID_STROKES.BLUE },
+            down: { fill: VIVID_FILLS.ORANGE, stroke: VIVID_STROKES.ORANGE },
+            neutral: { fill: VIVID_FILLS.GRAY, stroke: VIVID_STROKES.GRAY },
         };
     }
 
     override getTemplateParameters() {
         const params = super.getTemplateParameters();
 
-        params.set(DEFAULT_COLOURS, VividLight.getDefaultColors());
-        params.set(DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS, VividLight.getWaterfallSeriesDefaultPositiveColors());
-        params.set(DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS, VividLight.getWaterfallSeriesDefaultNegativeColors());
-        params.set(DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS, VividLight.getWaterfallSeriesDefaultTotalColors());
-
         params.set(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE, [VIVID_FILLS.ORANGE, VIVID_FILLS.YELLOW, VIVID_FILLS.GREEN]);
-
-        params.set(
-            DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
-            VividLight.getWaterfallSeriesDefaultTotalColors().stroke
-        );
 
         params.set(DEFAULT_ANNOTATION_STROKE, VIVID_FILLS.BLUE);
         params.set(DEFAULT_ANNOTATION_BACKGROUND_FILL, VIVID_FILLS.BLUE);

--- a/packages/ag-charts-community/src/module/coreModulesTypes.ts
+++ b/packages/ag-charts-community/src/module/coreModulesTypes.ts
@@ -1,13 +1,25 @@
-import type { AgChartOptions } from 'ag-charts-types';
+import type { AgChartOptions, AgChartThemePalette } from 'ag-charts-types';
 
 import type { SeriesOptionsTypes } from '../chart/mapping/types';
 
 export type RequiredSeriesType = NonNullable<SeriesOptionsTypes['type']>;
 
+export type PaletteType = 'inbuilt' | 'user-indexed' | 'user-full';
+
+export function paletteType(partial?: AgChartThemePalette): PaletteType {
+    if (partial?.up || partial?.down || partial?.neutral) {
+        return 'user-full';
+    } else if (partial?.fills || partial?.strokes) {
+        return 'user-indexed';
+    }
+    return 'inbuilt';
+}
+
 export interface SeriesPaletteFactoryParams {
     takeColors: (count: number) => { fills: string[]; strokes: string[] };
     colorsCount: number;
-    userPalette: boolean;
+    userPalette: PaletteType;
+    palette: Required<AgChartThemePalette>;
     themeTemplateParameters: Map<string, string | string[]>;
 }
 

--- a/packages/ag-charts-enterprise/src/features/status-bar/statusBarModule.ts
+++ b/packages/ag-charts-enterprise/src/features/status-bar/statusBarModule.ts
@@ -21,10 +21,10 @@ export const StatusBarModule: _ModuleSupport.RootModule = {
                 color: _Theme.DEFAULT_LABEL_COLOUR,
             },
             positive: {
-                color: 'green',
+                color: _Theme.PALETTE_UP_STROKE,
             },
             negative: {
-                color: 'red',
+                color: _Theme.PALETTE_DOWN_STROKE,
             },
         },
     },

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickModule.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickModule.ts
@@ -24,21 +24,27 @@ export const CandlestickModule: _ModuleSupport.SeriesModule<'candlestick'> = {
     ],
     themeTemplate: CANDLESTICK_SERIES_THEME,
     groupable: false,
-    paletteFactory: ({ takeColors, colorsCount, userPalette, themeTemplateParameters }) => {
-        const { fills, strokes } = takeColors(colorsCount);
-        const { fills: DEFAULT_FILLS, strokes: DEFAULT_STROKES } = themeTemplateParameters.get(
-            _Theme.DEFAULT_COLOURS
-        ) as unknown as _ModuleSupport.DefaultColors;
+    paletteFactory: ({ takeColors, colorsCount, userPalette, palette }) => {
+        if (userPalette === 'user-indexed') {
+            const { fills, strokes } = takeColors(colorsCount);
+            return {
+                item: {
+                    up: {
+                        fill: 'transparent',
+                        stroke: strokes[0],
+                    },
+                    down: {
+                        fill: fills[0],
+                        stroke: strokes[0],
+                    },
+                },
+            };
+        }
+
         return {
             item: {
-                up: {
-                    fill: userPalette ? 'transparent' : DEFAULT_FILLS.GREEN,
-                    stroke: userPalette ? strokes[0] : DEFAULT_STROKES.GREEN,
-                },
-                down: {
-                    fill: userPalette ? fills[0] : DEFAULT_FILLS.RED,
-                    stroke: userPalette ? strokes[0] : DEFAULT_STROKES.RED,
-                },
+                up: palette.up,
+                down: palette.down,
             },
         };
     },

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapModule.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapModule.ts
@@ -31,8 +31,8 @@ export const HeatmapModule: _ModuleSupport.SeriesModule<'heatmap'> = {
             (Array.isArray(defaultBackgroundColor) ? defaultBackgroundColor[0] : defaultBackgroundColor) ?? 'white';
         const { fills, strokes } = takeColors(colorsCount);
         return {
-            stroke: userPalette ? strokes[0] : backgroundFill,
-            colorRange: userPalette ? [fills[0], fills[1]] : defaultColorRange,
+            stroke: userPalette === 'inbuilt' ? backgroundFill : strokes[0],
+            colorRange: userPalette === 'inbuilt' ? defaultColorRange : [fills[0], fills[1]],
         };
     },
 };

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineModule.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineModule.ts
@@ -38,7 +38,7 @@ export const MapLineModule: _ModuleSupport.SeriesModule<'map-line'> = {
         const defaultColorRange = themeTemplateParameters.get(DEFAULT_DIVERGING_SERIES_COLOUR_RANGE);
         const { fills } = takeColors(colorsCount);
         return {
-            colorRange: userPalette ? [fills[0], fills[1]] : defaultColorRange,
+            colorRange: userPalette === 'inbuilt' ? defaultColorRange : [fills[0], fills[1]],
             stroke: fill,
         };
     },

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerModule.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerModule.ts
@@ -33,7 +33,7 @@ export const MapMarkerModule: _ModuleSupport.SeriesModule<'map-marker'> = {
         return {
             fill,
             stroke,
-            colorRange: userPalette ? [fills[0], fills[1]] : defaultColorRange,
+            colorRange: userPalette === 'inbuilt' ? defaultColorRange : [fills[0], fills[1]],
         };
     },
 };

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeModule.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeModule.ts
@@ -42,7 +42,7 @@ export const MapShapeModule: _ModuleSupport.SeriesModule<'map-shape'> = {
         return {
             fill,
             stroke: themeTemplateParameters.get(DEFAULT_BACKGROUND_COLOUR) as string,
-            colorRange: userPalette ? [fills[0], fills[1]] : defaultColorRange,
+            colorRange: userPalette === 'inbuilt' ? defaultColorRange : [fills[0], fills[1]],
         };
     },
 };

--- a/packages/ag-charts-enterprise/src/series/nightingale/nightingaleModule.ts
+++ b/packages/ag-charts-enterprise/src/series/nightingale/nightingaleModule.ts
@@ -29,7 +29,7 @@ export const NightingaleModule: _ModuleSupport.SeriesModule<'nightingale'> = {
         } = takeColors(1);
         return {
             fill,
-            stroke: userPalette ? stroke : _Theme.DEFAULT_POLAR_SERIES_STROKE,
+            stroke: userPalette !== 'inbuilt' ? stroke : _Theme.DEFAULT_POLAR_SERIES_STROKE,
         };
     },
     stackable: true,

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcModule.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcModule.ts
@@ -38,21 +38,27 @@ export const OhlcModule: _ModuleSupport.SeriesModule<'ohlc'> = {
         },
     },
     groupable: false,
-    paletteFactory: ({ takeColors, colorsCount, userPalette, themeTemplateParameters }) => {
-        const {
-            strokes: [stroke],
-        } = takeColors(colorsCount);
-        const { strokes: DEFAULT_STROKES } = themeTemplateParameters.get(
-            _Theme.DEFAULT_COLOURS
-        ) as unknown as _ModuleSupport.DefaultColors;
+    paletteFactory: ({ takeColors, colorsCount, userPalette, palette }) => {
+        if (userPalette === 'user-indexed') {
+            const {
+                strokes: [stroke],
+            } = takeColors(colorsCount);
+            return {
+                item: {
+                    up: {
+                        stroke: stroke,
+                    },
+                    down: {
+                        stroke: stroke,
+                    },
+                },
+            };
+        }
+
         return {
             item: {
-                up: {
-                    stroke: userPalette ? stroke : DEFAULT_STROKES.GREEN,
-                },
-                down: {
-                    stroke: userPalette ? stroke : DEFAULT_STROKES.RED,
-                },
+                up: { stroke: palette.up.stroke },
+                down: { stroke: palette.down.stroke },
             },
         };
     },

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallModule.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallModule.ts
@@ -26,31 +26,52 @@ export const WaterfallModule: _ModuleSupport.SeriesModule<'waterfall'> = {
     ],
     themeTemplate: WATERFALL_SERIES_THEME,
     swapDefaultAxesCondition: ({ direction }) => direction === 'horizontal',
-    paletteFactory: ({ takeColors, colorsCount, userPalette, themeTemplateParameters }) => {
-        const { fills, strokes } = takeColors(colorsCount);
-        return userPalette
-            ? {
-                  item: {
-                      positive: {
-                          fill: fills[0],
-                          stroke: strokes[0],
-                      },
-                      negative: {
-                          fill: fills[1],
-                          stroke: strokes[1],
-                      },
-                      total: {
-                          fill: fills[2],
-                          stroke: strokes[2],
-                      },
-                  },
-              }
-            : {
-                  item: {
-                      positive: themeTemplateParameters.get(_Theme.DEFAULT_WATERFALL_SERIES_POSITIVE_COLOURS),
-                      negative: themeTemplateParameters.get(_Theme.DEFAULT_WATERFALL_SERIES_NEGATIVE_COLOURS),
-                      total: themeTemplateParameters.get(_Theme.DEFAULT_WATERFALL_SERIES_TOTAL_COLOURS),
-                  },
-              };
+    paletteFactory: ({ takeColors, colorsCount, userPalette, palette }) => {
+        if (userPalette === 'user-indexed') {
+            const { fills, strokes } = takeColors(colorsCount);
+            return {
+                line: { stroke: palette.neutral.stroke },
+                item: {
+                    positive: {
+                        fill: fills[0],
+                        stroke: strokes[0],
+                    },
+                    negative: {
+                        fill: fills[1],
+                        stroke: strokes[1],
+                    },
+                    total: {
+                        fill: fills[2],
+                        stroke: strokes[2],
+                    },
+                },
+            };
+        }
+        return {
+            line: { stroke: palette.neutral.stroke },
+            item: {
+                positive: {
+                    fill: palette.up.fill,
+                    stroke: palette.up.stroke,
+                    label: {
+                        color: _Theme.DEFAULT_LABEL_COLOUR,
+                    },
+                },
+                negative: {
+                    fill: palette.down.fill,
+                    stroke: palette.down.stroke,
+                    label: {
+                        color: _Theme.DEFAULT_LABEL_COLOUR,
+                    },
+                },
+                total: {
+                    fill: palette.neutral.fill,
+                    stroke: palette.neutral.stroke,
+                    label: {
+                        color: _Theme.DEFAULT_LABEL_COLOUR,
+                    },
+                },
+            },
+        };
     },
 };

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallThemes.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallThemes.ts
@@ -22,7 +22,7 @@ export const WATERFALL_SERIES_THEME = {
             total: itemTheme,
         },
         line: {
-            stroke: _Theme.DEFAULT_WATERFALL_SERIES_CONNECTOR_LINE_STROKE,
+            stroke: _Theme.PALETTE_NEUTRAL_STROKE,
             strokeOpacity: 1,
             lineDash: [0],
             lineDashOffset: 0,

--- a/packages/ag-charts-types/src/chart/themeOptions.ts
+++ b/packages/ag-charts-types/src/chart/themeOptions.ts
@@ -39,10 +39,6 @@ import type { AgBaseChartOptions, AgBaseThemeableChartOptions } from './chartOpt
 import type { AgLocaleThemeableOptions } from './localeOptions';
 import type { CssColor } from './types';
 
-// import type { AgChartThemeName } from 'ag-shared';
-
-// export type { AgChartThemeName } from 'ag-shared';
-
 export type AgChartThemeName =
     | 'ag-default'
     | 'ag-default-dark'
@@ -56,14 +52,16 @@ export type AgChartThemeName =
     | 'ag-material-dark';
 
 /**
- * Temporary alias type of Partial<AgChartThemePalette>, until we can fix AgChartThemePalette in the
- * next major release.
+ * Palette used by the chart instance.
  */
 export interface AgChartThemePalette {
     /** The array of fills to be used. */
     fills?: CssColor[];
     /** The array of strokes to be used. */
     strokes?: CssColor[];
+    up?: { fill?: CssColor; stroke?: CssColor };
+    down?: { fill?: CssColor; stroke?: CssColor };
+    neutral?: { fill?: CssColor; stroke?: CssColor };
 }
 
 export interface AgBaseChartThemeOptions {

--- a/packages/ag-charts-website/src/content/docs/financial-chart-types/_examples/customization/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-chart-types/_examples/customization/main.ts
@@ -7,8 +7,8 @@ import { getData } from './data';
 const options: AgFinancialChartOptions = {
     theme: {
         palette: {
-            up: { fill: 'orange', stroke: 'light-orange' },
-            down: { fill: 'blue', stroke: 'light-blue' },
+            up: { fill: '#F3A93C', stroke: '#A8492D' },
+            down: { fill: '#1A00F4', stroke: '#75FBFD' },
         },
     },
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-chart-types/_examples/customization/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-chart-types/_examples/customization/main.ts
@@ -5,7 +5,12 @@ import { getData } from './data';
 (window as any).agChartsDebug = 'opts';
 
 const options: AgFinancialChartOptions = {
-    theme: {},
+    theme: {
+        palette: {
+            up: { fill: 'orange', stroke: 'light-orange' },
+            down: { fill: 'blue', stroke: 'light-blue' },
+        },
+    },
     container: document.getElementById('myChart'),
     data: getData(),
 };

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -16,8 +16,8 @@ const isAgThemeOrUndefined = (theme) => {
     return theme == null || (typeof theme === 'string' && theme.startsWith('ag-'));
 };
 
-const getDarkmodeTheme = (theme = 'ag-default') => {
-    const baseTheme = theme.replace(/-dark$/, '');
+const getDarkmodeTheme = (theme = 'ag-default', preset) => {
+    const baseTheme = preset ? 'ag-financial' : theme.replace(/-dark$/, '');
     return darkmode ? baseTheme + '-dark' : baseTheme;
 };
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11506

Introduce a theme mechanism to allow consistent up/down colours with minimal user config for Financial Charts use-cases.

Bonus: Cleanup waterfall, candlestick and OHLC colour config.