### PR TITLE
CRT-606 Tell screenreaders to pause between tooltip datums with `;`

### DIFF
--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -75,7 +75,7 @@ export function tooltipContentAriaLabel(content: TooltipContent | string) {
         ariaLabel.push(datum.label ?? datum.fallbackLabel, datum.value);
     });
 
-    return ariaLabel.join(' ');
+    return ariaLabel.join('; ');
 }
 
 function dataHtml(label: string | undefined, value: string, inline: boolean) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-606