### PR TITLE
AG-12404 - Fix options update resetting annotations

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -187,7 +187,6 @@ class AgChartsInternal {
             // so we need to remove all queue items up to the last successfully applied item.
             const queueIdx = chartRef.queuedUserOptions.indexOf(userOptions) + 1;
             chartRef.queuedUserOptions.splice(0, queueIdx);
-            chartRef.applyInitialState();
         });
 
         return proxy;

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1,4 +1,5 @@
 import type { AgBaseAxisOptions, AgChartInstance, AgChartOptions } from 'ag-charts-types';
+import type { AgInitialStateOptions } from 'ag-charts-types/src/api/initialStateOptions';
 
 import type { ModuleInstance } from '../module/baseModule';
 import type { LegendModule, RootModule } from '../module/coreModules';
@@ -1209,17 +1210,19 @@ export abstract class Chart extends Observable {
             forceNodeDataRefresh,
         });
         this.update(updateType, { forceNodeDataRefresh, newAnimationBatch: true });
+
+        if (deltaOptions.initialState) {
+            this.applyInitialState(newChartOptions.userOptions.initialState);
+        }
     }
 
-    applyInitialState() {
+    private applyInitialState(initialState?: AgInitialStateOptions) {
         const {
             ctx: { annotationManager, stateManager },
         } = this;
 
-        const options = this.getOptions();
-
-        if (options.initialState?.annotations != null) {
-            const annotations = options.initialState.annotations.map((annotation) => {
+        if (initialState?.annotations != null) {
+            const annotations = initialState.annotations.map((annotation) => {
                 const annotationTheme = annotationManager.getAnnotationTypeStyles(annotation.type);
                 return mergeDefaults(annotation, annotationTheme);
             });

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1,5 +1,4 @@
-import type { AgBaseAxisOptions, AgChartInstance, AgChartOptions } from 'ag-charts-types';
-import type { AgInitialStateOptions } from 'ag-charts-types/src/api/initialStateOptions';
+import type { AgBaseAxisOptions, AgChartInstance, AgChartOptions, AgInitialStateOptions } from 'ag-charts-types';
 
 import type { ModuleInstance } from '../module/baseModule';
 import type { LegendModule, RootModule } from '../module/coreModules';

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -47,7 +47,11 @@ export class Crosshair extends _ModuleSupport.BaseModuleInstance implements _Mod
     private axisLayout?: _ModuleSupport.AxisLayout;
     private labelFormatter?: (value: any) => string;
 
-    private readonly crosshairGroup: _Scene.Group = new Group({ layer: true, zIndex: Layers.SERIES_CROSSHAIR_ZINDEX });
+    private readonly crosshairGroup: _Scene.Group = new Group({
+        name: 'crosshairs',
+        layer: true,
+        zIndex: Layers.SERIES_CROSSHAIR_ZINDEX,
+    });
     protected readonly lineGroup = this.crosshairGroup.appendChild(
         new Group({
             name: `${this.id}-crosshair-lines`,

--- a/packages/ag-charts-types/src/main.ts
+++ b/packages/ag-charts-types/src/main.ts
@@ -1,4 +1,5 @@
 export * from './api/presetOptions';
+export * from './api/initialStateOptions';
 export * from './chart/annotationsOptions';
 export * from './chart/axisOptions';
 export * from './chart/callbackOptions';


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12404

Ignores `initialState` on options update, if there is no change in the `initialState` configuration.