### PR TITLE
AG-13145 Add typing to state machine event data

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -130,7 +130,7 @@ interface TickGenerationResult {
 }
 
 type AxisAnimationState = 'empty' | 'ready';
-type AxisAnimationEvent = 'update' | 'resize' | 'reset';
+type AxisAnimationEvent = { reset: undefined; resize: undefined; update: FromToDiff };
 
 export type AxisModuleMap = ModuleMap<AxisOptionModule, ModuleInstance, ModuleContextWithParent<AxisContext>>;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -92,16 +92,22 @@ export class CartesianSeriesNodeEvent<TEvent extends string = SeriesNodeEventTyp
 }
 
 type CartesianAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing' | 'disabled';
-type CartesianAnimationEvent =
-    | 'update'
-    | 'updateData'
-    | 'highlight'
-    | 'highlightMarkers'
-    | 'resize'
-    | 'clear'
-    | 'reset'
-    | 'skip'
-    | 'disable';
+type CartesianAnimationEvent<
+    TNode extends Node,
+    TDatum extends CartesianSeriesNodeDatum,
+    TLabel extends SeriesNodeDatum = TDatum,
+    TContext extends CartesianSeriesNodeDataContext<TDatum, TLabel> = CartesianSeriesNodeDataContext<TDatum, TLabel>,
+> = {
+    update: CartesianAnimationData<TNode, TDatum, TLabel, TContext>;
+    updateData: undefined;
+    highlight: Selection<TNode, TDatum>;
+    highlightMarkers: Selection<Marker, TDatum>;
+    resize: CartesianAnimationData<TNode, TDatum, TLabel, TContext>;
+    clear: CartesianAnimationData<TNode, TDatum, TLabel, TContext>;
+    reset: undefined;
+    skip: undefined;
+    disable: undefined;
+};
 
 export interface CartesianAnimationData<
     TNode extends Node,
@@ -190,7 +196,10 @@ export abstract class CartesianSeries<
 
     protected quadtree?: QuadtreeNearest<TDatum>;
 
