### PR TITLE
Pre-12.0.0 optimisations pt. 6

### DIFF
--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -192,6 +192,11 @@ export class OptionsGraph extends AdjacencyListGraph<unknown, string> implements
         // Once the full "static" version of the graph has been built, then graft on the dependencies. This ensures all
         // the dependents have been established and so the edges can be built in a single pass.
         this.buildDependencyGraph();
+
+        console.log((this as any)._edges.size);
+        for (const [edge, edgeVertices] of (this as any)._edges) {
+            console.log(edge, edgeVertices.size);
+        }
     }
 
     override clear() {

--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -192,11 +192,6 @@ export class OptionsGraph extends AdjacencyListGraph<unknown, string> implements
         // Once the full "static" version of the graph has been built, then graft on the dependencies. This ensures all
         // the dependents have been established and so the edges can be built in a single pass.
         this.buildDependencyGraph();
-
-        console.log((this as any)._edges.size);
-        for (const [edge, edgeVertices] of (this as any)._edges) {
-            console.log(edge, edgeVertices.size);
-        }
     }
 
     override clear() {

--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -558,7 +558,7 @@ export class OptionsGraph extends AdjacencyListGraph<unknown, string> implements
             dependenciesFn?.(this, valueVertex, operationValues);
         }
 
-        this.pendingProcessingEdges.clear();
+        this.pendingProcessingEdges = [];
     }
 
     private resolveVertex(vertex: Vertex<unknown>, object: PlainObject = this.resolved!) {

--- a/packages/ag-charts-core/src/utils/graph.test.ts
+++ b/packages/ag-charts-core/src/utils/graph.test.ts
@@ -16,6 +16,6 @@ describe('AdjacencyListGraph', () => {
         expect(graph.adjacent(v2, v1)).toBe(false);
         expect([...graph.neighbours(v2)].map((v) => graph.getVertexValue(v))).toEqual([]);
 
-        expect(graph.density()).toBe(0.5);
+        // expect(graph.density()).toBe(0.5);
     });
 });

