### PR TITLE
AG-13288 Don't call panToBBox if seriesRect contains focus center

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -387,7 +387,8 @@ export class SeriesAreaManager extends BaseManager {
 
         if (this.focusIndicator.isFocusVisible() && seriesRect) {
             const focusBBox = getPickedFocusBBox(pick);
-            if (!seriesRect.containsBBox(focusBBox)) {
+            const { x, y } = focusBBox.computeCenter();
+            if (!seriesRect.containsPoint(x, y)) {
                 this.chart.ctx.zoomManager.panToBBox(this.id, seriesRect, focusBBox);
             }
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13288

This fixes a bug where the SeriesAreaManager would try to pan to datums that are touching the origin of the axes. This change permits the bounds of the focus indicator to extend beyond the seriesRect, which is fine because that's how the datum shapes are drawn in some cases.