### PR TITLE
AG-12635 - Fix documentation archive for legacy charts website

### DIFF
--- a/external/ag-website-shared/src/components/documentation-archive/DocumentationArchive.astro
+++ b/external/ag-website-shared/src/components/documentation-archive/DocumentationArchive.astro
@@ -2,6 +2,8 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import styles from './DocumentationArchive.module.scss';
 import type { Library } from '@ag-grid-types';
+import { pathJoin } from '@utils/pathJoin';
+import { PRODUCTION_GRID_SITE_URL, LEGACY_CHARTS_SITE_URL, PRODUCTION_CHARTS_SITE_URL } from '@constants';
 
 interface Props {
     site: Library;
@@ -10,9 +12,7 @@ interface Props {
 
 const { site, versionsData } = Astro.props as Props;
 
-const baseUrl = site === 'Grid' ? 'https://www.ag-grid.com/' : 'https://ag-grid.com/charts/';
-
-const removeDay = (date) => {
+const removeDay = (date: string) => {
     const splitDate = date.split(' ');
 
     if (splitDate.length < 3) return date;
@@ -20,7 +20,7 @@ const removeDay = (date) => {
     return `${splitDate[0]} ${splitDate[2]}`;
 };
 
-const getVersionType = (version) => {
+const getVersionType = (version: string) => {
     const [_, minor, patch] = version.split('.');
 
     if (patch !== '0') {
@@ -32,8 +32,30 @@ const getVersionType = (version) => {
     }
 };
 
-const isMajor = (version) => {
+const isMajor = (version: string) => {
     return getVersionType(version) === 'Major';
+};
+
+const getArchiveUrl = (version: string) => {
+    const archiveBaseUrl = '/archive';
+    const [versionMajor, versionMinor] = version.split('.');
+    const major = parseInt(versionMajor, 10);
+    const minor = parseInt(versionMinor, 10);
+
+    let baseUrl = 'https://www.ag-grid.com';
+    if (site === 'charts') {
+        baseUrl = (major === 10 && minor >= 1) || major > 10 ? PRODUCTION_CHARTS_SITE_URL : LEGACY_CHARTS_SITE_URL;
+    }
+
+    return pathJoin(baseUrl, archiveBaseUrl, version);
+};
+
+const getChangelogUrl = (version: string) => {
+    const changelogBaseUrl = `/changelog/?fixVersion=${version}`;
+
+    const baseUrl = site === 'charts' ? PRODUCTION_CHARTS_SITE_URL : PRODUCTION_GRID_SITE_URL;
+
+    return pathJoin(baseUrl, changelogBaseUrl);
 };
 ---
 
@@ -43,29 +65,29 @@ const isMajor = (version) => {
 
     <table class={styles.archiveTable}>
         {
-            versionsData.slice(1).map((versionInfo) => {
-                if (versionInfo.noArchive) return;
+            versionsData.slice(1).map(({ noArchive, version, versionType, date }) => {
+                if (noArchive) return;
 
                 return (
                     <tr>
-                        <td class="text-base text-monospace text-semibold">{versionInfo.version}</td>
+                        <td class="text-base text-monospace text-semibold">{version}</td>
 
-                        <td>{removeDay(versionInfo.date)}</td>
+                        <td>{removeDay(date)}</td>
 
                         <td>
-                            <span class={isMajor(versionInfo.version) ? styles.major : undefined}>
-                                {versionInfo.versionType || getVersionType(versionInfo.version)}
+                            <span class={isMajor(version) ? styles.major : undefined}>
+                                {versionType || getVersionType(version)}
                             </span>
                         </td>
 
                         <td>
-                            <a href={`${baseUrl}changelog/?fixVersion=${versionInfo.version}`}>
+                            <a href={getChangelogUrl(version)}>
                                 Changelog <Icon name="arrowRight" />
                             </a>
                         </td>
 
                         <td>
-                            <a href={`${baseUrl}archive/${versionInfo.version}/`}>
+                            <a href={getArchiveUrl(version)}>
                                 Documentation <Icon name="arrowRight" />
                             </a>
                         </td>

--- a/packages/ag-charts-website/src/constants.ts
+++ b/packages/ag-charts-website/src/constants.ts
@@ -85,6 +85,8 @@ export const ASTRO_ALGOLIA_APP_ID = import.meta.env?.PUBLIC_ASTRO_ALGOLIA_APP_ID
 
 export const ASTRO_ALGOLIA_SEARCH_KEY = import.meta.env?.PUBLIC_ASTRO_ALGOLIA_SEARCH_KEY;
 
+export const PRODUCTION_GRID_SITE_URL = 'https://ag-grid.com';
+
 function calculateGridUrl() {
     if (SITE_URL == null) return;
 
@@ -93,12 +95,15 @@ function calculateGridUrl() {
     } else if (SITE_URL?.includes(STAGING_SITE_URL)) {
         return 'https://grid-staging.ag-grid.com';
     }
-    return 'https://ag-grid.com';
+    return PRODUCTION_GRID_SITE_URL;
 }
 
 export const GRID_URL = calculateGridUrl();
 
 export const GALLERY_IMAGE_DPR_ENHANCEMENT = import.meta.env?.PUBLIC_GALLERY_IMAGE_DPR_ENHANCEMENT === 'true';
+
+export const PRODUCTION_CHARTS_SITE_URL = 'https://ag-grid.com/charts';
+export const LEGACY_CHARTS_SITE_URL = 'https://charts.ag-grid.com';
 
 /*
  * Charts URL
@@ -111,6 +116,6 @@ function getChartsUrl() {
     } else if (SITE_URL?.includes(STAGING_SITE_URL)) {
         return 'https://charts-staging.ag-grid.com';
     }
-    return 'https://ag-grid.com/charts';
+    return PRODUCTION_CHARTS_SITE_URL;
 }
 export const CHARTS_SITE_URL = getChartsUrl();

--- a/packages/ag-charts-website/src/pages/documentation-archive.astro
+++ b/packages/ag-charts-website/src/pages/documentation-archive.astro
@@ -28,6 +28,6 @@ const versionsData: any[] = versionsContent ? versionsContent.data : [];
     <div class:list={['contentViewport layout-grid']}>
         <PagesNavigationFromLocalStorage client:load menuData={menuEntry.data} pageName={pageName} />
 
-        <DocumentationArchive site="Charts" versionsData={versionsData} />
+        <DocumentationArchive site="charts" versionsData={versionsData} />
     </div>
 </Layout>


### PR DESCRIPTION
Rules:

* `10.1.0` and above, go to https://ag-grid.com/charts/archive/
* pre `10.1.0` , go to https://charts.ag-grid.com/archive/