### PR TITLE
Clean up legend item symbol

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -8,6 +8,7 @@ import type { ModuleContext } from '../module/moduleContext';
 import type { ChartOptions } from '../module/optionsModule';
 import type { SeriesOptionModule } from '../module/optionsModuleTypes';
 import { BBox } from '../scene/bbox';
+import type { Gradient } from '../scene/gradient/gradient';
 import { Group, TranslatableGroup } from '../scene/group';
 import type { Scene } from '../scene/scene';
 import { groupBy } from '../util/array';
@@ -930,12 +931,12 @@ export abstract class Chart extends Observable {
 
         if (this.mode !== 'integrated') {
             // Validate each series that shares a legend item label uses the same fill colour
-            const seriesMarkerFills: { [key: string]: { [key: string]: string | undefined } } = {};
+            const seriesMarkerFills: { [key: string]: { [key: string]: string | Gradient | undefined } } = {};
             const seriesTypeMap = new Map(this.series.map((s) => [s.id, s.type]));
 
             for (const {
                 seriesId,
-                symbols: [{ marker }],
+                symbol: { marker },
                 label,
             } of legendData.filter((d) => !d.hideInLegend)) {
                 if (marker.fill == null) continue;

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -50,15 +50,15 @@ import { gridLayout } from '../gridLayout';
 import type { HighlightNodeDatum } from '../interaction/highlightManager';
 import { InteractionState } from '../interaction/interactionManager';
 import { LayoutElement } from '../layout/layoutManager';
-import type { Marker } from '../marker/marker';
 import { getMarker } from '../marker/util';
 import { Pagination } from '../pagination/pagination';
 import { type TooltipMeta, type TooltipPointerEvent, toTooltipHtml } from '../tooltip/tooltip';
 import { ZIndexMap } from '../zIndexMap';
 import { LegendDOMProxy } from './legendDOMProxy';
-import type { CategoryLegendDatum, LegendSymbolOptions } from './legendDatum';
+import type { CategoryLegendDatum } from './legendDatum';
 import type { LegendChangeEvent } from './legendManager';
 import { LegendMarkerLabel } from './legendMarkerLabel';
+import type { LegendSymbolOptions } from './legendSymbol';
 
 class LegendLabel extends BaseProperties {
     @Validate(POSITIVE_NUMBER, { optional: true })
@@ -532,23 +532,23 @@ export class Legend extends BaseProperties {
         let spriteHeight = 0;
         let markerWidth = 0;
         this.itemSelection.each((_, datum) => {
-            datum.symbols.forEach((symbol) => {
-                const {
-                    markerLength,
-                    markerStrokeWidth,
-                    lineLength,
-                    lineStrokeWidth,
-                    customMarkerSize = -Infinity,
-                } = this.calcSymbolsLengths(symbol);
-                const markerTotalLength = markerLength + markerStrokeWidth;
-                markerWidth = Math.max(markerWidth, lineLength, customMarkerSize, markerLength);
-                spriteWidth = Math.max(spriteWidth, lineLength, customMarkerSize, markerTotalLength);
-                spriteHeight = Math.max(spriteHeight, lineStrokeWidth, markerTotalLength);
-                // Add +0.5 padding to handle cases where the X/Y pixel coordinates are not integers
-                // (We need this extra row/column of pixels because legend's sprite render will use
-                // integers for X/Y coords).
-                spriteAAPadding = Math.max(spriteAAPadding, markerStrokeWidth + 0.5);
-            });
+            const { symbol } = datum;
+
+            const {
+                markerLength,
+                markerStrokeWidth,
+                lineLength,
+                lineStrokeWidth,
+                customMarkerSize = -Infinity,
+            } = this.calcSymbolsLengths(symbol);
+            const markerTotalLength = markerLength + markerStrokeWidth;
+            markerWidth = Math.max(markerWidth, lineLength, customMarkerSize, markerLength);
+            spriteWidth = Math.max(spriteWidth, lineLength, customMarkerSize, markerTotalLength);
+            spriteHeight = Math.max(spriteHeight, lineStrokeWidth, markerTotalLength);
+            // Add +0.5 padding to handle cases where the X/Y pixel coordinates are not integers
+            // (We need this extra row/column of pixels because legend's sprite render will use
+            // integers for X/Y coords).
+            spriteAAPadding = Math.max(spriteAAPadding, markerStrokeWidth + 0.5);
         });
         spriteWidth += spriteAAPadding * 2;
         spriteHeight += spriteAAPadding * 2;
@@ -564,57 +564,47 @@ export class Legend extends BaseProperties {
     ): number {
         const { marker: itemMarker, paddingX } = this.item;
         const { markerWidth } = spriteDims;
-        const dimensionProps: { length: number; spacing: number; isCustomMarker: boolean }[] = [];
+        const { symbol } = datum;
         let paddedSymbolWidth = paddingX;
 
         if (this._symbolsDirty) {
-            const markers: Marker[] = [];
-            const lines: Line[] = [];
+            const { shape: markerShape = symbol.marker.shape } = itemMarker;
+            const MarkerCtr = getMarker(markerShape);
 
-            datum.symbols.forEach((symbol) => {
-                const { shape: markerShape = symbol.marker.shape } = itemMarker;
-                const MarkerCtr = getMarker(markerShape);
-
-                lines.push(new Line({ zIndex: 0 }));
-                markers.push(new MarkerCtr({ zIndex: 1 }));
-            });
-
-            markerLabel.updateSymbols(markers, lines);
+            markerLabel.updateSymbols(new MarkerCtr({ zIndex: 1 }), new Line({ zIndex: 0 }));
         }
 
-        datum.symbols.forEach((symbol, i) => {
-            const spacing = symbol.marker.padding ?? itemMarker.padding;
-            const { markerEnabled, lineEnabled, isCustomMarker } = this.calcSymbolsEnabled(symbol);
+        const spacing = itemMarker.padding;
+        const { markerEnabled, lineEnabled, isCustomMarker } = this.calcSymbolsEnabled(symbol);
 
-            markerLabel.markers[i].size = markerEnabled || !lineEnabled ? itemMarker.size : 0;
-            dimensionProps.push({ length: markerWidth, spacing, isCustomMarker });
+        const { marker, line } = markerLabel;
+        if (marker != null) {
+            marker.size = markerEnabled || !lineEnabled ? itemMarker.size : 0;
+        }
+        const dimensionProps = { length: markerWidth, spacing, isCustomMarker };
 
-            if (markerEnabled || lineEnabled) {
-                paddedSymbolWidth += spacing + markerWidth;
-            }
+        if (markerEnabled || lineEnabled) {
+            paddedSymbolWidth += spacing + markerWidth;
+        }
 
-            const marker = markerLabel.markers[i];
-            const line = markerLabel.lines[i];
+        if (marker) {
+            const { strokeWidth, fill, stroke, fillOpacity, strokeOpacity } = this.getMarkerStyles(symbol);
 
-            if (marker) {
-                const { strokeWidth, fill, stroke, fillOpacity, strokeOpacity } = this.getMarkerStyles(symbol);
+            marker.fill = fill;
+            marker.stroke = stroke;
+            marker.strokeWidth = strokeWidth;
+            marker.fillOpacity = fillOpacity;
+            marker.strokeOpacity = strokeOpacity;
+        }
 
-                marker.fill = fill;
-                marker.stroke = stroke;
-                marker.strokeWidth = strokeWidth;
-                marker.fillOpacity = fillOpacity;
-                marker.strokeOpacity = strokeOpacity;
-            }
+        if (line) {
+            const lineStyles = this.getLineStyles(symbol);
 
-            if (line) {
-                const lineStyles = this.getLineStyles(symbol);
-
-                line.stroke = lineStyles.stroke;
-                line.strokeOpacity = lineStyles.strokeOpacity;
-                line.strokeWidth = lineStyles.strokeWidth;
-                line.lineDash = lineStyles.lineDash;
-            }
-        });
+            line.stroke = lineStyles.stroke;
+            line.strokeOpacity = lineStyles.strokeOpacity;
+            line.strokeWidth = lineStyles.strokeWidth;
+            line.lineDash = lineStyles.lineDash;
+        }
 
         markerLabel.update(spriteRenderer, spriteDims, dimensionProps);
         return paddedSymbolWidth;

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -1,6 +1,7 @@
-import type { AgChartLegendListeners, AgMarkerShape } from 'ag-charts-types';
+import type { AgChartLegendListeners } from 'ag-charts-types';
 
 import type { Scene } from '../../scene/scene';
+import type { LegendSymbolOptions } from './legendSymbol';
 
 export interface ChartLegend {
     attachLegend(scene: Scene): void;
@@ -27,30 +28,12 @@ export interface BaseChartLegendDatum {
     hideInLegend?: boolean;
 }
 
-export interface LegendSymbolOptions {
-    marker: {
-        shape?: AgMarkerShape;
-        fill?: string;
-        stroke?: string;
-        fillOpacity: number;
-        strokeOpacity: number;
-        strokeWidth: number;
-        enabled?: boolean;
-        padding?: number;
-    };
-    line?: {
-        stroke: string;
-        strokeOpacity: number;
-        strokeWidth: number;
-        lineDash: number[];
-    };
-}
 export interface CategoryLegendDatum extends BaseChartLegendDatum {
     legendType: 'category';
     id: string; // component ID
     itemId: any; // sub-component ID
     datum?: any; // series datum
-    symbols: LegendSymbolOptions[];
+    symbol: LegendSymbolOptions;
     /** Optional deduplication id - used to coordinate synced toggling of multiple items. */
     legendItemName?: string;
     label: {

--- a/packages/ag-charts-community/src/chart/legend/legendMarkerLabel.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendMarkerLabel.ts
@@ -7,9 +7,8 @@ import type { Line } from '../../scene/shape/line';
 import { Text } from '../../scene/shape/text';
 import type { SpriteDimensions, SpriteRenderer } from '../../scene/spriteRenderer';
 import { Translatable } from '../../scene/transformable';
-import { arraysEqual } from '../../util/array';
-import { iterate } from '../../util/iterator';
 import { ProxyPropertyOnWrite } from '../../util/proxy';
+import { isDefined } from '../../util/type-guards';
 import type { SwitchWidget } from '../../widget/switchWidget';
 import type { Marker } from '../marker/marker';
 import type { MarkerConstructor } from '../marker/util';
@@ -31,7 +30,7 @@ export class LegendMarkerLabel extends Translatable(Group) {
     constructor() {
         super({ name: 'markerLabelGroup' });
 
-        const { markers, label, lines } = this;
+        const { marker, label, line } = this;
         label.textBaseline = 'middle';
         label.fontSize = 12;
         label.fontFamily = 'Verdana, sans-serif';
@@ -39,7 +38,7 @@ export class LegendMarkerLabel extends Translatable(Group) {
         // For better looking vertical alignment of labels to markers.
         label.y = 1;
 
-        this.updateSymbols(markers, lines);
+        this.updateSymbols(marker, line);
         this.append([this.symbolsGroup, label]);
     }
 
@@ -70,24 +69,24 @@ export class LegendMarkerLabel extends Translatable(Group) {
     @ProxyPropertyOnWrite('label', 'fill')
     color?: string;
 
-    private _markers: Marker[] = [];
-    get markers(): Marker[] {
-        return this._markers;
+    private _marker: Marker | undefined = undefined;
+    get marker(): Marker | undefined {
+        return this._marker;
     }
 
-    private _lines: Line[] = [];
-    get lines(): Line[] {
-        return this._lines;
+    private _line: Line | undefined = undefined;
+    get line(): Line | undefined {
+        return this._line;
     }
 
-    updateSymbols(markers: Marker[], lines: Line[]) {
-        if (arraysEqual(this._markers, markers) && arraysEqual(this._lines, lines)) return;
+    updateSymbols(marker: Marker | undefined, line: Line | undefined) {
+        if (this._marker === marker && this._line === line) return;
 
         this.bitmapDirty = true;
-        this._markers = markers;
-        this._lines = lines;
+        this._marker = marker;
+        this._line = line;
         this.symbolsGroup.clear();
-        this.symbolsGroup.append([this.bitmap, ...lines, ...markers]);
+        this.symbolsGroup.append([this.bitmap, line, marker].filter(isDefined));
     }
 
     setEnabled(enabled: boolean) {
@@ -104,8 +103,13 @@ export class LegendMarkerLabel extends Translatable(Group) {
     }
 
     private setBitmapVisibility(visible: boolean) {
-        const { lines, markers } = this;
-        [lines, markers].forEach((shapes) => shapes.forEach((shape) => (shape.visible = !visible)));
+        const { line, marker } = this;
+        if (marker != null) {
+            marker.visible = !visible;
+        }
+        if (line != null) {
+            line.visible = !visible;
+        }
         this.bitmap.visible = visible;
     }
 
@@ -114,66 +118,53 @@ export class LegendMarkerLabel extends Translatable(Group) {
     update(
         spriteRenderer: SpriteRenderer,
         { spriteAAPadding, spritePixelRatio: scale }: SpriteDimensions,
-        dimensionProps: { length: number; spacing: number; isCustomMarker: boolean }[]
+        dimensionProps: { length: number; spacing: number; isCustomMarker: boolean }
     ) {
-        const { markers, lines } = this;
+        const { marker, line } = this;
+        const { length, spacing, isCustomMarker } = dimensionProps;
 
-        let spriteX = 0;
-        let spriteY = 0;
-        let shift = 0;
-        for (let i = 0; i < Math.max(markers.length, lines.length); i++) {
-            const { length, spacing, isCustomMarker } = dimensionProps[i] ?? 0;
-            const marker = markers[i];
-            const line = lines[i];
+        let lineTop = Infinity;
+        let lineX1 = Infinity;
+        let lineX2 = Infinity;
+        let markerTop = Infinity;
+        let markerLeft = Infinity;
+        if (marker) {
+            const { size } = marker;
+            const center = (marker.constructor as MarkerConstructor).center;
+            const radius = (size + marker.strokeWidth) / 2;
 
-            const size = marker?.size ?? 0;
-
-            let lineTop = Infinity;
-            let lineX1 = Infinity;
-            let lineX2 = Infinity;
-            let markerTop = Infinity;
-            let markerLeft = Infinity;
-            if (marker) {
-                const center = (marker.constructor as MarkerConstructor).center;
-                const radius = (size + marker.strokeWidth) / 2;
-
-                if (isCustomMarker) {
-                    marker.x = 0;
-                    marker.y = 0;
-                    marker.translationX = (center.x - 0.5) * size + length / 2 + shift;
-                    marker.translationY = (center.y - 0.5) * size;
-                    markerTop = marker.translationY - radius;
-                    markerLeft = marker.translationX - radius;
-                } else {
-                    marker.x = (center.x - 0.5) * size + length / 2 + shift;
-                    marker.y = (center.y - 0.5) * size;
-                    markerTop = marker.y - radius;
-                    markerLeft = marker.x - radius;
-                }
+            if (isCustomMarker) {
+                marker.x = 0;
+                marker.y = 0;
+                marker.translationX = (center.x - 0.5) * size + length / 2;
+                marker.translationY = (center.y - 0.5) * size;
+                markerTop = marker.translationY - radius;
+                markerLeft = marker.translationX - radius;
+            } else {
+                marker.x = (center.x - 0.5) * size + length / 2;
+                marker.y = (center.y - 0.5) * size;
+                markerTop = marker.y - radius;
+                markerLeft = marker.x - radius;
             }
-
-            if (line) {
-                line.x1 = shift;
-                line.x2 = shift + length;
-                line.y1 = 0;
-                line.y2 = 0;
-                line.markDirty();
-                lineTop = -line.strokeWidth / 2;
-                lineX1 = line.x1;
-                lineX2 = line.x2;
-            }
-
-            shift += spacing + Math.max(length, size);
-            spriteX = Math.min(spriteX, lineX1, lineX2, markerLeft);
-            spriteY = Math.min(spriteY, lineTop, markerTop);
         }
 
-        const lastSymbolProps = dimensionProps.at(-1);
-        const lastLine = this.lines.at(-1);
-        const lastMarker = this.markers.at(-1);
-        const lineEnd = lastLine ? lastLine.x2 : -Infinity;
-        const markerEnd = (lastMarker?.x ?? 0) + (lastMarker?.size ?? 0) / 2;
-        this.label.x = Math.max(lineEnd, markerEnd) + (lastSymbolProps?.spacing ?? 0);
+        if (line) {
+            line.x1 = 0;
+            line.x2 = length;
+            line.y1 = 0;
+            line.y2 = 0;
+            line.markDirty();
+            lineTop = -line.strokeWidth / 2;
+            lineX1 = line.x1;
+            lineX2 = line.x2;
+        }
+
+        const spriteX = Math.min(lineX1, lineX2, markerLeft);
+        const spriteY = Math.min(lineTop, markerTop);
+
+        const lineEnd = line?.x2 ?? -Infinity;
+        const markerEnd = (marker?.x ?? 0) + (marker?.size ?? 0) / 2;
+        this.label.x = Math.max(lineEnd, markerEnd) + spacing;
 
         if (this.bitmapDirty) {
             this.setBitmapVisibility(false);
@@ -190,24 +181,13 @@ export class LegendMarkerLabel extends Translatable(Group) {
 
             this.refreshVisibilities();
         }
-
-        if (dimensionProps.length < 2) {
-            return;
-        }
-
-        // clip the symbols to the size of a single symbol to match the size of other legend items
-        const bbox = this.symbolsGroup.getBBox();
-        const clippedWidth = Math.max(lastMarker?.size ?? 0, lastSymbolProps?.length ?? 0);
-        const clipRect = new BBox(bbox.x + clippedWidth / 2, bbox.y, clippedWidth, bbox.height);
-
-        this.symbolsGroup.setClipRect(clipRect);
     }
 
     protected override computeBBox(): BBox {
         // The Image node (bitmap) includes some padding to render antialiasing pixel correctly, but we do
         // not want to include this padding in the layout bounds. So just compute the bounds for the Line
         // and Marker nodes directly rather than Group's default behaviour of computing this.bitmap's BBox.
-        const { label, lines, markers } = this;
-        return this.toParent(Group.computeChildrenBBox(iterate([label], lines, markers), false));
+        const { label, line, marker } = this;
+        return this.toParent(Group.computeChildrenBBox([label, line, marker].filter(isDefined), false));
     }
 }

--- a/packages/ag-charts-community/src/chart/legend/legendSymbol.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendSymbol.ts
@@ -1,0 +1,25 @@
+import type { AgMarkerShape } from 'ag-charts-types';
+
+import type { Gradient } from '../../scene/gradient/gradient';
+
+export interface LegendMarker {
+    shape?: AgMarkerShape;
+    fill?: string | Gradient;
+    fillOpacity: number;
+    stroke?: string | Gradient;
+    strokeOpacity: number;
+    strokeWidth: number;
+    enabled?: boolean;
+}
+
+export interface LegendLine {
+    stroke: string;
+    strokeOpacity: number;
+    strokeWidth: number;
+    lineDash: number[];
+}
+
+export interface LegendSymbolOptions {
+    marker: LegendMarker;
+    line?: LegendLine;
+}

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -773,25 +773,23 @@ export class AreaSeries extends CartesianSeries<
                 label: {
                     text: legendItemName ?? yName ?? itemId,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            shape: marker.shape,
-                            fill: useAreaFill ? fill : marker.fill,
-                            fillOpacity: useAreaFill ? fillOpacity : marker.fillOpacity,
-                            stroke: marker.stroke ?? stroke,
-                            strokeOpacity: marker.strokeOpacity ?? strokeOpacity,
-                            strokeWidth: marker.strokeWidth ?? 0,
-                            enabled: marker.enabled || strokeWidth <= 0,
-                        },
-                        line: {
-                            stroke,
-                            strokeOpacity,
-                            strokeWidth,
-                            lineDash,
-                        },
+                symbol: {
+                    marker: {
+                        shape: marker.shape,
+                        fill: useAreaFill ? fill : marker.fill,
+                        fillOpacity: useAreaFill ? fillOpacity : marker.fillOpacity,
+                        stroke: marker.stroke ?? stroke,
+                        strokeOpacity: marker.strokeOpacity ?? strokeOpacity,
+                        strokeWidth: marker.strokeWidth ?? 0,
+                        enabled: marker.enabled || strokeWidth <= 0,
                     },
-                ],
+                    line: {
+                        stroke,
+                        strokeOpacity,
+                        strokeWidth,
+                        lineDash,
+                    },
+                },
                 legendItemName,
                 hideInLegend: !showInLegend,
             },

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -797,7 +797,15 @@ export class BarSeries extends AbstractBarSeries<Rect, BarSeriesProperties, BarN
                 seriesId,
                 enabled: visible && legendManager.getItemEnabled({ seriesId, itemId }),
                 label: { text: legendItemName ?? yName ?? itemId },
-                symbols: [{ marker: { fill, fillOpacity, stroke, strokeWidth, strokeOpacity } }],
+                symbol: {
+                    marker: {
+                        fill,
+                        fillOpacity,
+                        stroke,
+                        strokeWidth,
+                        strokeOpacity,
+                    },
+                },
                 legendItemName,
                 hideInLegend: !showInLegend,
             },

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -442,18 +442,16 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleSeriesProperties,
                 label: {
                     text: title ?? yName ?? itemId,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            shape,
-                            fill: fill ?? 'rgba(0, 0, 0, 0)',
-                            stroke: stroke ?? 'rgba(0, 0, 0, 0)',
-                            fillOpacity: fillOpacity ?? 1,
-                            strokeOpacity: strokeOpacity ?? 1,
-                            strokeWidth: strokeWidth ?? 0,
-                        },
+                symbol: {
+                    marker: {
+                        shape,
+                        fill: fill ?? 'rgba(0, 0, 0, 0)',
+                        stroke: stroke ?? 'rgba(0, 0, 0, 0)',
+                        fillOpacity: fillOpacity ?? 1,
+                        strokeOpacity: strokeOpacity ?? 1,
+                        strokeWidth: strokeWidth ?? 0,
                     },
-                ],
+                },
             },
         ];
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -530,17 +530,15 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramSeriesProper
                 label: {
                     text: yName ?? itemId ?? 'Frequency',
                 },
-                symbols: [
-                    {
-                        marker: {
-                            fill: fill ?? 'rgba(0, 0, 0, 0)',
-                            stroke: stroke ?? 'rgba(0, 0, 0, 0)',
-                            fillOpacity: fillOpacity,
-                            strokeOpacity: strokeOpacity,
-                            strokeWidth,
-                        },
+                symbol: {
+                    marker: {
+                        fill: fill ?? 'rgba(0, 0, 0, 0)',
+                        stroke: stroke ?? 'rgba(0, 0, 0, 0)',
+                        fillOpacity: fillOpacity,
+                        strokeOpacity: strokeOpacity,
+                        strokeWidth,
                     },
-                ],
+                },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -605,25 +605,23 @@ export class LineSeries extends CartesianSeries<
                 label: {
                     text: legendItemName ?? title ?? yName ?? itemId,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            shape: marker.shape,
-                            fill: marker.fill ?? color0,
-                            stroke: marker.stroke ?? stroke ?? color0,
-                            fillOpacity: marker.fillOpacity ?? 1,
-                            strokeOpacity: marker.strokeOpacity ?? strokeOpacity ?? 1,
-                            strokeWidth: marker.strokeWidth ?? 0,
-                            enabled: marker.enabled,
-                        },
-                        line: {
-                            stroke: stroke ?? color0,
-                            strokeOpacity,
-                            strokeWidth,
-                            lineDash,
-                        },
+                symbol: {
+                    marker: {
+                        shape: marker.shape,
+                        fill: marker.fill ?? color0,
+                        stroke: marker.stroke ?? stroke ?? color0,
+                        fillOpacity: marker.fillOpacity ?? 1,
+                        strokeOpacity: marker.strokeOpacity ?? strokeOpacity ?? 1,
+                        strokeWidth: marker.strokeWidth ?? 0,
+                        enabled: marker.enabled,
                     },
-                ],
+                    line: {
+                        stroke: stroke ?? color0,
+                        strokeOpacity,
+                        strokeWidth,
+                        lineDash,
+                    },
+                },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -365,18 +365,16 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesPropertie
                 label: {
                     text: title ?? yName ?? itemId,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            shape: marker.shape,
-                            fill: marker.fill ?? fill ?? 'rgba(0, 0, 0, 0)',
-                            stroke: marker.stroke ?? stroke ?? 'rgba(0, 0, 0, 0)',
-                            fillOpacity: fillOpacity ?? 1,
-                            strokeOpacity: strokeOpacity ?? 1,
-                            strokeWidth: strokeWidth ?? 0,
-                        },
+                symbol: {
+                    marker: {
+                        shape: marker.shape,
+                        fill: marker.fill ?? fill ?? 'rgba(0, 0, 0, 0)',
+                        stroke: marker.stroke ?? stroke ?? 'rgba(0, 0, 0, 0)',
+                        fillOpacity: fillOpacity ?? 1,
+                        strokeOpacity: strokeOpacity ?? 1,
+                        strokeWidth: strokeWidth ?? 0,
                     },
-                ],
+                },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -1478,17 +1478,15 @@ export class DonutSeries extends PolarSeries<DonutNodeDatum, DonutSeriesProperti
                 label: {
                     text: labelParts.join(' - '),
                 },
-                symbols: [
-                    {
-                        marker: {
-                            fill: sectorFormat.fill,
-                            stroke: sectorFormat.stroke,
-                            fillOpacity: this.properties.fillOpacity,
-                            strokeOpacity: this.properties.strokeOpacity,
-                            strokeWidth: this.properties.strokeWidth,
-                        },
+                symbol: {
+                    marker: {
+                        fill: sectorFormat.fill,
+                        stroke: sectorFormat.stroke,
+                        fillOpacity: this.properties.fillOpacity,
+                        strokeOpacity: this.properties.strokeOpacity,
+                        strokeWidth: this.properties.strokeWidth,
                     },
-                ],
+                },
                 legendItemName: legendItemKey != null ? datum[legendItemKey] : undefined,
                 hideInLegend: !showInLegend,
             });

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -1390,17 +1390,15 @@ export class PieSeries extends PolarSeries<PieNodeDatum, PieSeriesProperties, Se
                 label: {
                     text: labelParts.join(' - '),
                 },
-                symbols: [
-                    {
-                        marker: {
-                            fill: sectorFormat.fill,
-                            stroke: sectorFormat.stroke,
-                            fillOpacity: this.properties.fillOpacity,
-                            strokeOpacity: this.properties.strokeOpacity,
-                            strokeWidth: this.properties.strokeWidth,
-                        },
+                symbol: {
+                    marker: {
+                        fill: sectorFormat.fill,
+                        stroke: sectorFormat.stroke,
+                        fillOpacity: this.properties.fillOpacity,
+                        strokeOpacity: this.properties.strokeOpacity,
+                        strokeWidth: this.properties.strokeWidth,
                     },
-                ],
+                },
                 legendItemName: legendItemKey != null ? datum[legendItemKey] : undefined,
                 hideInLegend: !showInLegend,
             });

--- a/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
@@ -68,7 +68,7 @@ export function preparePieSeriesAnimationFunctions(
 
         if (status === 'updated') {
             fill = (sect.fill as any) ?? fill;
-            stroke = sect.stroke ?? stroke;
+            stroke = (typeof sect.stroke === 'string' ? sect.stroke : undefined) ?? stroke;
         }
 
         return { startAngle, endAngle, innerRadius, outerRadius, fill, stroke, phase };

--- a/packages/ag-charts-community/src/scene/shape/line.ts
+++ b/packages/ag-charts-community/src/scene/shape/line.ts
@@ -107,7 +107,7 @@ export class Line extends Shape implements DistantObject {
         element.setAttribute('y1', String(this.y1));
         element.setAttribute('x2', String(this.x2));
         element.setAttribute('y2', String(this.y2));
-        element.setAttribute('stroke', this.stroke ?? 'none');
+        element.setAttribute('stroke', typeof this.stroke === 'string' ? this.stroke : 'none');
         element.setAttribute('stroke-opacity', String(this.strokeOpacity));
         element.setAttribute('stroke-width', String(this.strokeWidth));
 

--- a/packages/ag-charts-community/src/scene/shape/path.ts
+++ b/packages/ag-charts-community/src/scene/shape/path.ts
@@ -153,7 +153,7 @@ export class Path extends Shape implements DistantObject {
         element.setAttribute('fill', typeof this.fill === 'string' ? this.fill : 'none');
         element.setAttribute('fill-opacity', String(this.fillOpacity));
         if (this.stroke != null) {
-            element.setAttribute('stroke', this.stroke);
+            element.setAttribute('stroke', typeof this.stroke === 'string' ? this.stroke : 'none');
             element.setAttribute('stroke-opacity', String(this.strokeOpacity));
             element.setAttribute('stroke-width', String(this.strokeWidth));
         }

--- a/packages/ag-charts-community/src/scene/shape/range.ts
+++ b/packages/ag-charts-community/src/scene/shape/range.ts
@@ -80,7 +80,7 @@ export class Range extends Shape {
         if (strokeActive) {
             const { strokeOpacity, lineDash, lineDashOffset, lineCap, lineJoin } = this;
 
-            ctx.strokeStyle = stroke;
+            this.applyStroke(ctx);
             ctx.globalAlpha = opacity * strokeOpacity;
 
             ctx.lineWidth = strokeWidth;

--- a/packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.ts
@@ -460,7 +460,7 @@ export class Rect extends Path implements DistantObject {
                 ctx.clip(borderClipPath.getPath2D());
             }
 
-            ctx.strokeStyle = stroke;
+            this.applyStroke(ctx);
             ctx.globalAlpha *= opacity * strokeOpacity * microPixelEffectOpacity;
             ctx.lineWidth = effectiveStrokeWidth;
 

--- a/packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/packages/ag-charts-community/src/scene/shape/shape.ts
@@ -67,13 +67,14 @@ export abstract class Shape extends Node {
     @SceneChangeDetection({ changeCb: (s: Shape) => s.onFillChange() })
     fill?: string | Gradient = Shape.defaultStyles.fill;
 
-    protected onFillChange() {
-        const { fill } = this;
-
+    private getGradient(pattern: string | Gradient | undefined) {
         let linearGradientMatch: RegExpMatchArray | null;
-        if (fill instanceof Gradient) {
-            this.gradient = fill;
-        } else if (fill?.startsWith('linear-gradient') && (linearGradientMatch = LINEAR_GRADIENT_REGEXP.exec(fill))) {
+        if (pattern instanceof Gradient) {
+            return pattern;
+        } else if (
+            pattern?.startsWith('linear-gradient') &&
+            (linearGradientMatch = LINEAR_GRADIENT_REGEXP.exec(pattern))
+        ) {
             const angle = parseFloat(linearGradientMatch[1]);
             const colors = [];
             const colorsPart = linearGradientMatch[2];
@@ -82,17 +83,21 @@ export abstract class Shape extends Node {
             while ((c = colorRegex.exec(colorsPart))) {
                 colors.push(c[0]);
             }
-            this.gradient = new LinearGradient(
+            return new LinearGradient(
                 'rgb',
                 colors.map((color, index) => ({ color, offset: index / (colors.length - 1) })),
                 angle
             );
         } else {
-            this.gradient = undefined;
+            return undefined;
         }
     }
 
-    protected gradient: Gradient | undefined;
+    protected onFillChange() {
+        this.fillGradient = this.getGradient(this.fill);
+    }
+
+    protected fillGradient: Gradient | undefined;
 
     /**
      * Note that `strokeStyle = null` means invisible stroke,
@@ -104,8 +109,14 @@ export abstract class Shape extends Node {
      * The preferred way of making the stroke invisible is setting the `lineWidth` to zero,
      * unless specific looks that is achieved by having an invisible stroke is desired.
      */
-    @SceneChangeDetection()
-    stroke?: string = Shape.defaultStyles.stroke;
+    @SceneChangeDetection({ changeCb: (s: Shape) => s.onStrokeChange() })
+    stroke?: string | Gradient = Shape.defaultStyles.stroke;
+
+    protected onStrokeChange() {
+        this.strokeGradient = this.getGradient(this.stroke);
+    }
+
+    protected strokeGradient: Gradient | undefined;
 
     @SceneChangeDetection()
     strokeWidth: number = Shape.defaultStyles.strokeWidth;
@@ -181,8 +192,15 @@ export abstract class Shape extends Node {
 
     protected applyFill(ctx: CanvasContext) {
         ctx.fillStyle =
-            this.gradient?.createGradient(ctx as any, this.getBBox()) ??
+            this.fillGradient?.createGradient(ctx as any, this.getBBox()) ??
             (typeof this.fill === 'string' ? this.fill : undefined) ??
+            'black';
+    }
+
+    protected applyStroke(ctx: CanvasContext) {
+        ctx.strokeStyle =
+            this.strokeGradient?.createGradient(ctx as any, this.getBBox()) ??
+            (typeof this.stroke === 'string' ? this.stroke : undefined) ??
             'black';
     }
 
@@ -207,7 +225,7 @@ export abstract class Shape extends Node {
     protected renderStroke(ctx: CanvasContext, path?: Path2D) {
         if (this.stroke && this.strokeWidth) {
             const { globalAlpha } = ctx;
-            ctx.strokeStyle = this.stroke;
+            this.applyStroke(ctx);
             ctx.globalAlpha *= this.opacity * this.strokeOpacity;
 
             ctx.lineWidth = this.strokeWidth;

--- a/packages/ag-charts-community/src/scene/shape/text.ts
+++ b/packages/ag-charts-community/src/scene/shape/text.ts
@@ -114,7 +114,7 @@ export class Text extends Shape {
         }
 
         if (stroke && strokeWidth) {
-            ctx.strokeStyle = stroke;
+            this.applyStroke(ctx);
             ctx.lineWidth = strokeWidth;
             ctx.globalAlpha *= this.opacity * this.strokeOpacity;
 

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -108,7 +108,7 @@ export class ErrorBarNode extends _ModuleSupport.Group {
         return { whiskerStyle, capsStyle };
     }
 
-    private applyStyling(target: ErrorBarStylingOptions, source?: ErrorBarStylingOptions) {
+    private applyStyling(target: _ModuleSupport.Path, source?: ErrorBarStylingOptions) {
         // Style can be any object, including user data (e.g. formatter
         // result). So filter out anything that isn't styling options:
         partialAssign(

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -270,7 +270,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
                 label: {
                     text: legendItemName ?? yName ?? seriesId,
                 },
-                symbols: [{ marker: { fill, fillOpacity, stroke, strokeOpacity, strokeWidth } }],
+                symbol: { marker: { fill, fillOpacity, stroke, strokeOpacity, strokeWidth } },
                 legendItemName,
                 hideInLegend: !showInLegend,
             },

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickNode.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickNode.ts
@@ -105,7 +105,7 @@ export class CandlestickNode extends OhlcBaseNode {
 
         ctx.globalAlpha *= wickStrokeOpacity;
 
-        if (wickStroke != null) {
+        if (typeof wickStroke === 'string') {
             ctx.strokeStyle = wickStroke;
         }
         ctx.lineWidth = wickStrokeWidth;

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
@@ -246,6 +246,26 @@ export class CandlestickSeries extends OhlcSeriesBase<CandlestickNode, Candlesti
             return [];
         }
 
+        const fill = new _ModuleSupport.LinearGradient(
+            'rgb',
+            [
+                { color: up.fill, offset: 0 },
+                { color: up.fill, offset: 0.5 },
+                { color: down.fill, offset: 0.5 },
+            ],
+            90
+        );
+
+        const stroke = new _ModuleSupport.LinearGradient(
+            'rgb',
+            [
+                { color: up.stroke, offset: 0 },
+                { color: up.stroke, offset: 0.5 },
+                { color: down.stroke, offset: 0.5 },
+            ],
+            90
+        );
+
         return [
             {
                 legendType: 'category',
@@ -256,27 +276,15 @@ export class CandlestickSeries extends OhlcSeriesBase<CandlestickNode, Candlesti
                 label: {
                     text: legendItemName ?? yName ?? id,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            fill: up.fill,
-                            fillOpacity: up.fillOpacity,
-                            stroke: up.stroke,
-                            strokeWidth: up.strokeWidth ?? 1,
-                            strokeOpacity: up.strokeOpacity ?? 1,
-                            padding: 0,
-                        },
+                symbol: {
+                    marker: {
+                        fill,
+                        fillOpacity: up.fillOpacity,
+                        stroke: stroke,
+                        strokeWidth: up.strokeWidth ?? 1,
+                        strokeOpacity: up.strokeOpacity ?? 1,
                     },
-                    {
-                        marker: {
-                            fill: down.fill,
-                            fillOpacity: down.fillOpacity,
-                            stroke: down.stroke,
-                            strokeWidth: down.strokeWidth ?? 1,
-                            strokeOpacity: down.strokeOpacity ?? 1,
-                        },
-                    },
-                ],
+                },
                 legendItemName,
                 hideInLegend: !showInLegend,
             },

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
@@ -232,7 +232,11 @@ export class CandlestickSeries extends OhlcSeriesBase<CandlestickNode, Candlesti
     }
 
     getLegendData(legendType: _ModuleSupport.ChartLegendType): _ModuleSupport.CategoryLegendDatum[] {
-        const { id, data } = this;
+        const {
+            id,
+            data,
+            ctx: { legendManager },
+        } = this;
         const {
             xKey,
             yName,
@@ -272,7 +276,7 @@ export class CandlestickSeries extends OhlcSeriesBase<CandlestickNode, Candlesti
                 id,
                 itemId: id,
                 seriesId: id,
-                enabled: visible,
+                enabled: visible && legendManager.getItemEnabled({ seriesId: id, itemId: id }),
                 label: {
                     text: legendItemName ?? yName ?? id,
                 },

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -484,17 +484,15 @@ export abstract class FlowProportionSeries<
                 seriesId: this.id,
                 enabled: true,
                 label: { text: label ?? id },
-                symbols: [
-                    {
-                        marker: {
-                            fill,
-                            fillOpacity: 1,
-                            stroke,
-                            strokeWidth: 0,
-                            strokeOpacity: 1,
-                        },
+                symbol: {
+                    marker: {
+                        fill,
+                        fillOpacity: 1,
+                        stroke,
+                        strokeWidth: 0,
+                        strokeOpacity: 1,
                     },
-                ],
+                },
                 hideInLegend: !showInLegend,
             })
         );

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -646,7 +646,7 @@ export abstract class BaseFunnelSeries<
                     seriesId,
                     enabled: visible && legendManager.getItemEnabled({ seriesId, itemId: datumIndex }),
                     label: { text: stageValue },
-                    symbols: [{ marker: { fill, fillOpacity, stroke, strokeWidth, strokeOpacity } }],
+                    symbol: { marker: { fill, fillOpacity, stroke, strokeWidth, strokeOpacity } },
                     skipAnimations: true,
                     hideInLegend: !showInLegend,
                 };

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -540,24 +540,22 @@ export class MapLineSeries extends TopologySeries<
                 seriesId,
                 enabled: visible,
                 label: { text: legendItemName ?? title ?? idName ?? idKey },
-                symbols: [
-                    {
-                        marker: {
-                            fill: stroke,
-                            fillOpacity: strokeOpacity,
-                            stroke: undefined,
-                            strokeWidth: 0,
-                            strokeOpacity: 0,
-                            enabled: false,
-                        },
-                        line: {
-                            stroke,
-                            strokeOpacity,
-                            strokeWidth,
-                            lineDash,
-                        },
+                symbol: {
+                    marker: {
+                        fill: stroke,
+                        fillOpacity: strokeOpacity,
+                        stroke: undefined,
+                        strokeWidth: 0,
+                        strokeOpacity: 0,
+                        enabled: false,
                     },
-                ],
+                    line: {
+                        stroke,
+                        strokeOpacity,
+                        strokeWidth,
+                        lineDash,
+                    },
+                },
                 legendItemName,
                 hideInLegend: !showInLegend,
             };

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -692,18 +692,16 @@ export class MapMarkerSeries
                 seriesId,
                 enabled: visible,
                 label: { text: legendItemName ?? title ?? idName ?? idKey ?? seriesId },
-                symbols: [
-                    {
-                        marker: {
-                            shape,
-                            fill,
-                            fillOpacity,
-                            stroke,
-                            strokeWidth,
-                            strokeOpacity,
-                        },
+                symbol: {
+                    marker: {
+                        shape,
+                        fill,
+                        fillOpacity,
+                        stroke,
+                        strokeWidth,
+                        strokeOpacity,
                     },
-                ],
+                },
                 legendItemName,
                 hideInLegend: !showInLegend,
             };

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -604,17 +604,15 @@ export class MapShapeSeries
                 seriesId,
                 enabled: visible,
                 label: { text: legendItemName ?? title ?? idName ?? idKey },
-                symbols: [
-                    {
-                        marker: {
-                            fill,
-                            fillOpacity,
-                            stroke,
-                            strokeWidth,
-                            strokeOpacity,
-                        },
+                symbol: {
+                    marker: {
+                        fill,
+                        fillOpacity,
+                        stroke,
+                        strokeWidth,
+                        strokeOpacity,
                     },
-                ],
+                },
                 legendItemName,
                 hideInLegend: !showInLegend,
             };

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeries.ts
@@ -201,6 +201,16 @@ export class OhlcSeries extends OhlcSeriesBase<OhlcNode, OhlcSeriesProperties> {
             return [];
         }
 
+        const stroke = new _ModuleSupport.LinearGradient(
+            'rgb',
+            [
+                { color: up.stroke, offset: 0 },
+                { color: up.stroke, offset: 0.5 },
+                { color: down.stroke, offset: 0.5 },
+            ],
+            90
+        );
+
         return [
             {
                 legendType: 'category',
@@ -211,27 +221,15 @@ export class OhlcSeries extends OhlcSeriesBase<OhlcNode, OhlcSeriesProperties> {
                 label: {
                     text: legendItemName ?? yName ?? id,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            fill: undefined,
-                            fillOpacity: 1,
-                            stroke: up.stroke,
-                            strokeWidth: up.strokeWidth ?? 1,
-                            strokeOpacity: up.strokeOpacity ?? 1,
-                            padding: 0,
-                        },
+                symbol: {
+                    marker: {
+                        fill: undefined,
+                        fillOpacity: 1,
+                        stroke,
+                        strokeWidth: up.strokeWidth ?? 1,
+                        strokeOpacity: up.strokeOpacity ?? 1,
                     },
-                    {
-                        marker: {
-                            fill: undefined,
-                            fillOpacity: 1,
-                            stroke: down.stroke,
-                            strokeWidth: down.strokeWidth ?? 1,
-                            strokeOpacity: down.strokeOpacity ?? 1,
-                        },
-                    },
-                ],
+                },
                 legendItemName,
                 hideInLegend: !showInLegend,
             },

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeries.ts
@@ -187,7 +187,11 @@ export class OhlcSeries extends OhlcSeriesBase<OhlcNode, OhlcSeriesProperties> {
     }
 
     getLegendData(legendType: _ModuleSupport.ChartLegendType): _ModuleSupport.CategoryLegendDatum[] {
-        const { id, data } = this;
+        const {
+            id,
+            data,
+            ctx: { legendManager },
+        } = this;
         const {
             xKey,
             yName,
@@ -217,7 +221,7 @@ export class OhlcSeries extends OhlcSeriesBase<OhlcNode, OhlcSeriesProperties> {
                 id,
                 itemId: id,
                 seriesId: id,
-                enabled: visible,
+                enabled: visible && legendManager.getItemEnabled({ seriesId: id, itemId: id }),
                 label: {
                     text: legendItemName ?? yName ?? id,
                 },

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -634,7 +634,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
                 seriesId,
                 enabled: visible && legendManager.getItemEnabled({ seriesId, itemId: datumIndex }),
                 label: { text: stageValue },
-                symbols: [{ marker: { fill, fillOpacity, stroke, strokeWidth, strokeOpacity } }],
+                symbol: { marker: { fill, fillOpacity, stroke, strokeWidth, strokeOpacity } },
                 hideInLegend: !showInLegend,
             });
         });

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -470,25 +470,23 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<
                 label: {
                     text: radiusName ?? radiusKey,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            shape: marker.shape,
-                            fill: this.getMarkerFill() ?? marker.stroke ?? stroke ?? 'rgba(0, 0, 0, 0)',
-                            stroke: marker.stroke ?? stroke ?? 'rgba(0, 0, 0, 0)',
-                            fillOpacity: marker.fillOpacity ?? 1,
-                            strokeOpacity: marker.strokeOpacity ?? strokeOpacity ?? 1,
-                            strokeWidth: marker.strokeWidth ?? 0,
-                            enabled: marker.enabled || strokeWidth <= 0,
-                        },
-                        line: {
-                            stroke,
-                            strokeOpacity,
-                            strokeWidth,
-                            lineDash,
-                        },
+                symbol: {
+                    marker: {
+                        shape: marker.shape,
+                        fill: this.getMarkerFill() ?? marker.stroke ?? stroke ?? 'rgba(0, 0, 0, 0)',
+                        stroke: marker.stroke ?? stroke ?? 'rgba(0, 0, 0, 0)',
+                        fillOpacity: marker.fillOpacity ?? 1,
+                        strokeOpacity: marker.strokeOpacity ?? strokeOpacity ?? 1,
+                        strokeWidth: marker.strokeWidth ?? 0,
+                        enabled: marker.enabled || strokeWidth <= 0,
                     },
-                ],
+                    line: {
+                        stroke,
+                        strokeOpacity,
+                        strokeWidth,
+                        lineDash,
+                    },
+                },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -595,17 +595,15 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
                 label: {
                     text: angleName ?? angleKey,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            fill: fill ?? 'rgba(0, 0, 0, 0)',
-                            stroke: stroke ?? 'rgba(0, 0, 0, 0)',
-                            fillOpacity: fillOpacity ?? 1,
-                            strokeOpacity: strokeOpacity ?? 1,
-                            strokeWidth,
-                        },
+                symbol: {
+                    marker: {
+                        fill: fill ?? 'rgba(0, 0, 0, 0)',
+                        stroke: stroke ?? 'rgba(0, 0, 0, 0)',
+                        fillOpacity: fillOpacity ?? 1,
+                        strokeOpacity: strokeOpacity ?? 1,
+                        strokeWidth,
                     },
-                ],
+                },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -603,17 +603,15 @@ export abstract class RadialColumnSeriesBase<
                 label: {
                     text: radiusName ?? radiusKey,
                 },
-                symbols: [
-                    {
-                        marker: {
-                            fill: fill ?? 'rgba(0, 0, 0, 0)',
-                            stroke: stroke ?? 'rgba(0, 0, 0, 0)',
-                            fillOpacity: fillOpacity ?? 1,
-                            strokeOpacity: strokeOpacity ?? 1,
-                            strokeWidth,
-                        },
+                symbol: {
+                    marker: {
+                        fill: fill ?? 'rgba(0, 0, 0, 0)',
+                        stroke: stroke ?? 'rgba(0, 0, 0, 0)',
+                        fillOpacity: fillOpacity ?? 1,
+                        strokeOpacity: strokeOpacity ?? 1,
+                        strokeWidth,
                     },
-                ],
+                },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -631,24 +631,22 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
                 seriesId,
                 enabled: visible,
                 label: { text: `${legendItemText}` },
-                symbols: [
-                    {
-                        marker: {
-                            shape: marker.shape,
-                            fill: marker.fill ?? fill,
-                            stroke: marker.stroke ?? stroke,
-                            fillOpacity: marker.fillOpacity,
-                            strokeOpacity: marker.strokeOpacity,
-                            strokeWidth: marker.strokeWidth,
-                        },
-                        line: {
-                            stroke,
-                            strokeOpacity,
-                            strokeWidth,
-                            lineDash,
-                        },
+                symbol: {
+                    marker: {
+                        shape: marker.shape,
+                        fill: marker.fill ?? fill,
+                        stroke: marker.stroke ?? stroke,
+                        fillOpacity: marker.fillOpacity,
+                        strokeOpacity: marker.strokeOpacity,
+                        strokeWidth: marker.strokeWidth,
                     },
-                ],
+                    line: {
+                        stroke,
+                        strokeOpacity,
+                        strokeWidth,
+                        lineDash,
+                    },
+                },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -677,7 +677,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
                 seriesId,
                 enabled: visible,
                 label: { text: `${legendItemText}` },
-                symbols: [{ marker: { fill, stroke, fillOpacity, strokeOpacity, strokeWidth } }],
+                symbol: { marker: { fill, stroke, fillOpacity, strokeOpacity, strokeWidth } },
                 hideInLegend: !showInLegend,
             },
         ];

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -686,7 +686,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
                 seriesId: id,
                 enabled: true,
                 label: { text: name ?? capitalise(item) },
-                symbols: [{ marker: { fill, stroke, fillOpacity, strokeOpacity, strokeWidth } }],
+                symbol: { marker: { fill, stroke, fillOpacity, strokeOpacity, strokeWidth } },
                 hideInLegend: !showInLegend,
             });
         });


### PR DESCRIPTION
Pre-requisite for https://ag-grid.atlassian.net/browse/AG-10574

Legend items could have multiple symbols for the candlestick/ohlc. This updates it to take one symbol, and applies a step gradient to those series (below)

Required so I can re-use the legend symbol logic for the tooltip redesigns

<img width="190" alt="image" src="https://github.com/user-attachments/assets/67ae073f-3cff-4fa8-8812-d50c969ce555">
