### PR TITLE
AG-11993 Deprecate zoom range/ratio and navigator min/max

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,4 +1,4 @@
-import type { AgZoomOptions } from 'ag-charts-types';
+import type { AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
 import type { MementoOriginator } from '../../api/state/memento';
 import { deepClone } from '../../util/json';
@@ -23,6 +23,13 @@ export interface DefinedZoomState {
     y: ZoomState;
 }
 
+export type ZoomMemento = {
+    rangeX?: AgZoomRange;
+    rangeY?: AgZoomRange;
+    ratioX?: AgZoomRatio;
+    ratioY?: AgZoomRatio;
+};
+
 export interface ZoomChangeEvent extends AxisZoomState {
     type: 'zoom-change';
     callerId: string;
@@ -34,7 +41,7 @@ export interface ZoomPanStartEvent {
     callerId: string;
 }
 
-export interface ZoomRestoreEvent extends Pick<AgZoomOptions, 'rangeX' | 'rangeY' | 'ratioX' | 'ratioY'> {
+export interface ZoomRestoreEvent extends ZoomMemento {
     type: 'restore-zoom';
 }
 
@@ -45,8 +52,6 @@ export type ChartAxisLike = {
 };
 
 type ZoomEvents = ZoomChangeEvent | ZoomPanStartEvent | ZoomRestoreEvent;
-
-export type ZoomMemento = Pick<AgZoomOptions, 'rangeX' | 'rangeY' | 'ratioX' | 'ratioY'>;
 
 /**
  * Manages the current zoom state for a chart. Tracks the requested zoom from distinct dependents

--- a/packages/ag-charts-community/src/chart/navigator/navigator.test.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.test.ts
@@ -8,6 +8,7 @@ import {
     type CartesianTestCase,
     IMAGE_SNAPSHOT_DEFAULTS,
     cartesianChartAssertions,
+    expectWarningsCalls,
     extractImageData,
     prepareTestOptions,
     repeat,
@@ -122,6 +123,11 @@ describe('Navigator', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
                 await example.assertions(chart);
+
+                expectWarningsCalls().toEqual([
+                    ['AG Charts - Property [navigator.min] is deprecated. Use [initialState.zoom.ratioX] instead.'],
+                    ['AG Charts - Property [navigator.max] is deprecated. Use [initialState.zoom.ratioX] instead.'],
+                ]);
             }
         );
 
@@ -140,6 +146,11 @@ describe('Navigator', () => {
 
                 chart = AgCharts.create(options);
                 await compare();
+
+                expectWarningsCalls().toEqual([
+                    ['AG Charts - Property [navigator.min] is deprecated. Use [initialState.zoom.ratioX] instead.'],
+                    ['AG Charts - Property [navigator.max] is deprecated. Use [initialState.zoom.ratioX] instead.'],
+                ]);
             }
         );
     });

--- a/packages/ag-charts-community/src/chart/navigator/navigator.ts
+++ b/packages/ag-charts-community/src/chart/navigator/navigator.ts
@@ -42,6 +42,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
 
     @ActionOnSet<Navigator>({
         newValue(min) {
+            Logger.warnOnce(`Property [navigator.min] is deprecated. Use [initialState.zoom.ratioX] instead.`);
             this._min = min;
             this.updateZoom();
         },
@@ -51,6 +52,7 @@ export class Navigator extends BaseModuleInstance implements ModuleInstance {
 
     @ActionOnSet<Navigator>({
         newValue(max) {
+            Logger.warnOnce(`Property [navigator.max] is deprecated. Use [initialState.zoom.ratioX] instead.`);
             this._max = max;
             this.updateZoom();
         },

--- a/packages/ag-charts-enterprise/src/features/data-source/dataSource.test.ts
+++ b/packages/ag-charts-enterprise/src/features/data-source/dataSource.test.ts
@@ -186,7 +186,7 @@ describe('DataSource', () => {
         it('should load a window at the end', async () => {
             await prepareChart(dataSource, {
                 ...EXAMPLE_OPTIONS,
-                navigator: { min: 0.5, max: 1.0 },
+                initialState: { zoom: { ratioX: { start: 0.5, end: 1.0 } } },
             });
             await response;
             await compare();
@@ -195,7 +195,7 @@ describe('DataSource', () => {
         it('should load a window in the middle', async () => {
             await prepareChart(dataSource, {
                 ...EXAMPLE_OPTIONS,
-                navigator: { min: 0.25, max: 0.75 },
+                initialState: { zoom: { ratioX: { start: 0.25, end: 0.75 } } },
             });
             await response;
             await compare();

--- a/packages/ag-charts-enterprise/src/features/features.test.ts
+++ b/packages/ag-charts-enterprise/src/features/features.test.ts
@@ -5,6 +5,7 @@ import {
     clickAction,
     contextMenuAction,
     dragAction,
+    expectWarningsCalls,
     extractImageData,
     hoverAction,
     scrollAction,
@@ -123,21 +124,73 @@ describe('Feature Combinations', () => {
         it('should init with navigator min/max', async () => {
             await prepareChart({ min: 0.1, max: 0.3 });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [navigator.min] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [navigator.max] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+]
+`);
         });
 
         it('should init with zoom ratio', async () => {
             await prepareChart(undefined, { ratioX: { start: 0.7, end: 0.9 } });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [zoom.ratioX] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [zoom.ratioY] is deprecated. Use [initialState.zoom.ratioY] instead.",
+  ],
+]
+`);
         });
 
         it('should prioritise zoom ratio over navigator min/max', async () => {
             await prepareChart({ min: 0.1, max: 0.3 }, { ratioX: { start: 0.7, end: 0.9 } });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [navigator.min] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [navigator.max] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [zoom.ratioX] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [zoom.ratioY] is deprecated. Use [initialState.zoom.ratioY] instead.",
+  ],
+]
+`);
         });
 
         it('should prioritise zoom range over navigator min/max', async () => {
             await prepareChart({ min: 0.1, max: 0.3 }, { rangeX: { start: 3, end: 6 } });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [navigator.min] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [navigator.max] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [zoom.rangeX] is deprecated. Use [initialState.zoom.rangeX] instead.",
+  ],
+  [
+    "AG Charts - Property [zoom.rangeY] is deprecated. Use [initialState.zoom.rangeY] instead.",
+  ],
+]
+`);
         });
     });
 

--- a/packages/ag-charts-enterprise/src/features/navigator/navigator.test.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigator.test.ts
@@ -5,6 +5,7 @@ import {
     type CartesianTestCase,
     IMAGE_SNAPSHOT_DEFAULTS,
     cartesianChartAssertions,
+    expectWarningsCalls,
     extractImageData,
     setupMockCanvas,
     setupMockConsole,
@@ -107,6 +108,10 @@ const NAVIGATOR_MINICHART_EXAMPLES: Record<string, CartesianTestCase> = {
             },
         },
         assertions: cartesianChartAssertions({ axisTypes: ['number', 'category'], seriesTypes: ['line', 'area'] }),
+        warnings: [
+            ['AG Charts - Property [navigator.min] is deprecated. Use [initialState.zoom.ratioX] instead.'],
+            ['AG Charts - Property [navigator.max] is deprecated. Use [initialState.zoom.ratioX] instead.'],
+        ],
     },
 };
 
@@ -134,6 +139,8 @@ describe('Navigator', () => {
                 chart = AgCharts.create(options);
                 await waitForChartStability(chart);
                 await example.assertions(chart);
+
+                if (example.warnings) expectWarningsCalls().toEqual(example.warnings);
             }
         );
 
@@ -152,6 +159,8 @@ describe('Navigator', () => {
 
                 chart = AgCharts.create(options);
                 await compare();
+
+                if (example.warnings) expectWarningsCalls().toEqual(example.warnings);
             }
         );
     });

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
@@ -6,6 +6,7 @@ import {
     clickAction,
     doubleClickAction,
     dragAction,
+    expectWarningsCalls,
     extractImageData,
     hoverAction,
     scrollAction,
@@ -240,6 +241,16 @@ describe('Zoom', () => {
         it('should start at the given zoom', async () => {
             await prepareChart({ ratioX: { start: 0.2, end: 0.8 }, ratioY: { start: 0.1, end: 0.9 } });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [zoom.ratioX] is deprecated. Use [initialState.zoom.ratioX] instead.",
+  ],
+  [
+    "AG Charts - Property [zoom.ratioY] is deprecated. Use [initialState.zoom.ratioY] instead.",
+  ],
+]
+`);
         });
     });
 
@@ -247,16 +258,40 @@ describe('Zoom', () => {
         it('should start with the given range', async () => {
             await prepareChart({ rangeX: { start: 3, end: 6 }, rangeY: { start: 30, end: 70 } });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [zoom.rangeX] is deprecated. Use [initialState.zoom.rangeX] instead.",
+  ],
+  [
+    "AG Charts - Property [zoom.rangeY] is deprecated. Use [initialState.zoom.rangeY] instead.",
+  ],
+]
+`);
         });
 
         it('should extend the range to the start', async () => {
-            await prepareChart({ rangeX: { start: undefined, end: 6 } });
+            await prepareChart({ rangeX: { end: 6 } });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [zoom.rangeY] is deprecated. Use [initialState.zoom.rangeY] instead.",
+  ],
+]
+`);
         });
 
         it('should extend the range to the end', async () => {
-            await prepareChart({ rangeX: { start: 3, end: undefined } });
+            await prepareChart({ rangeX: { start: 3 } });
             await compare();
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Property [zoom.rangeX] is deprecated. Use [initialState.zoom.rangeX] instead.",
+  ],
+]
+`);
         });
     });
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -148,8 +148,8 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
     public rangeX = new ZoomRange(this.onRangeChange.bind(this, ChartAxisDirection.X));
     public rangeY = new ZoomRange(this.onRangeChange.bind(this, ChartAxisDirection.Y));
 
-    public ratioX = new ZoomRatio(this.onRatioChange.bind(this, ChartAxisDirection.X));
-    public ratioY = new ZoomRatio(this.onRatioChange.bind(this, ChartAxisDirection.Y));
+    public ratioX = new ZoomRatio(this.onRangeChange.bind(this, ChartAxisDirection.X));
+    public ratioY = new ZoomRatio(this.onRangeChange.bind(this, ChartAxisDirection.Y));
 
     // Scenes
     private seriesRect?: _Scene.BBox;
@@ -260,12 +260,6 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const axisId = this.axisIds[direction];
         if (!axisId || !rangeZoom) return;
         this.updateAxisZoom(axisId, direction, rangeZoom);
-    }
-
-    private onRatioChange(direction: _ModuleSupport.ChartAxisDirection, ratioZoom?: DefinedZoomState['x' | 'y']) {
-        const axisId = this.axisIds[direction];
-        if (!axisId || !ratioZoom) return;
-        this.updateAxisZoom(axisId, direction, ratioZoom);
     }
 
     private onDoubleClick(

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -807,19 +807,19 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         const { rangeX, rangeY, ratioX, ratioY } = event;
 
         if (rangeX) {
-            this.rangeX.reset(rangeX.start, rangeX.end);
+            this.rangeX.restore(rangeX.start, rangeX.end);
         }
 
         if (rangeY) {
-            this.rangeY.reset(rangeY.start, rangeY.end);
+            this.rangeY.restore(rangeY.start, rangeY.end);
         }
 
         if (ratioX && !rangeX) {
-            this.ratioX.reset(ratioX.start, ratioX.end);
+            this.ratioX.restore(ratioX.start, ratioX.end);
         }
 
         if (ratioY && !rangeY) {
-            this.ratioY.reset(ratioY.start, ratioY.end);
+            this.ratioY.restore(ratioY.start, ratioY.end);
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomRange.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomRange.ts
@@ -5,7 +5,7 @@ const { Logger } = _Util;
 
 export class ZoomRange {
     @ObserveChanges<ZoomRange>((target, start) => {
-        if (target.initialStart == null) {
+        if (target.initialStart == null && !target.hasRestored) {
             Logger.warnOnce('Property [zoom.rangeX] is deprecated. Use [initialState.zoom.rangeX] instead.');
         }
         target.initialStart ??= start;
@@ -17,7 +17,7 @@ export class ZoomRange {
     public start?: Date | number;
 
     @ObserveChanges<ZoomRange>((target, end) => {
-        if (target.initialEnd == null) {
+        if (target.initialEnd == null && !target.hasRestored) {
             Logger.warnOnce('Property [zoom.rangeY] is deprecated. Use [initialState.zoom.rangeY] instead.');
         }
         target.initialEnd ??= end;
@@ -31,6 +31,7 @@ export class ZoomRange {
     private domain?: Array<Date | number>;
     private initialStart?: Date | number;
     private initialEnd?: Date | number;
+    private hasRestored = false;
 
     constructor(private readonly onChange: (range?: { min: number; max: number }) => void) {}
 
@@ -46,7 +47,9 @@ export class ZoomRange {
         this.domain = domain;
     }
 
-    public reset(start?: Date | number, end?: Date | number) {
+    public restore(start?: Date | number, end?: Date | number) {
+        this.hasRestored = true;
+
         this.initialStart = start;
         this.initialEnd = end;
         this.start = start;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomRange.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomRange.ts
@@ -1,9 +1,13 @@
-import { _ModuleSupport } from 'ag-charts-community';
+import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 const { AND, DATE, NUMBER, OR, ObserveChanges, Validate } = _ModuleSupport;
+const { Logger } = _Util;
 
 export class ZoomRange {
     @ObserveChanges<ZoomRange>((target, start) => {
+        if (target.initialStart == null) {
+            Logger.warnOnce('Property [zoom.rangeX] is deprecated. Use [initialState.zoom.rangeX] instead.');
+        }
         target.initialStart ??= start;
         const range = target.getRangeWithValues(start, target.end);
         if (range) target.onChange?.(range);
@@ -13,9 +17,12 @@ export class ZoomRange {
     public start?: Date | number;
 
     @ObserveChanges<ZoomRange>((target, end) => {
+        if (target.initialEnd == null) {
+            Logger.warnOnce('Property [zoom.rangeY] is deprecated. Use [initialState.zoom.rangeY] instead.');
+        }
         target.initialEnd ??= end;
         const range = target.getRangeWithValues(target.start, end);
-        if (range) target.onChange?.();
+        if (range) target.onChange?.(range);
     })
     // @todo(AG-11069)
     @Validate(AND(OR(DATE, NUMBER) /* GREATER_THAN('start') */), { optional: true })

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomRatio.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomRatio.ts
@@ -7,7 +7,7 @@ const { Logger } = _Util;
 
 export class ZoomRatio {
     @ObserveChanges<ZoomRatio>((target, start) => {
-        if (target.initialStart == null) {
+        if (target.initialStart == null && !target.hasRestored) {
             Logger.warnOnce('Property [zoom.ratioX] is deprecated. Use [initialState.zoom.ratioX] instead.');
         }
         target.initialStart ??= start;
@@ -18,7 +18,7 @@ export class ZoomRatio {
     public start?: number;
 
     @ObserveChanges<ZoomRatio>((target, end) => {
-        if (target.initialEnd == null) {
+        if (target.initialEnd == null && !target.hasRestored) {
             Logger.warnOnce('Property [zoom.ratioY] is deprecated. Use [initialState.zoom.ratioY] instead.');
         }
         target.initialEnd ??= end;
@@ -30,6 +30,7 @@ export class ZoomRatio {
 
     private initialStart?: number;
     private initialEnd?: number;
+    private hasRestored = false;
 
     constructor(private readonly onChange: (ratio?: { min: number; max: number }) => void) {}
 
@@ -41,7 +42,9 @@ export class ZoomRatio {
         return this.getRatioWithValues(this.initialStart, this.initialEnd);
     }
 
-    public reset(start?: number, end?: number) {
+    public restore(start?: number, end?: number) {
+        this.hasRestored = true;
+
         this.initialStart = start;
         this.initialEnd = end;
         this.start = start;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomRatio.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomRatio.ts
@@ -3,9 +3,13 @@ import { _ModuleSupport, _Util } from 'ag-charts-community';
 import { UNIT } from './zoomUtils';
 
 const { AND, GREATER_THAN, LESS_THAN, RATIO, ObserveChanges, Validate } = _ModuleSupport;
+const { Logger } = _Util;
 
 export class ZoomRatio {
     @ObserveChanges<ZoomRatio>((target, start) => {
+        if (target.initialStart == null) {
+            Logger.warnOnce('Property [zoom.ratioX] is deprecated. Use [initialState.zoom.ratioX] instead.');
+        }
         target.initialStart ??= start;
         const ratio = target.getRatioWithValues(start, target.end);
         if (ratio) target.onChange?.(ratio);
@@ -14,6 +18,9 @@ export class ZoomRatio {
     public start?: number;
 
     @ObserveChanges<ZoomRatio>((target, end) => {
+        if (target.initialEnd == null) {
+            Logger.warnOnce('Property [zoom.ratioY] is deprecated. Use [initialState.zoom.ratioY] instead.');
+        }
         target.initialEnd ??= end;
         const ratio = target.getRatioWithValues(target.start, end);
         if (ratio) target.onChange?.(ratio);

--- a/packages/ag-charts-types/src/chart/navigatorOptions.ts
+++ b/packages/ag-charts-types/src/chart/navigatorOptions.ts
@@ -197,9 +197,15 @@ export interface AgNavigatorOptions {
     height?: PixelSize;
     /** The distance between the Navigator and the bottom axis of the chart. */
     spacing?: PixelSize;
-    /** The start of the visible range in the `[0, 1]` interval. */
+    /**
+     * The start of the visible range in the `[0, 1]` interval.
+     * @deprecated v10.2.0 use `initialState.zoom.ratioX` instead.
+     */
     min?: Ratio;
-    /** The end of the visible range in the `[0, 1]` interval. */
+    /**
+     * The end of the visible range in the `[0, 1]` interval.
+     * @deprecated v10.2.0 use `initialState.zoom.ratioX` instead.
+     */
     max?: Ratio;
     /** Configuration for the Navigator's visible range mask. */
     mask?: AgNavigatorMaskOptions;

--- a/packages/ag-charts-types/src/chart/zoomOptions.ts
+++ b/packages/ag-charts-types/src/chart/zoomOptions.ts
@@ -107,13 +107,25 @@ export interface AgZoomOptions {
      * Default: `alt`
      */
     panKey?: AgZoomPanKey;
-    /** The initial x-axis range of the zoom, as values of the axis type. */
+    /**
+     * The initial x-axis range of the zoom, as values of the axis type.
+     * @deprecated v10.2.0 use `initialState.zoom.rangeX` instead.
+     */
     rangeX?: AgZoomRange;
-    /** The initial y-axis range of the zoom, as values of the axis type. */
+    /**
+     * The initial y-axis range of the zoom, as values of the axis type.
+     * @deprecated v10.2.0 use `initialState.zoom.rangeY` instead.
+     */
     rangeY?: AgZoomRange;
-    /** The initial x-axis range of the zoom, as a ratio between 0 to 1. */
+    /**
+     * The initial x-axis range of the zoom, as a ratio between 0 to 1.
+     * @deprecated v10.2.0 use `initialState.zoom.ratioX` instead.
+     */
     ratioX?: AgZoomRatio;
-    /** The initial y-axis range of the zoom, as a ratio between 0 to 1. */
+    /**
+     * The initial y-axis range of the zoom, as a ratio between 0 to 1.
+     * @deprecated v10.2.0 use `initialState.zoom.ratioY` instead.
+     */
     ratioY?: AgZoomRatio;
     /**
      * The amount to zoom when scrolling with the mouse wheel, as a ratio of the full chart.


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11993

Deprecate decorator is intended for renames within the same module, so used a custom warn message.