### PR TITLE
CRT-661: Funnel - Item styler params do not all include `datum` on hover

### DIFF
--- a/packages/ag-charts-enterprise/src/series/funnel/funnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/funnelSeries.ts
@@ -193,12 +193,9 @@ export class FunnelSeries extends BaseFunnelSeries<_ModuleSupport.Rect<FunnelNod
         });
     }
 
-    protected tooltipStyle(datum: any, datumIndex: number) {
-        const style = this.getItemBaseStyle(false) as any as Required<ItemStyle>;
-        Object.assign(
-            style,
-            this.getItemStyleOverrides(String(datum.datumIndex), datum.datum, datumIndex, style, false)
-        );
+    protected tooltipStyle(datum: unknown, datumIndex: number) {
+        const style = this.getItemBaseStyle(false) as Required<ItemStyle>;
+        Object.assign(style, this.getItemStyleOverrides(String(datumIndex), datum, datumIndex, style, false));
         return style;
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-661