### PR TITLE
AG-13799 Fix updates when series data is empty

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -244,7 +244,7 @@ export class AreaSeries extends CartesianSeries<
 
     override getSeriesDomain(direction: ChartAxisDirection): any[] {
         const { processedData, dataModel, axes } = this;
-        if (!processedData || !dataModel || !processedData.rawData?.length) return [];
+        if (!processedData || !dataModel || !processedData) return [];
 
         const yAxis = axes[ChartAxisDirection.Y];
         const keyDef = dataModel.resolveProcessedDataDefById(this, `xValue`);
@@ -260,7 +260,9 @@ export class AreaSeries extends CartesianSeries<
         } else if (yAxis instanceof LogAxis || yAxis instanceof TimeAxis) {
             return fixNumericExtent(yExtent);
         } else {
-            const fixedYExtent = [yExtent[0] > 0 ? 0 : yExtent[0], yExtent[1] < 0 ? 0 : yExtent[1]];
+            const fixedYExtent = Number.isFinite(yExtent[1] - yExtent[0])
+                ? [yExtent[0] > 0 ? 0 : yExtent[0], yExtent[1] < 0 ? 0 : yExtent[1]]
+                : [];
             return fixNumericExtent(fixedYExtent);
         }
     }
@@ -291,8 +293,7 @@ export class AreaSeries extends CartesianSeries<
             !yAxis ||
             !data ||
             !dataModel ||
-            !processedData?.rawData.length ||
-            processedData.type !== 'grouped' ||
+            processedData?.type !== 'grouped' ||
             !this.properties.isValid()
         ) {
             return;
@@ -758,9 +759,7 @@ export class AreaSeries extends CartesianSeries<
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -255,9 +255,6 @@ export class BarSeries extends AbstractBarSeries<
 
         if (dataModel == null || processedData == null) return [];
 
-        const rawData = processedData.rawDataSources?.get(this.id) ?? processedData.rawData;
-        if (rawData == null || rawData.length === 0) return [];
-
         const keyDef = dataModel.resolveProcessedDataDefById(this, `xValue`);
         const keys = dataModel.getDomain(this, `xValue`, 'key', processedData);
 
@@ -280,7 +277,9 @@ export class BarSeries extends AbstractBarSeries<
         } else if (this.getValueAxis() instanceof LogAxis) {
             return fixNumericExtent(yExtent);
         } else {
-            const fixedYExtent = [Math.min(0, yExtent[0]), Math.max(0, yExtent[1])];
+            const fixedYExtent = Number.isFinite(yExtent[1] - yExtent[0])
+                ? [Math.min(0, yExtent[0]), Math.max(0, yExtent[1])]
+                : [];
             return fixNumericExtent(fixedYExtent);
         }
     }
@@ -332,7 +331,7 @@ export class BarSeries extends AbstractBarSeries<
         }
 
         const rawData = processedData.rawDataSources?.get(this.id) ?? processedData.rawData;
-        if (rawData == null || rawData.length === 0) return;
+        if (rawData == null) return;
 
         const xScale = xAxis.scale;
         const yScale = yAxis.scale;
@@ -767,7 +766,7 @@ export class BarSeries extends AbstractBarSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
+        if (!dataModel || !processedData || !xAxis || !yAxis) {
             return;
         }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -205,7 +205,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleSeriesProperties,
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!(dataModel && processedData?.rawData.length && visible && xAxis && yAxis)) {
+        if (!(dataModel && processedData && visible && xAxis && yAxis)) {
             return;
         }
 
@@ -442,9 +442,7 @@ export class BubbleSeries extends CartesianSeries<Group, BubbleSeriesProperties,
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -249,12 +249,7 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramSeriesProper
             animationValid: true,
             visible: this.visible,
         };
