### PR TITLE
Fix Angular test timeouts by waiting for networkidle.

### DIFF
--- a/packages/ag-charts-website/e2e/examples.spec.ts
+++ b/packages/ag-charts-website/e2e/examples.spec.ts
@@ -167,12 +167,13 @@ test.describe('examples', () => {
                 test.describe(`Example ${pagePath}: ${example}${affected ? '' : ' (!!!SKIPPED!!!)'}`, () => {
                     if (status === 'ok') {
                         testFn(`should load ${url}`, async ({ page }) => {
-                            test.slow(framework === 'angular', 'allow more time for Angular load times');
+                            const slow = framework === 'angular';
+                            test.slow(slow, 'allow more time for Angular load times');
 
                             config.ignoreConsoleWarnings = ignoreConsoleWarnings;
 
                             // Load example and wait for things to settle.
-                            await gotoExample(page, url);
+                            await gotoExample(page, url, slow);
 
                             // Check we're dealing with a single canvas, otherwise things get tricky!
                             const canvases = await page.locator('.ag-charts-wrapper').all();

--- a/packages/ag-charts-website/e2e/examples.spec.ts
+++ b/packages/ag-charts-website/e2e/examples.spec.ts
@@ -167,13 +167,12 @@ test.describe('examples', () => {
                 test.describe(`Example ${pagePath}: ${example}${affected ? '' : ' (!!!SKIPPED!!!)'}`, () => {
                     if (status === 'ok') {
                         testFn(`should load ${url}`, async ({ page }) => {
-                            const slow = framework === 'angular';
-                            test.slow(slow, 'allow more time for Angular load times');
+                            test.slow(framework === 'angular', 'allow more time for Angular load times');
 
                             config.ignoreConsoleWarnings = ignoreConsoleWarnings;
 
                             // Load example and wait for things to settle.
-                            await gotoExample(page, url, slow);
+                            await gotoExample(page, url);
 
                             // Check we're dealing with a single canvas, otherwise things get tricky!
                             const canvases = await page.locator('.ag-charts-wrapper').all();

--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -85,16 +85,17 @@ export function setupIntrinsicAssertions() {
     return config;
 }
 
-export async function gotoExample(page: Page, url: string) {
+export async function gotoExample(page: Page, url: string, slow = false) {
     await page.goto(url);
-    await page.waitForLoadState('domcontentloaded');
+    await page.waitForLoadState('networkidle');
 
     expect(await page.title()).not.toMatch(/Page Not Found/);
 
     // Wait for synchronous JS execution to complete before we start waiting
     // for <canvas/> to appear.
     await page.evaluate(() => 1);
-    await expect(page.locator('canvas').first()).toBeVisible();
+    const timeout = slow ? 30_000 : 10_000;
+    await expect(page.locator('canvas').first()).toBeVisible({ timeout });
     for (const elements of await page.locator('canvas').all()) {
         await expect(elements).toBeVisible();
     }

--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -85,7 +85,7 @@ export function setupIntrinsicAssertions() {
     return config;
 }
 
-export async function gotoExample(page: Page, url: string, slow = false) {
+export async function gotoExample(page: Page, url: string) {
     await page.goto(url);
     await page.waitForLoadState('networkidle');
 
@@ -94,8 +94,7 @@ export async function gotoExample(page: Page, url: string, slow = false) {
     // Wait for synchronous JS execution to complete before we start waiting
     // for <canvas/> to appear.
     await page.evaluate(() => 1);
-    const timeout = slow ? 30_000 : 10_000;
-    await expect(page.locator('canvas').first()).toBeVisible({ timeout });
+    await expect(page.locator('canvas').first()).toBeVisible();
     for (const elements of await page.locator('canvas').all()) {
         await expect(elements).toBeVisible();
     }

--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -94,7 +94,7 @@ export async function gotoExample(page: Page, url: string) {
     // Wait for synchronous JS execution to complete before we start waiting
     // for <canvas/> to appear.
     await page.evaluate(() => 1);
-    await expect(page.locator('canvas').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('canvas').first()).toBeVisible();
     for (const elements of await page.locator('canvas').all()) {
         await expect(elements).toBeVisible();
     }


### PR DESCRIPTION
Attempt to fix Angular test timeouts such as:
https://github.com/ag-grid/ag-charts/actions/runs/10525125785/job/29163488654#step:5:44