### PR TITLE
AG-3390 - Docs content spelling and grammar fixes

### DIFF
--- a/packages/ag-charts-website/src/content/docs/accessibility-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/accessibility-test/index.mdoc
@@ -2,11 +2,11 @@
 title: 'Accessibility Tests'
 ---
 
-## keyboard-navigation-with-highlight
+## Keyboard Navigation With Highlight
 
 {% chartExampleRunner title="Keyboard Navigation" name="keyboard-navigation-with-highlight" type="generated" /%}
 
-## opening-context-menu-second-chart
+## Opening Context Menu Second Chart
 
 {% chartExampleRunner title="Context Menu Second Chart" name="opening-context-menu-second-chart" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
@@ -72,7 +72,7 @@ The following example demonstrates:
 
 ## Waiting for Options Update
 
-Creation and updates happen asynchronously, but in some situations it maybe useful to know when an update has been
+Creation and updates happen asynchronously, but in some situations it may be useful to know when an update has been
 rendered.
 
 To assist with this, `AgChartInstance.update()` and `AgChartInstance.updateDelta()` return `Promise`s that resolve once
@@ -82,7 +82,7 @@ Additionally `AgChartsInstance.waitForUpdate()` can be used after initial creati
 when the first rendering of the newly created chart is complete.
 
 {% note %}
-Although rendering maybe complete, browsers may not repaint until Javascript execution pauses.
+Although rendering may be complete, browsers may not repaint until Javascript execution pauses.
 
 `Promise`s do not take animations into account, they resolve after the first rendering in an animation sequence.
 {% /note %}

--- a/packages/ag-charts-website/src/content/docs/area-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/area-series/index.mdoc
@@ -87,7 +87,7 @@ series: [
 ],
 ```
 
-Please see the the [API Reference](./area-series/#reference-AgAreaSeriesOptions-interpolation) for a list of all available interpolation options.
+Please see the [API Reference](./area-series/#reference-AgAreaSeriesOptions-interpolation) for a list of all available interpolation options.
 
 ### Missing Data
 

--- a/packages/ag-charts-website/src/content/docs/cone-funnel-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/cone-funnel-series/index.mdoc
@@ -24,7 +24,7 @@ series: [
 
 In this configuration:
 
--   `stageKey` defines the stages which are used for the the lines of the cone funnel.
+-   `stageKey` defines the stages which are used for the lines of the cone funnel.
 -   `valueKey` provides the numerical values which determine the width of line.
 
 ## Horizontal Cone Funnel

--- a/packages/ag-charts-website/src/content/docs/context-menu/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/context-menu/index.mdoc
@@ -9,7 +9,7 @@ The Context Menu provides context-aware interactions with the chart elements.
 
 In this example:
 
--   Right clicking anywhere on the chart show the Context Menu with the option to download the chart.
+-   Right clicking anywhere on the chart shows the Context Menu with the option to download the chart.
 -   Right clicking on a legend item will show the Context Menu with additional options to toggle series visibility.
 
 The Context Menu is enabled by default, to disable set `contextMenu.enabled` to `false`.

--- a/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
@@ -51,7 +51,7 @@ Complete our [Quick Start](./quick-start/) (or open the example below in Plunker
         -   **Type:** Defines the type of chart to display (e.g. Line, Bar, etc...).
         -   **xKey:** The data to use for the X axis.
         -   **yKey:** The data to use for the Y axis.
--   **Create:** `AgCharts.create(chartOptions)` API for creating a new charts, using the Chart Options configurations.
+-   **Create:** `AgCharts.create(chartOptions)` API for creating new charts, using the Chart Options configurations.
 
 {% /if %}
 
@@ -410,7 +410,7 @@ Now we should see our Legend and Tooltips using the `yName` value as opposed to 
 
 The last thing to do is format our axes labels to make the chart more readable. We can do this by using a `formatter` on the `label` property of the axis.
 
-The `formatter` should be a function that receives the axis label data and returns a `String` to display. For example, we can format our right axes to include ' °C' with the following function:
+The `formatter` should be a function that receives the axis label data and returns a `String` to display. For example, we can format our right axis to include ' °C' with the following function:
 
 {% if isFramework("javascript") %}
 

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/index.mdoc
@@ -49,7 +49,7 @@ series: [
 ],
 ```
 
-The `colourRange` array must contain 2 or more values.
+The `colorRange` array must contain 2 or more values.
 
 ### Labels
 

--- a/packages/ag-charts-website/src/content/docs/installation/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/installation/index.mdoc
@@ -298,7 +298,7 @@ Once installed, you can then access AG Charts via the `agCharts.AgCharts` global
 
 ## Download
 
-If your project does not use package manager and you don't want to refer AG Charts from CDN, you can download AG Chart's source files and keep them in your project structure.
+If your project does not use a package manager and you don't want to refer to AG Charts from CDN, you can download AG Charts' source files and keep them in your project structure.
 
 {% warning %}
 Downloading AG Charts makes upgrading more complex and prone to errors. We recommend using AG Charts from an NPM/Yarn package or from CDN.

--- a/packages/ag-charts-website/src/content/docs/layout-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/layout-test/index.mdoc
@@ -15,7 +15,7 @@ title: 'Layout Test'
 
 {% chartExampleRunner title="Shadow DOM layout" name="layout-shadow-dom" type="generated" /%}
 
-# Detatched WebComponent / Shadow-DOM OOB
+# Detached WebComponent / Shadow-DOM OOB
 
 -   Should render at 300px high and full width of example.
 -   Hover/highlight and tooltips should work.

--- a/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
@@ -86,7 +86,7 @@ series: [
 ],
 ```
 
-Please see the the [API Reference](./line-series/#reference-AgLineSeriesOptions-interpolation) for a list of all available interpolation options.
+Please see the [API Reference](./line-series/#reference-AgLineSeriesOptions-interpolation) for a list of all available interpolation options.
 
 ## Data
 

--- a/packages/ag-charts-website/src/content/docs/map-markers/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/map-markers/index.mdoc
@@ -37,7 +37,7 @@ In this configuration:
 
 ## Map Marker Position from Data
 
-Instead of using a topology file, the Map Marker Series can use geographic data from within the data. This is best suited for data containing latitude and logitute coordinates such as crime data.
+Instead of using a topology file, the Map Marker Series can use geographic data from within the data. This is best suited for data containing latitude and longitude coordinates such as crime data.
 
 {% chartExampleRunner title="Marker Series" name="marker-series" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/quick-start/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/quick-start/index.mdoc
@@ -37,7 +37,7 @@ Add React Charts to your application in 60 seconds:
 
 {% if isFramework("angular") %}
 
-## Create a Angular Chart
+## Create an Angular Chart
 
 Add Angular Charts to your application in 60 seconds:
 

--- a/packages/ag-charts-website/src/content/docs/radar-area-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series/index.mdoc
@@ -15,7 +15,7 @@ To create a Radar Area Series, use the `radar-area` series type.
 ```js
 series: [
     { type: 'radar-area', angleKey: 'department', radiusKey: 'quality', radiusName: `Quality` },
-    { type: 'radar-area', , angleKey: 'department', radiusKey: 'efficiency', radiusName: `Efficiency` },
+    { type: 'radar-area', angleKey: 'department', radiusKey: 'efficiency', radiusName: `Efficiency` },
 ],
 ```
 

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series/index.mdoc
@@ -55,7 +55,7 @@ This is changed via the `innerRadiusRatio` option on the Radius Category Axis.
 ```js
 axes: [
     { type: 'angle-number' },
-    { type: 'radius-category' innerRadiusRatio: 0.3 },
+    { type: 'radius-category', innerRadiusRatio: 0.3 },
 ],
 ```
 

--- a/packages/ag-charts-website/src/content/docs/radial-column-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series/index.mdoc
@@ -55,7 +55,7 @@ This is changed via the `innerRadiusRatio` option on the Radius Number Axis.
 ```js
 axes: [
     { type: 'angle-category' },
-    { type: 'radius-number' innerRadiusRatio: 0.2 },
+    { type: 'radius-number', innerRadiusRatio: 0.2 },
 ],
 ```
 

--- a/packages/ag-charts-website/src/content/docs/sparklines/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sparklines/index.mdoc
@@ -135,8 +135,8 @@ Each of the Bar, Line, and Area Sparklines can be customised using the associate
 
 In this configuration:
 
--   `type` are corresponds to an axis type as documented in [Axis Types](./axes-types)
--   `visible` hides
+-   `type` corresponds to an axis type as documented in [Axis Types](./axes-types)
+-   `visible` hides the axis
 
 {% note %}
 When using `direction: 'horizontal'` on the Bar Series, the x- and y- axes are flipped so `xAxis` always corresponds to the categories and `yAxis` always corresponds to the values.

--- a/packages/ag-charts-website/src/content/docs/stylers/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/stylers/index.mdoc
@@ -28,7 +28,7 @@ series: [
         marker: {
             itemStyler: (params) => {
                 if (params.datum.coal > params.datum.nuclear) return { fill: 'red', size: 15 };
-                else return { fill: p.fill, size: p.size };
+                else return { fill: params.fill, size: params.size };
             },
         },
     },

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/index.mdoc
@@ -115,7 +115,7 @@ series: [
 
 In this configuration:
 
--   `fills` and `strokes` are an array of colours to use for the fills and strokes, where node receives the colour indexed by the index of its root node
+-   `fills` and `strokes` are an array of colours to use for the fills and strokes, where each node receives the colour indexed by the index of its root node
 
 {% note %}
 When a `colorRange` is used, the `fills` and `strokes` arrays are ignored

--- a/packages/ag-charts-website/src/content/docs/themes/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/themes/index.mdoc
@@ -3,7 +3,7 @@ title: 'Themes'
 description: 'Themes customise the appearance of your $framework charts. Browse stock $framework chart themes or create your own by overriding default chart options.'
 ---
 
-Themes allow you customise the appearance of your charts. They provide defaults for different properties of the chart that will be used unless overridden by the chart options.
+Themes allow you to customise the appearance of your charts. They provide defaults for different properties of the chart that will be used unless overridden by the chart options.
 
 ## Using Stock Themes
 


### PR DESCRIPTION
# Documentation Amendments

## Accessibility Tests
LN5: "## keyboard-navigation-with-highlight" => "## Keyboard Navigation With Highlight"
-- Converted heading to title case

LN9: "## opening-context-menu-second-chart" => "## Opening Context Menu Second Chart"
-- Converted heading to title case

## Area Series
LN90: "Please see the the [API Reference]" => "Please see the [API Reference]"
-- Removed duplicate word "the"

## Create/Update
LN75: "it maybe useful" => "it may be useful"
-- Corrected spacing for proper grammar (maybe -> may be)

LN85: "rendering maybe complete" => "rendering may be complete"
-- Corrected spacing for proper grammar (maybe -> may be)

## Cone Funnel Series
LN27: "used for the the lines" => "used for the lines"
-- Removed duplicate word "the"

## Context Menu
LN12: "chart show the Context" => "chart shows the Context"
-- Corrected verb tense for third person singular subject

## Create a Basic Chart
LN54: "creating a new charts" => "creating new charts"
-- Removed incorrect article "a" before plural noun
LN413: "format our right axes" => "format our right axis"
-- Corrected plural to singular for consistency

## Heatmap Series
LN52: "The `colourRange` array" => "The `colorRange` array"
-- Changed British spelling to American spelling for consistency with code

## Installation
LN301: "does not use package manager" => "does not use a package manager"
-- Added missing article "a"
LN301: "refer AG Charts from" => "refer to AG Charts from"
-- Added missing preposition "to"
LN301: "download AG Chart's source" => "download AG Charts' source"
-- Corrected possessive form (Chart's -> Charts')

## Layout Test
LN18: "# Detatched WebComponent" => "# Detached WebComponent"
-- Corrected spelling (Detatched -> Detached)

## Line Series
LN89: "Please see the the [API Reference]" => "Please see the [API Reference]"
-- Removed duplicate word "the"

## Map Markers
LN40: "latitude and logitute coordinates" => "latitude and longitude coordinates"
-- Corrected spelling (logitute -> longitude)

## Quick Start
LN40: "Create a Angular Chart" => "Create an Angular Chart"
-- Corrected article (a -> an) before vowel sound

## Radar Area Series
LN18: "{ type: 'radar-area', , angleKey:" => "{ type: 'radar-area', angleKey:"
-- Removed extra comma in JavaScript code

## Radial Bar Series
LN58: "{ type: 'radius-category' innerRadiusRatio:" => "{ type: 'radius-category', innerRadiusRatio:"
-- Added missing comma in JavaScript code

## Radial Column Series
LN58: "{ type: 'radius-number' innerRadiusRatio:" => "{ type: 'radius-number', innerRadiusRatio:"
-- Added missing comma in JavaScript code

## Sparklines - Overview
LN138: "`type` are corresponds to an" => "`type` corresponds to an"
-- Corrected grammar error (removed redundant "are")
LN139: "`visible` hides" => "`visible` hides the axis"
-- Completed sentence fragment for clarity

## Stylers
LN31: "return { fill: p.fill, size: p.size" => "return { fill: params.fill, size: params.size"
-- Corrected variable name for consistency (p -> params)

## Sunburst Series
LN118: "where node receives the colour" => "where each node receives the colour"
-- Added missing article "each" for clarity

## Themes
LN6: "Themes allow you customise the" => "Themes allow you to customise the"
-- Added missing infinitive marker "to"