### PR TITLE
AG-11990 - Fix Financial Charts volume + price series hover conflicts.

### DIFF
--- a/packages/ag-charts-community/src/api/preset/priceVolumePreset.ts
+++ b/packages/ag-charts-community/src/api/preset/priceVolumePreset.ts
@@ -230,6 +230,8 @@ function createVolumeSeries(
             xKey: 'date',
             yKey: volumeKey,
             tooltip: { enabled: false },
+            // @ts-expect-error
+            highlight: { enabled: false },
             fillOpacity: fromTheme(theme, (t) => t.overrides?.bar?.series?.fillOpacity) ?? 0.5,
             ...itemStyler,
         } satisfies AgBarSeriesOptions,

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1388,7 +1388,7 @@ export abstract class Chart extends Observable {
         if (isNewDatum) {
             html = pick.series.getTooltipHtml(pick.datum);
 
-            if (this.highlight.range === 'tooltip') {
+            if (this.highlight.range === 'tooltip' && pick.series.properties.highlight.enabled) {
                 this.ctx.highlightManager.updateHighlight(this.id, pick.datum);
             }
         }
@@ -1404,23 +1404,21 @@ export abstract class Chart extends Observable {
     }
 
     protected handlePointerNode(event: PointerOffsetsAndHistory, intent: SeriesNodePickIntent) {
+        const { range } = this.highlight;
+
         const found = this.checkSeriesNodeRange(intent, event, (series, datum) => {
             if (series.hasEventListener('nodeClick') || series.hasEventListener('nodeDoubleClick')) {
                 this.ctx.cursorManager.updateCursor('chart', 'pointer');
             }
 
-            if (this.highlight.range === 'node') {
-                this.ctx.highlightManager.updateHighlight(this.id, datum);
-            }
+            if (range === 'tooltip' && series.properties.tooltip.enabled) return;
+            this.ctx.highlightManager.updateHighlight(this.id, datum);
         });
+        if (found) return;
 
-        if (!found) {
-            this.ctx.cursorManager.updateCursor('chart');
-
-            if (this.highlight.range === 'node') {
-                this.ctx.highlightManager.updateHighlight(this.id);
-            }
-        }
+        this.ctx.cursorManager.updateCursor('chart');
+        if (range !== 'node') return;
+        this.ctx.highlightManager.updateHighlight(this.id);
     }
 
     protected onClick(event: PointerInteractionEvent<'click'>) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -658,8 +658,8 @@ export abstract class CartesianSeries<
         const [primaryDirection = ChartAxisDirection.X] = directions;
 
         const hitPoint = rootGroup.transformPoint(x, y);
-        const hitPointCoords =
-            primaryDirection === ChartAxisDirection.X ? [hitPoint.x, hitPoint.y] : [hitPoint.y, hitPoint.x];
+        const hitPointCoords = [hitPoint.x, hitPoint.y];
+        if (primaryDirection !== ChartAxisDirection.X) hitPointCoords.reverse();
 
         const minDistance = [Infinity, Infinity];
         let closestDatum: SeriesNodeDatum | undefined;
@@ -670,12 +670,14 @@ export abstract class CartesianSeries<
                 continue;
             }
 
-            const isInRange = xAxis?.inRange(datumX) && yAxis?.inRange(datumY);
-            if (!isInRange) {
+            const isInPrimaryRange =
+                primaryDirection === ChartAxisDirection.X ? xAxis?.inRange(datumX) : yAxis?.inRange(datumY);
+            if (!isInPrimaryRange) {
                 continue;
             }
 
-            const datumPoint = primaryDirection === ChartAxisDirection.X ? [datumX, datumY] : [datumY, datumX];
+            const datumPoint = [datumX, datumY];
+            if (primaryDirection !== ChartAxisDirection.X) datumPoint.reverse();
 
             // Compare distances from most significant dimension to least.
             let newMinDistance = true;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -649,15 +649,9 @@ export abstract class Series<
     ): { pickMode: SeriesNodePickMode; match: SeriesNodeDatum; distance: number } | undefined {
         const { pickModes, visible, rootGroup } = this;
 
-        if (!visible || !rootGroup.visible) {
-            return;
-        }
-
-        if (intent === 'highlight' && !this.properties.highlight.enabled) {
-            return;
-        } else if (intent === 'tooltip' && !this.properties.tooltip.enabled) {
-            return;
-        }
+        if (!visible || !rootGroup.visible) return;
+        if (intent === 'highlight' && !this.properties.highlight.enabled) return;
+        if (intent === 'tooltip' && !this.properties.tooltip.enabled) return;
 
         for (const pickMode of pickModes) {
             if (limitPickModes && !limitPickModes.includes(pickMode)) {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -58,6 +58,8 @@ export enum SeriesNodePickMode {
     NEAREST_NODE,
 }
 
+export type SeriesNodePickIntent = 'tooltip' | 'highlight' | 'context-menu' | 'event';
+
 export type SeriesNodePickMatch = {
     datum: SeriesNodeDatum;
     distance: number;
@@ -642,11 +644,18 @@ export abstract class Series<
 
     pickNode(
         point: Point,
+        intent: SeriesNodePickIntent,
         limitPickModes?: SeriesNodePickMode[]
     ): { pickMode: SeriesNodePickMode; match: SeriesNodeDatum; distance: number } | undefined {
         const { pickModes, visible, rootGroup } = this;
 
         if (!visible || !rootGroup.visible) {
+            return;
+        }
+
+        if (intent === 'highlight' && !this.properties.highlight.enabled) {
+            return;
+        } else if (intent === 'tooltip' && !this.properties.tooltip.enabled) {
             return;
         }
 

--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -83,7 +83,7 @@ export abstract class SeriesProperties<T extends object> extends BaseProperties<
     cursor = 'default';
 
     @Validate(INTERACTION_RANGE)
-    nodeClickRange: InteractionRange | 'none' = 'exact';
+    nodeClickRange: InteractionRange = 'exact';
 
     @Validate(OBJECT)
     readonly highlight = new HighlightProperties();

--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -53,6 +53,11 @@ class TextHighlightStyle extends BaseProperties {
     color?: string = 'black';
 }
 
+export class HighlightProperties extends BaseProperties {
+    @Validate(BOOLEAN, { optional: true })
+    enabled = true;
+}
+
 export class HighlightStyle extends BaseProperties {
     @Validate(OBJECT)
     readonly item = new SeriesItemHighlightStyle();
@@ -78,7 +83,10 @@ export abstract class SeriesProperties<T extends object> extends BaseProperties<
     cursor = 'default';
 
     @Validate(INTERACTION_RANGE)
-    nodeClickRange: InteractionRange = 'exact';
+    nodeClickRange: InteractionRange | 'none' = 'exact';
+
+    @Validate(OBJECT)
+    readonly highlight = new HighlightProperties();
 
     @Validate(OBJECT)
     readonly highlightStyle = new HighlightStyle();


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11990

Two changes to address Financial Charts volume + price series conflicting on hover/zoom:
- Allows node highlight to be disabled on a per-series basis, and the volume series has highlight disabled to avoid conflicts with selecting the closest price series datum.
- Updates category-axis ‘closest’ node logic to stop excluding nodes that are outside the other axis range (X-axis and Y-axis respectively for Financial Charts cases).