### PR TITLE
AG-12088 Refactor annotations state and add text editing

### DIFF
--- a/packages/ag-charts-community/src/util/vector.ts
+++ b/packages/ag-charts-community/src/util/vector.ts
@@ -14,7 +14,7 @@ export const Vec2 = {
     sub,
 };
 
-interface Vec2 {
+export interface Vec2 {
     x: number;
     y: number;
 }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationTypes.ts
@@ -65,27 +65,6 @@ export interface Point {
     y?: number;
 }
 
-export interface StateHoverEvent<Annotation, Scene> {
-    datum: Annotation;
-    node: Scene;
-    point: Coords;
-    region?: _ModuleSupport.RegionName;
-}
-
-export interface StateClickEvent<Annotation, Scene> {
-    datum?: Annotation;
-    node?: Scene;
-    point: Coords;
-    region?: _ModuleSupport.RegionName;
-}
-
-export interface StateInputEvent<Annotation> {
-    datum: Annotation;
-    value?: string;
-}
-
-export interface StateDragEvent<Annotation, Scene> extends StateClickEvent<Annotation, Scene> {}
-
 export interface AnnotationAxisContext
     extends Pick<
         _ModuleSupport.AxisContext,

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -25,7 +25,7 @@ import {
 } from './annotationsConfig';
 import { AnnotationsStateMachine } from './annotationsStateMachine';
 import { AxisButton, DEFAULT_ANNOTATION_AXIS_BUTTON_CLASS } from './axisButton';
-import type { Annotation } from './scenes/annotationScene';
+import type { AnnotationScene } from './scenes/annotationScene';
 import { TextProperties } from './text/textProperties';
 
 const {
@@ -100,7 +100,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
     // Elements
     private seriesRect?: _Scene.BBox;
     private readonly container = new _Scene.Group({ name: 'static-annotations' });
-    private readonly annotations = new _Scene.Selection<Annotation, AnnotationProperties>(
+    private readonly annotations = new _Scene.Selection<AnnotationScene, AnnotationProperties>(
         this.container,
         this.createAnnotationScene.bind(this)
     );
@@ -527,7 +527,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
 
         node.toggleActive(true);
 
-        const data: StateHoverEvent<AnnotationProperties, Annotation> = { datum, node, point };
+        const data: StateHoverEvent<AnnotationProperties, AnnotationScene> = { datum, node, point };
         this.state.transition('hover', data);
 
         this.update();
@@ -578,7 +578,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
             return;
         }
 
-        const data: StateClickEvent<AnnotationProperties, Annotation> = { point };
+        const data: StateClickEvent<AnnotationProperties, AnnotationScene> = { point };
         state.transition('click', data);
 
         this.update();
@@ -637,7 +637,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
             return;
         }
 
-        const data: StateClickEvent<AnnotationProperties, Annotation> = { datum, node, point };
+        const data: StateClickEvent<AnnotationProperties, AnnotationScene> = { datum, node, point };
         state.transition('click', data);
 
         this.update();
@@ -732,7 +732,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         interactionManager.pushState(InteractionState.Annotations);
 
         const point = invertCoords(offset, context);
-        const data: StateDragEvent<AnnotationProperties, Annotation> = { datum, node, point };
+        const data: StateDragEvent<AnnotationProperties, AnnotationScene> = { datum, node, point };
 
         state.transition('drag', data);
 

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -222,10 +222,10 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                 this.update();
             },
 
