### PR TITLE
AG-13163 Prevent default on all unconsumed arrow keys in our DOM

### DIFF
--- a/packages/ag-charts-community/src/dom/domManager.ts
+++ b/packages/ag-charts-community/src/dom/domManager.ts
@@ -5,6 +5,7 @@ import { BBox } from '../scene/bbox';
 import STYLES from '../styles.css';
 import { setAttribute } from '../util/attributeUtil';
 import { createElement, getDocument, getWindow } from '../util/dom';
+import { stopPageScrolling } from '../util/keynavUtil';
 import { type Size, SizeMonitor } from '../util/sizeMonitor';
 // TODO move to utils
 import BASE_DOM from './domLayout.html';
@@ -117,6 +118,8 @@ export class DOMManager extends BaseManager<Events['type'], Events> {
         if (container) {
             this.setContainer(container);
         }
+
+        this.destroyFns.push(stopPageScrolling(this.element));
     }
 
     override destroy() {

--- a/packages/ag-charts-community/src/util/keynavUtil.ts
+++ b/packages/ag-charts-community/src/util/keynavUtil.ts
@@ -255,3 +255,14 @@ export function getLastFocus(sourceEvent: Event | undefined): HTMLElement | unde
     }
     return undefined;
 }
+
+export function stopPageScrolling(element: HTMLElement) {
+    const handler = (event: KeyboardEvent) => {
+        if (event.defaultPrevented) return;
+        if (!event.defaultPrevented && matchesKey(event, 'ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp')) {
+            event.preventDefault();
+        }
+    };
+    element.addEventListener('keydown', handler);
+    return () => element.removeEventListener('keydown', handler);
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13163

This is to stop page scrolling in some browsers like Firefox and Chrome.