### PR TITLE
AG-8290 Remove unnecessary .context property complexity

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -306,13 +306,6 @@ export abstract class SeriesProperties<T extends object> extends BaseProperties<
 
     abstract tooltip: SeriesTooltip<never>;
 
-    // user pass-through option: no validation-decorator required.
+    @Property
     context?: unknown;
-
-    override handleUnknownProperties(unknownKeys: Set<string>, properties: T) {
-        if ('context' in properties) {
-            this.context = properties.context;
-            unknownKeys.delete('context');
-        }
-    }
 }

--- a/packages/ag-charts-community/src/util/properties.ts
+++ b/packages/ag-charts-community/src/util/properties.ts
@@ -6,10 +6,6 @@ import { merge } from './object';
 export const Property = addFakeTransformToInstanceProperty;
 
 export class BaseProperties<T extends object = object> {
-    handleUnknownProperties(_unknownKeys: Set<string>, _properties: T) {
-        // override point for derived class.
-    }
-
     set(properties: T) {
         const { className = this.constructor.name } = this.constructor as { className?: string };
 
@@ -35,7 +31,7 @@ export class BaseProperties<T extends object = object> {
                     } else {
                         self[propertyKey].set(value);
                     }
-                } else if (isPlainObject(value)) {
+                } else if (propertyKey !== 'context' && isPlainObject(value)) {
                     self[propertyKey] = merge(value, self[propertyKey] ?? {});
                 } else {
                     self[propertyKey] = value;
@@ -43,7 +39,6 @@ export class BaseProperties<T extends object = object> {
                 keys.delete(propertyKey);
             }
         }
-        this.handleUnknownProperties(keys, properties);
         for (const unknownKey of keys) {
             Logger.warn(`unable to set [${unknownKey}] in ${className} - property is unknown`);
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8290

The `handleUnknownProperties` was useful for when the `context` property was not public. But now that it's part of AG Charts API we can just use the `@Property` decorator.