### PR TITLE
AG-11509 Add intermediate container for role="toolbar"

### DIFF
--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -323,10 +323,13 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
 
         if (!alignElement) return;
 
+        const toolbarElement = createElement('div');
+        alignElement.classList.forEach((className) => toolbarElement.classList.add(className));
+        alignElement.appendChild(toolbarElement);
         const nextSection = () => {
             const newSection = createElement('div');
             newSection.classList.add(styles.elements.section, styles.modifiers[this[group].size]);
-            alignElement.appendChild(newSection);
+            toolbarElement.appendChild(newSection);
             return newSection;
         };
 
@@ -358,13 +361,13 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         const orientation = this.computeAriaOrientation(this[group].position);
         this.groupDestroyFns[group] = initToolbarKeyNav({
             orientation,
-            toolbar: alignElement,
+            toolbar: toolbarElement,
             buttons: this.groupButtons[group],
             onEscape,
             onFocus,
             onBlur,
         });
-        this.updateToolbarAriaLabel(group, alignElement);
+        this.updateToolbarAriaLabel(group, toolbarElement);
     }
 
     private computeAriaOrientation(position: ToolbarPosition): 'horizontal' | 'vertical' {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11509
This fixes a bug where two toolbars in the same position are seen by AT as a single role="toolbar".