### PR TITLE
CRT-559 Change text to use dragStart to ensure new mouse action

### DIFF
--- a/packages/ag-charts-community/src/scene/shape/svgPath.ts
+++ b/packages/ag-charts-community/src/scene/shape/svgPath.ts
@@ -23,7 +23,7 @@ export class SvgPath extends Path {
             this.commands.push([command, params]);
         }
 
-        this.checkPathDirty();
+        this.dirtyPath = true;
     }
 
     constructor(d: string = '') {
@@ -44,6 +44,7 @@ export class SvgPath extends Path {
                 case 'M':
                     path.moveTo(x + params[0], y + params[1]);
                     lastX = x + params[0];
+                    lastY = y + params[0];
                     break;
 
                 case 'C':

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -1231,7 +1231,13 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         const offset = Vec2.from(event);
         this.hoverCoords = offset;
 
-        state.transition('dragStart', { context, offset });
+        const shiftKey = (event.sourceEvent as MouseEvent).shiftKey;
+        const point = this.getPointFn(shiftKey, offset, context);
+
+        const textInputValue = this.textInput.getValue();
+        const bbox = this.textInput.getBBox();
+
+        state.transition('dragStart', { context, offset, point, textInputValue, bbox });
     }
 
     private onDrag(event: _ModuleSupport.RegionEvent<'drag'>) {
@@ -1246,10 +1252,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         const shiftKey = (event.sourceEvent as MouseEvent).shiftKey;
         const point = this.getPointFn(shiftKey, offset, context);
 
-        const textInputValue = this.textInput.getValue();
-        const bbox = this.textInput.getBBox();
-
-        state.transition('drag', { context, offset, point, textInputValue, bbox });
+        state.transition('drag', { context, offset, point });
     }
 
     private onDragEnd() {

--- a/packages/ag-charts-enterprise/src/features/annotations/states/textualPointState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/textualPointState.ts
@@ -28,7 +28,7 @@ export abstract class TextualPointStateMachine<
 > extends StateMachine<
     'start' | 'waiting-first-render' | 'edit',
     | 'click'
-    | 'drag'
+    | 'dragStart'
     | 'zoomChange'
     | 'cancel'
     | 'keyDown'
@@ -134,7 +134,7 @@ export abstract class TextualPointStateMachine<
                     target: 'waiting-first-render',
                     action: actionCreate,
                 },
-                drag: {
+                dragStart: {
                     target: 'waiting-first-render',
                     action: actionCreate,
                 },
@@ -168,7 +168,7 @@ export abstract class TextualPointStateMachine<
                     target: StateMachine.parent,
                     action: actionSave,
                 },
-                drag: {
+                dragStart: {
                     target: StateMachine.parent,
                     action: actionSave,
                 },

--- a/packages/ag-charts-enterprise/src/features/annotations/states/textualStartEndState.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/states/textualStartEndState.ts
@@ -32,6 +32,7 @@ export abstract class TextualStartEndStateMachine<
     | 'click'
     | 'drag'
     | 'dragEnd'
+    | 'dragStart'
     | 'zoomChange'
     | 'cancel'
     | 'hover'
@@ -146,7 +147,7 @@ export abstract class TextualStartEndStateMachine<
                     target: 'waiting-first-render',
                     action: actionCreate,
                 },
-                drag: {
+                dragStart: {
                     target: 'waiting-first-render',
                     action: actionCreate,
                 },
@@ -200,7 +201,7 @@ export abstract class TextualStartEndStateMachine<
                     target: StateMachine.parent,
                     action: actionSave,
                 },
-                drag: {
+                dragStart: {
                     target: StateMachine.parent,
                     action: actionSave,
                 },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-559

`drag` events from a single mouse move bled into the next state and caused it to create on one drag event and save on the next drag event, which led to it being deleted as the text was empty.