### PR TITLE
AG-12307 - Fix API pages top header for ALL API pages

### DIFF
--- a/packages/ag-charts-website/src/components/top-bar/ApiTopBar.module.scss
+++ b/packages/ag-charts-website/src/components/top-bar/ApiTopBar.module.scss
@@ -1,5 +1,10 @@
 @use 'design-system' as *;
 
+// Defined at :root as it's also used by ApiReferencePage .container
+:root {
+    --tab-bar-height: 52px;
+}
+
 .toolbar {
     width: 100%;
     position: relative;

--- a/packages/ag-charts-website/src/layouts/APIViewLayout.astro
+++ b/packages/ag-charts-website/src/layouts/APIViewLayout.astro
@@ -18,10 +18,6 @@ const { title, description } = Astro.props;
 <style lang="scss">
     @use 'design-system' as *;
 
-    :global(.mainContainer) {
-        --tab-bar-height: 52px;
-    }
-
     .container {
         --horizontal-padding: max(calc((100vw - var(--max-page-width)) / 2), var(--horizontal-margin));
         --menu-width: 14rem;


### PR DESCRIPTION
Fix an issue where Events API, Download API, & State API pages tab bar did not have correct height. 