### PR TITLE
AG-14631 Use the more intuitive `...` notation for `callWithContext`

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -565,7 +565,7 @@ export class ZoomManager extends BaseManager {
         this.eventsHub.emit('zoom:change', { ...this.getZoom(), axes, callerId });
 
         const zoomEvent: AgZoomEvent = { type: 'zoom', ...this.getMementoRanges() };
-        callWithContext(this.caller, this.fireChartEvent<AgZoomEvent>, [zoomEvent]);
+        callWithContext(this.caller, this.fireChartEvent<AgZoomEvent>, zoomEvent);
     }
 
     private getRangeDirection(ratio: ZoomState, direction: ChartAxisDirection): AgZoomRange | undefined {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1030,7 +1030,7 @@ export abstract class Series<
     }
 
     public callWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> {
-        return callWithContext([this.properties, this.ctx.chartService], fn, params);
+        return callWithContext([this.properties, this.ctx.chartService], fn, ...params);
     }
 
     protected formatTooltipWithContext<P extends AgSeriesTooltipRendererParams<any>, Tooltip extends SeriesTooltip<P>>(

--- a/packages/ag-charts-community/src/chart/series/seriesTooltip.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTooltip.ts
@@ -40,7 +40,7 @@ export class SeriesTooltip<P extends AgSeriesTooltipRendererParams<any>> extends
         content: TooltipStructuredContent,
         params: RequireOptional<P>
     ): TooltipContent {
-        const overrides = this.renderer == null ? undefined : callWithContext(callers, this.renderer, [params]);
+        const overrides = this.renderer == null ? undefined : callWithContext(callers, this.renderer, params);
         if (typeof overrides === 'string') return { type: 'raw', rawHtmlString: overrides };
         if (overrides != null) return { type: 'structured', ...content, ...overrides };
         return { type: 'structured', ...content };

--- a/packages/ag-charts-community/src/util/callbackCache.ts
+++ b/packages/ag-charts-community/src/util/callbackCache.ts
@@ -17,7 +17,7 @@ function maybeSetContext<I>(caller: Caller, params: I[]): boolean {
 export function callWithContext<F extends AnyFn>(
     callers: Caller | Caller[],
     fn: F,
-    params: Parameters<F>
+    ...params: Parameters<F>
 ): ReturnType<F> {
     if (Array.isArray(callers)) {
         for (const caller of callers) {
@@ -44,7 +44,7 @@ export class CallbackCache {
             // Unable to serialise params!
             // No caching possible.
 
-            return this.invoke(callers, fn, params, paramCache);
+            return this.invoke(callers, fn, paramCache, undefined, ...params);
         }
 
         if (paramCache == null) {
@@ -53,7 +53,7 @@ export class CallbackCache {
         }
 
         if (!paramCache.has(serialisedParams)) {
-            return this.invoke(callers, fn, params, paramCache, serialisedParams);
+            return this.invoke(callers, fn, paramCache, serialisedParams, ...params);
         }
 
         return paramCache.get(serialisedParams);
@@ -62,12 +62,12 @@ export class CallbackCache {
     private invoke<F extends AnyFn>(
         callers: Caller | Caller[],
         fn: F,
-        params: Parameters<F>,
-        paramCache?: Map<string, any>,
-        serialisedParams?: string
+        paramCache: Map<string, any> | undefined,
+        serialisedParams: string | undefined,
+        ...params: Parameters<F>
     ) {
         try {
-            const result = callWithContext(callers, fn, params);
+            const result = callWithContext(callers, fn, ...params);
             if (paramCache && serialisedParams != null) {
                 paramCache.set(serialisedParams, result);
             }

--- a/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
@@ -38,5 +38,5 @@ export function getLabelText(seriesId: string, ctx: Ctx, datum: GaugeLabelDatum,
 }
 
 export function formatWithContext<P>(ctx: Ctx, formatter: Formatter<P>, params: P): string | undefined {
-    return _ModuleSupport.callWithContext(ctx.chartService, formatter, [params]);
+    return _ModuleSupport.callWithContext(ctx.chartService, formatter, params);
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14631

Depends on:
- https://github.com/ag-grid/ag-charts/pull/4321
- https://github.com/ag-grid/ag-charts/pull/4334