### PR TITLE
Revert "AG-12417 Fix comment annotation radius"

### DIFF
--- a/packages/ag-charts-enterprise/src/features/annotations/comment/commentScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/comment/commentScene.ts
@@ -73,7 +73,8 @@ export class CommentScene extends TextualPointScene<CommentProperties> {
 
         const top = y - height;
         const right = x + width;
-        const cornerRadius = height / 2;
+
+        const cornerRadius = Math.min(20, Math.min(width, height) / 2);
 
         const { path } = this.shape;
         path.clear();


### PR DESCRIPTION
This reverts commit a8dc9fe30b97e6806d94d99fff2954ea82f33b5b.

It breaks on tall comments, the previous approach was a better solution.