### PR TITLE
AG-13036 Fix invalid cachedBBox bug when adding/removing children

### DIFF
--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -267,7 +267,7 @@ export abstract class Node {
             }
         }
 
-        this.cachedBBox = undefined;
+        this.invalidateCachedBBox();
         this.dirtyZIndex = true;
         this.markDirty(RedrawType.MAJOR);
     }
@@ -289,7 +289,7 @@ export abstract class Node {
             this.virtualChildrenCount--;
         }
 
-        this.cachedBBox = undefined;
+        this.invalidateCachedBBox();
         this.dirtyZIndex = true;
         this.markDirty(RedrawType.MAJOR);
 
@@ -306,7 +306,7 @@ export abstract class Node {
             child._setLayerManager();
         }
         this.childNodes?.clear();
-        this.cachedBBox = undefined;
+        this.invalidateCachedBBox();
         this.virtualChildrenCount = 0;
     }
 
@@ -370,6 +370,11 @@ export abstract class Node {
         }
     }
 
+    private invalidateCachedBBox() {
+        this.cachedBBox = undefined;
+        this.parentNode?.invalidateCachedBBox();
+    }
+
     getBBox(): BBox {
         if (this.cachedBBox == null) {
             this.cachedBBox = Object.freeze(this.computeBBox());
@@ -391,7 +396,7 @@ export abstract class Node {
         const noParentCachedBBox = this.cachedBBox == null;
         if (noParentCachedBBox && dirtyTypeBelowHighWatermark) return;
 
-        this.cachedBBox = undefined;
+        this.invalidateCachedBBox();
         this._dirty = Math.max(_dirty, type);
         if (this.parentNode) {
             this.parentNode.markDirty(parentType);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13036

When a scene nodes cached BBox is invalidated, then ALL of the ancestor cached BBoxes are also invalid because their computations is the union of the descendants.

The bug we were seeing was happening because if the user triggers hover events before the map chart has fully loaded, then the scene graph will compute a BBox for the root node that excludes the series area (i.e. the Geo nodes). The Node.append method unsets cachedBBox, but that does not matter because the RegionManager uses the getBBox() on an ancestor node, so it will just use an outdated BBox in its hit-testing.

Therefore, setting cachedBBox = undefined for all ancestors is the correct thing to do here.