### PR TITLE
AG-3390 - Docs content spelling and grammar fixes

### DIFF
--- a/packages/ag-charts-website/src/content/docs/accessibility/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/accessibility/index.mdoc
@@ -6,7 +6,7 @@ AG Charts are fully accessible, providing keyboard navigation and screen reader 
 
 ## Web Conformance Guidelines
 
-Even if you are not mandated to conform to any particular accessibility standard, it can be helpful to understand the guidelines outlined, as they are generally good practices worth incorporating into your web based applications.
+Even if you are not mandated to conform to any particular accessibility standard, it can be helpful to understand the guidelines outlined, as they are generally good practices worth incorporating into your web-based applications.
 
 Currently the most commonly encountered conformance guidelines are:
 

--- a/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
@@ -84,7 +84,7 @@ In this example:
 Note that all the state properties are optional, so a property can be excluded if you do not want to restore it.
 
 {% note %}
-Date objects can not be serialized, so should instead be provided as an `AgStateSerializableDate` object in the format `{ __type: 'date', value: string | number }` with a value of any date string or a timestamp number.
+Date objects cannot be serialized, so should instead be provided as an `AgStateSerializableDate` object in the format `{ __type: 'date', value: string | number }` with a value of any date string or a timestamp number.
 
 Dates returned from `chart.getState()` will be in the ISO-8601 format and UTC timezone.
 {% /note %}

--- a/packages/ag-charts-website/src/content/docs/fills/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/fills/index.mdoc
@@ -16,7 +16,7 @@ Supported Fill Types are:
 
 -   **Pattern Fill**: Predefined patterns including lines and shapes, or a user provided path.
 
--   **Image Fill**: An user provided image.
+-   **Image Fill**: A user provided image.
 
 The default colours and fills come from the default or user provided [Theme Palette](./themes/#palette).
 


### PR DESCRIPTION
# Documentation Amendments

## Series Fills
LN19: "An user provided" => "A user provided"
-- Corrected indefinite article usage

## API State
LN87: "can not be serialized" => "cannot be serialized"
-- Changed to single word form for correct grammar

## Accessibility
LN9: "into your web based" => "into your web-based"
-- Added hyphen to compound adjective