### PR TITLE
AG-14734 - Improve examples round 2

### DIFF
--- a/packages/ag-charts-website/src/components/example-runner/components/CodeViewer.tsx
+++ b/packages/ag-charts-website/src/components/example-runner/components/CodeViewer.tsx
@@ -6,6 +6,7 @@ import { doOnEnter } from '@utils/doOnEnter';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
 
+import { E2E_STYLE_END, E2E_STYLE_START } from '../constants';
 import { CodeOptions } from './CodeOptions';
 import styles from './CodeViewer.module.scss';
 
@@ -42,6 +43,9 @@ export function stripOutExampleGeneratorCode(files: FileContents) {
             files[mainFile] = files[mainFile].replace(darkModeRegex, '').replace(consoleLogRegex, '').trim() + '\n';
         }
     });
+
+    const e2eStyleRegex = getSnippetRegex({ startDelimiter: E2E_STYLE_START, endDelimiter: E2E_STYLE_END });
+    files['index.html'] = files['index.html']?.replace(e2eStyleRegex, '').trim();
 }
 
 /**

--- a/packages/ag-charts-website/src/middleware/index.ts
+++ b/packages/ag-charts-website/src/middleware/index.ts
@@ -5,7 +5,7 @@ import * as prettier from 'prettier';
 const env = import.meta.env;
 
 const rewriteAstroGeneratedContent = (body: string) => {
-    const html = parse(body);
+    const html = parse(body, { comment: true });
 
     // In dev, add public site url base for all scripts, so it works in external sites
     if (env.DEV) {

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/styles/getFrameworkStyles.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/styles/getFrameworkStyles.ts
@@ -68,7 +68,7 @@ body {
     gap: 8px;
 }
 
-#myChart {
+div:has(> .ag-charts-wrapper) {
     padding: 1rem;
     height: 100%;
     border-radius: 8px;


### PR DESCRIPTION
Follow up to https://github.com/ag-grid/ag-charts/pull/4043

## Changes

* Remove e2e check script for example runner
* Make typescript framework selector the same as vanilla