### PR TITLE
AG-13707 Allow channels to drag by handles out of continuous domains

### DIFF
--- a/packages/ag-charts-community/src/util/vector.ts
+++ b/packages/ag-charts-community/src/util/vector.ts
@@ -115,7 +115,8 @@ function normalized(a: Vec2): Vec2 {
 /**
  * Find the angle between two vectors.
  */
-function angle(a: Vec2, b: Vec2 = origin()) {
+function angle(a: Vec2, b?: Vec2) {
+    if (b == null) return Math.atan2(a.y, a.x);
     return Math.atan2(a.y, a.x) - Math.atan2(b.y, b.x);
 }
 
@@ -189,13 +190,13 @@ function equal(a: Vec2, b: Vec2): boolean {
  */
 function from(x: number, y: number): Vec2;
 /**
- * Create a vector from a html element's `offsetWidth` and `offsetHeight`.
- */
-function from(element: { offsetWidth: number; offsetHeight: number }): Vec2;
-/**
  * Create a vector from a widget event.
  */
 function from(event: { currentX: number; currentY: number }): Vec2;
+/**
+ * Create a vector from a html element's `offsetWidth` and `offsetHeight`.
+ */
+function from(element: { offsetWidth: number; offsetHeight: number }): Vec2;
 /**
  * Create a pair of vectors of the top left and bottom right of a bounding box.
  */
@@ -207,8 +208,8 @@ function from(vec4: Vec4): [Vec2, Vec2];
 function from(
     a:
         | number
-        | { offsetWidth: number; offsetHeight: number }
         | { currentX: number; currentY: number }
+        | { offsetWidth: number; offsetHeight: number }
         | { x: number; y: number; width: number; height: number }
         | Vec4,
     b?: number

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -121,7 +121,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
     private xAxis?: AnnotationAxis;
     private yAxis?: AnnotationAxis;
 
-    private restoreAnnotations = true;
+    private isRestoringAnnotations = true;
 
     constructor(private readonly ctx: _ModuleSupport.ModuleContext) {
         super();
@@ -696,7 +696,7 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         this.clear();
         this.annotationData.set(event.annotations);
 
-        this.restoreAnnotations = true;
+        this.isRestoringAnnotations = true;
         this.update();
     }
 
@@ -865,11 +865,10 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         this.toolbar.refreshButtonsEnabled(showAnnotations);
         this.toolbar.toggleClearButtonEnabled(annotationData.length > 0 && showAnnotations);
 
-        const shouldWarn = this.restoreAnnotations;
         annotations
             .update(annotationData ?? [], undefined, (datum) => datum.id)
             .each((node, datum) => {
-                if (!showAnnotations || !this.validateDatum(datum, shouldWarn)) {
+                if (!showAnnotations || !this.validateDatum(datum)) {
                     node.visible = false;
                     if ('setAxisLabelVisible' in node) {
                         node.setAxisLabelVisible(false);
@@ -887,15 +886,16 @@ export class Annotations extends _ModuleSupport.BaseModuleInstance implements _M
         this.postUpdateFns.forEach((fn) => fn());
         this.postUpdateFns = [];
 
-        this.restoreAnnotations = false;
+        this.isRestoringAnnotations = false;
     }
 
     private postUpdateFns: Array<() => void> = [];
 
     // Validation of the options beyond the scope of the @Validate decorator
-    private validateDatum(datum: AnnotationProperties, shouldWarn: boolean) {
+    private validateDatum(datum: AnnotationProperties) {
+        if (!this.isRestoringAnnotations) return true;
         const context = this.getAnnotationContext();
-        const warningPrefix = shouldWarn ? `Annotation [${datum.type}] ` : undefined;
+        const warningPrefix = `Annotation [${datum.type}] `;
         return context ? datum.isValidWithContext(context, warningPrefix) : true;
     }
 

--- a/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelProperties.ts
@@ -57,8 +57,8 @@ export class DisjointChannelProperties extends Annotation(
     override isValidWithContext(context: AnnotationContext, warningPrefix?: string) {
         return (
             super.isValid(warningPrefix) &&
-            validateDatumLine(context, this, { y: false }, warningPrefix) &&
-            validateDatumLine(context, this.bottom, { y: false }, warningPrefix)
+            validateDatumLine(context, this, { overflowContinuous: true }, warningPrefix) &&
+            validateDatumLine(context, this.bottom, { overflowContinuous: true }, warningPrefix)
         );
     }
 

--- a/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/disjoint-channel/disjointChannelScene.ts
@@ -1,14 +1,13 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { isNumber } from 'ag-charts-core';
 
 import type { AnnotationContext } from '../annotationTypes';
 import { AnnotationScene } from '../scenes/annotationScene';
 import { ChannelScene } from '../scenes/channelScene';
 import { CollidableText } from '../scenes/collidableTextScene';
 import { DivariantHandle, UnivariantHandle } from '../scenes/handle';
+import { translate } from '../utils/coords';
 import { updateChannelText } from '../utils/lineWithText';
-import { getGroupingValue } from '../utils/scale';
-import { invertCoords } from '../utils/values';
+import { convertLine } from '../utils/values';
 import type { DisjointChannelProperties } from './disjointChannelProperties';
 
 const { Vec2, Vec4 } = _ModuleSupport;
@@ -47,84 +46,67 @@ export class DisjointChannelScene extends ChannelScene<DisjointChannelProperties
         const { offset } = handles[activeHandle].drag(target);
         handles[activeHandle].toggleDragging(true);
 
-        const invert = (coords: _ModuleSupport.Vec2) => invertCoords(coords, context);
-        const prev = datum.toJson();
-        const angle = datum.snapToAngle;
+        if (activeHandle === 'bottomRight') {
+            offset.x = 0;
+        }
 
-        const { value: endY } = getGroupingValue(datum.end.y);
-        const { value: startY } = getGroupingValue(datum.start.y);
+        let translateVectors: Array<ChannelHandle> = [];
+        let invertYVectors: Array<ChannelHandle> = [];
+        let allowSnapping = snapping;
 
         switch (activeHandle) {
             case 'topLeft':
-            case 'bottomLeft': {
-                const direction = activeHandle === 'topLeft' ? 1 : -1;
-                const start = snapping
-                    ? this.snapToAngle(target, context, 'topLeft', 'topRight', angle, direction)
-                    : invert({
-                          x: handles.topLeft.handle.x + offset.x,
-                          y: handles.topLeft.handle.y + offset.y * direction,
-                      });
-
-                const bottomStart = snapping
-                    ? this.snapToAngle(target, context, 'bottomLeft', 'bottomRight', angle, -direction)
-                    : invert({
-                          x: handles.bottomLeft.handle.x + offset.x,
-                          y: handles.bottomLeft.handle.y + offset.y * -direction,
-                      });
-
-                if (start?.y == null || bottomStart?.y == null || startY == null || !isNumber(startY)) return;
-
-                const startHeight = datum.startHeight + (start.y - startY) * 2;
-
-                datum.start.x = start.x;
-                datum.start.y = start.y;
-                datum.startHeight = startHeight;
-
+                translateVectors = ['topLeft'];
+                invertYVectors = ['bottomLeft'];
                 break;
-            }
-
-            case 'topRight': {
-                const end = snapping
-                    ? this.snapToAngle(target, context, 'topRight', 'topLeft', angle)
-                    : invert({
-                          x: handles.topRight.handle.x + offset.x,
-                          y: handles.topRight.handle.y + offset.y,
-                      });
-
-                if (end?.y == null || endY == null || !isNumber(endY)) return;
-
-                const endHeight = datum.endHeight + (end.y - endY) * 2;
-
-                datum.end.x = end.x;
-                datum.end.y = end.y;
-                datum.endHeight = endHeight;
-
+            case 'bottomLeft':
+                translateVectors = ['bottomLeft'];
+                invertYVectors = ['topLeft'];
                 break;
-            }
-
-            case 'bottomRight': {
-                const bottomStart = invert({
-                    x: handles.bottomLeft.handle.x + offset.x,
-                    y: handles.bottomLeft.handle.y + offset.y,
-                });
-                const bottomEnd = invert({
-                    x: handles.bottomRight.handle.x + offset.x,
-                    y: handles.bottomRight.handle.y + offset.y,
-                });
-
-                if (!bottomStart || !bottomEnd || datum.start.y == null || endY == null || !isNumber(endY)) return;
-
-                const endHeight = endY - bottomEnd.y;
-                const startHeight = datum.startHeight - (datum.endHeight - endHeight);
-
-                datum.startHeight = startHeight;
-                datum.endHeight = endHeight;
-            }
+            case 'topRight':
+                translateVectors = ['topRight'];
+                invertYVectors = ['bottomRight'];
+                break;
+            case 'bottomRight':
+                translateVectors = ['bottomLeft', 'bottomRight'];
+                allowSnapping = false;
+                break;
         }
 
-        if (!datum.isValidWithContext(context)) {
-            datum.set(prev);
-        }
+        const top = convertLine(datum, context);
+        const bottom = convertLine(datum.bottom, context);
+        if (!top || !bottom) return;
+
+        const vectors = {
+            topLeft: Vec4.start(top),
+            topRight: Vec4.end(top),
+            bottomLeft: Vec4.start(bottom),
+            bottomRight: Vec4.end(bottom),
+        };
+
+        const snap = {
+            vectors: {
+                topLeft: vectors.topRight,
+                bottomLeft: vectors.bottomRight,
+                topRight: vectors.topLeft,
+                bottomRight: vectors.bottomLeft,
+            },
+            angle: datum.snapToAngle,
+        };
+
+        const points = translate(vectors, offset, context, {
+            overflowContinuous: this.overflowContinuous,
+            translateVectors,
+            invertYVectors,
+            snap: allowSnapping ? snap : undefined,
+        });
+
+        datum.start.x = points.topLeft.x;
+        datum.start.y = points.topLeft.y;
+        datum.end.x = points.topRight.x;
+        datum.end.y = points.topRight.y;
+        datum.startHeight = points.topLeft.y - points.bottomLeft.y;
+        datum.endHeight = points.topRight.y - points.bottomRight.y;
     }
 
     protected override getTranslatePointsVectors(start: _ModuleSupport.Vec2, end: _ModuleSupport.Vec2) {

--- a/packages/ag-charts-enterprise/src/features/annotations/fibonacci-retracement-trend-based/fibonacciRetracementTrendBasedProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/fibonacci-retracement-trend-based/fibonacciRetracementTrendBasedProperties.ts
@@ -14,7 +14,7 @@ export class FibonacciRetracementTrendBasedProperties extends FibonacciPropertie
     }
 
     override isValidWithContext(context: AnnotationContext, warningPrefix?: string) {
-        return validateDatumLine(context, this, { y: false }, warningPrefix);
+        return validateDatumLine(context, this, { overflowContinuous: true }, warningPrefix);
     }
 
     @Validate(STRING)

--- a/packages/ag-charts-enterprise/src/features/annotations/fibonacci-retracement/fibonacciRetracementProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/fibonacci-retracement/fibonacciRetracementProperties.ts
@@ -13,7 +13,7 @@ export class FibonacciRetracementProperties extends FibonacciProperties {
     }
 
     override isValidWithContext(context: AnnotationContext, warningPrefix?: string) {
-        return validateDatumLine(context, this, { y: false }, warningPrefix);
+        return validateDatumLine(context, this, { overflowContinuous: true }, warningPrefix);
     }
 
     @Validate(STRING)

--- a/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelProperties.ts
@@ -58,8 +58,8 @@ export class ParallelChannelProperties extends Annotation(
     override isValidWithContext(context: AnnotationContext, warningPrefix?: string) {
         return (
             super.isValid(warningPrefix) &&
-            validateDatumLine(context, this, { y: false }, warningPrefix) &&
-            validateDatumLine(context, this.bottom, { y: false }, warningPrefix)
+            validateDatumLine(context, this, { overflowContinuous: true }, warningPrefix) &&
+            validateDatumLine(context, this.bottom, { overflowContinuous: true }, warningPrefix)
         );
     }
 

--- a/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/parallel-channel/parallelChannelScene.ts
@@ -1,5 +1,4 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { isNumber } from 'ag-charts-core';
 
 import type { AnnotationContext } from '../annotationTypes';
 import { AnnotationScene } from '../scenes/annotationScene';
@@ -7,15 +6,15 @@ import { ChannelScene } from '../scenes/channelScene';
 import { CollidableLine } from '../scenes/collidableLineScene';
 import { CollidableText } from '../scenes/collidableTextScene';
 import { DivariantHandle, UnivariantHandle } from '../scenes/handle';
+import { translate } from '../utils/coords';
 import { updateChannelText } from '../utils/lineWithText';
-import { getGroupingValue } from '../utils/scale';
-import { isPoint, validateDatumPoint } from '../utils/validation';
-import { invertCoords } from '../utils/values';
+import { convertLine } from '../utils/values';
 import type { ParallelChannelProperties } from './parallelChannelProperties';
 
 const { Vec2, Vec4 } = _ModuleSupport;
 
 type ChannelHandle = keyof ParallelChannelScene['handles'];
+type DivariantChannelHandle = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 
 export class ParallelChannelScene extends ChannelScene<ParallelChannelProperties> {
     static override is(value: unknown): value is ParallelChannelScene {
@@ -53,74 +52,66 @@ export class ParallelChannelScene extends ChannelScene<ParallelChannelProperties
         const { offset } = handles[activeHandle].drag(target);
         handles[activeHandle].toggleDragging(true);
 
-        const prev = datum.toJson();
-        let moves: Array<ChannelHandle> = [];
-        let origins: Array<ChannelHandle> = [];
+        if (activeHandle === 'topMiddle' || activeHandle === 'bottomMiddle') {
+            offset.x = 0;
+        }
+
+        let translateVectors: Array<DivariantChannelHandle> = [];
+        let allowSnapping = snapping;
 
         switch (activeHandle) {
             case 'topLeft':
             case 'bottomLeft':
-                moves = ['topLeft', 'bottomLeft'];
-                origins = ['topRight', 'bottomRight'];
+                translateVectors = ['topLeft', 'bottomLeft'];
                 break;
             case 'topMiddle':
-                moves = ['topLeft', 'topRight'];
+                translateVectors = ['topLeft', 'topRight'];
                 offset.y -= UnivariantHandle.HANDLE_SIZE / 2;
+                allowSnapping = false;
                 break;
             case 'topRight':
             case 'bottomRight':
-                moves = ['topRight', 'bottomRight'];
-                origins = ['topLeft', 'bottomLeft'];
+                translateVectors = ['topRight', 'bottomRight'];
                 break;
             case 'bottomMiddle':
-                moves = ['bottomLeft', 'bottomRight'];
+                translateVectors = ['bottomLeft', 'bottomRight'];
                 offset.y -= UnivariantHandle.HANDLE_SIZE / 2;
+                allowSnapping = false;
                 break;
         }
 
-        const angle = datum.snapToAngle;
-        const invertedMoves = moves
-            .map((handle, index) =>
-                snapping && origins[index]
-                    ? this.snapToAngle(target, context, handle, origins[index], angle)
-                    : invertCoords(Vec2.add(handles[handle].handle, offset), context)
-            )
-            .filter(isPoint);
+        const top = convertLine(datum, context);
+        const bottom = convertLine(datum.bottom, context);
+        if (!top || !bottom) return;
 
-        // Do not move any handles if some of them are trying to move to invalid points
-        if (invertedMoves.some((invertedMove) => !validateDatumPoint(context, invertedMove, { y: false }))) {
-            return;
-        }
+        const vectors = {
+            topLeft: Vec4.start(top),
+            topRight: Vec4.end(top),
+            bottomLeft: Vec4.start(bottom),
+            bottomRight: Vec4.end(bottom),
+        };
 
-        // Adjust the height if dragging a middle handle
-        const { value: startY } = getGroupingValue(datum.start.y);
-        if ((activeHandle === 'topMiddle' || activeHandle === 'bottomMiddle') && startY != null && isNumber(startY)) {
-            const topLeft = invertCoords(Vec2.add(handles.topLeft.handle, offset), context);
-            if (activeHandle === 'topMiddle') {
-                datum.height += topLeft.y - startY;
-            } else {
-                datum.height -= topLeft.y - startY;
-            }
-        }
+        const snap = {
+            vectors: {
+                topLeft: vectors.topRight,
+                bottomLeft: vectors.bottomRight,
+                topRight: vectors.topLeft,
+                bottomRight: vectors.bottomLeft,
+            },
+            angle: datum.snapToAngle,
+        };
 
-        // Move the start and end points if required
-        for (const [index, invertedMove] of invertedMoves.entries()) {
-            switch (moves[index]) {
-                case 'topLeft':
-                    datum.start.x = invertedMove.x;
-                    datum.start.y = invertedMove.y;
-                    break;
+        const points = translate(vectors, offset, context, {
+            overflowContinuous: this.overflowContinuous,
+            translateVectors,
+            snap: allowSnapping ? snap : undefined,
+        });
 
-                case 'topRight':
-                    datum.end.x = invertedMove.x;
-                    datum.end.y = invertedMove.y;
-                    break;
-            }
-        }
-
-        if (!datum.isValidWithContext(context)) {
-            datum.set(prev);
-        }
+        datum.start.x = points.topLeft.x;
+        datum.start.y = points.topLeft.y;
+        datum.end.x = points.topRight.x;
+        datum.end.y = points.topRight.y;
+        datum.height = points.topLeft.y - points.bottomLeft.y;
     }
 
     protected override getTranslatePointsVectors(start: _ModuleSupport.Vec2, end: _ModuleSupport.Vec2) {

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/channelScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/channelScene.ts
@@ -3,8 +3,7 @@ import { _ModuleSupport } from 'ag-charts-community';
 
 import type { ChannelTextProperties } from '../annotationProperties';
 import type { AnnotationContext, Point } from '../annotationTypes';
-import { snapToAngle } from '../utils/coords';
-import { convertLine, invertCoords } from '../utils/values';
+import { convertLine } from '../utils/values';
 import { CollidableLine } from './collidableLineScene';
 import type { CollidableText } from './collidableTextScene';
 import type { Handle } from './handle';
@@ -26,6 +25,7 @@ export abstract class ChannelScene<
     },
 > extends LinearScene<Datum> {
     protected handles: { [key: string]: Handle } = {};
+    protected override overflowContinuous = 2;
 
     protected topLine = new CollidableLine();
     protected bottomLine = new CollidableLine();
@@ -58,22 +58,6 @@ export abstract class ChannelScene<
         for (const handle of Object.values(this.handles)) {
             handle.toggleLocked(locked ?? false);
         }
-    }
-
-    snapToAngle(
-        target: _ModuleSupport.Vec2,
-        context: AnnotationContext,
-        handle: ChannelHandle,
-        originHandle: ChannelHandle,
-        angle: number,
-        direction?: number
-    ): Point | undefined {
-        const { handles } = this;
-
-        const fixed = handles[originHandle].handle;
-        const active = handles[handle].drag(target).point;
-
-        return invertCoords(snapToAngle(active, fixed, angle, direction), context);
     }
 
     override toggleHandles(show: boolean | Partial<Record<ChannelHandle, boolean>>) {

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/linearScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/linearScene.ts
@@ -24,6 +24,8 @@ export abstract class LinearScene<
         end: _ModuleSupport.Vec2;
     };
 
+    protected overflowContinuous = 0;
+
     protected extendLine({ x1, y1, x2, y2 }: _ModuleSupport.Vec4, datum: Datum, context: AnnotationContext) {
         // Clone the points to prevent mutating the original
         const linePoints = { x1, y1, x2, y2 };
@@ -126,7 +128,7 @@ export abstract class LinearScene<
     ) {
         const vectors = this.getTranslatePointsVectors(start, end);
         const points = translate(vectors, translation, context, {
-            overflowContinuous: Math.max(0, Object.keys(vectors).length - 2),
+            overflowContinuous: this.overflowContinuous,
         });
 
         datum.start.x = points.start.x;

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/pointScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/pointScene.ts
@@ -3,7 +3,6 @@ import { _ModuleSupport } from 'ag-charts-community';
 import type { AnnotationContext } from '../annotationTypes';
 import type { PointProperties } from '../properties/pointProperties';
 import { getDragStartState, translate } from '../utils/coords';
-import { validateDatumPoint } from '../utils/validation';
 import { convertPoint, invertCoords } from '../utils/values';
 import { AnnotationScene } from './annotationScene';
 import { DivariantHandle } from './handle';
@@ -42,14 +41,9 @@ export abstract class PointScene<Datum extends PointProperties> extends Annotati
 
     public drag(datum: Datum, target: _ModuleSupport.Vec2, context: AnnotationContext) {
         const { dragState } = this;
-
         if (datum.locked || !dragState) return;
 
-        const coords = Vec2.add(dragState.handle, Vec2.sub(target, dragState.offset));
-        const point = invertCoords(coords, context);
-
-        if (!validateDatumPoint(context, point)) return;
-
+        const { point } = translate({ point: dragState.handle }, Vec2.sub(target, dragState.offset), context);
         datum.x = point.x;
         datum.y = point.y;
     }
@@ -58,7 +52,6 @@ export abstract class PointScene<Datum extends PointProperties> extends Annotati
         if (datum.locked) return;
 
         const { point } = translate({ point: convertPoint(datum, context) }, translation, context);
-
         datum.x = point.x;
         datum.y = point.y;
     }

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/startEndScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/startEndScene.ts
@@ -1,16 +1,14 @@
 import { type AgAnnotationHandleStyles, _ModuleSupport } from 'ag-charts-community';
 import { entries } from 'ag-charts-core';
 
-import type { PointProperties } from '../annotationProperties';
 import type { AnnotationContext } from '../annotationTypes';
 import type { StartEndProperties } from '../properties/startEndProperties';
-import { snapToAngle } from '../utils/coords';
-import { validateDatumPoint } from '../utils/validation';
-import { convertLine, convertPoint, invertCoords } from '../utils/values';
+import { translate } from '../utils/coords';
+import { convertLine, convertPoint } from '../utils/values';
 import { DivariantHandle } from './handle';
 import { LinearScene } from './linearScene';
 
-const { Vec4 } = _ModuleSupport;
+const { Vec2, Vec4 } = _ModuleSupport;
 
 export type StartEndHandle = 'start' | 'end';
 
@@ -63,33 +61,21 @@ export abstract class StartEndScene<Datum extends StartEndProperties> extends Li
         if (!activeHandle || !dragState) return;
 
         this[activeHandle].toggleDragging(true);
-        const point = snapping
-            ? this.snapToAngle(datum, target, context)
-            : invertCoords(this[activeHandle].drag(target).point, context);
 
-        if (!point || !validateDatumPoint(context, point)) return;
+        const snapHandle = activeHandle === 'start' ? 'end' : 'start';
+        const snap = snapping
+            ? { vectors: { [activeHandle]: convertPoint(datum[snapHandle], context) }, angle: datum.snapToAngle }
+            : undefined;
+
+        const { [activeHandle]: point } = translate(
+            { [activeHandle]: dragState[activeHandle] },
+            Vec2.sub(target, dragState.offset),
+            context,
+            { overflowContinuous: 0, snap }
+        );
 
         datum[activeHandle].x = point.x;
         datum[activeHandle].y = point.y;
-    }
-
-    snapToAngle(
-        datum: Datum,
-        coords: _ModuleSupport.Vec2,
-        context: AnnotationContext
-    ): Pick<PointProperties, 'x' | 'y'> | undefined {
-        const { activeHandle } = this;
-
-        const handles: StartEndHandle[] = ['start', 'end'];
-        const fixedHandle = handles.find((handle) => handle !== activeHandle);
-
-        if (!activeHandle || !fixedHandle) return;
-
-        this[activeHandle].toggleDragging(true);
-
-        const fixed = convertPoint(datum[fixedHandle], context);
-
-        return invertCoords(snapToAngle(coords, fixed, datum.snapToAngle), context);
     }
 
     override stopDragging() {

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/textualStartEndScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/textualStartEndScene.ts
@@ -3,11 +3,10 @@ import { type AgAnnotationHandleStyles, _ModuleSupport } from 'ag-charts-communi
 import type { AnnotationContext } from '../annotationTypes';
 import type { TextualStartEndProperties } from '../properties/textualStartEndProperties';
 import { getBBox, updateTextNode } from '../text/util';
-import { validateDatumPoint } from '../utils/validation';
-import { convertLine, invertCoords } from '../utils/values';
+import { convertLine } from '../utils/values';
 import { StartEndScene } from './startEndScene';
 
-const { Vec2, Vec4 } = _ModuleSupport;
+const { Vec4 } = _ModuleSupport;
 
 export abstract class TextualStartEndScene<Datum extends TextualStartEndProperties> extends StartEndScene<Datum> {
     override activeHandle?: 'start' | 'end';
@@ -41,25 +40,8 @@ export abstract class TextualStartEndScene<Datum extends TextualStartEndProperti
         this.updateAnchor(datum, coords, context, bbox);
     }
 
-    override dragHandle(datum: Datum, target: _ModuleSupport.Vec2, context: AnnotationContext, snapping: boolean) {
-        const { activeHandle, dragState } = this;
-
-        if (!activeHandle || !dragState) return;
-
-        this[activeHandle].toggleDragging(true);
-        const coords = Vec2.add(dragState.end, Vec2.sub(target, dragState.offset));
-        const point = snapping ? this.snapToAngle(datum, coords, context) : invertCoords(coords, context);
-
-        if (!point || !validateDatumPoint(context, point)) return;
-
-        datum[activeHandle].x = point.x;
-        datum[activeHandle].y = point.y;
-    }
-
     override containsPoint(x: number, y: number) {
-        const { label } = this;
-
-        return super.containsPoint(x, y) || label.containsPoint(x, y);
+        return super.containsPoint(x, y) || this.label.containsPoint(x, y);
     }
 
     public override getNodeAtCoords(x: number, y: number): string | undefined {

--- a/packages/ag-charts-enterprise/src/features/annotations/utils/coords.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/utils/coords.ts
@@ -4,7 +4,7 @@ import { entries } from 'ag-charts-core';
 import type { AnnotationContext, Point } from '../annotationTypes';
 import { convertPoint, invertCoords } from './values';
 
-const { Vec2, toRadians } = _ModuleSupport;
+const { ContinuousScale, Vec2, toRadians } = _ModuleSupport;
 
 export function snapPoint(
     offset: _ModuleSupport.Vec2,
@@ -19,23 +19,12 @@ export function snapPoint(
     return invertCoords(snapToAngle(offset, center, angleStep), context);
 }
 
-export function snapToAngle(
-    { x, y }: _ModuleSupport.Vec2,
-    center: _ModuleSupport.Vec2,
-    step: number,
-    direction: number = 1
-) {
-    const { x: cx, y: cy } = center;
-    const r = Math.sqrt(Math.pow(x - cx, 2) + Math.pow(y - cy, 2));
-    const theta = Math.atan2(y - cy, x - cx);
-
+export function snapToAngle(vector: _ModuleSupport.Vec2, center: _ModuleSupport.Vec2, step: number) {
+    const radial = Vec2.sub(vector, center);
     const stepRadians = toRadians(step);
-    const snapTheta = Math.round(theta / stepRadians) * stepRadians;
+    const theta = Math.round(Vec2.angle(radial) / stepRadians) * stepRadians;
 
-    return {
-        x: cx + r * Math.cos(snapTheta),
-        y: cy + r * Math.sin(snapTheta) * direction,
-    };
+    return Vec2.rotate(radial, theta, center);
 }
 
 export function getDragStartState<PointName extends string>(
@@ -51,39 +40,103 @@ export function getDragStartState<PointName extends string>(
     return dragState;
 }
 
+/**
+ * Translate an collection of vectors by the given translation. Clamp the vectors as a group within the series area.
+ *
+ * @param vectors The collection of vectors to translate.
+ * @param translation The translation to apply to the vectors.
+ * @param context Annotation context.
+ * @param options.overflowContinuous The tolerance for how many vectors can overflow before the group is clamped.
+ * @param options.snap Snap by which vector and at what angle.
+ * @param options.translateVectors Which vectors should be considered as currently translating.
+ * @param options.invertYVectors Invert the y-axis translation for these vectors.
+ * @returns A collection of translated points in domain space.
+ */
 export function translate<VectorName extends string>(
     vectors: Record<VectorName, _ModuleSupport.Vec2>,
     translation: _ModuleSupport.Vec2,
     context: AnnotationContext,
-    options: { overflowContinuous: number } = { overflowContinuous: 0 }
+    options: {
+        overflowContinuous: number;
+        translateVectors?: VectorName[];
+        invertYVectors?: VectorName[];
+        snap?: {
+            vectors: Record<VectorName, _ModuleSupport.Vec2>;
+            angle: number;
+        };
+    } = {
+        overflowContinuous: 0,
+        translateVectors: undefined,
+        invertYVectors: undefined,
+        snap: undefined,
+    }
 ) {
     const { xAxis, yAxis } = context;
     const vectorNames = Object.keys(vectors) as VectorName[];
     const overflowsX: number[] = [];
     const overflowsY: number[] = [];
 
+    const translateVectors = new Set(options.translateVectors ?? vectorNames);
+    const invertYVectors = new Set(options.invertYVectors ?? []);
+    const movingVectors = new Set([...translateVectors, ...invertYVectors]);
+    const invertYTranslation = Vec2.multiply(translation, Vec2.from(1, -1));
+
     for (const name of vectorNames) {
-        vectors[name] = Vec2.add(vectors[name], translation);
+        if (movingVectors.has(name)) {
+            vectors[name] = Vec2.add(vectors[name], invertYVectors.has(name) ? invertYTranslation : translation);
+            if (options.snap) {
+                vectors[name] = snapToAngle(vectors[name], options.snap.vectors[name], options.snap.angle);
+            }
+        }
 
         overflowsX.push(xAxis.getRangeOverflow(vectors[name].x));
         overflowsY.push(yAxis.getRangeOverflow(vectors[name].y));
     }
 
-    const sortedOverflowsX = overflowsX.toSorted((a, b) => Math.abs(a) - Math.abs(b));
-    const sortedOverflowsY = overflowsY.toSorted((a, b) => Math.abs(a) - Math.abs(b));
+    const sortNumbersAbs = (a: number, b: number) => Math.abs(a) - Math.abs(b);
 
-    const overflow = Vec2.from(sortedOverflowsX.at(-1) ?? 0, sortedOverflowsY.at(-1) ?? 0);
+    const overflowDirection = (
+        scale: _ModuleSupport.Scale<any, any>,
+        directionTranslation: number,
+        overflows: number[]
+    ) => {
+        // Explicitly test the scales because ordinal time axes report as continuous. When there is no tolerance for
+        // overflowing, take the largest overflow
+        if (options.overflowContinuous === 0 || !ContinuousScale.is(scale)) {
+            return overflows.toSorted(sortNumbersAbs).at(-1) ?? 0;
+        }
 
-    // Explicitly test the scales because ordinal time axes report as continuous
-    if (_ModuleSupport.ContinuousScale.is(xAxis.scale) && options.overflowContinuous > 0) {
-        overflow.x = sortedOverflowsX.at(-options.overflowContinuous - 1) ?? 0;
-    }
-    if (_ModuleSupport.ContinuousScale.is(yAxis.scale) && options.overflowContinuous > 0) {
-        overflow.y = sortedOverflowsY.at(-options.overflowContinuous - 1) ?? 0;
-    }
+        // When translating all vectors, we just want to get the largest overflow
+        if (vectorNames.length === movingVectors.size) {
+            return overflows.toSorted(sortNumbersAbs).at(-options.overflowContinuous - 1) ?? 0;
+        }
+
+        // When translating only some vectors but we are still within the tolerance, pretend there is no overflow
+        if (overflows.filter((value) => value !== 0).length <= options.overflowContinuous) {
+            return 0;
+        }
+
+        // When translating only some vectors, and enough are overflowing, only consider the vectors that are
+        // overflowing by less than the translation, i.e. are newly overflowing with this current action
+        const newTranslatedOverflows = overflows.filter(
+            (value, index) =>
+                value !== 0 &&
+                Math.abs(value) <= Math.abs(directionTranslation) &&
+                movingVectors.has(vectorNames[index])
+        );
+        return newTranslatedOverflows.toSorted(sortNumbersAbs).at(-1) ?? 0;
+    };
+
+    const overflow = Vec2.from(
+        overflowDirection(xAxis.scale, translation.x, overflowsX),
+        overflowDirection(yAxis.scale, translation.y, overflowsY)
+    );
 
     if (!Vec2.equal(overflow, Vec2.origin())) {
         for (const name of vectorNames) {
+            // Only apply the overflow adjustment to those vectors being moved
+            if (!movingVectors.has(name)) continue;
+
             // Round to prevent slight adjustments from floating point imprecision
             vectors[name] = Vec2.round(Vec2.sub(vectors[name], overflow), 4);
         }

--- a/packages/ag-charts-enterprise/src/features/annotations/utils/validation.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/utils/validation.ts
@@ -4,16 +4,18 @@ import { Logger } from 'ag-charts-core';
 import type { AnnotationAxisContext, AnnotationContext, Point } from '../annotationTypes';
 import { getGroupingValue } from './scale';
 
+const { ContinuousScale } = _ModuleSupport;
+
 export function validateDatumLine(
     context: AnnotationContext,
     datum: { start: Point; end: Point },
-    directions?: Partial<Record<_ModuleSupport.ChartAxisDirection, boolean>>,
+    options: { overflowContinuous: boolean } = { overflowContinuous: false },
     warningPrefix?: string
 ) {
     let valid = true;
 
-    valid &&= validateDatumPoint(context, datum.start, directions, warningPrefix && `${warningPrefix}[start] `);
-    valid &&= validateDatumPoint(context, datum.end, directions, warningPrefix && `${warningPrefix}[end] `);
+    valid &&= validateDatumPoint(context, datum.start, options, warningPrefix && `${warningPrefix}[start] `);
+    valid &&= validateDatumPoint(context, datum.end, options, warningPrefix && `${warningPrefix}[end] `);
 
     return valid;
 }
@@ -37,7 +39,7 @@ export function validateDatumValue(
 export function validateDatumPoint(
     context: AnnotationContext,
     point: Point,
-    directions?: Partial<Record<_ModuleSupport.ChartAxisDirection, boolean>>,
+    options: { overflowContinuous: boolean } = { overflowContinuous: false },
     warningPrefix?: string
 ) {
     if (point.x == null || point.y == null) {
@@ -47,22 +49,26 @@ export function validateDatumPoint(
         return false;
     }
 
-    const validX = directions?.x === false ? true : validateDatumPointDirection(point.x, context.xAxis);
-    const validY = directions?.y === false ? true : validateDatumPointDirection(point.y, context.yAxis);
+    const { xAxis, yAxis } = context;
 
-    if (!validX || !validY) {
+    // Explicitly test the scales because ordinal time axes report as continuous
+    const continuousX = options.overflowContinuous && ContinuousScale.is(xAxis.scale);
+    const continuousY = options.overflowContinuous && ContinuousScale.is(yAxis.scale);
+    const validX = continuousX || validateDatumPointDirection(point.x, xAxis);
+    const validY = continuousY || validateDatumPointDirection(point.y, yAxis);
+
+    if (validX && validY) return true;
+
+    if (warningPrefix) {
         let text = 'x & y domains';
         if (validX) text = 'y domain';
         if (validY) text = 'x domain';
-        if (warningPrefix) {
-            const { value: xValue } = getGroupingValue(point.x);
-            const { value: yValue } = getGroupingValue(point.y);
-            Logger.warnOnce(`${warningPrefix}is outside the ${text}, ignoring. - x: [${xValue}], y: ${yValue}]`);
-        }
-        return false;
+        const { value: xValue } = getGroupingValue(point.x);
+        const { value: yValue } = getGroupingValue(point.y);
+        Logger.warnOnce(`${warningPrefix}is outside the ${text}, ignoring. - x: [${xValue}], y: ${yValue}]`);
     }
 
-    return true;
+    return false;
 }
 
 function validateDatumPointDirection(d: any, context: AnnotationAxisContext) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13707

- When channels dragged by a single handle, it allows 2 of the handles to be dragged outside a continuous domain
- Remove validation from annotations except when restoring. This was preventing annotations from being dragged outside the domains, but this is now managed more precisely by the `translate()` fn.
  - I will split out a new ticket related to this but a tangent from this bug to refactor the `initialState` annotation validation to use the new validation methods and perhaps become part of the annotation manager instead.