### PR TITLE
AG-11754 Fix `aglint/require-explicit-generic` warnings

### DIFF
--- a/eslint-rules/require-explicit-generic.mjs
+++ b/eslint-rules/require-explicit-generic.mjs
@@ -50,20 +50,29 @@ export default {
             });
         }
 
+        // Helper to check and report if type ref is missing generics
+        function checkTypeReference(node, typeName, typeArguments) {
+            if (
+                typeName &&
+                genericTypeNames.has(typeName.name || typeName.right?.name) &&
+                (!typeArguments || typeArguments.length === 0)
+            ) {
+                context.report({
+                    node,
+                    messageId: 'requireGeneric',
+                    data: { name: typeName.name || typeName.right?.name },
+                });
+            }
+        }
+
         return {
-            TSTypeReference(node) {
-                const name = node.typeName?.name;
-                if (
-                    name &&
-                    genericTypeNames.has(name) &&
-                    (!node.typeArguments || node.typeArguments.params.length === 0)
-                ) {
-                    context.report({
-                        node,
-                        messageId: 'requireGeneric',
-                        data: { name },
-                    });
+            TSInterfaceDeclaration(node) {
+                for (const baseNode of node.extends) {
+                    checkTypeReference(baseNode, baseNode.expression, baseNode.typeArguments);
                 }
+            },
+            TSTypeReference(node) {
+                checkTypeReference(node, node.typeName, node.typeArguments?.params);
             },
         };
     },

--- a/nx.json
+++ b/nx.json
@@ -209,7 +209,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "npx eslint --quiet"
+        "command": "npx eslint"
       },
       "cache": true,
       "inputs": [

--- a/packages/ag-charts-types/eslint.config.mjs
+++ b/packages/ag-charts-types/eslint.config.mjs
@@ -6,7 +6,7 @@ export default [
     {
         files: ['**/*.ts'],
         rules: {
-            'aglint/require-explicit-generic': 1, // TODO: upgrade from warning to error once all violation are resolved
+            'aglint/require-explicit-generic': 2,
         },
     },
 ];

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -171,13 +171,13 @@ export interface AgOrdinalTimeAxisOptions<TContext = TContextDefault>
 
 export interface AgNumberAxisOptions<TContext = TContextDefault>
     extends Omit<AgBaseCartesianAxisOptions<AgCartesianAxisLabelOptions, AgCrosshairLabel, TContext>, 'interval'>,
-        AgContinuousAxisOptions {
+        AgContinuousAxisOptions<number, number> {
     type: 'number';
 }
 
 export interface AgLogAxisOptions<TContext = TContextDefault>
     extends Omit<AgBaseCartesianAxisOptions<AgCartesianAxisLabelOptions, AgCrosshairLabel, TContext>, 'interval'>,
-        AgContinuousAxisOptions {
+        AgContinuousAxisOptions<number, number> {
     type: 'log';
     /** The base of the logarithm used. */
     base?: number;

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -228,59 +228,59 @@ export interface AgCartesianAxesCrossLineThemeOptions<LabelType = AgBaseCrossLin
 
 export interface AgCartesianAxesTheme {
     /** This extends the common axis configuration with options specific to number axes. */
-    number?: AgNumberAxisThemeOptions;
+    number?: AgNumberAxisThemeOptions<AgBaseCrossLineLabelOptions>;
     /** This extends the common axis configuration with options specific to number axes. */
-    log?: AgLogAxisThemeOptions;
+    log?: AgLogAxisThemeOptions<AgBaseCrossLineLabelOptions>;
     /** This extends the common axis configuration with options specific to category axes. */
-    category?: AgCategoryAxisThemeOptions;
+    category?: AgCategoryAxisThemeOptions<AgBaseCrossLineLabelOptions>;
     /** This extends the common axis configuration with options specific to time axes. */
-    'continuous-time'?: AgContinuousTimeAxisThemeOptions;
+    'continuous-time'?: AgContinuousTimeAxisThemeOptions<AgBaseCrossLineLabelOptions>;
     /** This extends the common axis configuration with options specific to ordinal-time axes. */
-    'ordinal-time'?: AgOrdinalTimeAxisThemeOptions;
+    'ordinal-time'?: AgOrdinalTimeAxisThemeOptions<AgBaseCrossLineLabelOptions>;
     /** This extends the common axis configuration with options specific to grouped-category axes. */
-    'grouped-category'?: AgGroupedCategoryAxisThemeOptions;
+    'grouped-category'?: AgGroupedCategoryAxisThemeOptions<AgBaseCrossLineLabelOptions>;
     /** This extends the common axis configuration with options specific to unit-time axes. */
-    time?: AgTimeAxisThemeOptions;
+    time?: AgTimeAxisThemeOptions<AgBaseCrossLineLabelOptions>;
 }
 
 export type AgContinuousCartesianAxesTheme = Pick<AgCartesianAxesTheme, 'number' | 'log' | 'continuous-time'>;
 
 type ThemeOmittedAxisOptions = 'context' | 'type' | 'crossLines';
 
-export interface AgNumberAxisThemeOptions
+export interface AgNumberAxisThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
     extends Omit<AgNumberAxisOptions<never>, ThemeOmittedAxisOptions>,
         AgCartesianAxisThemeOptions<AgNumberAxisOptions<never>>,
-        AgCartesianAxesCrossLineThemeOptions {}
+        AgCartesianAxesCrossLineThemeOptions<LabelType> {}
 
-export interface AgLogAxisThemeOptions
+export interface AgLogAxisThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
     extends Omit<AgLogAxisOptions<never>, ThemeOmittedAxisOptions>,
         AgCartesianAxisThemeOptions<AgLogAxisOptions<never>>,
-        AgCartesianAxesCrossLineThemeOptions {}
+        AgCartesianAxesCrossLineThemeOptions<LabelType> {}
 
-export interface AgCategoryAxisThemeOptions
+export interface AgCategoryAxisThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
     extends Omit<AgCategoryAxisOptions<never>, ThemeOmittedAxisOptions>,
         AgCartesianAxisThemeOptions<AgCategoryAxisOptions<never>>,
-        AgCartesianAxesCrossLineThemeOptions {}
+        AgCartesianAxesCrossLineThemeOptions<LabelType> {}
 
-export interface AgOrdinalTimeAxisThemeOptions
+export interface AgOrdinalTimeAxisThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
     extends Omit<AgOrdinalTimeAxisOptions<never>, ThemeOmittedAxisOptions>,
         AgCartesianAxisThemeOptions<AgOrdinalTimeAxisOptions<never>>,
-        AgCartesianAxesCrossLineThemeOptions {}
+        AgCartesianAxesCrossLineThemeOptions<LabelType> {}
 
-export interface AgGroupedCategoryAxisThemeOptions
+export interface AgGroupedCategoryAxisThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
     extends Omit<AgGroupedCategoryAxisOptions<never>, ThemeOmittedAxisOptions>,
         AgCartesianAxisThemeOptions<AgGroupedCategoryAxisOptions<never>>,
-        AgCartesianAxesCrossLineThemeOptions {}
+        AgCartesianAxesCrossLineThemeOptions<LabelType> {}
 
-export interface AgContinuousTimeAxisThemeOptions
+export interface AgContinuousTimeAxisThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
     extends Omit<AgContinuousTimeAxisOptions<never>, ThemeOmittedAxisOptions>,
         AgCartesianAxisThemeOptions<AgContinuousTimeAxisOptions<never>>,
-        AgCartesianAxesCrossLineThemeOptions {}
+        AgCartesianAxesCrossLineThemeOptions<LabelType> {}
 
-export interface AgTimeAxisThemeOptions
+export interface AgTimeAxisThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
     extends Omit<AgTimeAxisOptions<never>, ThemeOmittedAxisOptions>,
         AgCartesianAxisThemeOptions<AgTimeAxisOptions<never>>,
-        AgCartesianAxesCrossLineThemeOptions {}
+        AgCartesianAxesCrossLineThemeOptions<LabelType> {}
 
 export interface AgCartesianCrossLineOptions extends AgBaseCrossLineOptions<AgCartesianCrossLineLabelOptions> {}
 

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -222,8 +222,8 @@ export interface AgBaseCartesianThemeOptions<TDatum = TDatumDefault> extends AgB
     axes?: AgCartesianAxesTheme;
 }
 
-export interface AgCartesianAxesCrossLineThemeOptions {
-    crossLines?: AgCrossLineThemeOptions;
+export interface AgCartesianAxesCrossLineThemeOptions<LabelType = AgBaseCrossLineLabelOptions> {
+    crossLines?: AgCrossLineThemeOptions<LabelType>;
 }
 
 export interface AgCartesianAxesTheme {

--- a/packages/ag-charts-types/src/chart/crossLineOptions.ts
+++ b/packages/ag-charts-types/src/chart/crossLineOptions.ts
@@ -1,6 +1,7 @@
 import type { AxisValue, CssColor, FontFamilyFull, FontSize, FontStyle, FontWeight, Opacity, PixelSize } from './types';
 
-export interface AgCrossLineThemeOptions extends Omit<AgBaseCrossLineOptions, 'type'> {}
+export interface AgCrossLineThemeOptions<LabelType = AgBaseCrossLineLabelOptions>
+    extends Omit<AgBaseCrossLineOptions<LabelType>, 'type'> {}
 
 export interface AgBaseCrossLineOptions<LabelType = AgBaseCrossLineLabelOptions> {
     /** Whether to show the Cross Line. */

--- a/packages/ag-charts-types/src/chart/operationOptions.ts
+++ b/packages/ag-charts-types/src/chart/operationOptions.ts
@@ -11,7 +11,8 @@ export type Operation =
     | FontOperation
     | ColorOperation;
 
-type Leaf<T = ExcludeLeaves> = Operation | T;
+type Leaf<T extends ExcludeLeaves> = Operation | T;
+type AnyLeaf = Leaf<ExcludeLeaves>;
 
 type ExcludeLeaves = string | symbol | number | undefined | AgGradientColor | AgPatternColor | AgImageFill;
 
@@ -70,33 +71,33 @@ type PaletteParam =
 type PathOperation =
     | { $ref: ThemeParam }
     | { $palette: PaletteParam }
-    | { $path: Leaf<string> | [Leaf<string>, Leaf] | [Leaf<string>, Leaf, Leaf] };
+    | { $path: Leaf<string> | [Leaf<string>, AnyLeaf] | [Leaf<string>, AnyLeaf, AnyLeaf] };
 
 type LogicOperation =
-    | { $if: [Leaf, Leaf, Leaf] }
-    | { $or: Leaf[] }
-    | { $and: Leaf[] }
-    | { $eq: [Leaf, Leaf] }
-    | { $not: [Leaf] }
-    | { $switch: [Leaf] }
+    | { $if: [AnyLeaf, AnyLeaf, AnyLeaf] }
+    | { $or: AnyLeaf[] }
+    | { $and: AnyLeaf[] }
+    | { $eq: [AnyLeaf, AnyLeaf] }
+    | { $not: [AnyLeaf] }
+    | { $switch: [AnyLeaf] }
     | { $isOperation: string };
 
 type NumericOperation = { $even: [Leaf<number>] } | { $mul: [Leaf<number>, Leaf<number>] } | { $round: [Leaf<number>] };
 
 type TransformOperation =
-    | { $map: [Leaf, Leaf] }
-    | { $find: [Leaf, Leaf] }
+    | { $map: [AnyLeaf, AnyLeaf] }
+    | { $find: [AnyLeaf, AnyLeaf] }
     | { $merge: Leaf<object>[] }
     | { $omit: [Leaf<Array<string>>, Leaf<object>] }
     | { $value: '$1' | '$index' };
 
-type FontOperation = { $rem: [Leaf] | [Leaf, Leaf] };
+type FontOperation = { $rem: [AnyLeaf] | [AnyLeaf, AnyLeaf] };
 
 type ColorOperation =
     | { $mix: [Leaf<string>, Leaf<string>, Leaf<number>] }
     | { $foregroundBackgroundMix: [Leaf<number>] }
     | { $foregroundBackgroundAccentMix: [Leaf<number>, Leaf<number>] }
-    | { $interpolate: [Leaf, Leaf<number>] }
-    | { $isGradient: [Leaf] }
-    | { $isPattern: [Leaf] }
-    | { $isImage: [Leaf] };
+    | { $interpolate: [AnyLeaf, Leaf<number>] }
+    | { $isGradient: [AnyLeaf] }
+    | { $isPattern: [AnyLeaf] }
+    | { $isImage: [AnyLeaf] };

--- a/packages/ag-charts-types/src/chart/operationOptions.ts
+++ b/packages/ag-charts-types/src/chart/operationOptions.ts
@@ -11,7 +11,7 @@ export type Operation =
     | FontOperation
     | ColorOperation;
 
-type Leaf<T extends ExcludeLeaves> = Operation | T;
+type Leaf<T extends ExcludeLeaves | object> = Operation | T;
 type AnyLeaf = Leaf<ExcludeLeaves>;
 
 type ExcludeLeaves = string | symbol | number | undefined | AgGradientColor | AgPatternColor | AgImageFill;

--- a/packages/ag-charts-types/src/chart/polarAxisOptions.ts
+++ b/packages/ag-charts-types/src/chart/polarAxisOptions.ts
@@ -4,7 +4,7 @@ import type {
     AgContinuousAxisOptions,
     AgFormattableLabelOptions,
 } from './axisOptions';
-import type { AgBaseCrossLineOptions, AgCrossLineThemeOptions } from './crossLineOptions';
+import type { AgBaseCrossLineLabelOptions, AgBaseCrossLineOptions, AgCrossLineThemeOptions } from './crossLineOptions';
 import type { Degree, Ratio, TContextDefault } from './types';
 
 export type AgPolarAxisShape = 'polygon' | 'circle';
@@ -65,5 +65,5 @@ interface OrientableLabel {
 export interface AgAngleAxisFormattableLabelOptions extends AgFormattableLabelOptions, OrientableLabel {}
 export interface AgAngleAxisLabelOptions extends AgBaseAxisLabelOptions, OrientableLabel {}
 
-export interface AgAngleCrossLineOptions extends AgBaseCrossLineOptions<AgBaseAxisLabelOptions> {}
-export interface AgAngleCrossLineThemeOptions extends AgCrossLineThemeOptions<AgBaseAxisLabelOptions> {}
+export interface AgAngleCrossLineOptions extends AgBaseCrossLineOptions<AgBaseCrossLineLabelOptions> {}
+export interface AgAngleCrossLineThemeOptions extends AgCrossLineThemeOptions<AgBaseCrossLineLabelOptions> {}

--- a/packages/ag-charts-types/src/chart/polarAxisOptions.ts
+++ b/packages/ag-charts-types/src/chart/polarAxisOptions.ts
@@ -38,7 +38,7 @@ export interface AgAngleAxesCrossLineThemeOptions {
 
 export interface AgAngleNumberAxisOptions<TContext = TContextDefault>
     extends Omit<AgBaseAxisOptions<AgAngleAxisFormattableLabelOptions, TContext>, 'interval'>,
-        AgContinuousAxisOptions {
+        AgContinuousAxisOptions<number, number> {
     type: 'angle-number';
     /** Angle in degrees to start ticks positioning from. */
     startAngle?: Degree;
@@ -65,5 +65,5 @@ interface OrientableLabel {
 export interface AgAngleAxisFormattableLabelOptions extends AgFormattableLabelOptions, OrientableLabel {}
 export interface AgAngleAxisLabelOptions extends AgBaseAxisLabelOptions, OrientableLabel {}
 
-export interface AgAngleCrossLineOptions extends AgBaseCrossLineOptions {}
-export interface AgAngleCrossLineThemeOptions extends AgCrossLineThemeOptions {}
+export interface AgAngleCrossLineOptions extends AgBaseCrossLineOptions<AgBaseAxisLabelOptions> {}
+export interface AgAngleCrossLineThemeOptions extends AgCrossLineThemeOptions<AgBaseAxisLabelOptions> {}

--- a/packages/ag-charts-types/src/chart/radiusAxisOptions.ts
+++ b/packages/ag-charts-types/src/chart/radiusAxisOptions.ts
@@ -14,7 +14,7 @@ interface AgRadiusAxisLabelOptions extends AgBaseAxisLabelOptions {}
 
 export interface AgRadiusNumberAxisOptions<TContext = TContextDefault>
     extends Omit<AgBaseAxisOptions<AgRadiusAxisFormattableLabelOptions, TContext>, 'interval'>,
-        AgContinuousAxisOptions {
+        AgContinuousAxisOptions<number, number> {
     type: 'radius-number';
     /** The rotation angle of axis line and labels in degrees. */
     positionAngle?: Degree;

--- a/packages/ag-charts-types/src/chart/themeOptions.ts
+++ b/packages/ag-charts-types/src/chart/themeOptions.ts
@@ -348,7 +348,7 @@ export interface AgThemeOverrides<TDatum = TDatumDefault> extends AgChartThemeOv
 
 // Use Typescript function types to verify that all series types are present in the manually
 // maintained AgBaseChartThemeOverrides type.
-type VerifyAgBaseChartThemeOverrides<T = AgBaseChartOptions<never, never>> = {
+type VerifyAgBaseChartThemeOverrides<T> = {
     [K in NonNullable<AgCartesianSeriesOptions<never, never>['type']>]?: T;
 } & {
     [K in NonNullable<AgPolarSeriesOptions<never, never>['type']>]?: T;
@@ -363,5 +363,6 @@ type VerifyAgBaseChartThemeOverrides<T = AgBaseChartOptions<never, never>> = {
 // Verification checks for completeness/correctness.
 const __THEME_OVERRIDES = undefined as any as Required<AgChartThemeOverrides<never>>;
 // @ts-expect-error TS6133 - this is used to validate completeness by the compiler, but is deliberately unused.
-let __VERIFY_THEME_OVERRIDES: Required<VerifyAgBaseChartThemeOverrides> = undefined as any;
+let __VERIFY_THEME_OVERRIDES: Required<VerifyAgBaseChartThemeOverrides<AgBaseChartOptions<never, never>>> =
+    undefined as any;
 __VERIFY_THEME_OVERRIDES = __THEME_OVERRIDES;

--- a/packages/ag-charts-types/src/presets/sparkline/sparklineOptions.ts
+++ b/packages/ag-charts-types/src/presets/sparkline/sparklineOptions.ts
@@ -7,7 +7,7 @@ import type { AgBarSeriesOptions } from '../../series/cartesian/barOptions';
 import type { AgLineSeriesOptions } from '../../series/cartesian/lineOptions';
 import type { AgSparklineAxisOptions } from './sparklineAxisOptions';
 
-export interface AgSparklineCrosshairOptions extends Omit<AgCrosshairOptions, 'label'> {}
+export interface AgSparklineCrosshairOptions extends Omit<AgCrosshairOptions<never>, 'label'> {}
 
 export interface AgSparklineTooltipRendererParams<TDatum> {
     /** Context passed into the Sparkline options, if provided. */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11754

* Fix all `aglint/require-explicit-generic` violations.
* Promote the `aglint/require-explicit-generic` rule from warning to error.