### PR TITLE
AG-12983 a11y captions

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -559,6 +559,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
         const { callbackCache } = this.moduleCtx;
         const { formatter = (p) => p.defaultValue } = title;
         const text = callbackCache.call(formatter, this.getTitleFormatterParams());
+        caption.text = text;
 
         titleNode.setProperties({ visible: true, text, textBaseline, x, y, rotation });
     }

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -286,7 +286,7 @@ export abstract class Axis<S extends Scale<D, number, TickInterval<S>> = Scale<a
 
         let previousSize: { width: number; height: number } | undefined = undefined;
         this.destroyFns.push(
-            this.title.caption.registerInteraction(this.moduleCtx),
+            this.title.caption.registerInteraction(this.moduleCtx, 'afterend'),
             moduleCtx.layoutManager.addListener('layout:complete', (e) => {
                 // Fire resize animation action if chart canvas size changes.
                 if (previousSize != null && jsonDiff(e.chart, previousSize) != null) {

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -90,11 +90,11 @@ export class Caption extends BaseProperties implements CaptionLike {
     private truncated = false;
     private proxyText?: BoundedText;
 
-    registerInteraction(moduleCtx: ModuleContext) {
+    registerInteraction(moduleCtx: ModuleContext, where: 'beforebegin' | 'afterend') {
         const { regionManager, proxyInteractionService, layoutManager } = moduleCtx;
         const region = regionManager.getRegion('root');
         const destroyFns = [
-            layoutManager.addListener('layout:complete', () => this.updateA11yText(proxyInteractionService)),
+            layoutManager.addListener('layout:complete', () => this.updateA11yText(proxyInteractionService, where)),
             region.addListener('hover', (event) => this.handleMouseMove(moduleCtx, event)),
             region.addListener('leave', (event) => this.handleMouseLeave(moduleCtx, event)),
         ];
@@ -115,12 +115,12 @@ export class Caption extends BaseProperties implements CaptionLike {
         this.truncated = wrappedText.includes(TextUtils.EllipsisChar);
     }
 
-    updateA11yText(proxyService: ProxyInteractionService) {
+    updateA11yText(proxyService: ProxyInteractionService, where: 'beforebegin' | 'afterend') {
         if (this.enabled && this.text) {
             const bbox = Transformable.toCanvas(this.node);
             if (bbox) {
                 const { id } = this;
-                this.proxyText ??= proxyService.createProxyElement({ type: 'text', id, parent: 'canvas-proxy' });
+                this.proxyText ??= proxyService.createProxyElement({ type: 'text', id, parent: where });
                 this.proxyText.textContent = this.text;
                 this.proxyText.updateBounds(bbox);
             }

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -342,9 +342,9 @@ export abstract class Chart extends Observable {
                 this.data = event.data;
             }),
 
-            this.title.registerInteraction(moduleContext),
-            this.subtitle.registerInteraction(moduleContext),
-            this.footnote.registerInteraction(moduleContext),
+            this.title.registerInteraction(moduleContext, 'beforebegin'),
+            this.subtitle.registerInteraction(moduleContext, 'beforebegin'),
+            this.footnote.registerInteraction(moduleContext, 'afterend'),
 
             ctx.interactionManager.addListener('page-left', () => this.destroy()),
 

--- a/packages/ag-charts-community/src/dom/domManager.ts
+++ b/packages/ag-charts-community/src/dom/domManager.ts
@@ -20,6 +20,7 @@ const DOM_ELEMENT_CLASSES = [
 ] as const;
 type DOMElementClass = (typeof DOM_ELEMENT_CLASSES)[number];
 type DOMElementConfig = { childElementType: 'style' | 'canvas' | 'div'; style?: Partial<CSSStyleDeclaration> };
+type DOMInsertOption = { where: InsertPosition; query: string };
 
 const domElementConfig: Map<DOMElementClass, DOMElementConfig> = new Map([
     ['styles', { childElementType: 'style' }],
@@ -387,7 +388,7 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
         return this.element.style.cursor;
     }
 
-    addChild(domElementClass: DOMElementClass, id: string, child?: HTMLElement) {
+    addChild(domElementClass: DOMElementClass, id: string, child?: HTMLElement, insert?: DOMInsertOption) {
         const { element, children, listeners } = this.rootElements[domElementClass];
 
         if (!children) {
@@ -407,7 +408,15 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
             newChild.addEventListener(type, fn as any, opts);
         }
         children.set(id, newChild);
-        element?.appendChild(newChild);
+        if (insert) {
+            const queryResult = element.querySelector(insert.query);
+            if (!(queryResult instanceof HTMLElement)) {
+                throw new Error(`AG Charts - addChild query failed ${insert.query}`);
+            }
+            queryResult.insertAdjacentElement(insert.where, newChild);
+        } else {
+            element?.appendChild(newChild);
+        }
         return newChild;
     }
 

--- a/packages/ag-charts-community/src/dom/proxyInteractionService.ts
+++ b/packages/ag-charts-community/src/dom/proxyInteractionService.ts
@@ -10,7 +10,7 @@ export type ListSwitch = { button: HTMLButtonElement; listitem: HTMLElement };
 type ElemParams<T extends ProxyElementType> = {
     readonly type: T;
     readonly id: string;
-    readonly parent: HTMLElement | 'canvas-proxy';
+    readonly parent: HTMLElement | 'beforebegin' | 'afterend';
     readonly cursor?: 'pointer';
 };
 
@@ -258,7 +258,8 @@ export class ProxyInteractionService {
     private setParent<T extends ProxyElementType, TElem extends HTMLElement>(params: ElemParams<T>, element: TElem) {
         const { id, parent } = params;
         if (typeof parent === 'string') {
-            this.domManager.addChild(parent, id, element);
+            const insert = { where: parent, query: '.ag-charts-series-area' };
+            this.domManager.addChild('canvas-proxy', id, element, insert);
         } else {
             parent.appendChild(element);
         }


### PR DESCRIPTION
Depends on https://github.com/ag-grid/ag-charts/pull/2581

PR changes the positioning of the a11y captions (title/subtitle go before the series-area, footnote & axes go after)