### PR TITLE
Sonar - Refactor methods that use boolean selector param

### DIFF
--- a/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
@@ -259,23 +259,21 @@ export class CartesianCrossLine extends BaseProperties implements CrossLine<Cart
 
         this.data = [clampedYStart, clampedYEnd];
 
-        if (this.label.enabled) {
-            const yDirection = direction === ChartAxisDirection.Y;
+        if (!this.label.enabled) return;
 
-            const { c = POSITION_TOP_COORDINATES } = labelDirectionHandling[position] ?? {};
-            const { x: labelX, y: labelY } = c({
-                yDirection,
-                xStart,
-                xEnd,
-                yStart: clampedYStart,
-                yEnd: clampedYEnd,
-            });
+        const { c = POSITION_TOP_COORDINATES } = labelDirectionHandling[position] ?? {};
+        const { x: labelX, y: labelY } = c({
+            direction,
+            xStart,
+            xEnd,
+            yStart: clampedYStart,
+            yEnd: clampedYEnd,
+        });
 
-            this.labelPoint = {
-                x: labelX,
-                y: labelY,
-            };
-        }
+        this.labelPoint = {
+            x: labelX,
+            y: labelY,
+        };
     }
 
     private updateNodes() {

--- a/packages/ag-charts-community/src/chart/crossline/crossLineLabelPosition.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLineLabelPosition.ts
@@ -2,6 +2,7 @@ import type { AgCartesianAxisPosition } from 'ag-charts-types';
 
 import type { BBox } from '../../scene/bbox';
 import type { Point } from '../../scene/point';
+import { ChartAxisDirection } from '../chartAxisDirection';
 
 export type CrossLineLabelPosition =
     | 'top'
@@ -22,9 +23,9 @@ export type CrossLineLabelPosition =
     | 'insideTopRight'
     | 'insideBottomRight';
 
-type CoordinatesFnOpts = { yDirection: boolean; xStart: number; xEnd: number; yStart: number; yEnd: number };
+type CoordinatesFnOpts = { direction: ChartAxisDirection; xStart: number; xEnd: number; yStart: number; yEnd: number };
 
-type CoordinatesFn = ({ yDirection, xStart, xEnd, yStart, yEnd }: CoordinatesFnOpts) => Point;
+type CoordinatesFn = ({ direction, xStart, xEnd, yStart, yEnd }: CoordinatesFnOpts) => Point;
 
 type PositionCalcFns = {
     c: CoordinatesFn;
@@ -127,32 +128,32 @@ export function calculateLabelChartPadding({
     return chartPadding;
 }
 
-export const POSITION_TOP_COORDINATES: CoordinatesFn = ({ yDirection, xEnd, yStart, yEnd }) => {
-    if (yDirection) {
+export const POSITION_TOP_COORDINATES: CoordinatesFn = ({ direction, xEnd, yStart, yEnd }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xEnd / 2, y: yStart };
     } else {
         return { x: xEnd, y: isNaN(yEnd) ? yStart : (yStart + yEnd) / 2 };
     }
 };
 
-const POSITION_LEFT_COORDINATES: CoordinatesFn = ({ yDirection, xStart, xEnd, yStart, yEnd }) => {
-    if (yDirection) {
+const POSITION_LEFT_COORDINATES: CoordinatesFn = ({ direction, xStart, xEnd, yStart, yEnd }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xStart, y: isNaN(yEnd) ? yStart : (yStart + yEnd) / 2 };
     } else {
         return { x: xEnd / 2, y: yStart };
     }
 };
 
-const POSITION_RIGHT_COORDINATES: CoordinatesFn = ({ yDirection, xEnd, yStart, yEnd }) => {
-    if (yDirection) {
+const POSITION_RIGHT_COORDINATES: CoordinatesFn = ({ direction, xEnd, yStart, yEnd }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xEnd, y: isNaN(yEnd) ? yStart : (yStart + yEnd) / 2 };
     } else {
         return { x: xEnd / 2, y: isNaN(yEnd) ? yStart : yEnd };
     }
 };
 
-const POSITION_BOTTOM_COORDINATES: CoordinatesFn = ({ yDirection, xStart, xEnd, yStart, yEnd }) => {
-    if (yDirection) {
+const POSITION_BOTTOM_COORDINATES: CoordinatesFn = ({ direction, xStart, xEnd, yStart, yEnd }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xEnd / 2, y: isNaN(yEnd) ? yStart : yEnd };
     } else {
         return { x: xStart, y: isNaN(yEnd) ? yStart : (yStart + yEnd) / 2 };
@@ -163,32 +164,32 @@ const POSITION_INSIDE_COORDINATES: CoordinatesFn = ({ xEnd, yStart, yEnd }) => {
     return { x: xEnd / 2, y: isNaN(yEnd) ? yStart : (yStart + yEnd) / 2 };
 };
 
-const POSITION_TOP_LEFT_COORDINATES: CoordinatesFn = ({ yDirection, xStart, xEnd, yStart }) => {
-    if (yDirection) {
+const POSITION_TOP_LEFT_COORDINATES: CoordinatesFn = ({ direction, xStart, xEnd, yStart }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xStart / 2, y: yStart };
     } else {
         return { x: xEnd, y: yStart };
     }
 };
 
-const POSITION_BOTTOM_LEFT_COORDINATES: CoordinatesFn = ({ yDirection, xStart, yStart, yEnd }) => {
-    if (yDirection) {
+const POSITION_BOTTOM_LEFT_COORDINATES: CoordinatesFn = ({ direction, xStart, yStart, yEnd }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xStart, y: isNaN(yEnd) ? yStart : yEnd };
     } else {
         return { x: xStart, y: yStart };
     }
 };
 
-const POSITION_TOP_RIGHT_COORDINATES: CoordinatesFn = ({ yDirection, xEnd, yStart, yEnd }) => {
-    if (yDirection) {
+const POSITION_TOP_RIGHT_COORDINATES: CoordinatesFn = ({ direction, xEnd, yStart, yEnd }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xEnd, y: yStart };
     } else {
         return { x: xEnd, y: isNaN(yEnd) ? yStart : yEnd };
     }
 };
 
-const POSITION_BOTTOM_RIGHT_COORDINATES: CoordinatesFn = ({ yDirection, xStart, xEnd, yStart, yEnd }) => {
-    if (yDirection) {
+const POSITION_BOTTOM_RIGHT_COORDINATES: CoordinatesFn = ({ direction, xStart, xEnd, yStart, yEnd }) => {
+    if (direction === ChartAxisDirection.Y) {
         return { x: xEnd, y: isNaN(yEnd) ? yStart : yEnd };
     } else {
         return { x: xStart, y: isNaN(yEnd) ? yStart : yEnd };

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
@@ -135,12 +135,12 @@ export class ContextMenuRegistry {
         this.disabledActions.add(actionId);
     }
 
-    public setActionVisibility(actionId: string, visible: boolean) {
-        if (visible) {
-            this.hiddenActions.delete(actionId);
-        } else {
-            this.hiddenActions.add(actionId);
-        }
+    public showAction(actionId: string) {
+        this.hiddenActions.add(actionId);
+    }
+
+    public hideAction(actionId: string) {
+        this.hiddenActions.delete(actionId);
     }
 
     public isDisabled(actionId: string): boolean {

--- a/packages/ag-charts-community/src/chart/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend.ts
@@ -945,9 +945,18 @@ export class Legend extends BaseProperties {
     }
 
     private updateContextMenu() {
-        const { toggleSeries } = this;
-        this.ctx.contextMenuRegistry.setActionVisibility(ID_LEGEND_VISIBILITY, toggleSeries);
-        this.ctx.contextMenuRegistry.setActionVisibility(ID_LEGEND_OTHER_SERIES, toggleSeries);
+        const {
+            toggleSeries,
+            ctx: { contextMenuRegistry },
+        } = this;
+
+        if (toggleSeries) {
+            contextMenuRegistry.hideAction(ID_LEGEND_VISIBILITY);
+            contextMenuRegistry.hideAction(ID_LEGEND_OTHER_SERIES);
+        } else {
+            contextMenuRegistry.showAction(ID_LEGEND_VISIBILITY);
+            contextMenuRegistry.showAction(ID_LEGEND_OTHER_SERIES);
+        }
     }
 
     private getLineStyles(datum: LegendSymbolOptions) {

--- a/packages/ag-charts-community/src/chart/update/overlaysProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/overlaysProcessor.ts
@@ -55,28 +55,42 @@ export class OverlaysProcessor<D extends object> implements UpdateProcessor {
         const noDataShown = !isLoading && !hasData;
         const noVisibleSeriesShown = hasData && !anySeriesVisible;
 
-        this.toggleOverlay(this.overlays.loading, rect, loadingShown);
-        this.toggleOverlay(this.overlays.noData, rect, noDataShown);
-        this.toggleOverlay(this.overlays.noVisibleSeries, rect, noVisibleSeriesShown);
+        if (loadingShown) {
+            this.showOverlay(this.overlays.loading, rect);
+        } else {
+            this.hideOverlay(this.overlays.loading);
+        }
+
+        if (noDataShown) {
+            this.showOverlay(this.overlays.noData, rect);
+        } else {
+            this.hideOverlay(this.overlays.noData);
+        }
+
+        if (noVisibleSeriesShown) {
+            this.showOverlay(this.overlays.noVisibleSeries, rect);
+        } else {
+            this.hideOverlay(this.overlays.noVisibleSeries);
+        }
 
         const shown = loadingShown || noDataShown || noVisibleSeriesShown;
         setAttribute(this.overlayElem, 'aria-hidden', !shown);
     }
 
-    private toggleOverlay(overlay: Overlay, seriesRect: BBox, visible: boolean) {
-        if (visible) {
-            const element = overlay.getElement(this.animationManager, this.localeManager, seriesRect);
-            this.overlayElem.appendChild(element);
-        } else {
-            // AG-11424 Frustratingly, browsers do not reliable announce aria-live changes to overlayElem when
-            // re-adding an identical element. This seems that if, for example, the user toggle the last visible
-            // series off/on/off, then the second "No visible series" overlay announcement may not get fired.
-            // Firefox & Safari seem to handle this correctly, whereas Chromium does not. However setting the
-            // content to a No-Break Space helps the browser to understand that the aria status has changed,
-            // and also tells the no screenreader not to announce anything because it's just whitespace.
-            overlay.removeElement(() => {
-                this.overlayElem.innerText = '\xA0';
-            }, this.animationManager);
-        }
+    private showOverlay(overlay: Overlay, seriesRect: BBox) {
+        const element = overlay.getElement(this.animationManager, this.localeManager, seriesRect);
+        this.overlayElem.appendChild(element);
+    }
+
+    private hideOverlay(overlay: Overlay) {
+        // AG-11424 Frustratingly, browsers do not reliably announce aria-live changes to overlayElem when
+        // re-adding an identical element. This seems that if, for example, the user toggle the last visible
+        // series off/on/off, then the second "No visible series" overlay announcement may not get fired.
+        // Firefox & Safari seem to handle this correctly, whereas Chromium does not. However setting the
+        // content to a No-Break Space helps the browser to understand that the aria status has changed,
+        // and also tells the no screenreader not to announce anything because it's just whitespace.
+        overlay.removeElement(() => {
+            this.overlayElem.innerText = '\xA0';
+        }, this.animationManager);
     }
 }

--- a/packages/ag-charts-community/src/scene/group.ts
+++ b/packages/ag-charts-community/src/scene/group.ts
@@ -215,14 +215,17 @@ export class Group extends Node {
      * Transforms bbox given in the canvas coordinate space to bbox in this group's coordinate space and
      * sets this group's clipRect to the transformed bbox.
      * @param bbox clipRect bbox in the canvas coordinate space.
-     * @param transformToGroupSpace set false to keep provided bbox coordinate space.
      */
-    setClipRect(bbox?: BBox, transformToGroupSpace = true) {
-        if (transformToGroupSpace) {
-            this.clipRect = bbox ? Transformable.fromCanvas(this, bbox) : undefined;
-        } else {
-            this.clipRect = bbox;
-        }
+    setClipRect(bbox?: BBox) {
+        this.clipRect = bbox ? Transformable.fromCanvas(this, bbox) : undefined;
+    }
+
+    /**
+     * Set the clip rect within the canvas coordinate space.
+     * @param bbox clipRect bbox in the canvas coordinate space.
+     */
+    setClipRectCanvasSpace(bbox?: BBox) {
+        this.clipRect = bbox;
     }
 
     override toSVG(): { elements: SVGElement[]; defs?: SVGElement[] } | undefined {

--- a/packages/ag-charts-enterprise/src/features/navigator/miniChart.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/miniChart.ts
@@ -235,7 +235,7 @@ export class MiniChart extends _ModuleSupport.BaseModuleInstance implements _Mod
 
         this.seriesRect = seriesRect;
         this.seriesRoot.translationY = padding.top;
-        this.seriesRoot.setClipRect(new BBox(0, -padding.top, width, height), false);
+        this.seriesRoot.setClipRectCanvasSpace(new BBox(0, -padding.top, width, height));
 
         this.axes.forEach((axis) => {
             const { position = 'left' } = axis;


### PR DESCRIPTION
See https://sonarcloud.io/organizations/ag-grid/rules?open=typescript%3AS2301&rule_key=typescript%3AS2301

While I agree that `doThing(false)` is bad, it does add increase the lines of code in some instances (though to be fair, with greater clarity).