### PR TITLE
AG-13343 Tech-Debt: Event handling clean up

### DIFF
--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -114,8 +114,8 @@ export class Caption extends BaseProperties implements CaptionLike {
                 this.proxyText ??= proxyInteractionService.createProxyElement({ type: 'text', domManagerId, where });
                 this.proxyText.textContent = this.text;
                 this.proxyText.setBounds(bbox);
-                this.proxyText.addListener('mousemove', (_target, ev) => this.handleMouseMove(moduleCtx, ev));
-                this.proxyText.addListener('mouseleave', (_target, ev) => this.handleMouseLeave(moduleCtx, ev));
+                this.proxyText.addListener('mousemove', (ev) => this.handleMouseMove(moduleCtx, ev));
+                this.proxyText.addListener('mouseleave', (ev) => this.handleMouseLeave(moduleCtx, ev));
             }
         } else {
             this.proxyText?.destroy();

--- a/packages/ag-charts-community/src/chart/interaction/regionManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/regionManager.ts
@@ -281,7 +281,7 @@ export class RegionManager {
         current.listeners.dispatch(event.type, event);
     }
 
-    private readonly processPointerEvent = (widget: Widget, event: TWidgetEvent) => {
+    private readonly processPointerEvent = (event: TWidgetEvent, widget: Widget) => {
         const ignore = shouldIgnore(event);
         const { current } = this;
 

--- a/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
@@ -103,13 +103,13 @@ export class LegendDOMProxy {
             // The method parameter `datum` gets destroyed when the data is refreshed
             // using Series.getLegendData(). But the scene node will stay the same.
             const button = markerLabel.proxyButton;
-            button.addListener('click', (_t, ev) => itemListener.onClick(ev.sourceEvent, markerLabel.datum, button));
-            button.addListener('dblclick', (_t, ev) => itemListener.onDoubleClick(ev.sourceEvent, markerLabel.datum));
-            button.addListener('mouseenter', (_t, ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
+            button.addListener('click', (ev) => itemListener.onClick(ev.sourceEvent, markerLabel.datum, button));
+            button.addListener('dblclick', (ev) => itemListener.onDoubleClick(ev.sourceEvent, markerLabel.datum));
+            button.addListener('mouseenter', (ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
             button.addListener('mouseleave', () => itemListener.onLeave());
-            button.addListener('contextmenu', (_t, ev) => itemListener.onContextClick(ev.sourceEvent, markerLabel));
+            button.addListener('contextmenu', (ev) => itemListener.onContextClick(ev.sourceEvent, markerLabel));
             button.addListener('blur', () => itemListener.onLeave());
-            button.addListener('focus', (_t, ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
+            button.addListener('focus', (ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
         });
         this.dirty = false;
     }
@@ -164,7 +164,7 @@ export class LegendDOMProxy {
                     tabIndex: 0,
                     parent: this.paginationGroup,
                 });
-                this.prevButton.addListener('click', (_t, ev) => pagination.onClick(ev.sourceEvent, 'previous'));
+                this.prevButton.addListener('click', (ev) => pagination.onClick(ev.sourceEvent, 'previous'));
                 this.prevButton.addListener('mouseenter', () => pagination.onMouseHover('previous'));
                 this.prevButton.addListener('mouseleave', () => pagination.onMouseHover(undefined));
 
@@ -175,7 +175,7 @@ export class LegendDOMProxy {
                     tabIndex: 0,
                     parent: this.paginationGroup,
                 });
-                this.nextButton.addListener('click', (_t, ev) => pagination.onClick(ev.sourceEvent, 'next'));
+                this.nextButton.addListener('click', (ev) => pagination.onClick(ev.sourceEvent, 'next'));
                 this.nextButton.addListener('mouseenter', () => pagination.onMouseHover('next'));
                 this.nextButton.addListener('mouseleave', () => pagination.onMouseHover(undefined));
             } else {

--- a/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
@@ -98,17 +98,18 @@ export class LegendDOMProxy {
                 ariaChecked: !!markerLabel.datum.enabled,
                 ariaDescribedBy: this.itemDescription.id,
                 parent: this.itemList,
-                // Retrieve the datum from the node rather than from the method parameter.
-                // The method parameter `datum` gets destroyed when the data is refreshed
-                // using Series.getLegendData(). But the scene node will stay the same.
-                onclick: (ev) => itemListener.onClick(ev, markerLabel.datum, markerLabel.proxyButton!),
-                ondblclick: (ev) => itemListener.onDoubleClick(ev, markerLabel.datum),
-                onmouseenter: (ev) => itemListener.onHover(ev, markerLabel),
-                onmouseleave: () => itemListener.onLeave(),
-                oncontextmenu: (ev) => itemListener.onContextClick(ev, markerLabel),
-                onblur: () => itemListener.onLeave(),
-                onfocus: (ev) => itemListener.onHover(ev, markerLabel),
             });
+            // Retrieve the datum from the node rather than from the each() parameter.
+            // The method parameter `datum` gets destroyed when the data is refreshed
+            // using Series.getLegendData(). But the scene node will stay the same.
+            const button = markerLabel.proxyButton;
+            button.addListener('click', (_t, ev) => itemListener.onClick(ev.sourceEvent, markerLabel.datum, button));
+            button.addListener('dblclick', (_t, ev) => itemListener.onDoubleClick(ev.sourceEvent, markerLabel.datum));
+            button.addListener('mouseenter', (_t, ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
+            button.addListener('mouseleave', () => itemListener.onLeave());
+            button.addListener('contextmenu', (_t, ev) => itemListener.onContextClick(ev.sourceEvent, markerLabel));
+            button.addListener('blur', () => itemListener.onLeave());
+            button.addListener('focus', (_t, ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
         });
         this.dirty = false;
     }
@@ -162,20 +163,21 @@ export class LegendDOMProxy {
                     textContent: { id: 'ariaLabelLegendPagePrevious' },
                     tabIndex: 0,
                     parent: this.paginationGroup,
-                    onclick: (ev) => pagination.onClick(ev, 'previous'),
-                    onmouseenter: () => pagination.onMouseHover('previous'),
-                    onmouseleave: () => pagination.onMouseHover(undefined),
                 });
+                this.prevButton.addListener('click', (_t, ev) => pagination.onClick(ev.sourceEvent, 'previous'));
+                this.prevButton.addListener('mouseenter', () => pagination.onMouseHover('previous'));
+                this.prevButton.addListener('mouseleave', () => pagination.onMouseHover(undefined));
+
                 this.nextButton ??= ctx.proxyInteractionService.createProxyElement({
                     type: 'button',
                     id: `${this.idPrefix}-next-page`,
                     textContent: { id: 'ariaLabelLegendPageNext' },
                     tabIndex: 0,
                     parent: this.paginationGroup,
-                    onclick: (ev) => pagination.onClick(ev, 'next'),
-                    onmouseenter: () => pagination.onMouseHover('next'),
-                    onmouseleave: () => pagination.onMouseHover(undefined),
                 });
+                this.nextButton.addListener('click', (_t, ev) => pagination.onClick(ev.sourceEvent, 'next'));
+                this.nextButton.addListener('mouseenter', () => pagination.onMouseHover('next'));
+                this.nextButton.addListener('mouseleave', () => pagination.onMouseHover(undefined));
             } else {
                 this.nextButton?.destroy();
                 this.prevButton?.destroy();

--- a/packages/ag-charts-community/src/components/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/components/toolbar/toolbar.ts
@@ -134,7 +134,7 @@ export abstract class BaseToolbar<
         const buttonWidget = this.createButtonWidget();
         buttonWidget.addClass('ag-charts-toolbar__button');
 
-        buttonWidget.addListener('click', (_, event) => {
+        buttonWidget.addListener('click', (event) => {
             const buttonOptions = { index, ...(button instanceof BaseProperties ? button.toJson() : button) };
             const buttonBounds = this.getButtonWidgetBounds(buttonWidget);
             this.events.dispatch('button-pressed', { event, button: buttonOptions, buttonBounds });

--- a/packages/ag-charts-community/src/dom/proxyInteractionService.ts
+++ b/packages/ag-charts-community/src/dom/proxyInteractionService.ts
@@ -27,13 +27,6 @@ type ElemParams<T extends ProxyElementType> = {
 type InteractParams<T extends ProxyElementType> = ElemParams<T> & {
     readonly tabIndex?: number;
     readonly domIndex?: number;
-    readonly onclick?: (ev: MouseEvent) => void;
-    readonly ondblclick?: (ev: MouseEvent) => void;
-    readonly onmouseenter?: (ev: MouseEvent) => void;
-    readonly onmouseleave?: (ev: MouseEvent) => void;
-    readonly oncontextmenu?: (ev: MouseEvent) => void;
-    readonly onfocus?: (ev: FocusEvent) => void;
-    readonly onblur?: (ev: FocusEvent) => void;
 };
 
 type TranslationKey = { id: string; params?: Record<string, any> };
@@ -236,38 +229,14 @@ export class ProxyInteractionService {
     }
 
     private initInteract<T extends ProxyElementType>(params: InteractParams<T>, widget: Widget) {
-        const { onclick, ondblclick, onmouseenter, onmouseleave, oncontextmenu, onfocus, onblur, tabIndex, domIndex } =
-            params;
+        const { tabIndex, domIndex } = params;
         const element = this.initElement(params, widget);
 
         if (tabIndex !== undefined) {
             element.tabIndex = tabIndex;
         }
-
         if (domIndex !== undefined) {
             widget.domIndex = domIndex;
-        }
-
-        if (onclick) {
-            element.addEventListener('click', onclick);
-        }
-        if (ondblclick) {
-            element.addEventListener('dblclick', ondblclick);
-        }
-        if (onmouseenter) {
-            element.addEventListener('mouseenter', onmouseenter);
-        }
-        if (onmouseleave) {
-            element.addEventListener('mouseleave', onmouseleave);
-        }
-        if (oncontextmenu) {
-            element.addEventListener('contextmenu', oncontextmenu);
-        }
-        if (onfocus) {
-            element.addEventListener('focus', onfocus);
-        }
-        if (onblur) {
-            element.addEventListener('blur', onblur);
         }
     }
 

--- a/packages/ag-charts-community/src/widget/rovingTabContainerWidget.ts
+++ b/packages/ag-charts-community/src/widget/rovingTabContainerWidget.ts
@@ -42,14 +42,14 @@ export abstract class RovingTabContainerWidget extends Widget<HTMLDivElement, Ro
         child.removeListener('keydown', this.onChildKeyDown);
     }
 
-    private readonly onChildFocus = (child: RovingChildWidgets, _event: FocusWidgetEvent): void => {
+    private readonly onChildFocus = (_event: FocusWidgetEvent, child: RovingChildWidgets): void => {
         const oldFocus = this.children[this.focusedChildIndex];
         this.focusedChildIndex = child.index;
         oldFocus?.setTabIndex(-1);
         child.setTabIndex(0);
     };
 
-    private readonly onChildKeyDown = (child: RovingChildWidgets, event: KeyboardWidgetEvent): void => {
+    private readonly onChildKeyDown = (event: KeyboardWidgetEvent, child: RovingChildWidgets): void => {
         const rovingOrientation = this.orientation;
         const [primaryKeys, secondaryKeys]: [RovingKeys, RovingKeys | undefined] =
             rovingOrientation === 'both'

--- a/packages/ag-charts-community/src/widget/sliderWidget.ts
+++ b/packages/ag-charts-community/src/widget/sliderWidget.ts
@@ -13,9 +13,9 @@ export class SliderWidget extends Widget<HTMLInputElement> {
     private _step: Readonly<SliderStep> = SliderWidget.STEP_ONE;
     private _keyboardStep?: {
         step: Readonly<SliderStep>;
-        onKeyDown: (target: SliderWidget, ev: KeyboardWidgetEvent) => void;
-        onKeyUp: (target: SliderWidget, ev: KeyboardWidgetEvent) => void;
-        onBlur: (target: SliderWidget, ev: FocusWidgetEvent) => void;
+        onKeyDown: (ev: KeyboardWidgetEvent, target: SliderWidget) => void;
+        onKeyUp: (ev: KeyboardWidgetEvent, target: SliderWidget) => void;
+        onBlur: (ev: FocusWidgetEvent, target: SliderWidget) => void;
     };
 
     public get step() {
@@ -96,7 +96,7 @@ export class SliderWidget extends Widget<HTMLInputElement> {
         }
     }
 
-    private static onKeyDown(this: void, target: SliderWidget, ev: KeyboardWidgetEvent) {
+    private static onKeyDown(this: void, ev: KeyboardWidgetEvent, target: SliderWidget) {
         let ignoredKeys: string[] = [];
         const { orientation } = target;
         if (orientation === 'horizontal') {

--- a/packages/ag-charts-community/src/widget/sliderWidget.ts
+++ b/packages/ag-charts-community/src/widget/sliderWidget.ts
@@ -13,9 +13,9 @@ export class SliderWidget extends Widget<HTMLInputElement> {
     private _step: Readonly<SliderStep> = SliderWidget.STEP_ONE;
     private _keyboardStep?: {
         step: Readonly<SliderStep>;
-        onKeyDown: (ev: KeyboardWidgetEvent, target: SliderWidget) => void;
-        onKeyUp: (ev: KeyboardWidgetEvent, target: SliderWidget) => void;
-        onBlur: (ev: FocusWidgetEvent, target: SliderWidget) => void;
+        onKeyDown: (ev: KeyboardWidgetEvent, current: SliderWidget) => void;
+        onKeyUp: (ev: KeyboardWidgetEvent, current: SliderWidget) => void;
+        onBlur: (ev: FocusWidgetEvent, current: SliderWidget) => void;
     };
 
     public get step() {
@@ -96,9 +96,9 @@ export class SliderWidget extends Widget<HTMLInputElement> {
         }
     }
 
-    private static onKeyDown(this: void, ev: KeyboardWidgetEvent, target: SliderWidget) {
+    private static onKeyDown(this: void, ev: KeyboardWidgetEvent, current: SliderWidget) {
         let ignoredKeys: string[] = [];
-        const { orientation } = target;
+        const { orientation } = current;
         if (orientation === 'horizontal') {
             ignoredKeys = ['ArrowUp', 'ArrowDown'];
         } else if (orientation === 'vertical') {

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -169,8 +169,8 @@ export abstract class Widget<
             .reduce<R | undefined>((prev, curr) => (!prev || curr.domIndex < prev.domIndex ? curr : prev), undefined);
     }
 
-    addListener<K extends EventType>(type: K, listener: (target: typeof this, ev: EventMap[K]) => unknown): void;
-    addListener<K extends EventType>(type: K, listener: (target: typeof this, ev: unknown) => unknown): void {
+    addListener<K extends EventType>(type: K, listener: (ev: EventMap[K], target: typeof this) => unknown): void;
+    addListener<K extends EventType>(type: K, listener: (ev: unknown, target: typeof this) => unknown): void {
         if (WidgetEventUtil.isHTMLEvent(type)) {
             this.htmlListener ??= new WidgetListenerHTML();
             this.htmlListener.add(type, this, listener);
@@ -180,8 +180,8 @@ export abstract class Widget<
         }
     }
 
-    removeListener<K extends EventType>(type: K, listener: (target: typeof this, ev: EventMap[K]) => unknown): void;
-    removeListener<K extends EventType>(type: K, listener: (target: typeof this, ev: unknown) => unknown): void {
+    removeListener<K extends EventType>(type: K, listener: (ev: EventMap[K], target: typeof this) => unknown): void;
+    removeListener<K extends EventType>(type: K, listener: (ev: unknown, target: typeof this) => unknown): void {
         if (WidgetEventUtil.isHTMLEvent(type)) {
             this.htmlListener?.remove(type, this, listener);
         } else if (this.htmlListener != null) {

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -169,8 +169,8 @@ export abstract class Widget<
             .reduce<R | undefined>((prev, curr) => (!prev || curr.domIndex < prev.domIndex ? curr : prev), undefined);
     }
 
-    addListener<K extends EventType>(type: K, listener: (ev: EventMap[K], target: typeof this) => unknown): void;
-    addListener<K extends EventType>(type: K, listener: (ev: unknown, target: typeof this) => unknown): void {
+    addListener<K extends EventType>(type: K, listener: (ev: EventMap[K], current: typeof this) => unknown): void;
+    addListener<K extends EventType>(type: K, listener: (ev: unknown, current: typeof this) => unknown): void {
         if (WidgetEventUtil.isHTMLEvent(type)) {
             this.htmlListener ??= new WidgetListenerHTML();
             this.htmlListener.add(type, this, listener);
@@ -180,8 +180,8 @@ export abstract class Widget<
         }
     }
 
-    removeListener<K extends EventType>(type: K, listener: (ev: EventMap[K], target: typeof this) => unknown): void;
-    removeListener<K extends EventType>(type: K, listener: (ev: unknown, target: typeof this) => unknown): void {
+    removeListener<K extends EventType>(type: K, listener: (ev: EventMap[K], current: typeof this) => unknown): void;
+    removeListener<K extends EventType>(type: K, listener: (ev: unknown, current: typeof this) => unknown): void {
         if (WidgetEventUtil.isHTMLEvent(type)) {
             this.htmlListener?.remove(type, this, listener);
         } else if (this.htmlListener != null) {

--- a/packages/ag-charts-community/src/widget/widgetListenerHTML.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerHTML.ts
@@ -5,10 +5,10 @@ type EventMap = WidgetEventMap_HTML;
 type EventType = keyof WidgetEventMap_HTML;
 type SourceEventMap = WidgetSourceEventMap_HTML;
 type Targetable = { getElement(): HTMLElement };
-type Handler<T, K extends EventType> = (target: T, event: EventMap[K]) => unknown;
+type Handler<T, K extends EventType> = (event: EventMap[K], target: T) => unknown;
 
 type TypedMap<K extends EventType> = Map<
-    (target: Targetable, widgetEvent: EventMap[K]) => unknown,
+    (widgetEvent: EventMap[K], target: Targetable) => unknown,
     (this: HTMLElement, sourceEvent: SourceEventMap[K]) => void
 >;
 
@@ -31,7 +31,7 @@ export class WidgetListenerHTML {
 
         const sourceHandler = (sourceEvent: SourceEventMap[K]): void => {
             const widgetEvent = WidgetEventUtil.alloc(type, sourceEvent);
-            handler(target, widgetEvent);
+            handler(widgetEvent, target);
         };
         target.getElement().addEventListener(type, sourceHandler);
         map.set(handler, sourceHandler);

--- a/packages/ag-charts-community/src/widget/widgetListenerHTML.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerHTML.ts
@@ -5,10 +5,10 @@ type EventMap = WidgetEventMap_HTML;
 type EventType = keyof WidgetEventMap_HTML;
 type SourceEventMap = WidgetSourceEventMap_HTML;
 type Targetable = { getElement(): HTMLElement };
-type Handler<T, K extends EventType> = (event: EventMap[K], target: T) => unknown;
+type Handler<T, K extends EventType> = (event: EventMap[K], current: T) => unknown;
 
 type TypedMap<K extends EventType> = Map<
-    (widgetEvent: EventMap[K], target: Targetable) => unknown,
+    (widgetEvent: EventMap[K], current: Targetable) => unknown,
     (this: HTMLElement, sourceEvent: SourceEventMap[K]) => void
 >;
 

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -4,7 +4,7 @@ import type { DragWidgetEvent, WidgetEventMap_Internal } from './widgetEvents';
 
 type EventMap = WidgetEventMap_Internal;
 type EventType = keyof WidgetEventMap_Internal;
-type EventHandler<T, K extends EventType = EventType> = (target: T, event: EventMap[K]) => unknown;
+type EventHandler<T, K extends EventType = EventType> = (event: EventMap[K], target: T) => unknown;
 type Targetable = { getElement(): HTMLElement };
 
 type DragEvents = 'drag-start' | 'drag-move' | 'drag-end';
@@ -118,11 +118,11 @@ export class WidgetListenerInternal {
     private dispatch<T extends Targetable, K extends EventType>(type: K, target: T, event: EventMap[K]): void {
         switch (type) {
             case 'drag-start':
-                return this.dragStartListeners?.forEach((handler) => handler(target, event));
+                return this.dragStartListeners?.forEach((handler) => handler(event, target));
             case 'drag-move':
-                return this.dragMoveListeners?.forEach((handler) => handler(target, event));
+                return this.dragMoveListeners?.forEach((handler) => handler(event, target));
             case 'drag-end':
-                return this.dragEndListeners?.forEach((handler) => handler(target, event));
+                return this.dragEndListeners?.forEach((handler) => handler(event, target));
         }
     }
 }

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -4,7 +4,7 @@ import type { DragWidgetEvent, WidgetEventMap_Internal } from './widgetEvents';
 
 type EventMap = WidgetEventMap_Internal;
 type EventType = keyof WidgetEventMap_Internal;
-type EventHandler<T, K extends EventType = EventType> = (event: EventMap[K], target: T) => unknown;
+type EventHandler<T, K extends EventType = EventType> = (event: EventMap[K], current: T) => unknown;
 type Targetable = { getElement(): HTMLElement };
 
 type DragEvents = 'drag-start' | 'drag-move' | 'drag-end';
@@ -90,14 +90,14 @@ export class WidgetListenerInternal {
         );
     }
 
-    private startDrag<T extends Targetable>(target: T, downEvent: MouseEvent) {
+    private startDrag<T extends Targetable>(current: T, downEvent: MouseEvent) {
         const window = getWindow();
         const origin: DragOrigin = { pageX: NaN, pageY: NaN, offsetX: NaN, offsetY: NaN };
         partialAssign(['pageX', 'pageY', 'offsetX', 'offsetY'], origin, downEvent);
 
         const mousemove = (moveEvent: MouseEvent) => {
             const dragMoveEvent = makeDragEvent('drag-move', origin, moveEvent);
-            this.dispatch('drag-move', target, dragMoveEvent);
+            this.dispatch('drag-move', current, dragMoveEvent);
         };
 
         const mouseup = (upEvent: MouseEvent) => {
@@ -105,24 +105,24 @@ export class WidgetListenerInternal {
                 window.removeEventListener('mousemove', mousemove);
                 window.removeEventListener('mouseup', mouseup);
                 const dragEndEvent = makeDragEvent('drag-end', origin, upEvent);
-                this.dispatch('drag-end', target, dragEndEvent);
+                this.dispatch('drag-end', current, dragEndEvent);
             }
         };
 
         window.addEventListener('mousemove', mousemove);
         window.addEventListener('mouseup', mouseup);
         const dragStartEvent = makeDragEvent('drag-start', origin, downEvent);
-        this.dispatch('drag-start', target, dragStartEvent);
+        this.dispatch('drag-start', current, dragStartEvent);
     }
 
-    private dispatch<T extends Targetable, K extends EventType>(type: K, target: T, event: EventMap[K]): void {
+    private dispatch<T extends Targetable, K extends EventType>(type: K, current: T, event: EventMap[K]): void {
         switch (type) {
             case 'drag-start':
-                return this.dragStartListeners?.forEach((handler) => handler(event, target));
+                return this.dragStartListeners?.forEach((handler) => handler(event, current));
             case 'drag-move':
-                return this.dragMoveListeners?.forEach((handler) => handler(event, target));
+                return this.dragMoveListeners?.forEach((handler) => handler(event, current));
             case 'drag-end':
-                return this.dragEndListeners?.forEach((handler) => handler(event, target));
+                return this.dragEndListeners?.forEach((handler) => handler(event, current));
         }
     }
 }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsToolbar.ts
@@ -209,7 +209,7 @@ export class AnnotationsToolbar extends _ModuleSupport.BaseProperties {
         this.annotationMenu.hide();
     }
 
-    private onKeyDown(_: _ModuleSupport.Widget, { sourceEvent }: _ModuleSupport.KeyboardWidgetEvent) {
+    private onKeyDown({ sourceEvent }: _ModuleSupport.KeyboardWidgetEvent) {
         if (sourceEvent.key === 'Escape') {
             this.dispatch('cancel-create-annotation');
         }

--- a/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
@@ -67,10 +67,10 @@ export class NavigatorDOMProxy {
             slider.keyboardStep = SliderWidget.STEP_ONE;
             slider.orientation = 'horizontal';
             slider.setPreventsDefault(false);
-            slider.addListener('drag-start', (ev, target) => this.onDragStart(target, ev, key));
-            slider.addListener('drag-move', (ev, target) => this.onDrag(target, ev, key));
+            slider.addListener('drag-start', (ev) => this.onDragStart(slider, ev, key));
+            slider.addListener('drag-move', (ev) => this.onDrag(slider, ev, key));
             slider.addListener('drag-end', () => this.updateSliderRatios());
-            slider.addListener('contextmenu', (ev, target) => this.onContextMenu(target, ev));
+            slider.addListener('contextmenu', (ev) => this.onContextMenu(slider, ev));
         }
         this.sliders[0].addListener('change', () => this.onMinSliderChange());
         this.sliders[1].addListener('change', () => this.onPanSliderChange());

--- a/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
@@ -67,10 +67,10 @@ export class NavigatorDOMProxy {
             slider.keyboardStep = SliderWidget.STEP_ONE;
             slider.orientation = 'horizontal';
             slider.setPreventsDefault(false);
-            slider.addListener('drag-start', (target, ev) => this.onDragStart(target, ev, key));
-            slider.addListener('drag-move', (target, ev) => this.onDrag(target, ev, key));
+            slider.addListener('drag-start', (ev, target) => this.onDragStart(target, ev, key));
+            slider.addListener('drag-move', (ev, target) => this.onDrag(target, ev, key));
             slider.addListener('drag-end', () => this.updateSliderRatios());
-            slider.addListener('contextmenu', (target, ev) => this.onContextMenu(target, ev));
+            slider.addListener('contextmenu', (ev, target) => this.onContextMenu(target, ev));
         }
         this.sliders[0].addListener('change', () => this.onMinSliderChange());
         this.sliders[1].addListener('change', () => this.onPanSliderChange());

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomDOMProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomDOMProxy.ts
@@ -29,7 +29,7 @@ export class ZoomDOMProxy {
         const div = ctx.proxyInteractionService.createProxyElement({ type: 'region', domManagerId: axisId, where });
         div.setCursor(cursor);
         div.addListener('drag-start', () => handlers.onDragStart(axisId, direction));
-        div.addListener('drag-move', (_target, ev) => handlers.onDrag(ev));
+        div.addListener('drag-move', (ev) => handlers.onDrag(ev));
         div.addListener('drag-end', handlers.onDragEnd);
         div.addListener('dblclick', () => handlers.onDoubleClick(axisId, direction));
         return { axisId, div };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13343

Key changes:
* Remove `ProxyInteractiveService` event handling (use `Widget.addListener` directly).
* Swap `target` and `event` parameters around.
* Rename `target` parameter to `current`.

Depends on:
* https://github.com/ag-grid/ag-charts/pull/3049