### PR TITLE
AG-13553 Fix the focus indicator of box-plot series

### DIFF
--- a/packages/ag-charts-community/src/scene/bbox.ts
+++ b/packages/ag-charts-community/src/scene/bbox.ts
@@ -162,8 +162,8 @@ export class BBox implements BBoxValues, BBoxContainsTester, DistantObject, Inte
         const y2 = Math.min(absY + this.height, clipRect.y + clipRect.height);
         this.x = x1 - clipRect.x;
         this.y = y1 - clipRect.y;
-        this.width = Math.max(0, x2 - x1);
-        this.height = Math.max(0, y2 - y1);
+        this.width = x2 - x1;
+        this.height = y2 - y1;
         return this;
     }
 

--- a/packages/ag-charts-community/src/util/bboxinterface.ts
+++ b/packages/ag-charts-community/src/util/bboxinterface.ts
@@ -1,4 +1,4 @@
-export const BBoxValues = { containsPoint, isEmpty };
+export const BBoxValues = { containsPoint, isEmpty, normalize };
 
 export interface BBoxValues {
     x: number;
@@ -24,4 +24,18 @@ function containsPoint(bbox: BBoxValues, x: number, y: number): boolean {
 
 function isEmpty(bbox: BBoxValues | undefined): boolean {
     return bbox == null || bbox.height === 0 || bbox.width === 0 || isNaN(bbox.height) || isNaN(bbox.width);
+}
+
+function normalize(bbox: Partial<BBoxValues>): Partial<BBoxValues> {
+    let { x, y, width, height } = bbox;
+    if ((width == null || width > 0) && (height == null || height > 0)) return bbox;
+    if (x != null && width != null && width < 0) {
+        width = -width;
+        x = x - width;
+    }
+    if (y != null && height != null && height < 0) {
+        height = -height;
+        y = y - height;
+    }
+    return { x, y, width, height };
 }

--- a/packages/ag-charts-community/src/util/dom.ts
+++ b/packages/ag-charts-community/src/util/dom.ts
@@ -1,6 +1,6 @@
 import type { AgIconName } from 'ag-charts-types';
 
-import type { BBoxValues } from './bboxinterface';
+import { BBoxValues } from './bboxinterface';
 
 const verifiedGlobals = {} as { document: Document; window: Window };
 
@@ -87,6 +87,7 @@ export function setWindow(window: Window) {
 
 export function setElementBBox(element: HTMLElement | undefined, bbox: Partial<BBoxValues>) {
     if (!element) return;
+    bbox = BBoxValues.normalize(bbox);
 
     if (bbox.width == null) {
         element.style.removeProperty('width');


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13553

For reason, the box-plot datums BBoxes have negative heights. This is unusual, but there is nothing mathematically wrong about that (it just means that `y` is the bottom rather than the top). It is a problem when setting the CSS bounds however; we want a positive height for that. Therefore, normalize the input BBox before setting the CSS bounds.