### PR TITLE
AG-15782 Restrict `callWithContext` to single-arg functions

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1,5 +1,6 @@
 import {
-    type AnyFn,
+    type Callback,
+    type CallbackParam,
     CleanupRegistry,
     type Point,
     type RequireOptional,
@@ -1019,19 +1020,19 @@ export abstract class Axis<
         return this.reverse;
     }
 
-    protected cachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
+    protected cachedCallWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> | undefined {
         const { callbackCache, chartService } = this.moduleCtx;
-        return callbackCache.call([this, chartService], fn, ...params);
+        return callbackCache.call([this, chartService], fn, params);
     }
 
-    private uncachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
+    private uncachedCallWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> | undefined {
         const { chartService } = this.moduleCtx;
-        return callWithContext([this, chartService], fn, ...params);
+        return callWithContext([this, chartService], fn, params);
     }
 
     private createCallWithContext(contextProvider: { context?: unknown } | undefined) {
         const { chartService } = this.moduleCtx;
-        return <F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> =>
-            callWithContext([contextProvider, this, chartService], fn, ...params);
+        return <F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> =>
+            callWithContext([contextProvider, this, chartService], fn, params);
     }
 }

--- a/packages/ag-charts-community/src/chart/labelUtil.ts
+++ b/packages/ag-charts-community/src/chart/labelUtil.ts
@@ -1,4 +1,4 @@
-import type { AnyFn, IsAny, Point, RequireOptional } from 'ag-charts-core';
+import type { Callback, CallbackParam, IsAny, Point, RequireOptional } from 'ag-charts-core';
 import type {
     AgChartLabelStyleOptions,
     AgChartLabelStylerParams,
@@ -19,7 +19,7 @@ interface SeriesLike<TDatumIndex extends DatumIndexType> {
     ctx: ModuleContext;
     declarationOrder: number;
     get visible(): boolean;
-    cachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined;
+    cachedCallWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> | undefined;
     isSeriesHighlighted(highlightedDatum: HighlightNodeDatum | undefined): boolean;
     getHighlightStateString(
         datum: HighlightNodeDatum | undefined,

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -1,5 +1,6 @@
 import {
-    type AnyFn,
+    type Callback,
+    type CallbackParam,
     CleanupRegistry,
     type ITextMeasurer,
     LineSplitter,
@@ -1384,8 +1385,8 @@ export class Legend extends BaseProperties {
         return [legendWidth, legendHeight];
     }
 
-    private cachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
+    private cachedCallWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> | undefined {
         const { callbackCache, chartService } = this.ctx;
-        return callbackCache.call([this, chartService], fn, ...params);
+        return callbackCache.call([this, chartService], fn, params);
     }
 }

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1,5 +1,6 @@
 import {
-    type AnyFn,
+    type Callback,
+    type CallbackParam,
     CleanupRegistry,
     EventEmitter,
     type InternalAgColorType,
@@ -1193,12 +1194,12 @@ export abstract class Series<
         }
     }
 
-    public cachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
-        return this.ctx.callbackCache.call([this.properties, this.ctx.chartService], fn, ...params);
+    public cachedCallWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> | undefined {
+        return this.ctx.callbackCache.call([this.properties, this.ctx.chartService], fn, params);
     }
 
-    public callWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> {
-        return callWithContext([this.properties, this.ctx.chartService], fn, ...params);
+    public callWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> {
+        return callWithContext([this.properties, this.ctx.chartService], fn, params);
     }
 
     protected formatTooltipWithContext<P extends AgSeriesTooltipRendererParams<any>, Tooltip extends SeriesTooltip<P>>(

--- a/packages/ag-charts-community/src/util/callbackCache.ts
+++ b/packages/ag-charts-community/src/util/callbackCache.ts
@@ -1,25 +1,29 @@
-import { type AnyFn, Logger, type RequireOptional } from 'ag-charts-core';
+import { type Callback, type CallbackParam, Logger, type RequireOptional } from 'ag-charts-core';
 
 type Caller = { context?: unknown } | undefined;
 
 export type CallbackParamRules<P> = RequireOptional<Omit<P, 'context'>>;
 
-function needsContext<I>(caller: NonNullable<Caller>, _params: I[]): _params is (I & { context: unknown })[] {
+function needsContext<F extends Callback>(
+    caller: NonNullable<Caller>,
+    _params: CallbackParam<F>
+): _params is CallbackParam<F> & { context: unknown } {
     return 'context' in caller;
 }
-function maybeSetContext<I>(caller: Caller, params: I[]): boolean {
+
+function maybeSetContext<F extends Callback>(caller: Caller, params: CallbackParam<F>): boolean {
     if (caller != null && needsContext(caller, params)) {
-        if (params[0] != null && typeof params[0] === 'object' && params[0].context === undefined) {
-            params[0].context = caller.context;
+        if (params != null && typeof params === 'object' && params.context === undefined) {
+            params.context = caller.context;
             return true;
         }
     }
     return false;
 }
-export function callWithContext<F extends AnyFn>(
+export function callWithContext<F extends Callback>(
     callers: Caller | Caller[],
     fn: F,
-    ...params: Parameters<F>
+    params: CallbackParam<F>
 ): ReturnType<F> {
     if (Array.isArray(callers)) {
         for (const caller of callers) {
@@ -30,13 +34,13 @@ export function callWithContext<F extends AnyFn>(
     } else {
         maybeSetContext(callers, params);
     }
-    return fn(...params);
+    return fn(params);
 }
 
 export class CallbackCache {
     private cache: WeakMap<Function, Map<string, any>> = new WeakMap();
 
-    call<F extends AnyFn>(callers: Caller | Caller[], fn: F, ...params: Parameters<F>): ReturnType<F> | undefined {
+    call<F extends Callback>(callers: Caller | Caller[], fn: F, params: CallbackParam<F>): ReturnType<F> | undefined {
         let serialisedParams: string;
         let paramCache = this.cache.get(fn);
 
@@ -46,7 +50,7 @@ export class CallbackCache {
             // Unable to serialise params!
             // No caching possible.
 
-            return this.invoke(callers, fn, paramCache, undefined, ...params);
+            return this.invoke(callers, fn, paramCache, undefined, params);
         }
 
         if (paramCache == null) {
@@ -55,21 +59,21 @@ export class CallbackCache {
         }
 
         if (!paramCache.has(serialisedParams)) {
-            return this.invoke(callers, fn, paramCache, serialisedParams, ...params);
+            return this.invoke(callers, fn, paramCache, serialisedParams, params);
         }
 
         return paramCache.get(serialisedParams);
     }
 
-    private invoke<F extends AnyFn>(
+    private invoke<F extends Callback>(
         callers: Caller | Caller[],
         fn: F,
         paramCache: Map<string, any> | undefined,
         serialisedParams: string | undefined,
-        ...params: Parameters<F>
+        params: CallbackParam<F>
     ) {
         try {
-            const result = callWithContext(callers, fn, ...params);
+            const result = callWithContext(callers, fn, params);
             if (paramCache && serialisedParams != null) {
                 paramCache.set(serialisedParams, result);
             }

--- a/packages/ag-charts-core/src/interfaces/globalTypes.ts
+++ b/packages/ag-charts-core/src/interfaces/globalTypes.ts
@@ -1,5 +1,9 @@
 export type AnyFn = (...args: any[]) => any;
 
+export type Callback = (params: any) => any;
+
+export type CallbackParam<F extends Callback> = Parameters<F>[0];
+
 export type Nullable<T> = T | null | undefined;
 
 export type PlainObject = { [key: string | number | symbol]: any };

--- a/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
@@ -7,7 +7,7 @@ import type {
     Styler,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import type { AnyFn, InternalAgColorType } from 'ag-charts-core';
+import type { Callback, CallbackParam, InternalAgColorType } from 'ag-charts-core';
 
 const { createDatumId, mergeDefaults, toHighlightString } = _ModuleSupport;
 
@@ -38,8 +38,8 @@ interface RadialSectorSeries<D extends BaseNodeDatum> {
         readonly styler?: Styler<AgRadialSeriesStylerParams<unknown, unknown>, AgRadialSeriesStyle>;
         readonly itemStyler?: Styler<AgRadialSeriesItemStylerParams<unknown>, AgRadialSeriesStyle>;
     };
-    callWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F>;
-    cachedCallWithContext<F extends AnyFn>(fn: F, ...params: Parameters<F>): ReturnType<F> | undefined;
+    callWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F>;
+    cachedCallWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> | undefined;
     cachedDatumCallback<T>(id: any, fn: () => T): T | undefined;
     filterItemStylerFillParams(fill: AgColorType | undefined): InternalAgColorType | undefined;
     getDatumId(datum: D): string | number | boolean | undefined;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15782

The `callWithContext` function is only ever called with one argument, and wouldn't work when being called with multiple arguments anyway. See function `maybeSetContext` in `callbackCache.ts`; it deferences `params[0]`.

This change cleans up & simplifies the code, but also helps to workaround an error when trying to generalise the `getStyle` implementation of `RadarAreaSeries` and `RadarLineSeries`.

See commit https://github.com/ag-grid/ag-charts/commit/19b712feadd104dff8dc0f84b92073a82d0dede8. The return type of the abstract `RadarSeries.makeStylerParams` was conflicting the expected type for `cachedCallWithContext` at line 742
