### PR TITLE
AG-15592 Part 3: Add expandable / controller interfaces

### DIFF
--- a/packages/ag-charts-community/src/components/menu/menu.ts
+++ b/packages/ag-charts-community/src/components/menu/menu.ts
@@ -80,7 +80,7 @@ export class Menu extends AnchoredPopover {
             options.onPress?.(item);
             sourceEvent.preventDefault();
             sourceEvent.stopPropagation();
-            this.menuWidget?.collapse();
+            this.widget?.collapse();
         });
 
         return row;

--- a/packages/ag-charts-community/src/components/popover/popover.ts
+++ b/packages/ag-charts-community/src/components/popover/popover.ts
@@ -5,7 +5,7 @@ import { BaseModuleInstance } from '../../module/module';
 import type { ModuleContext } from '../../module/moduleContext';
 import { getLastFocus } from '../../util/keynavUtil';
 import type { Vec2 } from '../../util/vector';
-import type { MenuWidget } from '../../widget/menuWidget';
+import type { ExpandableWidget } from '../../widget/expandableWidget';
 
 const canvasOverlay = 'canvas-overlay';
 
@@ -30,7 +30,7 @@ export abstract class Popover<Options extends PopoverOptions = PopoverOptions>
     extends BaseModuleInstance
     implements ModuleInstance
 {
-    protected menuWidget?: MenuWidget;
+    protected widget?: ExpandableWidget;
 
     protected readonly hideFns: Array<() => void> = [];
 
@@ -60,8 +60,8 @@ export abstract class Popover<Options extends PopoverOptions = PopoverOptions>
     }
 
     private destroyWidget() {
-        this.menuWidget?.destroy();
-        this.menuWidget = undefined;
+        this.widget?.destroy();
+        this.widget = undefined;
     }
 
     public attachTo(popover: Popover) {
@@ -103,14 +103,14 @@ export abstract class Popover<Options extends PopoverOptions = PopoverOptions>
         return popover;
     }
 
-    protected showWidget(widget: MenuWidget, options: Options) {
+    protected showWidget(widget: ExpandableWidget, options: Options) {
         const { sourceEvent } = options;
         if (sourceEvent) {
             this.destroyWidget();
             this.initPopoverElement(widget.getElement(), options);
             widget.expand({ sourceEvent });
             widget.addListener('collapse-widget', () => this.removeChildren());
-            this.menuWidget = widget;
+            this.widget = widget;
         }
     }
 

--- a/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
+++ b/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
@@ -42,6 +42,10 @@ export class AbstractButtonWidget<TElement extends HTMLElement>
         return this.lazyControllerImpl().setControlled(controls);
     }
 
+    getControlled(): ExpandableWidget<TElement> | undefined {
+        return this.lazyControllerImpl().getControlled();
+    }
+
     expandControlled(opts?: ExpandOpts): void {
         return this.lazyControllerImpl().expandControlled(opts);
     }

--- a/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
+++ b/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
@@ -1,12 +1,23 @@
 import { setAttribute } from 'ag-charts-core';
 
 import { isButtonClickEvent } from '../util/keynavUtil';
+import type { ExpandOpts, ExpandableWidget, ExpansionControllerWidget } from './expandableWidget';
+import { ExpansionControllerImpl } from './expansionControllerImpl';
 import { Widget } from './widget';
 import type { WidgetEventMap as EventMap, KeyboardWidgetEvent } from './widgetEvents';
 
 type R = ReturnType<Widget['addListener']>;
 
