### PR TITLE
Switch to shallow cloning on CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
               id: checkout
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
+
             - name: Fetch Refs
-              run: git fetch origin latest-success latest
+              run: git fetch origin --depth 1 latest-success latest
 
             - name: Setup
               id: setup
@@ -136,7 +137,10 @@ jobs:
               id: checkout
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
+
+            - name: Fetch Refs
+              run: git fetch origin --depth 1 latest-success latest
 
             - name: Setup
               id: setup
@@ -184,7 +188,11 @@ jobs:
               id: checkout
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
+
+            - name: Fetch Refs
+              run: git fetch origin --depth 1 latest-success latest
+
             - name: Setup
               id: setup
               uses: ./.github/actions/setup-nx
@@ -389,7 +397,10 @@ jobs:
               if: matrix.framework != 'none'
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
+
+            - name: Fetch Refs
+              run: git fetch origin --depth 1 latest-success latest
 
             - name: Setup
               id: setup
@@ -412,9 +423,10 @@ jobs:
               id: checkout
               uses: actions/checkout@v4
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
+
             - name: Fetch Refs
-              run: git fetch origin latest-success latest
+              run: git fetch origin --depth 1 latest-success latest
 
             - uses: actions/download-artifact@v4
               with:
@@ -517,7 +529,11 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   # Disabling shallow clones is recommended for improving the relevancy of reporting
-                  fetch-depth: 0
+                  fetch-depth: 1
+
+            - name: Fetch Refs
+              run: git fetch origin --depth 1 latest-success latest
+
             - name: SonarQube Scan
               uses: sonarsource/sonarqube-scan-action@master
               with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,9 @@ jobs:
             - name: Checkout
               id: checkout
               uses: actions/checkout@v4
+
             - name: Fetch Refs
-              run: git fetch origin latest-success latest
+              run: git fetch origin --depth 1 latest-success latest
 
             - name: Setup Node.js
               id: setup_node


### PR DESCRIPTION
- Switch to using shallow clones for CI checkouts.
