### PR TITLE
AG-13414 Use image elements in gallery

### DIFF
--- a/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.module.scss
+++ b/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.module.scss
@@ -1,24 +1,12 @@
 @use 'design-system' as *;
 
-.image {
+.imageWrapper {
     aspect-ratio: 600 / 375;
-    background: center / contain var(--image-png);
-    background: center / contain
-        image-set(
-            var(--image-webp-2x) 2x type('image/webp'),
-            var(--image-webp) type('image/webp'),
-            var(--image-png-2x) 2x type('image/png'),
-            var(--image-png) type('image/png')
-        );
+}
 
-    #{$selector-darkmode} & {
-        background: center / contain var(--image-png-dark);
-        background: center / contain
-            image-set(
-                var(--image-webp-dark-2x) 2x type('image/webp'),
-                var(--image-webp-dark) type('image/webp'),
-                var(--image-png-dark-2x) 2x type('image/png'),
-                var(--image-png-dark) type('image/png')
-            );
-    }
+.image {
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+    object-position: center;
 }

--- a/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.tsx
+++ b/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.tsx
@@ -14,6 +14,18 @@ interface Props {
     enableDprScaling: boolean;
 }
 
+const optimizeAltTextForSeo = (label: string): string => {
+    if (label.toLowerCase().endsWith('chart')) {
+        return label;
+    }
+
+    if (label.toLowerCase().includes('with')) {
+        return label.replace(/with/i, 'Chart with');
+    }
+
+    return `${label} Chart`;
+};
+
 export const GalleryExampleImage: FunctionComponent<Props> = ({ label, exampleName, className, enableDprScaling }) => {
     const [theme] = useTheme();
     const [darkMode] = useDarkmode();
@@ -48,7 +60,7 @@ export const GalleryExampleImage: FunctionComponent<Props> = ({ label, exampleNa
                 <img
                     src={src}
                     srcSet={srcSet}
-                    alt={label}
+                    alt={optimizeAltTextForSeo(label)}
                     className={classNames(styles.image, className)}
                     onError={(e) => (e.currentTarget.style.display = 'none')}
                 />

--- a/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.tsx
+++ b/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.tsx
@@ -1,3 +1,4 @@
+import { useDarkmode } from '@utils/hooks/useDarkmode';
 import classNames from 'classnames';
 import { type FunctionComponent, useEffect, useState } from 'react';
 
@@ -15,26 +16,43 @@ interface Props {
 
 export const GalleryExampleImage: FunctionComponent<Props> = ({ label, exampleName, className, enableDprScaling }) => {
     const [theme] = useTheme();
-    const [style, setStyle] = useState<Record<string, string>>();
+    const [darkMode] = useDarkmode();
+    const [src, setSrc] = useState<string>('');
+    const [srcSet, setSrcSet] = useState<string>('');
 
     const urlFor = (variant: 'light' | 'dark', dpi: 1 | 2, ext: 'png' | 'webp') => {
         const url = getExampleImageUrl({ exampleName, theme: variant === 'dark' ? `${theme}-dark` : theme, dpi, ext });
-        return `url(${JSON.stringify(url)})`;
+        return url;
     };
 
     useEffect(() => {
         const dprFor2x = enableDprScaling ? 2 : 1;
-        setStyle({
-            '--image-webp': urlFor('light', 1, 'webp'),
-            '--image-webp-2x': urlFor('light', dprFor2x, 'webp'),
-            '--image-png': urlFor('light', 1, 'png'),
-            '--image-png-2x': urlFor('light', dprFor2x, 'png'),
-            '--image-webp-dark': urlFor('dark', 1, 'webp'),
-            '--image-webp-dark-2x': urlFor('dark', dprFor2x, 'webp'),
-            '--image-png-dark': urlFor('dark', 1, 'png'),
-            '--image-png-dark-2x': urlFor('dark', dprFor2x, 'png'),
-        });
-    }, [theme]);
 
-    return <div className={classNames(styles.image, className)} aria-label={label} style={style} />;
+        const srcSetLight = `
+            ${urlFor('light', 1, 'webp')} 1x, 
+            ${urlFor('light', dprFor2x, 'webp')} 2x,
+        `;
+
+        const srcSetDark = `
+            ${urlFor('dark', 1, 'webp')} 1x, 
+            ${urlFor('dark', dprFor2x, 'webp')} 2x,
+        `;
+
+        setSrc(urlFor('light', 1, 'png'));
+        setSrcSet(darkMode ? srcSetDark : srcSetLight);
+    }, [darkMode, theme]);
+
+    return (
+        <div className={styles.imageWrapper}>
+            {srcSet && (
+                <img
+                    src={src}
+                    srcSet={srcSet}
+                    alt={label}
+                    className={classNames(styles.image, className)}
+                    onError={(e) => (e.currentTarget.style.display = 'none')}
+                />
+            )}
+        </div>
+    );
 };


### PR DESCRIPTION
Replace `background-image` with `<img>` elements so that we can include an alt-tag that is optimised for SEO.

Does not produce a flicker or increase CLS on initial load, which I believe was the original reason for using `background-image`. 