### PR TITLE
AG-11986 Refactor annotations toolbars into separate classes

### DIFF
--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -5,6 +5,7 @@ export * from './util/dom';
 export * from './util/deprecation';
 export * from './util/json';
 export * from './util/keynavUtil';
+export * from './util/listeners';
 export * from './util/nearest';
 export * from './util/number';
 export * from './util/object';

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationOptionsToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationOptionsToolbar.ts
@@ -1,0 +1,370 @@
+import { type AgAnnotationLineStyleType, _ModuleSupport, _Util } from 'ag-charts-community';
+
+import { Menu, type MenuItem } from '../../components/menu/menu';
+import { ColorPicker } from '../color-picker/colorPicker';
+import {
+    type AnnotationOptionsColorPickerType,
+    type HasColorAnnotationType,
+    type HasFontSizeAnnotationType,
+    type HasLineStyleAnnotationType,
+} from './annotationTypes';
+import {
+    AnnotationOptions,
+    LINE_STROKE_WIDTH_ITEMS,
+    LINE_STYLE_TYPE_ITEMS,
+    TEXT_SIZE_ITEMS,
+} from './annotationsMenuOptions';
+import type { AnnotationProperties, AnnotationScene } from './annotationsSuperTypes';
+import { hasFillColor, hasFontSize, hasLineColor, hasLineStyle, hasLineText, hasTextColor } from './utils/has';
+import { getLineStyle } from './utils/line';
+import { isTextType } from './utils/types';
+
+const { ToolbarManager, Vec2 } = _ModuleSupport;
+
+interface EventMap {
+    'pressed-delete': void;
+    'pressed-settings': { sourceEvent: Event };
+    'save-color': {
+        type: HasColorAnnotationType;
+        colorPickerType: AnnotationOptionsColorPickerType;
+        color: string | undefined;
+    };
+    'update-color': {
+        type: HasColorAnnotationType;
+        colorPickerType: AnnotationOptionsColorPickerType;
+        colorOpacity: string;
+        color: string;
+        opacity: number;
+    };
+    'update-font-size': { type: HasFontSizeAnnotationType; fontSize: number };
+    'update-line-style': { type: HasLineStyleAnnotationType; lineStyleType: AgAnnotationLineStyleType };
+    'update-line-width': { type: HasLineStyleAnnotationType; strokeWidth: number };
+}
+
+export class AnnotationOptionsToolbar
+    extends _ModuleSupport.BaseModuleInstance
+    implements _ModuleSupport.ModuleInstance
+{
+    private readonly events = new _ModuleSupport.Listeners<keyof EventMap, any>();
+
+    private readonly colorPicker = new ColorPicker(this.ctx);
+    private readonly textSizeMenu = new Menu(this.ctx, 'text-size');
+    private readonly lineStyleTypeMenu = new Menu(this.ctx, 'annotations-line-style-type');
+    private readonly lineStrokeWidthMenu = new Menu(this.ctx, 'annotations-line-stroke-width');
+
+    constructor(
+        private readonly ctx: _ModuleSupport.ModuleContext,
+        private readonly getActiveDatum: () => AnnotationProperties | undefined
+    ) {
+        super();
+
+        const { toolbarManager } = ctx;
+
+        this.destroyFns.push(
+            toolbarManager.addListener('button-pressed', this.onButtonPress.bind(this)),
+            toolbarManager.addListener('button-moved', this.onButtonMoved.bind(this)),
+            toolbarManager.addListener('group-moved', this.onGroupMoved.bind(this)),
+
+            () => this.colorPicker.destroy()
+        );
+    }
+
+    public addListener<K extends keyof EventMap>(eventType: K, handler: (event: EventMap[K]) => void) {
+        return this.events.addListener(eventType, handler);
+    }
+
+    public toggleVisibility(visible: boolean) {
+        this.ctx.toolbarManager.toggleGroup('annotations', 'annotationOptions', { visible });
+    }
+
+    public toggleAnnotationOptionsButtons() {
+        const {
+            ctx: { toolbarManager },
+        } = this;
+
+        const datum = this.getActiveDatum();
+        if (!datum) return;
+
+        const locked = datum?.locked ?? false;
+
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.LineStyleType, {
+            enabled: !locked,
+            visible: hasLineStyle(datum),
+        });
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.LineStrokeWidth, {
+            enabled: !locked,
+            visible: hasLineStyle(datum),
+        });
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.LineColor, {
+            enabled: !locked,
+            visible: hasLineColor(datum),
+        });
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.TextColor, {
+            enabled: !locked,
+            visible: hasTextColor(datum),
+        });
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.FillColor, {
+            enabled: !locked,
+            visible: hasFillColor(datum),
+        });
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.TextSize, {
+            enabled: !locked,
+            visible: hasFontSize(datum),
+        });
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.Settings, {
+            enabled: !locked,
+            visible: hasLineText(datum),
+        });
+
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.Delete, { enabled: !locked });
+        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.Lock, { checked: locked });
+
+        toolbarManager.updateGroup('annotationOptions');
+
+        this.updateFontSize(datum != null && 'fontSize' in datum ? datum.fontSize : undefined);
+        this.updateFills();
+        this.updateLineStyles(datum);
+    }
+
+    public setAnchorScene(scene: AnnotationScene) {
+        this.ctx.toolbarManager.changeFloatingAnchor('annotationOptions', scene.getAnchor());
+    }
+
+    public hideOverlays() {
+        this.colorPicker.hide({ lastFocus: null });
+        this.textSizeMenu.hide();
+        this.lineStyleTypeMenu.hide();
+        this.lineStrokeWidthMenu.hide();
+    }
+
+    public updateColorPickerFill(colorPickerType: AnnotationOptionsColorPickerType, color?: string, opacity?: number) {
+        if (color != null && opacity != null) {
+            const { r, g, b } = _Util.Color.fromString(color);
+            color = _Util.Color.fromArray([r, g, b, opacity]).toHexString();
+        }
+        this.ctx.toolbarManager.updateButton('annotationOptions', colorPickerType, {
+            fill: color,
+        });
+    }
+
+    public updateFills() {
+        const datum = this.getActiveDatum();
+
+        this.updateColorPickerFill(
+            AnnotationOptions.LineColor,
+            datum?.getDefaultColor(AnnotationOptions.LineColor),
+            datum?.getDefaultOpacity(AnnotationOptions.LineColor)
+        );
+        this.updateColorPickerFill(
+            AnnotationOptions.FillColor,
+            datum?.getDefaultColor(AnnotationOptions.FillColor),
+            datum?.getDefaultOpacity(AnnotationOptions.FillColor)
+        );
+        this.updateColorPickerFill(
+            AnnotationOptions.TextColor,
+            datum?.getDefaultColor(AnnotationOptions.TextColor),
+            datum?.getDefaultOpacity(AnnotationOptions.TextColor)
+        );
+    }
+
+    public updateFontSize(fontSize: number | undefined) {
+        this.ctx.toolbarManager.updateButton('annotationOptions', AnnotationOptions.TextSize, {
+            label: fontSize != null ? String(fontSize) : undefined,
+        });
+    }
+
+    public updateLineStyleType(item: MenuItem<AgAnnotationLineStyleType>) {
+        this.ctx.toolbarManager.updateButton('annotationOptions', AnnotationOptions.LineStyleType, {
+            icon: item.icon,
+        });
+    }
+
+    public updateStrokeWidth(item: MenuItem<number>) {
+        this.ctx.toolbarManager.updateButton('annotationOptions', AnnotationOptions.LineStrokeWidth, {
+            label: item.label,
+            strokeWidth: item.value,
+        });
+    }
+
+    private dispatch<K extends keyof EventMap>(eventType: K, event?: EventMap[K]) {
+        this.events.dispatch(eventType, event);
+    }
+
+    private onButtonPress(event: _ModuleSupport.ToolbarButtonPressedEvent) {
+        if (!ToolbarManager.isGroup('annotationOptions', event)) return;
+
+        const datum = this.getActiveDatum();
+        if (!datum) return;
+
+        this.hideOverlays();
+
+        switch (event.value) {
+            case AnnotationOptions.LineStyleType: {
+                const lineStyle = hasLineStyle(datum) ? getLineStyle(datum.lineDash, datum.lineStyle) : undefined;
+                this.lineStyleTypeMenu.show<AgAnnotationLineStyleType>({
+                    items: LINE_STYLE_TYPE_ITEMS,
+                    ariaLabel: this.ctx.localeManager.t('toolbarAnnotationsLineStyle'),
+                    value: lineStyle,
+                    sourceEvent: event.sourceEvent,
+                    onPress: (item) => this.onLineStyleTypeMenuPress(item, datum),
+                    class: 'annotations__line-style-type',
+                });
+                break;
+            }
+
+            case AnnotationOptions.LineStrokeWidth: {
+                const strokeWidth = hasLineStyle(datum) ? datum.strokeWidth : undefined;
+                this.lineStrokeWidthMenu.show<number>({
+                    items: LINE_STROKE_WIDTH_ITEMS,
+                    ariaLabel: this.ctx.localeManager.t('toolbarAnnotationsLineStrokeWidth'),
+                    value: strokeWidth,
+                    sourceEvent: event.sourceEvent,
+                    onPress: (item) => this.onLineStrokeWidthMenuPress(item, datum),
+                    class: 'annotations__line-stroke-width',
+                });
+                break;
+            }
+
+            case AnnotationOptions.LineColor:
+            case AnnotationOptions.FillColor:
+            case AnnotationOptions.TextColor: {
+                this.colorPicker.show({
+                    color: datum?.getDefaultColor(event.value),
+                    opacity: datum?.getDefaultOpacity(event.value),
+                    sourceEvent: event.sourceEvent,
+                    onChange: datum != null ? this.onColorPickerChange.bind(this, event.value, datum) : undefined,
+                    onChangeHide: ((type: AnnotationOptionsColorPickerType) => {
+                        this.dispatch('save-color', {
+                            type: datum.type,
+                            colorPickerType: event.value as AnnotationOptionsColorPickerType,
+                            color: datum.getDefaultColor(type),
+                        });
+                    }).bind(this, event.value),
+                });
+                break;
+            }
+
+            case AnnotationOptions.TextSize: {
+                const fontSize = isTextType(datum) ? datum.fontSize : undefined;
+                this.textSizeMenu.show<number>({
+                    items: TEXT_SIZE_ITEMS,
+                    ariaLabel: this.ctx.localeManager.t('toolbarAnnotationsTextSize'),
+                    value: fontSize,
+                    sourceEvent: event.sourceEvent,
+                    onPress: (item) => this.onTextSizeMenuPress(item, datum),
+                    class: 'ag-charts-annotations-text-size-menu',
+                });
+                break;
+            }
+
+            case AnnotationOptions.Delete: {
+                this.dispatch('pressed-delete');
+                break;
+            }
+
+            case AnnotationOptions.Lock: {
+                datum.locked = !datum.locked;
+                this.toggleAnnotationOptionsButtons();
+                break;
+            }
+
+            case AnnotationOptions.Settings: {
+                this.dispatch('pressed-settings', { sourceEvent: event.sourceEvent });
+                break;
+            }
+        }
+    }
+
+    private onButtonMoved(event: _ModuleSupport.ToolbarButtonMovedEvent) {
+        const { group, rect, groupRect, value } = event;
+
+        if (group !== 'annotationOptions') return;
+
+        const anchor = { x: rect.x, y: rect.y + rect.height - 1 };
+
+        switch (value as AnnotationOptions) {
+            case AnnotationOptions.FillColor:
+            case AnnotationOptions.LineColor:
+            case AnnotationOptions.TextColor: {
+                const colorPickerAnchor = Vec2.add(groupRect, Vec2.from(0, groupRect.height + 4));
+                const fallback = { y: groupRect.y - 4 };
+                this.colorPicker.setAnchor(colorPickerAnchor, fallback);
+                break;
+            }
+
+            case AnnotationOptions.LineStrokeWidth:
+                this.lineStrokeWidthMenu.setAnchor(anchor);
+                break;
+
+            case AnnotationOptions.LineStyleType:
+                this.lineStyleTypeMenu.setAnchor(anchor);
+                break;
+
+            case AnnotationOptions.TextSize:
+                this.textSizeMenu.setAnchor(anchor);
+                break;
+        }
+    }
+
+    private onGroupMoved(_event: _ModuleSupport.ToolbarGroupMovedEvent) {
+        this.hideOverlays();
+    }
+
+    private onColorPickerChange(
+        colorPickerType: AnnotationOptionsColorPickerType,
+        datum: AnnotationProperties,
+        colorOpacity: string,
+        color: string,
+        opacity: number
+    ) {
+        this.dispatch('update-color', { type: datum.type, colorPickerType, colorOpacity, color, opacity });
+        this.updateColorPickerFill(colorPickerType, colorOpacity);
+    }
+
+    private onTextSizeMenuPress(item: MenuItem<number>, datum?: AnnotationProperties) {
+        if (!hasFontSize(datum)) return;
+
+        const fontSize = item.value;
+        this.dispatch('update-font-size', { type: datum.type, fontSize });
+        this.textSizeMenu.hide();
+        this.updateFontSize(fontSize);
+    }
+
+    private onLineStyleTypeMenuPress(item: MenuItem<AgAnnotationLineStyleType>, datum?: AnnotationProperties) {
+        if (!hasLineStyle(datum)) return;
+
+        const type = item.value;
+        this.dispatch('update-line-style', { type: datum.type, lineStyleType: type });
+        this.lineStyleTypeMenu.hide();
+        this.updateLineStyleType(item);
+    }
+
+    private onLineStrokeWidthMenuPress(item: MenuItem<number>, datum?: AnnotationProperties) {
+        if (!hasLineStyle(datum)) {
+            return;
+        }
+
+        const strokeWidth = item.value;
+        this.dispatch('update-line-width', { type: datum.type, strokeWidth });
+        this.lineStrokeWidthMenu.hide();
+        this.updateStrokeWidth(item);
+    }
+
+    private updateLineStyles(datum?: AnnotationProperties) {
+        if (!hasLineStyle(datum)) {
+            return;
+        }
+        const strokeWidth = datum.strokeWidth ?? 1;
+        const lineStyleType = getLineStyle(datum.lineDash, datum.lineStyle);
+
+        this.updateStrokeWidth({
+            strokeWidth,
+            value: strokeWidth,
+            label: String(strokeWidth),
+        });
+
+        this.updateLineStyleType(
+            LINE_STYLE_TYPE_ITEMS.find((item) => item.value === lineStyleType) ?? LINE_STYLE_TYPE_ITEMS[0]
+        );
+    }
+}

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -1,18 +1,10 @@
-import {
-    type AgAnnotationLineStyleType,
-    type AgToolbarAnnotationsButtonValue,
-    type Direction,
-    _ModuleSupport,
-    _Scene,
-    _Util,
-} from 'ag-charts-community';
+import { type AgAnnotationLineStyleType, type Direction, _ModuleSupport, _Scene, _Util } from 'ag-charts-community';
 