-    protected animationState: StateMachine<CartesianAnimationState, CartesianAnimationEvent>;
+    protected animationState: StateMachine<
+        CartesianAnimationState,
+        CartesianAnimationEvent<TNode, TDatum, TLabel, TContext>
+    >;
 
     protected constructor({
         pathsPerSeries = ['path'],
@@ -244,7 +253,10 @@ export abstract class CartesianSeries<
             markerSelectionGarbageCollection
         );
 
-        this.animationState = new StateMachine<CartesianAnimationState, CartesianAnimationEvent>(
+        this.animationState = new StateMachine<
+            CartesianAnimationState,
+            CartesianAnimationEvent<TNode, TDatum, TLabel, TContext>
+        >(
             'empty',
             {
                 empty: {
@@ -441,7 +453,7 @@ export abstract class CartesianSeries<
                 markerSelection: highlightSelection as any,
                 isHighlight: true,
             });
-            this.animationState.transition('highlightMarkers', highlightSelection);
+            this.animationState.transition('highlightMarkers', highlightSelection as any);
         } else {
             await this.updateDatumNodes({
                 datumSelection: highlightSelection,

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -24,7 +24,15 @@ type Mutable<T> = {
 };
 
 type HierarchyAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
-type HierarchyAnimationEvent = 'update' | 'updateData' | 'highlight' | 'resize' | 'clear' | 'reset' | 'skip';
+type HierarchyAnimationEvent<TNode extends Node, TDatum> = {
+    update: HierarchyAnimationData<TNode, TDatum>;
+    updateData: undefined;
+    highlight: Selection<TNode, HierarchyNode<TDatum>>;
+    resize: HierarchyAnimationData<TNode, TDatum>;
+    clear: HierarchyAnimationData<TNode, TDatum>;
+    reset: undefined;
+    skip: undefined;
+};
 
 export interface HierarchyAnimationData<TNode extends Node, TDatum> {
     datumSelections: Selection<TNode, HierarchyNode<TDatum>>[];
@@ -117,7 +125,7 @@ export abstract class HierarchySeries<
     colorDomain: number[] = [0, 0];
     maxDepth = 0;
 
-    protected animationState: StateMachine<HierarchyAnimationState, HierarchyAnimationEvent>;
+    protected animationState: StateMachine<HierarchyAnimationState, HierarchyAnimationEvent<TNode, TDatum>>;
 
     protected abstract groupSelection: Selection<TNode, HierarchyNode<TDatum>>;
 
@@ -131,7 +139,7 @@ export abstract class HierarchySeries<
             pickModes: [SeriesNodePickMode.NEAREST_NODE, SeriesNodePickMode.EXACT_SHAPE_MATCH],
         });
 
-        this.animationState = new StateMachine<HierarchyAnimationState, HierarchyAnimationEvent>(
+        this.animationState = new StateMachine<HierarchyAnimationState, HierarchyAnimationEvent<TNode, TDatum>>(
             'empty',
             {
                 empty: {

--- a/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/polarSeries.ts
@@ -18,15 +18,16 @@ import type { SeriesNodeDatum } from '../seriesTypes';
 import { PolarZIndexMap } from './polarZIndexMap';
 
 export type PolarAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
-export type PolarAnimationEvent =
-    | 'update'
-    | 'updateData'
-    | 'highlight'
-    | 'highlightMarkers'
-    | 'resize'
-    | 'clear'
-    | 'reset'
-    | 'skip';
+export type PolarAnimationEvent = {
+    update: PolarAnimationData;
+    updateData: undefined;
+    highlight: undefined;
+    highlightMarkers: undefined;
+    resize: PolarAnimationData;
+    clear: { seriesRect?: BBox };
+    reset: undefined;
+    skip: undefined;
+};
 export type PolarAnimationData = { duration?: number };
 
 type PolarSeriesProperties = {

--- a/packages/ag-charts-community/src/util/stateMachine.test.ts
+++ b/packages/ag-charts-community/src/util/stateMachine.test.ts
@@ -11,7 +11,7 @@ describe('State Machine', () => {
         beforeEach(() => {
             initialEventNext = jest.fn();
             nextEnter = jest.fn();
-            state = new StateMachine<'initial' | 'next', 'event'>('initial', {
+            state = new StateMachine<'initial' | 'next', { event: undefined }>('initial', {
                 initial: {
                     event: {
                         target: 'next',
@@ -48,7 +48,7 @@ describe('State Machine', () => {
         let child: any;
 
         beforeEach(() => {
-            child = new StateMachine<'child-initial' | 'child-next', 'event'>('child-initial', {
+            child = new StateMachine<'child-initial' | 'child-next', { event: undefined }>('child-initial', {
                 'child-initial': {
                     event: {
                         target: 'child-next',
@@ -60,7 +60,7 @@ describe('State Machine', () => {
                     },
                 },
             });
-            state = new StateMachine<'initial', 'event'>('initial', {
+            state = new StateMachine<'initial', { event: undefined }>('initial', {
                 initial: {
                     event: {
                         target: child,

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -868,7 +868,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         const textInputValue = this.textInput.getValue();
         const bbox = this.textInput.getBBox();
 
-        state.transition('click', { offset, point, textInputValue, bbox });
+        state.transition('click', { point, textInputValue, bbox });
     }
 
     private onDoubleClick(event: _ModuleSupport.RegionEvent<'dblclick'>) {
@@ -979,7 +979,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         const textInputValue = this.textInput.getValue();
         const bbox = this.textInput.getBBox();
 
-        state.transition('keyDown', { key, shiftKey, textInputValue, bbox, context });
+        state.transition('textInput', { key, shiftKey, textInputValue, bbox, context });
     }
 
     private onKeyDown(event: _ModuleSupport.KeyInteractionEvent<'keydown'>) {
@@ -1024,7 +1024,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         }
 
         if (translation.x || translation.y) {
-            state.transition('translate', { translation, context });
+            state.transition('translate', { translation });
 
             sourceEvent.stopPropagation();
             sourceEvent.preventDefault();

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsStateMachine.ts
@@ -12,10 +12,8 @@ import type {
     AnnotationsStateMachineContext,
     AnnotationsStateMachineHelperFns,
 } from './annotationsSuperTypes';
-import type {
-    LinearSettingsDialogLineChangeProps,
-    LinearSettingsDialogTextChangeProps,
-} from './settings-dialog/settingsDialog';
+import type { LinearSettingsDialogTextChangeProps } from './settings-dialog/settingsDialog';
+import type { AnnotationStateEvents } from './states/stateTypes';
 import { guardCancelAndExit, guardSaveAndExit } from './states/textualStateUtils';
 import { wrapText } from './text/util';
 import { hasLineStyle, hasLineText } from './utils/has';
@@ -29,41 +27,8 @@ enum States {
     Dragging = 'dragging',
     TextInput = 'text-input',
 }
-type AnnotationEvent =
-    // Interaction events
-    | 'hover'
-    | 'click'
-    | 'dblclick'
-    | 'zoomChange'
-    | 'drag'
-    | 'dragStart'
-    | 'dragEnd'
-    | 'keyDown'
-    | 'keyUp'
-    // Data events
-    | 'selectLast'
-    | 'translate'
-    | 'translateEnd'
-    | 'copy'
-    | 'cut'
-    | 'paste'
-    | 'cancel'
-    | 'reset'
-    | 'delete'
-    | 'deleteAll'
-    // Annotation properties events
-    | 'color'
-    | 'fontSize'
-    | 'lineProps'
-    | 'lineStyle'
-    | 'lineText'
-    | 'updateTextInputBBox'
-    // Toolbar events
-    | 'toolbarPressSettings'
-    // Process events
-    | 'render';
 
-export class AnnotationsStateMachine extends StateMachine<States, AnnotationType | AnnotationEvent> {
+export class AnnotationsStateMachine extends StateMachine<States, AnnotationStateEvents> {
     override debug = _Util.Debug.create(true, 'annotations');
 
     // eslint-disable-next-line @typescript-eslint/prefer-readonly
@@ -220,16 +185,16 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
             ctx.update();
         };
 
-        const actionUpdateTextInputBBox = (bbox: _Scene.BBox) => {
+        const actionUpdateTextInputBBox = (bbox?: _Scene.BBox) => {
             const node = ctx.node(this.active!);
             if (!node || !('setTextInputBBox' in node)) return;
             node.setTextInputBBox(bbox);
             ctx.update();
         };
 
-        const actionSaveText = ({ textInputValue, bbox }: { textInputValue?: string; bbox: _Scene.BBox }) => {
+        const actionSaveText = ({ textInputValue, bbox }: { textInputValue?: string; bbox?: _Scene.BBox }) => {
             const datum = ctx.datum(this.active!);
-            if (textInputValue != null && textInputValue.length > 0) {
+            if (bbox != null && textInputValue != null && textInputValue.length > 0) {
                 if (!isTextType(datum)) {
                     return;
                 }
@@ -269,21 +234,21 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
                     }
                 },
 
-                hover: ({ offset }: { offset: _ModuleSupport.Vec2 }) => {
+                hover: ({ offset }) => {
                     this.hovered = ctx.hoverAtCoords(offset, this.active);
                 },
 
-                keyDown: ({ shiftKey }: { shiftKey: boolean }) => {
+                keyDown: ({ shiftKey }) => {
                     this.snapping = shiftKey;
                 },
 
-                keyUp: ({ shiftKey }: { shiftKey: boolean }) => {
+                keyUp: ({ shiftKey }) => {
                     this.snapping = shiftKey;
                 },
 
                 translate: {
                     guard: guardActive,
-                    action: ({ translation }: { translation: _ModuleSupport.Vec2 }) => {
+                    action: ({ translation }) => {
                         ctx.startInteracting();
                         ctx.translate(this.active!, translation);
                         ctx.update();
@@ -387,7 +352,7 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
 
                 lineProps: {
                     guard: guardActive,
-                    action: (props: LinearSettingsDialogLineChangeProps) => {
+                    action: (props) => {
                         const datum = getTypedDatum(ctx.datum(this.active!));
                         datum?.set(props);
                         ctx.update();
@@ -498,7 +463,7 @@ export class AnnotationsStateMachine extends StateMachine<States, AnnotationType
                     action: actionSaveText,
                 },
 
-                keyDown: [
+                textInput: [
                     {
                         guard: guardCancelAndExit,
                         target: States.Idle,

--- a/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/cross-line/crossLineState.ts
@@ -2,6 +2,7 @@ import { type Direction, _ModuleSupport, _Util } from 'ag-charts-community';
 
 import { AnnotationType, type Point } from '../annotationTypes';
 import type { AnnotationsStateMachineContext } from '../annotationsSuperTypes';
+import type { AnnotationStateEvents } from '../states/stateTypes';
 import { type CrossLineProperties, HorizontalLineProperties, VerticalLineProperties } from './crossLineProperties';
 import type { CrossLineScene } from './crossLineScene';
 
@@ -19,7 +20,7 @@ interface CrossLineStateMachineContext extends Omit<AnnotationsStateMachineConte
 
 export class CrossLineStateMachine extends StateMachine<
     'start' | 'waiting-first-render',
-    'click' | 'cancel' | 'render' | 'reset'
+    Pick<AnnotationStateEvents, 'click' | 'cancel' | 'render' | 'reset'>
 > {
     override debug = _Util.Debug.create(true, 'annotations');
 

--- a/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelState.ts
@@ -2,6 +2,7 @@ import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 import { AnnotationType, type GuardDragClickDoubleEvent, type Point } from '../annotationTypes';
 import type { AnnotationsStateMachineContext } from '../annotationsSuperTypes';
+import type { AnnotationStateEvents } from '../states/stateTypes';
 import { DisjointChannelProperties } from './disjointChannelProperties';
 import type { DisjointChannelScene } from './disjointChannelScene';
 
@@ -18,7 +19,7 @@ interface DisjointChannelStateMachineContext extends Omit<AnnotationsStateMachin
 
 export class DisjointChannelStateMachine extends StateMachine<
     'start' | 'end' | 'height',
-    'click' | 'hover' | 'keyDown' | 'keyUp' | 'drag' | 'cancel' | 'reset'
+    Pick<AnnotationStateEvents, 'click' | 'hover' | 'keyDown' | 'keyUp' | 'drag' | 'cancel' | 'reset'>
 > {
     override debug = _Util.Debug.create(true, 'annotations');
 
@@ -40,11 +41,13 @@ export class DisjointChannelStateMachine extends StateMachine<
             );
         };
 
-        const actionEndUpdate = ({ point }: { point: (origin?: Point, snapToAngle?: number) => Point }) => {
+        const actionEndUpdate = ({ point }: { point?: (origin?: Point, snapToAngle?: number) => Point }) => {
             ctx.guardDragClickDoubleEvent.hover();
 
-            const datum = ctx.datum();
-            datum?.set({ end: point(datum?.start, datum?.snapToAngle) });
+            if (point) {
+                const datum = ctx.datum();
+                datum?.set({ end: point(datum?.start, datum?.snapToAngle) });
+            }
 
             ctx.update();
         };

--- a/packages/ag-charts-enterprise/src/features/annotations/line/lineState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/line/lineState.ts
@@ -2,6 +2,7 @@ import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 import type { GuardDragClickDoubleEvent, Point } from '../annotationTypes';
 import type { AnnotationsStateMachineContext } from '../annotationsSuperTypes';
+import type { AnnotationStateEvents } from '../states/stateTypes';
 import { ArrowProperties, LineProperties } from './lineProperties';
 import type { LineScene } from './lineScene';
 
@@ -19,7 +20,7 @@ interface LineStateMachineContext<Datum extends ArrowProperties | LineProperties
 
 abstract class LineTypeStateMachine<Datum extends ArrowProperties | LineProperties> extends StateMachine<
     'start' | 'end',
-    'click' | 'hover' | 'keyDown' | 'keyUp' | 'drag' | 'reset' | 'cancel'
+    Pick<AnnotationStateEvents, 'click' | 'hover' | 'keyDown' | 'keyUp' | 'drag' | 'reset' | 'cancel'>
 > {
     override debug = _Util.Debug.create(true, 'annotations');
 
@@ -35,11 +36,13 @@ abstract class LineTypeStateMachine<Datum extends ArrowProperties | LineProperti
             );
         };
 
-        const actionEndUpdate = ({ point }: { point: (origin?: Point, snapToAngle?: number) => Point }) => {
+        const actionEndUpdate = ({ point }: { point?: (origin?: Point, snapToAngle?: number) => Point }) => {
             ctx.guardDragClickDoubleEvent.hover();
 
-            const datum = ctx.datum();
-            datum?.set({ end: point(datum?.start, datum?.snapToAngle) });
+            if (point) {
+                const datum = ctx.datum();
+                datum?.set({ end: point(datum?.start, datum?.snapToAngle) });
+            }
 
             ctx.update();
         };

--- a/packages/ag-charts-enterprise/src/features/annotations/measurer/measurerState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/measurer/measurerState.ts
@@ -2,6 +2,7 @@ import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 import type { GuardDragClickDoubleEvent, Point } from '../annotationTypes';
 import type { AnnotationsStateMachineContext, MeasurerPropertiesType } from '../annotationsSuperTypes';
+import type { AnnotationStateEvents } from '../states/stateTypes';
 import {
     DatePriceRangeProperties,
     DateRangeProperties,
@@ -24,7 +25,7 @@ interface MeasurerStateMachineContext<Datum extends MeasurerPropertiesType>
 
 abstract class MeasurerTypeStateMachine<Datum extends MeasurerPropertiesType> extends StateMachine<
     'start' | 'end',
-    'click' | 'hover' | 'drag' | 'reset' | 'cancel'
+    Pick<AnnotationStateEvents, 'click' | 'hover' | 'drag' | 'reset' | 'cancel'>
 > {
     override debug = _Util.Debug.create(true, 'annotations');
 

--- a/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelState.ts
@@ -2,6 +2,7 @@ import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 import { AnnotationType, type GuardDragClickDoubleEvent, type Point } from '../annotationTypes';
 import type { AnnotationsStateMachineContext } from '../annotationsSuperTypes';
+import type { AnnotationStateEvents } from '../states/stateTypes';
 import { ParallelChannelProperties } from './parallelChannelProperties';
 import type { ParallelChannelScene } from './parallelChannelScene';
 
@@ -18,7 +19,7 @@ interface ParallelChannelStateMachineContext extends Omit<AnnotationsStateMachin
 
 export class ParallelChannelStateMachine extends StateMachine<
     'start' | 'end' | 'height',
-    'click' | 'hover' | 'keyDown' | 'keyUp' | 'drag' | 'cancel' | 'reset'
+    Pick<AnnotationStateEvents, 'click' | 'hover' | 'keyDown' | 'keyUp' | 'drag' | 'cancel' | 'reset'>
 > {
     override debug = _Util.Debug.create(true, 'annotations');
 
@@ -42,11 +43,13 @@ export class ParallelChannelStateMachine extends StateMachine<
             );
         };
 
-        const actionEndUpdate = ({ point }: { point: (origin?: Point, snapToAngle?: number) => Point }) => {
+        const actionEndUpdate = ({ point }: { point?: (origin?: Point, snapToAngle?: number) => Point }) => {
             ctx.guardDragClickDoubleEvent.hover();
 
-            const datum = ctx.datum();
-            datum?.set({ end: point(datum?.start, datum?.snapToAngle), height: 0 });
+            if (point) {
+                const datum = ctx.datum();
+                datum?.set({ end: point(datum?.start, datum?.snapToAngle), height: 0 });
+            }
 
             ctx.update();
         };

--- a/packages/ag-charts-enterprise/src/features/annotations/states/dragState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/dragState.ts
@@ -2,6 +2,7 @@ import { _ModuleSupport, _Util } from 'ag-charts-community';
 
 import type { AnnotationContext } from '../annotationTypes';
 import type { AnnotationProperties, AnnotationsStateMachineContext } from '../annotationsSuperTypes';
+import type { AnnotationStateEvents } from './stateTypes';
 
 const { StateMachine, Vec2 } = _ModuleSupport;
 
@@ -12,7 +13,10 @@ export class DragStateMachine<
         drag: (datum: D, offset: _ModuleSupport.Vec2, context: AnnotationContext, snapping: boolean) => void;
         stopDragging: () => void;
     },
-> extends StateMachine<'idle' | 'dragging', 'keyDown' | 'keyUp' | 'drag' | 'dragStart' | 'dragEnd'> {
+> extends StateMachine<
+    'idle' | 'dragging',
+    Pick<AnnotationStateEvents, 'keyDown' | 'keyUp' | 'drag' | 'dragStart' | 'dragEnd'>
+> {
     override debug = _Util.Debug.create(true, 'annotations');
 
     // eslint-disable-next-line @typescript-eslint/prefer-readonly

--- a/packages/ag-charts-enterprise/src/features/annotations/states/pointState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/pointState.ts
@@ -4,6 +4,7 @@ import type { Point } from '../annotationTypes';
 import type { AnnotationsStateMachineContext } from '../annotationsSuperTypes';
 import type { PointProperties } from '../properties/pointProperties';
 import type { PointScene } from '../scenes/pointScene';
+import type { AnnotationStateEvents } from './stateTypes';
 
 const { StateMachine } = _ModuleSupport;
 
@@ -17,7 +18,10 @@ interface PointStateMachineContext<Datum extends PointProperties, Node extends P
 export abstract class PointStateMachine<
     Datum extends PointProperties,
     Node extends PointScene<Datum>,
-> extends StateMachine<'start' | 'waiting-first-render', 'click' | 'cancel' | 'render' | 'reset'> {
+> extends StateMachine<
+    'start' | 'waiting-first-render',
+    Pick<AnnotationStateEvents, 'click' | 'cancel' | 'render' | 'reset'>
+> {
     override debug = _Util.Debug.create(true, 'annotations');
 
     constructor(ctx: PointStateMachineContext<Datum, Node>) {

--- a/packages/ag-charts-enterprise/src/features/annotations/states/stateTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/stateTypes.ts
@@ -1,0 +1,74 @@
+import type { _ModuleSupport, _Scene } from 'ag-charts-community';
+
+import type {
+    AnnotationContext,
+    AnnotationLineStyle,
+    AnnotationOptionsColorPickerType,
+    AnnotationType,
+    Point,
+} from '../annotationTypes';
+import type {
+    LinearSettingsDialogLineChangeProps,
+    LinearSettingsDialogTextChangeProps,
+} from '../settings-dialog/settingsDialog';
+
+export type AnnotationStateEvents = InteractionEvents &
+    ActionEvents &
+    DataEvents &
+    ProcessEvents &
+    Record<AnnotationType, undefined>;
+
+type InteractionEvents = {
+    click: { textInputValue?: string; bbox?: _Scene.BBox; point: () => Point };
+    dblclick: { offset: _ModuleSupport.Vec2 };
+    drag: { offset: _ModuleSupport.Vec2; context: AnnotationContext; point: () => Point };
+    dragStart: { offset: _ModuleSupport.Vec2; context: AnnotationContext };
+    dragEnd: undefined;
+    hover: { offset: _ModuleSupport.Vec2; point: () => Point };
+    keyDown: {
+        shiftKey: boolean;
+        context: AnnotationContext;
+        point?: () => Point;
+    };
+    keyUp: { shiftKey: boolean; context: AnnotationContext; point?: () => Point };
+    textInput: {
+        key: string;
+        shiftKey: boolean;
+        textInputValue: string | undefined;
+        bbox: _Scene.BBox | undefined;
+        context: AnnotationContext;
+    };
+    zoomChange: { textInputValue?: string; bbox: _Scene.BBox };
+};
+
+type ActionEvents = {
+    copy: undefined;
+    cut: undefined;
+    paste: undefined;
+    translate: { translation: _ModuleSupport.Vec2 };
+    translateEnd: undefined;
+    color: {
+        colorPickerType: AnnotationOptionsColorPickerType;
+        colorOpacity: string;
+        color: string;
+        opacity: number;
+    };
+    fontSize: number;
+    lineProps: LinearSettingsDialogLineChangeProps;
+    lineStyle: AnnotationLineStyle;
+    lineText: LinearSettingsDialogTextChangeProps;
+    toolbarPressSettings: Event;
+    updateTextInputBBox: _Scene.BBox | undefined;
+};
+
+type DataEvents = {
+    cancel: undefined;
+    delete: undefined;
+    deleteAll: undefined;
+    reset: undefined;
+    selectLast: undefined;
+};
+
+type ProcessEvents = {
+    render: undefined;
+};

--- a/packages/ag-charts-enterprise/src/features/annotations/states/textualPointState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/textualPointState.ts
@@ -7,6 +7,7 @@ import type { TextualPointScene } from '../scenes/textualPointScene';
 import { wrapText } from '../text/util';
 import { setColor } from '../utils/styles';
 import { isTextType } from '../utils/types';
+import type { AnnotationStateEvents } from './stateTypes';
 import { guardCancelAndExit, guardSaveAndExit } from './textualStateUtils';
 
 const { StateMachine } = _ModuleSupport;
@@ -27,7 +28,18 @@ export abstract class TextualPointStateMachine<
     Node extends TextualPointScene<Datum>,
 > extends StateMachine<
     'start' | 'waiting-first-render' | 'edit',
-    'click' | 'zoomChange' | 'cancel' | 'keyDown' | 'updateTextInputBBox' | 'color' | 'fontSize' | 'render' | 'reset'
+    Pick<
+        AnnotationStateEvents,
+        | 'click'
+        | 'zoomChange'
+        | 'cancel'
+        | 'textInput'
+        | 'updateTextInputBBox'
+        | 'color'
+        | 'fontSize'
+        | 'render'
+        | 'reset'
+    >
 > {
     override debug = _Util.Debug.create(true, 'annotations');
 
@@ -60,7 +72,7 @@ export abstract class TextualPointStateMachine<
             ctx.deselect();
         };
 
-        const actionUpdateTextInputBBox = (bbox: _Scene.BBox) => {
+        const actionUpdateTextInputBBox = (bbox?: _Scene.BBox) => {
             const node = ctx.node();
             node?.setTextInputBBox(bbox);
             ctx.update();
@@ -101,8 +113,8 @@ export abstract class TextualPointStateMachine<
             ctx.delete();
         };
 
-        const actionSave = ({ textInputValue, bbox }: { textInputValue?: string; bbox: _Scene.BBox }) => {
-            if (textInputValue != null && textInputValue.length > 0) {
+        const actionSave = ({ textInputValue, bbox }: { textInputValue?: string; bbox?: _Scene.BBox }) => {
+            if (bbox != null && textInputValue != null && textInputValue.length > 0) {
                 const datum = ctx.datum();
 
                 if (!isTextType(datum)) {
@@ -139,7 +151,7 @@ export abstract class TextualPointStateMachine<
                 updateTextInputBBox: actionUpdateTextInputBBox,
                 color: actionColor,
                 fontSize: actionFontSize,
-                keyDown: [
+                textInput: [
                     {
                         guard: guardCancelAndExit,
                         target: StateMachine.parent,

--- a/packages/ag-charts-enterprise/src/features/annotations/states/textualStartEndState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/textualStartEndState.ts
@@ -7,6 +7,7 @@ import type { TextualStartEndScene } from '../scenes/textualStartEndScene';
 import { wrapText } from '../text/util';
 import { setColor } from '../utils/styles';
 import { isTextType } from '../utils/types';
+import type { AnnotationStateEvents } from './stateTypes';
 import { guardCancelAndExit, guardSaveAndExit } from './textualStateUtils';
 
 const { StateMachine } = _ModuleSupport;
@@ -29,16 +30,19 @@ export abstract class TextualStartEndStateMachine<
     Node extends TextualStartEndScene<Datum>,
 > extends StateMachine<
     'start' | 'waiting-first-render' | 'edit' | 'end',
-    | 'click'
-    | 'zoomChange'
-    | 'cancel'
-    | 'hover'
-    | 'keyDown'
-    | 'updateTextInputBBox'
-    | 'color'
-    | 'fontSize'
-    | 'render'
-    | 'reset'
+    Pick<
+        AnnotationStateEvents,
+        | 'click'
+        | 'zoomChange'
+        | 'cancel'
+        | 'hover'
+        | 'textInput'
+        | 'updateTextInputBBox'
+        | 'color'
+        | 'fontSize'
+        | 'render'
+        | 'reset'
+    >
 > {
     override debug = _Util.Debug.create(true, 'annotations');
 
@@ -67,7 +71,7 @@ export abstract class TextualStartEndStateMachine<
             ctx.deselect();
         };
 
-        const actionUpdateTextInputBBox = (bbox: _Scene.BBox) => {
+        const actionUpdateTextInputBBox = (bbox?: _Scene.BBox) => {
             const node = ctx.node();
             node?.setTextInputBBox(bbox);
             ctx.update();
@@ -120,8 +124,8 @@ export abstract class TextualStartEndStateMachine<
             ctx.delete();
         };
 
-        const actionSave = ({ textInputValue, bbox }: { textInputValue?: string; bbox: _Scene.BBox }) => {
-            if (textInputValue != null && textInputValue.length > 0) {
+        const actionSave = ({ textInputValue, bbox }: { textInputValue?: string; bbox?: _Scene.BBox }) => {
+            if (bbox != null && textInputValue != null && textInputValue.length > 0) {
                 const datum = ctx.datum();
 
                 if (!isTextType(datum)) {
@@ -173,7 +177,7 @@ export abstract class TextualStartEndStateMachine<
                 updateTextInputBBox: actionUpdateTextInputBBox,
                 color: actionColor,
                 fontSize: actionFontSize,
-                keyDown: [
+                textInput: [
                     {
                         guard: guardCancelAndExit,
                         target: StateMachine.parent,

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -71,15 +71,16 @@ interface Target {
 }
 
 export type GaugeAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
-export type GaugeAnimationEvent =
-    | 'update'
-    | 'updateData'
-    | 'highlight'
-    | 'highlightMarkers'
-    | 'resize'
-    | 'clear'
-    | 'reset'
-    | 'skip';
+export type GaugeAnimationEvent = {
+    update: undefined;
+    updateData: undefined;
+    highlight: undefined;
+    highlightMarkers: undefined;
+    resize: undefined;
+    clear: undefined;
+    reset: undefined;
+    skip: undefined;
+};
 export type GaugeAnimationData = { duration?: number };
 
 interface LinearGaugeNodeDataContext

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -32,7 +32,15 @@ export interface MapMarkerNodeDataContext
     extends _ModuleSupport.SeriesNodeDataContext<MapMarkerNodeDatum, MapMarkerNodeLabelDatum> {}
 
 type MapMarkerAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
-type MapMarkerAnimationEvent = 'update' | 'updateData' | 'highlight' | 'resize' | 'clear' | 'reset' | 'skip';
+type MapMarkerAnimationEvent = {
+    update: undefined;
+    updateData: undefined;
+    highlight: undefined;
+    resize: undefined;
+    clear: undefined;
+    reset: undefined;
+    skip: undefined;
+};
 
 export class MapMarkerSeries
     extends DataModelSeries<

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -73,15 +73,16 @@ interface Target {
 }
 
 export type GaugeAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
-export type GaugeAnimationEvent =
-    | 'update'
-    | 'updateData'
-    | 'highlight'
-    | 'highlightMarkers'
-    | 'resize'
-    | 'clear'
-    | 'reset'
-    | 'skip';
+export type GaugeAnimationEvent = {
+    update: undefined;
+    updateData: undefined;
+    highlight: undefined;
+    highlightMarkers: undefined;
+    resize: undefined;
+    clear: undefined;
+    reset: undefined;
+    skip: undefined;
+};
 export type GaugeAnimationData = { duration?: number };
 
 interface RadialGaugeNeedleDatum {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13145

This adds typings to the state machine event data passed in from the transitions to the actions, for example:

```
new StateMachine<'state', { myEvent: { foo: string } }>({
    myEvent: ({ foo }) => {} 
});

state.transition('myEvent', { foo: 'bar' });
```

It can be a bit verbose when events don't require data and end up as `{ foo: undefined }`, but on balance I think it's more useful than not. (It showed up a couple of minor issues in the annotations state machine).