### PR TITLE
AG-15592 Part 6: Close sibling buttons in toolbars on `expand-widget`

### DIFF
--- a/packages/ag-charts-community/src/components/toolbar/toolbar.ts
+++ b/packages/ag-charts-community/src/components/toolbar/toolbar.ts
@@ -6,7 +6,8 @@ import type { ModuleContext } from '../../module/moduleContext';
 import { BBox } from '../../scene/bbox';
 import { Listeners } from '../../util/listeners';
 import { BaseProperties } from '../../util/properties';
-import type { ExpansionControllerWidget } from '../../widget/expandableWidget';
+import { CollapseMode } from '../../widget/collapseMode';
+import type { ExpandableWidget, ExpansionControllerWidget } from '../../widget/expandableWidget';
 import type { RovingDirection } from '../../widget/rovingDirection';
 import { ToolbarWidget } from '../../widget/toolbarWidget';
 import type { MouseWidgetEvent } from '../../widget/widgetEvents';
@@ -42,6 +43,7 @@ export abstract class BaseToolbar<
     protected hasPrefix = false;
 
     private readonly buttonWidgets: Array<ButtonWidget> = [];
+    private expanded?: ExpandableWidget;
 
     protected readonly eventsHub: EventsHub;
     protected readonly localeManager: LocaleManager;
@@ -74,6 +76,7 @@ export abstract class BaseToolbar<
     }
 
     public clearButtons() {
+        this.expanded?.collapse({ mode: CollapseMode.DESTROY });
         for (const button of this.buttonWidgets) {
             button.destroy();
         }
@@ -178,6 +181,14 @@ export abstract class BaseToolbar<
         buttonWidget.addListener('focus', () => {
             const params: ToolbarEventMap<ButtonOptions>['button-focused'] = { button: { index } };
             this.events.dispatch('button-focused', params);
+        });
+        buttonWidget.addListener('expand-controlled-widget', (e) => {
+            this.expanded?.collapse({ mode: CollapseMode.SIDLING_OPENED });
+            this.expanded = e.controlled;
+            const removeListener = this.expanded.addListener('collapse-widget', () => {
+                this.expanded = undefined;
+                removeListener();
+            });
         });
 
         if (button.section) {

--- a/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
+++ b/packages/ag-charts-community/src/widget/abstractButtonWidget.ts
@@ -14,7 +14,7 @@ export class AbstractButtonWidget<TElement extends HTMLElement>
 {
     private controllerImpl?: ExpansionControllerImpl<TElement>;
     private lazyControllerImpl(): ExpansionControllerImpl<TElement> {
-        this.controllerImpl ??= new ExpansionControllerImpl<TElement>(this);
+        this.controllerImpl ??= new ExpansionControllerImpl<TElement>(this, () => this.internalListener);
         return this.controllerImpl;
     }
 

--- a/packages/ag-charts-community/src/widget/expandableWidget.ts
+++ b/packages/ag-charts-community/src/widget/expandableWidget.ts
@@ -13,6 +13,12 @@ export type ExpandWidgetEvent = {
     sourceEvent?: never;
 };
 
+export type ExpandControlledWidgetEvent = {
+    type: 'expand-controlled-widget';
+    controlled: ExpandableWidget;
+    sourceEvent?: never;
+};
+
 // Either a controller (e.g. Financial Charts toolbar buttons) or sourceEvent (e.g. Context menu) is required in order for ExpandableWidget.expand() to
 export type ExpandOpts =
     | {

--- a/packages/ag-charts-community/src/widget/expansionControllerImpl.ts
+++ b/packages/ag-charts-community/src/widget/expansionControllerImpl.ts
@@ -4,10 +4,15 @@ import { CollapseMode } from './collapseMode';
 import type {
     CollapseWidgetEvent,
     ExpandControlledOpts,
+    ExpandControlledWidgetEvent,
     ExpandableWidget,
     ExpansionControllerWidget,
 } from './expandableWidget';
 import type { Widget } from './widget';
+
+interface Dispatcher {
+    dispatch(type: 'expand-controlled-widget', current: Widget, event: ExpandControlledWidgetEvent): void;
+}
 
 export class ExpansionControllerImpl<TElement extends HTMLElement> implements ExpansionControllerWidget<TElement> {
     private readonly controller: Widget & ExpansionControllerWidget<TElement>;
@@ -15,6 +20,14 @@ export class ExpansionControllerImpl<TElement extends HTMLElement> implements Ex
 
     private readonly onExpanded = () => {
         this.controller.setAriaExpanded(true);
+        const dispatcher = this.getDispatcher();
+        if (dispatcher && this.controls) {
+            const event: ExpandControlledWidgetEvent = {
+                type: 'expand-controlled-widget',
+                controlled: this.controls,
+            };
+            dispatcher.dispatch('expand-controlled-widget', this.controller, event);
+        }
     };
 
     private readonly onCollapsed = (e: CollapseWidgetEvent) => {
@@ -24,7 +37,10 @@ export class ExpansionControllerImpl<TElement extends HTMLElement> implements Ex
         }
     };
 
-    constructor(controller: Widget & ExpansionControllerWidget<TElement>) {
+    constructor(
+        controller: Widget & ExpansionControllerWidget<TElement>,
+        private readonly getDispatcher: () => Dispatcher | undefined
+    ) {
         controller.setAriaExpanded(false);
         this.controller = controller;
     }

--- a/packages/ag-charts-community/src/widget/widgetEvents.ts
+++ b/packages/ag-charts-community/src/widget/widgetEvents.ts
@@ -1,4 +1,4 @@
-import type { CollapseWidgetEvent, ExpandWidgetEvent } from './expandableWidget';
+import type { CollapseWidgetEvent, ExpandControlledWidgetEvent, ExpandWidgetEvent } from './expandableWidget';
 
 type FocusWidgetEventType = 'blur' | 'focus';
 type KeyboardWidgetEventType = 'keyup' | 'keydown';
@@ -117,6 +117,7 @@ export type WidgetEventMap = {
     'drag-end': DragWidgetEvent<'drag-end'>;
     'collapse-widget': CollapseWidgetEvent;
     'expand-widget': ExpandWidgetEvent;
+    'expand-controlled-widget': ExpandControlledWidgetEvent;
 
     blur: FocusWidgetEvent<'blur'>;
     change: WidgetEvent;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15592

> [!IMPORTANT]
> **Key Changes**
> 1. Add `expanded?` property to `toolbar.ts`
> 2. Call `expanded?.collapse({ mode: CollapseMode.SIBLING_OPENED })` when expanding a button (similar to how `MenuWidget` closes sibling popups).