### PR TITLE
AG-14990 Add focusout/mouseout listeners on interactive tooltips

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/tooltipManager.ts
@@ -122,9 +122,7 @@ export class TooltipManager {
         return meta;
     }
 
-    public isEnteringInteractiveTooltip(event: Pick<FocusEvent | MouseEvent, 'relatedTarget'>): boolean {
-        const { tooltip } = this;
-        const relatedTarget = event.relatedTarget as Node | null;
-        return tooltip.interactive && tooltip.enabled && tooltip.isVisible() && tooltip.contains(relatedTarget);
+    public maybeEnterInteractiveTooltip(callerId: string, event: FocusEvent | MouseEvent): boolean {
+        return this.tooltip.maybeEnterInteractiveTooltip(event, () => this.removeTooltip(callerId));
     }
 }

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -360,7 +360,7 @@ export class SeriesAreaManager extends BaseManager {
         if (relatedTarget?.className === 'ag-charts-text-input__textarea') {
             return;
         }
-        if (this.chart.ctx.tooltipManager.isEnteringInteractiveTooltip(event.sourceEvent)) {
+        if (this.chart.ctx.tooltipManager.maybeEnterInteractiveTooltip(this.id, event.sourceEvent)) {
             return;
         }
 
@@ -472,7 +472,7 @@ export class SeriesAreaManager extends BaseManager {
     private onBlur(event: FocusEvent) {
         if (!this.isState(InteractionState.Focusable)) return;
         this.hoverDevice = 'pointer';
-        if (!this.chart.ctx.tooltipManager.isEnteringInteractiveTooltip(event)) {
+        if (!this.chart.ctx.tooltipManager.maybeEnterInteractiveTooltip(this.id, event)) {
             this.clearAll();
         }
         this.focusIndicator?.overrideFocusVisible(undefined);

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -171,6 +171,11 @@ export class Tooltip extends BaseProperties {
     private element?: HTMLElement;
     private readonly sizeMonitor = new SizeMonitor();
 
+    private interactiveLeave?: {
+        callback: () => void;
+        listener: (e: MouseEvent | FocusEvent) => void;
+    };
+
     // Reading the element size is expensive, so cache the result
     private _elementSize: { width: number; height: number } | undefined = undefined;
     private _showTimeout: NodeJS.Timeout | undefined = undefined;
@@ -365,6 +370,45 @@ export class Tooltip extends BaseProperties {
         this.toggle(false);
     }
 
+    maybeEnterInteractiveTooltip({ relatedTarget }: FocusEvent | MouseEvent, callback: () => void): boolean {
+        const { interactive, interactiveLeave, enabled, element } = this;
+        if (element == null) return false;
+        if (interactiveLeave) return true;
+
+        const isEntering =
+            interactive && enabled && this.isVisible() && relatedTarget instanceof Node && this.contains(relatedTarget);
+
+        // AG-14990 Add a custom listener to dismiss the tooltip when the user is done interacting with it.
+        if (isEntering) {
+            this.interactiveLeave = {
+                callback,
+                listener: (popoverEvent: FocusEvent | MouseEvent): void => {
+                    const isLeaving =
+                        popoverEvent.relatedTarget instanceof Node && !this.contains(popoverEvent.relatedTarget);
+                    if (isLeaving) {
+                        this.popInteractiveLeaveCallback();
+                    }
+                },
+            };
+            element.addEventListener('focusout', this.interactiveLeave.listener);
+            element.addEventListener('mouseout', this.interactiveLeave.listener);
+        }
+
+        return isEntering;
+    }
+
+    private popInteractiveLeaveCallback() {
+        const { interactiveLeave, element } = this;
+        this.interactiveLeave = undefined; // prevent re-entrancy.
+        if (interactiveLeave) {
+            if (element) {
+                element.removeEventListener('focusout', interactiveLeave.listener);
+                element.removeEventListener('mouseout', interactiveLeave.listener);
+            }
+            interactiveLeave.callback();
+        }
+    }
+
     private toggle(visible: boolean, instantly: boolean = false) {
         const { delay } = this;
 
@@ -395,6 +439,7 @@ export class Tooltip extends BaseProperties {
             this.updateTooltipPosition();
         } else {
             this.springAnimation.reset();
+            this.popInteractiveLeaveCallback();
         }
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14990

The `SeriesAreaManager` class ignores event for type `'leave'` (for mouse users) and `'blur'` (for keyboard users) to allow the user to interact with the tooltip.

However, this means that the tooltip can incorrectly remain shown when the mouse moves or the focus changes.

Therefore, add custom event listeners to interactive tooltip to address is anomaly.