### PR TITLE
Offscreen canvas

### DIFF
--- a/packages/ag-charts-community/src/scene/canvas/canvasUtil.ts
+++ b/packages/ag-charts-community/src/scene/canvas/canvasUtil.ts
@@ -1,0 +1,44 @@
+import { Debug } from '../../util/debug';
+
+export function clearContext({
+    context,
+    pixelRatio,
+    width,
+    height,
+}: {
+    context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    pixelRatio: number;
+    width: number;
+    height: number;
+}) {
+    context.save();
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    context.clearRect(0, 0, width, height);
+    context.restore();
+}
+
+export function debugContext(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D) {
+    if (Debug.check('canvas')) {
+        const save = ctx.save.bind(ctx);
+        const restore = ctx.restore.bind(ctx);
+        let depth = 0;
+        Object.assign(ctx, {
+            save() {
+                save();
+                depth++;
+            },
+            restore() {
+                if (depth === 0) {
+                    throw new Error('AG Charts - Unable to restore() past depth 0');
+                }
+                restore();
+                depth--;
+            },
+            verifyDepthZero() {
+                if (depth !== 0) {
+                    throw new Error(`AG Charts - Save/restore depth is non-zero: ${depth}`);
+                }
+            },
+        });
+    }
+}

--- a/packages/ag-charts-community/src/scene/canvas/hdpiOffscreenCanvas.ts
+++ b/packages/ag-charts-community/src/scene/canvas/hdpiOffscreenCanvas.ts
@@ -1,0 +1,73 @@
+import { getWindow } from '../../util/dom';
+import { hasConstrainedCanvasMemory } from '../../util/userAgent';
+import { clearContext, debugContext } from './canvasUtil';
+
+// Work-around for typing issues with Angular 13+ (see AG-6969),
+type OffscreenCanvasRenderingContext2D = any;
+
+export interface CanvasOptions {
+    width?: number;
+    height?: number;
+    pixelRatio?: number;
+    willReadFrequently?: boolean;
+    canvasElement?: HTMLCanvasElement;
+}
+
+/**
+ * Wraps the native Canvas element and overrides its CanvasRenderingContext2D to
+ * provide resolution independent rendering based on `window.devicePixelRatio`.
+ */
+export class HdpiOffscreenCanvas {
+    readonly canvas: OffscreenCanvas;
+    readonly context: OffscreenCanvasRenderingContext2D & { verifyDepthZero?: () => void };
+
+    width: number = 600;
+    height: number = 300;
+    pixelRatio: number;
+
+    constructor(options: CanvasOptions) {
+        const { width, height, pixelRatio, willReadFrequently = false } = options;
+
+        this.pixelRatio = hasConstrainedCanvasMemory() ? 1 : pixelRatio ?? getWindow('devicePixelRatio');
+
+        this.canvas = new OffscreenCanvas(width ?? this.width, height ?? this.height);
+
+        this.context = this.canvas.getContext('2d', { willReadFrequently })!;
+
+        this.resize(width ?? 0, height ?? 0);
+
+        debugContext(this.context);
+    }
+
+    drawImage(context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, dx = 0, dy = 0) {
+        return context.drawImage(this.context.canvas, dx, dy);
+    }
+
+    resize(width: number, height: number) {
+        if (!(width > 0 && height > 0)) return;
+
+        const { canvas, context, pixelRatio } = this;
+        canvas.width = Math.round(width * pixelRatio);
+        canvas.height = Math.round(height * pixelRatio);
+        context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+
+        this.width = width;
+        this.height = height;
+    }
+
+    clear() {
+        clearContext(this);
+    }
+
+    destroy() {
+        // Workaround memory allocation quirks in iOS Safari by resizing to 0x0 and clearing.
+        // See https://bugs.webkit.org/show_bug.cgi?id=195325.
+        this.canvas.width = 0;
+        this.canvas.height = 0;
+        this.context.clearRect(0, 0, 0, 0);
+
+        (this as any).canvas = null!;
+
+        Object.freeze(this);
+    }
+}

--- a/packages/ag-charts-community/src/scene/group.ts
+++ b/packages/ag-charts-community/src/scene/group.ts
@@ -1,7 +1,7 @@
-import { ascendingStringNumberUndefined, compoundAscending } from '../util/compare';
+import { ascendingStringNumberUndefined } from '../util/compare';
 import { clamp } from '../util/number';
 import { BBox } from './bbox';
-import type { HdpiCanvas } from './canvas/hdpiCanvas';
+import type { HdpiOffscreenCanvas } from './canvas/hdpiOffscreenCanvas';
 import { nodeCount } from './debug.util';
 import type { LayersManager } from './layersManager';
 import type { ChildNodeCounts, RenderContext } from './node';
