### PR TITLE
AG-12486 QA Feedback

### DIFF
--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -354,6 +354,7 @@ export class Legend extends BaseProperties {
             orientation: this.getOrientation(),
             buttons,
         });
+        this.proxyLegendToolbar.ariaHidden = (buttons.length === 0).toString();
     }
 
     public onMarkerShapeChange() {
@@ -754,10 +755,12 @@ export class Legend extends BaseProperties {
                     focusable: new NodeRegionBBoxProvider(this.pagination.nextButton),
                     onclick: () => this.pagination.clickNext(),
                 });
+                this.proxyLegendPagination.ariaHidden = 'false';
             } else {
                 this.proxyNextButton?.remove();
                 this.proxyPrevButton?.remove();
                 [this.proxyNextButton, this.proxyPrevButton] = [undefined, undefined];
+                this.proxyLegendPagination.ariaHidden = 'true';
             }
         }
 

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -327,7 +327,6 @@ export class Legend extends BaseProperties {
                 id: `ag-charts-legend-item-${i}`,
                 textContent: this.getItemAriaText(i),
                 ariaChecked: !!markerLabel.datum.enabled,
-                ariaRoleDescription: { id: 'ariaRoleDescriptionLegendItem' },
                 ariaDescribedBy: this.proxyLegendItemDescription.id,
                 parent: this.proxyLegendToolbar,
                 focusable: new NodeRegionBBoxProvider(markerLabel),
@@ -1234,10 +1233,13 @@ export class Legend extends BaseProperties {
     private getItemAriaText(nodeIndex: number): string {
         const datum = this.data[nodeIndex];
         const label = datum && this.getItemLabel(datum);
+        const lm = this.ctx.localeManager;
         if (nodeIndex >= 0 && label) {
-            return label;
+            const index = nodeIndex + 1;
+            const count = this.data.length;
+            return lm.t('ariaLabelLegendItem', { label, index, count });
         }
-        return this.ctx.localeManager.t('ariaLabelLegendItemUnknown');
+        return lm.t('ariaLabelLegendItemUnknown');
     }
 
     private getItemAriaDescription(): string {

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -335,7 +335,6 @@ export class Legend extends BaseProperties {
                 // using Series.getLegendData(). But the scene node will stay the same.
                 onclick: () => {
                     this.doClick(markerLabel.datum, markerLabel.proxyButton?.button);
-                    markerLabel.proxyButton!.button.ariaChecked = (!!markerLabel.datum.enabled).toString();
                 },
                 onblur: () => this.handleLegendMouseExit(),
                 onfocus: () => {

--- a/packages/ag-charts-community/src/dom/proxyInteractionService.ts
+++ b/packages/ag-charts-community/src/dom/proxyInteractionService.ts
@@ -58,7 +58,6 @@ type ProxyMeta = {
         params: InteractParams<'listswitch'> & {
             readonly textContent: string;
             readonly ariaChecked: boolean;
-            readonly ariaRoleDescription: TranslationKey;
             readonly ariaDescribedBy: string;
         };
         result: ListSwitch;
@@ -214,9 +213,6 @@ export class ProxyInteractionService {
             button.role = 'switch';
             button.ariaChecked = params.ariaChecked.toString();
             button.setAttribute('aria-describedby', params.ariaDescribedBy);
-            this.addLocalisation(() => {
-                button.ariaRoleDescription = this.localeManager.t(params.ariaRoleDescription.id);
-            });
 
             listitem.role = 'listitem';
             listitem.style.position = 'absolute';

--- a/packages/ag-charts-locale/src/en-US.ts
+++ b/packages/ag-charts-locale/src/en-US.ts
@@ -31,6 +31,8 @@ export const AG_CHARTS_LOCALE_EN_US: Record<string, string> = {
     ariaLabelLegendPagePrevious: 'Previous Legend Page',
     // Screen reader text for the next legend page button
     ariaLabelLegendPageNext: 'Next Legend Page',
+    // Screen reader text for the an item in the legend
+    ariaLabelLegendItem: '${label}, Legend item ${index}[number] of ${count}[number]',
     // Screen reader text for the an unknown item in the legend
     ariaLabelLegendItemUnknown: 'Unknown legend item',
     // Screen reader text for the navigator element
@@ -45,8 +47,6 @@ export const AG_CHARTS_LOCALE_EN_US: Record<string, string> = {
     ariaLabelRangesToolbar: 'Ranges',
     // Screen reader text for zoom toolbar
     ariaLabelZoomToolbar: 'Zoom',
-    // Screen reader text for the an item in the legend
-    ariaRoleDescriptionLegendItem: 'legend item',
     // Screen reader text for the value of the navigator's range
     ariaValuePanRange: '${min}[percent] to ${max}[percent]',
     // Alt-text for the solid line dash style menu item icon


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12486

Fixes:
- Set correct `aria-checked` value on legend item `<button>` elements.
- Restore `Legend item {index} of {count}` part of the legend button labels.
- Remove `aria-hidden="true"` from interactive legend elements.