### PR TITLE
Data model perf

### DIFF
--- a/packages/ag-charts-community/src/chart/data/dataModel.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.ts
@@ -802,7 +802,7 @@ export class DataModel<
                     continue;
                 }
 
-                const keys = new Array<unknown>();
+                const keys: unknown[] = [];
                 keyDefKeys.set(scope, keys);
                 scopeDataProcessed.set(data, scope);
 
@@ -875,12 +875,8 @@ export class DataModel<
             const columnScopes = new Set(def.scopes);
             const columnScope = first(def.scopes);
             const columnSource = sources.get(columnScope) as unknown[];
-            const column = new Array(columnSource.length);
-
-            for (let datumIndex = 0; datumIndex < columnSource.length; datumIndex++) {
+            const column = columnSource.map((valueDatum, datumIndex) => {
                 const invalidKey = invalidKeys.get(columnScope)?.[datumIndex];
-
-                const valueDatum = columnSource[datumIndex];
 
                 let value = processValue(def, valueDatum, datumIndex, def.scopes);
 
@@ -896,8 +892,8 @@ export class DataModel<
                     value = invalidValue;
                 }
 
-                column[datumIndex] ??= value;
-            }
+                return value;
+            });
 
             columns.push(column);
             allColumnScopes.push(columnScopes);
@@ -1134,7 +1130,7 @@ export class DataModel<
             } else {
                 const onlyScope = first(dataSources.keys());
                 const keyColumns = keys.map((k) => k.get(onlyScope)).filter((k) => k != null);
-                const keysParam = new Array(keyColumns.length);
+                const keysParam = keyColumns.map((): unknown => undefined!);
                 const rawData = dataSources.get(onlyScope)!;
                 for (let datumIndex = 0; datumIndex < rawData.length; datumIndex += 1) {
                     for (let keyIdx = 0; keyIdx < keysParam.length; keyIdx++) {


### PR DESCRIPTION
We had a case in the high performance case where an array couldn't directly store the floats inside it, and instead has to allocate an object to store the number, then reference the object by pointer in array. This happens because by a JS quirk `new Array(nonZeroLength)` creates the most inefficient array storage method possible. The effect is the array takes up much more memory, and is more expensive for the GC.

![image](https://github.com/user-attachments/assets/a141e9c9-cda7-4e94-88b9-ddaa97647308)

I've updated these performance-sensitive cases to use `.map` The heap snapshot for the 1m points dropped from 223mb to 214mb with no change in time to process the data. We might need to debug the performance, because it's taking just under 3s to process 1m points