@@ -21,10 +21,7 @@ export class Group extends Node {
     }
 
     private static compareChildren(a: Node, b: Node) {
-        return (
-            compareZIndex(a.zIndex, b.zIndex) ||
-            compoundAscending([a.serialNumber], [b.serialNumber], ascendingStringNumberUndefined)
-        );
+        return compareZIndex(a.zIndex, b.zIndex) || ascendingStringNumberUndefined(a.serialNumber, b.serialNumber);
     }
 
     private clipRect?: BBox;
@@ -34,7 +31,7 @@ export class Group extends Node {
     })
     opacity: number = 1;
 
-    private layer: HdpiCanvas | undefined = undefined;
+    private layer: HdpiOffscreenCanvas | undefined = undefined;
     renderToOffscreenCanvas: boolean = false;
 
     constructor(opts?: {
@@ -87,18 +84,14 @@ export class Group extends Node {
     }
 
     override render(renderCtx: RenderContext) {
-        if (!this.visible) {
-            return super.render(renderCtx);
-        }
-
+        const { layer } = this;
         const childRenderCtx: RenderContext = { ...renderCtx };
 
-        if (this.layer == null) {
+        if (layer == null) {
             this.renderInContext(childRenderCtx);
             return;
         }
 
-        const { layer } = this;
         const { ctx } = renderCtx;
 
         if (this.isDirty(renderCtx)) {
@@ -123,21 +116,6 @@ export class Group extends Node {
         ctx.resetTransform();
         layer.drawImage(ctx as any);
         ctx.restore();
-    }
-
-    private renderClip(renderCtx: RenderContext, clipRect: BBox) {
-        // clipRect is in the group's coordinate space
-        const { x, y, width, height } = clipRect;
-        const { ctx } = renderCtx;
-
-        ctx.beginPath();
-        ctx.rect(x, y, width, height);
-        ctx.clip();
-
-        // clipBBox is in the canvas coordinate space,
-        // when we hit a layer we apply the new clipping
-        // at which point there are no transforms in play
-        return Transformable.toCanvas(this, clipRect);
     }
 
     private skipRender(childRenderCtx: RenderContext) {
@@ -166,7 +144,17 @@ export class Group extends Node {
         ctx.globalAlpha *= this.opacity;
 
         if (this.clipRect != null) {
-            childRenderCtx.clipBBox = this.renderClip(childRenderCtx, this.clipRect);
+            // clipRect is in the group's coordinate space
+            const { x, y, width, height } = this.clipRect;
+
+            ctx.beginPath();
+            ctx.rect(x, y, width, height);
+            ctx.clip();
+
+            // clipBBox is in the canvas coordinate space,
+            // when we hit a layer we apply the new clipping
+            // at which point there are no transforms in play
+            childRenderCtx.clipBBox = Transformable.toCanvas(this, this.clipRect);
         }
 
         for (const child of this.children()) {

--- a/packages/ag-charts-community/src/scene/layersManager.ts
+++ b/packages/ag-charts-community/src/scene/layersManager.ts
@@ -1,16 +1,17 @@
 import { Debug } from '../util/debug';
 import { HdpiCanvas } from './canvas/hdpiCanvas';
+import { HdpiOffscreenCanvas } from './canvas/hdpiOffscreenCanvas';
 
 interface SceneLayer {
     id: number;
     name?: string;
-    canvas: HdpiCanvas;
+    canvas: HdpiOffscreenCanvas;
 }
 
 export class LayersManager {
     readonly debug = Debug.create(true, 'scene');
 
-    private readonly layersMap = new Map<HdpiCanvas, SceneLayer>();
+    private readonly layersMap = new Map<HdpiOffscreenCanvas, SceneLayer>();
 
     private nextLayerId = 0;
 
@@ -28,7 +29,7 @@ export class LayersManager {
     addLayer(opts: { name?: string }) {
         const { width, height, pixelRatio } = this.canvas;
         const { name } = opts;
-        const canvas = new HdpiCanvas({ width, height, pixelRatio });
+        const canvas = new HdpiOffscreenCanvas({ width, height, pixelRatio });
 
         this.layersMap.set(canvas, {
             id: this.nextLayerId++,
@@ -41,7 +42,7 @@ export class LayersManager {
         return canvas;
     }
 
-    removeLayer(canvas: HdpiCanvas) {
+    removeLayer(canvas: HdpiOffscreenCanvas) {
         if (this.layersMap.has(canvas)) {
             this.layersMap.delete(canvas);
             canvas.destroy();


### PR DESCRIPTION
Currently we use unmounted canvas elements for offscreen canvases. Normally any update to a canvas element would cause the browser to at least partially redraw the page, and I'm not so sure they have optimisations to not do this for unmounted canvases. Using OffscreenCanvas provides a better guarantee that updates to the canvas won't lead to redrawing the browser page