### PR TITLE
Improve performance for continuous ticks

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axisTickGenerator.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisTickGenerator.ts
@@ -413,19 +413,17 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
         tickData: TickData,
         terminate: boolean
     ): TickStrategyResult {
+        // Find the next tick data where the tick data is different from the previous tick data - and return the index of this data
         const { scale, interval } = this.axis;
         const { step, values, minSpacing, maxSpacing } = interval;
         const { maxTickCount, minTickCount, tickCount } = this.estimateTickCount(visibleRange, minSpacing, maxSpacing);
 
-        const visibleTickStep = Math.floor(1 / (visibleRange[1] - visibleRange[0]));
-        const tickIterationReduction = Math.max(1, visibleTickStep);
-
         const continuous = ContinuousScale.is(scale) || DiscreteTimeScale.is(scale);
-        const maxIterations =
-            !continuous || isNaN(maxTickCount) ? 10 : Math.floor(maxTickCount / tickIterationReduction);
+        const maxIterations = !continuous || isNaN(maxTickCount) ? 10 : maxTickCount;
 
-        const countTicks = (i: number) =>
-            continuous ? Math.max(tickCount - i * tickIterationReduction, minTickCount) : maxTickCount;
+        const countTicks = (i: number) => (continuous ? Math.max(tickCount - i, minTickCount) : maxTickCount);
+
+        const previousTicks = tickData.rawTicks;
 
         const regenerateTicks =
             step == null &&
@@ -433,26 +431,41 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
             countTicks(index) > minTickCount &&
             (continuous || tickGenerationType === TickGenerationType.FILTER);
 
-        while (index <= maxIterations) {
-            const previousTicks = tickData.rawTicks;
+        const getTickParams = {
+            domain,
+            niceMode,
+            visibleRange,
+            primaryTickCount,
+            tickGenerationType,
+            previousTicks,
+            minTickCount,
+            maxTickCount,
+            tickCount: 0,
+        };
 
-            tickData = this.getTicks({
-                domain,
-                niceMode,
-                visibleRange,
-                primaryTickCount,
-                tickGenerationType,
-                previousTicks,
-                minTickCount,
-                maxTickCount,
-                tickCount: countTicks(index),
-            });
+        // First guess - generate ticks at current index
+        getTickParams.tickCount = countTicks(index);
+        tickData = this.getTicks(getTickParams);
 
-            index++;
+        if (regenerateTicks && this.ticksEqual(tickData.rawTicks, previousTicks)) {
+            // Ticks didn't change
+            // Use binary search to find the index, as there could be a lot of ticks in some cases
+            let lowerBound = index;
+            let upperBound = maxIterations;
+            while (lowerBound <= upperBound) {
+                index = ((lowerBound + upperBound) / 2) | 0;
+                getTickParams.tickCount = countTicks(index);
+                tickData = this.getTicks(getTickParams);
 
-            if (!regenerateTicks || !this.ticksEqual(tickData.rawTicks, previousTicks)) break;
+                if (this.ticksEqual(tickData.rawTicks, previousTicks)) {
+                    lowerBound = index + 1;
+                } else {
+                    upperBound = index - 1;
+                }
+            }
         }
 
+        index += 1;
         terminate ||= step != null || values != null;
 
         return { tickData, index, autoRotation: 0, terminate };

--- a/packages/ag-charts-community/src/chart/axis/axisTickGenerator.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisTickGenerator.ts
@@ -417,10 +417,15 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
         const { step, values, minSpacing, maxSpacing } = interval;
         const { maxTickCount, minTickCount, tickCount } = this.estimateTickCount(visibleRange, minSpacing, maxSpacing);
 
-        const continuous = ContinuousScale.is(scale) || DiscreteTimeScale.is(scale);
-        const maxIterations = !continuous || isNaN(maxTickCount) ? 10 : maxTickCount;
+        const visibleTickStep = Math.floor(1 / (visibleRange[1] - visibleRange[0]));
+        const tickIterationReduction = Math.max(1, visibleTickStep);
 
-        const countTicks = (i: number) => (continuous ? Math.max(tickCount - i, minTickCount) : maxTickCount);
+        const continuous = ContinuousScale.is(scale) || DiscreteTimeScale.is(scale);
+        const maxIterations =
+            !continuous || isNaN(maxTickCount) ? 10 : Math.floor(maxTickCount / tickIterationReduction);
+
+        const countTicks = (i: number) =>
+            continuous ? Math.max(tickCount - i * tickIterationReduction, minTickCount) : maxTickCount;
 
         const regenerateTicks =
             step == null &&


### PR DESCRIPTION
For some zoomed-in cases, maxTickCount would be 6,000. The continuous mode will reduce these ticks one-by-one until it finds a suitable tick step. Instead, we can use binary search to find this value faster