### PR TITLE
AG-15393 Improve tick generation performance

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -651,6 +651,7 @@ export abstract class Axis<
             truncateDate = tickFormatParams.truncateDate;
         }
 
+        // The serialization required for caching is too slow for large category domains
         const f = this.uncachedCallWithContext.bind(this);
 
         const params: FormatDatumParams = {

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -424,7 +424,7 @@ export abstract class Axis<
         };
         let stylerOutput: AgBaseAxisLabelStyleOptions | undefined;
         if (label.itemStyler) {
-            stylerOutput = this.callWithContext(label.itemStyler, {
+            stylerOutput = this.cachedCallWithContext(label.itemStyler, {
                 ...params,
                 ...defaultStyle,
             });
@@ -651,7 +651,7 @@ export abstract class Axis<
             truncateDate = tickFormatParams.truncateDate;
         }
 
-        const f = this.callWithContext.bind(this);
+        const f = this.uncachedCallWithContext.bind(this);
 
         const params: FormatDatumParams = {
             datum: undefined,
@@ -915,9 +915,14 @@ export abstract class Axis<
         return this.reverse;
     }
 
-    protected callWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
+    protected cachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
         const { callbackCache, chartService } = this.moduleCtx;
         return callbackCache.call([this, chartService], fn, ...params);
+    }
+
+    private uncachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
+        const { chartService } = this.moduleCtx;
+        return callWithContext([this, chartService], fn, ...params);
     }
 
     private createCallWithContext(contextProvider: { context?: unknown } | undefined) {

--- a/packages/ag-charts-community/src/chart/axis/axisTickGenerator.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisTickGenerator.ts
@@ -49,13 +49,13 @@ import { NiceMode, type TickDatum } from './axisUtil';
 export type AnyTimeInterval = AgTimeInterval | AgTimeIntervalUnit;
 
 export interface TickData<D = any> {
+    niceDomain: D[];
     tickDomain: D[];
     rawTicks: D[];
     rawTickCount: number | undefined;
     fractionDigits: number;
     ticks: TickDatum[];
     timeInterval: AnyTimeInterval | undefined;
-    niceDomain?: D[];
 }
 
 export interface TickGenerationParams<D = any> {
@@ -70,7 +70,7 @@ export interface TickGenerationParams<D = any> {
     regularFlipRotation: number;
     labelX: number;
     sideFlag: ChartAxisLabelFlipFlag;
-    sizeLimit?: number;
+    sizeLimit: number | undefined;
     removeOverflowLabels: boolean;
     removeOverflowThreshold?: number;
 }
@@ -269,12 +269,12 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
 
         let tickData: TickData = {
             tickDomain: [],
+            niceDomain: domain,
             ticks: [],
             rawTicks: [],
             rawTickCount: undefined,
             timeInterval: undefined,
             fractionDigits: 0,
-            niceDomain: undefined,
         };
 
         let index = 0;
@@ -345,7 +345,7 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
         reverse: boolean;
         niceMode: NiceMode;
         secondaryAxis: boolean;
-        sizeLimit?: number;
+        sizeLimit: number | undefined;
     }): TickStrategy[] {
         const { label, interval } = this.axis;
         const avoidLabelCollisions = label.enabled && label.avoidCollisions;
@@ -409,9 +409,9 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
         defaultTickMinSpacing: number,
         tickGenerationType: TickGenerationType,
         index: number,
-        tickData: TickData,
+        previousTickData: TickData,
         terminate: boolean,
-        sizeLimit?: number
+        sizeLimit: number | undefined
     ): TickStrategyResult {
         // Find the next tick data where the tick data is different from the previous tick data - and return the index of this data
         const { interval } = this.axis;
@@ -428,13 +428,12 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
         const maxIterations = tickCount - minTickCount;
         const countTicks = (i: number) => Math.max(tickCount - i, minTickCount);
 
-        const previousTicks = tickData.rawTicks;
+        const previousTicks = previousTickData.rawTicks;
 
         const regenerateTicks = step == null && values == null && countTicks(index) > minTickCount;
 
         const getTickParams = {
             domain,
-            range,
             reverse,
             niceMode,
             visibleRange,
@@ -443,14 +442,13 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
             minTickCount,
             maxTickCount,
             tickCount: 0,
-            sizeLimit,
         };
 
         // First guess - generate ticks at current index
         getTickParams.tickCount = countTicks(index);
-        tickData = this.getTicks(getTickParams);
+        let nextTicks = this.getTicks(getTickParams);
 
-        if (regenerateTicks && ticksEqual(tickData.rawTicks, previousTicks)) {
+        if (regenerateTicks && ticksEqual(nextTicks.rawTicks, previousTicks)) {
             // Ticks didn't change
             // Use binary search to find the index, as there could be a lot of ticks in some cases
             let lowerBound = index;
@@ -458,16 +456,50 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
             while (lowerBound <= upperBound) {
                 index = ((lowerBound + upperBound) / 2) | 0;
                 getTickParams.tickCount = countTicks(index);
-                const nextTickData = this.getTicks(getTickParams);
+                const nextTicksCandidate = this.getTicks(getTickParams);
 
-                if (ticksEqual(nextTickData.rawTicks, previousTicks)) {
+                if (ticksEqual(nextTicksCandidate.rawTicks, previousTicks)) {
                     lowerBound = index + 1;
                 } else {
-                    tickData = nextTickData;
+                    nextTicks = nextTicksCandidate;
                     upperBound = index - 1;
                 }
             }
         }
+
+        const {
+            tickDomain,
+            niceDomain,
+            rawTicks,
+            rawTickCount,
+            generatePrimaryTicks,
+            primaryTicksIndices,
+            alignment,
+            fractionDigits,
+            timeInterval,
+        } = nextTicks;
+
+        const ticks = this.formatTicks({
+            range,
+            niceDomain,
+            rawTicks,
+            generatePrimaryTicks,
+            primaryTicksIndices,
+            alignment,
+            fractionDigits,
+            timeInterval,
+            sizeLimit,
+        });
+
+        const tickData: TickData = {
+            tickDomain,
+            niceDomain,
+            rawTicks,
+            rawTickCount,
+            timeInterval,
+            fractionDigits,
+            ticks,
+        };
 
         index += 1;
         terminate ||= step != null || values != null;
@@ -620,7 +652,6 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
 
     private getTicks({
         domain,
-        range,
         reverse,
         niceMode,
         visibleRange,
@@ -629,10 +660,8 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
         minTickCount,
         maxTickCount,
         primaryTickCount,
-        sizeLimit = Infinity,
     }: {
         domain: D[];
-        range: [number, number];
         reverse: boolean;
         niceMode: NiceMode;
         visibleRange: [number, number];
@@ -641,10 +670,9 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
         tickCount: number;
         minTickCount: number;
         maxTickCount: number;
-        sizeLimit?: number;
-    }): TickData {
+    }) {
         const { axis } = this;
-        const { label, primaryLabel, scale, interval } = axis;
+        const { primaryLabel, scale, interval } = axis;
 
         const domainParams: ScaleTickParams<any> = {
             nice: niceMode === NiceMode.TickAndDomain,
@@ -789,6 +817,48 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
             primaryTicksIndices = undefined;
         }
 
+        scale.domain = scaleDomain;
+
+        return {
+            tickDomain,
+            niceDomain,
+            rawTicks,
+            rawTickCount,
+            generatePrimaryTicks,
+            primaryTicksIndices,
+            alignment,
+            fractionDigits,
+            timeInterval,
+        };
+    }
+
+    private formatTicks({
+        niceDomain,
+        range,
+        rawTicks,
+        generatePrimaryTicks,
+        primaryTicksIndices,
+        alignment,
+        fractionDigits,
+        timeInterval,
+        sizeLimit = Infinity,
+    }: {
+        niceDomain: D[];
+        range: [number, number];
+        rawTicks: any[];
+        generatePrimaryTicks: boolean;
+        primaryTicksIndices: Set<number> | undefined;
+        alignment: ScaleAlignment | undefined;
+        fractionDigits: number;
+        timeInterval: AnyTimeInterval | undefined;
+        sizeLimit: number | undefined;
+    }) {
+        const { axis } = this;
+        const { label, scale } = axis;
+
+        const scaleDomain = scale.domain;
+        scale.domain = niceDomain; // Reset at end of function
+
         const dateStyle: DateFormatterStyle = generatePrimaryTicks ? 'component' : 'long';
         const axisTickFormatter = label.enabled
             ? axis.tickFormatter(niceDomain, rawTicks, false, fractionDigits, timeInterval, dateStyle)
@@ -847,15 +917,7 @@ export class AxisTickGenerator<S extends Scale<D, number, TickInterval<S>>, D> {
 
         scale.domain = scaleDomain;
 
-        return {
-            tickDomain,
-            rawTicks,
-            rawTickCount,
-            fractionDigits,
-            timeInterval,
-            ticks,
-            niceDomain,
-        };
+        return ticks;
     }
 }
 

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -254,21 +254,13 @@ export abstract class CartesianAxis<S extends Scale<D, number, any> = Scale<any,
             regularFlipRotation,
             labelX,
             sideFlag,
+            sizeLimit: this.chartLayout?.sizeLimit,
             removeOverflowLabels,
             removeOverflowThreshold: this.chartLayout?.padding.right,
-            sizeLimit: this.chartLayout?.sizeLimit,
         });
 
         const { tickData } = tickGenerationResult;
