### PR TITLE
AG-7670 Fix zoom event example

### DIFF
--- a/packages/ag-charts-website/src/content/docs/events/_examples/zoom-event/main.ts
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/zoom-event/main.ts
@@ -16,10 +16,7 @@ const options: AgCartesianChartOptions = {
     },
     listeners: {
         zoom: (event) => {
-            const percentX = Math.floor(100 / (event.ratioX.end - event.ratioX.start));
-            const percentY = Math.floor(100 / (event.ratioY.end - event.ratioY.start));
-            options.subtitle!.text = `Zoom: x = ${percentX}%, y = ${percentY}%`;
-            chart.update(options);
+            console.log(event);
         },
     },
     data: getData(),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-7670

The website example compiler can't handle `chart.update(options)` within a callback on the chart. Just changed it to do a `console.log()` per other examples.