### PR TITLE
AG-13798 Fix 'wheel' zoom events in Safari

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -119,9 +119,11 @@ export class SeriesAreaManager extends BaseManager {
         this.focusIndicator.overrideFocusVisible(chart.mode === 'integrated' ? false : undefined); // AG-13197
 
         const { seriesWidget, containerWidget } = chart.ctx.widgets;
+        seriesWidget.setTabIndex(-1);
         this.destroyFns.push(
             () => chart.ctx.domManager.removeChild('series-area', 'series-area-aria-label1'),
             () => chart.ctx.domManager.removeChild('series-area', 'series-area-aria-label2'),
+            seriesWidget.addListener('focus', () => this.swapChain.focus()),
             seriesWidget.addListener('drag-move', (event) => this.onDragMove(event)),
             seriesWidget.addListener('mousemove', (event) => this.onHover(event)),
             seriesWidget.addListener('wheel', (event) => this.onWheel(event)),

--- a/packages/ag-charts-community/src/dom/container.css
+++ b/packages/ag-charts-community/src/dom/container.css
@@ -37,14 +37,14 @@
 
 .ag-charts-series-area {
     outline: none;
-    pointer-events: none;
+    pointer-events: auto;
     position: absolute;
 }
 
 .ag-charts-swapchain {
     outline: none;
     opacity: 0;
-    pointer-events: auto;
+    pointer-events: none;
     position: absolute;
     width: 100%;
     height: 100%;

--- a/packages/ag-charts-community/src/dom/focusSwapChain.ts
+++ b/packages/ag-charts-community/src/dom/focusSwapChain.ts
@@ -20,8 +20,14 @@ export class FocusSwapChain {
         focus: [],
         swap: [],
     };
-    private readonly onBlur = (e: FocusEvent) => !this.skipDispatch && this.dispatch('blur', e);
-    private readonly onFocus = (e: FocusEvent) => !this.skipDispatch && this.dispatch('focus', e);
+    private readonly onBlur = (e: FocusEvent) => {
+        setElementStyle(e.target as HTMLElement, 'pointer-events', undefined);
+        return !this.skipDispatch && this.dispatch('blur', e);
+    };
+    private readonly onFocus = (e: FocusEvent) => {
+        setElementStyle(e.target as HTMLElement, 'pointer-events', 'auto');
+        return !this.skipDispatch && this.dispatch('focus', e);
+    };
 
     private createAnnouncer(role: BaseAttributeTypeMap['role']) {
         const announcer = createElement('div');

--- a/packages/ag-charts-community/src/dom/focusSwapChain.ts
+++ b/packages/ag-charts-community/src/dom/focusSwapChain.ts
@@ -103,8 +103,6 @@ export class FocusSwapChain {
             'aria-hidden': false,
             tabindex: userTabIndex,
         });
-        setElementStyle(this.inactiveAnnouncer, 'pointer-events', 'none');
-        setElementStyle(this.activeAnnouncer, 'pointer-events', undefined);
 
         this.dispatch('swap', this.activeAnnouncer);
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13798

This might be because the `passive` defaults in Safari is different to other browsers. Regardless, we're adding `'wheel'` event listeners to the .ag-charts-series-area element which has the CSS value `pointer-events: none`. This is sort of asking for trouble.

Making the .ag-charts-series-area have `pointer-event: auto` works on all browsers (Safari, Firefox, Chrome), although we need to set the .ag-charts-series-area's tabindex to -1 and focus on the .ag-charts-swapchain child when the series area is clicked on.