### PR TITLE
AG-3390 - Ignore dark mode for examples in new tab

### DIFF
--- a/packages/ag-charts-website/src/components/docs/components/DocsFrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/components/docs/components/DocsFrameworkTemplate.astro
@@ -28,6 +28,10 @@ interface Props {
      * Whether to not include system js code
      */
     ignoreSystemJs?: boolean;
+    /**
+     * Ignore dark mode (always use light mode)
+     */
+    ignoreDarkMode?: boolean;
 }
 
 const {
@@ -39,6 +43,7 @@ const {
     addE2ECheckScript,
     addExternalExampleStyles,
     ignoreSystemJs,
+    ignoreDarkMode,
 } = Astro.props as Props;
 
 const generatedContents = await getGeneratedContents({
@@ -66,4 +71,5 @@ const exampleUrl = getExampleUrl({
     addInitMessageScript={addInitMessageScript}
     addE2ECheckScript={addE2ECheckScript}
     addExternalExampleStyles={addExternalExampleStyles}
+    ignoreDarkMode={ignoreDarkMode}
 />

--- a/packages/ag-charts-website/src/components/example-runner/components/FrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/components/example-runner/components/FrameworkTemplate.astro
@@ -39,6 +39,10 @@ interface Props {
      * Whether to not include system js code
      */
     ignoreSystemJs?: boolean;
+    /**
+     * Ignore dark mode (always use light mode)
+     */
+    ignoreDarkMode?: boolean;
 }
 
 const {
@@ -52,6 +56,7 @@ const {
     addE2ECheckScript,
     addExternalExampleStyles,
     ignoreSystemJs,
+    ignoreDarkMode,
 } = Astro.props as Props;
 
 const isDev = getIsDev();
@@ -174,6 +179,14 @@ const title = `${toTitle(pageName)} - ${toTitle(exampleName)}`;
         />
     )
 }
+
+<script define:vars={{
+    ignoreDarkMode
+}} nonce="123123">
+    if (ignoreDarkMode) {
+        document.documentElement.dataset.ignoreDarkMode = 'true';
+    }
+</script>
 
 {
     addE2ECheckScript && (

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName].astro
@@ -24,4 +24,5 @@ const { internalFramework, pageName, exampleName } = Astro.params;
     exampleName={exampleName!}
     addE2ECheckScript={true}
     addExternalExampleStyles={true}
+    ignoreDarkMode={true}
 />

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -10,7 +10,8 @@ ${
         : `const __chartAPI = ${chartAPI};`
 }
 
-let darkmode =
+const ignoreDarkMode = document.documentElement.dataset.ignoreDarkMode === 'true';
+let darkmode = !ignoreDarkMode &&
     (localStorage['documentation:darkmode'] || String(matchMedia('(prefers-color-scheme: dark)').matches)) === 'true';
 
 const isAgThemeOrUndefined = (theme) => {


### PR DESCRIPTION
Allow dark mode to be ignored based on the rendering page. In this case, we want to ignore dark mode rendering on the new tabs page.