### PR TITLE
AG-13397 Fix popover drag handles and disabled buttons

### DIFF
--- a/packages/ag-charts-community/src/components/popover/draggablePopover.ts
+++ b/packages/ag-charts-community/src/components/popover/draggablePopover.ts
@@ -1,4 +1,6 @@
 import { Vec2 } from '../../util/vector';
+import type { NativeWidget } from '../../widget/nativeWidget';
+import type { DragWidgetEvent } from '../../widget/widgetEvents';
 import { Popover, type PopoverOptions } from './popover';
 
 export abstract class DraggablePopover<Options extends PopoverOptions = PopoverOptions> extends Popover<Options> {
@@ -8,16 +10,24 @@ export abstract class DraggablePopover<Options extends PopoverOptions = PopoverO
 
     private dragStartState?: { client: Vec2; position: Vec2 };
 
-    protected onDragStart(event: MouseEvent, dragHandle?: HTMLElement) {
+    public setDragHandle(dragHandle: NativeWidget) {
+        dragHandle.addListener('drag-start', (event) => {
+            dragHandle.addClass(this.dragHandleDraggingClass);
+            this.onDragStart(event);
+        });
+        dragHandle.addListener('drag-move', this.onDragMove.bind(this));
+        dragHandle.addListener('drag-end', () => {
+            dragHandle.removeClass(this.dragHandleDraggingClass);
+            this.onDragEnd.bind(this);
+        });
+    }
+
+    protected onDragStart(event: DragWidgetEvent<'drag-start'>) {
         const popover = this.getPopoverElement();
         if (!popover) return;
 
-        const {
-            ctx: { domManager },
-        } = this;
-
         // Prevent text selection while dragging
-        event.preventDefault();
+        event.sourceEvent.preventDefault();
 
         this.dragged = true;
 
@@ -28,22 +38,9 @@ export abstract class DraggablePopover<Options extends PopoverOptions = PopoverO
                 Number(popover.style.getPropertyValue('top').replace('px', ''))
             ),
         };
-        dragHandle?.classList.add(this.dragHandleDraggingClass);
-
-        const onDrag = this.onDrag.bind(this);
-        const onDragEnd = () => {
-            domManager.removeEventListener('mousemove', onDrag);
-            dragHandle?.classList.remove(this.dragHandleDraggingClass);
-        };
-
-        domManager.addEventListener('mousemove', onDrag);
-        domManager.addEventListener('mouseup', onDragEnd, { once: true });
-
-        // Catch `mouseup` events that do not propagate beyond the overlay
-        popover.addEventListener('mouseup', () => onDragEnd, { once: true });
     }
 
-    private onDrag(event: MouseEvent) {
+    protected onDragMove(event: DragWidgetEvent<'drag-move'>) {
         const { dragStartState } = this;
         const popover = this.getPopoverElement();
 
@@ -65,5 +62,9 @@ export abstract class DraggablePopover<Options extends PopoverOptions = PopoverO
         }
 
         this.updatePosition(partialPosition);
+    }
+
+    protected onDragEnd() {
+        this.dragStartState = undefined;
     }
 }

--- a/packages/ag-charts-community/src/components/toolbar/floatingToolbar.ts
+++ b/packages/ag-charts-community/src/components/toolbar/floatingToolbar.ts
@@ -112,15 +112,17 @@ export abstract class FloatingToolbar<
 
     private readonly popover: FloatingToolbarPopover;
     private popoverBounds?: BBox;
