### PR TITLE
AG-13715 Set data-preventdefault: false on text-edit elements

### DIFF
--- a/packages/ag-charts-community/src/dom/elements.ts
+++ b/packages/ag-charts-community/src/dom/elements.ts
@@ -76,6 +76,7 @@ export function createTextArea(options: TextAreaOptions, attrs?: InputAttributeS
     textArea.value = options.value;
     textArea.addEventListener('input', (event) => options.onChange(textArea.value, event));
     setAttributes(textArea, attrs);
+    setAttribute(textArea, 'data-preventdefault', false); // AG-13715
     return textArea;
 }
 

--- a/packages/ag-charts-enterprise/src/features/text-input/textInput.ts
+++ b/packages/ag-charts-enterprise/src/features/text-input/textInput.ts
@@ -53,6 +53,7 @@ export class TextInput extends _ModuleSupport.BaseModuleInstance implements _Mod
         this.element.innerHTML = textInputTemplate;
 
         const textArea = this.element.firstElementChild! as HTMLDivElement;
+        _ModuleSupport.setAttribute(textArea, 'data-preventdefault', false); // AG-13715
 
         // FireFox does not yet support `contenteditable="plaintext-only", so it defaults to false and has to be
         // added back on to the element as the normal richtext version. The plaintext version is preferred as


### PR DESCRIPTION
This fixes a regression where the DOMManager calls `preventDefault()` on Arrow keydown events using the `stopPageScrolling()` method.