### PR TITLE
AG-13142 Fix bug with Chrome sometimes focusing on aria-hidden elems

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -6,7 +6,6 @@ import type { BBox } from '../../scene/bbox';
 import type { TranslatableGroup } from '../../scene/group';
 import { Transformable } from '../../scene/transformable';
 import { createId } from '../../util/id';
-import { Logger } from '../../util/logger';
 import { clamp } from '../../util/number';
 import type { TypedEvent } from '../../util/observable';
 import { debouncedAnimationFrame } from '../../util/render';
@@ -170,10 +169,6 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     public setTabIndex(tabIndex: number) {
-        // FIXME: Remove keyboard.tabIndex option in next major release
-        if (tabIndex !== 0 && tabIndex !== -1) {
-            Logger.warnOnce(`Tab indices other than 0 and -1 are deprecated`);
-        }
         this.swapChain.setTabIndex(tabIndex as 0 | -1);
     }
 

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -6,6 +6,7 @@ import type { BBox } from '../../scene/bbox';
 import type { TranslatableGroup } from '../../scene/group';
 import { Transformable } from '../../scene/transformable';
 import { createId } from '../../util/id';
+import { Logger } from '../../util/logger';
 import { clamp } from '../../util/number';
 import type { TypedEvent } from '../../util/observable';
 import { debouncedAnimationFrame } from '../../util/render';
@@ -169,7 +170,9 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     public setTabIndex(tabIndex: number) {
-        this.swapChain.setTabIndex(tabIndex);
+        // FIXME: Remove keyboard.tabIndex option in next major release
+        Logger.warnOnce(`Tab indices other than 0 and -1 are deprecated`);
+        this.swapChain.setTabIndex(tabIndex as 0 | -1);
     }
 
     public seriesChanged(series: Series<SeriesNodeDatum, SeriesProperties<object>>[]) {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -171,7 +171,9 @@ export class SeriesAreaManager extends BaseManager {
 
     public setTabIndex(tabIndex: number) {
         // FIXME: Remove keyboard.tabIndex option in next major release
-        Logger.warnOnce(`Tab indices other than 0 and -1 are deprecated`);
+        if (tabIndex !== 0 && tabIndex !== -1) {
+            Logger.warnOnce(`Tab indices other than 0 and -1 are deprecated`);
+        }
         this.swapChain.setTabIndex(tabIndex as 0 | -1);
     }
 

--- a/packages/ag-charts-community/src/dom/focusSwapChain.ts
+++ b/packages/ag-charts-community/src/dom/focusSwapChain.ts
@@ -9,8 +9,8 @@ type SwapChainEventMap = { focus: FocusEvent; blur: FocusEvent; swap: HTMLElemen
  * two identical divs to accomplish this.
  */
 export class FocusSwapChain {
-    private inactiveAnnouncer: HTMLElement;
-    private activeAnnouncer: HTMLElement;
+    private inactiveAnnouncer: HTMLElement & { tabIndex: 0 | -1 };
+    private activeAnnouncer: HTMLElement & { tabIndex: 0 | -1 };
 
     private hasFocus = false;
     private skipDispatch = false;
@@ -29,7 +29,7 @@ export class FocusSwapChain {
         announcer.className = 'ag-charts-swapchain';
         announcer.addEventListener('blur', this.onBlur);
         announcer.addEventListener('focus', this.onFocus);
-        return announcer;
+        return announcer as typeof announcer & { tabIndex: 0 | -1 };
     }
 
     constructor(
@@ -45,6 +45,8 @@ export class FocusSwapChain {
 
         this.activeAnnouncer = this.createAnnouncer(announcerRole);
         this.inactiveAnnouncer = this.createAnnouncer(announcerRole);
+        this.activeAnnouncer.dataset['id'] = '1';
+        this.inactiveAnnouncer.dataset['id'] = '2';
 
         this.label2.insertAdjacentElement('afterend', this.activeAnnouncer);
         this.label2.insertAdjacentElement('afterend', this.inactiveAnnouncer);
@@ -59,7 +61,7 @@ export class FocusSwapChain {
         }
     }
 
-    setTabIndex(tabIndex: number) {
+    setTabIndex(tabIndex: 0 | -1) {
         this.activeAnnouncer.tabIndex = tabIndex;
     }
 
@@ -104,12 +106,19 @@ export class FocusSwapChain {
 
         [this.inactiveAnnouncer, this.activeAnnouncer] = [this.activeAnnouncer, this.inactiveAnnouncer];
         [this.label1, this.label2] = [this.label2, this.label1];
-        setAttributes(this.inactiveAnnouncer, { 'aria-labelledby': this.label1.id, 'aria-hidden': true, tabindex: -1 });
-        setAttributes(this.activeAnnouncer, { 'aria-labelledby': this.label1.id, 'aria-hidden': false });
+        setAttributes(this.inactiveAnnouncer, {
+            'aria-labelledby': this.label1.id,
+            'aria-hidden': true,
+            tabindex: undefined,
+        });
+        setAttributes(this.activeAnnouncer, {
+            'aria-labelledby': this.label1.id,
+            'aria-hidden': false,
+            tabindex: userTabIndex,
+        });
         setElementStyle(this.inactiveAnnouncer, 'pointer-events', 'none');
         setElementStyle(this.activeAnnouncer, 'pointer-events', undefined);
 
-        this.activeAnnouncer.tabIndex = userTabIndex;
         this.dispatch('swap', this.activeAnnouncer);
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13142

When a screen-reader is enabled, Chrome allows the user to browse to elems with `tabindex="-1"` even if `aria-hidden="true"`. We do not want that, therefore remove the tabindex attribute on the hidden swapchain element to make it non-focusable.