### PR TITLE
AG-12686 Partially revert 2c70a83a09883bf9c5cf2ef6874cd8a1e56ed6a2

### DIFF
--- a/packages/ag-charts-enterprise/src/features/color-picker/colorPickerStyles.css
+++ b/packages/ag-charts-enterprise/src/features/color-picker/colorPickerStyles.css
@@ -54,7 +54,10 @@
 
 .ag-charts-color-picker__palette:focus-visible::after {
     outline: var(--ag-charts-focus-border);
-    box-shadow: var(--ag-charts-focus-box-shadow);
+    box-shadow:
+        var(--box-shadow),
+        0 0 0 2px #fff8,
+        var(--ag-charts-focus-border-shadow);
 }
 
 .ag-charts-color-picker__hue-input,


### PR DESCRIPTION
This fixes the focus indicator on the color picker's 2D thumb.

See
* commit 2c70a83a09883bf9c5cf2ef6874cd8a1e56ed6a2
* https://ag-grid.atlassian.net/browse/AG-12686