### PR TITLE
AG-13316 Fix regression where `no-animation` class was not set

### DIFF
--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -200,7 +200,10 @@ export class Tooltip extends BaseProperties {
         const { element } = this;
         if (element == null) return;
 
-        element.className = DEFAULT_TOOLTIP_CLASS;
+        // AG-13316 The `hidden` class is used to determine if the `no-animation` class is required.
+        const hiddenClass = `${DEFAULT_TOOLTIP_CLASS}-hidden`;
+        const classNameSuffix = element.classList.contains(hiddenClass) ? ` ${hiddenClass}` : '';
+        element.className = `${DEFAULT_TOOLTIP_CLASS}${classNameSuffix}`;
 
         if (this.class != null) {
             element.classList.add(this.class);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13316

The `Tooltip.toggle` method uses `Toggle.isVisible()` to calculate the `wasVisible` and `visible` variabled.

The `Tooltip.isVisible()` method checks if the `hidden` class exists, so we need to make sure that this class isn't removed because the `Tooltip.toggle` method is called.