### PR TITLE
CRT-510 Fix series focus order sorting

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaFocusManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaFocusManager.ts
@@ -54,15 +54,21 @@ export class SeriesAreaFocusManager extends BaseManager {
     }
 
     public seriesChanged(series: Series<any, SeriesProperties<any>>[]) {
-        this.series = [...series].sort((a, b) => {
-            let fpA = a.properties.focusPriority ?? Infinity;
-            let fpB = b.properties.focusPriority ?? Infinity;
+        const unsortedSeries = series.map((series, index) => {
+            return {series, index}
+        });
+        const sortedSeries = unsortedSeries.sort((a, b) => {
+            let fpA = a.series.properties.focusPriority ?? Infinity;
+            let fpB = b.series.properties.focusPriority ?? Infinity;
             if (fpA === fpB) {
-                [fpA, fpB] = [a._declarationOrder, b._declarationOrder];
+                [fpA, fpB] = [a.index, b.index];
             }
             // Note: `Infinity-Infinity` results in `NaN`, so use `<` comparison instead of `-` subtraction.
-            return fpA < fpB ? -1 : 1;
+            if (fpA < fpB) return -1;
+            else if(fpA > fpB) return 1;
+            else return 0;
         });
+        this.series = sortedSeries.map((entry) => entry.series);
         this.onBlur();
     }
 

--- a/packages/ag-charts-community/src/chart/series/seriesAreaFocusManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaFocusManager.ts
@@ -55,7 +55,7 @@ export class SeriesAreaFocusManager extends BaseManager {
 
     public seriesChanged(series: Series<any, SeriesProperties<any>>[]) {
         const unsortedSeries = series.map((series, index) => {
-            return {series, index}
+            return { series, index };
         });
         const sortedSeries = unsortedSeries.sort((a, b) => {
             let fpA = a.series.properties.focusPriority ?? Infinity;
@@ -65,7 +65,7 @@ export class SeriesAreaFocusManager extends BaseManager {
             }
             // Note: `Infinity-Infinity` results in `NaN`, so use `<` comparison instead of `-` subtraction.
             if (fpA < fpB) return -1;
-            else if(fpA > fpB) return 1;
+            else if (fpA > fpB) return 1;
             else return 0;
         });
         this.series = sortedSeries.map((entry) => entry.series);

--- a/packages/ag-charts-community/src/chart/series/seriesAreaFocusManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaFocusManager.ts
@@ -53,8 +53,8 @@ export class SeriesAreaFocusManager extends BaseManager {
         );
     }
 
-    public seriesChanged(series: Series<any, SeriesProperties<any>>[]) {
-        const unsortedSeries = series.map((series, index) => {
+    public seriesChanged(declaredSeries: Series<any, SeriesProperties<any>>[]) {
+        const unsortedSeries = declaredSeries.map((series, index) => {
             return { series, index };
         });
         const sortedSeries = unsortedSeries.sort((a, b) => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-510

Use the index value from the .map() function rather than the _declarationOrder member. When testing this on Firefox, all the _declarationOrder values were -1. Returning 0 in the sort function solves this, but let's just avoid using this faulty property anyway.