### PR TITLE
AG-12186 - Improve status bar chart type handling.

### DIFF
--- a/packages/ag-charts-enterprise/src/features/status-bar/statusBar.ts
+++ b/packages/ag-charts-enterprise/src/features/status-bar/statusBar.ts
@@ -327,6 +327,13 @@ export class StatusBar
             label = this.positive;
         } else if (labelType === 'negative') {
             label = this.negative;
+        } else if (labelType == null && this.openKey != null && this.closeKey != null) {
+            // Fallback for series without distinct positive/negative items.
+            if (datum[this.openKey] < datum[this.closeKey]) {
+                label = this.positive;
+            } else {
+                label = this.negative;
+            }
         }
 
         for (const { domain, value, key, formatter, style } of this.labels) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12186

Corrects the status bar presentation for line/step-line/HLC/high-low financial chart types.

Additionally fixes the color of status bar text to follow the volume series logic for these series types (previously these were always shown in negative colours).