### PR TITLE
CRT-476 Fix overflow scrolling in Safari

### DIFF
--- a/external/ag-website-shared/src/components/license-pricing/LicensePricing.tsx
+++ b/external/ag-website-shared/src/components/license-pricing/LicensePricing.tsx
@@ -79,35 +79,33 @@ export const LicensePricing: FunctionComponent<Props> = ({ defaultSelection }) =
                 </div>
             )}
 
+            <div className={styles.introSection}>
+                <div className={styles.toggleWrapper}>
+                    <input
+                        type="checkbox"
+                        id="toggle"
+                        className={styles.toggleCheckbox}
+                        checked={chartsIsSelected}
+                        onChange={handleToggle}
+                    />
+                    <label htmlFor="toggle" className={styles.toggleContainer}>
+                        <div className={styles.gridToggle}>
+                            <GridActive className={styles.gridActive} />
+                            <GridInactive className={styles.gridInactive} />
+                            AG Grid
+                        </div>
+                        <div className={styles.chartsToggle}>
+                            <ChartsActive className={styles.chartsActive} />
+                            <ChartsInactive className={styles.chartsInactive} />
+                            AG Charts
+                        </div>
+                    </label>
+                </div>
+            </div>
+
             <div className={classnames('layout-max-width-small', styles.container)}>
                 <div className={styles.topSection}>
                     <div className={styles.intro}>
-                        <div className={styles.introSection}>
-                            <div className={styles.switchContainer}>
-                                <div className={styles.gradient}></div>
-                                <div className={styles.toggleWrapper}>
-                                    <input
-                                        type="checkbox"
-                                        id="toggle"
-                                        className={styles.toggleCheckbox}
-                                        checked={chartsIsSelected}
-                                        onChange={handleToggle}
-                                    />
-                                    <label htmlFor="toggle" className={styles.toggleContainer}>
-                                        <div className={styles.gridToggle}>
-                                            <GridActive className={styles.gridActive} />
-                                            <GridInactive className={styles.gridInactive} />
-                                            AG Grid
-                                        </div>
-                                        <div className={styles.chartsToggle}>
-                                            <ChartsActive className={styles.chartsActive} />
-                                            <ChartsInactive className={styles.chartsInactive} />
-                                            AG Charts
-                                        </div>
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
                         <div className={styles.licensesOuter}>
                             <Licenses className={styles.licensesInfo} isChecked={chartsIsSelected} />
                         </div>

--- a/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
@@ -15,16 +15,25 @@
 }
 
 .introSection {
-    width: 80%;
-    margin: 0 auto;
     display: flex;
     align-items: center;
     flex-direction: column;
-    margin-bottom: $spacing-size-8;
+    padding-top: $spacing-size-12 + ($spacing-size-1 / 2);
+    background: linear-gradient(
+        to bottom,
+        transparent,
+        color-mix(in srgb, var(--background) 5%, transparent) ($spacing-size-12 + 64px / 2),
+        transparent 0
+    );
+    --background: var(--color-bg-brand-solid);
 
     p {
         text-align: center;
         text-wrap: balance;
+    }
+
+    #{$selector-darkmode} & {
+        --background: var(--color-fg-primary);
     }
 }
 
@@ -490,7 +499,6 @@
     cursor: pointer;
     user-select: none;
     box-shadow: var(--shadow-sm);
-    margin-bottom: $spacing-size-4;
 
     #{$selector-darkmode} & {
         border: 2px solid var(--color-bg-primary);
@@ -627,14 +635,6 @@
     transition: all 0.3s ease-in;
 }
 
-.switchContainer {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    top: 42px;
-}
-
 .toggleBackground {
     opacity: 0.7;
     position: absolute;
@@ -663,19 +663,6 @@
 .toggleWrapper {
     top: 48px;
     max-height: 70px; // Prevents 1px height change on toggle
-}
-
-.gradient {
-    position: absolute;
-    top: -70px;
-    height: 100px;
-    width: 100vw;
-    background: linear-gradient(transparent, var(--color-bg-brand-solid));
-    opacity: 0.05;
-
-    #{$selector-darkmode} & {
-        background: linear-gradient(transparent, var(--color-fg-primary));
-    }
 }
 
 .videoPrompt {

--- a/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
@@ -15,6 +15,7 @@
 }
 
 .introSection {
+    --background: var(--color-bg-brand-solid);
     display: flex;
     align-items: center;
     flex-direction: column;
@@ -25,7 +26,6 @@
         color-mix(in srgb, var(--background) 5%, transparent) ($spacing-size-12 + 64px / 2),
         transparent 0
     );
-    --background: var(--color-bg-brand-solid);
 
     p {
         text-align: center;

--- a/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
+++ b/external/ag-website-shared/src/components/license-pricing/license-pricing.module.scss
@@ -19,11 +19,11 @@
     display: flex;
     align-items: center;
     flex-direction: column;
-    padding-top: $spacing-size-12 + ($spacing-size-1 / 2);
+    padding-top: calc($spacing-size-12 + ($spacing-size-1 / 2));
     background: linear-gradient(
         to bottom,
         transparent,
-        color-mix(in srgb, var(--background) 5%, transparent) ($spacing-size-12 + 64px / 2),
+        color-mix(in srgb, var(--background) 5%, transparent) calc($spacing-size-12 + 64px / 2),
         transparent 0
     );
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-476

Caused by the element shown extending the bounds of the page. It did this because it was placed in a container smaller than the page width, and tried to match the page width via `100vw`. Refactors the layout to give this element the natural full width of the page

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/e695dabd-be10-409c-aed4-30eca97a0f90">
