### PR TITLE
AG-13098 Use `opacity: 0` instead of `appearance`

### DIFF
--- a/packages/ag-charts-community/src/dom/proxyInteractionStyles.css
+++ b/packages/ag-charts-community/src/dom/proxyInteractionStyles.css
@@ -14,15 +14,11 @@
     position: absolute;
 }
 
+.ag-charts-proxy-elem::-moz-range-thumb,
+.ag-charts-proxy-elem::-moz-range-track,
+.ag-charts-proxy-elem::-webkit-slider-runnable-track,
 .ag-charts-proxy-elem::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-}
-
-.ag-charts-proxy-elem::-moz-range-thumb {
-    appearance: none;
-    background: none;
-    border: none;
+    opacity: 0;
 }
 
 .ag-charts-proxy-elem:focus-visible {

--- a/packages/ag-charts-community/src/dom/proxyInteractionStyles.css
+++ b/packages/ag-charts-community/src/dom/proxyInteractionStyles.css
@@ -15,7 +15,10 @@
 }
 
 .ag-charts-proxy-elem::-moz-range-thumb,
-.ag-charts-proxy-elem::-moz-range-track,
+.ag-charts-proxy-elem::-moz-range-track {
+    opacity: 0;
+}
+
 .ag-charts-proxy-elem::-webkit-slider-runnable-track,
 .ag-charts-proxy-elem::-webkit-slider-thumb {
     opacity: 0;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13098

This is to ensure that ag-grid does not show parts of the navigator proxy.

Also hide other experiemental pseudo-elemements define used by ag-grid: https://github.com/ag-grid/ag-grid/blob/b42ae20f8eca2336c5b553e98d0b2efcaf4227b9/packages/ag-grid-community/src/theming/core/css/range.css