### PR TITLE
AG-13314: Support configuring secondary time & log axes

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/logAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/logAxis.ts
@@ -3,6 +3,7 @@ import { LogScale } from '../../scale/logScale';
 import { normalisedExtentWithMetadata } from '../../util/array';
 import { Default } from '../../util/default';
 import { Logger } from '../../util/logger';
+import { calculateNiceSecondaryAxis } from '../../util/secondaryAxisTicks';
 import { isNumber } from '../../util/type-guards';
 import { AND, GREATER_THAN, LESS_THAN, NUMBER_OR_NAN, Validate, predicateWithMessage } from '../../util/validation';
 import { NumberAxis } from './numberAxis';
@@ -48,5 +49,23 @@ export class LogAxis extends NumberAxis {
 
     constructor(moduleCtx: ModuleContext) {
         super(moduleCtx, new LogScale());
+    }
+
+    override updateSecondaryAxisTicks(primaryTickCount: number | undefined): any[] {
+        if (!this.dataDomain?.domain.length) {
+            return [];
+        }
+
+        const { domain, ticks } = calculateNiceSecondaryAxis(
+            this.dataDomain.domain,
+            primaryTickCount ?? 0,
+            this.reverse
+        );
+
+        this.scale.nice = false;
+        this.scale.domain = domain;
+        this.scale.update();
+
+        return ticks;
     }
 }

--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -31,11 +31,7 @@ export class NumberAxis extends CartesianAxis<LinearScale | LogScale, number> {
     max: number = NaN;
 
     override updateSecondaryAxisTicks(primaryTickCount: number | undefined): any[] {
-        if (this.dataDomain == null) {
-            throw new Error('AG Charts - dataDomain not calculated, cannot perform tick calculation.');
-        }
-
-        if (this.dataDomain.domain.length === 0) {
+        if (!this.dataDomain?.domain.length) {
             return [];
         }
 

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -1,6 +1,7 @@
 import type { ModuleContext } from '../../module/moduleContext';
 import { TimeScale } from '../../scale/timeScale';
 import { extent } from '../../util/array';
+import { calculateNiceSecondaryAxis } from '../../util/secondaryAxisTicks';
 import { AND, DATE_OR_DATETIME_MS, GREATER_THAN, LESS_THAN, Validate } from '../../util/validation';
 import { CartesianAxis } from './cartesianAxis';
 
@@ -55,5 +56,23 @@ export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
             this.labelFormatter = this.scale.tickFormat({ ticks, domain });
             this.datumFormatter = this.scale.tickFormat({ ticks, domain, formatOffset: 1 });
         }
+    }
+
+    override updateSecondaryAxisTicks(primaryTickCount: number | undefined): any[] {
+        if (!this.dataDomain?.domain.length) {
+            return [];
+        }
+
+        const { domain, ticks } = calculateNiceSecondaryAxis(
+            this.dataDomain.domain.map(Number),
+            primaryTickCount ?? 0,
+            this.reverse
+        );
+
+        this.scale.nice = false;
+        this.scale.domain = domain.map((d) => new Date(d));
+        this.scale.update();
+
+        return ticks;
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13314
note: support can be improved, this fix is to make sure we don't crash in such cases