-        const {
-            ticks,
-            tickDomain,
-            rawTicks,
-            rawTickCount,
-            fractionDigits,
-            timeInterval,
-            niceDomain = domain,
-        } = tickData;
+        const { ticks, tickDomain, rawTicks, rawTickCount, fractionDigits, timeInterval, niceDomain } = tickData;
 
         const labels = ticks.map((d) => this.getTickLabelProps(d, tickGenerationResult));
 
@@ -530,7 +522,7 @@ export abstract class CartesianAxis<S extends Scale<D, number, any> = Scale<any,
         }
 
         const { formatter = (p) => p.defaultValue } = title;
-        const text = this.callWithContext(formatter, this.getTitleFormatterParams(domain));
+        const text = this.cachedCallWithContext(formatter, this.getTitleFormatterParams(domain));
         caption.text = text;
 
         return {

--- a/packages/ag-charts-community/src/chart/callbacks.test.ts
+++ b/packages/ag-charts-community/src/chart/callbacks.test.ts
@@ -187,7 +187,7 @@ describe('AG-13024 API context', () => {
             seriesLabelFormatter.expect().nthCalledWithContext(11, seriesContext2);
         });
         test('axisLabelFormatter', () => {
-            axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withContext(axisContext);
+            axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withContext(axisContext);
         });
         test('tooltipRenderer', async () => {
             tooltipRenderer.expect().toHaveBeenCalledTimes(0);
@@ -237,7 +237,7 @@ describe('AG-13024 API context', () => {
             seriesLabelFormatter.expect().nthCalledWithContext(9, seriesContext2);
             seriesLabelFormatter.expect().nthCalledWithContext(10, seriesContext2);
             seriesLabelFormatter.expect().nthCalledWithContext(11, seriesContext2);
-            axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withContext(axisContext);
+            axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withContext(axisContext);
             await oneTooltipCallback();
             tooltipRenderer.expect().toHaveBeenCalledTimes(3);
             tooltipRenderer.expect().nthCalledWithContext(0, seriesContext0);
@@ -250,7 +250,7 @@ describe('AG-13024 API context', () => {
             chart = await createChart(options);
             itemStyler.expect().toHaveBeenCalledTimes(12).withContext(rootContext);
             seriesLabelFormatter.expect().toHaveBeenCalledTimes(12).withContext(rootContext);
-            axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withContext(rootContext);
+            axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withContext(rootContext);
             await oneTooltipCallback();
             tooltipRenderer.expect().toHaveBeenCalledTimes(3).withContext(rootContext);
         });
@@ -269,7 +269,7 @@ describe('AG-13024 API context', () => {
                 chart = await createChart(options);
                 itemStyler.expect().toHaveBeenCalledTimes(12).withoutContext();
                 seriesLabelFormatter.expect().toHaveBeenCalledTimes(12).withoutContext();
-                axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withoutContext();
+                axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withoutContext();
                 await oneTooltipCallback();
                 tooltipRenderer.expect().toHaveBeenCalledTimes(3).withoutContext();
             });
@@ -281,7 +281,7 @@ describe('AG-13024 API context', () => {
                 chart = await createChart(options);
                 itemStyler.expect().toHaveBeenCalledTimes(12).withoutContext();
                 seriesLabelFormatter.expect().toHaveBeenCalledTimes(12).withoutContext();
-                axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withoutContext();
+                axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withoutContext();
                 await oneTooltipCallback();
                 tooltipRenderer.expect().toHaveBeenCalledTimes(3).withoutContext();
             });
@@ -293,7 +293,7 @@ describe('AG-13024 API context', () => {
                 chart = await createChart(options);
                 itemStyler.expect().toHaveBeenCalledTimes(12).withContext(null);
                 seriesLabelFormatter.expect().toHaveBeenCalledTimes(12).withContext(null);
-                axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withContext(null);
+                axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withContext(null);
                 await oneTooltipCallback();
                 tooltipRenderer.expect().toHaveBeenCalledTimes(3).withContext(null);
             });
@@ -310,7 +310,7 @@ describe('AG-13024 API context', () => {
                 chart = await createChart(options);
                 itemStyler.expect().toHaveBeenCalledTimes(12).withContext(rootContext);
                 seriesLabelFormatter.expect().toHaveBeenCalledTimes(12).withContext(rootContext);
-                axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withContext(rootContext);
+                axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withContext(rootContext);
                 await oneTooltipCallback();
                 tooltipRenderer.expect().toHaveBeenCalledTimes(3).withContext(rootContext);
             });
@@ -322,7 +322,7 @@ describe('AG-13024 API context', () => {
                 chart = await createChart(options);
                 itemStyler.expect().toHaveBeenCalledTimes(12).withContext(null);
                 seriesLabelFormatter.expect().toHaveBeenCalledTimes(12).withContext(null);
-                axisLabelFormatter.expect().toHaveBeenCalledTimes(4).withContext(null);
+                axisLabelFormatter.expect().toHaveBeenCalledTimes(8).withContext(null);
                 await oneTooltipCallback();
                 tooltipRenderer.expect().toHaveBeenCalledTimes(3).withContext(null);
             });

--- a/packages/ag-charts-community/src/scale/categoryScale.ts
+++ b/packages/ag-charts-community/src/scale/categoryScale.ts
@@ -104,7 +104,9 @@ export class CategoryScale<D, I = number> extends BandScale<D, I> {
 
         const out: D[] = [];
         for (let i = i0; i < i1; i += step) {
-            out.push(bands[i]);
+            if (i >= 0 && i < bands.length) {
+                out.push(bands[i]);
+            }
         }
 
         return { ticks: out, count: undefined };

--- a/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
@@ -174,6 +174,7 @@ export abstract class RadiusAxis<
             regularFlipRotation,
             labelX,
             sideFlag,
+            sizeLimit: undefined,
             removeOverflowLabels: false,
         });
 
@@ -327,7 +328,7 @@ export abstract class RadiusAxis<
             titleNode.textAlign = 'center';
             titleNode.textBaseline = 'bottom';
 
-            titleNode.text = this.callWithContext(formatter, this.getTitleFormatterParams(this.scale.domain));
+            titleNode.text = this.cachedCallWithContext(formatter, this.getTitleFormatterParams(this.scale.domain));
         }
 
         titleNode.visible = titleVisible;

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -603,6 +603,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
             parallelFlipRotation,
             regularFlipRotation,
             sideFlag,
+            sizeLimit: undefined,
             removeOverflowLabels: false,
         }).tickData;
 


### PR DESCRIPTION
About 10% of the bottleneck was down to formatting all ticks - even though in many cases we only needed the rawTicks. The  remaining 90% was caching of callbacks. We do expect in 90+% of cases that the previous iteration's cache will be invalid, because things like the domain will change, so it's unlikely that removing the cache entirely will have much real impact (other than a performance win)