### PR TITLE
AG-12471 Fix escape key handling on annotations

### DIFF
--- a/packages/ag-charts-community/src/util/stateMachine.ts
+++ b/packages/ag-charts-community/src/util/stateMachine.ts
@@ -52,14 +52,6 @@ export class StateMachine<State extends string, Event extends string> {
         this.debug(`%c${this.constructor.name} | init -> ${defaultState}`, debugColor);
     }
 
-    // TODO: make this `protected` to prevent leaky design
-    is(value: any): boolean {
-        if (this.state === StateMachine.child && this.childState) {
-            return this.childState.is(value);
-        }
-        return this.state === value;
-    }
-
     transition(event: Event, data?: any) {
         const shouldTransitionSelf = this.transitionChild(event, data);
 
@@ -121,6 +113,13 @@ export class StateMachine<State extends string, Event extends string> {
         ) {
             this.states[destinationState].onEnter?.(currentState, data);
         }
+    }
+
+    protected is(value: any): boolean {
+        if (this.state === StateMachine.child && this.childState) {
+            return this.childState.is(value);
+        }
+        return this.state === value;
     }
 
     protected resetHierarchy() {

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -947,17 +947,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private cancel() {
-        const { annotationData, state } = this;
-        const active = state.getActive();
-
-        state.transition('cancel');
-
-        // TODO: shift delete into state machine
-        // Delete active annotation if it is in the process of being created
-        if (active != null && annotationData) {
-            annotationData.splice(active, 1);
-            this.update();
-        }
+        this.state.transition('cancel');
     }
 
     private hideOverlays() {

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
@@ -111,6 +111,11 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
                 this.active = ctx.selectLast();
             };
 
+        const deleteDatum = () => {
+            if (this.active != null) ctx.delete(this.active);
+            this.active = ctx.select();
+        };
+
         const dragStateMachine = <
             D extends AnnotationProperties,
             N extends {
@@ -168,10 +173,7 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
         ) => ({
             ...ctx,
             create: createDatum(type),
-            delete: () => {
-                if (this.active != null) ctx.delete(this.active);
-                this.active = ctx.select();
-            },
+            delete: deleteDatum,
             datum: getDatum<T>(isDatum),
             node: getNode<U>(isNode),
             showTextInput: () => {
@@ -294,6 +296,7 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
                 [AnnotationType.Line]: new LineStateMachine({
                     ...ctx,
                     create: createDatum<LineProperties>(AnnotationType.Line),
+                    delete: deleteDatum,
                     datum: getDatum<LineProperties>(LineProperties.is),
                     node: getNode<LineScene>(LineScene.is),
                     guardDragClickDoubleEvent,
@@ -311,6 +314,7 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
                 [AnnotationType.DisjointChannel]: new DisjointChannelStateMachine({
                     ...ctx,
                     create: createDatum<DisjointChannelProperties>(AnnotationType.DisjointChannel),
+                    delete: deleteDatum,
                     datum: getDatum<DisjointChannelProperties>(DisjointChannelProperties.is),
                     node: getNode<DisjointChannelScene>(DisjointChannelScene.is),
                     guardDragClickDoubleEvent,
@@ -318,6 +322,7 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
                 [AnnotationType.ParallelChannel]: new ParallelChannelStateMachine({
                     ...ctx,
                     create: createDatum<ParallelChannelProperties>(AnnotationType.ParallelChannel),
+                    delete: deleteDatum,
                     datum: getDatum<ParallelChannelProperties>(ParallelChannelProperties.is),
                     node: getNode<ParallelChannelScene>(ParallelChannelScene.is),
                     guardDragClickDoubleEvent,

--- a/packages/ag-charts-enterprise/src/features/annotations/states/textualPointState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/textualPointState.ts
@@ -99,7 +99,6 @@ export abstract class TextualPointStateMachine<
                     target: 'waiting-first-render',
                     action: actionCreate,
                 },
-                cancel: StateMachine.parent,
             },
             'waiting-first-render': {
                 render: {
@@ -127,7 +126,6 @@ export abstract class TextualPointStateMachine<
                     target: StateMachine.parent,
                     action: actionSave,
                 },
-                cancel: StateMachine.parent,
                 onExit: onStopEditing,
             },
         });

--- a/packages/ag-charts-enterprise/src/features/annotations/states/textualStartEndState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/textualStartEndState.ts
@@ -131,7 +131,10 @@ export abstract class TextualStartEndStateMachine<
                     target: 'edit',
                     action: onEndClick,
                 },
-                cancel: StateMachine.parent,
+                cancel: {
+                    target: StateMachine.parent,
+                    action: actionCancel,
+                },
             },
             edit: {
                 onEnter: onStartEditing,
@@ -153,7 +156,6 @@ export abstract class TextualStartEndStateMachine<
                     target: StateMachine.parent,
                     action: actionSave,
                 },
-                cancel: StateMachine.parent,
                 onExit: onStopEditing,
             },
         });


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12471

This shifts responsibility for deleting while creating fully into the child state machines, allowing the removal of the leaky `state.is('some state')` check.