### PR TITLE
AG-12628 - Fix Node.cachedBBox invalidation on child markDirty().

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -116,7 +116,6 @@ runs:
           uses: actions/setup-node@v4
           with:
               node-version: '20'
-              cache: ${{ inputs.cache_mode != 'none' && !(steps.cache_rw.outputs.cache-hit == 'true' || steps.cache_ro.outputs.cache-hit == 'true') && 'yarn' || '' }}
 
         - name: yarn install
           # if: steps.cache_rw.outputs.cache-hit == 'false' || steps.cache_ro.outputs.cache-hit == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
               id: setup
               uses: ./.github/actions/setup-nx
               with:
-                  cache_mode: ${{ github.event.inputs.clean_checkout == 'true' && 'none' || 'rw' }}
+                  cache_mode: ${{ github.event.inputs.clean_checkout == 'true' && 'off' || 'rw' }}
 
             - name: nx format:check
               id: format

--- a/packages/ag-charts-community/src/scene/node.test.ts
+++ b/packages/ag-charts-community/src/scene/node.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { BBox } from './bbox';
+import { Node, RedrawType } from './node';
+
+class TestNode extends Node {
+    protected override computeBBox(): BBox | undefined {
+        return BBox.merge(this.children.map((c) => c.getBBox()));
+    }
+}
+
+class FixedTestNode extends Node {
+    public constructor(private readonly bbox: BBox) {
+        super();
+    }
+    protected override computeBBox(): BBox | undefined {
+        return this.bbox.clone();
+    }
+}
+
+describe('Node', () => {
+    describe('getBBox()', () => {
+        it('should cache BBox reference from Node.computeBBox()', () => {
+            const bboxRef = BBox.zero.clone().grow(20);
+            const testee = new FixedTestNode(bboxRef);
+            const result = testee.getBBox();
+
+            expect(result).not.toBe(bboxRef);
+            expect(testee.getBBox()).toBe(result);
+        });
+
+        it('should clear BBox reference on markDirty()', () => {
+            const bboxRef = BBox.zero.clone().grow(20);
+            const testee = new FixedTestNode(bboxRef);
+            const result = testee.getBBox();
+
+            expect(result).not.toBe(bboxRef);
+
+            testee.markDirty(testee, RedrawType.TRIVIAL);
+            expect(testee.getBBox()).not.toBe(result);
+        });
+
+        it('should clear BBox reference on 2nd markDirty()', () => {
+            const bboxRef = BBox.zero.clone().grow(20);
+            const testee = new FixedTestNode(bboxRef);
+            testee.getBBox(); // Populate cache.
+            testee.markDirty(testee, RedrawType.TRIVIAL);
+
+            const result = testee.getBBox();
+            testee.markDirty(testee, RedrawType.TRIVIAL);
+            expect(testee.getBBox()).not.toBe(result);
+        });
+
+        describe('with child nodes', () => {
+            it('should clear BBox reference on child add', () => {
+                const bboxRef = BBox.zero.clone().grow(20);
+                const child = new FixedTestNode(bboxRef);
+                const testee = new TestNode();
+
+                const result = testee.getBBox();
+                expect(result).not.toBe(bboxRef);
+                expect(testee.getBBox()).toBe(result);
+
+                testee.appendChild(child);
+                expect(testee.getBBox()).not.toBe(result);
+            });
+
+            it('should clear BBox reference on child remove', () => {
+                const bboxRef = BBox.zero.clone().grow(20);
+                const testee = new TestNode();
+                const child = testee.appendChild(new FixedTestNode(bboxRef));
+
+                const result = testee.getBBox();
+                expect(result).not.toBe(bboxRef);
+                expect(testee.getBBox()).toBe(result);
+
+                testee.removeChild(child);
+                expect(testee.getBBox()).not.toBe(result);
+            });
+
+            it('should clear BBox reference on child markDirty()', () => {
+                const bboxRef = BBox.zero.clone().grow(20);
+                const testee = new TestNode();
+                const child = testee.appendChild(new FixedTestNode(bboxRef));
+
+                const result = testee.getBBox();
+                expect(result).not.toBe(bboxRef);
+                expect(testee.getBBox()).toBe(result);
+
+                child.markDirty(child, RedrawType.TRIVIAL);
+                expect(testee.getBBox()).not.toBe(result);
+            });
+
+            it('should clear BBox reference on child double markDirty()', () => {
+                const bboxRef = BBox.zero.clone().grow(20);
+                const testee = new TestNode();
+                const child = testee.appendChild(new FixedTestNode(bboxRef));
+
+                const result = testee.getBBox();
+                expect(result).not.toBe(bboxRef);
+                expect(testee.getBBox()).toBe(result);
+
+                child.markDirty(child, RedrawType.TRIVIAL);
+                const result2 = testee.getBBox();
+                expect(result2).not.toBe(result);
+
+                child.markDirty(child, RedrawType.TRIVIAL);
+                expect(testee.getBBox()).not.toBe(result);
+                expect(testee.getBBox()).not.toBe(result2);
+            });
+        });
+    });
+});

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -354,15 +354,16 @@ export abstract class Node extends ChangeDetectable {
     }
 
     override markDirty(_source: Node, type = RedrawType.TRIVIAL, parentType = type) {
+        const _dirty = this._dirty;
         // Short-circuit case to avoid needing to percolate all dirty flag changes if redundant.
-        const dirtyTypeBelowHighWatermark = this._dirty > type || (this._dirty === type && type === parentType);
+        const dirtyTypeBelowHighWatermark = _dirty > type || (_dirty === type && type === parentType);
         // If parent node cached a bbox previously, this node will have a cached bbox too. Therefore
         // if this node has no cached bbox, we don't need to force clearing of parents cached bbox.
         const noParentCachedBBox = this.cachedBBox == null;
         if (noParentCachedBBox && dirtyTypeBelowHighWatermark) return;
 
         this.cachedBBox = undefined;
-        this._dirty = type;
+        this._dirty = Math.max(_dirty, type);
         if (this.parent) {
             this.parent.markDirty(this, parentType);
         } else if (this.layerManager) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12628