### PR TITLE
Fix toolbar button border flash

### DIFF
--- a/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbar.ts
@@ -651,6 +651,10 @@ export class Toolbar extends BaseModuleInstance implements ModuleInstance {
         );
         this.updateButton(button, options);
 
+        setTimeout(() => {
+            button.classList.add(styles.modifiers.button.withTransition);
+        }, 1);
+
         this.destroyFns.push(() => button.remove());
 
         return button;

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.css
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.css
@@ -116,10 +116,6 @@
 }
 
 .ag-charts-toolbar__button {
-    /* Using a variable for the transition ensures it is evaluated at the same time as the border color variable,
-       preventing a flash of the default border color on initial render. */
-    --transition: background-color 0.25s ease-in-out, border-color 0.25s ease-in-out, color 0.25s ease-in-out;
-
     align-items: center;
     background: var(--ag-charts-toolbar-background-color);
     border: var(--ag-charts-toolbar-border);
@@ -133,8 +129,17 @@
     padding: var(--ag-charts-toolbar-button-padding);
     pointer-events: all;
     position: relative;
-    transition: var(--transition);
     white-space: nowrap;
+}
+
+/* Applying this class just after the element is created prevents the flash of the default border color on initial
+   render. The border color variable is evaluated after the transition and a fallback value can not be provided as it
+   differs per theme. */
+.ag-charts-toolbar__button--with-transition {
+    transition:
+        background-color 0.25s ease-in-out,
+        border-color 0.25s ease-in-out,
+        color 0.25s ease-in-out;
 }
 
 .ag-charts-toolbar__button[data-toolbar-group='ranges'] {

--- a/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
+++ b/packages/ag-charts-community/src/chart/toolbar/toolbarStyles.ts
@@ -27,9 +27,10 @@ export const modifiers = {
         end: 'ag-charts-toolbar__align--end',
     },
     button: {
-        active: `ag-charts-toolbar__button--active`,
-        hiddenValue: `ag-charts-toolbar__button--hidden-value`,
-        hiddenToggled: `ag-charts-toolbar__button--hidden-toggled`,
-        fillVisible: `ag-charts-toolbar__button--fill-visible`,
+        active: 'ag-charts-toolbar__button--active',
+        hiddenValue: 'ag-charts-toolbar__button--hidden-value',
+        hiddenToggled: 'ag-charts-toolbar__button--hidden-toggled',
+        fillVisible: 'ag-charts-toolbar__button--fill-visible',
+        withTransition: 'ag-charts-toolbar__button--with-transition',
     },
 };


### PR DESCRIPTION
My previous assumption was false, it only appeared correct due to the `align-items` property getting caught in the `--transition` variable definition and blocking all transitions.

The only solution appears to be a hacky js one...