### PR TITLE
AG-11947 Fix nested CSS in examples getting altered

### DIFF
--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getOtherScriptFiles.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getOtherScriptFiles.ts
@@ -79,11 +79,17 @@ export const getOtherScriptFiles = async ({
 
     const contents: Record<string, string> = {};
     for (const [filename, content] of Object.entries(otherTsGeneratedFileContents)) {
-        contents[filename] = await prettier.format(content, { parser: 'typescript' });
+        contents[filename] = await prettier.format(content, {
+            parser: 'typescript',
+            embeddedLanguageFormatting: 'off',
+        });
     }
 
     for (const [filename, content] of Object.entries(otherJsFileContents)) {
-        contents[filename] = await prettier.format(content, { parser: 'typescript' });
+        contents[filename] = await prettier.format(content, {
+            parser: 'typescript',
+            embeddedLanguageFormatting: 'off',
+        });
     }
 
     return contents;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11947

We have snippets like:-

```js
        html`
            <div
                style="${css`
                    display: grid;
                    grid: 'a b' auto / 1fr auto;
                `}"
            >
                <div id="myChart"></div>
                <textarea></textarea>
            </div>
        `
```

The issue is running prettier in the example generator was changing the single quotes to double quotes, breaking the HTML. I've turned off prettifying nested CSS in the example generator, and it'll still run in VSCode etc. This is only used for our internal tests