### PR TITLE
AG-15743 Improve Caster by inferring constructor return-types

### DIFF
--- a/libraries/ag-charts-test/src/caster.ts
+++ b/libraries/ag-charts-test/src/caster.ts
@@ -60,38 +60,8 @@ function convert<NewT>(caster: Caster<unknown>): Caster<NewT> {
     return caster as Caster<NewT>;
 }
 
-/**
- * Usage: new ClassTypePair<MyClass, typeof MyClass>(MyClass)>
- *
- * Unfortunately due to the way that constructors work, the only way to write generic methods that take a constructor
- * arguments is to use `new (...args: any[]) => T` or `new (..args: unknown[]) => T`. Neither is ideal, beucase the
- * `any` approach mutes important compiler errors (causing random runtime errors), and the `unknown` approach causes
- * undesirable compilation errors because constructor arguments are not always assignable to `unknown`.
- *
- * Another approach is to use a CtorArgs generic parameter: `example<T, Args>(ctor: new (...args: Args[]) => T);`.
- * However, this doesn't always work, because with a constructor like `constructor(a: number, b: string)` the compiler
- * will complain that it is not assignable to `new (...args: (number|string)[]) => T`.
- *
- * Therefore, the generic must be the entire constructor type, but this would make the caller code very verbose but the
- * generic parameters would not be automatically derived:
- *
- *     class Example {
- *       example<T, Ctor>(ctor: Ctor): boolean;
- *     };
- *
- *     const thing = (new Example()).example<MyClass, typeof MyClass>(MyClass);
- *
- * The `MyClass` name must be typed three times for each call, which can quickly get very verbose if there are multiple
- * calls to the `example()` method. This class helps to reduce the verbosity of the caller to just:
- *
- *     const thing = (new Example()).example(CAST_INFO.MyClass)
- */
-export class ClassTypePair<Type, ConstructorType> {
-    constructor(
-        readonly ctor: ConstructorType,
-        _type?: Type
-    ) {}
-}
+type AnyCtor = abstract new (...arg: any[]) => any;
+type CtorReturnType<Ctor extends AnyCtor> = Ctor extends abstract new (...arg: any[]) => infer R ? R : never;
 
 /**
  * This class converts an input value type into new types. There are no compile-time checks (uses `as` internally), but
@@ -102,10 +72,10 @@ export class ClassTypePair<Type, ConstructorType> {
 export class Caster<T> {
     constructor(readonly value: T) {}
 
-    cast<NewT, Ctor>({ ctor }: ClassTypePair<NewT, Ctor>): Caster<NewT> {
+    cast<C extends AnyCtor>(ctor: C) {
         expect(this.value).toBeDefined();
         expect(this.value).toBeInstanceOf(ctor);
-        return convert<NewT>(this);
+        return convert<CtorReturnType<C>>(this);
     }
 
     findProperty<K extends string>(propertyName: K) {
@@ -132,18 +102,18 @@ export class Caster<T> {
         return convert<NewT>(this);
     }
 
-    castProperty<V, Ctor, K extends keyof T>(propertyName: K, { ctor: propertyCtor }: ClassTypePair<V, Ctor>) {
-        type NewT = Omit<T, K> & { [P in K]: V };
+    castProperty<C extends AnyCtor, K extends keyof T>(propertyName: K, propertyCtor: C) {
+        type NewT = Omit<T, K> & { [P in K]: CtorReturnType<C> };
         expect(this.value[propertyName]).toBeDefined();
         expect(this.value[propertyName]).toBeInstanceOf(propertyCtor);
         return convert<NewT>(this);
     }
 
-    castPropertyArray<V, Ctor, K extends keyof T>(
+    castPropertyArray<C extends AnyCtor, K extends keyof T>(
         propertyName: K,
-        { ctor: elementCtor }: ClassTypePair<V, Ctor>
-    ): Caster<Omit<T, K> & { [P in K]: V[] }> {
-        type NewT = Omit<T, K> & { [P in K]: V[] };
+        elementCtor: C
+    ): Caster<Omit<T, K> & { [P in K]: CtorReturnType<C>[] }> {
+        type NewT = Omit<T, K> & { [P in K]: CtorReturnType<C>[] };
         expect(this.value[propertyName]).toBeInstanceOf(Array);
         for (const elem of this.value[propertyName] as unknown[]) {
             expect(elem).toBeInstanceOf(elementCtor);
@@ -152,12 +122,11 @@ export class Caster<T> {
     }
 
     castArrayElementProperties<
-        V,
-        Ctor,
+        C extends AnyCtor,
         K extends string & keyof ArraysPropertiesOf<T>,
         L extends string & KeysOfUnionOfArrayPropertiesOf<T>,
-    >(arrayName: K, elementPropertyName: L, { ctor: elementPropertyCtor }: ClassTypePair<V, Ctor>) {
-        type NewT = Omit<T, K> & { [Pk in K]: ArraysPropertiesOf<T>[K] & { [Pl in L]: V }[] };
+    >(arrayName: K, elementPropertyName: L, elementPropertyCtor: C) {
+        type NewT = Omit<T, K> & { [Pk in K]: ArraysPropertiesOf<T>[K] & { [Pl in L]: CtorReturnType<C> }[] };
         expect(this.value[arrayName]).toBeInstanceOf(Array);
         for (const unknownElem of this.value[arrayName] as unknown[]) {
             expect(unknownElem).toHaveProperty(elementPropertyName);

--- a/packages/ag-charts-community/src/chart/test/findTarget.ts
+++ b/packages/ag-charts-community/src/chart/test/findTarget.ts
@@ -1,10 +1,9 @@
 import { boxContains } from 'ag-charts-core';
-import { CANVAS_HEIGHT, CANVAS_WIDTH, Caster, ClassTypePair, type MockEvent, makeMockEvent } from 'ag-charts-test';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, Caster, type MockEvent, makeMockEvent } from 'ag-charts-test';
 
 import { BBox } from '../../scene/bbox';
 import { TranslatableGroup } from '../../scene/group';
 import { Node } from '../../scene/node';
-import { Scene } from '../../scene/scene';
 import { Selection } from '../../scene/selection';
 import { Transformable } from '../../scene/transformable';
 import { ListWidget } from '../../widget/listWidget';
@@ -18,25 +17,6 @@ import { Legend } from '../legend/legend';
 import { LegendDOMProxy } from '../legend/legendDOMProxy';
 import { LegendMarkerLabel } from '../legend/legendMarkerLabel';
 import { SeriesAreaManager } from '../series/seriesAreaManager';
-
-const CAST_INFO = {
-    Array: new ClassTypePair<unknown[], typeof Array>(Array),
-
-    BBox: new ClassTypePair<BBox, typeof BBox>(BBox),
-    TranslatableGroup: new ClassTypePair<TranslatableGroup, typeof TranslatableGroup>(TranslatableGroup),
-    Scene: new ClassTypePair<Scene, typeof Scene>(Scene),
-    Node: new ClassTypePair<Node, typeof Node>(Node),
-
-    Legend: new ClassTypePair<Legend, typeof Legend>(Legend),
-    LegendDOMProxy: new ClassTypePair<LegendDOMProxy, typeof LegendDOMProxy>(LegendDOMProxy),
-    SeriesAreaManager: new ClassTypePair<SeriesAreaManager, typeof SeriesAreaManager>(SeriesAreaManager),
-
-    ToolbarWidget: new ClassTypePair<ToolbarWidget, typeof ToolbarWidget>(ToolbarWidget),
-    SliderWidget: new ClassTypePair<SliderWidget, typeof SliderWidget>(SliderWidget),
-    ListWidget: new ClassTypePair<ListWidget, typeof ListWidget>(ListWidget),
-    NativeWidget: new ClassTypePair<NativeWidget, typeof NativeWidget>(NativeWidget),
-    WidgetSet: new ClassTypePair<WidgetSet, typeof WidgetSet>(WidgetSet),
-} as const;
 
 function initBoundingClientRect(widgets: WidgetSet) {
     // getBoundingClientRect doesn't work correctly in node.js, but it's used in some parts of ag-charts.
@@ -89,14 +69,14 @@ function findLegendTarget(legendModule: unknown, clientX: number, clientY: numbe
     if (legendModule === undefined) return undefined;
 
     const legend = new Caster(legendModule)
-        .cast(CAST_INFO.Legend)
+        .cast(Legend)
         .findProperty('group')
-        .castProperty('group', CAST_INFO.TranslatableGroup).value;
+        .castProperty('group', TranslatableGroup).value;
     const legendDOMProxy = new Caster(legendModule)
         .accessProperty('domProxy')
-        .cast(CAST_INFO.LegendDOMProxy)
+        .cast(LegendDOMProxy)
         .findProperty('itemList')
-        .castProperty('itemList', CAST_INFO.ListWidget).value;
+        .castProperty('itemList', ListWidget).value;
 
     if (!isClickable(legendDOMProxy.itemList)) return undefined;
 
@@ -118,17 +98,17 @@ function findNavigatorTarget(navigatorModule: unknown, clientX: number, clientY:
     const navigator = caster
         .findBoolean('enabled')
         .findProperty('minHandle')
-        .castProperty('minHandle', CAST_INFO.Node)
+        .castProperty('minHandle', Node)
         .findProperty('maxHandle')
-        .castProperty('maxHandle', CAST_INFO.Node)
+        .castProperty('maxHandle', Node)
         .findProperty('mask')
-        .castProperty('mask', CAST_INFO.Node).value;
+        .castProperty('mask', Node).value;
     const domProxy = caster
         .accessProperty('domProxy')
         .findProperty('toolbar')
-        .castProperty('toolbar', CAST_INFO.ToolbarWidget)
+        .castProperty('toolbar', ToolbarWidget)
         .findProperty('sliders')
-        .castPropertyArray('sliders', CAST_INFO.SliderWidget).value;
+        .castPropertyArray('sliders', SliderWidget).value;
 
     if (!navigator.enabled) return undefined;
 
@@ -161,9 +141,9 @@ function findZoomTarget(zoomModule: unknown, clientX: number, clientY: number): 
         const domProxy = caster
             .accessProperty('domProxy')
             .findProperty('axes')
-            .castProperty('axes', CAST_INFO.Array)
+            .castProperty('axes', Array)
             .findArrayElementProperties('axes', 'div')
-            .castArrayElementProperties('axes', 'div', CAST_INFO.NativeWidget).value;
+            .castArrayElementProperties('axes', 'div', NativeWidget).value;
 
         for (const axis of domProxy.axes) {
             const bbox = axis.div.getBounds();
@@ -182,9 +162,9 @@ function findZoomTarget(zoomModule: unknown, clientX: number, clientY: number): 
 function findSeriesAreaTarget(chart: unknown, widgets: WidgetSet, clientX: number, clientY: number): MockEvent {
     const seriesRect = new Caster(chart)
         .accessProperty('seriesAreaManager')
-        .cast(CAST_INFO.SeriesAreaManager)
+        .cast(SeriesAreaManager)
         .findProperty('seriesRect')
-        .castProperty('seriesRect', CAST_INFO.BBox).value.seriesRect;
+        .castProperty('seriesRect', BBox).value.seriesRect;
     const { seriesWidget, containerWidget } = widgets;
 
     const inSeriesRect = seriesRect?.containsPoint(clientX, clientY);
@@ -196,7 +176,7 @@ function findSeriesAreaTarget(chart: unknown, widgets: WidgetSet, clientX: numbe
 }
 
 export function findChartTarget(chart: Chart, clientX: number, clientY: number): MockEvent {
-    const widgets = new Caster(chart).accessProperty('ctx').accessProperty('widgets').cast(CAST_INFO.WidgetSet).value;
+    const widgets = new Caster(chart).accessProperty('ctx').accessProperty('widgets').cast(WidgetSet).value;
     initBoundingClientRect(widgets);
 
     const getModule = (s: string) => chart.modulesManager.getModule<unknown>(s);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15743

This removes the need for CAST_INFO meta-data in `caster.ts`