### PR TITLE
AG-12936 Fix zoom buttons direction check to before layout

### DIFF
--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -86,6 +86,8 @@ export class CartesianChart extends Chart {
                 (axis as any).setDomains(syncedDomain);
             }
         }
+
+        this.ctx.updateService.dispatchProcessData({ series: { shouldFlipXY: this.shouldFlipXY() } });
     }
 
     protected performLayout(ctx: LayoutContext) {
@@ -145,7 +147,6 @@ export class CartesianChart extends Chart {
                 visible,
                 rect: seriesRect,
                 paddedRect: seriesPaddedRect,
-                shouldFlipXY: this.shouldFlipXY(),
             },
             clipSeries,
         });

--- a/packages/ag-charts-community/src/chart/layout/layoutManager.ts
+++ b/packages/ag-charts-community/src/chart/layout/layoutManager.ts
@@ -25,7 +25,7 @@ export interface AxisLayout {
 export type LayoutCompleteEvent = {
     readonly type: 'layout:complete';
     readonly chart: Readonly<{ width: number; height: number }>;
-    readonly series: Readonly<{ rect: BBox; paddedRect: BBox; visible: boolean; shouldFlipXY?: boolean }>;
+    readonly series: Readonly<{ rect: BBox; paddedRect: BBox; visible: boolean }>;
     readonly clipSeries: boolean;
     readonly axes?: Readonly<AxisLayout>[];
 };
@@ -33,7 +33,7 @@ export type LayoutCompleteEvent = {
 export interface LayoutState {
     axes?: AxisLayout[];
     clipSeries?: boolean;
-    series: { rect: BBox; paddedRect: BBox; visible: boolean; shouldFlipXY?: boolean };
+    series: { rect: BBox; paddedRect: BBox; visible: boolean };
 }
 
 interface EventMap {

--- a/packages/ag-charts-community/src/chart/updateService.ts
+++ b/packages/ag-charts-community/src/chart/updateService.ts
@@ -1,4 +1,5 @@
-import { Listeners } from '../util/listeners';
+import { EventEmitter, type EventListener } from 'ag-charts-core';
+
 import { ChartUpdateType } from './chartUpdateType';
 import type { ISeries } from './series/seriesTypes';
 
@@ -16,6 +17,11 @@ export interface PreSceneRenderEvent {
     readonly type: 'pre-scene-render';
 }
 
+export interface ProcessDataEvent {
+    readonly type: 'process-data';
+    readonly series: { shouldFlipXY?: boolean };
+}
+
 export type UpdateOpts = {
     forceNodeDataRefresh?: boolean;
     skipAnimations?: boolean;
@@ -25,13 +31,28 @@ export type UpdateOpts = {
     skipSync?: boolean;
 };
 
-type UpdateEventTypes = 'update-complete' | 'pre-dom-update' | 'pre-scene-render';
+interface EventMap {
+    'update-complete': UpdateCompleteEvent;
+    'pre-dom-update': PreDomUpdateEvent;
+    'pre-scene-render': PreSceneRenderEvent;
+    'process-data': ProcessDataEvent;
+}
 
-type UpdateEvents = UpdateCompleteEvent | PreDomUpdateEvent | PreSceneRenderEvent;
+export class UpdateService {
+    private readonly events = new EventEmitter<EventMap>();
 
-export class UpdateService extends Listeners<UpdateEventTypes, (event: UpdateEvents) => void> {
-    constructor(private readonly updateCallback: UpdateCallback) {
-        super();
+    constructor(private readonly updateCallback: UpdateCallback) {}
+
+    public addListener<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[K]>) {
+        return this.events.on(eventName, listener);
+    }
+
+    public removeListener<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[K]>) {
+        return this.events.on(eventName, listener);
+    }
+
+    public destroy() {
+        this.events.clear();
     }
 
     public update(type = ChartUpdateType.FULL, options?: UpdateOpts) {
@@ -39,14 +60,18 @@ export class UpdateService extends Listeners<UpdateEventTypes, (event: UpdateEve
     }
 
     public dispatchUpdateComplete() {
-        this.dispatch('update-complete', { type: 'update-complete' });
+        this.events.emit('update-complete', { type: 'update-complete' });
     }
 
     public dispatchPreDomUpdate() {
-        this.dispatch('pre-dom-update', { type: 'pre-dom-update' });
+        this.events.emit('pre-dom-update', { type: 'pre-dom-update' });
     }
 
     public dispatchPreSceneRender() {
-        this.dispatch('pre-scene-render', { type: 'pre-scene-render' });
+        this.events.emit('pre-scene-render', { type: 'pre-scene-render' });
+    }
+
+    public dispatchProcessData({ series }: { series: { shouldFlipXY?: boolean } }) {
+        this.events.emit('process-data', { type: 'process-data', series });
     }
 }

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -231,6 +231,7 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
             ctx.widgets.seriesWidget.addListener('touchmove', (event, current) => this.onTouchMove(event, current)),
             ctx.widgets.seriesWidget.addListener('touchend', (event) => this.onTouchEnd(event)),
             ctx.widgets.seriesWidget.addListener('touchcancel', (event) => this.onTouchEnd(event)),
+            ctx.updateService.addListener('process-data', (event) => this.onProcessData(event)),
             ctx.layoutManager.addListener('layout:complete', (event) => this.onLayoutComplete(event)),
             ctx.zoomManager.addListener('zoom-change', (event) => this.onZoomChange(event)),
             ctx.zoomManager.addListener('zoom-pan-start', (event) => this.onZoomPanStart(event)),
@@ -551,6 +552,10 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         }
     }
 
+    private onProcessData(event: _ModuleSupport.ProcessDataEvent) {
+        this.shouldFlipXY = event.series.shouldFlipXY;
+    }
+
     private onLayoutComplete(event: _ModuleSupport.LayoutCompleteEvent) {
         this.domProxy.update(this.enableAxisDragging, this.ctx);
         const { enabled } = this;
@@ -558,12 +563,11 @@ export class Zoom extends _ModuleSupport.BaseModuleInstance implements _ModuleSu
         if (!enabled) return;
 
         const {
-            series: { rect, paddedRect, shouldFlipXY },
+            series: { rect, paddedRect },
         } = event;
 
         this.seriesRect = rect;
         this.paddedRect = paddedRect;
-        this.shouldFlipXY = shouldFlipXY;
     }
 
     private onZoomChange(event: _ModuleSupport.ZoomChangeEvent) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-12936

Caused by `shouldFlipXY` not getting set on the zoom module until after a layout. So the toolbar buttons were a step behind and did their check with the wrong x/y zoom values.

This moves it into the process data step on the update service (and a small change on that service to allow mixed event types).