### PR TITLE
Remove unused exports

### DIFF
--- a/packages/ag-charts-community/benchmarks/benchmark.ts
+++ b/packages/ag-charts-community/benchmarks/benchmark.ts
@@ -18,7 +18,7 @@ if (isHistoricBenchmarkTest()) {
     console.warn('Attempting to run against version: ', getVersion().join('.'));
 }
 
-export interface BenchmarkExpectations {
+interface BenchmarkExpectations {
     expectedMaxMemoryMB: number;
     autoSnapshot?: boolean;
 }

--- a/packages/ag-charts-community/src/api/preset/chartTypeOriginator.ts
+++ b/packages/ag-charts-community/src/api/preset/chartTypeOriginator.ts
@@ -6,7 +6,7 @@ import { Logger } from '../../util/logger';
 import { isString } from '../../util/type-guards';
 import type { MementoOriginator } from '../state/memento';
 
-export type ChartTypeMemento = AgInitialStateChartType;
+type ChartTypeMemento = AgInitialStateChartType;
 
 const chartTypes: Array<AgInitialStateChartType> = [
     'candlestick',

--- a/packages/ag-charts-community/src/chart/annotation/annotationManager.ts
+++ b/packages/ag-charts-community/src/chart/annotation/annotationManager.ts
@@ -12,7 +12,7 @@ interface AnnotationsRestoreEvent {
     annotations: AnnotationsMemento;
 }
 
-export type AnnotationsMemento = AgAnnotation[];
+type AnnotationsMemento = AgAnnotation[];
 
 export class AnnotationManager
     extends BaseManager<AnnotationsRestoreEvent['type'], AnnotationsRestoreEvent>

--- a/packages/ag-charts-community/src/chart/axis/tree.ts
+++ b/packages/ag-charts-community/src/chart/axis/tree.ts
@@ -99,7 +99,7 @@ class TreeNode {
  * Converts an array of ticks, where each tick has an array of labels, to a label tree.
  * Ensures that every branch matches the depth of the tree by creating empty labels.
  */
-export function ticksToTree(ticks: string[][]): TreeNode {
+function ticksToTree(ticks: string[][]): TreeNode {
     const maxDepth = ticks.reduce((depth, tick) => (depth < tick.length ? tick.length : depth), 0);
     const root = new TreeNode();
     for (let i = 0; i < ticks.length; i++) {

--- a/packages/ag-charts-community/src/chart/data/caching.ts
+++ b/packages/ag-charts-community/src/chart/data/caching.ts
@@ -2,7 +2,7 @@ import { arraysEqual } from '../../util/array';
 import { objectsEqual } from '../../util/object';
 import type { DataModel, DataModelOptions, PropertyDefinition, UngroupedData } from './dataModel';
 
-export interface CachedDataItem<D extends object, K extends keyof D & string = keyof D & string> {
+interface CachedDataItem<D extends object, K extends keyof D & string = keyof D & string> {
     ids: string[];
     opts: DataModelOptions<K, any>;
     data: D[];

--- a/packages/ag-charts-community/src/chart/legend/legendManager.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendManager.ts
@@ -13,7 +13,7 @@ export interface LegendChangeEvent {
 }
 
 type LegendDataMap = Map<string, CategoryLegendDatum[]>;
-export type LegendDataMemento = AgInitialStateLegendOptions[];
+type LegendDataMemento = AgInitialStateLegendOptions[];
 
 export class LegendManager
     extends BaseManager<LegendChangeEvent['type'], LegendChangeEvent>

--- a/packages/ag-charts-community/src/chart/mapping/types.ts
+++ b/packages/ag-charts-community/src/chart/mapping/types.ts
@@ -28,7 +28,7 @@ import {
     isEnterpriseTopology,
 } from '../factory/expectedEnterpriseModules';
 
-export type AxesOptionsTypes = NonNullable<AgCartesianChartOptions['axes']>[number];
+type AxesOptionsTypes = NonNullable<AgCartesianChartOptions['axes']>[number];
 
 export type SeriesOptionsTypes =
     | AgCartesianSeriesOptions

--- a/packages/ag-charts-community/src/chart/series/seriesLayerManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesLayerManager.ts
@@ -4,7 +4,7 @@ import { clamp } from '../../util/number';
 import type { SeriesGrouping } from './seriesStateManager';
 import { SeriesZIndexMap } from './seriesZIndexMap';
 
-export interface SeriesConfig {
+interface SeriesConfig {
     internalId: string;
     seriesGrouping?: SeriesGrouping;
     contentGroup: Group;

--- a/packages/ag-charts-community/src/chart/series/seriesStateManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesStateManager.ts
@@ -5,7 +5,7 @@ export type SeriesGrouping = {
     stackCount: number;
 };
 
-export type SeriesGroupingResult = {
+type SeriesGroupingResult = {
     visibleGroupCount: number;
     visibleSameStackCount: number;
     index: number;

--- a/packages/ag-charts-community/src/chart/tooltip/springAnimation.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/springAnimation.ts
@@ -1,6 +1,6 @@
 import { Listeners } from '../../util/listeners';
 
-export interface SpringAnimationUpdateEvent {
+interface SpringAnimationUpdateEvent {
     type: 'update';
     x: number;
     y: number;

--- a/packages/ag-charts-community/src/chart/update/processor.ts
+++ b/packages/ag-charts-community/src/chart/update/processor.ts
@@ -17,7 +17,7 @@ export interface AxisLike {
     scale: Scale<any, any>;
 }
 
-export interface SeriesLike {
+interface SeriesLike {
     hasData: boolean;
     visible: boolean;
 }

--- a/packages/ag-charts-community/src/scene/canvas/hdpiOffscreenCanvas.ts
+++ b/packages/ag-charts-community/src/scene/canvas/hdpiOffscreenCanvas.ts
@@ -4,7 +4,7 @@ import { clearContext, debugContext } from './canvasUtil';
 // Work-around for typing issues with Angular 13+ (see AG-6969),
 type OffscreenCanvasRenderingContext2D = any;
 
-export interface CanvasOptions {
+interface CanvasOptions {
     width?: number;
     height?: number;
     pixelRatio?: number;

--- a/packages/ag-charts-community/src/scene/util/labelPlacement.ts
+++ b/packages/ag-charts-community/src/scene/util/labelPlacement.ts
@@ -33,7 +33,7 @@ export interface PlacedLabel<PLD = PointLabelDatum> extends MeasuredLabel, Reado
     readonly datum: PLD;
 }
 
-export interface LabelBounds extends Readonly<Point> {
+interface LabelBounds extends Readonly<Point> {
     readonly width: number;
     readonly height: number;
 }

--- a/packages/ag-charts-community/src/util/validate.ts
+++ b/packages/ag-charts-community/src/util/validate.ts
@@ -14,13 +14,13 @@ export type OptionsDefs<T> = { [K in keyof T]-?: Validator | ObjectLikeDef<T[K]>
 };
 
 // Validator interface with optional description and required flag for better error messages.
-export interface Validator extends Function {
+interface Validator extends Function {
     (value: unknown): boolean;
     [descriptionSymbol]?: string;
     [requiredSymbol]?: boolean;
 }
 
-export interface ValidationError {
+interface ValidationError {
     key?: string;
     path: string;
     message: string;

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationTypes.ts
@@ -73,37 +73,6 @@ export type HasFontSizeAnnotationType = Exclude<
 >;
 
 const ANNOTATION_TYPES = Object.values(AnnotationType);
-export const ANNOTATION_BUTTONS = [
-    // Lines
-    AnnotationType.Line,
-    AnnotationType.HorizontalLine,
-    AnnotationType.VerticalLine,
-
-    // Channels
-    AnnotationType.DisjointChannel,
-    AnnotationType.ParallelChannel,
-
-    // Fibonaccis
-    AnnotationType.FibonacciRetracement,
-
-    // Texts
-    AnnotationType.Callout,
-    AnnotationType.Comment,
-    AnnotationType.Note,
-    AnnotationType.Text,
-
-    // Shapes
-    AnnotationType.Arrow,
-    AnnotationType.ArrowUp,
-    AnnotationType.ArrowDown,
-] as const;
-export const ANNOTATION_BUTTON_GROUPS = [
-    'line-menu',
-    'fibonacci-menu',
-    'text-menu',
-    'shape-menu',
-    'measurer-menu',
-] as const;
 
 export function stringToAnnotationType(value: unknown) {
     for (const t of ANNOTATION_TYPES) {

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/collidableLineScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/collidableLineScene.ts
@@ -2,7 +2,7 @@ import { _ModuleSupport } from 'ag-charts-community';
 
 const { Vec2 } = _ModuleSupport;
 
-export type ShapeClipMask = { x: number; y: number; radius: number };
+type ShapeClipMask = { x: number; y: number; radius: number };
 
 export class CollidableLine extends _ModuleSupport.Line {
     public collisionBBox?: _ModuleSupport.BBox;

--- a/packages/ag-charts-enterprise/src/features/annotations/text/util.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/text/util.ts
@@ -5,7 +5,7 @@ const { TextWrapper, CachedTextMeasurerPool, BBox } = _ModuleSupport;
 export type AnnotationTextPosition = 'top' | 'center' | 'bottom';
 export type AnnotationTextAlignment = 'left' | 'center' | 'right';
 
-export type TextOptions = _ModuleSupport.FontOptions & { textAlign: TextAlign; position: AnnotationTextPosition };
+type TextOptions = _ModuleSupport.FontOptions & { textAlign: TextAlign; position: AnnotationTextPosition };
 
 export const ANNOTATION_TEXT_LINE_HEIGHT = 1.38;
 

--- a/packages/ag-charts-enterprise/src/features/annotations/utils/fibonacci.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/utils/fibonacci.ts
@@ -2,9 +2,9 @@ import type { _ModuleSupport } from 'ag-charts-community';
 
 import type { AnnotationContext, FibonacciBands } from '../annotationTypes';
 
-export const FIBONACCI_RETRACEMENT_RATIOS = [0, 23.6, 38.2, 50, 61.8, 78.6, 100];
-export const FIBONACCI_EXTENSION_RATIOS = [161.8, 261.8, 361.8, 423.6];
-export const FIBONACCI_RATIOS = [...FIBONACCI_RETRACEMENT_RATIOS, ...FIBONACCI_EXTENSION_RATIOS];
+const FIBONACCI_RETRACEMENT_RATIOS = [0, 23.6, 38.2, 50, 61.8, 78.6, 100];
+const FIBONACCI_EXTENSION_RATIOS = [161.8, 261.8, 361.8, 423.6];
+const FIBONACCI_RATIOS = [...FIBONACCI_RETRACEMENT_RATIOS, ...FIBONACCI_EXTENSION_RATIOS];
 
 const FIBONACCI_RATIOS_MAP: Record<FibonacciBands, number[]> = {
     10: FIBONACCI_RATIOS,
@@ -12,7 +12,7 @@ const FIBONACCI_RATIOS_MAP: Record<FibonacciBands, number[]> = {
     4: FIBONACCI_RETRACEMENT_RATIOS.filter((r) => r !== 78.6 && r !== 23.6),
 };
 
-export const FIBONACCI_RANGE_LABEL_PADDING = 10;
+const FIBONACCI_RANGE_LABEL_PADDING = 10;
 
 export enum FibonacciNodeTag {
     OneLine,

--- a/packages/ag-charts-enterprise/src/features/annotations/utils/lineWithText.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/utils/lineWithText.ts
@@ -94,7 +94,7 @@ export function updateChannelText(
     setProperties(textNode, text, textProperties, point, numbers.angle, textBaseline);
 }
 
-export function getNumbers(coords: _ModuleSupport.Vec4, fontSize?: number, strokeWidth?: number): Numbers {
+function getNumbers(coords: _ModuleSupport.Vec4, fontSize?: number, strokeWidth?: number): Numbers {
     let [left, right] = Vec2.from(coords);
     if (left.x > right.x) [left, right] = [right, left];
 
@@ -110,7 +110,7 @@ export function getNumbers(coords: _ModuleSupport.Vec4, fontSize?: number, strok
     return { left, right, normal, angle, inset, offset };
 }
 
-export function positionAndAlignment(
+function positionAndAlignment(
     { left, right, normal, angle, inset, offset }: Numbers,
     position?: 'top' | 'center' | 'bottom',
     alignment?: 'left' | 'center' | 'right',
@@ -138,7 +138,7 @@ export function positionAndAlignment(
     return { point, textBaseline };
 }
 
-export function setProperties(
+function setProperties(
     scene: _ModuleSupport.TransformableText,
     text: string,
     textProperties: Partial<LineTextProperties> | Partial<ChannelTextProperties>,

--- a/packages/ag-charts-enterprise/src/features/data-source/dataSource.ts
+++ b/packages/ag-charts-enterprise/src/features/data-source/dataSource.ts
@@ -2,7 +2,7 @@ import { _ModuleSupport } from 'ag-charts-community';
 
 const { BOOLEAN, FUNCTION, ActionOnSet, Validate } = _ModuleSupport;
 
-export interface DataSourceGetDataCallbackParams {
+interface DataSourceGetDataCallbackParams {
     windowStart?: Date;
     windowEnd?: Date;
 }

--- a/packages/ag-charts-enterprise/src/features/ranges/rangesButtonProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/rangesButtonProperties.ts
@@ -2,7 +2,7 @@ import { _ModuleSupport } from 'ag-charts-community';
 
 const { AND, ARRAY, FUNCTION, NUMBER, OR, ToolbarButtonProperties, Validate } = _ModuleSupport;
 
-export type RangesButtonValue =
+type RangesButtonValue =
     | number
     | [Date | number, Date | number]
     | ((start: Date | number, end: Date | number) => [Date | number, Date | number]);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -22,11 +22,7 @@ export function dy(zoom: DefinedZoomState) {
     return zoom.y.max - zoom.y.min;
 }
 
-export function isZoomRangeEqual(
-    left: _ModuleSupport.ZoomState,
-    right: _ModuleSupport.ZoomState,
-    epsilon: number = 1e-10
-) {
+function isZoomRangeEqual(left: _ModuleSupport.ZoomState, right: _ModuleSupport.ZoomState, epsilon: number = 1e-10) {
     return isNumberEqual(left.min, right.min, epsilon) && isNumberEqual(left.max, right.max, epsilon);
 }
 

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeries.ts
@@ -57,7 +57,7 @@ type NodeStyle = Pick<FillOptions & StrokeOptions & LineDashOptions, 'fill' | 's
 
 type LinkStyle = NodeStyle & { tension: number };
 
-export interface ChordNodeDataContext extends _ModuleSupport.SeriesNodeDataContext<ChordDatum, ChordNodeLabelDatum> {}
+interface ChordNodeDataContext extends _ModuleSupport.SeriesNodeDataContext<ChordDatum, ChordNodeLabelDatum> {}
 
 const nodeMidAngle = (node: ChordNodeDatum) => node.startAngle + angleBetween(node.startAngle, node.endAngle) / 2;
 export class ChordSeries extends FlowProportionSeries<

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -37,10 +37,9 @@ export interface FlowProportionNodeDatum extends _ModuleSupport.DataModelSeriesN
     label: string | undefined;
 }
 
-export type TDatum<
-    TNodeDatum extends FlowProportionNodeDatum,
-    TLinkDatum extends FlowProportionLinkDatum<TNodeDatum>,
-> = TLinkDatum | TNodeDatum;
+type TDatum<TNodeDatum extends FlowProportionNodeDatum, TLinkDatum extends FlowProportionLinkDatum<TNodeDatum>> =
+    | TLinkDatum
+    | TNodeDatum;
 
 export abstract class FlowProportionSeries<
         TNodeDatum extends FlowProportionNodeDatum,

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionUtil.ts
@@ -2,11 +2,11 @@ import { _ModuleSupport } from 'ag-charts-community';
 
 const { Logger } = _ModuleSupport;
 
-export interface Node {
+interface Node {
     id: string;
 }
 
-export interface Link<N extends Node> {
+interface Link<N extends Node> {
     fromNode: N;
     toNode: N;
 }

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -57,7 +57,7 @@ export interface FunnelNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum
     readonly visible: boolean;
 }
 
-export interface FunnelConnectorDatum {
+interface FunnelConnectorDatum {
     readonly datum: FunnelNodeDatum;
     readonly datumIndex: number;
     readonly x0: number;
@@ -71,8 +71,7 @@ export interface FunnelConnectorDatum {
     readonly opacity: number;
 }
 
-export interface FunnelContext
-    extends _ModuleSupport.CartesianSeriesNodeDataContext<FunnelNodeDatum, FunnelNodeLabelDatum> {
+interface FunnelContext extends _ModuleSupport.CartesianSeriesNodeDataContext<FunnelNodeDatum, FunnelNodeLabelDatum> {
     connectorData: FunnelConnectorDatum[];
 }
 

--- a/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
@@ -1,6 +1,6 @@
 import type { AgChartLabelFormatterParams, Formatter, _ModuleSupport } from 'ag-charts-community';
 
-export interface GaugeLabelDatum {
+interface GaugeLabelDatum {
     value: number;
     text?: string;
     formatter?: Formatter<AgChartLabelFormatterParams<any>>;

--- a/packages/ag-charts-enterprise/src/series/gauge-util/stops.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/stops.ts
@@ -10,7 +10,7 @@ export class GaugeStopProperties extends BaseProperties {
     color?: string = 'black';
 }
 
-export interface GaugeColorStopDatum {
+interface GaugeColorStopDatum {
     offset: number;
     color: string;
 }

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -75,8 +75,8 @@ interface Target {
     label: TargetLabel;
 }
 
-export type GaugeAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
-export type GaugeAnimationEvent = {
+type GaugeAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
+type GaugeAnimationEvent = {
     update: undefined;
     updateData: undefined;
     highlight: undefined;

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeUtil.ts
@@ -21,7 +21,7 @@ interface TextProperties {
     lineHeight?: number;
 }
 
-export interface AnimatableRectDatum {
+interface AnimatableRectDatum {
     x0: number;
     y0: number;
     x1: number;

--- a/packages/ag-charts-enterprise/src/series/map-line-background/mapLineBackgroundSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line-background/mapLineBackgroundSeries.ts
@@ -12,7 +12,7 @@ import {
 
 const { createDatumId, SeriesNodePickMode, Validate, Logger, Group, Selection, PointerEvents } = _ModuleSupport;
 
-export interface MapLineNodeDataContext extends _ModuleSupport.SeriesNodeDataContext<MapLineBackgroundNodeDatum> {}
+interface MapLineNodeDataContext extends _ModuleSupport.SeriesNodeDataContext<MapLineBackgroundNodeDatum> {}
 
 export class MapLineBackgroundSeries
     extends TopologySeries<

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -23,7 +23,7 @@ const {
     Text,
 } = _ModuleSupport;
 
-export interface MapLineNodeDataContext
+interface MapLineNodeDataContext
     extends _ModuleSupport.SeriesNodeDataContext<MapLineNodeDatum, MapLineNodeLabelDatum> {}
 
 type ItemStyle = Required<AgMapLineSeriesStyle>;

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -32,7 +32,7 @@ const {
     getMarker,
 } = _ModuleSupport;
 
-export interface MapMarkerNodeDataContext
+interface MapMarkerNodeDataContext
     extends _ModuleSupport.SeriesNodeDataContext<MapMarkerNodeDatum, MapMarkerNodeLabelDatum> {}
 
 type MapMarkerAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';

--- a/packages/ag-charts-enterprise/src/series/map-shape-background/mapShapeBackgroundSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape-background/mapShapeBackgroundSeries.ts
@@ -12,8 +12,7 @@ import {
 
 const { createDatumId, SeriesNodePickMode, Validate, Logger, Selection, Group, PointerEvents } = _ModuleSupport;
 
-export interface MapShapeBackgroundNodeDataContext
-    extends _ModuleSupport.SeriesNodeDataContext<MapShapeBackgroundNodeDatum> {}
+interface MapShapeBackgroundNodeDataContext extends _ModuleSupport.SeriesNodeDataContext<MapShapeBackgroundNodeDatum> {}
 
 export class MapShapeBackgroundSeries
     extends TopologySeries<

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -32,7 +32,7 @@ const {
     PointerEvents,
 } = _ModuleSupport;
 
-export interface MapShapeNodeDataContext
+interface MapShapeNodeDataContext
     extends _ModuleSupport.SeriesNodeDataContext<MapShapeNodeDatum, MapShapeNodeLabelDatum> {}
 
 type ItemStyle = Required<AgMapShapeSeriesStyle>;

--- a/packages/ag-charts-enterprise/src/series/map-util/topologySeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-util/topologySeries.ts
@@ -1,13 +1,13 @@
 import { _ModuleSupport } from 'ag-charts-community';
 
-export interface TopologySeriesNodeDatum extends _ModuleSupport.SeriesNodeDatum {}
+interface TopologySeriesNodeDatum extends _ModuleSupport.SeriesNodeDatum {}
 
-export interface TopologySeriesNodeDataContext<
+interface TopologySeriesNodeDataContext<
     TDatum extends TopologySeriesNodeDatum = TopologySeriesNodeDatum,
     TLabel extends object = object,
 > extends _ModuleSupport.SeriesNodeDataContext<TDatum, TLabel> {}
 
-export abstract class TopologySeriesProperties<T extends object> extends _ModuleSupport.SeriesProperties<T> {}
+abstract class TopologySeriesProperties<T extends object> extends _ModuleSupport.SeriesProperties<T> {}
 
 export abstract class TopologySeries<
     TDatum extends TopologySeriesNodeDatum,

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -22,14 +22,14 @@ const {
 
 type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
-export type PyramidNodeLabelDatum = Readonly<_ModuleSupport.Point> & {
+type PyramidNodeLabelDatum = Readonly<_ModuleSupport.Point> & {
     readonly text: string;
     readonly textAlign: CanvasTextAlign;
     readonly textBaseline: CanvasTextBaseline;
     readonly visible: boolean;
 };
 
-export interface PyramidNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatum, Readonly<_ModuleSupport.Point> {
+interface PyramidNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatum, Readonly<_ModuleSupport.Point> {
     readonly index: number;
     readonly xValue: string;
     readonly yValue: number;
@@ -40,8 +40,7 @@ export interface PyramidNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatu
     readonly label: PyramidNodeLabelDatum | undefined;
 }
 
-export interface PyramidNodeDataContext
-    extends _ModuleSupport.SeriesNodeDataContext<PyramidNodeDatum, PyramidNodeLabelDatum> {
+interface PyramidNodeDataContext extends _ModuleSupport.SeriesNodeDataContext<PyramidNodeDatum, PyramidNodeLabelDatum> {
     stageLabelData: PyramidNodeLabelDatum[] | undefined;
 }
 

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -47,7 +47,7 @@ interface RadialBarLabelNodeDatum {
     textBaseline: CanvasTextBaseline;
 }
 
-export interface RadialBarNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatum {
+interface RadialBarNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatum {
     readonly label?: RadialBarLabelNodeDatum;
     readonly angleValue: any;
     readonly radiusValue: any;

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnUtil.ts
@@ -2,7 +2,7 @@ import { _ModuleSupport } from 'ag-charts-community';
 
 const { motion } = _ModuleSupport;
 
-export type AnimatableRadialColumnDatum = {
+type AnimatableRadialColumnDatum = {
     innerRadius: number;
     outerRadius: number;
     columnWidth: number;

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -79,8 +79,8 @@ interface Target {
     label: TargetLabel;
 }
 
-export type GaugeAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
-export type GaugeAnimationEvent = {
+type GaugeAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing';
+type GaugeAnimationEvent = {
     update: undefined;
     updateData: undefined;
     highlight: undefined;

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeUtil.ts
@@ -7,7 +7,7 @@ import { LabelType, type RadialGaugeLabelDatum } from './radialGaugeSeriesProper
 
 const { SectorBox } = _ModuleSupport;
 
-export interface AnimatableSectorDatum {
+interface AnimatableSectorDatum {
     innerRadius: number;
     outerRadius: number;
     startAngle: number;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeAreaUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeAreaUtil.ts
@@ -20,13 +20,13 @@ export interface RangeAreaLabelDatum extends Readonly<_ModuleSupport.Point> {
     series: _ModuleSupport.CartesianSeriesNodeDatum['series'];
 }
 
-export interface RangeAreaFillPathDatum {
+interface RangeAreaFillPathDatum {
     readonly spans: _ModuleSupport.LinePathSpan[];
     readonly phantomSpans: _ModuleSupport.LinePathSpan[];
     readonly itemId: string;
 }
 
-export interface RangeAreaStrokePathDatum {
+interface RangeAreaStrokePathDatum {
     readonly spans: _ModuleSupport.LinePathSpan[];
     readonly itemId: string;
 }

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
@@ -15,9 +15,6 @@ import {
 const { SeriesNodePickMode, CachedTextMeasurerPool, TextWrapper, TextUtils, createDatumId, Logger, Rect, BBox } =
     _ModuleSupport;
 
-export interface SankeyNodeDataContext
-    extends _ModuleSupport.SeriesNodeDataContext<SankeyDatum, SankeyNodeLabelDatum> {}
-
 type NodeStyle = Pick<FillOptions & StrokeOptions & LineDashOptions, 'fill' | 'stroke'> &
     Omit<Required<FillOptions & StrokeOptions & LineDashOptions>, 'fill' | 'stroke'>;
 

--- a/packages/ag-charts-enterprise/src/series/util/labelFormatter.ts
+++ b/packages/ag-charts-enterprise/src/series/util/labelFormatter.ts
@@ -93,7 +93,7 @@ export type LabelFormatting = {
     height: number;
 };
 
-export type StackedLabelFormatting<Meta> = {
+type StackedLabelFormatting<Meta> = {
     width: number;
     height: number;
     meta: Meta;


### PR DESCRIPTION
Removes unused exports that are not public facing.

Also leaves ones that are hidden inside mixins, these are not directly used but cause build errors on private names.