-export class AbstractButtonWidget<TElement extends HTMLElement> extends Widget<TElement> {
+export class AbstractButtonWidget<TElement extends HTMLElement>
+    extends Widget<TElement>
+    implements ExpansionControllerWidget<TElement>
+{
+    private controllerImpl?: ExpansionControllerImpl<TElement>;
+    private lazyControllerImpl(): ExpansionControllerImpl<TElement> {
+        this.controllerImpl ??= new ExpansionControllerImpl<TElement>(this);
+        return this.controllerImpl;
+    }
+
     constructor(element: TElement, role?: 'menuitem' | 'menuitemradio') {
         super(element);
         setAttribute(this.elem, 'role', role);
@@ -25,6 +36,14 @@ export class AbstractButtonWidget<TElement extends HTMLElement> extends Widget<T
 
     setEnabled(enabled: boolean) {
         setAttribute(this.elem, 'aria-disabled', !enabled);
+    }
+
+    setControlled(controls: ExpandableWidget<TElement> | undefined): void {
+        return this.lazyControllerImpl().setControlled(controls);
+    }
+
+    expandControlled(opts?: ExpandOpts): void {
+        return this.lazyControllerImpl().expandControlled(opts);
     }
 
     override addListener<K extends keyof EventMap>(type: K, listener: (ev: EventMap[K], current: this) => unknown): R;

--- a/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
+++ b/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
@@ -31,7 +31,7 @@ export class AbstractButtonWidget<TElement extends HTMLElement>
     }
 
     protected override destructor() {
-        // Nothing to destroy.
+        this.controllerImpl?.destroy();
     }
 
     setEnabled(enabled: boolean) {

--- a/packages/ag-charts-community/src/widget/collapseMode.ts
+++ b/packages/ag-charts-community/src/widget/collapseMode.ts
@@ -1,0 +1,7 @@
+export enum CollapseMode {
+    CLOSE = '0',
+    ABORT = '1',
+    DESTROY = '2',
+    PARENT_CLOSED = '3',
+    SIDLING_OPENED = '4',
+}

--- a/packages/ag-charts-community/src/widget/expandableWidget.ts
+++ b/packages/ag-charts-community/src/widget/expandableWidget.ts
@@ -40,7 +40,7 @@ export interface ExpandableWidget<TElement extends HTMLElement = HTMLElement> ex
     collapse(opts?: CollapseOpts): void;
 }
 
-export interface ExpansionControllerWidget<TElement extends HTMLElement> {
+export interface ExpansionControllerWidget<TElement extends HTMLElement = HTMLElement> {
     setControlled(controls: ExpandableWidget<TElement> | undefined): void;
     getControlled(): ExpandableWidget<TElement> | undefined;
     expandControlled(opts?: ExpandControlledOpts): void;

--- a/packages/ag-charts-community/src/widget/expandableWidget.ts
+++ b/packages/ag-charts-community/src/widget/expandableWidget.ts
@@ -1,10 +1,27 @@
+import type { ElementID } from 'ag-charts-core';
+
+import type { CollapseMode } from './collapseMode';
 import type { CollapseWidgetEvent, ExpandWidgetEvent } from './widgetEvents';
 
-export type ExpandEvent = {
-    readonly sourceEvent: Event;
-};
-export type ExpandOpts = {
+// Either a controller (e.g. Financial Charts toolbar buttons) or sourceEvent (e.g. Context menu) is required in order for ExpandableWidget.expand() to
+export type ExpandOpts =
+    | {
+          readonly sourceEvent: Event;
+          readonly controller?: never;
+          readonly overrideFocusVisible?: boolean;
+      }
+    | {
+          readonly sourceEvent?: never;
+          readonly controller: ExpansionControllerWidget<HTMLElement>;
+          readonly overrideFocusVisible?: boolean;
+      };
+
+export type ExpandControlledOpts = {
     readonly overrideFocusVisible?: boolean;
+};
+
+export type CollapseOpts = {
+    readonly mode: CollapseMode;
 };
 
 // Widget interface
@@ -18,6 +35,12 @@ interface WidgetProps<TElement extends HTMLElement> {
 }
 
 export interface ExpandableWidget<TElement extends HTMLElement = HTMLElement> extends WidgetProps<TElement> {
-    expand(event: ExpandEvent, opts?: ExpandOpts): void;
-    collapse(): void;
+    id?: ElementID;
+    expand(opts: ExpandOpts): void;
+    collapse(opts?: CollapseOpts): void;
+}
+
+export interface ExpansionControllerWidget<TElement extends HTMLElement> {
+    setControlled(controls: ExpandableWidget<TElement> | undefined): void;
+    expandControlled(opts?: ExpandControlledOpts): void;
 }

--- a/packages/ag-charts-community/src/widget/expandableWidget.ts
+++ b/packages/ag-charts-community/src/widget/expandableWidget.ts
@@ -42,5 +42,6 @@ export interface ExpandableWidget<TElement extends HTMLElement = HTMLElement> ex
 
 export interface ExpansionControllerWidget<TElement extends HTMLElement> {
     setControlled(controls: ExpandableWidget<TElement> | undefined): void;
+    getControlled(): ExpandableWidget<TElement> | undefined;
     expandControlled(opts?: ExpandControlledOpts): void;
 }

--- a/packages/ag-charts-community/src/widget/expandableWidget.ts
+++ b/packages/ag-charts-community/src/widget/expandableWidget.ts
@@ -1,0 +1,23 @@
+import type { CollapseWidgetEvent, ExpandWidgetEvent } from './widgetEvents';
+
+export type ExpandEvent = {
+    readonly sourceEvent: Event;
+};
+export type ExpandOpts = {
+    readonly overrideFocusVisible?: boolean;
+};
+
+// Widget interface
+interface WidgetProps<TElement extends HTMLElement> {
+    destroy(): void;
+    getElement(): TElement;
+    addListener(type: 'collapse-widget', listener: (ev: CollapseWidgetEvent, current: this) => unknown): () => void;
+    addListener(type: 'expand-widget', listener: (ev: ExpandWidgetEvent, current: this) => unknown): () => void;
+    removeListener(type: 'collapse-widget', listener: (ev: CollapseWidgetEvent, current: this) => unknown): void;
+    removeListener(type: 'expand-widget', listener: (ev: ExpandWidgetEvent, current: this) => unknown): void;
+}
+
+export interface ExpandableWidget<TElement extends HTMLElement = HTMLElement> extends WidgetProps<TElement> {
+    expand(event: ExpandEvent, opts?: ExpandOpts): void;
+    collapse(): void;
+}

--- a/packages/ag-charts-community/src/widget/expansionControllerImpl.ts
+++ b/packages/ag-charts-community/src/widget/expansionControllerImpl.ts
@@ -1,0 +1,58 @@
+import type { RequireOptional } from 'ag-charts-core';
+
+import { CollapseMode } from './collapseMode';
+import type { ExpandControlledOpts, ExpandableWidget, ExpansionControllerWidget } from './expandableWidget';
+import type { Widget } from './widget';
+import type { CollapseWidgetEvent } from './widgetEvents';
+
+export class ExpansionControllerImpl<TElement extends HTMLElement> implements ExpansionControllerWidget<TElement> {
+    private readonly controller: Widget & ExpansionControllerWidget<TElement>;
+    private controls?: ExpandableWidget<TElement>;
+
+    private readonly onExpanded = () => {
+        this.controller.setAriaExpanded(true);
+    };
+
+    private readonly onCollapsed = (e: CollapseWidgetEvent) => {
+        this.controller.setAriaExpanded(false);
+        if (e.mode === CollapseMode.CLOSE) {
+            this.controller.focus();
+        }
+    };
+
+    constructor(controller: Widget & ExpansionControllerWidget<TElement>) {
+        controller.setAriaExpanded(false);
+        this.controller = controller;
+    }
+
+    destroy(): void {
+        this.controls?.collapse({ mode: CollapseMode.DESTROY });
+        this.setControlled(undefined);
+    }
+
+    setControlled(controls: ExpandableWidget<TElement> | undefined): void {
+        if (this.controls) {
+            this.controls.removeListener('expand-widget', this.onExpanded);
+            this.controls.removeListener('collapse-widget', this.onCollapsed);
+        }
+        this.controls = controls;
+        if (this.controls) {
+            this.controller.setAriaControls(this.controls.id);
+            this.controls.addListener('expand-widget', this.onExpanded);
+            this.controls.addListener('collapse-widget', this.onCollapsed);
+        }
+    }
+
+    expandControlled(opts?: ExpandControlledOpts): void {
+        // Disabled buttons are focusable and can receive events, but have aria-disabled="true"
+        if (!this.controller.isDisabled()) {
+            // Check that all options in ExpandControlledOpts are copied over to ExpandOpts
+            type AllDefined = RequireOptional<Parameters<NonNullable<typeof this.controls>['expand']>[0]>;
+            this.controls?.expand({
+                controller: this.controller,
+                sourceEvent: undefined,
+                overrideFocusVisible: opts?.overrideFocusVisible,
+            } satisfies AllDefined);
+        }
+    }
+}

--- a/packages/ag-charts-community/src/widget/expansionControllerImpl.ts
+++ b/packages/ag-charts-community/src/widget/expansionControllerImpl.ts
@@ -43,6 +43,10 @@ export class ExpansionControllerImpl<TElement extends HTMLElement> implements Ex
         }
     }
 
+    getControlled(): ExpandableWidget<TElement> | undefined {
+        return this.controls;
+    }
+
     expandControlled(opts?: ExpandControlledOpts): void {
         // Disabled buttons are focusable and can receive events, but have aria-disabled="true"
         if (!this.controller.isDisabled()) {

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -9,7 +9,7 @@ import {
     hasNoModifiers,
 } from '../util/keynavUtil';
 import { CollapseMode } from './collapseMode';
-import type { ExpandEvent, ExpandOpts, ExpandableWidget } from './expandableWidget';
+import type { CollapseOpts, ExpandOpts, ExpandableWidget } from './expandableWidget';
 import { MenuItemWidget } from './menuItemWidget';
 import type { RovingDirection } from './rovingDirection';
 import { RovingTabContainerWidget } from './rovingTabContainerWidget';
@@ -33,7 +33,7 @@ export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> impleme
     }
 
     protected override destructor() {
-        this.selfCollapse(CollapseMode.DESTROY);
+        this.collapse({ mode: CollapseMode.DESTROY });
     }
 
     public addSeparator(): Element {
@@ -67,28 +67,21 @@ export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> impleme
 
     public addSubMenu(): { subMenuButton: MenuItemWidget; subMenu: MenuWidget } {
         const subMenuButton = new MenuItemWidget();
-        const subMenuId = createElementId();
         const subMenu = new MenuWidget(this.orientation);
-        const accessibleOpener = (ev: WidgetEvent) => {
-            // Disabled buttons are focusable and can receive events, but have aria-disabled="true"
-            if (!subMenuButton.isDisabled()) {
-                this.expandSubMenu(ev, subMenu);
-            }
-        };
+        subMenu.id = createElementId();
+
+        const expand = () => subMenuButton.expandControlled();
         const arrowRightOpener = (ev: KeyboardWidgetEvent) => {
             if (hasNoModifiers(ev.sourceEvent) && ev.sourceEvent.code === 'ArrowRight') {
-                accessibleOpener(ev);
+                subMenuButton.expandControlled();
             }
         };
+
+        subMenuButton.setControlled(subMenu);
         subMenuButton.setAriaHasPopup('menu');
-        subMenuButton.setAriaExpanded(false);
-        subMenuButton.setAriaControls(subMenuId);
-        subMenuButton.addListener('click', accessibleOpener);
-        subMenuButton.addListener('mouseenter', accessibleOpener);
+        subMenuButton.addListener('click', expand);
+        subMenuButton.addListener('mouseenter', expand);
         subMenuButton.addListener('keydown', arrowRightOpener);
-        subMenu.addListener('expand-widget', () => subMenuButton.setAriaExpanded(false));
-        subMenu.addListener('collapse-widget', () => subMenuButton.setAriaExpanded(true));
-        subMenu.id = subMenuId;
         this.addChild(subMenuButton);
         return { subMenuButton, subMenu };
     }
@@ -97,19 +90,19 @@ export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> impleme
         const { expansionScope } = this;
         if (!expansionScope) return;
 
-        expansionScope.expandedSubMenu?.selfCollapse(CollapseMode.SIDLING_OPENED);
+        expansionScope.expandedSubMenu?.collapse({ mode: CollapseMode.SIDLING_OPENED });
         subMenu?.expand(ev);
         expansionScope.expandedSubMenu = subMenu;
     }
 
-    public expand(event: ExpandEvent, opts?: ExpandOpts): void {
+    expand(opts: ExpandOpts): void {
         if (this.expansionScope != null) return; // already open
 
         this.expansionScope = {
-            lastFocus: getLastFocus(event.sourceEvent),
+            lastFocus: getLastFocus(opts.sourceEvent),
             expandedSubMenu: undefined,
-            abort: () => this.selfCollapse(CollapseMode.ABORT),
-            close: () => this.selfCollapse(CollapseMode.CLOSE),
+            abort: () => this.collapse({ mode: CollapseMode.ABORT }),
+            close: () => this.collapse({ mode: CollapseMode.CLOSE }),
             removers: new CleanupRegistry(),
         };
         const scope = this.expansionScope;
@@ -128,12 +121,14 @@ export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> impleme
         this.children[0]?.focus({ preventScroll: true });
     }
 
-    private selfCollapse(mode: CollapseMode) {
+    collapse(opts?: CollapseOpts): void {
+        const { mode = CollapseMode.CLOSE } = opts ?? {};
+
         if (this.expansionScope === undefined) return;
         const { lastFocus, removers, expandedSubMenu } = this.expansionScope;
         this.expansionScope = undefined; // stop re-entrance
 
-        expandedSubMenu?.selfCollapse(CollapseMode.PARENT_CLOSED);
+        expandedSubMenu?.collapse({ mode: CollapseMode.PARENT_CLOSED });
         setAttribute(lastFocus, 'aria-expanded', false);
         if (mode === CollapseMode.CLOSE) {
             lastFocus?.focus({ preventScroll: true });
@@ -141,9 +136,5 @@ export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> impleme
         removers.flush();
 
         this.internalListener?.dispatch('collapse-widget', this, { type: 'collapse-widget', mode });
-    }
-
-    public collapse() {
-        this.selfCollapse(CollapseMode.CLOSE);
     }
 }

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -8,6 +8,7 @@ import {
     getLastFocus,
     hasNoModifiers,
 } from '../util/keynavUtil';
+import type { ExpandEvent, ExpandOpts, ExpandableWidget } from './expandableWidget';
 import { MenuItemWidget } from './menuItemWidget';
 import type { RovingDirection } from './rovingDirection';
 import { RovingTabContainerWidget } from './rovingTabContainerWidget';
@@ -21,8 +22,6 @@ interface ExpansionScope {
     close: () => void;
 }
 
-type ExpandEvent = Pick<WidgetEvent, 'sourceEvent'>;
-
 enum CollapseMode {
     CLOSE = '0',
     ABORT = '1',
@@ -32,7 +31,7 @@ enum CollapseMode {
 }
 const closeKeys = ['Escape', 'ArrowLeft'] as const;
 
-export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> {
+export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> implements ExpandableWidget<HTMLDivElement> {
     private expansionScope?: ExpansionScope;
 
     constructor(orientation: RovingDirection = 'vertical') {
@@ -109,7 +108,7 @@ export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> {
         expansionScope.expandedSubMenu = subMenu;
     }
 
-    public expand(event: ExpandEvent, opts?: { overrideFocusVisible?: boolean }): void {
+    public expand(event: ExpandEvent, opts?: ExpandOpts): void {
         if (this.expansionScope != null) return; // already open
 
         this.expansionScope = {

--- a/packages/ag-charts-community/src/widget/menuWidget.ts
+++ b/packages/ag-charts-community/src/widget/menuWidget.ts
@@ -8,6 +8,7 @@ import {
     getLastFocus,
     hasNoModifiers,
 } from '../util/keynavUtil';
+import { CollapseMode } from './collapseMode';
 import type { ExpandEvent, ExpandOpts, ExpandableWidget } from './expandableWidget';
 import { MenuItemWidget } from './menuItemWidget';
 import type { RovingDirection } from './rovingDirection';
@@ -22,13 +23,6 @@ interface ExpansionScope {
     close: () => void;
 }
 
-enum CollapseMode {
-    CLOSE = '0',
-    ABORT = '1',
-    DESTROY = '2',
-    PARENT_CLOSED = '3',
-    SIDLING_OPENED = '4',
-}
 const closeKeys = ['Escape', 'ArrowLeft'] as const;
 
 export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> implements ExpandableWidget<HTMLDivElement> {
@@ -146,7 +140,7 @@ export class MenuWidget extends RovingTabContainerWidget<MenuItemWidget> impleme
         }
         removers.flush();
 
-        this.internalListener?.dispatch('collapse-widget', this, { type: 'collapse-widget' });
+        this.internalListener?.dispatch('collapse-widget', this, { type: 'collapse-widget', mode });
     }
 
     public collapse() {

--- a/packages/ag-charts-community/src/widget/widgetEvents.ts
+++ b/packages/ag-charts-community/src/widget/widgetEvents.ts
@@ -1,3 +1,5 @@
+import type { CollapseMode } from './collapseMode';
+
 type FocusWidgetEventType = 'blur' | 'focus';
 type KeyboardWidgetEventType = 'keyup' | 'keydown';
 type KeyboardSyntheticMouseWidgetEventType = 'click';
@@ -111,6 +113,7 @@ export type DragWidgetEvent<T extends DragWidgetEventType = DragWidgetEventType>
 
 export type CollapseWidgetEvent = {
     type: 'collapse-widget';
+    mode: CollapseMode;
     sourceEvent?: never;
 };
 

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -122,17 +122,18 @@ export class ContextMenu extends _ModuleSupport.BaseModuleInstance implements _M
     }
 
     private show(widgetEvent: ContextMenuEvent['widgetEvent'], expandedItems: ContextMenuItem[]) {
+        const { sourceEvent } = widgetEvent;
         this.interactionManager.pushState(_ModuleSupport.InteractionState.ContextMenu);
         this.element.style.display = 'block';
 
-        const overrideFocusVisible = widgetEvent.sourceEvent.pointerType === 'touch' ? false : undefined;
+        const overrideFocusVisible = sourceEvent.pointerType === 'touch' ? false : undefined;
         if (overrideFocusVisible !== undefined) {
             this.ctx.chartService.overrideFocusVisible(overrideFocusVisible);
         }
 
         this.createMenu(expandedItems);
         this.element.appendChild(this.menuWidget.getElement());
-        this.menuWidget.expand(widgetEvent, { overrideFocusVisible });
+        this.menuWidget.expand({ sourceEvent, overrideFocusVisible });
     }
 
     private hide() {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15592

> [!IMPORTANT]
> **Key Changes**
> 1. Add `ExpandableWidget` and `ExpansionControllerWidget` interfaces.
> 2. Implement `ExpandableWidget` interface in `MenuWidget` class.
> 3. Implement `ExpansionControllerWidget` interface in `AbstractButtonWidget` class (base class of `MenuWidgetItem`).
> 4. Use `ExpandableWidget` (instead of `MenuWidget`) in `popover.ts`.