### PR TITLE
Re-enable Angular example tests.

### DIFF
--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -5,7 +5,7 @@ import glob from 'glob';
 import { expect, test } from './fixture';
 
 const baseUrl = process.env.PUBLIC_SITE_URL;
-const fws = [/*'vanilla', 'typescript', 'reactFunctional', 'reactFunctionalTs', */ 'angular' /*, 'vue3'*/] as const;
+const fws = ['vanilla', 'typescript', 'reactFunctional', 'reactFunctionalTs', 'angular', 'vue3'] as const;
 
 export const SELECTORS = {
     wrapper: '.ag-charts-wrapper',

--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -5,7 +5,7 @@ import glob from 'glob';
 import { expect, test } from './fixture';
 
 const baseUrl = process.env.PUBLIC_SITE_URL;
-const fws = ['vanilla', 'typescript', 'reactFunctional', 'reactFunctionalTs', /*'angular',*/ 'vue3'] as const;
+const fws = [/*'vanilla', 'typescript', 'reactFunctional', 'reactFunctionalTs', */ 'angular' /*, 'vue3'*/] as const;
 
 export const SELECTORS = {
     wrapper: '.ag-charts-wrapper',

--- a/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
+++ b/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.dev.js
@@ -1,5 +1,5 @@
 (function (global) {
-    var ANGULAR_VERSION = '^19';
+    var ANGULAR_VERSION = '19.1.7';
 
     System.config({
         // DEMO ONLY! REAL CODE SHOULD NOT TRANSPILE IN THE BROWSER

--- a/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.js
+++ b/packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/systemjs.config.js
@@ -1,5 +1,5 @@
 (function (global) {
-    var ANGULAR_VERSION = '^19';
+    var ANGULAR_VERSION = '19.1.7';
 
     var sjsPaths = {};
     if (typeof systemJsPaths !== 'undefined') {


### PR DESCRIPTION
- **Pin Angular version to avoid 19.1.8.** due to `No value provided for @angular/core symbol 'ɵɵInputTransformsFeature'.` errors.
