### PR TITLE
AG-15233 Set role="textbox" on annotations text input elems

### DIFF
--- a/packages/ag-charts-core/src/utils/attributeUtil.ts
+++ b/packages/ag-charts-core/src/utils/attributeUtil.ts
@@ -22,6 +22,7 @@ type AriaRole =
     | 'tab'
     | 'tablist'
     | 'tabpanel'
+    | 'textbox'
     | 'toolbar';
 
 export type BaseAttributeTypeMap = {

--- a/packages/ag-charts-enterprise/src/features/text-input/textInput.ts
+++ b/packages/ag-charts-enterprise/src/features/text-input/textInput.ts
@@ -1,5 +1,5 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { attachListener, setAttribute } from 'ag-charts-core';
+import { attachListener, setAttributes } from 'ag-charts-core';
 import type { FontOptions, TextAlign } from 'ag-charts-types';
 
 import type { AnnotationTextPosition } from '../annotations/text/util';
@@ -53,7 +53,10 @@ export class TextInput extends _ModuleSupport.BaseModuleInstance implements _Mod
         this.element.innerHTML = textInputTemplate;
 
         const textArea = this.element.firstElementChild! as HTMLDivElement;
-        setAttribute(textArea, 'data-preventdefault', false); // AG-13715
+        setAttributes(textArea, {
+            role: 'textbox', // AG-15233
+            'data-preventdefault': false, // AG-13715
+        });
 
         // FireFox does not yet support `contenteditable="plaintext-only", so it defaults to false and has to be
         // added back on to the element as the normal richtext version. The plaintext version is preferred as

--- a/packages/ag-charts-enterprise/src/features/text-input/textInputTemplate.html
+++ b/packages/ag-charts-enterprise/src/features/text-input/textInputTemplate.html
@@ -1,1 +1,1 @@
-<div role="textbox" contenteditable="plaintext-only" class="ag-charts-text-input__textarea" tabindex="0"></div>
+<div contenteditable="plaintext-only" class="ag-charts-text-input__textarea" tabindex="0"></div>

--- a/packages/ag-charts-enterprise/src/features/text-input/textInputTemplate.html
+++ b/packages/ag-charts-enterprise/src/features/text-input/textInputTemplate.html
@@ -1,1 +1,1 @@
-<div contenteditable="plaintext-only" class="ag-charts-text-input__textarea" tabindex="0"></div>
+<div role="textbox" contenteditable="plaintext-only" class="ag-charts-text-input__textarea" tabindex="0"></div>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15233

This fixes bugs with screenreaders not announcing key presses on text annotations edits.