### PR TITLE
CRT-685 Make panToBBox fail if zoom is disabled

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -356,6 +356,8 @@ export class ZoomManager extends BaseManager<ZoomEvents['type'], ZoomEvents> imp
     }
 
     public panToBBox(callerId: string, seriesRect: BBox, target: BBoxValues): boolean {
+        if (!this.isZoomEnabled()) return false;
+
         const zoom = this.getZoom();
         if (zoom === undefined || (!zoom.x && !zoom.y)) return false;
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-685

This fixes keyboard navigation on non-zoom-pannable charts.