-import { Menu, type MenuItem } from '../../components/menu/menu';
 import { buildBounds } from '../../utils/position';
-import { ColorPicker } from '../color-picker/colorPicker';
 import { TextInput } from '../text-input/textInput';
 import { AxesButtons } from './annotationAxesButtons';
 import { AnnotationDefaults } from './annotationDefaults';
+import { AnnotationOptionsToolbar } from './annotationOptionsToolbar';
 import type {
     AnnotationContext,
     AnnotationOptionsColorPickerType,
@@ -20,32 +12,17 @@ import type {
     HasLineStyleAnnotationType,
     Point,
 } from './annotationTypes';
-import {
-    ANNOTATION_BUTTONS,
-    ANNOTATION_BUTTON_GROUPS,
-    AnnotationType,
-    stringToAnnotationType,
-} from './annotationTypes';
+import { AnnotationType, stringToAnnotationType } from './annotationTypes';
 import { annotationConfigs, getTypedDatum } from './annotationsConfig';
-import {
-    AnnotationOptions,
-    LINE_ANNOTATION_ITEMS,
-    LINE_STROKE_WIDTH_ITEMS,
-    LINE_STYLE_TYPE_ITEMS,
-    MEASURER_ANNOTATION_ITEMS,
-    SHAPE_ANNOTATION_ITEMS,
-    TEXT_ANNOTATION_ITEMS,
-    TEXT_SIZE_ITEMS,
-} from './annotationsMenuOptions';
+import { LINE_STYLE_TYPE_ITEMS } from './annotationsMenuOptions';
 import { AnnotationsStateMachine } from './annotationsStateMachine';
 import type { AnnotationProperties, AnnotationScene } from './annotationsSuperTypes';
+import { AnnotationsToolbar } from './annotationsToolbar';
 import { AxisButton, DEFAULT_ANNOTATION_AXIS_BUTTON_CLASS } from './axisButton';
 import { AnnotationSettingsDialog, type LinearSettingsDialogOptions } from './settings-dialog/settingsDialog';
 import { calculateAxisLabelPadding } from './utils/axis';
 import { snapToAngle } from './utils/coords';
-import { hasFillColor, hasFontSize, hasLineColor, hasLineStyle, hasLineText, hasTextColor } from './utils/has';
-import { getLineStyle } from './utils/line';
-import { isChannelType, isEphemeralType, isLineType, isMeasurerType, isTextType } from './utils/types';
+import { isChannelType, isEphemeralType, isLineType, isMeasurerType } from './utils/types';
 import { updateAnnotation } from './utils/update';
 import { validateDatumPoint } from './utils/validation';
 import { convertPoint, invertCoords } from './utils/values';
@@ -56,7 +33,6 @@ const {
     InteractionState,
     ObserveChanges,
     PropertiesArray,
-    ToolbarManager,
     Validate,
     REGIONS,
     ChartAxisDirection,
@@ -78,12 +54,14 @@ type AnnotationAxis = {
 export class Annotations extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     @ObserveChanges<Annotations>((target, newValue?: boolean, oldValue?: boolean) => {
         const {
-            ctx: { annotationManager, stateManager, toolbarManager },
+            ctx: { annotationManager, stateManager },
         } = target;
 
         if (newValue === oldValue) return;
 
-        toolbarManager.toggleGroup('annotations', 'annotations', { visible: Boolean(newValue) });
+        // TODO: This should call `target.toolbar.toggle(Boolean(newValue))`, but `target.toolbar` is undefined when
+        // the module is first enabled.
+        target.ctx.toolbarManager.toggleGroup('annotations', 'annotations', { visible: Boolean(newValue) });
 
         // Restore the annotations only if this module was previously disabled
         if (oldValue === false && newValue === true) {
@@ -118,16 +96,18 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         this.container,
         this.createAnnotationScene.bind(this)
     );
-    private readonly colorPicker = new ColorPicker(this.ctx);
-    private readonly textSizeMenu = new Menu(this.ctx, 'text-size');
-    private readonly lineStyleTypeMenu = new Menu(this.ctx, 'annotations-line-style-type');
-    private readonly lineStrokeWidthMenu = new Menu(this.ctx, 'annotations-line-stroke-width');
-    private readonly annotationMenu = new Menu(this.ctx, 'annotations');
     private readonly settingsDialog = new AnnotationSettingsDialog(this.ctx);
     private readonly textInput = new TextInput(this.ctx);
 
     private xAxis?: AnnotationAxis;
     private yAxis?: AnnotationAxis;
+
+    private readonly toolbar = new AnnotationsToolbar(this.ctx);
+    private readonly optionsToolbar = new AnnotationOptionsToolbar(this.ctx, () => {
+        const active = this.state.getActive();
+        if (active == null) return;
+        return getTypedDatum(this.annotationData.at(active));
+    });
 
     constructor(private readonly ctx: _ModuleSupport.ModuleContext) {
         super();
@@ -147,12 +127,12 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
             resetToIdle: () => {
                 ctx.cursorManager.updateCursor('annotations');
                 ctx.interactionManager.popState(InteractionState.Annotations);
-                ctx.toolbarManager.toggleGroup('annotations', 'annotationOptions', { visible: false });
+                this.optionsToolbar.toggleVisibility(false);
                 ctx.tooltipManager.unsuppressTooltip('annotations');
                 this.hideOverlays();
                 this.deleteEphemeralAnnotations();
-                this.resetToolbarButtonStates();
-                this.toggleAnnotationOptionsButtons();
+                this.toolbar.resetButtonStates();
+                this.optionsToolbar.toggleAnnotationOptionsButtons();
                 this.update();
             },
 
@@ -215,7 +195,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
             select: (index?: number, previous?: number) => {
                 const {
                     annotations,
-                    ctx: { toolbarManager, tooltipManager },
+                    ctx: { tooltipManager },
                 } = this;
 
                 this.hideOverlays();
@@ -232,18 +212,18 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                 previousNode?.toggleActive(false);
 
                 // Hide the annotation options so it has time to update before being shown again
-                toolbarManager.toggleGroup('annotations', 'annotationOptions', { visible: false });
+                this.optionsToolbar.toggleVisibility(false);
 
                 if (selectedNode) {
                     this.ctx.interactionManager.pushState(InteractionState.AnnotationsSelected);
                     selectedNode.toggleActive(true);
                     tooltipManager.suppressTooltip('annotations');
-                    this.toggleAnnotationOptionsButtons();
+                    this.optionsToolbar.toggleAnnotationOptionsButtons();
                     this.postUpdateFns.push(() => {
                         // Set the annotation options to be visible _before_ setting the anchor to ensure the toolbar
                         // element has a width and height that it can use in the anchor calculations.
-                        toolbarManager.toggleGroup('annotations', 'annotationOptions', { visible: true });
-                        toolbarManager.changeFloatingAnchor('annotationOptions', selectedNode.getAnchor());
+                        this.optionsToolbar.toggleVisibility(true);
+                        this.optionsToolbar.setAnchorScene(selectedNode);
                     });
                 } else {
                     this.ctx.interactionManager.popState(InteractionState.AnnotationsSelected);
@@ -251,9 +231,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                 }
 
                 // Reset the icons on the annotation toolbars
-                toolbarManager.updateButton('annotations', 'line-menu', { icon: undefined });
-                toolbarManager.updateButton('annotations', 'text-menu', { icon: undefined });
-                toolbarManager.updateButton('annotations', 'shape-menu', { icon: undefined });
+                this.toolbar.resetButtonIcons();
 
                 this.deleteEphemeralAnnotations();
                 this.update();
@@ -310,7 +288,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                     const active = this.state.getActive();
                     const node = active != null ? this.annotations.at(active) : null;
                     if (node == null) return;
-                    ctx.toolbarManager.changeFloatingAnchor('annotationOptions', node.getAnchor());
+                    this.optionsToolbar.setAnchorScene(node);
                 });
                 this.update();
             },
@@ -380,9 +358,9 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                 const node = this.annotations.at(active);
                 if (!node || isEphemeralType(this.annotationData.at(active))) return;
 
-                this.toggleAnnotationOptionsButtons();
-                ctx.toolbarManager.toggleGroup('annotations', 'annotationOptions', { visible: true });
-                ctx.toolbarManager.changeFloatingAnchor('annotationOptions', node.getAnchor());
+                this.optionsToolbar.toggleAnnotationOptionsButtons();
+                this.optionsToolbar.toggleVisibility(true);
+                this.optionsToolbar.setAnchorScene(node);
             },
 
             showAnnotationSettings: (active: number, sourceEvent?: Event, initialTab: 'line' | 'text' = 'line') => {
@@ -410,7 +388,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                     },
                     onChangeLineColor: (colorOpacity, color, opacity) => {
                         this.setColorAndDefault(datum.type, 'line-color', colorOpacity, color, opacity);
-                        this.updateToolbarColorPickerFill('line-color', color, opacity);
+                        this.optionsToolbar.updateColorPickerFill('line-color', color, opacity);
                     },
                     onChangeHideLineColor: () => {
                         this.recordActionAfterNextUpdate(
@@ -421,18 +399,22 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
                     },
                     onChangeLineStyleType: (lineStyleType) => {
                         this.setLineStyleTypeAndDefault(datum.type, lineStyleType);
-                        this.updateToolbarLineStyleType(
+                        this.optionsToolbar.updateLineStyleType(
                             LINE_STYLE_TYPE_ITEMS.find((item) => item.value === lineStyleType) ??
                                 LINE_STYLE_TYPE_ITEMS[0]
                         );
                     },
                     onChangeLineStyleWidth: (strokeWidth) => {
                         this.setLineStyleWidthAndDefault(datum.type, strokeWidth);
-                        this.updateToolbarStrokeWidth({ strokeWidth, value: strokeWidth, label: String(strokeWidth) });
+                        this.optionsToolbar.updateStrokeWidth({
+                            strokeWidth,
+                            value: strokeWidth,
+                            label: String(strokeWidth),
+                        });
                     },
                     onChangeTextColor: (colorOpacity, color, opacity) => {
                         this.setColorAndDefault(datum.type, 'text-color', colorOpacity, color, opacity);
-                        this.updateToolbarColorPickerFill('text-color', color, opacity);
+                        this.optionsToolbar.updateColorPickerFill('text-color', color, opacity);
                     },
                     onChangeHideTextColor: () => {
                         this.recordActionAfterNextUpdate(
@@ -452,7 +434,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private setupListeners() {
-        const { ctx } = this;
+        const { ctx, optionsToolbar, toolbar } = this;
         const { All, Default, Annotations: AnnotationsState, AnnotationsSelected, ZoomDrag } = InteractionState;
 
         const seriesRegion = ctx.regionManager.getRegion(REGIONS.SERIES);
@@ -487,23 +469,66 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
 
             // Services
             ctx.annotationManager.addListener('restore-annotations', this.onRestoreAnnotations.bind(this)),
-            ctx.toolbarManager.addListener('button-pressed', this.onToolbarButtonPress.bind(this)),
-            ctx.toolbarManager.addListener('button-moved', this.onToolbarButtonMoved.bind(this)),
-            ctx.toolbarManager.addListener('group-moved', this.onToolbarGroupMoved.bind(this)),
-            ctx.toolbarManager.addListener('cancelled', this.onToolbarCancelled.bind(this)),
             ctx.layoutManager.addListener('layout:complete', this.onLayoutComplete.bind(this)),
             ctx.updateService.addListener('pre-scene-render', this.onPreRender.bind(this)),
             ctx.zoomManager.addListener('zoom-change', () => this.onZoomChange()),
 
+            // Toolbar
+            toolbar.addListener('cancel-create-annotation', () => {
+                this.cancel();
+                this.toolbar.resetButtonStates();
+                this.reset();
+                this.update();
+            }),
+            toolbar.addListener('pressed-create-annotation', ({ annotation }) => {
+                this.cancel();
+                this.ctx.interactionManager.pushState(InteractionState.Annotations);
+                this.state.transition(annotation);
+                this.update();
+            }),
+            toolbar.addListener('pressed-clear', () => {
+                this.clear();
+            }),
+            toolbar.addListener('pressed-show-menu', () => {
+                this.cancel();
+                this.reset();
+            }),
+            toolbar.addListener('pressed-unrelated', () => {
+                this.reset();
+            }),
+
+            // Annotation Options Toolbar
+            optionsToolbar.addListener('pressed-delete', () => {
+                this.cancel();
+                this.delete();
+                this.reset();
+            }),
+            optionsToolbar.addListener('pressed-settings', ({ sourceEvent }) => {
+                this.state.transition('toolbarPressSettings', sourceEvent);
+            }),
+            optionsToolbar.addListener('save-color', ({ type, colorPickerType, color }) => {
+                this.recordActionAfterNextUpdate(`Change ${type} ${colorPickerType} to ${color}`, [
+                    'annotations',
+                    'defaults',
+                ]);
+            }),
+            optionsToolbar.addListener('update-color', ({ type, colorPickerType, colorOpacity, color, opacity }) => {
+                this.setColorAndDefault(type, colorPickerType, colorOpacity, color, opacity);
+            }),
+            optionsToolbar.addListener('update-font-size', ({ type, fontSize }) => {
+                this.setFontSizeAndDefault(type, fontSize);
+            }),
+            optionsToolbar.addListener('update-line-style', ({ type, lineStyleType }) => {
+                this.setLineStyleTypeAndDefault(type, lineStyleType);
+            }),
+            optionsToolbar.addListener('update-line-width', ({ type, strokeWidth }) => {
+                this.setLineStyleWidthAndDefault(type, strokeWidth);
+            }),
+
             // DOM
             ctx.annotationManager.attachNode(this.container),
-            () => this.colorPicker.destroy(),
             () => ctx.domManager.removeStyles(DEFAULT_ANNOTATION_AXIS_BUTTON_CLASS)
         );
-    }
-
-    override destroy(): void {
-        super.destroy();
     }
 
     async processData(dataController: _ModuleSupport.DataController) {
@@ -560,7 +585,8 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         }
 
         this.injectDatumDependencies(datum);
-        this.resetToolbarButtonStates();
+        this.toolbar.resetButtonStates();
+
         this.update();
     }
 
@@ -635,331 +661,6 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
 
         this.clear();
         this.annotationData.set(event.annotations);
-        this.update();
-    }
-
-    private onToolbarButtonPress(event: _ModuleSupport.ToolbarButtonPressedEvent) {
-        if (ToolbarManager.isGroup('annotationOptions', event)) {
-            this.onToolbarAnnotationOptionButtonPress(event);
-            return;
-        }
-
-        if (!ToolbarManager.isGroup('annotations', event)) {
-            this.reset();
-            return;
-        }
-
-        if (event.value === 'clear') {
-            this.clear();
-            this.recordActionAfterNextUpdate('Clear all annotations');
-            return;
-        }
-
-        if (event.value === 'line-menu') {
-            this.onToolbarButtonPressMenu(event, 'toolbarAnnotationsLineAnnotations', LINE_ANNOTATION_ITEMS);
-            return;
-        }
-
-        if (event.value === 'text-menu') {
-            this.onToolbarButtonPressMenu(event, 'toolbarAnnotationsTextAnnotations', TEXT_ANNOTATION_ITEMS);
-            return;
-        }
-
-        if (event.value === 'shape-menu') {
-            this.onToolbarButtonPressMenu(event, 'toolbarAnnotationsShapeAnnotations', SHAPE_ANNOTATION_ITEMS);
-            return;
-        }
-
-        if (event.value === 'measurer-menu') {
-            this.onToolbarButtonPressMenu(event, 'toolbarAnnotationsMeasurerAnnotations', MEASURER_ANNOTATION_ITEMS);
-            return;
-        }
-
-        this.onToolbarButtonPressAnnotation(event);
-    }
-
-    private onToolbarAnnotationOptionButtonPress(event: _ModuleSupport.ToolbarButtonPressedEvent) {
-        if (!ToolbarManager.isGroup('annotationOptions', event)) return;
-
-        const { annotationData, state } = this;
-        const active = state.getActive();
-
-        if (active == null) return;
-
-        this.hideOverlays();
-
-        const datum = getTypedDatum(annotationData[active]);
-        const node = this.annotations.at(active);
-
-        switch (event.value) {
-            case AnnotationOptions.LineStyleType: {
-                const lineStyle = hasLineStyle(datum) ? getLineStyle(datum.lineDash, datum.lineStyle) : undefined;
-                this.lineStyleTypeMenu.show<AgAnnotationLineStyleType>({
-                    items: LINE_STYLE_TYPE_ITEMS,
-                    ariaLabel: this.ctx.localeManager.t('toolbarAnnotationsLineStyle'),
-                    value: lineStyle,
-                    sourceEvent: event.sourceEvent,
-                    onPress: (item) => this.onLineStyleTypeMenuPress(item, datum),
-                    class: 'annotations__line-style-type',
-                });
-                break;
-            }
-
-            case AnnotationOptions.LineStrokeWidth: {
-                const strokeWidth = hasLineStyle(datum) ? datum.strokeWidth : undefined;
-                this.lineStrokeWidthMenu.show<number>({
-                    items: LINE_STROKE_WIDTH_ITEMS,
-                    ariaLabel: this.ctx.localeManager.t('toolbarAnnotationsLineStrokeWidth'),
-                    value: strokeWidth,
-                    sourceEvent: event.sourceEvent,
-                    onPress: (item) => this.onLineStrokeWidthMenuPress(item, datum),
-                    class: 'annotations__line-stroke-width',
-                });
-                break;
-            }
-
-            case AnnotationOptions.LineColor:
-            case AnnotationOptions.FillColor:
-            case AnnotationOptions.TextColor: {
-                this.colorPicker.show({
-                    color: datum?.getDefaultColor(event.value),
-                    opacity: datum?.getDefaultOpacity(event.value),
-                    sourceEvent: event.sourceEvent,
-                    onChange: datum != null ? this.onColorPickerChange.bind(this, event.value, datum) : undefined,
-                    onChangeHide: ((type: AnnotationOptionsColorPickerType) => {
-                        this.recordActionAfterNextUpdate(
-                            `Change ${node?.type} ${event.value} to ${datum?.getDefaultColor(type)}`,
-                            ['annotations', 'defaults']
-                        );
-                    }).bind(this, event.value),
-                });
-                break;
-            }
-
-            case AnnotationOptions.TextSize: {
-                const fontSize = isTextType(datum) ? datum.fontSize : undefined;
-                this.textSizeMenu.show<number>({
-                    items: TEXT_SIZE_ITEMS,
-                    ariaLabel: this.ctx.localeManager.t('toolbarAnnotationsTextSize'),
-                    value: fontSize,
-                    sourceEvent: event.sourceEvent,
-                    onPress: (item) => this.onTextSizeMenuPress(item, datum),
-                    class: 'ag-charts-annotations-text-size-menu',
-                });
-                break;
-            }
-
-            case AnnotationOptions.Delete: {
-                this.cancel();
-                this.delete();
-                this.reset();
-                break;
-            }
-
-            case AnnotationOptions.Lock: {
-                annotationData[active].locked = !annotationData[active].locked;
-                this.toggleAnnotationOptionsButtons();
-                break;
-            }
-
-            case AnnotationOptions.Settings: {
-                state.transition('toolbarPressSettings', event.sourceEvent);
-                break;
-            }
-        }
-
-        this.update();
-    }
-
-    private onToolbarButtonPressMenu(
-        event: _ModuleSupport.ToolbarButtonPressedEvent,
-        ariaLabel: string,
-        items: Array<MenuItem<AnnotationType>>
-    ) {
-        const { x, y, width } = event.rect;
-
-        this.cancel();
-        this.reset();
-
-        this.annotationMenu.setAnchor({ x: x + width + 6, y });
-        this.annotationMenu.show<AnnotationType>({
-            items,
-            ariaLabel: this.ctx.localeManager.t(ariaLabel),
-            sourceEvent: event.sourceEvent,
-            onPress: this.onAnnotationsMenuPress.bind(this, event),
-        });
-    }
-
-    private onToolbarButtonPressAnnotation(event: _ModuleSupport.ToolbarButtonPressedEvent) {
-        this.ctx.tooltipManager.suppressTooltip('annotations');
-
-        const annotation = stringToAnnotationType(event.value);
-        if (annotation) {
-            this.beginAnnotationPlacement(annotation);
-        } else {
-            _Util.Logger.errorOnce(`Can not create unknown annotation type [${event.value}], ignoring.`);
-            this.update();
-        }
-    }
-
-    private onToolbarButtonMoved(event: _ModuleSupport.ToolbarButtonMovedEvent) {
-        const { group, rect, groupRect, value } = event;
-
-        if (group !== 'annotationOptions') return;
-
-        const anchor = { x: rect.x, y: rect.y + rect.height - 1 };
-
-        switch (value as AnnotationOptions) {
-            case AnnotationOptions.FillColor:
-            case AnnotationOptions.LineColor:
-            case AnnotationOptions.TextColor: {
-                const colorPickerAnchor = Vec2.add(groupRect, Vec2.from(0, groupRect.height + 4));
-                const fallback = { y: groupRect.y - 4 };
-                this.colorPicker.setAnchor(colorPickerAnchor, fallback);
-                break;
-            }
-            case AnnotationOptions.LineStrokeWidth: {
-                this.lineStrokeWidthMenu.setAnchor(anchor);
-                break;
-            }
-            case AnnotationOptions.LineStyleType: {
-                this.lineStyleTypeMenu.setAnchor(anchor);
-                break;
-            }
-            case AnnotationOptions.TextSize: {
-                this.textSizeMenu.setAnchor(anchor);
-                break;
-            }
-            default:
-                break;
-        }
-    }
-
-    private onToolbarGroupMoved(_event: _ModuleSupport.ToolbarGroupMovedEvent) {
-        this.hideOverlays();
-    }
-
-    private onColorPickerChange(
-        colorPickerType: AnnotationOptionsColorPickerType,
-        datum: AnnotationProperties,
-        colorOpacity: string,
-        color: string,
-        opacity: number
-    ) {
-        this.setColorAndDefault(datum.type, colorPickerType, colorOpacity, color, opacity);
-        this.updateToolbarColorPickerFill(colorPickerType, colorOpacity);
-    }
-
-    private updateToolbarColorPickerFill(
-        colorPickerType: AnnotationOptionsColorPickerType,
-        color?: string,
-        opacity?: number
-    ) {
-        if (color != null && opacity != null) {
-            const { r, g, b } = _Util.Color.fromString(color);
-            color = _Util.Color.fromArray([r, g, b, opacity]).toHexString();
-        }
-        this.ctx.toolbarManager.updateButton('annotationOptions', colorPickerType, {
-            fill: color,
-        });
-    }
-
-    private updateToolbarFills() {
-        const active = this.state.getActive();
-        const annotation = active != null ? this.annotationData[active] : undefined;
-        const datum = getTypedDatum(annotation);
-        this.updateToolbarColorPickerFill(
-            AnnotationOptions.LineColor,
-            datum?.getDefaultColor(AnnotationOptions.LineColor),
-            datum?.getDefaultOpacity(AnnotationOptions.LineColor)
-        );
-        this.updateToolbarColorPickerFill(
-            AnnotationOptions.FillColor,
-            datum?.getDefaultColor(AnnotationOptions.FillColor),
-            datum?.getDefaultOpacity(AnnotationOptions.FillColor)
-        );
-        this.updateToolbarColorPickerFill(
-            AnnotationOptions.TextColor,
-            datum?.getDefaultColor(AnnotationOptions.TextColor),
-            datum?.getDefaultOpacity(AnnotationOptions.TextColor)
-        );
-    }
-
-    private updateToolbarFontSize(fontSize: number | undefined) {
-        this.ctx.toolbarManager.updateButton('annotationOptions', AnnotationOptions.TextSize, {
-            label: fontSize != null ? String(fontSize) : undefined,
-        });
-    }
-
-    private updateToolbarLineStyleType(item: MenuItem<AgAnnotationLineStyleType>) {
-        this.ctx.toolbarManager.updateButton('annotationOptions', AnnotationOptions.LineStyleType, {
-            icon: item.icon,
-        });
-    }
-
-    private updateToolbarStrokeWidth(item: MenuItem<number>) {
-        this.ctx.toolbarManager.updateButton('annotationOptions', AnnotationOptions.LineStrokeWidth, {
-            label: item.label,
-            strokeWidth: item.value,
-        });
-    }
-
-    private onTextSizeMenuPress(item: MenuItem<number>, datum?: AnnotationProperties) {
-        if (!hasFontSize(datum)) return;
-
-        const fontSize = item.value;
-        this.setFontSizeAndDefault(datum.type, fontSize);
-        this.textSizeMenu.hide();
-        this.updateToolbarFontSize(fontSize);
-    }
-
-    private onLineStyleTypeMenuPress(item: MenuItem<AgAnnotationLineStyleType>, datum?: AnnotationProperties) {
-        if (!hasLineStyle(datum)) return;
-
-        const type = item.value;
-        this.setLineStyleTypeAndDefault(datum.type, type);
-        this.lineStyleTypeMenu.hide();
-        this.updateToolbarLineStyleType(item);
-    }
-
-    private onLineStrokeWidthMenuPress(item: MenuItem<number>, datum?: AnnotationProperties) {
-        if (!hasLineStyle(datum)) {
-            return;
-        }
-
-        const strokeWidth = item.value;
-        this.setLineStyleWidthAndDefault(datum.type, strokeWidth);
-        this.lineStrokeWidthMenu.hide();
-        this.updateToolbarStrokeWidth(item);
-    }
-
-    private onAnnotationsMenuPress(
-        event: _ModuleSupport.ToolbarButtonPressedEvent<AgToolbarAnnotationsButtonValue>,
-        item: MenuItem<AnnotationType>
-    ) {
-        const { toolbarManager } = this.ctx;
-
-        toolbarManager.toggleButton('annotations', event.id, {
-            active: true,
-        });
-        toolbarManager.updateButton('annotations', event.id, {
-            icon: item.icon,
-        });
-
-        this.beginAnnotationPlacement(item.value);
-        this.annotationMenu.hide();
-    }
-
-    private onToolbarCancelled(event: _ModuleSupport.ToolbarCancelledEvent) {
-        if (event.group === 'annotations') {
-            this.cancelPlacementInteraction();
-        }
-    }
-
-    private cancelPlacementInteraction() {
-        this.cancel();
-        this.resetToolbarButtonStates();
-        this.reset();
         this.update();
     }
 
@@ -1063,18 +764,15 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
             annotationData,
             annotations,
             seriesRect,
-            ctx: { annotationManager, toolbarManager },
+            ctx: { annotationManager },
         } = this;
 
         const context = this.getAnnotationContext();
-        if (!seriesRect || !context) {
-            return;
-        }
+        if (!seriesRect || !context) return;
 
         annotationManager.updateData(annotationData.toJson() as any);
 
-        const clearAllEnabled = annotationData.length > 0;
-        toolbarManager.toggleButton('annotations', 'clear', { enabled: clearAllEnabled });
+        this.toolbar.toggleClearButtonEnabled(annotationData.length > 0);
 
         annotations
             .update(annotationData ?? [], undefined, (datum) => datum.id)
@@ -1176,7 +874,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
 
         const {
             state,
-            ctx: { toolbarManager, interactionManager },
+            ctx: { interactionManager },
         } = this;
 
         interactionManager.pushState(InteractionState.Annotations);
@@ -1184,7 +882,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         const isHorizontal = direction === 'horizontal';
         state.transition(isHorizontal ? AnnotationType.HorizontalLine : AnnotationType.VerticalLine);
 
-        toolbarManager.toggleGroup('annotations', 'annotationOptions', { visible: false });
+        this.optionsToolbar.toggleVisibility(false);
 
         if (!coords) {
             return;
@@ -1330,85 +1028,6 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         this.state.transition('translateEnd');
     }
 
-    private beginAnnotationPlacement(annotation: AnnotationType) {
-        this.cancel();
-
-        this.ctx.interactionManager.pushState(InteractionState.Annotations);
-        this.state.transition(annotation);
-
-        this.update();
-    }
-
-    private toggleAnnotationOptionsButtons() {
-        const {
-            annotationData,
-            state,
-            ctx: { toolbarManager },
-        } = this;
-        const active = state.getActive();
-
-        if (active == null) return;
-
-        const datum = getTypedDatum(annotationData.at(active));
-        const locked = datum?.locked ?? false;
-
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.LineStyleType, {
-            enabled: !locked,
-            visible: hasLineStyle(datum),
-        });
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.LineStrokeWidth, {
-            enabled: !locked,
-            visible: hasLineStyle(datum),
-        });
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.LineColor, {
-            enabled: !locked,
-            visible: hasLineColor(datum),
-        });
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.TextColor, {
-            enabled: !locked,
-            visible: hasTextColor(datum),
-        });
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.FillColor, {
-            enabled: !locked,
-            visible: hasFillColor(datum),
-        });
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.TextSize, {
-            enabled: !locked,
-            visible: hasFontSize(datum),
-        });
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.Settings, {
-            enabled: !locked,
-            visible: hasLineText(datum),
-        });
-
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.Delete, { enabled: !locked });
-        toolbarManager.toggleButton('annotationOptions', AnnotationOptions.Lock, { checked: locked });
-
-        toolbarManager.updateGroup('annotationOptions');
-
-        this.updateToolbarFontSize(datum != null && 'fontSize' in datum ? datum.fontSize : undefined);
-        this.updateToolbarFills();
-        this.updateToolbarLineStyles(datum);
-    }
-
-    private updateToolbarLineStyles(datum?: AnnotationProperties) {
-        if (!hasLineStyle(datum)) {
-            return;
-        }
-        const strokeWidth = datum.strokeWidth ?? 1;
-        const lineStyleType = getLineStyle(datum.lineDash, datum.lineStyle);
-
-        this.updateToolbarStrokeWidth({
-            strokeWidth,
-            value: strokeWidth,
-            label: String(strokeWidth),
-        });
-
-        this.updateToolbarLineStyleType(
-            LINE_STYLE_TYPE_ITEMS.find((item) => item.value === lineStyleType) ?? LINE_STYLE_TYPE_ITEMS[0]
-        );
-    }
-
     private clear() {
         this.cancel();
         this.deleteAll();
@@ -1440,26 +1059,9 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private hideOverlays() {
-        this.colorPicker.hide({ lastFocus: null });
-        this.textSizeMenu.hide();
-        this.lineStyleTypeMenu.hide();
-        this.lineStrokeWidthMenu.hide();
-        this.annotationMenu.hide();
         this.settingsDialog.hide();
-    }
-
-    private resetToolbarButtonStates() {
-        const {
-            ctx: { toolbarManager },
-        } = this;
-
-        for (const annotationType of ANNOTATION_BUTTONS) {
-            toolbarManager.toggleButton('annotations', annotationType, { active: false });
-        }
-
-        for (const annotationGroup of ANNOTATION_BUTTON_GROUPS) {
-            toolbarManager.toggleButton('annotations', annotationGroup, { active: false });
-        }
+        this.toolbar.hideOverlays();
+        this.optionsToolbar.hideOverlays();
     }
 
     private update(status = ChartUpdateType.PRE_SCENE_RENDER) {

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsToolbar.ts
@@ -1,0 +1,172 @@
+import { type AgToolbarAnnotationsButtonValue, _ModuleSupport, _Util } from 'ag-charts-community';
+
+import { Menu, type MenuItem } from '../../components/menu/menu';
+import {
+    ANNOTATION_BUTTONS,
+    ANNOTATION_BUTTON_GROUPS,
+    type AnnotationType,
+    stringToAnnotationType,
+} from './annotationTypes';
+import {
+    LINE_ANNOTATION_ITEMS,
+    MEASURER_ANNOTATION_ITEMS,
+    SHAPE_ANNOTATION_ITEMS,
+    TEXT_ANNOTATION_ITEMS,
+} from './annotationsMenuOptions';
+
+const { ToolbarManager } = _ModuleSupport;
+
+interface EventMap {
+    'cancel-create-annotation': void;
+    'pressed-create-annotation': { annotation: AnnotationType };
+    'pressed-clear': void;
+    'pressed-show-menu': void;
+    'pressed-unrelated': void;
+}
+
+export class AnnotationsToolbar extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
+    private readonly events = new _ModuleSupport.Listeners<keyof EventMap, any>();
+
+    private readonly annotationMenu = new Menu(this.ctx, 'annotations');
+
+    constructor(private readonly ctx: _ModuleSupport.ModuleContext) {
+        super();
+
+        const { toolbarManager } = ctx;
+
+        this.destroyFns.push(
+            toolbarManager.addListener('button-pressed', this.onButtonPress.bind(this)),
+            toolbarManager.addListener('cancelled', this.onCancelled.bind(this))
+        );
+    }
+
+    public addListener<K extends keyof EventMap>(eventType: K, handler: (event: EventMap[K]) => void) {
+        return this.events.addListener(eventType, handler);
+    }
+
+    public toggleVisibility(visible: boolean) {
+        this.ctx.toolbarManager.toggleGroup('annotations', 'annotations', { visible });
+    }
+
+    public toggleClearButtonEnabled(enabled: boolean) {
+        this.ctx.toolbarManager.toggleButton('annotations', 'clear', { enabled });
+    }
+
+    public resetButtonIcons() {
+        this.ctx.toolbarManager.updateButton('annotations', 'line-menu', { icon: undefined });
+        this.ctx.toolbarManager.updateButton('annotations', 'text-menu', { icon: undefined });
+        this.ctx.toolbarManager.updateButton('annotations', 'shape-menu', { icon: undefined });
+    }
+
+    public hideOverlays() {
+        this.annotationMenu.hide();
+    }
+
+    public resetButtonStates() {
+        const {
+            ctx: { toolbarManager },
+        } = this;
+
+        // Reset buttons that are _not_ part of a menu
+        for (const annotationType of ANNOTATION_BUTTONS) {
+            toolbarManager.toggleButton('annotations', annotationType, { active: false });
+        }
+
+        // Reset buttons that open a menu
+        for (const annotationGroup of ANNOTATION_BUTTON_GROUPS) {
+            toolbarManager.toggleButton('annotations', annotationGroup, { active: false });
+        }
+    }
+
+    private dispatch<K extends keyof EventMap>(eventType: K, event?: EventMap[K]) {
+        this.events.dispatch(eventType, event);
+    }
+
+    private onButtonPress(event: _ModuleSupport.ToolbarButtonPressedEvent) {
+        if (!ToolbarManager.isGroup('annotations', event)) {
+            if (!ToolbarManager.isGroup('annotationOptions', event)) {
+                this.dispatch('pressed-unrelated');
+            }
+            return;
+        }
+
+        if (event.value === 'clear') {
+            this.dispatch('pressed-clear');
+            return;
+        }
+
+        if (event.value === 'line-menu') {
+            this.onButtonPressShowMenu(event, 'toolbarAnnotationsLineAnnotations', LINE_ANNOTATION_ITEMS);
+            return;
+        }
+
+        if (event.value === 'text-menu') {
+            this.onButtonPressShowMenu(event, 'toolbarAnnotationsTextAnnotations', TEXT_ANNOTATION_ITEMS);
+            return;
+        }
+
+        if (event.value === 'shape-menu') {
+            this.onButtonPressShowMenu(event, 'toolbarAnnotationsShapeAnnotations', SHAPE_ANNOTATION_ITEMS);
+            return;
+        }
+
+        if (event.value === 'measurer-menu') {
+            this.onButtonPressShowMenu(event, 'toolbarAnnotationsMeasurerAnnotations', MEASURER_ANNOTATION_ITEMS);
+            return;
+        }
+
+        this.onButtonPressCreateAnnotation(event);
+    }
+
+    private onButtonPressShowMenu(
+        event: _ModuleSupport.ToolbarButtonPressedEvent,
+        ariaLabel: string,
+        items: Array<MenuItem<AnnotationType>>
+    ) {
+        const { x, y, width } = event.rect;
+
+        this.dispatch('pressed-show-menu');
+
+        this.annotationMenu.setAnchor({ x: x + width + 6, y });
+        this.annotationMenu.show<AnnotationType>({
+            items,
+            ariaLabel: this.ctx.localeManager.t(ariaLabel),
+            sourceEvent: event.sourceEvent,
+            onPress: this.onButtonPressMenuCreateAnnotation.bind(this, event),
+        });
+    }
+
+    private onButtonPressCreateAnnotation(event: _ModuleSupport.ToolbarButtonPressedEvent) {
+        this.ctx.tooltipManager.suppressTooltip('annotations');
+
+        const annotation = stringToAnnotationType(event.value);
+        if (annotation) {
+            this.dispatch('pressed-create-annotation', { annotation });
+        } else {
+            _Util.Logger.errorOnce(`Can not create unknown annotation type [${event.value}], ignoring.`);
+        }
+    }
+
+    private onButtonPressMenuCreateAnnotation(
+        event: _ModuleSupport.ToolbarButtonPressedEvent<AgToolbarAnnotationsButtonValue>,
+        item: MenuItem<AnnotationType>
+    ) {
+        const { toolbarManager } = this.ctx;
+
+        toolbarManager.toggleButton('annotations', event.id, {
+            active: true,
+        });
+        toolbarManager.updateButton('annotations', event.id, {
+            icon: item.icon,
+        });
+
+        this.dispatch('pressed-create-annotation', { annotation: item.value });
+        this.annotationMenu.hide();
+    }
+
+    private onCancelled(event: _ModuleSupport.ToolbarCancelledEvent) {
+        if (event.group === 'annotations') {
+            this.dispatch('cancel-create-annotation');
+        }
+    }
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11986

Splits out the two toolbars (main one on the left and the floating options one) into two separate classes.

Behaviour should be identical.

This is predominantly a copy-paste job, so I will highlight the main changes below.