### PR TITLE
AG-8876 Add `MenuWidget` class and use it in `contextMenu.ts`

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
@@ -2,6 +2,7 @@ import type { Writeable } from 'ag-charts-core';
 import type { AgContextMenuItemLiteral, AgContextMenuItemShowOn } from 'ag-charts-types';
 
 import { BaseManager } from '../../util/baseManager';
+import type { MouseWidgetEvent } from '../../widget/widgetEvents';
 import type { ContextMenuCallback, ContextMenuEvent, ContextMenuEventType, ContextShowOnMap } from './contextMenuTypes';
 import { ContextMenuBuiltins } from './contextMenuTypes';
 
@@ -33,19 +34,19 @@ export class ContextMenuRegistry extends BaseManager<ContextMenuEventType, Conte
 
     public dispatchContext<T extends AgContextMenuItemShowOn>(
         showOn: T,
-        pointerEvent: { sourceEvent: MouseEvent; canvasX: number; canvasY: number },
+        pointerEvent: { widgetEvent: MouseWidgetEvent<'contextmenu'>; canvasX: number; canvasY: number },
         context: ContextShowOnMap[T]['context'],
         position?: { x: number; y: number }
     ) {
-        const { sourceEvent } = pointerEvent;
-        if (sourceEvent.defaultPrevented) {
+        const { widgetEvent } = pointerEvent;
+        if (widgetEvent.sourceEvent.defaultPrevented) {
             // AG-12894 'contextmenu' event bubbles, do not re-dispatch ContextMenuEvent if we're already draw own menu
             return;
         }
         const x = position?.x ?? pointerEvent.canvasX;
         const y = position?.y ?? pointerEvent.canvasY;
 
-        const event: Writeable<ContextMenuEvent> = { type: 'context-setup', showOn, x, y, context, sourceEvent };
+        const event: Writeable<ContextMenuEvent> = { type: 'context-setup', showOn, x, y, context, widgetEvent };
         this.listeners.dispatch('context-setup', event);
 
         event.type = 'context-complete';

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
@@ -7,6 +7,7 @@ import type {
     AgContextMenuItemShowOn,
 } from 'ag-charts-types';
 
+import type { MouseWidgetEvent } from '../../widget/widgetEvents';
 import type { CategoryLegendDatum } from '../legend/legendDatum';
 import type { ISeries, SeriesNodeDatum } from '../series/seriesTypes';
 
@@ -57,7 +58,7 @@ export type ContextMenuEvent<K extends AgContextMenuItemShowOn = AgContextMenuIt
     readonly x: number;
     readonly y: number;
     readonly context: Readonly<ContextShowOnMap[K]['context']>;
-    readonly sourceEvent: MouseEvent & Partial<Pick<PointerEvent, 'pointerType'>>;
+    readonly widgetEvent: MouseWidgetEvent<'contextmenu'> & { sourceEvent: Partial<Pick<PointerEvent, 'pointerType'>> };
 };
 
 export type ContextMenuCallback<K extends AgContextMenuItemShowOn> = ContextShowOnMap[K]['callback'];

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -35,6 +35,7 @@ import { ObserveChanges } from '../../util/proxy';
 import { CachedTextMeasurerPool, TextUtils } from '../../util/textMeasurer';
 import { TextWrapper } from '../../util/textWrapper';
 import type { SwitchWidget } from '../../widget/switchWidget';
+import type { MouseWidgetEvent } from '../../widget/widgetEvents';
 import { ChartUpdateType } from '../chartUpdateType';
 import type { Page } from '../gridLayout';
 import { gridLayout } from '../gridLayout';
@@ -860,7 +861,8 @@ export class Legend extends BaseProperties {
         this.doDoubleClick(params.event, this.findNode(params).datum);
     }
 
-    onContextClick(sourceEvent: MouseEvent, node: LegendMarkerLabel) {
+    onContextClick(widgetEvent: MouseWidgetEvent<'contextmenu'>, node: LegendMarkerLabel) {
+        const { sourceEvent } = widgetEvent;
         const legendItem: CategoryLegendDatum = node.datum;
         if (this.preventHidingAll && this.contextMenuDatum?.enabled && this.getVisibleItemCount() <= 1) {
             this.ctx.contextMenuRegistry.builtins.items['toggle-series-visibility'].enable = false;
@@ -870,7 +872,7 @@ export class Legend extends BaseProperties {
 
         const { offsetX, offsetY } = sourceEvent;
         const { x: canvasX, y: canvasY } = Transformable.toCanvasPoint(node, offsetX, offsetY);
-        this.ctx.contextMenuRegistry.dispatchContext('legend-item', { sourceEvent, canvasX, canvasY }, { legendItem });
+        this.ctx.contextMenuRegistry.dispatchContext('legend-item', { widgetEvent, canvasX, canvasY }, { legendItem });
     }
 
     onClick(event: Event, datum: CategoryLegendDatum, proxyButton: SwitchWidget) {

--- a/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
@@ -152,8 +152,10 @@ export class LegendDOMProxy {
                 const margin = (maxHeight - height) / 2; // CRT-543 Give the legend items the same heights for a better look.
                 const bbox: BBoxValues = { x: x - groupBBox.x, y: y - margin - groupBBox.y, height: maxHeight, width };
 
+                const enabled = interactive && visible;
                 l.proxyButton.setCursor('pointer');
-                l.proxyButton.setEnabled(interactive && visible);
+                l.proxyButton.setEnabled(enabled);
+                l.proxyButton.setPointerEvents(enabled ? undefined : 'none');
                 l.proxyButton.setBounds(bbox);
             }
         });

--- a/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
@@ -25,7 +25,7 @@ interface ButtonListener {
     onDoubleClick(event: MouseEvent, datum: CategoryLegendDatum): void;
     onHover(event: FocusEvent | MouseEvent, node: LegendMarkerLabel): void;
     onLeave(): void;
-    onContextClick(sourceEvent: MouseEvent, node: LegendMarkerLabel): void;
+    onContextClick(widgetEvent: MouseWidgetEvent<'contextmenu'>, node: LegendMarkerLabel): void;
 }
 
 type LegendDOMProxyUpdateParams = {
@@ -110,7 +110,7 @@ export class LegendDOMProxy {
             button.addListener('dblclick', (ev) => itemListener.onDoubleClick(ev.sourceEvent, markerLabel.datum));
             button.addListener('mouseenter', (ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
             button.addListener('mouseleave', () => itemListener.onLeave());
-            button.addListener('contextmenu', (ev) => itemListener.onContextClick(ev.sourceEvent, markerLabel));
+            button.addListener('contextmenu', (ev) => itemListener.onContextClick(ev, markerLabel));
             button.addListener('blur', () => itemListener.onLeave());
             button.addListener('focus', (ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
             // Enable touch long-tap context menus:

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -311,7 +311,7 @@ export class SeriesAreaManager extends BaseManager {
                 const { currentX: canvasX, currentY: canvasY } = event;
                 this.chart.ctx.contextMenuRegistry.dispatchContext(
                     'always',
-                    { sourceEvent, canvasX, canvasY },
+                    { widgetEvent: event, canvasX, canvasY },
                     undefined
                 );
             }
@@ -345,14 +345,14 @@ export class SeriesAreaManager extends BaseManager {
         if (pickedSeries && pickedNode) {
             this.chart.ctx.contextMenuRegistry.dispatchContext(
                 'series-node',
-                { sourceEvent, canvasX, canvasY },
+                { widgetEvent: event, canvasX, canvasY },
                 { pickedSeries, pickedNode },
                 position
             );
         } else {
             this.chart.ctx.contextMenuRegistry.dispatchContext(
                 'series-area',
-                { sourceEvent, canvasX, canvasY },
+                { widgetEvent: event, canvasX, canvasY },
                 undefined,
                 position
             );

--- a/packages/ag-charts-community/src/util/attributeUtil.ts
+++ b/packages/ag-charts-community/src/util/attributeUtil.ts
@@ -9,6 +9,8 @@ type AriaRole =
     | 'img'
     | 'list'
     | 'listitem'
+    | 'menu'
+    | 'menuitem'
     | 'radio'
     | 'radiogroup'
     | 'status'

--- a/packages/ag-charts-community/src/util/keynavUtil.ts
+++ b/packages/ag-charts-community/src/util/keynavUtil.ts
@@ -1,7 +1,9 @@
 import { getAttribute, setAttribute } from './attributeUtil';
 
+type DestroyFns = { push(...args: (() => void)[]): void };
+
 function addRemovableEventListener<K extends keyof WindowEventMap>(
-    destroyFns: (() => void)[],
+    destroyFns: DestroyFns,
     elem: Window,
     type: K,
     listener: (this: Window, ev: WindowEventMap[K]) => any,
@@ -9,7 +11,7 @@ function addRemovableEventListener<K extends keyof WindowEventMap>(
 ): () => void;
 
 function addRemovableEventListener<K extends keyof HTMLElementEventMap>(
-    destroyFns: (() => void)[],
+    destroyFns: DestroyFns,
     elem: HTMLElement,
     type: K,
     listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
@@ -17,7 +19,7 @@ function addRemovableEventListener<K extends keyof HTMLElementEventMap>(
 ): () => void;
 
 function addRemovableEventListener<K extends keyof (HTMLElementEventMap | WindowEventMap)>(
-    destroyFns: (() => void)[],
+    destroyFns: DestroyFns,
     elem: HTMLElement | Window,
     type: K,
     listener: (this: unknown, ev: unknown) => unknown,
@@ -29,8 +31,8 @@ function addRemovableEventListener<K extends keyof (HTMLElementEventMap | Window
     return remover;
 }
 
-function addEscapeEventListener(
-    destroyFns: (() => void)[],
+export function addEscapeEventListener(
+    destroyFns: DestroyFns,
     elem: HTMLElement,
     onEscape: (event: KeyboardEvent) => void
 ) {
@@ -41,7 +43,7 @@ function addEscapeEventListener(
     });
 }
 
-function addMouseCloseListener(destroyFns: (() => void)[], menu: HTMLElement, hideCallback: () => void): () => void {
+export function addMouseCloseListener(destroyFns: DestroyFns, menu: HTMLElement, hideCallback: () => void): () => void {
     const self = addRemovableEventListener(destroyFns, window, 'mousedown', (event: MouseEvent) => {
         if ([0, 2].includes(event.button) && !containsPoint(menu, event)) {
             hideCallback();
@@ -51,7 +53,7 @@ function addMouseCloseListener(destroyFns: (() => void)[], menu: HTMLElement, hi
     return self;
 }
 
-function addTouchCloseListener(destroyFns: (() => void)[], menu: HTMLElement, hideCallback: () => void): () => void {
+export function addTouchCloseListener(destroyFns: DestroyFns, menu: HTMLElement, hideCallback: () => void): () => void {
     const self = addRemovableEventListener(destroyFns, window, 'touchstart', (event: TouchEvent) => {
         const touches = Array.from(event.targetTouches);
         if (touches.some((touch) => !containsPoint(menu, touch))) {
@@ -69,6 +71,32 @@ function containsPoint(container: Element, event: Pick<MouseEvent & TouchEvent, 
         return ex >= x && ey >= y && ex <= x + width && ey <= y + height;
     }
     return false;
+}
+
+export function addAutoCloseOnBlurEventListener(destroyFns: DestroyFns, buttons: HTMLElement[], hideCb: () => void) {
+    const handler = (ev: FocusEvent) => {
+        const buttonArray: (EventTarget | null)[] = buttons;
+        const isLeavingMenu = !buttonArray.includes(ev.relatedTarget);
+        if (isLeavingMenu) {
+            hideCb();
+        }
+    };
+    for (const button of buttons) {
+        addRemovableEventListener(destroyFns, button, 'blur', handler);
+    }
+}
+
+export function addOverrideFocusVisibleEventListener(
+    destroyFns: DestroyFns,
+    menu: HTMLElement,
+    buttons: HTMLElement[],
+    overrideFocusVisible: boolean
+) {
+    buttons.forEach((b) => b.setAttribute('data-focus-visible-override', overrideFocusVisible.toString()));
+    const keydownTrueOverrider = () => {
+        buttons.forEach((b) => b.setAttribute('data-focus-visible-override', 'true'));
+    };
+    addRemovableEventListener(destroyFns, menu, 'keydown', keydownTrueOverrider, { once: true });
 }
 
 export function hasNoModifiers(event: KeyboardEvent | MouseEvent): boolean {
@@ -234,26 +262,13 @@ export function initMenuKeyNav(opts: {
     });
 
     if (autoCloseOnBlur) {
-        const handler = (ev: FocusEvent) => {
-            const buttonArray: (EventTarget | null)[] = buttons;
-            const isLeavingMenu = !buttonArray.includes(ev.relatedTarget);
-            if (isLeavingMenu) {
-                onEscape();
-            }
-        };
-        for (const button of buttons) {
-            addRemovableEventListener(destroyFns, button, 'blur', handler);
-        }
+        addAutoCloseOnBlurEventListener(destroyFns, buttons, onEscape);
     }
 
     buttons[0]?.focus({ preventScroll: true });
 
     if (overrideFocusVisible !== undefined) {
-        buttons.forEach((b) => b.setAttribute('data-focus-visible-override', overrideFocusVisible.toString()));
-        const keydownTrueOverrider = () => {
-            buttons.forEach((b) => b.setAttribute('data-focus-visible-override', 'true'));
-        };
-        addRemovableEventListener(destroyFns, menu, 'keydown', keydownTrueOverrider, { once: true });
+        addOverrideFocusVisibleEventListener(destroyFns, menu, buttons, overrideFocusVisible);
     }
     return menuCloser;
 }

--- a/packages/ag-charts-community/src/widget/buttonWidget.ts
+++ b/packages/ag-charts-community/src/widget/buttonWidget.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'ag-charts-core';
 
-import { setAttribute, setElementStyle } from '../util/attributeUtil';
+import { setAttribute } from '../util/attributeUtil';
 import { Widget } from './widget';
 import type { WidgetEventMap as EventMap } from './widgetEvents';
 
@@ -18,7 +18,6 @@ export class ButtonWidget extends Widget<HTMLButtonElement> {
 
     setEnabled(enabled: boolean) {
         setAttribute(this.elem, 'aria-disabled', !enabled);
-        setElementStyle(this.elem, 'pointer-events', enabled ? undefined : 'none');
     }
 
     override addListener<K extends keyof EventMap>(type: K, listener: (ev: EventMap[K], current: this) => unknown): R;

--- a/packages/ag-charts-community/src/widget/exports.ts
+++ b/packages/ag-charts-community/src/widget/exports.ts
@@ -4,3 +4,4 @@ export * from './nativeWidget';
 export * from './toolbarWidget';
 export * from './buttonWidget';
 export * from './sliderWidget';
+export * from './menuWidget';

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -1,7 +1,7 @@
 import { getDocument } from 'ag-charts-core';
 import type { Direction } from 'ag-charts-types';
 
-import { setAttribute } from '../module-support';
+import { setAttribute } from '../util/attributeUtil';
 import { DestroyFns } from '../util/destroy';
 import {
     addAutoCloseOnBlurEventListener,

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -18,8 +18,8 @@ type OpenScope = {
     lastFocus: HTMLElement | undefined;
     lastFocusAborted: boolean;
     removers: DestroyFns;
-    abort(): void;
-    close(): void;
+    abort: () => void;
+    close: () => void;
 };
 
 export class MenuWidget extends RovingTabContainerWidget {

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -25,7 +25,7 @@ type OpenScope = {
 export class MenuWidget extends RovingTabContainerWidget {
     private openScope?: OpenScope;
 
-    constructor(orientation: Direction = 'horizontal') {
+    constructor(orientation: Direction = 'vertical') {
         super(orientation, 'menu');
     }
 

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -1,0 +1,89 @@
+import { getDocument } from 'ag-charts-core';
+import type { Direction } from 'ag-charts-types';
+
+import { setAttribute } from '../module-support';
+import { DestroyFns } from '../util/destroy';
+import {
+    addAutoCloseOnBlurEventListener,
+    addEscapeEventListener,
+    addMouseCloseListener,
+    addOverrideFocusVisibleEventListener,
+    addTouchCloseListener,
+    getLastFocus,
+} from '../util/keynavUtil';
+import { RovingTabContainerWidget } from './rovingTabContainerWidget';
+import type { WidgetEvent } from './widgetEvents';
+
+type OpenScope = {
+    lastFocus: HTMLElement | undefined;
+    lastFocusAborted: boolean;
+    removers: DestroyFns;
+    abort(): void;
+    close(): void;
+};
+
+export class MenuWidget extends RovingTabContainerWidget {
+    private openScope?: OpenScope;
+
+    constructor(orientation: Direction = 'horizontal') {
+        super(orientation, 'menu');
+    }
+
+    protected override destructor() {
+        // Nothing to destroy.
+    }
+
+    public addSeparator(): Element {
+        const sep = getDocument().createElement('div');
+        this.elem.appendChild(sep);
+        return sep;
+    }
+
+    public open(event: WidgetEvent, opts?: { overrideFocusVisible?: boolean; autoCloseOnBlur?: boolean }): void {
+        const { autoCloseOnBlur = false, overrideFocusVisible = undefined } = opts ?? {};
+        this.openScope = {
+            lastFocus: getLastFocus(event.sourceEvent),
+            lastFocusAborted: false,
+            abort: () => this.abort(),
+            close: () => this.selfClose(),
+            removers: new DestroyFns(),
+        };
+        const buttons: HTMLElement[] = this.children.map((value) => value.getElement());
+        setAttribute(this.openScope.lastFocus, 'aria-expanded', true);
+
+        addMouseCloseListener(this.openScope.removers, this.elem, this.openScope.abort);
+        addTouchCloseListener(this.openScope.removers, this.elem, this.openScope.abort);
+        addEscapeEventListener(this.openScope.removers, this.elem, this.openScope.close);
+        if (autoCloseOnBlur === true) {
+            addAutoCloseOnBlurEventListener(this.openScope.removers, buttons, this.openScope.close);
+        }
+        if (overrideFocusVisible !== undefined) {
+            addOverrideFocusVisibleEventListener(this.openScope.removers, this.elem, buttons, overrideFocusVisible);
+        }
+
+        this.children[0]?.focus({ preventScroll: true });
+    }
+
+    private selfClose() {
+        if (this.openScope === undefined) return;
+        const { lastFocus, lastFocusAborted, removers } = this.openScope;
+
+        setAttribute(lastFocus, 'aria-expanded', false);
+        if (!lastFocusAborted) {
+            lastFocus?.focus({ preventScroll: true });
+        }
+        removers.destroy();
+
+        this.internalListener?.dispatch('close-widget', this, { type: 'close-widget' });
+        this.openScope = undefined;
+    }
+
+    public close() {
+        this.selfClose();
+    }
+
+    private abort() {
+        this.openScope!.lastFocusAborted = true;
+        this.selfClose();
+    }
+}

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -67,6 +67,7 @@ export class MenuWidget extends RovingTabContainerWidget {
     private selfClose() {
         if (this.openScope === undefined) return;
         const { lastFocus, lastFocusAborted, removers } = this.openScope;
+        this.openScope = undefined; // stop re-entrance
 
         setAttribute(lastFocus, 'aria-expanded', false);
         if (!lastFocusAborted) {
@@ -75,7 +76,6 @@ export class MenuWidget extends RovingTabContainerWidget {
         removers.destroy();
 
         this.internalListener?.dispatch('close-widget', this, { type: 'close-widget' });
-        this.openScope = undefined;
     }
 
     public close() {

--- a/packages/ag-charts-community/src/widget/rovingTabContainerWidget.ts
+++ b/packages/ag-charts-community/src/widget/rovingTabContainerWidget.ts
@@ -38,6 +38,7 @@ export abstract class RovingTabContainerWidget extends Widget<HTMLDivElement, Ro
             this.removeChildListeners(child);
             child.parent = undefined;
         }
+        this.elem.textContent = '';
         this.children.length = 0;
     }
 

--- a/packages/ag-charts-community/src/widget/rovingTabContainerWidget.ts
+++ b/packages/ag-charts-community/src/widget/rovingTabContainerWidget.ts
@@ -22,7 +22,7 @@ export abstract class RovingTabContainerWidget extends Widget<HTMLDivElement, Ro
         setAttribute(this.elem, 'aria-orientation', orientation !== 'both' ? orientation : undefined);
     }
 
-    constructor(initialOrientation: RovingDirection, role: 'toolbar' | 'list') {
+    constructor(initialOrientation: RovingDirection, role: 'toolbar' | 'list' | 'menu') {
         super(createElement('div'));
         this.orientation = initialOrientation;
         setAttribute(this.elem, 'role', role);
@@ -32,15 +32,32 @@ export abstract class RovingTabContainerWidget extends Widget<HTMLDivElement, Ro
         this.children[this.focusedChildIndex]?.focus();
     }
 
-    protected override onChildAdded(child: RovingChildWidgets): void {
+    public clear() {
+        this.focusedChildIndex = 0;
+        for (const child of this.children) {
+            this.removeChildListeners(child);
+            child.parent = undefined;
+        }
+        this.children.length = 0;
+    }
+
+    private addChildListeners(child: RovingChildWidgets): void {
         child.addListener('focus', this.onChildFocus);
         child.addListener('keydown', this.onChildKeyDown);
+    }
+
+    private removeChildListeners(child: RovingChildWidgets): void {
+        child.removeListener('focus', this.onChildFocus);
+        child.removeListener('keydown', this.onChildKeyDown);
+    }
+
+    protected override onChildAdded(child: RovingChildWidgets): void {
+        this.addChildListeners(child);
         child.setTabIndex(this.children.length === 1 ? 0 : -1);
     }
 
     protected override onChildRemoved(removedChild: RovingChildWidgets): void {
-        removedChild.removeListener('focus', this.onChildFocus);
-        removedChild.removeListener('keydown', this.onChildKeyDown);
+        this.removeChildListeners(removedChild);
 
         // Repair `this.focusedChildIndex` and `this.children[].index`
         const { focusedChildIndex, children } = this;

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -137,6 +137,10 @@ export abstract class Widget<
         this.elem.innerHTML = html;
     }
 
+    setPointerEvents(pointerEvents: BaseStyleTypeMap['pointer-events'] | undefined) {
+        setElementStyle(this.elem, 'pointer-events', pointerEvents);
+    }
+
     isDisabled() {
         return getAttribute(this.elem, 'aria-disabled', false);
     }

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -157,8 +157,8 @@ export abstract class Widget<
         return this.parseFloat(this.elem.style.height);
     }
 
-    focus(): void {
-        this.elem.focus();
+    focus(opts?: Parameters<HTMLElement['focus']>[0]): void {
+        this.elem.focus(opts);
     }
 
     setPreventsDefault(preventDefault: boolean) {
@@ -260,7 +260,7 @@ export abstract class Widget<
 
     private onDispatch<K extends keyof WidgetEventMap_Internal>(type: K, event: WidgetEventMap_Internal[K]) {
         // Handle event bubbling for drag events.
-        if (!event.sourceEvent.bubbles) return;
+        if (!event.sourceEvent?.bubbles) return;
         let { parent } = this;
         while (parent != null) {
             const { internalListener } = parent;

--- a/packages/ag-charts-community/src/widget/widgetEvents.ts
+++ b/packages/ag-charts-community/src/widget/widgetEvents.ts
@@ -76,10 +76,17 @@ export type DragWidgetEvent<T extends DragWidgetEventType = DragWidgetEventType>
           readonly sourceEvent: TouchEvent;
       };
 
+export type CloseWidgetEvent = {
+    type: 'close-widget';
+    sourceEvent?: never;
+};
+
 export type WidgetEventMap = {
     'drag-start': DragWidgetEvent<'drag-start'>;
     'drag-move': DragWidgetEvent<'drag-move'>;
     'drag-end': DragWidgetEvent<'drag-end'>;
+    'close-widget': CloseWidgetEvent;
+
     blur: FocusWidgetEvent<'blur'>;
     change: WidgetEvent;
     contextmenu: MouseWidgetEvent<'contextmenu'>;

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -119,6 +119,8 @@ export class WidgetListenerInternal {
                 this.registerDragTrigger(target);
                 break;
             }
+            default:
+                (type) satisfies 'close-widget';
         }
     }
 

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -119,8 +119,6 @@ export class WidgetListenerInternal {
                 this.registerDragTrigger(target);
                 break;
             }
-            default:
-                (type) satisfies 'close-widget';
         }
     }
 

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -103,7 +103,8 @@ export class WidgetListenerInternal {
         this.listeners ??= new Map();
         let result: Set<EventHandler<T, K>> | undefined = this.listeners.get(type);
         if (result === undefined) {
-            this.listeners.set(type, (result = new Set()));
+            result = new Set();
+            this.listeners.set(type, result);
         }
         return result;
     }

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -1,3 +1,5 @@
+import { type AnyFn } from 'ag-charts-core';
+
 import { BBoxValues } from '../util/bboxinterface';
 import { partialAssign } from '../util/object';
 import { type MouseDragCallbacks, type MouseDragger, startMouseDrag } from './mouseDragger';
@@ -83,9 +85,7 @@ const GlobalCallbacks: {
 export class WidgetListenerInternal {
     public dragTouchEnabled = true;
     private dragTriggerRemover?: () => void;
-    private dragStartListeners?: EventHandler<Targetable>[];
-    private dragMoveListeners?: EventHandler<Targetable>[];
-    private dragEndListeners?: EventHandler<Targetable>[];
+    private listeners?: Map<EventType, Set<AnyFn>>;
     public mouseDragger?: MouseDragger;
     public touchDragger?: TouchDragger;
 
@@ -94,31 +94,27 @@ export class WidgetListenerInternal {
     destroy(): void {
         this.dragTriggerRemover?.();
         this.dragTriggerRemover = undefined;
-        this.dragStartListeners = undefined;
-        this.dragMoveListeners = undefined;
-        this.dragEndListeners = undefined;
+        this.listeners?.clear();
         this.mouseDragger?.destroy();
         this.touchDragger?.destroy();
     }
 
+    private getListenerSet<T extends Targetable, K extends EventType>(type: K): Set<EventHandler<T, K>> {
+        this.listeners ??= new Map();
+        let result: Set<EventHandler<T, K>> | undefined = this.listeners.get(type);
+        if (result === undefined) {
+            this.listeners.set(type, (result = new Set()));
+        }
+        return result;
+    }
+
     add<T extends Targetable, K extends EventType>(type: K, target: T, handler: EventHandler<T, K>): void;
     add<T extends Targetable, K extends EventType>(type: K, target: T, handler: EventHandler<unknown>): void {
+        this.getListenerSet(type).add(handler);
         switch (type) {
-            case 'drag-start': {
-                this.dragStartListeners ??= [];
-                this.dragStartListeners.push(handler);
-                this.registerDragTrigger(target);
-                break;
-            }
-            case 'drag-move': {
-                this.dragMoveListeners ??= [];
-                this.dragMoveListeners.push(handler);
-                this.registerDragTrigger(target);
-                break;
-            }
+            case 'drag-start':
+            case 'drag-move':
             case 'drag-end': {
-                this.dragEndListeners ??= [];
-                this.dragEndListeners.push(handler);
                 this.registerDragTrigger(target);
                 break;
             }
@@ -127,19 +123,7 @@ export class WidgetListenerInternal {
 
     remove<T extends Targetable, K extends EventType>(type: K, _target: T, handler: EventHandler<T, K>): void;
     remove<T extends Targetable, K extends EventType>(type: K, _target: T, handler: EventHandler<unknown>): void {
-        switch (type) {
-            case 'drag-start':
-                return this.removeHandler(this.dragStartListeners, handler);
-            case 'drag-move':
-                return this.removeHandler(this.dragMoveListeners, handler);
-            case 'drag-end':
-                return this.removeHandler(this.dragEndListeners, handler);
-        }
-    }
-
-    private removeHandler<T extends Targetable>(array: EventHandler<T>[] | undefined, handler: EventHandler<T>): void {
-        const index = array?.indexOf(handler);
-        if (index !== undefined) array?.splice(index, 1);
+        this.getListenerSet(type).delete(handler);
     }
 
     private registerDragTrigger<T extends Targetable>(target: T) {
@@ -223,18 +207,9 @@ export class WidgetListenerInternal {
     }
 
     public dispatch<T extends Targetable, K extends EventType>(type: K, current: T, event: EventMap[K]): void {
-        switch (type) {
-            case 'drag-start':
-                this.dragStartListeners?.forEach((handler) => handler(event, current));
-                break;
-            case 'drag-move':
-                this.dragMoveListeners?.forEach((handler) => handler(event, current));
-                break;
-            case 'drag-end':
-                this.dragEndListeners?.forEach((handler) => handler(event, current));
-                break;
+        for (const handler of this.getListenerSet(type)) {
+            handler(event, current);
         }
-
         this.dispatchCallback(type, event);
     }
 }

--- a/packages/ag-charts-enterprise/src/features/__snapshots__/features.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/features/__snapshots__/features.test.ts.snap
@@ -7,22 +7,27 @@ HTMLCollection [
     style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
+      aria-orientation="vertical"
       class="ag-charts-context-menu__menu"
+      role="menu"
       tabindex="-1"
     >
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="0"
       >
         Download
       </button>
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
         Zoom to here
       </button>
       <button
+        aria-disabled="true"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
@@ -40,22 +45,27 @@ HTMLCollection [
     style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
+      aria-orientation="vertical"
       class="ag-charts-context-menu__menu"
+      role="menu"
       tabindex="-1"
     >
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="0"
       >
         Download
       </button>
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
         Zoom to here
       </button>
       <button
+        aria-disabled="true"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
@@ -73,22 +83,27 @@ HTMLCollection [
     style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
+      aria-orientation="vertical"
       class="ag-charts-context-menu__menu"
+      role="menu"
       tabindex="-1"
     >
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="0"
       >
         Download
       </button>
       <button
+        aria-disabled="true"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
         Zoom to here
       </button>
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >

--- a/packages/ag-charts-enterprise/src/features/context-menu/__snapshots__/contextMenu.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/features/context-menu/__snapshots__/contextMenu.test.ts.snap
@@ -4,7 +4,6 @@ exports[`Context Menu should initially be hidden 1`] = `
 HTMLCollection [
   <div
     class="ag-charts-context-menu"
-    style="display: none;"
   />,
 ]
 `;
@@ -16,10 +15,13 @@ HTMLCollection [
     style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
+      aria-orientation="vertical"
       class="ag-charts-context-menu__menu"
+      role="menu"
       tabindex="-1"
     >
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="0"
       >
@@ -37,10 +39,13 @@ HTMLCollection [
     style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
+      aria-orientation="vertical"
       class="ag-charts-context-menu__menu"
+      role="menu"
       tabindex="-1"
     >
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="0"
       >
@@ -58,22 +63,27 @@ HTMLCollection [
     style="display: block; left: 0px; top: calc(0px - 0.5em);"
   >
     <div
+      aria-orientation="vertical"
       class="ag-charts-context-menu__menu"
+      role="menu"
       tabindex="-1"
     >
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="0"
       >
         Download
       </button>
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
         Toggle Visibility
       </button>
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
@@ -91,22 +101,27 @@ HTMLCollection [
     style="display: block; top: calc(NaNpx - 0.5em);"
   >
     <div
+      aria-orientation="vertical"
       class="ag-charts-context-menu__menu"
+      role="menu"
       tabindex="-1"
     >
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="0"
       >
         Download
       </button>
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >
         Toggle Visibility
       </button>
       <button
+        aria-disabled="false"
         class="ag-charts-context-menu__item"
         tabindex="-1"
       >

--- a/packages/ag-charts-enterprise/src/features/context-menu/__snapshots__/contextMenu.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/features/context-menu/__snapshots__/contextMenu.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Context Menu should initially be hidden 1`] = `
 HTMLCollection [
   <div
     class="ag-charts-context-menu"
+    style="display: none;"
   />,
 ]
 `;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -1,3 +1,5 @@
+import type { MouseWidgetEvent } from 'packages/ag-charts-community/src/module-support';
+
 import type { AgContextMenuItem, AgContextMenuItemShowOn, AgContextMenuOptions } from 'ag-charts-community';
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
 import { Logger, clamp } from 'ag-charts-core';
@@ -229,9 +231,10 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     private createButtonOnClick(
         showOn: AgContextMenuItemShowOn,
         callback: ContextMenuCallback
-    ): (event: MouseEvent) => void {
+    ): (event: _ModuleSupport.MouseWidgetEvent) => void {
         if (ContextMenuRegistry.checkCallback('legend-item', showOn, callback)) {
-            return (event: Event) => {
+            return (widgetEvent: _ModuleSupport.MouseWidgetEvent) => {
+                const event: Event = widgetEvent.sourceEvent;
                 if (this.pickedLegendItem) {
                     const { seriesId, itemId } = this.pickedLegendItem;
                     callback({ type: 'contextmenu', seriesId, itemId, event });
@@ -272,7 +275,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         button.setTextContent(this.ctx.localeManager.t(item.label));
         const { showOn, action } = item;
         if (action != null) {
-            button.addListener('click', () => this.createButtonOnClick(showOn, action));
+            button.addListener('click', this.createButtonOnClick(showOn, action));
         }
         button.addListener('mousemove', () => button.focus({ preventScroll: true }));
         return button;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -90,6 +90,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         this.element = ctx.domManager.addChild('canvas-overlay', moduleId);
         this.element.classList.add(DEFAULT_CONTEXT_MENU_CLASS);
         this.element.addEventListener('contextmenu', (event) => event.preventDefault()); // AG-10223
+        this.element.appendChild(this.menuWidget.getElement());
         this.destroyFns.push(
             () => this.element.parentNode?.removeChild(this.element),
             () => this.menuWidget.destroy(),
@@ -199,7 +200,6 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
     private onClose() {
         this.interactionManager.popState(_ModuleSupport.InteractionState.ContextMenu);
-        this.element.removeChild(this.menuWidget.getElement());
         this.element.style.display = 'none';
     }
 

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -1,5 +1,3 @@
-import type { MouseWidgetEvent } from 'packages/ag-charts-community/src/module-support';
-
 import type { AgContextMenuItem, AgContextMenuItemShowOn, AgContextMenuOptions } from 'ag-charts-community';
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
 import { Logger, clamp } from 'ag-charts-core';

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -1,6 +1,6 @@
 import type { AgContextMenuItem, AgContextMenuItemShowOn, AgContextMenuOptions } from 'ag-charts-community';
-import { _ModuleSupport } from 'ag-charts-community';
-import { Logger, clamp, createElement } from 'ag-charts-core';
+import { _ModuleSupport, _Widget } from 'ag-charts-community';
+import { Logger, clamp } from 'ag-charts-core';
 
 import { ContextMenuItem, appendItem, expandBuiltin } from './contextMenuItem';
 import { DEFAULT_CONTEXT_MENU_CLASS, DEFAULT_CONTEXT_MENU_DARK_CLASS } from './contextMenuStyles';
@@ -16,22 +16,9 @@ type DeprecatedMap = {
     };
 };
 
-const { Property, initMenuKeyNav, makeAccessibleClickListener, ContextMenuRegistry } = _ModuleSupport;
+const { Property, ContextMenuRegistry } = _ModuleSupport;
 
 const moduleId = 'context-menu';
-
-function getChildrenOfType<TElem extends Element>(parent: Element, ctor: new () => TElem): TElem[] {
-    const { children } = parent ?? {};
-    if (!children) return [];
-
-    const result: TElem[] = [];
-    for (const child of Array.from(children)) {
-        if (child instanceof ctor) {
-            result.push(child);
-        }
-    }
-    return result;
-}
 
 export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _ModuleSupport.ModuleInstance {
     @Property
@@ -62,8 +49,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
     // HTML elements
     private readonly element: HTMLElement;
-    private menuElement?: HTMLDivElement;
-    private menuCloser?: _ModuleSupport.MenuCloser;
+    private menuWidget: _Widget.MenuWidget = new _Widget.MenuWidget();
     private readonly mutationObserver?: MutationObserver;
 
     constructor(readonly ctx: _ModuleSupport.ModuleContext) {
@@ -104,15 +90,17 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         this.element = ctx.domManager.addChild('canvas-overlay', moduleId);
         this.element.classList.add(DEFAULT_CONTEXT_MENU_CLASS);
         this.element.addEventListener('contextmenu', (event) => event.preventDefault()); // AG-10223
-        this.destroyFns.push(() => this.element.parentNode?.removeChild(this.element));
-
-        this.doClose();
-
-        this.destroyFns.push(ctx.domManager.addListener('hidden', () => this.hide()));
+        this.destroyFns.push(
+            () => this.element.parentNode?.removeChild(this.element),
+            () => this.menuWidget.destroy(),
+            ctx.domManager.addListener('hidden', () => this.hide()),
+            this.menuWidget.addListener('close-widget', () => this.onClose())
+        );
+        this.menuWidget.addClass(`${DEFAULT_CONTEXT_MENU_CLASS}__menu`);
 
         if (typeof MutationObserver !== 'undefined') {
             const observer = new MutationObserver(() => {
-                if (this.menuElement && this.element.contains(this.menuElement)) {
+                if (this.element.contains(this.menuWidget.getElement())) {
                     this.reposition();
                 }
             });
@@ -172,10 +160,9 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
     private onContext(event: ContextMenuEvent) {
         if (!this.enabled) return;
-        const sourceEvent = event.widgetEvent.sourceEvent;
-        sourceEvent.preventDefault();
 
-        this.showEvent = sourceEvent;
+        event.widgetEvent.sourceEvent.preventDefault();
+        this.showEvent = event.widgetEvent.sourceEvent;
         this.x = event.x;
         this.y = event.y;
         this.pickedNode = undefined;
@@ -189,71 +176,47 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         const expandedItems = this.expandItemsOptions(event.showOn);
         if (expandedItems.length === 0) return;
 
-        this.show(sourceEvent, expandedItems);
+        this.show(event.widgetEvent, expandedItems);
     }
 
-    private show(sourceEvent: ContextMenuEvent['widgetEvent']['sourceEvent'], expandedItems: ContextMenuItem[]) {
+    private show(widgetEvent: ContextMenuEvent['widgetEvent'], expandedItems: ContextMenuItem[]) {
         this.interactionManager.pushState(_ModuleSupport.InteractionState.ContextMenu);
         this.element.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
-
-        const newMenuElement = this.renderMenu(expandedItems);
-
-        this.menuCloser?.close();
-        if (this.menuElement) {
-            this.element.replaceChild(newMenuElement, this.menuElement);
-        } else {
-            this.element.appendChild(newMenuElement);
-        }
-
-        this.menuElement = newMenuElement;
-
         this.element.style.display = 'block';
 
-        const overrideFocusVisible = sourceEvent.pointerType === 'touch' ? false : undefined;
-        const buttons = getChildrenOfType(newMenuElement, HTMLButtonElement);
-        this.menuCloser = initMenuKeyNav({
-            menu: newMenuElement,
-            buttons,
-            orientation: 'vertical',
-            sourceEvent,
-            overrideFocusVisible,
-            autoCloseOnBlur: true,
-            closeCallback: () => this.doClose(),
-        });
-        if (sourceEvent.pointerType === 'touch') {
-            this.ctx.chartService.overrideFocusVisible(false);
+        const overrideFocusVisible = widgetEvent.sourceEvent.pointerType === 'touch' ? false : undefined;
+        if (overrideFocusVisible !== undefined) {
+            this.ctx.chartService.overrideFocusVisible(overrideFocusVisible);
         }
+
+        this.createMenu(expandedItems);
+        this.menuWidget.open(widgetEvent, { overrideFocusVisible, autoCloseOnBlur: true });
     }
 
     private hide() {
-        this.menuCloser?.close();
+        this.menuWidget.close();
     }
 
-    private doClose() {
+    private onClose() {
         this.interactionManager.popState(_ModuleSupport.InteractionState.ContextMenu);
-
-        if (this.menuElement) {
-            this.element.removeChild(this.menuElement);
-            this.menuElement = undefined;
-            this.menuCloser = undefined;
-        }
-
+        this.element.removeChild(this.menuWidget.getElement());
         this.element.style.display = 'none';
     }
 
-    private renderMenu(expandedItems: ContextMenuItem[]) {
-        const menuElement = createElement('div');
-        menuElement.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__menu`);
-        menuElement.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
-        menuElement.role = 'menu';
+    private createMenu(expandedItems: ContextMenuItem[]) {
+        const { menuWidget } = this;
+        menuWidget.clear();
+        menuWidget.toggleClass(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
 
         for (const item of expandedItems) {
             switch (item.type) {
                 case 'separator':
-                    menuElement.append(this.createDividerElement());
+                    const sep = menuWidget.addSeparator();
+                    sep.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__divider`);
+                    sep.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
                     break;
                 case 'action':
-                    menuElement.append(this.createActionElement(item));
+                    menuWidget.addChild(this.createButtonElement(item));
                     break;
                 case 'submenu':
                     break;
@@ -261,23 +224,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
                     throw new Error('unhandled case');
             }
         }
-
-        return menuElement;
     }
-
-    private createDividerElement(): HTMLElement {
-        const el = createElement('div');
-        el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__divider`);
-        el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
-        el.role = 'separator';
-        return el;
-    }
-
-    private createActionElement(item: ContextMenuItem): HTMLElement {
-        const { showOn, label, action, enable } = item;
-        return this.createButtonElement(showOn, label, action, !enable);
-    }
-
     private createButtonOnClick(
         showOn: AgContextMenuItemShowOn,
         callback: ContextMenuCallback
@@ -316,23 +263,18 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         };
     }
 
-    private createButtonElement(
-        showOn: AgContextMenuItemShowOn,
-        label: string,
-        callback: ContextMenuCallback | undefined,
-        disabled: boolean
-    ): HTMLElement {
-        const el = createElement('button');
-        el.classList.add(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
-        el.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
-        el.ariaDisabled = disabled.toString();
-        el.textContent = this.ctx.localeManager.t(label);
-        el.role = 'menuitem';
-        if (callback != null) {
-            el.onclick = makeAccessibleClickListener(el, this.createButtonOnClick(showOn, callback));
+    private createButtonElement(item: ContextMenuItem): _Widget.ButtonWidget {
+        const button = new _Widget.ButtonWidget();
+        button.addClass(`${DEFAULT_CONTEXT_MENU_CLASS}__item`);
+        button.toggleClass(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
+        button.setEnabled(item.enable);
+        button.setTextContent(this.ctx.localeManager.t(item.label));
+        const { showOn, action } = item;
+        if (action != null) {
+            button.addListener('click', () => this.createButtonOnClick(showOn, action));
         }
-        el.addEventListener('mouseover', () => el.focus({ preventScroll: true }));
-        return el;
+        button.addListener('mousemove', () => button.focus({ preventScroll: true }));
+        return button;
     }
 
     private reposition() {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -172,9 +172,10 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
     private onContext(event: ContextMenuEvent) {
         if (!this.enabled) return;
-        event.sourceEvent.preventDefault();
+        const sourceEvent = event.widgetEvent.sourceEvent;
+        sourceEvent.preventDefault();
 
-        this.showEvent = event.sourceEvent as MouseEvent;
+        this.showEvent = sourceEvent;
         this.x = event.x;
         this.y = event.y;
         this.pickedNode = undefined;
@@ -188,10 +189,10 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         const expandedItems = this.expandItemsOptions(event.showOn);
         if (expandedItems.length === 0) return;
 
-        this.show(event.sourceEvent, expandedItems);
+        this.show(sourceEvent, expandedItems);
     }
 
-    private show(sourceEvent: ContextMenuEvent['sourceEvent'], expandedItems: ContextMenuItem[]) {
+    private show(sourceEvent: ContextMenuEvent['widgetEvent']['sourceEvent'], expandedItems: ContextMenuItem[]) {
         this.interactionManager.pushState(_ModuleSupport.InteractionState.ContextMenu);
         this.element.classList.toggle(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
 

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -208,6 +208,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         const { menuWidget } = this;
         menuWidget.clear();
         menuWidget.toggleClass(DEFAULT_CONTEXT_MENU_DARK_CLASS, this.darkTheme);
+        menuWidget.setTabIndex(-1);
 
         for (const item of expandedItems) {
             switch (item.type) {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -89,6 +89,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         // State
         this.element = ctx.domManager.addChild('canvas-overlay', moduleId);
         this.element.classList.add(DEFAULT_CONTEXT_MENU_CLASS);
+        this.element.style.display = 'none';
         this.element.addEventListener('contextmenu', (event) => event.preventDefault()); // AG-10223
         this.destroyFns.push(
             () => this.element.parentNode?.removeChild(this.element),

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -49,7 +49,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
     // HTML elements
     private readonly element: HTMLElement;
-    private menuWidget: _Widget.MenuWidget = new _Widget.MenuWidget();
+    private readonly menuWidget: _Widget.MenuWidget = new _Widget.MenuWidget();
     private readonly mutationObserver?: MutationObserver;
 
     constructor(readonly ctx: _ModuleSupport.ModuleContext) {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -90,7 +90,6 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         this.element = ctx.domManager.addChild('canvas-overlay', moduleId);
         this.element.classList.add(DEFAULT_CONTEXT_MENU_CLASS);
         this.element.addEventListener('contextmenu', (event) => event.preventDefault()); // AG-10223
-        this.element.appendChild(this.menuWidget.getElement());
         this.destroyFns.push(
             () => this.element.parentNode?.removeChild(this.element),
             () => this.menuWidget.destroy(),
@@ -191,6 +190,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
         }
 
         this.createMenu(expandedItems);
+        this.element.appendChild(this.menuWidget.getElement());
         this.menuWidget.open(widgetEvent, { overrideFocusVisible, autoCloseOnBlur: true });
     }
 
@@ -200,6 +200,7 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
 
     private onClose() {
         this.interactionManager.popState(_ModuleSupport.InteractionState.ContextMenu);
+        this.element.removeChild(this.menuWidget.getElement());
         this.element.style.display = 'none';
     }
 

--- a/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
@@ -157,13 +157,14 @@ export class NavigatorDOMProxy {
 
     private onContextMenu(
         slider: _ModuleSupport.SliderWidget,
-        { sourceEvent, offsetX, offsetY }: _ModuleSupport.MouseWidgetEvent<'contextmenu'>
+        widgetEvent: _ModuleSupport.MouseWidgetEvent<'contextmenu'>
     ) {
+        const { offsetX, offsetY } = widgetEvent;
         const { x: toolbarX, y: toolbarY } = this.toolbar.getBounds();
         const { x: sliderX, y: sliderY } = slider.getBounds();
         const canvasX = offsetX + toolbarX + sliderX;
         const canvasY = offsetY + toolbarY + sliderY;
-        this.ctx.contextMenuRegistry.dispatchContext('always', { sourceEvent, canvasX, canvasY }, undefined);
+        this.ctx.contextMenuRegistry.dispatchContext('always', { widgetEvent, canvasX, canvasY }, undefined);
     }
 
     private onPanSliderChange() {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8876

This refactoring is necessary for good interaction management (a11y, keynav, focus, etc..) of submenus (which is currently unimplemented).