### PR TITLE
CRT-860: `grouped` option is missing on range-bar series

### DIFF
--- a/packages/ag-charts-community/src/chart/themes/enterpriseThemeableOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/themes/enterpriseThemeableOptionsDef.ts
@@ -484,6 +484,7 @@ export const rangeAreaSeriesThemeableOptionsDef: OptionsDefs<AgRangeAreaSeriesTh
 
 export const rangeBarSeriesThemeableOptionsDef: OptionsDefs<AgRangeBarSeriesThemeableOptions> = {
     direction: union('horizontal', 'vertical'),
+    grouped: boolean,
     showInMiniChart: boolean,
     cornerRadius: positiveNumber,
     itemStyler: callbackDefs<AgRangeBarSeriesStyle>({

--- a/packages/ag-charts-types/src/series/cartesian/rangeBarOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/rangeBarOptions.ts
@@ -63,6 +63,8 @@ export interface AgRangeBarSeriesThemeableOptions<TDatum = TDatumDefault, TConte
     itemStyler?: Styler<AgRangeBarSeriesItemStylerParams<TDatum, TContext>, AgRangeBarSeriesStyle>;
     /** Configuration for highlighting when a series or legend item is hovered over. */
     highlight?: AgMultiSeriesHighlightOptions<AgRangeBarHighlightStyleOptions>;
+    /** Whether to group together (adjacently) separate bars. */
+    grouped?: boolean;
 }
 
 export interface AgRangeBarHighlightStyleOptions extends AgRangeBarSeriesStyle {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-860