### PR TITLE
AG-14001 - Hide Plunker and CodeSandbox buttons on iOS

### DIFF
--- a/external/ag-website-shared/src/components/open-in-cta/OpenInCTA.module.scss
+++ b/external/ag-website-shared/src/components/open-in-cta/OpenInCTA.module.scss
@@ -47,6 +47,13 @@
     }
 }
 
+// Hide button (CodeSandbox & Plunker) CTA items for Mobile Safari only
+@supports (-webkit-touch-callout: none) {
+    .cta button {
+        display: none;
+    }
+}
+
 .tooltip {
     --tooltip-background: var(--color-fg-primary);
 


### PR DESCRIPTION
Hide Plunker and CodeSandbox buttons on iOS as it's not possible to make them function satisfactorily.  