### PR TITLE
React API experiment

### DIFF
--- a/packages/ag-charts-react/src/index.ts
+++ b/packages/ag-charts-react/src/index.ts
@@ -3,6 +3,7 @@ import {
     RefObject,
     createElement,
     forwardRef,
+    memo,
     useEffect,
     useImperativeHandle,
     useLayoutEffect,
@@ -24,6 +25,13 @@ interface BaseChartProps {
     className?: string;
 }
 
+function isEmpty<T extends object>(obj: T): boolean {
+    for (const _ in obj) {
+        return false;
+    }
+    return true;
+}
+
 function getOptions(options: AgChartOptions, containerRef: RefObject<HTMLElement | null>): AgChartOptions {
     return {
         ...options,
@@ -36,9 +44,11 @@ function ChartWithConstructor<Props extends BaseChartProps>(
     displayName: string
 ) {
     const Component = forwardRef<AgChartInstance, Props>(function AgChartsReact(props, ref) {
-        const { options, style, className } = props;
+        const { style, className, options: optionsProp, ...topLevelOptions } = props;
         const containerRef = useRef<HTMLDivElement>(null);
         const chartRef = useRef<AgChartInstance | undefined>();
+
+        const options = isEmpty(topLevelOptions) ? optionsProp : { ...topLevelOptions, ...optionsProp };
 
         // This fires earlier than ideal - so has a negative impact on mounting performance
         // but it's important we do this so refs work as expected
@@ -58,7 +68,7 @@ function ChartWithConstructor<Props extends BaseChartProps>(
                 // eslint-disable-next-line no-console
                 chartRef.current?.update(getOptions(options, containerRef)).catch((e) => console.error(e));
             }
-        }, [options]);
+        }); // Dependency array does nothing here - but the component is already memo'd
 
         // Note useLayoutEffect is called before useImperativeHandle
         useImperativeHandle(ref, () => chartRef.current!, []);
@@ -74,10 +84,10 @@ function ChartWithConstructor<Props extends BaseChartProps>(
 
     Component.displayName = displayName;
 
-    return Component;
+    return memo(Component);
 }
 
-export interface AgChartProps {
+export interface AgChartProps extends Omit<AgChartOptions, 'container'> {
     options: AgChartOptions;
     style?: CSSProperties;
     className?: string;
@@ -88,7 +98,7 @@ export const AgCharts = /*#__PURE__*/ ChartWithConstructor<AgChartProps>(
     'AgCharts'
 );
 
-export interface AgFinancialChartProps {
+export interface AgFinancialChartProps extends Omit<AgFinancialChartOptions, 'container'> {
     options: AgFinancialChartOptions;
     style?: CSSProperties;
     className?: string;
@@ -99,7 +109,7 @@ export const AgFinancialCharts = /*#__PURE__*/ ChartWithConstructor<AgFinancialC
     'AgFinancialCharts'
 );
 
-export interface AgGaugeProps {
+export interface AgGaugeProps extends Omit<AgGaugeOptions, 'container'> {
     options: AgGaugeOptions;
     style?: CSSProperties;
     className?: string;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-src-parser.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-src-parser.ts
@@ -134,6 +134,20 @@ export function internalParser(js, html, exampleSettings: ExampleSettings, dirPa
             registered.push(propertyName);
             bindings.chartProperties[id] = propertyName;
             bindings.properties.push({ name: propertyName, value: code });
+
+            if (
+                propertyName === 'options' &&
+                propertyAssignment.initializer.kind === ts.SyntaxKind.ObjectLiteralExpression
+            ) {
+                for (const property of propertyAssignment.initializer.properties) {
+                    if (property.kind !== ts.SyntaxKind.PropertyAssignment) continue;
+
+                    const name = property.name.escapedText;
+                    if (name === 'container') continue;
+
+                    bindings.optionsProperties.push(name);
+                }
+            }
         },
     });
 
@@ -224,6 +238,7 @@ export function internalParser(js, html, exampleSettings: ExampleSettings, dirPa
         tsTree,
         {
             properties: [],
+            optionsProperties: [],
             chartProperties: {},
             externalEventHandlers: [],
             instanceMethods: [],

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional-ts.ts
@@ -94,8 +94,8 @@ function getTemplate(bindings: any, componentAttributes: string[]): string {
     return convertFunctionalTemplate(template);
 }
 
-function getComponentMetadata(bindings: any, id: string, property: any) {
-    const { optionsTypeInfo } = bindings;
+function getComponentMetadata(bindings: any, id: string, property: any, flattenOptions: boolean) {
+    const { optionsTypeInfo, optionsProperties } = bindings;
 
     const stateProperties = [];
     const componentAttributes = [];
@@ -106,7 +106,13 @@ function getComponentMetadata(bindings: any, id: string, property: any) {
         `const [${property.name}, set${toTitleCase(property.name)}] = useState<${chartOptionsType}>(${property.value});`
     );
 
-    componentAttributes.push(`options={${property.name}}`);
+    if (flattenOptions && optionsProperties.length > 0) {
+        new Set(optionsProperties).forEach((option: string) => {
+            componentAttributes.push(`${option}={${property.name}.${option}}`);
+        });
+    } else {
+        componentAttributes.push(`options={${property.name}}`);
+    }
 
     Object.entries(bindings.chartAttributes[id]).forEach(([key, value]) => {
         if (key === 'style') {
@@ -139,7 +145,8 @@ export async function vanillaToReactFunctionalTs(
         const { stateProperties, componentAttributes } = getComponentMetadata(
             bindings,
             placeholders[0],
-            properties.find((p) => p.name === 'options')
+            properties.find((p) => p.name === 'options'),
+            true
         );
 
         let template = getTemplate(bindings, componentAttributes);
@@ -190,7 +197,8 @@ export async function vanillaToReactFunctionalTs(
             const { stateProperties, componentAttributes } = getComponentMetadata(
                 bindings,
                 id,
-                properties.find((p) => p.name === propertyName)
+                properties.find((p) => p.name === propertyName),
+                false
             );
 
             indexFile = `${indexFile}

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-react-functional.ts
@@ -98,12 +98,21 @@ function getTemplate(bindings: any, componentAttributes: string[]): string {
     return convertFunctionalTemplate(template);
 }
 
-function getComponentMetadata(bindings: any, id: string, property: any) {
+function getComponentMetadata(bindings: any, id: string, property: any, flattenOptions: boolean) {
+    const { optionsProperties } = bindings;
+
     const stateProperties = [];
     const componentAttributes = [];
 
     stateProperties.push(`const [${property.name}, set${toTitleCase(property.name)}] = useState(${property.value});`);
-    componentAttributes.push(`options={${property.name}}`);
+
+    if (flattenOptions && optionsProperties.length > 0) {
+        new Set(optionsProperties).forEach((option: string) => {
+            componentAttributes.push(`${option}={${property.name}.${option}}`);
+        });
+    } else {
+        componentAttributes.push(`options={${property.name}}`);
+    }
 
     Object.entries(bindings.chartAttributes[id]).forEach(([key, value]) => {
         if (key === 'style') {
@@ -136,7 +145,8 @@ export async function vanillaToReactFunctional(
         const { stateProperties, componentAttributes } = getComponentMetadata(
             bindings,
             placeholders[0],
-            properties.find((p) => p.name === 'options')
+            properties.find((p) => p.name === 'options'),
+            true
         );
 
         let template = getTemplate(bindings, componentAttributes);
@@ -187,7 +197,8 @@ export async function vanillaToReactFunctional(
             const { stateProperties, componentAttributes } = getComponentMetadata(
                 bindings,
                 id,
-                properties.find((p) => p.name === propertyName)
+                properties.find((p) => p.name === propertyName),
+                false
             );
 
             indexFile = `${indexFile}


### PR DESCRIPTION
React API experiment

Implements both the API and example generation to do this:-

```diff
 const ChartExample = () => {
   const [options, setOptions] = useState({
     // Data: Data to be displayed in the chart
     data: [
       { month: "Jan", avgTemp: 2.3, iceCreamSales: 162000 },
       { month: "Mar", avgTemp: 6.3, iceCreamSales: 302000 },
       { month: "May", avgTemp: 16.2, iceCreamSales: 800000 },
       { month: "Jul", avgTemp: 22.8, iceCreamSales: 1254000 },
       { month: "Sep", avgTemp: 14.5, iceCreamSales: 950000 },
       { month: "Nov", avgTemp: 8.9, iceCreamSales: 200000 },
     ],
     // Series: Defines which chart type and data to use
     series: [{ type: "bar", xKey: "month", yKey: "iceCreamSales" }],
   });
 
-  return <AgCharts options={options} />;
+  return <AgCharts data={options.data} series={options.series} />;
 };
```

A more idiomatic usage would be this

https://plnkr.co/edit/EVxOsM4IFk8R8mSC?open=index.jsx

This is backwards compatible - you can still pass `options` if you wish

Longer term we may wish to consider an additional single series API

```js
<AgBarChart
  data={data}
  xKey="month"
  yKey="iceCreamSales"
/>
```

However, we need to ensure top-level options never conflict with series options - e.g. `title` exists both on the pie series options and top-level options