### PR TITLE
AG-12437 - Extract out childPropertiesButton to new component (2nd attempt)

### DIFF
--- a/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
+++ b/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
@@ -240,6 +240,43 @@ a.metaValue {
     transform: rotate(180deg);
 }
 
+.childButton {
+    color: color-mix(in srgb, var(--color-fg-secondary), var(--color-bg-primary) 20%);
+    font-weight: var(--text-regular);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: $spacing-size-2;
+
+    .childButtonName {
+        font-family: var(--text-monospace-font-family);
+        font-weight: var(--text-semibold);
+        font-size: var(--text-fs-sm);
+    }
+
+    &:hover {
+        color: var(--color-text-primary);
+    }
+
+    &::before {
+        content: '';
+        display: inline-block;
+        width: 0px;
+        height: 0px;
+        border-style: solid;
+        border-width: 0 6px 8px 6px;
+        border-color: transparent transparent color-mix(in srgb, var(--color-fg-secondary), var(--color-bg-primary) 50%)
+            transparent;
+        transform: rotate(90deg);
+        transition: transform 0.25s ease-in-out;
+    }
+
+    &.isExpanded::before {
+        transform: rotate(180deg);
+        transition: transform 0.25s ease-in-out;
+    }
+}
+
 button.seeMore {
     color: var(--color-link);
     justify-content: center;
@@ -338,24 +375,6 @@ button.seeMore {
 
 .isChildProp {
     border-top: 1px dashed var(--color-util-gray-200);
-
-    .name {
-        font-size: calc(var(--text-fs-base) * 0.92);
-    }
-
-    .description p,
-    .description ul,
-    .actions button {
-        font-size: calc(var(--text-fs-base) * 0.9);
-    }
-
-    .description code {
-        font-size: calc(var(--text-fs-base) * 0.8125);
-    }
-
-    .metaValue {
-        font-size: calc(var(--text-fs-sm) * 0.92);
-    }
 }
 
 @container (max-width: #{$breakpoint-table-small}) {

--- a/packages/ag-charts-website/src/features/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/ApiReference.tsx
@@ -29,6 +29,7 @@ import {
 } from '../apiReferenceHelpers';
 import { SelectionContext } from './OptionsNavigation';
 import { type CollapsibleType, PropertyTitle, PropertyType } from './Properties';
+import { ChildPropertiesButton } from './Properties';
 
 export const ApiReferenceContext = createContext<ApiReferenceType | undefined>(undefined);
 export const ApiReferenceConfigContext = createContext<ApiReferenceConfig>({});
@@ -135,6 +136,7 @@ export function ApiReference({
                         Properties available on the <code>{id}</code> interface.
                     </p>
                 ))}
+
             <div className={classnames(styles.reference, styles.apiReference, 'no-zebra')}>
                 <div>
                     {processMembers(interfaceRef, config).map((member) => (
@@ -259,6 +261,9 @@ function ApiReferenceRow({
                     <Markdown remarkPlugins={[remarkBreaks]} urlTransform={(url: string) => urlWithBaseUrl(url)}>
                         {member.docs?.join('\n')}
                     </Markdown>
+                    {collapsibleType === 'childrenProperties' && (
+                        <ChildPropertiesButton name={memberName} isExpanded={isExpanded} onClick={onDetailsToggle} />
+                    )}
                 </div>
                 {nestedPath && (
                     <div className={styles.actions}>

--- a/packages/ag-charts-website/src/features/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/ApiReference.tsx
@@ -29,7 +29,6 @@ import {
 } from '../apiReferenceHelpers';
 import { SelectionContext } from './OptionsNavigation';
 import { type CollapsibleType, PropertyTitle, PropertyType } from './Properties';
-import { ChildPropertiesButton } from './Properties';
 
 export const ApiReferenceContext = createContext<ApiReferenceType | undefined>(undefined);
 export const ApiReferenceConfigContext = createContext<ApiReferenceConfig>({});
@@ -96,6 +95,31 @@ export function ApiReferenceWithReferenceContext(props: ApiReferenceOptions & Ap
         <ApiReferenceContext.Provider value={reference}>
             <ApiReference {...props} />
         </ApiReferenceContext.Provider>
+    );
+}
+
+export function ChildPropertiesButton({
+    name,
+    isExpanded,
+    onClick,
+}: {
+    name: string;
+    isExpanded?: boolean;
+    onClick?: () => void;
+    collapsibleType?: CollapsibleType;
+}) {
+    return (
+        <button
+            className={classnames(styles.childButton, 'button-style-none', {
+                [styles.isExpanded]: isExpanded,
+            })}
+            onClick={onClick}
+            aria-label={`See child properties of ${name}`}
+        >
+            <span>
+                See child properties of <span className={styles.childButtonName}>{name}</span>
+            </span>
+        </button>
     );
 }
 

--- a/packages/ag-charts-website/src/features/api-documentation/components/Properties.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/Properties.tsx
@@ -61,13 +61,9 @@ function CollapsibleButton({
     onClick?: () => void;
     collapsibleType?: CollapsibleType;
 }) {
-    const isCollapsible = collapsibleType === 'childrenProperties' || collapsibleType === 'code';
-
-    if (!isCollapsible) {
-        return;
+    if (collapsibleType !== 'code') {
+        return null;
     }
-
-    const iconName: IconName = collapsibleType === 'childrenProperties' ? 'arrowDown' : 'chevronDown';
 
     return (
         <button
@@ -77,11 +73,36 @@ function CollapsibleButton({
             onClick={onClick}
             aria-label={`See more details about ${name}`}
         >
-            <Icon className={`${styles.chevron} ${isExpanded ? 'expandedIcon' : ''}`} name={iconName} />
+            <Icon className={`${styles.chevron} ${isExpanded ? 'expandedIcon' : ''}`} name="chevronDown" />
         </button>
     );
 }
 
+export function ChildPropertiesButton({
+    name,
+    isExpanded,
+    onClick,
+    collapsibleType,
+}: {
+    name: string;
+    isExpanded?: boolean;
+    onClick?: () => void;
+    collapsibleType?: CollapsibleType;
+}) {
+    return (
+        <button
+            className={classnames(styles.childButton, 'button-style-none', {
+                [styles.isExpanded]: isExpanded,
+            })}
+            onClick={onClick}
+            aria-label={`See child properties of ${name}`}
+        >
+            <span>
+                See child properties of <span className={styles.childButtonName}>{name}</span>
+            </span>
+        </button>
+    );
+}
 export function PropertyType({
     name,
     type,

--- a/packages/ag-charts-website/src/features/api-documentation/components/Properties.tsx
+++ b/packages/ag-charts-website/src/features/api-documentation/components/Properties.tsx
@@ -1,4 +1,4 @@
-import { Icon, type IconName } from '@ag-website-shared/components/icon/Icon';
+import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { LinkIcon } from '@ag-website-shared/components/link-icon/LinkIcon';
 import styles from '@ag-website-shared/components/reference-documentation/ApiReference.module.scss';
 import { useScrollToAnchor } from '@ag-website-shared/utils/navigation';
@@ -50,7 +50,7 @@ export function PropertyNamePrefix({
     );
 }
 
-function CollapsibleButton({
+function CodeCollapsibleButton({
     name,
     isExpanded,
     onClick,
@@ -78,31 +78,6 @@ function CollapsibleButton({
     );
 }
 
-export function ChildPropertiesButton({
-    name,
-    isExpanded,
-    onClick,
-    collapsibleType,
-}: {
-    name: string;
-    isExpanded?: boolean;
-    onClick?: () => void;
-    collapsibleType?: CollapsibleType;
-}) {
-    return (
-        <button
-            className={classnames(styles.childButton, 'button-style-none', {
-                [styles.isExpanded]: isExpanded,
-            })}
-            onClick={onClick}
-            aria-label={`See child properties of ${name}`}
-        >
-            <span>
-                See child properties of <span className={styles.childButtonName}>{name}</span>
-            </span>
-        </button>
-    );
-}
 export function PropertyType({
     name,
     type,
@@ -125,7 +100,7 @@ export function PropertyType({
     return (
         <div className={styles.metaItem}>
             <div className={styles.metaRow}>
-                <CollapsibleButton
+                <CodeCollapsibleButton
                     name={name}
                     isExpanded={isExpanded}
                     onClick={onCollapseClick!}


### PR DESCRIPTION
Applying https://github.com/ag-grid/ag-charts/pull/2388 again due to bad merge commit.