### PR TITLE
Reduce pixel color diff threshold from 0.2 on playwright config

### DIFF
--- a/packages/ag-charts-website/playwright.config.ts
+++ b/packages/ag-charts-website/playwright.config.ts
@@ -43,6 +43,16 @@ export default defineConfig({
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
     },
+    expect: {
+        toMatchSnapshot: {
+            maxDiffPixels: 0,
+            threshold: 0.01,
+        },
+        toHaveScreenshot: {
+            maxDiffPixels: 0,
+            threshold: 0.01,
+        },
+    },
 
     /* Configure projects for major browsers */
     projects: [

--- a/tests/shared/playwright.config.ts
+++ b/tests/shared/playwright.config.ts
@@ -39,6 +39,16 @@ export default defineConfig({
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
     },
+    expect: {
+        toMatchSnapshot: {
+            maxDiffPixels: 0,
+            threshold: 0,
+        },
+        toHaveScreenshot: {
+            maxDiffPixels: 0,
+            threshold: 0,
+        },
+    },
 
     /* Configure projects for major browsers */
     projects: [


### PR DESCRIPTION
Default color diff threshold is `0.2` (20%).

Setting it to 0% makes the tests a bit flaky with varying handfuls of pixels on aliased rounded corners being detected as changing (though with no actual human recognisable change).

So I've set it to 1% which should catch any actual errors.

(`maxDiffPixels` is only relevant if a pixel breaches this threshold, else it is considered to not be different).