--- a/packages/ag-charts-core/src/utils/graph.ts
+++ b/packages/ag-charts-core/src/utils/graph.ts
@@ -59,23 +59,18 @@ export class AdjacencyListGraph<V, E = undefined> {
         for (const [_edge, adjacentVertices] of edges) {
             this._vertexCount -= adjacentVertices.length;
         }
-        vertex.edges.clear();
+        vertex.clear();
 
         // TODO: iterate all edges and their vertices to find and delete references to `vertex`
     }
 
     removeEdge(from: Vertex<V>, to: Vertex<V>): void {
-        const edges = from.edges;
-        if (!edges) return;
-        for (const [edge, adjacentVertices] of edges) {
+        for (const [edge, adjacentVertices] of from.edges) {
             const index = adjacentVertices.indexOf(to);
             adjacentVertices.splice(index, 1);
             if (adjacentVertices.length === 0) {
-                edges.delete(edge);
+                from.edges.delete(edge);
             }
-        }
-        if (edges.size === 0) {
-            from.edges.clear();
         }
     }
 
@@ -175,4 +170,9 @@ export class Vertex<V, E = unknown> {
     public cachedNeighbours: Map<V, Vertex<V>> = new Map();
 
     constructor(public value: V) {}
+
+    clear() {
+        this.edges.clear();
+        this.cachedNeighbours.clear();
+    }
 }

--- a/packages/ag-charts-core/src/utils/graph.ts
+++ b/packages/ag-charts-core/src/utils/graph.ts
@@ -17,7 +17,7 @@ export class AdjacencyListGraph<V, E = undefined> {
     // Stores edges that are pending processing on a given edge value, optimised for iteration of pairs of adjacent
     // vertices. Should call `.clear()` once the edges have been processed.
     private readonly processedEdge?: E;
-    protected readonly pendingProcessingEdges: Set<[Vertex<V>, Vertex<V>]> = new Set();
+    protected pendingProcessingEdges: [Vertex<V>, Vertex<V>][] = [];
 
     constructor(cachedNeighboursEdge?: E, processedEdge?: E) {
         this.cachedNeighboursEdge = cachedNeighboursEdge;
@@ -28,7 +28,7 @@ export class AdjacencyListGraph<V, E = undefined> {
         this._vertexCount = 0;
         this._edges.clear();
         this._cachedNeighbours.clear();
-        this.pendingProcessingEdges.clear();
+        this.pendingProcessingEdges = [];
     }
 
     addVertex(value: V): Vertex<V> {
@@ -48,7 +48,7 @@ export class AdjacencyListGraph<V, E = undefined> {
         }
 
         if (edge === this.processedEdge) {
-            this.pendingProcessingEdges.add([from, to]);
+            this.pendingProcessingEdges.push([from, to]);
         }
 
         const edges = this._edges.get(from)!;

--- a/packages/ag-charts-core/src/utils/graph.ts
+++ b/packages/ag-charts-core/src/utils/graph.ts
@@ -1,5 +1,3 @@
-import { isObject } from './typeGuards';
-
 /**
  * A graph that is optimised for vertex lookup and adjacency by edge value.
  */
@@ -8,11 +6,9 @@ export class AdjacencyListGraph<V, E = undefined> {
 
     // Stores edges in a way to optimise lookup of vertices adjacent by edge value to a vertex. This is less optimal
     // for iteration of all edges and deletion of vertices & edges, however this is less useful for our case.
-    private readonly _edges: Map<Vertex<V>, Map<E, Vertex<V>[]>> = new Map();
 
     // Caches neighbours on a given edge value, optimised for lookup by the `to` vertex value.
     private readonly cachedNeighboursEdge?: E;
-    private readonly _cachedNeighbours: Map<Vertex<V>, Map<V, Vertex<V>>> = new Map();
 
     // Stores edges that are pending processing on a given edge value, optimised for iteration of pairs of adjacent
     // vertices. Should call `.clear()` once the edges have been processed.
@@ -26,8 +22,6 @@ export class AdjacencyListGraph<V, E = undefined> {
 
     clear() {
         this._vertexCount = 0;
-        this._edges.clear();
-        this._cachedNeighbours.clear();
         this.pendingProcessingEdges = [];
     }
 
@@ -38,20 +32,9 @@ export class AdjacencyListGraph<V, E = undefined> {
     }
 
     addEdge(from: Vertex<V>, to: Vertex<V>, edge: E): void {
-        let cachedNeighbours;
-        let edges;
-        if (!from.graphInitialised) {
-            cachedNeighbours = new Map();
-            edges = new Map();
-            this._cachedNeighbours.set(from, cachedNeighbours);
-            this._edges.set(from, edges);
-            from.graphInitialised = true;
-        }
-
         // Optimize cached neighbours handling
         if (edge === this.cachedNeighboursEdge) {
-            cachedNeighbours ??= this._cachedNeighbours.get(from);
-            cachedNeighbours?.set(to.value, to);
+            from.cachedNeighbours.set(to.value, to);
         }
 
         if (edge === this.processedEdge) {
@@ -59,10 +42,11 @@ export class AdjacencyListGraph<V, E = undefined> {
         }
 
         // Optimize edges handling - single lookup with fallback
-        edges ??= this._edges.get(from);
-        const vertices = edges?.get(edge);
+        // edges ??= this._edges.get(from);
+        const { edges } = from;
+        const vertices = edges.get(edge);
         if (!vertices) {
-            edges?.set(edge, [to]);
+            edges.set(edge, [to]);
         } else if (vertices.indexOf(to) === -1) {
             vertices.push(to);
         }
@@ -70,18 +54,18 @@ export class AdjacencyListGraph<V, E = undefined> {
 
     removeVertex(vertex: Vertex<V>): void {
         this._vertexCount--;
-        const edges = this._edges.get(vertex);
+        const edges = vertex.edges;
         if (!edges) return;
         for (const [_edge, adjacentVertices] of edges) {
             this._vertexCount -= adjacentVertices.length;
         }
-        this._edges.delete(vertex);
+        vertex.edges.clear();
 
         // TODO: iterate all edges and their vertices to find and delete references to `vertex`
     }
 
     removeEdge(from: Vertex<V>, to: Vertex<V>): void {
-        const edges = this._edges.get(from);
+        const edges = from.edges;
         if (!edges) return;
         for (const [edge, adjacentVertices] of edges) {
             const index = adjacentVertices.indexOf(to);
@@ -91,12 +75,12 @@ export class AdjacencyListGraph<V, E = undefined> {
             }
         }
         if (edges.size === 0) {
-            this._edges.delete(from);
+            from.edges.clear();
         }
     }
 
     removeEdges(from: Vertex<V>, edgeValue: E): void {
-        this._edges.get(from)?.delete(edgeValue);
+        from.edges.delete(edgeValue);
     }
 
     getVertexValue(vertex: Vertex<V>): V {
@@ -105,9 +89,7 @@ export class AdjacencyListGraph<V, E = undefined> {
 
     // Iterate all the neighbours of a given vertex.
     *neighbours(from: Vertex<V>): Generator<Vertex<V>, void, unknown> {
-        const edges = this._edges.get(from);
-        if (!edges) return;
-        for (const [_edge, adjacentVertices] of edges) {
+        for (const [_edge, adjacentVertices] of from.edges) {
             for (const adjacentVertex of adjacentVertices) {
                 yield adjacentVertex;
             }
@@ -115,10 +97,8 @@ export class AdjacencyListGraph<V, E = undefined> {
     }
 
     // Iterate all the neighbours and their edges of a given vertex
-    *neighboursAndEdges(from: Vertex<V>): Generator<[Vertex<V>, E], void, unknown> {
-        const edges = this._edges.get(from);
-        if (!edges) return;
-        for (const [edge, adjacentVertices] of edges) {
+    *neighboursAndEdges(from: Vertex<V, E>): Generator<[Vertex<V>, E], void, unknown> {
+        for (const [edge, adjacentVertices] of from.edges) {
             for (const adjacentVertex of adjacentVertices) {
                 yield [adjacentVertex, edge];
             }
@@ -127,12 +107,12 @@ export class AdjacencyListGraph<V, E = undefined> {
 
     // Get the set of neighbours along a given edge.
     neighboursWithEdgeValue(from: Vertex<V>, edgeValue: E): Vertex<V>[] {
-        return this._edges.get(from)?.get(edgeValue) ?? [];
+        return from.edges.get(edgeValue) ?? [];
     }
 
     // Find the first neighbour along the given edge.
     findNeighbour(from: Vertex<V>, edgeValue: E): Vertex<V> | undefined {
-        return this._edges.get(from)?.get(edgeValue)?.[0];
+        return from.edges.get(edgeValue)?.[0];
     }
 
     // Find the value of the first neighbour along the given edge.
@@ -157,7 +137,7 @@ export class AdjacencyListGraph<V, E = undefined> {
         if (edgeValue === this.cachedNeighboursEdge) {
             let found;
             for (const value of findValues) {
-                found = this._cachedNeighbours.get(found ?? from)?.get(value);
+                found = (found ?? from).cachedNeighbours.get(value);
                 if (!found) return;
             }
             return found;
@@ -179,57 +159,20 @@ export class AdjacencyListGraph<V, E = undefined> {
         return found;
     }
 
-    density(): number {
-        let numEdges = 0;
-        for (const [, edges] of this._edges) {
-            for (const adjacentVertices of edges.values()) {
-                numEdges += adjacentVertices.length;
-            }
-        }
-
-        return numEdges / (this._vertexCount * (this._vertexCount - 1));
-    }
-
     adjacent(from: Vertex<V>, to: Vertex<V>): boolean {
-        const edges = this._edges.get(from);
-        if (!edges) return false;
-        for (const [_edge, adjacentVertices] of edges) {
+        for (const [_edge, adjacentVertices] of from.edges) {
             if (adjacentVertices.includes(to)) return true;
         }
         return false;
-    }
-
-    debug() {
-        let string = '';
-        for (const from of this._edges.keys()) {
-            string += this.debugVertex(from);
-        }
-        return string;
-    }
-
-    debugVertex(vertex: Vertex<V>) {
-        let string = '';
-        const edges = this._edges.get(vertex);
-        if (!edges) return string;
-
-        let f: any = this.getVertexValue(vertex);
-        if (isObject(f)) f = `{${Object.keys(f).join(',')}}`;
-        string += `${f}\n`;
-        for (const [edge, tos] of edges) {
-            for (const to of tos) {
-                let t: any = this.getVertexValue(to);
-                if (isObject(t)) t = `{${Object.keys(t).join(',')}}`;
-                string += `  -> ${edge as any} -> ${t}\n`;
-            }
-        }
-
-        return string;
     }
 }
 
 /**
  * A wrapper class to ensure each vertex is unique even if the value is the same object.
  */
-export class Vertex<V> {
+export class Vertex<V, E = unknown> {
+    public edges: Map<E, Vertex<V>[]> = new Map();
+    public cachedNeighbours: Map<V, Vertex<V>> = new Map();
+
     constructor(public value: V) {}
 }

--- a/packages/ag-charts-core/src/utils/graph.ts
+++ b/packages/ag-charts-core/src/utils/graph.ts
@@ -38,27 +38,30 @@ export class AdjacencyListGraph<V, E = undefined> {
     }
 
     addEdge(from: Vertex<V>, to: Vertex<V>, edge: E): void {
+        // Optimize cached neighbours handling
         if (edge === this.cachedNeighboursEdge) {
-            const cache = this._cachedNeighbours.get(from);
-            if (cache) {
-                cache.set(to.value, to);
-            } else {
-                this._cachedNeighbours.set(from, new Map().set(to.value, to));
+            let cache = this._cachedNeighbours.get(from);
+            if (!cache) {
+                cache = new Map();
+                this._cachedNeighbours.set(from, cache);
             }
+            cache.set(to.value, to);
         }
 
         if (edge === this.processedEdge) {
             this.pendingProcessingEdges.push([from, to]);
         }
 
-        const edges = this._edges.get(from)!;
+        // Optimize edges handling - single lookup with fallback
+        let edges = this._edges.get(from);
         if (!edges) {
-            this._edges.set(from, new Map().set(edge, [to]));
-            return;
+            edges = new Map();
+            this._edges.set(from, edges);
         }
 
+        // Optimize vertices handling - single lookup with fallback
         const vertices = edges.get(edge);
-        if (vertices == null) {
+        if (!vertices) {
             edges.set(edge, [to]);
         } else if (vertices.indexOf(to) === -1) {
             vertices.push(to);
@@ -129,10 +132,7 @@ export class AdjacencyListGraph<V, E = undefined> {
 
     // Find the first neighbour along the given edge.
     findNeighbour(from: Vertex<V>, edgeValue: E): Vertex<V> | undefined {
-        const neighbours = this._edges.get(from)?.get(edgeValue);
-        if (!neighbours) return;
-        const [neighbour] = neighbours;
-        return neighbour;
+        return this._edges.get(from)?.get(edgeValue)?.[0];
     }
 
     // Find the value of the first neighbour along the given edge.
@@ -194,7 +194,7 @@ export class AdjacencyListGraph<V, E = undefined> {
         const edges = this._edges.get(from);
         if (!edges) return false;
         for (const [_edge, adjacentVertices] of edges) {
-            if (adjacentVertices.indexOf(to) !== -1) return true;
+            if (adjacentVertices.includes(to)) return true;
         }
         return false;
     }

--- a/packages/ag-charts-core/src/utils/graph.ts
+++ b/packages/ag-charts-core/src/utils/graph.ts
@@ -38,14 +38,20 @@ export class AdjacencyListGraph<V, E = undefined> {
     }
 
     addEdge(from: Vertex<V>, to: Vertex<V>, edge: E): void {
+        let cachedNeighbours;
+        let edges;
+        if (!from.graphInitialised) {
+            cachedNeighbours = new Map();
+            edges = new Map();
+            this._cachedNeighbours.set(from, cachedNeighbours);
+            this._edges.set(from, edges);
+            from.graphInitialised = true;
+        }
+
         // Optimize cached neighbours handling
         if (edge === this.cachedNeighboursEdge) {
-            let cache = this._cachedNeighbours.get(from);
-            if (!cache) {
-                cache = new Map();
-                this._cachedNeighbours.set(from, cache);
-            }
-            cache.set(to.value, to);
+            cachedNeighbours ??= this._cachedNeighbours.get(from);
+            cachedNeighbours?.set(to.value, to);
         }
 
         if (edge === this.processedEdge) {
@@ -53,16 +59,10 @@ export class AdjacencyListGraph<V, E = undefined> {
         }
 
         // Optimize edges handling - single lookup with fallback
-        let edges = this._edges.get(from);
-        if (!edges) {
-            edges = new Map();
-            this._edges.set(from, edges);
-        }
-
-        // Optimize vertices handling - single lookup with fallback
-        const vertices = edges.get(edge);
+        edges ??= this._edges.get(from);
+        const vertices = edges?.get(edge);
         if (!vertices) {
-            edges.set(edge, [to]);
+            edges?.set(edge, [to]);
         } else if (vertices.indexOf(to) === -1) {
             vertices.push(to);
         }


### PR DESCRIPTION
More graph.ts optimisations - biggest win is removing cost of lookups in `AdjacencyListGraph.{_cachedNeighbours,_edges}`.