-            showTextInput: (active?: number) => {
-                if (active == null) return;
+            showTextInput: (active: number) => {
+                const datum = getTypedDatum(this.annotationData.at(active));
+                if (!datum || !('getTextBBox' in datum)) return;
 
-                const datum = this.annotationData[active];
                 const styles = {
                     color: datum.color,
                     fontFamily: datum.fontFamily,
@@ -234,7 +234,18 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                     fontWeight: datum.fontWeight,
                 };
 
-                this.textInput.show({ styles });
+                this.textInput.show({ styles, text: datum.text });
+
+                const bbox = datum.getTextBBox(this.getAnnotationContext()!);
+                const coords = Vec2.add(bbox, Vec2.required(this.seriesRect));
+                bbox.x = coords.x;
+                bbox.y = coords.y;
+
+                this.textInput.setLayout({
+                    bbox,
+                    position: datum.position,
+                    alignment: datum.alignment,
+                });
             },
 
             hideTextInput: () => {
@@ -492,7 +503,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                     return;
                 }
 
-                updateAnnotation(node, datum, context, state.isActive(index), this.textInput);
+                updateAnnotation(node, datum, context);
 
                 if (state.isActive(index)) {
                     toolbarManager.changeFloatingAnchor('annotationOptions', node.getAnchor());

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
@@ -1,6 +1,5 @@
 import type { _Util } from 'ag-charts-community';
 
-import type { TextInput } from '../text-input/textInput';
 import { type AnnotationContext, AnnotationType } from './annotationTypes';
 import type { AnnotationProperties } from './annotationsSuperTypes';
 import { HorizontalLineProperties, VerticalLineProperties } from './cross-line/crossLineProperties';
@@ -45,13 +44,7 @@ export const annotationScenes: Record<AnnotationType, Constructor<AnnotationScen
     [AnnotationType.Text]: TextScene,
 };
 
-export function updateAnnotation(
-    node: AnnotationScene,
-    datum: AnnotationProperties,
-    context: AnnotationContext,
-    isActive: boolean,
-    textInput: TextInput
-) {
+export function updateAnnotation(node: AnnotationScene, datum: AnnotationProperties, context: AnnotationContext) {
     // Lines
     if (LineProperties.is(datum) && LineScene.is(node)) {
         node.update(datum, context);
@@ -73,15 +66,6 @@ export function updateAnnotation(
     // Texts
     if (TextProperties.is(datum) && TextScene.is(node)) {
         node.update(datum, context);
-
-        if (isActive) {
-            // TODO: remove this from here
-            textInput.setLayout({
-                bbox: node.getTextRect(),
-                position: datum.position,
-                alignment: datum.alignment,
-            });
-        }
     }
 }
 

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
@@ -10,7 +10,7 @@ import { LineProperties } from './line/lineProperties';
 import { LineScene } from './line/lineScene';
 import { ParallelChannelProperties } from './parallel-channel/parallelChannelProperties';
 import { ParallelChannelScene } from './parallel-channel/parallelChannelScene';
-import type { Annotation } from './scenes/annotationScene';
+import type { AnnotationScene } from './scenes/annotationScene';
 import { TextProperties } from './text/textProperties';
 import { TextScene } from './text/textScene';
 
@@ -38,7 +38,7 @@ export const annotationDatums: Record<AnnotationType, Constructor<AnnotationProp
     [AnnotationType.Text]: TextProperties,
 };
 
-export const annotationScenes: Record<AnnotationType, Constructor<Annotation>> = {
+export const annotationScenes: Record<AnnotationType, Constructor<AnnotationScene>> = {
     // Lines
     [AnnotationType.Line]: LineScene,
     [AnnotationType.HorizontalLine]: CrossLineScene,
@@ -53,7 +53,7 @@ export const annotationScenes: Record<AnnotationType, Constructor<Annotation>> =
 };
 
 export function updateAnnotation(
-    node: Annotation,
+    node: AnnotationScene,
     datum: AnnotationProperties,
     context: AnnotationContext,
     isActive: boolean,
@@ -93,7 +93,7 @@ export function updateAnnotation(
 }
 
 export function dragStartAnnotation(
-    node: Annotation,
+    node: AnnotationScene,
     datum: AnnotationProperties,
     context: AnnotationContext,
     offset: _Util.Vec2
@@ -121,7 +121,7 @@ export function dragStartAnnotation(
 }
 
 export function dragAnnotation(
-    node: Annotation,
+    node: AnnotationScene,
     datum: AnnotationProperties,
     context: AnnotationContext,
     offset: _Util.Vec2,

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
@@ -2,6 +2,7 @@ import type { _Util } from 'ag-charts-community';
 
 import type { TextInput } from '../text-input/textInput';
 import { type AnnotationContext, AnnotationType } from './annotationTypes';
+import type { AnnotationProperties } from './annotationsSuperTypes';
 import { HorizontalLineProperties, VerticalLineProperties } from './cross-line/crossLineProperties';
 import { CrossLineScene } from './cross-line/crossLineScene';
 import { DisjointChannelProperties } from './disjoint-channel/disjointChannelProperties';
@@ -15,14 +16,6 @@ import { TextProperties } from './text/textProperties';
 import { TextScene } from './text/textScene';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
-
-export type AnnotationProperties =
-    | LineProperties
-    | HorizontalLineProperties
-    | VerticalLineProperties
-    | ParallelChannelProperties
-    | DisjointChannelProperties
-    | TextProperties;
 
 export const annotationDatums: Record<AnnotationType, Constructor<AnnotationProperties>> = {
     // Lines
@@ -92,65 +85,6 @@ export function updateAnnotation(
     }
 }
 
-export function dragStartAnnotation(
-    node: AnnotationScene,
-    datum: AnnotationProperties,
-    context: AnnotationContext,
-    offset: _Util.Vec2
-) {
-    // Lines
-    if (LineProperties.is(datum) && LineScene.is(node)) {
-        node.dragStart(datum, offset, context);
-    }
-
-    if ((HorizontalLineProperties.is(datum) || VerticalLineProperties.is(datum)) && CrossLineScene.is(node)) {
-        node.dragStart(datum, offset, context);
-    }
-
-    // Channels
-    if (DisjointChannelProperties.is(datum) && DisjointChannelScene.is(node)) {
-        node.dragStart(datum, offset, context);
-    }
-
-    if (ParallelChannelProperties.is(datum) && ParallelChannelScene.is(node)) {
-        node.dragStart(datum, offset, context);
-    }
-
-    // Texts
-    // ...
-}
-
-export function dragAnnotation(
-    node: AnnotationScene,
-    datum: AnnotationProperties,
-    context: AnnotationContext,
-    offset: _Util.Vec2,
-    onDragInvalid: () => void
-) {
-    // Lines
-    if (LineProperties.is(datum) && LineScene.is(node)) {
-        node.drag(datum, offset, context, onDragInvalid);
-    }
-
-    if ((HorizontalLineProperties.is(datum) || VerticalLineProperties.is(datum)) && CrossLineScene.is(node)) {
-        node.drag(datum, offset, context, onDragInvalid);
-    }
-
-    // Channels
-    if (DisjointChannelProperties.is(datum) && DisjointChannelScene.is(node)) {
-        node.drag(datum, offset, context, onDragInvalid);
-    }
-
-    if (ParallelChannelProperties.is(datum) && ParallelChannelScene.is(node)) {
-        node.drag(datum, offset, context, onDragInvalid);
-    }
-
-    // Texts
-    if (TextProperties.is(datum) && TextScene.is(node)) {
-        node.drag(datum, offset, context, onDragInvalid);
-    }
-}
-
 export function getTypedDatum(datum: unknown) {
     if (
         // Lines
@@ -165,4 +99,15 @@ export function getTypedDatum(datum: unknown) {
     ) {
         return datum;
     }
+}
+
+export function colorDatum(datum: AnnotationProperties, color: string) {
+    if ('stroke' in datum) datum.stroke = color;
+
+    if ('axisLabel' in datum) {
+        datum.axisLabel.fill = color;
+        datum.axisLabel.stroke = color;
+    }
+
+    if ('background' in datum) datum.background.fill = color;
 }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsConfig.ts
@@ -1,0 +1,168 @@
+import type { _Util } from 'ag-charts-community';
+
+import type { TextInput } from '../text-input/textInput';
+import { type AnnotationContext, AnnotationType } from './annotationTypes';
+import { HorizontalLineProperties, VerticalLineProperties } from './cross-line/crossLineProperties';
+import { CrossLineScene } from './cross-line/crossLineScene';
+import { DisjointChannelProperties } from './disjoint-channel/disjointChannelProperties';
+import { DisjointChannelScene } from './disjoint-channel/disjointChannelScene';
+import { LineProperties } from './line/lineProperties';
+import { LineScene } from './line/lineScene';
+import { ParallelChannelProperties } from './parallel-channel/parallelChannelProperties';
+import { ParallelChannelScene } from './parallel-channel/parallelChannelScene';
+import type { Annotation } from './scenes/annotationScene';
+import { TextProperties } from './text/textProperties';
+import { TextScene } from './text/textScene';
+
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+export type AnnotationProperties =
+    | LineProperties
+    | HorizontalLineProperties
+    | VerticalLineProperties
+    | ParallelChannelProperties
+    | DisjointChannelProperties
+    | TextProperties;
+
+export const annotationDatums: Record<AnnotationType, Constructor<AnnotationProperties>> = {
+    // Lines
+    [AnnotationType.Line]: LineProperties,
+    [AnnotationType.HorizontalLine]: HorizontalLineProperties,
+    [AnnotationType.VerticalLine]: VerticalLineProperties,
+
+    // Channels
+    [AnnotationType.ParallelChannel]: ParallelChannelProperties,
+    [AnnotationType.DisjointChannel]: DisjointChannelProperties,
+
+    // Texts
+    [AnnotationType.Text]: TextProperties,
+};
+
+export const annotationScenes: Record<AnnotationType, Constructor<Annotation>> = {
+    // Lines
+    [AnnotationType.Line]: LineScene,
+    [AnnotationType.HorizontalLine]: CrossLineScene,
+    [AnnotationType.VerticalLine]: CrossLineScene,
+
+    // Channels
+    [AnnotationType.DisjointChannel]: DisjointChannelScene,
+    [AnnotationType.ParallelChannel]: ParallelChannelScene,
+
+    // Texts
+    [AnnotationType.Text]: TextScene,
+};
+
+export function updateAnnotation(
+    node: Annotation,
+    datum: AnnotationProperties,
+    context: AnnotationContext,
+    isActive: boolean,
+    textInput: TextInput
+) {
+    // Lines
+    if (LineProperties.is(datum) && LineScene.is(node)) {
+        node.update(datum, context);
+    }
+
+    if ((HorizontalLineProperties.is(datum) || VerticalLineProperties.is(datum)) && CrossLineScene.is(node)) {
+        node.update(datum, context);
+    }
+
+    // Channels
+    if (DisjointChannelProperties.is(datum) && DisjointChannelScene.is(node)) {
+        node.update(datum, context);
+    }
+
+    if (ParallelChannelProperties.is(datum) && ParallelChannelScene.is(node)) {
+        node.update(datum, context);
+    }
+
+    // Texts
+    if (TextProperties.is(datum) && TextScene.is(node)) {
+        node.update(datum, context);
+
+        if (isActive) {
+            // TODO: remove this from here
+            textInput.setLayout({
+                bbox: node.getTextRect(),
+                position: datum.position,
+                alignment: datum.alignment,
+            });
+        }
+    }
+}
+
+export function dragStartAnnotation(
+    node: Annotation,
+    datum: AnnotationProperties,
+    context: AnnotationContext,
+    offset: _Util.Vec2
+) {
+    // Lines
+    if (LineProperties.is(datum) && LineScene.is(node)) {
+        node.dragStart(datum, offset, context);
+    }
+
+    if ((HorizontalLineProperties.is(datum) || VerticalLineProperties.is(datum)) && CrossLineScene.is(node)) {
+        node.dragStart(datum, offset, context);
+    }
+
+    // Channels
+    if (DisjointChannelProperties.is(datum) && DisjointChannelScene.is(node)) {
+        node.dragStart(datum, offset, context);
+    }
+
+    if (ParallelChannelProperties.is(datum) && ParallelChannelScene.is(node)) {
+        node.dragStart(datum, offset, context);
+    }
+
+    // Texts
+    // ...
+}
+
+export function dragAnnotation(
+    node: Annotation,
+    datum: AnnotationProperties,
+    context: AnnotationContext,
+    offset: _Util.Vec2,
+    onDragInvalid: () => void
+) {
+    // Lines
+    if (LineProperties.is(datum) && LineScene.is(node)) {
+        node.drag(datum, offset, context, onDragInvalid);
+    }
+
+    if ((HorizontalLineProperties.is(datum) || VerticalLineProperties.is(datum)) && CrossLineScene.is(node)) {
+        node.drag(datum, offset, context, onDragInvalid);
+    }
+
+    // Channels
+    if (DisjointChannelProperties.is(datum) && DisjointChannelScene.is(node)) {
+        node.drag(datum, offset, context, onDragInvalid);
+    }
+
+    if (ParallelChannelProperties.is(datum) && ParallelChannelScene.is(node)) {
+        node.drag(datum, offset, context, onDragInvalid);
+    }
+
+    // Texts
+    if (TextProperties.is(datum) && TextScene.is(node)) {
+        node.drag(datum, offset, context, onDragInvalid);
+    }
+}
+
+export function getTypedDatum(datum: unknown) {
+    if (
+        // Lines
+        LineProperties.is(datum) ||
+        HorizontalLineProperties.is(datum) ||
+        VerticalLineProperties.is(datum) ||
+        // Channels
+        DisjointChannelProperties.is(datum) ||
+        ParallelChannelProperties.is(datum) ||
+        // Texts
+        TextProperties.is(datum)
+    ) {
+        return datum;
+    }
+}

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
@@ -1,63 +1,285 @@
 import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
-import type { Point } from './annotationTypes';
-import { AnnotationType } from './annotationTypes';
-import type { AnnotationProperties } from './annotationsConfig';
+import { type AnnotationContext, AnnotationType } from './annotationTypes';
+import { colorDatum } from './annotationsConfig';
+import type { AnnotationProperties, AnnotationsStateMachineContext } from './annotationsSuperTypes';
+import {
+    type CrossLineProperties,
+    HorizontalLineProperties,
+    VerticalLineProperties,
+} from './cross-line/crossLineProperties';
+import { CrossLineScene } from './cross-line/crossLineScene';
 import { CrossLineStateMachine } from './cross-line/crossLineState';
+import { DisjointChannelProperties } from './disjoint-channel/disjointChannelProperties';
+import { DisjointChannelScene } from './disjoint-channel/disjointChannelScene';
 import { DisjointChannelStateMachine } from './disjoint-channel/disjointChannelState';
+import { LineProperties } from './line/lineProperties';
+import { LineScene } from './line/lineScene';
 import { LineStateMachine } from './line/lineState';
+import { ParallelChannelProperties } from './parallel-channel/parallelChannelProperties';
+import { ParallelChannelScene } from './parallel-channel/parallelChannelScene';
 import { ParallelChannelStateMachine } from './parallel-channel/parallelChannelState';
+import { TextProperties } from './text/textProperties';
+import { TextScene } from './text/textScene';
 import { TextStateMachine } from './text/textState';
 
 const { StateMachine } = _ModuleSupport;
 
-type AnnotationEvent = 'click' | 'hover' | 'drag' | 'input' | 'cancel';
+enum States {
+    Idle = 'idle',
+    Dragging = 'dragging',
+}
+type AnnotationEvent =
+    | 'click'
+    | 'hover'
+    | 'drag'
+    | 'dragStart'
+    | 'dragEnd'
+    | 'input'
+    | 'cancel'
+    | 'reset'
+    | 'color'
+    | 'keyDown';
 
-export class AnnotationsStateMachine extends StateMachine<'idle', AnnotationType | AnnotationEvent> {
+export class AnnotationsStateMachine extends StateMachine<
+    States | AnnotationType.Line,
+    AnnotationType | AnnotationEvent
+> {
     override debug = _Util.Debug.create(true, 'annotations');
 
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly
+    private hovered?: number;
+
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly
+    private active?: number;
+
+    constructor(ctx: AnnotationsStateMachineContext) {
+        const getDatum =
+            <T>(is: (value: unknown) => value is T) =>
+            () => {
+                if (this.active == null) return;
+                const datum = ctx.datum(this.active);
+                if (is(datum)) return datum;
+            };
+
+        const getNode =
+            <T>(is: (value: unknown) => value is T) =>
+            () => {
+                if (this.active == null) return;
+                const node = ctx.node(this.active);
+                if (is(node)) return node;
+            };
+
+        const createDatum =
+            <T extends AnnotationProperties>(type: AnnotationType) =>
+            (datum: T) => {
+                ctx.create(type, datum);
+                this.active = ctx.selectLast();
+            };
+
+        super(States.Idle, {
+            [States.Idle]: {
+                onEnter: () => {
+                    ctx.resetToIdle();
+                    ctx.select(this.active);
+                },
+
+                hover: ({ offset }: { offset: _Util.Vec2 }) => {
+                    this.hovered = ctx.hoverAtCoords(offset, this.active);
+                },
+
+                click: () => {
+                    this.active = ctx.select(this.hovered, this.active);
+                },
+
+                drag: {
+                    guard: () => this.hovered != null,
+                    target: States.Idle,
+                    action: () => {
+                        this.active = ctx.select(this.hovered, this.active);
+                    },
+                },
+
+                dragStart: {
+                    guard: () => this.hovered != null,
+                    target: States.Dragging,
+                    action: () => {
+                        this.active = ctx.select(this.hovered, this.active);
+                        ctx.startInteracting();
+                    },
+                },
+
+                color: {
+                    guard: () => this.active != null,
+                    target: States.Idle,
+                    action: (color: string) => {
+                        const datum = ctx.datum(this.active!);
+                        if (!datum) return;
+
+                        colorDatum(datum, color);
+                        ctx.update();
+                    },
+                },
+
+                reset: () => {
+                    if (this.active != null) {
+                        ctx.node(this.active)?.toggleActive(false);
+                    }
+
+                    this.hovered = undefined;
+                    this.active = undefined;
+
+                    ctx.resetToIdle();
+                },
+
+                // Lines
+                [AnnotationType.Line]: new LineStateMachine({
+                    ...ctx,
+                    create: createDatum<LineProperties>(AnnotationType.Line),
+                    datum: getDatum<LineProperties>(LineProperties.is),
+                    node: getNode<LineScene>(LineScene.is),
+                }),
+                [AnnotationType.HorizontalLine]: new CrossLineStateMachine('horizontal', {
+                    ...ctx,
+                    create: createDatum<CrossLineProperties>(AnnotationType.HorizontalLine),
+                    datum: getDatum<HorizontalLineProperties>(HorizontalLineProperties.is),
+                    node: getNode<CrossLineScene>(CrossLineScene.is),
+                }),
+                [AnnotationType.VerticalLine]: new CrossLineStateMachine('vertical', {
+                    ...ctx,
+                    create: createDatum<CrossLineProperties>(AnnotationType.VerticalLine),
+                    datum: getDatum<VerticalLineProperties>(VerticalLineProperties.is),
+                    node: getNode<CrossLineScene>(CrossLineScene.is),
+                }),
+
+                // Channels
+                [AnnotationType.DisjointChannel]: new DisjointChannelStateMachine({
+                    ...ctx,
+                    create: createDatum<DisjointChannelProperties>(AnnotationType.DisjointChannel),
+                    datum: getDatum<DisjointChannelProperties>(DisjointChannelProperties.is),
+                    node: getNode<DisjointChannelScene>(DisjointChannelScene.is),
+                }),
+                [AnnotationType.ParallelChannel]: new ParallelChannelStateMachine({
+                    ...ctx,
+                    create: createDatum<ParallelChannelProperties>(AnnotationType.ParallelChannel),
+                    datum: getDatum<ParallelChannelProperties>(ParallelChannelProperties.is),
+                    node: getNode<ParallelChannelScene>(ParallelChannelScene.is),
+                }),
+
+                // Texts
+                [AnnotationType.Text]: new TextStateMachine({
+                    ...ctx,
+                    create: createDatum<TextProperties>(AnnotationType.Text),
+                    datum: getDatum<TextProperties>(TextProperties.is),
+                    node: getNode<TextScene>(TextScene.is),
+                    showTextInput: () => ctx.showTextInput(this.active),
+                }),
+            },
+
+            [States.Dragging]: {
+                onEnter: (_, data: any) => {
+                    if (this.active == null) return;
+
+                    const type = ctx.getAnnotationType(this.active);
+                    if (!type) return;
+
+                    this.transition(type);
+                    this.transition('dragStart', data);
+                },
+
+                // Lines
+                [AnnotationType.Line]: new DragStateMachine({
+                    ...ctx,
+                    datum: getDatum<LineProperties>(LineProperties.is),
+                    node: getNode<LineScene>(LineScene.is),
+                }),
+
+                [AnnotationType.HorizontalLine]: new DragStateMachine({
+                    ...ctx,
+                    datum: getDatum<HorizontalLineProperties>(HorizontalLineProperties.is),
+                    node: getNode<CrossLineScene>(CrossLineScene.is),
+                }),
+
+                [AnnotationType.VerticalLine]: new DragStateMachine({
+                    ...ctx,
+                    datum: getDatum<VerticalLineProperties>(VerticalLineProperties.is),
+                    node: getNode<CrossLineScene>(CrossLineScene.is),
+                }),
+
+                // Channels
+                [AnnotationType.ParallelChannel]: new DragStateMachine({
+                    ...ctx,
+                    datum: getDatum<ParallelChannelProperties>(ParallelChannelProperties.is),
+                    node: getNode<ParallelChannelScene>(ParallelChannelScene.is),
+                }),
+
+                [AnnotationType.DisjointChannel]: new DragStateMachine({
+                    ...ctx,
+                    datum: getDatum<DisjointChannelProperties>(DisjointChannelProperties.is),
+                    node: getNode<DisjointChannelScene>(DisjointChannelScene.is),
+                }),
+
+                // Texts
+                [AnnotationType.Text]: new DragStateMachine({
+                    ...ctx,
+                    datum: getDatum<TextProperties>(TextProperties.is),
+                    node: getNode<TextScene>(TextScene.is),
+                }),
+            },
+
+            [AnnotationType.Line]: {},
+        });
+    }
+
+    // TODO: remove this leak
+    public getActive() {
+        return this.active;
+    }
+
+    // TODO: remove this leak
+    public isActive(index: Number) {
+        return index === this.active;
+    }
+}
+
+class DragStateMachine<
+    D extends AnnotationProperties,
+    N extends {
+        dragStart?: (datum: D, offset: _Util.Vec2, context: AnnotationContext) => void;
+        drag: (datum: D, offset: _Util.Vec2, context: AnnotationContext) => void;
+        stopDragging: () => void;
+    },
+> extends StateMachine<'idle' | 'dragging', 'drag' | 'dragStart' | 'dragEnd'> {
+    override debug = _Util.Debug.create(true, 'annotations');
     constructor(
-        onEnterIdle: () => void,
-        appendDatum: (type: AnnotationType, datum: AnnotationProperties) => void,
-        onExitSingleClick: () => void,
-        validateChildStateDatumPoint: (point: Point) => boolean,
-        showTextInput: () => void,
-        hideTextInput: () => void
+        ctx: {
+            datum: () => D | undefined;
+            node: () => N | undefined;
+        } & AnnotationsStateMachineContext
     ) {
         super('idle', {
             idle: {
-                onEnter: () => onEnterIdle(),
+                dragStart: {
+                    target: 'dragging',
+                    action: ({ offset, context }) => {
+                        ctx.node()?.dragStart?.(ctx.datum()!, offset, context);
+                    },
+                },
+            },
 
-                // Lines
-                [AnnotationType.Line]: new LineStateMachine((datum) => appendDatum(AnnotationType.Line, datum)),
-                [AnnotationType.HorizontalLine]: new CrossLineStateMachine(
-                    'horizontal',
-                    (datum) => appendDatum(AnnotationType.HorizontalLine, datum),
-                    onExitSingleClick
-                ),
-                [AnnotationType.VerticalLine]: new CrossLineStateMachine(
-                    'vertical',
-                    (datum) => appendDatum(AnnotationType.VerticalLine, datum),
-                    onExitSingleClick
-                ),
+            dragging: {
+                drag: ({ offset, context }) => {
+                    ctx.node()?.drag(ctx.datum()!, offset, context);
+                    ctx.update();
+                },
 
-                // Channels
-                [AnnotationType.DisjointChannel]: new DisjointChannelStateMachine(
-                    (datum) => appendDatum(AnnotationType.DisjointChannel, datum),
-                    validateChildStateDatumPoint
-                ),
-                [AnnotationType.ParallelChannel]: new ParallelChannelStateMachine(
-                    (datum) => appendDatum(AnnotationType.ParallelChannel, datum),
-                    validateChildStateDatumPoint
-                ),
-
-                // Texts
-                [AnnotationType.Text]: new TextStateMachine(
-                    (datum) => appendDatum(AnnotationType.Text, datum),
-                    onExitSingleClick,
-                    showTextInput,
-                    hideTextInput
-                ),
+                dragEnd: {
+                    target: StateMachine.parent,
+                    action: () => {
+                        ctx.node()?.stopDragging();
+                        ctx.stopInteracting();
+                    },
+                },
             },
         });
     }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
@@ -1,0 +1,64 @@
+import { _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
+
+import type { Point } from './annotationTypes';
+import { AnnotationType } from './annotationTypes';
+import type { AnnotationProperties } from './annotationsConfig';
+import { CrossLineStateMachine } from './cross-line/crossLineState';
+import { DisjointChannelStateMachine } from './disjoint-channel/disjointChannelState';
+import { LineStateMachine } from './line/lineState';
+import { ParallelChannelStateMachine } from './parallel-channel/parallelChannelState';
+import { TextStateMachine } from './text/textState';
+
+const { StateMachine } = _ModuleSupport;
+
+type AnnotationEvent = 'click' | 'hover' | 'drag' | 'input' | 'cancel';
+
+export class AnnotationsStateMachine extends StateMachine<'idle', AnnotationType | AnnotationEvent> {
+    override debug = _Util.Debug.create(true, 'annotations');
+
+    constructor(
+        onEnterIdle: () => void,
+        appendDatum: (type: AnnotationType, datum: AnnotationProperties) => void,
+        onExitSingleClick: () => void,
+        validateChildStateDatumPoint: (point: Point) => boolean,
+        showTextInput: () => void,
+        hideTextInput: () => void
+    ) {
+        super('idle', {
+            idle: {
+                onEnter: () => onEnterIdle(),
+
+                // Lines
+                [AnnotationType.Line]: new LineStateMachine((datum) => appendDatum(AnnotationType.Line, datum)),
+                [AnnotationType.HorizontalLine]: new CrossLineStateMachine(
+                    'horizontal',
+                    (datum) => appendDatum(AnnotationType.HorizontalLine, datum),
+                    onExitSingleClick
+                ),
+                [AnnotationType.VerticalLine]: new CrossLineStateMachine(
+                    'vertical',
+                    (datum) => appendDatum(AnnotationType.VerticalLine, datum),
+                    onExitSingleClick
+                ),
+
+                // Channels
+                [AnnotationType.DisjointChannel]: new DisjointChannelStateMachine(
+                    (datum) => appendDatum(AnnotationType.DisjointChannel, datum),
+                    validateChildStateDatumPoint
+                ),
+                [AnnotationType.ParallelChannel]: new ParallelChannelStateMachine(
+                    (datum) => appendDatum(AnnotationType.ParallelChannel, datum),
+                    validateChildStateDatumPoint
+                ),
+
+                // Texts
+                [AnnotationType.Text]: new TextStateMachine(
+                    (datum) => appendDatum(AnnotationType.Text, datum),
+                    onExitSingleClick,
+                    showTextInput,
+                    hideTextInput
+                ),
+            },
+        });
+    }
+}

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsSuperTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsSuperTypes.ts
@@ -1,0 +1,41 @@
+import type { _Util } from 'ag-charts-community';
+
+import { AnnotationType, type Point } from './annotationTypes';
+import { HorizontalLineProperties, VerticalLineProperties } from './cross-line/crossLineProperties';
+import { DisjointChannelProperties } from './disjoint-channel/disjointChannelProperties';
+import { LineProperties } from './line/lineProperties';
+import { ParallelChannelProperties } from './parallel-channel/parallelChannelProperties';
+import type { AnnotationScene } from './scenes/annotationScene';
+import { TextProperties } from './text/textProperties';
+
+export type AnnotationProperties =
+    | LineProperties
+    | HorizontalLineProperties
+    | VerticalLineProperties
+    | ParallelChannelProperties
+    | DisjointChannelProperties
+    | TextProperties;
+
+export interface AnnotationsStateMachineContext {
+    resetToIdle: () => void;
+    hoverAtCoords: (coords: _Util.Vec2, active?: number) => number | undefined;
+    select: (index?: number, previous?: number) => number | undefined;
+    selectLast: () => number;
+
+    startInteracting: () => void;
+    stopInteracting: () => void;
+
+    create: (type: AnnotationType, datum: AnnotationProperties) => void;
+    delete: (index: number) => void;
+    validatePoint: (point: Point) => boolean;
+
+    getAnnotationType: (index: number) => AnnotationType | undefined;
+
+    datum: (index: number) => AnnotationProperties | undefined;
+    node: (index: number) => AnnotationScene | undefined;
+
+    showTextInput: (index?: number) => void;
+    hideTextInput: () => void;
+
+    update: () => void;
+}

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsSuperTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsSuperTypes.ts
@@ -34,7 +34,7 @@ export interface AnnotationsStateMachineContext {
     datum: (index: number) => AnnotationProperties | undefined;
     node: (index: number) => AnnotationScene | undefined;
 
-    showTextInput: (index?: number) => void;
+    showTextInput: (index: number) => void;
     hideTextInput: () => void;
 
     update: () => void;

--- a/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineScene.ts
@@ -1,7 +1,7 @@
 import { _ModuleSupport, type _Scene, _Util } from 'ag-charts-community';
 
 import type { AnnotationAxisContext, AnnotationContext, Coords, LineCoords } from '../annotationTypes';
-import { convert, invertCoords, validateDatumPoint } from '../annotationUtils';
+import { convert, invertCoords } from '../annotationUtils';
 import { AnnotationScene } from '../scenes/annotationScene';
 import { AxisLabelScene } from '../scenes/axisLabelScene';
 import { UnivariantHandle } from '../scenes/handle';
@@ -156,7 +156,7 @@ export class CrossLineScene extends AnnotationScene {
         };
     }
 
-    public drag(datum: CrossLineProperties, target: Coords, context: AnnotationContext, onInvalid: () => void) {
+    public drag(datum: CrossLineProperties, target: Coords, context: AnnotationContext) {
         const { activeHandle, dragState, locked } = this;
 
         if (locked) return;
@@ -173,11 +173,6 @@ export class CrossLineScene extends AnnotationScene {
         }
 
         const point = invertCoords(coords, context);
-
-        if (!validateDatumPoint(context, point)) {
-            onInvalid();
-            return;
-        }
 
         const isHorizontal = HorizontalLineProperties.is(datum);
         datum.set({ value: isHorizontal ? point.y : point.x });

--- a/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineScene.ts
@@ -2,7 +2,7 @@ import { _ModuleSupport, type _Scene, _Util } from 'ag-charts-community';
 
 import type { AnnotationAxisContext, AnnotationContext, Coords, LineCoords } from '../annotationTypes';
 import { convert, invertCoords, validateDatumPoint } from '../annotationUtils';
-import { Annotation } from '../scenes/annotationScene';
+import { AnnotationScene } from '../scenes/annotationScene';
 import { AxisLabelScene } from '../scenes/axisLabelScene';
 import { UnivariantHandle } from '../scenes/handle';
 import { CollidableLine } from '../scenes/shapes';
@@ -11,9 +11,9 @@ import { type CrossLineProperties, HorizontalLineProperties } from './crossLineP
 const { Vec2 } = _Util;
 const { ChartAxisDirection } = _ModuleSupport;
 
-export class CrossLineScene extends Annotation {
+export class CrossLineScene extends AnnotationScene {
     static override is(value: unknown): value is CrossLineScene {
-        return Annotation.isCheck(value, 'cross-line');
+        return AnnotationScene.isCheck(value, 'cross-line');
     }
 
     type = 'cross-line';

--- a/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineState.ts
@@ -36,9 +36,6 @@ export class CrossLineStateMachine extends StateMachine<'start', 'click' | 'canc
                     action: onClick,
                 },
                 cancel: StateMachine.parent,
-                onExit: () => {
-                    ctx.selectLast();
-                },
             },
         });
     }

--- a/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelScene.ts
@@ -55,12 +55,7 @@ export class DisjointChannelScene extends ChannelScene<DisjointChannelProperties
         }
     }
 
-    override dragHandle(
-        datum: DisjointChannelProperties,
-        target: Coords,
-        context: AnnotationContext,
-        onInvalid: () => void
-    ) {
+    override dragHandle(datum: DisjointChannelProperties, target: Coords, context: AnnotationContext) {
         const { activeHandle, handles } = this;
         if (activeHandle == null) return;
 
@@ -133,7 +128,6 @@ export class DisjointChannelScene extends ChannelScene<DisjointChannelProperties
 
         if (!datum.isValidWithContext(context)) {
             datum.set(prev);
-            onInvalid();
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelScene.ts
@@ -2,7 +2,7 @@ import { _Util } from 'ag-charts-community';
 
 import type { AnnotationContext, Coords, LineCoords } from '../annotationTypes';
 import { convertPoint, invertCoords } from '../annotationUtils';
-import { Annotation } from '../scenes/annotationScene';
+import { AnnotationScene } from '../scenes/annotationScene';
 import { ChannelScene } from '../scenes/channelScene';
 import { DivariantHandle, UnivariantHandle } from '../scenes/handle';
 import type { DisjointChannelProperties } from './disjointChannelProperties';
@@ -13,7 +13,7 @@ type ChannelHandle = keyof DisjointChannelScene['handles'];
 
 export class DisjointChannelScene extends ChannelScene<DisjointChannelProperties> {
     static override is(value: unknown): value is DisjointChannelScene {
-        return Annotation.isCheck(value, 'disjoint-channel');
+        return AnnotationScene.isCheck(value, 'disjoint-channel');
     }
 
     type = 'disjoint-channel';

--- a/packages/ag-charts-enterprise/src/features/annotations/line/lineScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/line/lineScene.ts
@@ -92,7 +92,7 @@ export class LineScene extends LinearScene<LineProperties> {
         this.end.toggleActive(active);
     }
 
-    override dragHandle(datum: LineProperties, target: Coords, context: AnnotationContext, onInvalid: () => void) {
+    override dragHandle(datum: LineProperties, target: Coords, context: AnnotationContext) {
         const { activeHandle } = this;
 
         if (!activeHandle) return;
@@ -100,10 +100,7 @@ export class LineScene extends LinearScene<LineProperties> {
         this[activeHandle].toggleDragging(true);
         const point = invertCoords(this[activeHandle].drag(target).point, context);
 
-        if (!validateDatumPoint(context, point)) {
-            onInvalid();
-            return;
-        }
+        if (!validateDatumPoint(context, point)) return;
 
         datum[activeHandle].x = point.x;
         datum[activeHandle].y = point.y;

--- a/packages/ag-charts-enterprise/src/features/annotations/line/lineScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/line/lineScene.ts
@@ -2,7 +2,7 @@ import { _Scene } from 'ag-charts-community';
 
 import type { AnnotationContext, Coords } from '../annotationTypes';
 import { convertLine, invertCoords, validateDatumPoint } from '../annotationUtils';
-import { Annotation } from '../scenes/annotationScene';
+import { AnnotationScene } from '../scenes/annotationScene';
 import { DivariantHandle } from '../scenes/handle';
 import { LinearScene } from '../scenes/linearScene';
 import { CollidableLine } from '../scenes/shapes';
@@ -10,7 +10,7 @@ import type { LineProperties } from './lineProperties';
 
 export class LineScene extends LinearScene<LineProperties> {
     static override is(value: unknown): value is LineScene {
-        return Annotation.isCheck(value, 'line');
+        return AnnotationScene.isCheck(value, 'line');
     }
 
     type = 'line';

--- a/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelScene.ts
@@ -60,12 +60,7 @@ export class ParallelChannelScene extends ChannelScene<ParallelChannelProperties
         }
     }
 
-    override dragHandle(
-        datum: ParallelChannelProperties,
-        target: Coords,
-        context: AnnotationContext,
-        onInvalid: () => void
-    ) {
+    override dragHandle(datum: ParallelChannelProperties, target: Coords, context: AnnotationContext) {
         const { activeHandle, handles } = this;
         if (activeHandle == null) return;
 
@@ -98,7 +93,6 @@ export class ParallelChannelScene extends ChannelScene<ParallelChannelProperties
 
         // Do not move any handles if some of them are trying to move to invalid points
         if (invertedMoves.some((invertedMove) => !validateDatumPoint(context, invertedMove))) {
-            onInvalid();
             return;
         }
 
@@ -132,7 +126,6 @@ export class ParallelChannelScene extends ChannelScene<ParallelChannelProperties
 
         if (!datum.isValidWithContext(context)) {
             datum.set(prev);
-            onInvalid();
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelScene.ts
@@ -2,7 +2,7 @@ import { _Scene, _Util } from 'ag-charts-community';
 
 import type { AnnotationContext, Coords, LineCoords } from '../annotationTypes';
 import { convertPoint, invertCoords, validateDatumPoint } from '../annotationUtils';
-import { Annotation } from '../scenes/annotationScene';
+import { AnnotationScene } from '../scenes/annotationScene';
 import { ChannelScene } from '../scenes/channelScene';
 import { DivariantHandle, UnivariantHandle } from '../scenes/handle';
 import type { ParallelChannelProperties } from './parallelChannelProperties';
@@ -13,7 +13,7 @@ type ChannelHandle = keyof ParallelChannelScene['handles'];
 
 export class ParallelChannelScene extends ChannelScene<ParallelChannelProperties> {
     static override is(value: unknown): value is ParallelChannelScene {
-        return Annotation.isCheck(value, 'parallel-channel');
+        return AnnotationScene.isCheck(value, 'parallel-channel');
     }
 
     type = 'parallel-channel';

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/annotationScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/annotationScene.ts
@@ -4,7 +4,7 @@ import { Handle } from './handle';
 
 const { isObject } = _ModuleSupport;
 
-export abstract class Annotation extends _Scene.Group {
+export abstract class AnnotationScene extends _Scene.Group {
     static isCheck(value: unknown, type: string) {
         return isObject(value) && Object.hasOwn(value, 'type') && value.type === type;
     }

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/linearScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/linearScene.ts
@@ -24,22 +24,17 @@ export abstract class LinearScene<
         };
     }
 
-    public drag(datum: Datum, target: Coords, context: AnnotationContext, onInvalid: () => void) {
+    public drag(datum: Datum, target: Coords, context: AnnotationContext) {
         if (datum.locked) return;
 
         if (this.activeHandle) {
-            this.dragHandle(datum, target, context, onInvalid);
+            this.dragHandle(datum, target, context);
         } else {
             this.dragAll(datum, target, context);
         }
     }
 
-    protected abstract dragHandle(
-        datum: Datum,
-        target: Coords,
-        context: AnnotationContext,
-        onInvalid: () => void
-    ): void;
+    protected abstract dragHandle(datum: Datum, target: Coords, context: AnnotationContext): void;
 
     protected dragAll(datum: Datum, target: Coords, context: AnnotationContext) {
         const { dragState } = this;

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/linearScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/linearScene.ts
@@ -3,13 +3,13 @@ import { _Util } from 'ag-charts-community';
 import type { PointProperties } from '../annotationProperties';
 import type { AnnotationContext, Coords } from '../annotationTypes';
 import { convertPoint, invertCoords } from '../annotationUtils';
-import { Annotation } from './annotationScene';
+import { AnnotationScene } from './annotationScene';
 
 const { Vec2 } = _Util;
 
 export abstract class LinearScene<
     Datum extends { start: Pick<PointProperties, 'x' | 'y'>; end: Pick<PointProperties, 'x' | 'y'>; locked?: boolean },
-> extends Annotation {
+> extends AnnotationScene {
     protected dragState?: {
         offset: Coords;
         start: Coords;

--- a/packages/ag-charts-enterprise/src/features/annotations/text/textProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/text/textProperties.ts
@@ -1,7 +1,8 @@
-import { _ModuleSupport } from 'ag-charts-community';
+import { _ModuleSupport, _Scene } from 'ag-charts-community';
 
 import { Annotation, Font, Handle, Label, PointProperties } from '../annotationProperties';
 import { type AnnotationContext, AnnotationType } from '../annotationTypes';
+import { convertPoint } from '../annotationUtils';
 
 const { STRING, Validate, isObject } = _ModuleSupport;
 
@@ -16,8 +17,8 @@ export class TextProperties extends Annotation(Handle(Label(Font(PointProperties
     @Validate(STRING)
     text!: string;
 
-    position: 'top' | 'center' | 'bottom' = 'bottom';
-    alignment: 'left' | 'center' | 'right' = 'center';
+    position: 'top' | 'center' | 'bottom' = 'top';
+    alignment: 'left' | 'center' | 'right' = 'left';
 
     override isValidWithContext(_context: AnnotationContext, warningPrefix?: string) {
         return super.isValid(warningPrefix);
@@ -25,5 +26,10 @@ export class TextProperties extends Annotation(Handle(Label(Font(PointProperties
 
     override getDefaultColor() {
         return this.color;
+    }
+
+    public getTextBBox(context: AnnotationContext) {
+        const coords = convertPoint(this, context);
+        return new _Scene.BBox(coords.x, coords.y, 0, 0);
     }
 }

--- a/packages/ag-charts-enterprise/src/features/annotations/text/textScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/text/textScene.ts
@@ -35,7 +35,8 @@ export class TextScene extends AnnotationScene {
         this.label.fontSize = datum.fontSize;
         this.label.fontStyle = datum.fontStyle;
         this.label.fontWeight = datum.fontWeight;
-        this.label.textAlign = datum.textAlign;
+        this.label.textAlign = datum.alignment;
+        this.label.textBaseline = datum.position == 'center' ? 'middle' : datum.position;
 
         const handleStyles = {
             fill: datum.handle.fill,
@@ -44,10 +45,14 @@ export class TextScene extends AnnotationScene {
             strokeWidth: datum.handle.strokeWidth,
         };
 
+        let bbox = this.getCachedBBoxWithoutHandles();
+        if (bbox.width === 0 && bbox.height === 0) {
+            bbox = this.computeBBoxWithoutHandles();
+        }
         this.handle.update({
             ...handleStyles,
-            x: coords.x,
-            y: coords.y + DivariantHandle.HANDLE_SIZE,
+            x: coords.x + bbox.width / 2,
+            y: coords.y + bbox.height + DivariantHandle.HANDLE_SIZE,
         });
     }
 
@@ -55,9 +60,10 @@ export class TextScene extends AnnotationScene {
         if (datum.locked || this.activeHandle == null) return;
 
         this.handle.toggleDragging(true);
+        const bbox = this.getCachedBBoxWithoutHandles();
         const offsetTarget = {
-            x: target.x,
-            y: target.y - DivariantHandle.HANDLE_SIZE,
+            x: target.x - bbox.width / 2,
+            y: target.y - (bbox.height + DivariantHandle.HANDLE_SIZE),
         };
         const point = invertCoords(this.handle.drag(offsetTarget).point, context);
 
@@ -82,10 +88,6 @@ export class TextScene extends AnnotationScene {
     override getAnchor() {
         const bbox = this.getCachedBBoxWithoutHandles();
         return { x: bbox.x + bbox.width / 2, y: bbox.y };
-    }
-
-    public getTextRect() {
-        return this.getCachedBBoxWithoutHandles();
     }
 
     override getCursor() {

--- a/packages/ag-charts-enterprise/src/features/annotations/text/textScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/text/textScene.ts
@@ -2,13 +2,13 @@ import { _Scene } from 'ag-charts-community';
 
 import type { AnnotationContext, Coords } from '../annotationTypes';
 import { convertPoint, invertCoords, validateDatumPoint } from '../annotationUtils';
-import { Annotation } from '../scenes/annotationScene';
+import { AnnotationScene } from '../scenes/annotationScene';
 import { DivariantHandle } from '../scenes/handle';
 import type { TextProperties } from './textProperties';
 
-export class TextScene extends Annotation {
+export class TextScene extends AnnotationScene {
     static override is(value: unknown): value is TextScene {
-        return Annotation.isCheck(value, 'text');
+        return AnnotationScene.isCheck(value, 'text');
     }
 
     override type = 'text';

--- a/packages/ag-charts-enterprise/src/features/annotations/text/textScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/text/textScene.ts
@@ -1,7 +1,7 @@
 import { _Scene } from 'ag-charts-community';
 
 import type { AnnotationContext, Coords } from '../annotationTypes';
-import { convertPoint, invertCoords, validateDatumPoint } from '../annotationUtils';
+import { convertPoint, invertCoords } from '../annotationUtils';
 import { AnnotationScene } from '../scenes/annotationScene';
 import { DivariantHandle } from '../scenes/handle';
 import type { TextProperties } from './textProperties';
@@ -51,7 +51,7 @@ export class TextScene extends AnnotationScene {
         });
     }
 
-    public drag(datum: TextProperties, target: Coords, context: AnnotationContext, onInvalid: () => void) {
+    public drag(datum: TextProperties, target: Coords, context: AnnotationContext) {
         if (datum.locked || this.activeHandle == null) return;
 
         this.handle.toggleDragging(true);
@@ -60,11 +60,6 @@ export class TextScene extends AnnotationScene {
             y: target.y - DivariantHandle.HANDLE_SIZE,
         };
         const point = invertCoords(this.handle.drag(offsetTarget).point, context);
-
-        if (!validateDatumPoint(context, point)) {
-            onInvalid();
-            return;
-        }
 
         datum.x = point.x;
         datum.y = point.y;

--- a/packages/ag-charts-enterprise/src/features/annotations/text/textState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/text/textState.ts
@@ -36,9 +36,6 @@ export class TextStateMachine extends StateMachine<'start' | 'edit', 'click' | '
                     action: onClick,
                 },
                 cancel: StateMachine.parent,
-                onExit: () => {
-                    ctx.selectLast();
-                },
             },
             edit: {
                 onEnter: () => {

--- a/packages/ag-charts-enterprise/src/features/annotations/text/textState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/text/textState.ts
@@ -1,28 +1,32 @@
 import { _ModuleSupport, _Util } from 'ag-charts-community';
 
-import type { StateClickEvent, StateInputEvent } from '../annotationTypes';
+import type { Point } from '../annotationTypes';
+import type { AnnotationsStateMachineContext } from '../annotationsSuperTypes';
 import { TextProperties } from './textProperties';
 import type { TextScene } from './textScene';
 
 const { StateMachine } = _ModuleSupport;
 
-export class TextStateMachine extends StateMachine<'start' | 'edit', 'click' | 'cancel' | 'input'> {
+interface TextStateMachineContext extends Omit<AnnotationsStateMachineContext, 'create'> {
+    create: (datum: TextProperties) => void;
+    datum: () => TextProperties | undefined;
+    node: () => TextScene | undefined;
+    showTextInput: () => void;
+}
+
+export class TextStateMachine extends StateMachine<'start' | 'edit', 'click' | 'cancel' | 'keyDown'> {
     override debug = _Util.Debug.create(true, 'annotations');
 
-    constructor(
-        appendDatum: (datum: TextProperties) => void,
-        onExitCreate: () => void,
-        showTextInput: () => void,
-        hideTextInput: () => void
-    ) {
-        const onClick = ({ point }: StateClickEvent<TextProperties, TextScene>) => {
+    constructor(ctx: TextStateMachineContext) {
+        const onClick = ({ point }: { point: Point }) => {
             const datum = new TextProperties();
             datum.set({ x: point.x, y: point.y, text: '' });
-            appendDatum(datum);
+            ctx.create(datum);
         };
 
-        const onInput = ({ datum, value }: StateInputEvent<TextProperties>) => {
-            datum.text = value ?? '';
+        const onInput = ({ value }: { value?: string }) => {
+            ctx.datum()?.set({ text: value ?? '' });
+            ctx.update();
         };
 
         super('start', {
@@ -32,16 +36,23 @@ export class TextStateMachine extends StateMachine<'start' | 'edit', 'click' | '
                     action: onClick,
                 },
                 cancel: StateMachine.parent,
-                onExit: onExitCreate,
+                onExit: () => {
+                    ctx.selectLast();
+                },
             },
             edit: {
-                onEnter: showTextInput,
-                input: {
+                onEnter: () => {
+                    ctx.showTextInput();
+                },
+                keyDown: {
+                    guard: ({ key }: { key: string }) => key === 'Tab',
                     target: StateMachine.parent,
                     action: onInput,
                 },
                 cancel: StateMachine.parent,
-                onExit: hideTextInput,
+                onExit: () => {
+                    ctx.hideTextInput();
+                },
             },
         });
     }

--- a/packages/ag-charts-enterprise/src/features/text-input/textInput.ts
+++ b/packages/ag-charts-enterprise/src/features/text-input/textInput.ts
@@ -38,7 +38,7 @@ export class TextInput extends _ModuleSupport.BaseModuleInstance implements _Mod
     }) {
         this.element.innerHTML = textInputTemplate;
 
-        const textArea = this.element.firstElementChild! as HTMLTextAreaElement;
+        const textArea = this.element.firstElementChild! as HTMLDivElement;
 
         textArea.innerText = opts.text ?? '';
 
@@ -52,6 +52,17 @@ export class TextInput extends _ModuleSupport.BaseModuleInstance implements _Mod
                 : opts.styles?.fontWeight ?? 'inherit';
 
         textArea.focus();
+
+        // Set the cursor to the end of the text
+        if (textArea.lastChild?.textContent != null) {
+            const range = document.createRange();
+            range.setStart(textArea.lastChild, textArea.lastChild.textContent.length);
+            range.setEnd(textArea.lastChild, textArea.lastChild.textContent.length);
+
+            const selection = window.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+        }
 
         textArea.oninput = () => {
             this.updatePosition();
@@ -75,14 +86,14 @@ export class TextInput extends _ModuleSupport.BaseModuleInstance implements _Mod
 
     public getValue() {
         if (!this.element.firstElementChild) return;
-        return (this.element.firstElementChild as HTMLTextAreaElement).innerText;
+        return (this.element.firstElementChild as HTMLDivElement).innerText;
     }
 
     private updatePosition() {
         const { element, layout } = this;
         const { bbox, position, alignment } = layout;
 
-        const textArea = element.firstElementChild as HTMLTextAreaElement | undefined;
+        const textArea = element.firstElementChild as HTMLDivElement | undefined;
 
         const height = textArea?.offsetHeight ?? bbox.height;
         const width = textArea?.offsetWidth ?? bbox.width;
@@ -105,17 +116,14 @@ export class TextInput extends _ModuleSupport.BaseModuleInstance implements _Mod
         switch (alignment) {
             case 'left':
                 element.style.setProperty('left', `${bbox.x}px`);
-                element.style.setProperty('right', 'unset');
                 textArea?.style.setProperty(textAlign, 'left');
                 break;
             case 'center':
                 element.style.setProperty('left', `${bbox.x - width / 2}px`);
-                element.style.setProperty('right', 'unset');
                 textArea?.style.setProperty(textAlign, 'center');
                 break;
             case 'right':
-                element.style.setProperty('left', 'unset');
-                element.style.setProperty('right', `${bbox.x}px`);
+                element.style.setProperty('left', `${bbox.x - width}px`);
                 textArea?.style.setProperty(textAlign, 'right');
                 break;
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12159

Apologies for the size of this PR.

- Refactors the hover, click and drag actions out of `annotations.ts` and into the `AnnotationsStateMachine`, simplifying a lot of the logic and removing much of the need for `state.is('idle')` checks etc.
- Adds text annotation editing. This is the feature that needed the above refactoring.

There are a few `TODO` comments remaining, largely around removing leaky design of the state machine. These are held up by refactoring out this behaviour from annotation toolbar buttons. But this PR is already big enough.