+    private readonly dragHandle: DragHandleWidget;
 
     constructor(ctx: ModuleContext, id: string) {
         super(ctx.localeManager);
         this.popover = new FloatingToolbarPopover(ctx, id, this.onPopoverMoved.bind(this));
-        this.createDragHandle();
+        this.dragHandle = new DragHandleWidget(ctx.localeManager.t('toolbarAnnotationsDragHandle'));
+        this.popover.setDragHandle(this.dragHandle);
     }
 
     public show(options: PopoverOptions) {
-        this.popover.show([this.getElement()], options);
+        this.popover.show([this.dragHandle.getElement(), this.getElement()], options);
     }
 
     public hide() {
@@ -150,25 +152,27 @@ export abstract class FloatingToolbar<
         if (this.popoverBounds?.equals(popoverBounds)) return;
 
         this.popoverBounds = popoverBounds.clone();
-        const buttonBounds = this.getButtonBounds().map(
-            (bounds) => new BBox(bounds.x + popoverBounds.x, bounds.y + popoverBounds.y, bounds.width, bounds.height)
-        );
+        const buttonBounds = this.getButtonBounds();
 
         this.events.dispatch('toolbar-moved', { popoverBounds, buttonBounds });
     }
 
-    private createDragHandle() {
-        const { localeManager, popover } = this;
-
-        const dragHandle = new DragHandleWidget(localeManager.t('toolbarAnnotationsDragHandle'));
-        popover.setDragHandle(dragHandle);
-        this.addChild(dragHandle);
+    protected override getButtonWidgetBounds(buttonWidget: ButtonWidget) {
+        const popoverBounds = this.popover.getBounds();
+        const bounds = super.getButtonWidgetBounds(buttonWidget);
+        const dragHandleBounds = this.dragHandle.getBounds();
+        return new BBox(
+            bounds.x + popoverBounds.x - dragHandleBounds.width,
+            bounds.y + popoverBounds.y,
+            bounds.width,
+            bounds.height
+        );
     }
 }
 
 class DragHandleWidget extends NativeWidget {
     constructor(title: string) {
-        super(createElement('button', 'ag-charts-floating-toolbar__drag-handle'));
+        super(createElement('div', 'ag-charts-floating-toolbar__drag-handle'));
 
         const icon = new NativeWidget<HTMLElement>(
             createElement('span', `${getIconClassNames('drag-handle')} ag-charts-toolbar__icon`)

--- a/packages/ag-charts-community/src/components/toolbar/floatingToolbar.ts
+++ b/packages/ag-charts-community/src/components/toolbar/floatingToolbar.ts
@@ -82,10 +82,6 @@ class FloatingToolbarPopover extends DraggablePopover<PopoverOptions> {
         this.updatePosition({ x: left, y: top });
     }
 
-    public startDragging(event: MouseEvent, dragHandle?: HTMLElement) {
-        this.onDragStart(event, dragHandle);
-    }
-
     public ignorePointerEvents() {
         const element = this.getPopoverElement();
         if (element) element.style.pointerEvents = 'none';
@@ -164,15 +160,22 @@ export abstract class FloatingToolbar<
     private createDragHandle() {
         const { localeManager, popover } = this;
 
-        const dragHandle = new NativeWidget<HTMLElement>(
-            createElement('div', 'ag-charts-floating-toolbar__drag-handle')
-        );
-        dragHandle.getElement().innerHTML = `<span class="${getIconClassNames('drag-handle')} ag-charts-toolbar__icon"></span>`;
-        dragHandle.getElement().addEventListener('mousedown', (event) => {
-            popover.startDragging(event, dragHandle.getElement());
-        });
-        dragHandle.getElement().title = localeManager.t('toolbarAnnotationsDragHandle');
-
+        const dragHandle = new DragHandleWidget(localeManager.t('toolbarAnnotationsDragHandle'));
+        popover.setDragHandle(dragHandle);
         this.addChild(dragHandle);
+    }
+}
+
+class DragHandleWidget extends NativeWidget {
+    constructor(title: string) {
+        super(createElement('button', 'ag-charts-floating-toolbar__drag-handle'));
+
+        const icon = new NativeWidget<HTMLElement>(
+            createElement('span', `${getIconClassNames('drag-handle')} ag-charts-toolbar__icon`)
+        );
+        icon.setAriaHidden(true);
+        this.addChild(icon);
+
+        this.elem.title = title;
     }
 }

--- a/packages/ag-charts-community/src/components/toolbar/toolbar.css
+++ b/packages/ag-charts-community/src/components/toolbar/toolbar.css
@@ -128,3 +128,7 @@
     padding-left: 0;
     padding-right: 0;
 }
+
+.ag-charts-floating-toolbar__drag-handle--dragging {
+    cursor: grabbing;
+}

--- a/packages/ag-charts-community/src/components/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/components/toolbar/toolbar.ts
@@ -111,7 +111,7 @@ export abstract class BaseToolbar<
         this.buttonWidgets.at(index)?.setHidden(hidden);
     }
 
-    private getButtonWidgetBounds(buttonWidget: ButtonWidget) {
+    protected getButtonWidgetBounds(buttonWidget: ButtonWidget) {
         const parent = this.getBounds();
         const bounds = buttonWidget.getBounds();
         return new BBox(bounds.x + parent.x, bounds.y + parent.y, bounds.width, bounds.height);

--- a/packages/ag-charts-community/src/widget/buttonWidget.ts
+++ b/packages/ag-charts-community/src/widget/buttonWidget.ts
@@ -1,6 +1,7 @@
 import { setAttribute, setElementStyle } from '../util/attributeUtil';
 import { getDocument } from '../util/dom';
 import { Widget } from './widget';
+import type { WidgetEventMap } from './widgetEvents';
 
 export class ButtonWidget extends Widget<HTMLButtonElement> {
     constructor() {
@@ -15,5 +16,19 @@ export class ButtonWidget extends Widget<HTMLButtonElement> {
     setEnabled(enabled: boolean) {
         setAttribute(this.elem, 'aria-disabled', !enabled);
         setElementStyle(this.elem, 'pointer-events', enabled ? undefined : 'none');
+    }
+
+    override addListener<K extends keyof WidgetEventMap>(
+        type: K,
+        listener: (ev: WidgetEventMap[K], current: this) => unknown
+    ): void;
+    override addListener<K extends keyof WidgetEventMap>(
+        type: K,
+        listener: (ev: unknown, current: this) => unknown
+    ): void {
+        return super.addListener(type, (ev, current: this) => {
+            if ((type === 'click' || type === 'dblclick') && this.isDisabled()) return;
+            listener(ev, current);
+        });
     }
 }

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -1,6 +1,7 @@
 import {
     type BaseAttributeTypeMap,
     type BaseStyleTypeMap,
+    getAttribute,
     setAttribute,
     setElementStyle,
     setElementStyles,
@@ -106,6 +107,10 @@ export abstract class Widget<
 
     setAriaHidden(ariaHidden: BaseAttributeTypeMap['aria-hidden'] | undefined) {
         setAttribute(this.elem, 'aria-hidden', ariaHidden);
+    }
+
+    isDisabled() {
+        return getAttribute(this.elem, 'aria-disabled', false);
     }
 
     private parseFloat(s: string) {

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -104,6 +104,10 @@ export abstract class Widget<
         setAttribute(this.elem, 'aria-describedby', ariaDescribedBy);
     }
 
+    setAriaHidden(ariaHidden: BaseAttributeTypeMap['aria-hidden'] | undefined) {
+        setAttribute(this.elem, 'aria-hidden', ariaHidden);
+    }
+
     private parseFloat(s: string) {
         return s === '' ? 0 : parseFloat(s);
     }
@@ -135,6 +139,10 @@ export abstract class Widget<
 
     addClass(...tokens: string[]) {
         this.elem.classList.add(...tokens);
+    }
+
+    removeClass(...tokens: string[]) {
+        this.elem.classList.remove(...tokens);
     }
 
     toggleClass(token: string, force?: boolean) {

--- a/packages/ag-charts-enterprise/src/components/dialog/dialog.ts
+++ b/packages/ag-charts-enterprise/src/components/dialog/dialog.ts
@@ -6,15 +6,16 @@ import { ColorPicker } from '../color-picker/colorPicker';
 const {
     Color,
     DraggablePopover,
+    NativeWidget,
     Vec2,
     createButton,
     createCheckbox,
     createElement,
     createElementId,
-    createIcon,
     createSelect,
     createTextArea,
     initRovingTabIndex,
+    getIconClassNames,
     getWindow,
     mapValues,
     setAttribute,
@@ -133,15 +134,22 @@ export abstract class Dialog<Options extends DialogOptions = DialogOptions> exte
             }
         };
 
-        const header = createElement('div', 'ag-charts-dialog__header');
-        header.addEventListener('mousedown', (event) => {
+        const header = new NativeWidget(createElement('div', 'ag-charts-dialog__header'));
+        header.addListener('drag-start', (event) => {
+            const { sourceEvent } = event;
             // Only start dragging when an empty part of the header is dragged
-            if (event.target instanceof Element && event.target.classList.contains('ag-charts-dialog__header')) {
+            if (
+                sourceEvent.target instanceof Element &&
+                sourceEvent.target.classList.contains('ag-charts-dialog__header')
+            ) {
                 this.onDragStart(event);
             }
         });
+        header.addListener('drag-move', (event) => this.onDragMove(event));
+        header.addListener('drag-end', () => this.onDragEnd());
 
-        const dragHandle = this.createHeaderDragHandle();
+        const dragHandle = new DragHandleWidget();
+        this.setDragHandle(dragHandle);
         const tabButtons = mapValues(tabs, (tab, key) =>
             createButton(
                 {
@@ -163,8 +171,8 @@ export abstract class Dialog<Options extends DialogOptions = DialogOptions> exte
 
         const closeButton = this.createHeaderCloseButton();
 
-        header.append(dragHandle, tabList, closeButton);
-        element.append(header, ...Object.values(tabs).map((t) => t.panel));
+        header.getElement().append(dragHandle.getElement(), tabList, closeButton);
+        element.append(header.getElement(), ...Object.values(tabs).map((t) => t.panel));
 
         onPressTab(initial);
         initRovingTabIndex({ orientation: 'horizontal', buttons: Object.values(tabButtons) });
@@ -337,14 +345,6 @@ export abstract class Dialog<Options extends DialogOptions = DialogOptions> exte
     /***********
      * Private *
      ***********/
-    private createHeaderDragHandle() {
-        const dragHandle = createElement('div', 'ag-charts-dialog__drag-handle');
-        const dragHandleIcon = createIcon('drag-handle');
-        dragHandle.append(dragHandleIcon);
-        dragHandle.addEventListener('mousedown', (event) => this.onDragStart(event, dragHandle));
-
-        return dragHandle;
-    }
 
     private createHeaderCloseButton() {
         return createButton(
@@ -416,5 +416,14 @@ export abstract class Dialog<Options extends DialogOptions = DialogOptions> exte
         const fallbackAnchor = Vec2.sub(topLeft, Vec2.from(0, 5));
 
         return { anchor, fallbackAnchor };
+    }
+}
+
+class DragHandleWidget extends NativeWidget {
+    constructor() {
+        super(createElement('div', 'ag-charts-dialog__drag-handle'));
+        const icon = new NativeWidget<HTMLElement>(createElement('span', getIconClassNames('drag-handle')));
+        icon.setAriaHidden(true);
+        this.addChild(icon);
     }
 }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationOptionsToolbar.css
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationOptionsToolbar.css
@@ -1,3 +1,11 @@
+.ag-charts-annotations__line-stroke-width-menu,
+.ag-charts-annotations__line-style-type-menu,
+.ag-charts-annotations__text-size-menu {
+    .ag-charts-menu__row:first-child {
+        border-radius: 0;
+    }
+}
+
 .ag-charts-annotations__stroke-width-button::before {
     --stroke-width-color: var(--ag-charts-toolbar-foreground-color);
     background: var(--stroke-width-color);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13397

Changes drag handles to be widgets, the existing `'mousemove'` events were being consumed somewhere else while the mouse was down.

Dialog and popover components will be properly converted to use widgets at a later date.