### PR TITLE
AG-NONE Partially revert PR #2353

### DIFF
--- a/packages/ag-charts-community/src/scene/scene.ts
+++ b/packages/ag-charts-community/src/scene/scene.ts
@@ -44,6 +44,14 @@ export class Scene {
         return this.pendingSize?.[1] ?? this.canvas.height;
     }
 
+    /** @deprecated v10.2.0 Only used by AG Grid Sparklines */
+    setContainer(value: HTMLElement) {
+        const { element } = this.canvas;
+        element.parentElement?.removeChild(element);
+        value.appendChild(element);
+        return this;
+    }
+
     setRoot(node: Node | null) {
         if (this.root === node) {
             return this;


### PR DESCRIPTION
This PR restores `Scene.setContainer(value: HTMLElement)` to fix an impending AG Grid Sparkline breakage