### PR TITLE
AG-14319 Update palette fills to take gradients

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/themes.test.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.test.ts
@@ -158,7 +158,7 @@ describe('themes module', () => {
         expectWarningsCalls().toMatchInlineSnapshot(`
 [
   [
-    "AG Charts - Option \`theme.palette.fills\` cannot be set to \`"red"\`; expecting a color array, ignoring.",
+    "AG Charts - Option \`theme.palette.fills\` cannot be set to \`"red"\`; expecting a color or a gradient object array, ignoring.",
   ],
   [
     "AG Charts - Option \`theme.palette.strokes\` cannot be set to \`"black"\`; expecting a color array, ignoring.",

--- a/packages/ag-charts-community/src/chart/mapping/themes.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.ts
@@ -1,4 +1,4 @@
-import { Logger, type OptionsDefs, arrayOf, color, object, or, string, validate } from 'ag-charts-core';
+import { Logger, type OptionsDefs, arrayOf, color, gradient, object, or, string, validate } from 'ag-charts-core';
 import type {
     AgChartTheme,
     AgChartThemeName,
@@ -111,7 +111,7 @@ const themeOptionsDef: OptionsDefs<AgChartTheme> = {
     overrides: object,
     params: object,
     palette: {
-        fills: arrayOf(color),
+        fills: arrayOf(or(color, gradient)),
         strokes: arrayOf(color),
         up: { fill: color, stroke: color },
         down: { fill: color, stroke: color },

--- a/packages/ag-charts-community/src/chart/series/polar/pieTheme.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieTheme.ts
@@ -34,7 +34,22 @@ export const pieTheme: ExtensibleTheme<'pie'> = {
             length: 10,
             strokeWidth: 2,
             colors: {
-                $if: [{ $eq: [{ $path: '../strokeWidth' }, 0] }, { $path: '../fills' }, { $path: '../strokes' }],
+                $map: [
+                    {
+                        $if: [
+                            { $isGradient: [{ $value: '$1' }] },
+                            { $path: ['../../strokes/$index', { $ref: 'foregroundColor' }] },
+                            { $value: '$1' },
+                        ],
+                    },
+                    {
+                        $if: [
+                            { $eq: [{ $path: '../strokeWidth' }, 0] },
+                            { $path: '../fills' },
+                            { $path: '../strokes' },
+                        ],
+                    },
+                ],
             },
         },
         fills: { $palette: 'fills' },

--- a/packages/ag-charts-community/src/util/json.test.ts
+++ b/packages/ag-charts-community/src/util/json.test.ts
@@ -783,6 +783,29 @@ describe('json module', () => {
             expect(source).toEqual({ a: '#808080' });
         });
 
+        it('should resolve `$mix` operation with gradients', () => {
+            const source = {
+                a: {
+                    $mix: [
+                        {
+                            type: 'gradient',
+                            colorStops: [{ color: '#ffffff' }, { color: '#ffff00', stop: 0.3 }, { color: '#ff0000' }],
+                        },
+                        '#000000',
+                        0.5,
+                    ],
+                },
+            };
+            jsonResolveOperations(source, {});
+            expect(source).toEqual({
+                a: {
+                    type: 'gradient',
+                    colorStops: [{ color: '#808080' }, { color: '#808000', stop: 0.3 }, { color: '#800000' }],
+                },
+            });
+        });
+
+        // Combined
         it('should resolve nested operations', () => {
             const source = {
                 a: { $ref: 'indirectRelative' },

--- a/packages/ag-charts-community/src/util/json.ts
+++ b/packages/ag-charts-community/src/util/json.ts
@@ -12,6 +12,7 @@ import {
     isString,
 } from 'ag-charts-core';
 import type { DeepPartial, PlainObject } from 'ag-charts-core';
+import type { AgGradientFill } from 'ag-charts-types';
 
 import { Color } from './color';
 import { SKIP_JS_BUILTINS, getPath, mergeDefaults } from './object';
@@ -432,6 +433,7 @@ enum ColorOperation {
     ForegroundBackgroundMix = '$foregroundBackgroundMix',
     ForegroundBackgroundAccentMix = '$foregroundBackgroundAccentMix',
     Interpolate = '$interpolate',
+    IsGradient = '$isGradient',
 }
 
 type Operation =
@@ -473,11 +475,20 @@ function resolveOperation<T extends object, P extends object>(
 }
 
 function isKey<T extends object>(key: unknown, obj: T): key is keyof T & string {
-    return isString(key) && obj != null && key in obj;
+    return isString(key) && (isObject(obj) || isArray(obj)) && key in obj;
 }
 
 function isRatio(value: unknown): value is number {
     return isNumber(value) && value >= 0 && value <= 1;
+}
+
+// Duplicates `isGradientFill()` from `../scene/util/fill` due to dependency violations
+function isGradientFill(fill: any): fill is AgGradientFill {
+    return (
+        fill !== null &&
+        isObject(fill) &&
+        (fill.type == 'gradient' || fill.type === 'radial-gradient' || fill.type === 'conic-gradient')
+    );
 }
 
 function resolvePath(root: string[], path: string) {
@@ -488,10 +499,11 @@ function resolvePath(root: string[], path: string) {
         relativePathParts.shift();
     }
 
+    let prevPartWasTwoDots = false;
     for (const part of relativePathParts) {
         if (part === '..') {
             resolvedPath.pop();
-            resolvedPath.pop();
+            if (!prevPartWasTwoDots) resolvedPath.pop();
         } else if (part === '.') {
             resolvedPath.pop();
         } else if (part === '$index') {
@@ -500,6 +512,8 @@ function resolvePath(root: string[], path: string) {
         } else if (part.length !== 0) {
             resolvedPath.push(part);
         }
+
+        prevPartWasTwoDots = part === '..';
     }
 
     return resolvedPath;
@@ -552,6 +566,7 @@ const colorOperations: Record<ColorOperation, OperationFn> = {
     $foregroundBackgroundMix: foregroundBackgroundMix,
     $foregroundBackgroundAccentMix: foregroundBackgroundAccentMix,
     $interpolate: interpolate,
+    $isGradient: ([value]: string | Array<unknown>) => isGradientFill(value),
 };
 
 const operations: Record<Operation, OperationFn<any, any>> = {
@@ -777,16 +792,43 @@ function rem<P extends object>([a]: string | Array<unknown>, path: string[], par
 }
 
 function mix([a, b, c]: string | Array<unknown>, path: string[]) {
-    if (typeof a === 'string' && typeof b === 'string' && isRatio(c)) {
+    const warningPrefix = `\`$mix\` json operation failed on [${String(a)}, ${String(b)}, ${String(c)}] at [${path.join('.')}], expecting`;
+    const warningMessage = `${warningPrefix} two colors and a number between 0 and 1.`;
+
+    if (typeof b !== 'string' || !isRatio(c)) {
+        Logger.warnOnce(warningMessage);
+        return;
+    }
+
+    if (typeof a === 'string') {
         try {
             return Color.mix(Color.fromString(a), Color.fromString(b), c).toString();
         } catch {
-            // Discard and log below
+            Logger.warnOnce(warningMessage);
+            return;
         }
     }
-    Logger.warnOnce(
-        `\`$mix\` json operation failed on [${String(a)}, ${String(b)}, ${String(c)}] at [${path.join('.')}], expecting two colors and a number between 0 and 1.`
-    );
+
+    if (!isGradientFill(a)) {
+        Logger.warnOnce(warningMessage);
+        return;
+    }
+
+    let colorStops = a.colorStops;
+    try {
+        colorStops = colorStops?.map((value) => {
+            let color;
+            if (typeof value.color === 'string') {
+                color = Color.mix(Color.fromString(value.color), Color.fromString(b), c).toString();
+            }
+            return { ...value, color };
+        });
+    } catch {
+        Logger.warnOnce(`${warningPrefix} a gradient, a color and a number between 0 and 1.`);
+        return;
+    }
+
+    return { ...a, colorStops };
 }
 
 function foregroundBackgroundMix<P extends object>([background]: string | Array<unknown>, path: string[], params: P) {

--- a/packages/ag-charts-types/src/chart/operationOptions.ts
+++ b/packages/ag-charts-types/src/chart/operationOptions.ts
@@ -68,7 +68,7 @@ type PaletteParam =
 type PathOperation =
     | { $ref: ThemeParam }
     | { $palette: PaletteParam }
-    | { $path: string | [string, Leaf] | [string, Leaf, Leaf] };
+    | { $path: Leaf<string> | [Leaf<string>, Leaf] | [Leaf<string>, Leaf, Leaf] };
 
 type LogicOperation =
     | { $if: [Leaf, Leaf, Leaf] }
@@ -91,4 +91,5 @@ type ColorOperation =
     | { $mix: [Leaf<string>, Leaf<string>, Leaf<number>] }
     | { $foregroundBackgroundMix: [Leaf<number>] }
     | { $foregroundBackgroundAccentMix: [Leaf<number>, Leaf<number>] }
-    | { $interpolate: [Leaf, Leaf<number>] };
+    | { $interpolate: [Leaf, Leaf<number>] }
+    | { $isGradient: [Leaf] };

--- a/packages/ag-charts-types/src/chart/themeOptions.ts
+++ b/packages/ag-charts-types/src/chart/themeOptions.ts
@@ -8,6 +8,7 @@ import type { AgBubbleSeriesThemeableOptions } from '../series/cartesian/bubbleO
 import type { AgCandlestickSeriesThemeableOptions } from '../series/cartesian/candlestickOptions';
 import type { AgBaseCartesianThemeOptions, AgCartesianAxesTheme } from '../series/cartesian/cartesianOptions';
 import type { AgCartesianSeriesOptions } from '../series/cartesian/cartesianSeriesTypes';
+import type { AgFillType } from '../series/cartesian/commonOptions';
 import type { AgConeFunnelSeriesThemeableOptions } from '../series/cartesian/coneFunnelOptions';
 import type { AgFunnelSeriesThemeableOptions } from '../series/cartesian/funnelOptions';
 import type { AgHeatmapSeriesThemeableOptions } from '../series/cartesian/heatmapOptions';
@@ -71,7 +72,7 @@ export interface AgPaletteColors {
  */
 export interface AgChartThemePalette {
     /** The array of fills to be used. */
-    fills?: CssColor[];
+    fills?: AgFillType[];
     /** The array of strokes to be used. */
     strokes?: CssColor[];
     up?: AgPaletteColors;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14319

- Callout lines check if it is a gradient and then pick the stroke instead (or foreground color if no stroke for that index)
- Box plot mixes the palette fill with the background, so `$mix` can now handle gradients