### PR TITLE
Example generation fixes

### DIFF
--- a/packages/ag-charts-vue3/src/index.ts
+++ b/packages/ag-charts-vue3/src/index.ts
@@ -9,7 +9,7 @@ export const AgCharts = /*#__PURE__*/ defineComponent({
             default: (): AgChartOptions => ({}),
         },
     },
-    data(): { chart: AgChartInstance | undefined } {
+    setup(): { chart: AgChartInstance | undefined } {
         return {
             chart: undefined,
         };
@@ -19,7 +19,7 @@ export const AgCharts = /*#__PURE__*/ defineComponent({
     },
     watch: {
         options(options) {
-            toRaw(this.chart)?.update({ ...options, container: this.$el });
+            this.chart?.update({ ...options, container: this.$el });
         },
     },
     mounted() {

--- a/packages/ag-charts-website/e2e/examples.spec.ts
+++ b/packages/ag-charts-website/e2e/examples.spec.ts
@@ -4,54 +4,102 @@ import * as glob from 'glob';
 
 import { gotoExample, setupIntrinsicAssertions, toExamplePageUrls, toGalleryPageUrls } from './util';
 
-const ignorePages = ['benchmarks', /.*-test/];
-const notServedGalleryExamples = [
-    'time-axis-with-irregular-intervals',
-    'simple-bubble',
-    'scatter-series-error-bars',
-    'reversed-horizontal-bar',
-    'reversed-bullet',
-    'reversed-bar',
-    'per-marker-customisation',
-    'log-axis',
-    'line-series-error-bars',
-    'grouped-column',
-    'custom-tooltips',
-    'custom-marker-shapes',
-    'cross-lines',
-    'chart-customisation',
-    'bubble-with-labels',
-    'bubble-with-custom-markers',
-    'box-plot-scatter-combination',
-    'bar-with-labels',
-    'bar-series-error-bars',
-    '100--stacked-column',
-    '100--stacked-bar',
-];
-const ignoreFWExamples = {
-    // FW pages don't have these examples, as they make no sense.
-    'api-create-update': ['update-partial', 'wait-for-update'],
+type Status = 'ok' | '404';
+type ClickOrder = 'normal' | 'reverse';
+
+type ExampleOptions = {
+    pagePath: string;
+    url: string;
+    example: string;
+    framework: string;
+    status: Status;
+    clickOrder: ClickOrder;
+    skipCanvasUpdateCheck: boolean;
+    ignoreConsoleWarnings: boolean;
 };
-const clickBehaviorExamples = {
-    // Buttons have no visible rendering change.
-    // 'api-download': { download: 'no-update' },
-    events: { 'interaction-ranges': 'no-update' },
-    tooltips: { 'interaction-range': 'no-update' },
 
-    // First button is the default option, so no rendering change.
-    legend: { 'legend-position': 'reverse' },
-    themes: { 'stock-themes': 'reverse', 'advanced-theme': 'reverse' },
-    'financial-chart-types': { 'toggle-financial-features': 'reverse' },
+type ExampleOverrides = {
+    frameworks?: string[];
+    status?: Status;
+    skipFrameworks?: boolean;
+    clickOrder?: ClickOrder;
+    skipCanvasUpdateCheck?: boolean;
+    ignoreConsoleWarnings?: boolean;
+};
 
-    // Too complex to test with a naive button-click sweep.
-    'axis-labels': { 'axis-label-rotation': 'skip' },
+const ignorePages = ['benchmarks', /.*-test/];
+const exampleOptions: Record<string, Record<string, ExampleOverrides>> = {
+    gallery: {
+        '*': { frameworks: ['vanilla', 'typescript'] },
+
+        // Hidden gallery examples
+        'time-axis-with-irregular-intervals': { status: '404' },
+        'simple-bubble': { status: '404' },
+        'scatter-series-error-bars': { status: '404' },
+        'reversed-horizontal-bar': { status: '404' },
+        'reversed-bullet': { status: '404' },
+        'reversed-bar': { status: '404' },
+        'per-marker-customisation': { status: '404' },
+        'log-axis': { status: '404' },
+        'line-series-error-bars': { status: '404' },
+        'grouped-column': { status: '404' },
+        'custom-tooltips': { status: '404' },
+        'custom-marker-shapes': { status: '404' },
+        'cross-lines': { status: '404' },
+        'chart-customisation': { status: '404' },
+        'bubble-with-labels': { status: '404' },
+        'bubble-with-custom-markers': { status: '404' },
+        'box-plot-scatter-combination': { status: '404' },
+        'bar-with-labels': { status: '404' },
+        'bar-series-error-bars': { status: '404' },
+        '100--stacked-column': { status: '404' },
+        '100--stacked-bar': { status: '404' },
+    },
+
+    'axes-labels': {
+        // Too complex to test with a naive button-click sweep
+        'axis-label-rotation': { skipCanvasUpdateCheck: true },
+    },
+    'api-create-update': {
+        // No framework examples
+        'update-partial': { frameworks: ['vanilla', 'typescript'] },
+        // No framework examples, stop button does not cause visible change
+        'wait-for-update': {
+            frameworks: ['vanilla', 'typescript'],
+            skipCanvasUpdateCheck: true,
+        },
+    },
+    events: {
+        // Buttons have no visible rendering change
+        'interaction-ranges': { skipCanvasUpdateCheck: true },
+    },
+    'financial-chart-types': {
+        'toggle-financial-features': { clickOrder: 'reverse' },
+    },
+    legend: {
+        'legend-position': { clickOrder: 'reverse' },
+    },
+    'range-bar-series': {
+        // Warns for missing data
+        'range-bar-missing-data': { ignoreConsoleWarnings: true },
+    },
+    'sankey-series': {
+        alignment: { clickOrder: 'reverse' },
+    },
+    themes: {
+        'stock-themes': { clickOrder: 'reverse' },
+        // The canvas element changes, and we don't currently have a way to handle this
+        'advanced-theme': { frameworks: [] },
+    },
+    tooltips: {
+        // Buttons have no visible rendering change
+        'interaction-range': { skipCanvasUpdateCheck: true },
+    },
 
     // BROKEN!!!!!!!
-    'api-download': { download: 'skip' },
-
-    // ????
-    'sankey-series': { alignment: 'no-update' },
-    'range-bar-series': { 'range-bar-missing-data': 'skip' },
+    'api-download': {
+        download: { frameworks: [] },
+    },
 };
 
 function convertPageUrls(path: string) {
@@ -59,33 +107,38 @@ function convertPageUrls(path: string) {
     const [pagePath, examplePath] = astroPath.split('/_examples/');
     const example = examplePath.replace(/\/[a-zA-Z-]+\.ts$/, '');
 
-    let status: 'ok' | 'skip' | '404' = 'ok';
-    if (pagePath === 'gallery') {
-        if (notServedGalleryExamples.includes(example)) {
-            status = '404';
-        }
-
-        return toGalleryPageUrls(example).map((r) => ({
-            ...r,
-            status,
-            pagePath,
-            ignoreFWs: false,
-            clickBehavior: clickBehaviorExamples['gallery']?.[example] ?? 'normal',
-        }));
-    }
     const page = pagePath.replace(/^docs\//, '');
+    const pages = pagePath === 'gallery' ? toGalleryPageUrls(example) : toExamplePageUrls(page, example);
 
     if (ignorePages.some((m) => (typeof m === 'string' ? m === page : m.test(page)))) {
-        status = 'skip';
+        return [];
     }
 
-    return toExamplePageUrls(page, example).map((r) => ({
-        ...r,
-        status,
-        pagePath,
-        ignoreFWs: ignoreFWExamples[page]?.includes(example) ?? false,
-        clickBehavior: clickBehaviorExamples[page]?.[example] ?? 'normal',
-    }));
+    const {
+        frameworks,
+        status = 'ok',
+        clickOrder = 'normal',
+        skipCanvasUpdateCheck = false,
+        ignoreConsoleWarnings = false,
+    } = {
+        ...exampleOptions[page]?.['*'],
+        ...exampleOptions[page]?.[example],
+    };
+
+    return pages
+        .filter((r) => frameworks?.includes(r.framework) !== false)
+        .map(
+            ({ url, example, framework }): ExampleOptions => ({
+                pagePath,
+                url,
+                example,
+                framework,
+                status,
+                clickOrder,
+                skipCanvasUpdateCheck,
+                ignoreConsoleWarnings,
+            })
+        );
 }
 
 test.describe('examples', () => {
@@ -117,14 +170,23 @@ test.describe('examples', () => {
 
     for (const { path, affected } of examples) {
         for (const opts of convertPageUrls(path)) {
-            const { url, status, fw, pagePath, example: exampleName, ignoreFWs, clickBehavior } = opts;
+            const {
+                url,
+                status,
+                framework,
+                pagePath,
+                example,
+                clickOrder,
+                skipCanvasUpdateCheck,
+                ignoreConsoleWarnings,
+            } = opts;
 
-            if (ignoreFWs && fw !== 'vanilla' && fw !== 'typescript') continue;
-
-            test.describe(`Framework: ${fw}`, () => {
-                test.describe(`Example ${pagePath}: ${exampleName}`, () => {
+            test.describe(`Framework: ${framework}`, () => {
+                test.describe(`Example ${pagePath}: ${example}`, () => {
                     if (status === 'ok') {
                         test(`should load ${url}`, async ({ page }) => {
+                            config.ignoreConsoleWarnings = ignoreConsoleWarnings;
+
                             test.skip(!affected, 'unaffected example');
 
                             // Load example and wait for things to settle.
@@ -136,17 +198,19 @@ test.describe('examples', () => {
                             const canvas = canvases[0];
 
                             // Try pressing the buttons to see if any errors are thrown.
-                            if (clickBehavior === 'skip') return;
                             const buttons = await page.locator('.toolPanel > button').all();
-                            if (clickBehavior === 'reverse') buttons.reverse();
+                            if (clickOrder === 'reverse') buttons.reverse();
 
                             for (const button of buttons) {
                                 const sceneRenderCount = Number(await canvas.getAttribute('data-scene-renders'));
 
                                 await button.click();
 
-                                if (clickBehavior === 'normal') {
+                                if (!skipCanvasUpdateCheck) {
                                     await expect
+                                        .configure({
+                                            message: `Pressing button ${await button.textContent()}`,
+                                        })
                                         .poll(async () => Number(await canvas.getAttribute('data-scene-renders')))
                                         .toBeGreaterThan(sceneRenderCount);
                                 } else {

--- a/packages/ag-charts-website/e2e/examples.spec.ts
+++ b/packages/ag-charts-website/e2e/examples.spec.ts
@@ -95,11 +95,6 @@ const exampleOptions: Record<string, Record<string, ExampleOverrides>> = {
         // Buttons have no visible rendering change
         'interaction-range': { skipCanvasUpdateCheck: true },
     },
-
-    // BROKEN!!!!!!!
-    'api-download': {
-        download: { frameworks: [] },
-    },
 };
 
 function convertPageUrls(path: string) {

--- a/packages/ag-charts-website/e2e/keyboard-nav.spec.ts
+++ b/packages/ag-charts-website/e2e/keyboard-nav.spec.ts
@@ -7,8 +7,8 @@ test.describe('keyboard-nav', () => {
 
     const testUrls = toExamplePageUrls('accessibility', 'keyboard-navigation');
 
-    for (const { fw, url } of testUrls) {
-        test.describe(`for ${fw}`, () => {
+    for (const { framework, url } of testUrls) {
+        test.describe(`for ${framework}`, () => {
             test('basic keyboard navigation', async ({ page }) => {
                 await gotoExample(page, url);
                 page.check;

--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -4,20 +4,21 @@ const baseUrl = 'http://localhost:4601';
 const fws = ['vanilla', 'typescript', 'reactFunctional', 'reactFunctionalTs', 'angular', 'vue3'];
 
 export function toExamplePageUrls(page: string, example: string) {
-    return fws.map((fw) => ({ fw, url: `${baseUrl}/${fw}/${page}/examples/${example}`, example }));
+    return fws.map((framework) => ({ framework, url: `${baseUrl}/${framework}/${page}/examples/${example}`, example }));
 }
 
 export function toGalleryPageUrls(example: string) {
-    return [{ fw: 'vanilla', url: `${baseUrl}/gallery/examples/${example}`, example }];
+    return [{ framework: 'vanilla', url: `${baseUrl}/gallery/examples/${example}`, example }];
 }
 
 export function setupIntrinsicAssertions() {
     let consoleWarnOrErrors: string[] = [];
-    const config = { ignore404s: false };
+    const config = { ignore404s: false, ignoreConsoleWarnings: false };
 
     test.beforeEach(({ page }) => {
         consoleWarnOrErrors = [];
         config.ignore404s = false;
+        config.ignoreConsoleWarnings = false;
 
         page.on('console', (msg) => {
             // We only care about warnings/errors.
@@ -43,7 +44,9 @@ export function setupIntrinsicAssertions() {
     });
 
     test.afterEach(() => {
-        expect(consoleWarnOrErrors).toHaveLength(0);
+        if (!config.ignoreConsoleWarnings) {
+            expect(consoleWarnOrErrors).toHaveLength(0);
+        }
     });
 
     return config;

--- a/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
@@ -44,6 +44,8 @@
 
             css: 'npm:systemjs-plugin-css@0.1.37/css.js',
 
+            deepclone: 'npm:deepclone@1.0.2',
+
             ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
             tslib: 'npm:tslib@2.3.1/tslib.js',
             typescript: 'npm:typescript@4.4/lib/typescript.min.js',

--- a/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.js
+++ b/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.js
@@ -50,6 +50,8 @@
 
             css: 'npm:systemjs-plugin-css@0.1.37/css.js',
 
+            deepclone: 'npm:deepclone@1.0.2',
+
             ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
             tslib: 'npm:tslib@2.3.1/tslib.js',
             typescript: 'npm:typescript@4.4/lib/typescript.min.js',

--- a/packages/ag-charts-website/public/example-runner/charts-vue3-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-vue3-boilerplate/systemjs.config.dev.js
@@ -13,6 +13,8 @@
             ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
             typescript: 'npm:typescript@4.3.5/lib/typescript.min.js',
 
+            deepclone: 'npm:deepclone@1.0.2',
+
             // vuejs
             vue: 'npm:vue@3.2.29/dist/vue.esm-browser.js',
             '@vue/reactivity': 'npm:@vue/reactivity@3.0.0/dist/reactivity.esm-browser.js',

--- a/packages/ag-charts-website/public/example-runner/charts-vue3-boilerplate/systemjs.config.js
+++ b/packages/ag-charts-website/public/example-runner/charts-vue3-boilerplate/systemjs.config.js
@@ -27,6 +27,8 @@
             ts: 'npm:plugin-typescript@8.0.0/lib/plugin.js',
             typescript: 'npm:typescript@4.3.5/lib/typescript.min.js',
 
+            deepclone: 'npm:deepclone@1.0.2',
+
             // vuejs
             vue: 'npm:vue@3.2.29/dist/vue.esm-browser.js',
             '@vue/reactivity': 'npm:@vue/reactivity@3.0.0/dist/reactivity.esm-browser.prod.js',

--- a/packages/ag-charts-website/src/content/docs/axes-labels/_examples/axis-label-rotation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-labels/_examples/axis-label-rotation/main.ts
@@ -29,10 +29,6 @@ const options: AgCartesianChartOptions = {
 const chart = AgCharts.create(options);
 
 function reset() {
-    const element = document.getElementsByClassName('ag-chart-wrapper')![0]! as HTMLElement;
-    element.style.width = '100%';
-    element.style.height = '100%';
-
     delete options.axes![0].label!.rotation;
     delete options.axes![0].label!.autoRotate;
     delete options.axes![0].label!.avoidCollisions;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.test.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.test.ts
@@ -38,7 +38,7 @@ describe('wrapOptionsUpdateCode', () => {
 
         const propertyDefinition = wrapOptionsUpdateCode(functionDefinition);
         const expected =
-            'foo(bar) { const options = {...this.options}; options.axes[0].gridLine.style = [{ lineDash: [1, 3] }]; this.options = options; }';
+            'foo(bar) { const options = deepClone(this.options); options.axes[0].gridLine.style = [{ lineDash: [1, 3] }]; this.options = options; }';
 
         expect(standardiseWhitespace(propertyDefinition)).toBe(expected);
     });

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.test.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.test.ts
@@ -9,7 +9,7 @@ describe('wrapOptionsUpdateCode', () => {
 
         const propertyDefinition = wrapOptionsUpdateCode(functionDefinition);
         const expected =
-            'function foo(bar) { const options = {...this.options}; options.padding.top = 20; this.options = options; }';
+            'function foo(bar) { const options = deepClone(this.options); options.padding.top = 20; this.options = options; }';
 
         expect(standardiseWhitespace(propertyDefinition)).toBe(expected);
     });

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-utils.ts
@@ -2,16 +2,17 @@ import type { BindingImport } from './parser-utils';
 
 export function wrapOptionsUpdateCode(
     code: string,
-    before = 'const options = {...this.options};',
+    before = 'const options = deepClone(this.options);',
     after = 'this.options = options;',
     localVar = 'options'
 ): string {
-    if (code.indexOf('options.') < 0) {
+    if (!code.includes('options.') && !code.includes('options[')) {
         return code;
     }
 
     return code
         .replace(/(?<!\w)options\./g, localVar + '.')
+        .replace(/(?<!\w)options\[/g, localVar + '[')
         .replace(/(.*?)\{(.*)\}/s, `$1{\n${before}\n$2\n${after}\n}`);
 }
 

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
@@ -32,6 +32,10 @@ function getImports(bindings, componentFileNames: string[], { typeParts }): stri
         imports.push(...componentFileNames.map(getImport));
     }
 
+    if (bindings.externalEventHandlers.length > 0 || bindings.instanceMethods.length > 0) {
+        imports.push(`import deepClone from 'deepclone';`);
+    }
+
     return imports;
 }
 

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
@@ -198,5 +198,11 @@ export async function vanillaToReactFunctional(bindings: any, componentFilenames
         `;
     }
 
+    if (bindings.usesChartApi) {
+        indexFile = indexFile.replace(/AgCharts.(\w*)\((\w*)(,|\))/g, 'AgCharts.$1(chartRef.current$3');
+        indexFile = indexFile.replace(/chart.(\w*)\(/g, 'chartRef.current.$1(');
+        indexFile = indexFile.replace(/this.chartRef.current/g, 'chartRef.current');
+    }
+
     return indexFile;
 }

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-vue3.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-vue3.ts
@@ -36,6 +36,10 @@ function getImports(componentFileNames: string[], bindings): string[] {
         imports.push("import 'ag-charts-enterprise';");
     }
 
+    if (bindings.externalEventHandlers.length > 0 || bindings.instanceMethods.length > 0) {
+        imports.push(`import deepClone from 'deepclone';`);
+    }
+
     return imports;
 }
 


### PR DESCRIPTION
* Fixes all e2es
* Cleans up e2e tests
* Allows using `options[key] = value` in examples
* Uses `deepclone` for Vue and Angular (we were already using it for React)