### PR TITLE
AG-14724: When a heatmap colorKey value is invalid, don't show warning

### DIFF
--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -116,7 +116,9 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<
             props: [
                 valueProperty(xKey, xScaleType, { id: 'xValue' }),
                 valueProperty(yKey, yScaleType, { id: 'yValue' }),
-                ...(colorKey ? [valueProperty(colorKey, colorScaleType, { id: 'colorValue' })] : []),
+                ...(colorKey
+                    ? [valueProperty(colorKey, colorScaleType, { id: 'colorValue', invalidValue: null })]
+                    : []),
             ],
         });
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14724