### PR TITLE
AG-12688 - Force series region to have seriesArea bbox, fixing line + area tooltips.

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -43,7 +43,7 @@ import { axisRegistry } from './factory/axisRegistry';
 import { EXPECTED_ENTERPRISE_MODULES } from './factory/expectedEnterpriseModules';
 import { legendRegistry } from './factory/legendRegistry';
 import { seriesRegistry } from './factory/seriesRegistry';
-import { REGIONS } from './interaction/regions';
+import { REGIONS, SimpleRegionBBoxProvider } from './interaction/regions';
 import { SyncManager } from './interaction/syncManager';
 import { ZoomManager } from './interaction/zoomManager';
 import { Keyboard } from './keyboard';
@@ -309,7 +309,12 @@ export abstract class Chart extends Observable {
         this.container = container;
 
         const moduleContext = this.getModuleContext();
-        ctx.regionManager.addRegion(REGIONS.SERIES, this.seriesRoot, this.ctx.axisManager.axisGridGroup);
+        ctx.regionManager.addRegion(
+            REGIONS.SERIES,
+            this.seriesRoot,
+            new SimpleRegionBBoxProvider(this.seriesRoot, () => this.seriesRect ?? BBox.zero),
+            this.ctx.axisManager.axisGridGroup
+        );
         ctx.regionManager.addRegion(REGIONS.HORIZONTAL_AXES);
         ctx.regionManager.addRegion(REGIONS.VERTICAL_AXES);
 

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -52,9 +52,9 @@ function addHandler<T extends RegionEvent['type']>(
     );
 }
 
-type RegionNodeType = Node | { id: string; node: Node };
+type RegionNodeType = NodeRegionBBoxProvider | Node | { id: string; node: Node };
 
-function nodeToBBoxProvider(node: RegionNodeType | NodeRegionBBoxProvider) {
+function nodeToBBoxProvider(node: RegionNodeType) {
     if (node instanceof Node) {
         return new NodeRegionBBoxProvider(node);
     }
@@ -99,7 +99,7 @@ export class RegionManager {
         this.regions.clear();
     }
 
-    public addRegion(name: RegionName, ...nodes: (RegionNodeType | NodeRegionBBoxProvider)[]) {
+    public addRegion(name: RegionName, ...nodes: RegionNodeType[]) {
         if (this.regions.has(name)) {
             throw new Error(`AG Charts - Region: ${name} already exists`);
         }

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -54,9 +54,12 @@ function addHandler<T extends RegionEvent['type']>(
 
 type RegionNodeType = Node | { id: string; node: Node };
 
-function nodeToBBoxProvider(node: RegionNodeType) {
+function nodeToBBoxProvider(node: RegionNodeType | NodeRegionBBoxProvider) {
     if (node instanceof Node) {
         return new NodeRegionBBoxProvider(node);
+    }
+    if (node instanceof NodeRegionBBoxProvider) {
+        return node;
     }
 
     return new NodeRegionBBoxProvider(node.node, node.id);
@@ -96,7 +99,7 @@ export class RegionManager {
         this.regions.clear();
     }
 
-    public addRegion(name: RegionName, ...nodes: RegionNodeType[]) {
+    public addRegion(name: RegionName, ...nodes: (RegionNodeType | NodeRegionBBoxProvider)[]) {
         if (this.regions.has(name)) {
             throw new Error(`AG Charts - Region: ${name} already exists`);
         }

--- a/packages/ag-charts-community/src/chart/interaction/regions.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regions.ts
@@ -1,3 +1,4 @@
+import { BBox } from '../../scene/bbox';
 import { Node } from '../../scene/node';
 import { Transformable } from '../../scene/transformable';
 import type { BBoxContainsTester, BBoxProvider, BBoxValues } from '../../util/bboxinterface';
@@ -40,5 +41,19 @@ export class NodeRegionBBoxProvider implements RegionBBoxProvider {
 
     fromCanvasPoint(x: number, y: number) {
         return Transformable.fromCanvasPoint(this.node, x, y);
+    }
+}
+
+export class SimpleRegionBBoxProvider extends NodeRegionBBoxProvider {
+    constructor(
+        node: Node,
+        private readonly bboxFn: () => BBox,
+        overrideId?: string
+    ) {
+        super(node, overrideId);
+    }
+
+    override toCanvasBBox() {
+        return this.bboxFn();
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12688

Fixes series-area region bbox calculation, so that `Chart.seriesRect` is used as a fallback - this fixes series-area hover detection for path-based series when no markers or grid-lines are present.