-        if (
-            !this.visible ||
-            processedData == null ||
-            processedData.rawData.length === 0 ||
-            processedData.type !== 'grouped'
-        ) {
+        if (!this.visible || processedData == null || processedData.type !== 'grouped') {
             return context;
         }
 
@@ -455,7 +450,7 @@ export class HistogramSeries extends CartesianSeries<Rect, HistogramSeriesProper
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || processedData?.type !== 'grouped' || processedData.rawData.length === 0 || !xAxis || !yAxis) {
+        if (!dataModel || processedData?.type !== 'grouped' || !xAxis || !yAxis) {
             return;
         }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -210,7 +210,7 @@ export class LineSeries extends CartesianSeries<
 
     override getSeriesDomain(direction: ChartAxisDirection): any[] {
         const { dataModel, processedData } = this;
-        if (!dataModel || !processedData?.rawData.length) return [];
+        if (!dataModel || !processedData) return [];
 
         const xDef = dataModel.resolveProcessedDataDefById(this, `xValue`);
         if (direction === ChartAxisDirection.X) {
@@ -262,9 +262,7 @@ export class LineSeries extends CartesianSeries<
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const {
             xKey,
@@ -579,7 +577,7 @@ export class LineSeries extends CartesianSeries<
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
+        if (!dataModel || !processedData || !xAxis || !yAxis) {
             return;
         }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.ts
@@ -156,9 +156,7 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesPropertie
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!(dataModel && processedData?.rawData.length && visible && xAxis && yAxis)) {
-            return;
-        }
+        if (!(dataModel && processedData && visible && xAxis && yAxis)) return;
 
         const xDataValues = dataModel.resolveColumnById(this, `xValue`, processedData);
         const yDataValues = dataModel.resolveColumnById(this, `yValue`, processedData);
@@ -358,7 +356,7 @@ export class ScatterSeries extends CartesianSeries<Group, ScatterSeriesPropertie
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
+        if (!dataModel || !processedData || !xAxis || !yAxis) {
             return;
         }
 

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -371,7 +371,7 @@ export class DonutSeries extends PolarSeries<DonutNodeDatum, DonutSeriesProperti
             return { itemId: seriesId, nodeData: [], labelData: [] };
         }
 
-        if (!processedData?.rawData.length || !dataModel || processedData.type !== 'ungrouped') return;
+        if (!dataModel || processedData?.type !== 'ungrouped') return;
 
         const {
             angleValues,
@@ -1365,7 +1365,7 @@ export class DonutSeries extends PolarSeries<DonutNodeDatum, DonutSeriesProperti
         } = properties;
         const title = this.properties.title.text;
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0) return;
+        if (!dataModel || !processedData) return;
 
         const { datumIndex } = nodeDatum;
 

--- a/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieSeries.ts
@@ -359,7 +359,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, PieSeriesProperties, Se
         } = this;
         const { rotation } = this.properties;
 
-        if (!processedData?.rawData.length || !dataModel || processedData.type !== 'ungrouped') return;
+        if (!dataModel || processedData?.type !== 'ungrouped') return;
 
         const {
             angleValues,
@@ -1274,7 +1274,7 @@ export class PieSeries extends PolarSeries<PieNodeDatum, PieSeriesProperties, Se
         } = properties;
         const title = this.properties.title.text;
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0) return;
+        if (!dataModel || !processedData) return;
 
         const { datumIndex } = nodeDatum;
 

--- a/packages/ag-charts-enterprise/src/series/bar/barSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/bar/barSeries.ts
@@ -19,7 +19,7 @@ export class BarSeries extends _ModuleSupport.BarSeries {
         dataModel: _ModuleSupport.DataModel<any, any, false>,
         processedData: _ModuleSupport.ProcessedData<any>
     ) {
-        if (processedData.rawData.length === 0 || processedData.type !== 'ungrouped') return;
+        if (processedData?.type !== 'ungrouped') return;
 
         const xAxis = this.axes[ChartAxisDirection.X];
         if (xAxis == null || !(ContinuousScale.is(xAxis.scale) || OrdinalTimeScale.is(xAxis.scale))) return;

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -139,9 +139,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!(dataModel && processedData != null && processedData.rawData.length !== 0 && xAxis && yAxis)) {
-            return;
-        }
+        if (!(dataModel && processedData && xAxis && yAxis)) return;
 
         const { xKey, fill, fillOpacity, stroke, strokeWidth, strokeOpacity, lineDash, lineDashOffset, cap, whisker } =
             this.properties;
@@ -321,9 +319,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -273,7 +273,7 @@ export abstract class FlowProportionSeries<
     ) {
         const { linksDataModel, linksProcessedData } = this;
 
-        if (linksDataModel == null || linksProcessedData == null || linksProcessedData.rawData.length === 0) {
+        if (linksDataModel == null || linksProcessedData == null) {
             const { links, nodeGraph, maxPathLength } = computeNodeGraph(
                 new Map<string, TNodeDatum>().values(),
                 [],

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -273,17 +273,7 @@ export abstract class BaseFunnelSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (
-            !(
-                hasData &&
-                data &&
-                xAxis &&
-                yAxis &&
-                dataModel &&
-                processedData?.type === 'ungrouped' &&
-                processedData.rawData.length !== 0
-            )
-        ) {
+        if (!(hasData && data && xAxis && yAxis && dataModel && processedData?.type === 'ungrouped')) {
             return;
         }
 
@@ -529,9 +519,7 @@ export abstract class BaseFunnelSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -170,9 +170,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!(data && dataModel && processedData?.rawData.length && visible && xAxis && yAxis)) {
-            return;
-        }
+        if (!(data && dataModel && processedData && visible && xAxis && yAxis)) return;
 
         if (xAxis.type !== 'category' || yAxis.type !== 'category') {
             Logger.warnOnce(
@@ -436,9 +434,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/line/lineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/line/lineSeries.ts
@@ -9,8 +9,6 @@ export class LineSeries extends _ModuleSupport.LineSeries {
         dataModel: _ModuleSupport.DataModel<any, any, false>,
         processedData: _ModuleSupport.UngroupedData<any>
     ) {
-        if (processedData.rawData.length === 0) return;
-
         const xAxis = this.axes[ChartAxisDirection.X];
         if (xAxis == null || !(ContinuousScale.is(xAxis.scale) || OrdinalTimeScale.is(xAxis.scale))) return;
 

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -151,11 +151,12 @@ export class MapLineSeries extends TopologySeries<
             ],
         });
 
-        const featureValues =
-            processedData.rawData.length !== 0
-                ? dataModel.resolveColumnById<_ModuleSupport.Feature | undefined>(this, `featureValue`, processedData)
-                : undefined;
-        this.topologyBounds = featureValues?.reduce<_ModuleSupport.LonLatBBox | undefined>((current, feature) => {
+        const featureValues = dataModel.resolveColumnById<_ModuleSupport.Feature | undefined>(
+            this,
+            `featureValue`,
+            processedData
+        );
+        this.topologyBounds = featureValues.reduce<_ModuleSupport.LonLatBBox | undefined>((current, feature) => {
             const geometry = feature?.geometry;
             if (geometry == null) return current;
             return geometryBbox(geometry, current);
@@ -243,7 +244,7 @@ export class MapLineSeries extends TopologySeries<
         const { id: seriesId, dataModel, processedData, sizeScale, properties, scale } = this;
         const { idKey, sizeKey, colorKey, labelKey, label } = properties;
 
-        if (dataModel == null || processedData == null || processedData.rawData.length === 0) return;
+        if (dataModel == null || processedData == null) return;
 
         const idValues = dataModel.resolveColumnById<string>(this, `idValue`, processedData);
         const featureValues = dataModel.resolveColumnById<_ModuleSupport.Feature | undefined>(
@@ -614,7 +615,7 @@ export class MapLineSeries extends TopologySeries<
             legendItemName,
             tooltip,
         } = properties;
-        if (!dataModel || !processedData?.rawData.length) return;
+        if (!dataModel || !processedData) return;
 
         const { datumIndex } = seriesDatum;
 

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -225,15 +225,12 @@ export class MapMarkerSeries
             ],
         });
 
-        const hasData = processedData.rawData.length !== 0;
         const featureValues =
-            hasData && idKey != null
+            idKey != null
                 ? dataModel.resolveColumnById<_ModuleSupport.Feature | undefined>(this, `featureValue`, processedData)
                 : undefined;
-        const latValues =
-            hasData && hasLatLon ? dataModel.resolveColumnById<number>(this, `latValue`, processedData) : undefined;
-        const lonValues =
-            hasData && hasLatLon ? dataModel.resolveColumnById<number>(this, `lonValue`, processedData) : undefined;
+        const latValues = hasLatLon ? dataModel.resolveColumnById<number>(this, `latValue`, processedData) : undefined;
+        const lonValues = hasLatLon ? dataModel.resolveColumnById<number>(this, `lonValue`, processedData) : undefined;
         this.topologyBounds = processedData.rawData.reduce<_ModuleSupport.LonLatBBox | undefined>(
             (current, _datum, datumIndex) => {
                 const feature: _ModuleSupport.Feature | undefined = featureValues?.[datumIndex];
@@ -345,7 +342,7 @@ export class MapMarkerSeries
         const { id: seriesId, dataModel, processedData, sizeScale, properties, scale } = this;
         const { idKey, latitudeKey, longitudeKey, sizeKey, colorKey, labelKey, label } = properties;
 
-        if (dataModel == null || processedData == null || processedData.rawData.length === 0 || scale == null) return;
+        if (dataModel == null || processedData == null || scale == null) return;
 
         const hasLatLon = latitudeKey != null && longitudeKey != null;
 
@@ -790,7 +787,7 @@ export class MapMarkerSeries
             legendItemName,
             tooltip,
         } = properties;
-        if (!dataModel || !processedData?.rawData.length) return;
+        if (!dataModel || !processedData) return;
 
         const { datumIndex } = seriesDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -169,11 +169,12 @@ export class MapShapeSeries
             ],
         });
 
-        const featureValues =
-            processedData.rawData.length !== 0
-                ? dataModel.resolveColumnById<_ModuleSupport.Feature | undefined>(this, `featureValue`, processedData)
-                : undefined;
-        this.topologyBounds = featureValues?.reduce<_ModuleSupport.LonLatBBox | undefined>((current, feature) => {
+        const featureValues = dataModel.resolveColumnById<_ModuleSupport.Feature | undefined>(
+            this,
+            `featureValue`,
+            processedData
+        );
+        this.topologyBounds = featureValues.reduce<_ModuleSupport.LonLatBBox | undefined>((current, feature) => {
             const geometry = feature?.geometry;
             if (geometry == null) return current;
             return geometryBbox(geometry, current);
@@ -307,7 +308,7 @@ export class MapShapeSeries
         const { id: seriesId, dataModel, processedData, properties, scale, previousLabelLayouts } = this;
         const { idKey, colorKey, labelKey, label } = properties;
 
-        if (dataModel == null || processedData == null || processedData.rawData.length === 0) return;
+        if (dataModel == null || processedData == null) return;
 
         const scaling = scale != null ? (scale.range[1][0] - scale.range[0][0]) / scale.bounds.width : NaN;
 
@@ -646,7 +647,7 @@ export class MapShapeSeries
     override getTooltipContent(seriesDatum: any): _ModuleSupport.TooltipContent | string | undefined {
         const { id: seriesId, dataModel, processedData, properties } = this;
         const { idKey, idName, colorKey, colorName, labelKey, labelName, legendItemName, title, tooltip } = properties;
-        if (!dataModel || !processedData?.rawData.length) return;
+        if (!dataModel || !processedData) return;
 
         const { datumIndex } = seriesDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -152,8 +152,6 @@ export abstract class OhlcSeriesBase<
         dataModel: _ModuleSupport.DataModel<any, any, any>,
         processedData: _ModuleSupport.UngroupedData<any>
     ) {
-        if (processedData.rawData.length === 0) return;
-
         const xAxis = this.axes[ChartAxisDirection.X];
         if (xAxis == null || !(ContinuousScale.is(xAxis.scale) || OrdinalTimeScale.is(xAxis.scale))) return;
 
@@ -217,9 +215,7 @@ export abstract class OhlcSeriesBase<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!(dataModel && processedData != null && processedData.rawData.length !== 0 && xAxis && yAxis)) {
-            return;
-        }
+        if (!(dataModel && processedData && xAxis && yAxis)) return;
 
         const nodeData: OhlcNodeDatum[] = [];
         const { xKey, highKey, lowKey } = this.properties;
@@ -488,9 +484,7 @@ export abstract class OhlcSeriesBase<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -149,7 +149,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
             stageLabel,
         } = properties;
 
-        if (dataModel == null || processedData == null || processedData.rawData.length === 0) return;
+        if (dataModel == null || processedData == null) return;
 
         const horizontal = direction === 'horizontal';
 
@@ -555,9 +555,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
         const { id: seriesId, dataModel, processedData, properties } = this;
         const { stageKey, valueKey, tooltip } = properties;
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0) {
-            return;
-        }
+        if (!dataModel || !processedData) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -181,9 +181,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<
     override createNodeData() {
         const { processedData, dataModel } = this;
 
-        if (!processedData || !dataModel || processedData.rawData.length === 0 || !this.properties.isValid()) {
-            return;
-        }
+        if (!processedData || !dataModel || !this.properties.isValid()) return;
 
         const { angleKey, radiusKey, angleName, radiusName, marker, label } = this.properties;
         const angleScale = this.axes[ChartAxisDirection.X]?.scale;
@@ -417,9 +415,7 @@ export abstract class RadarSeries extends _ModuleSupport.PolarSeries<
         const angleAxis = axes[ChartAxisDirection.X];
         const radiusAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !angleAxis || !radiusAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !angleAxis || !radiusAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -206,13 +206,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
     override createNodeData() {
         const { processedData, dataModel } = this;
 
-        if (
-            !dataModel ||
-            !processedData ||
-            processedData.type !== 'ungrouped' ||
-            processedData.rawData.length === 0 ||
-            !this.properties.isValid()
-        ) {
+        if (!dataModel || !processedData || processedData.type !== 'ungrouped' || !this.properties.isValid()) {
             return;
         }
 
@@ -501,9 +495,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
         const angleAxis = axes[ChartAxisDirection.X];
         const radiusAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !angleAxis || !radiusAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !angleAxis || !radiusAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -215,13 +215,7 @@ export abstract class RadialColumnSeriesBase<
     override createNodeData() {
         const { processedData, dataModel, groupScale } = this;
 
-        if (
-            !dataModel ||
-            !processedData ||
-            processedData.type !== 'ungrouped' ||
-            processedData.rawData.length === 0 ||
-            !this.properties.isValid()
-        ) {
+        if (!dataModel || !processedData || processedData.type !== 'ungrouped' || !this.properties.isValid()) {
             return;
         }
 
@@ -502,9 +496,7 @@ export abstract class RadialColumnSeriesBase<
         const angleAxis = axes[ChartAxisDirection.X];
         const radiusAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !angleAxis || !radiusAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !angleAxis || !radiusAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -141,8 +141,6 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
         dataModel: _ModuleSupport.DataModel<any, any, any>,
         processedData: _ModuleSupport.ProcessedData<any>
     ) {
-        if (processedData.rawData.length === 0) return;
-
         const xAxis = this.axes[ChartAxisDirection.X];
         if (xAxis == null || !(ContinuousScale.is(xAxis.scale) || OrdinalTimeScale.is(xAxis.scale))) return;
 
@@ -212,9 +210,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!(data && xAxis && yAxis && dataModel && processedData != null && processedData.rawData.length !== 0)) {
-            return;
-        }
+        if (!(data && xAxis && yAxis && dataModel && processedData)) return;
 
         const xScale = xAxis.scale;
         const yScale = yAxis.scale;
@@ -611,9 +607,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<
         const xAxis = axes[ChartAxisDirection.X];
         const yAxis = axes[ChartAxisDirection.Y];
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -172,7 +172,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
         dataModel: _ModuleSupport.DataModel<any, any, any>,
         processedData: _ModuleSupport.ProcessedData<any>
     ) {
-        if (processedData.type !== 'grouped' || processedData.rawData.length === 0) return;
+        if (processedData.type !== 'grouped') return;
 
         const xAxis = this.axes[ChartAxisDirection.X];
         if (xAxis == null || !(ContinuousScale.is(xAxis.scale) || OrdinalTimeScale.is(xAxis.scale))) return;
@@ -235,9 +235,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!(data && xAxis && yAxis && dataModel && processedData?.rawData.length)) {
-            return;
-        }
+        if (!(data && xAxis && yAxis && dataModel && processedData?.rawData)) return;
 
         const xScale = xAxis.scale;
         const yScale = yAxis.scale;
@@ -585,7 +583,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
+        if (!dataModel || !processedData || !xAxis || !yAxis) {
             return;
         }
 

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -216,14 +216,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
         const categoryAxis = this.getCategoryAxis();
         const valueAxis = this.getValueAxis();
 
-        if (
-            !data ||
-            !categoryAxis ||
-            !valueAxis ||
-            !dataModel ||
-            processedData == null ||
-            processedData.rawData.length === 0
-        ) {
+        if (!data || !categoryAxis || !valueAxis || !dataModel || !processedData) {
             return;
         }
 
@@ -604,9 +597,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<
         const xAxis = this.getCategoryAxis();
         const yAxis = this.getValueAxis();
 
-        if (!dataModel || !processedData || processedData.rawData.length === 0 || !xAxis || !yAxis) {
-            return;
-        }
+        if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const { datumIndex } = nodeDatum;
         const datum = processedData.rawData[datumIndex];


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13799

Previously we used to check `rawData.length` because calls to `dataModel.resolveProcessedDataDefById` would throw errors for empty data. I'm not sure why this is no longer the case - but it seems to just work now.