### PR TITLE
CRT-960 Make the "en-US" locale explicit

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -793,8 +793,9 @@ export abstract class Axis<
             // For time axis, the datum is aligned. However, for ticks, we don't want to align the datum.
             formatParams.value = value;
 
+            const locale = formatManager.locale;
             return (
-                currentLabel.formatValue(f, formatParams, index, { specifier, dateStyle, truncateDate }) ??
+                currentLabel.formatValue(locale, f, formatParams, index, { specifier, dateStyle, truncateDate }) ??
                 formatManager.format(f, formatParams, options) ??
                 formatManager.defaultFormat(formatParams, options)
             );
@@ -889,10 +890,11 @@ export abstract class Axis<
         const { type, value } = formatParams;
 
         const f = this.createCallWithContext(contextProvider);
+        const { locale } = formatManager;
         const result =
-            label?.formatValue(f, type, value, params ?? formatParams) ??
+            label?.formatValue(locale, f, type, value, params ?? formatParams) ??
             formatManager.format(f, formatParams) ??
-            this.label.formatValue(f, formatParams, Number.NaN) ??
+            this.label.formatValue(locale, f, formatParams, Number.NaN) ??
             formatManager.defaultFormat(formatParams);
 
         return isArray(result) ? result : String(result);

--- a/packages/ag-charts-community/src/chart/axis/axisLabel.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisLabel.ts
@@ -1,4 +1,4 @@
-import { isArray } from 'ag-charts-core';
+import { type LocaleString, isArray } from 'ag-charts-core';
 import type {
     AgAxisLabelFormatterParams,
     AgAxisLabelStylerParams,
@@ -161,7 +161,7 @@ export class AxisLabel extends BaseProperties implements ChartAxisLabel {
         'long:none': undefined,
     };
     formatValue(
-        locale: string,
+        locale: LocaleString,
         callWithContext: (
             formatter: (params: AgAxisLabelFormatterParams) => TextOrSegments | undefined,
             params: AgAxisLabelFormatterParams

--- a/packages/ag-charts-community/src/chart/axis/axisLabel.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisLabel.ts
@@ -161,6 +161,7 @@ export class AxisLabel extends BaseProperties implements ChartAxisLabel {
         'long:none': undefined,
     };
     formatValue(
+        locale: string,
         callWithContext: (
             formatter: (params: AgAxisLabelFormatterParams) => TextOrSegments | undefined,
             params: AgAxisLabelFormatterParams
@@ -200,7 +201,9 @@ export class AxisLabel extends BaseProperties implements ChartAxisLabel {
                     type,
                     mergedFormat,
                     unit,
-                    formatter: FormatManager.getFormatter(type, mergedFormat, unit, dateStyle, { truncateDate }),
+                    formatter: FormatManager.getFormatter(locale, type, mergedFormat, unit, dateStyle, {
+                        truncateDate,
+                    }),
                 };
 
                 this._formatters[cacheKey] = valueFormatter;

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -251,7 +251,9 @@ export abstract class CartesianAxis<S extends Scale<D, number, any> = Scale<any,
         const { label, primaryLabel, scale, range, interval, reverse, defaultTickMinSpacing, minimumTimeGranularity } =
             this;
 
+        const { locale } = this.moduleCtx.formatManager;
         const tickGenerationResult = generateTicks({
+            locale,
             label,
             scale,
             interval,

--- a/packages/ag-charts-community/src/chart/axis/generateTicks.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.ts
@@ -406,8 +406,9 @@ function createTimeLabelData<TScale extends Scale<TDatum, number, TickInterval<T
     if (timeInterval == null) return [];
 
     const spacing = ticksSpacing(ticks);
-    const { label, labelOffset, primaryLabel, domain } = options;
+    const { locale, label, labelOffset, primaryLabel, domain } = options;
     const { width, height } = timeIntervalMaxLabelSize(
+        locale,
         label,
         primaryLabel,
         niceDomain ?? domain,

--- a/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
@@ -1,6 +1,7 @@
 import {
     type BoxBounds,
     type ITextMeasurer,
+    type LocaleString,
     type WrapOptions,
     boxCollides,
     buildDateFormatter,
@@ -46,7 +47,7 @@ import { NiceMode, type TickDatum } from './axisUtil';
 export type AnyTimeInterval = AgTimeInterval | AgTimeIntervalUnit;
 
 export interface GenerateTicksOptions<TScale extends Scale<TDatum, number, TickInterval<TScale>>, TDatum> {
-    locale: string;
+    locale: LocaleString;
     label: ChartAxisLabel;
     scale: TScale;
     domain: TDatum[];
@@ -444,7 +445,7 @@ export function getTimeIntervalTicks<S extends Scale<D, number, TickInterval<S>>
 }
 
 export function timeIntervalMaxLabelSize(
-    locale: string,
+    locale: LocaleString,
     label: ChartAxisLabel,
     primaryLabel: ChartAxisLabel | undefined,
     domain: Date[],

--- a/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
@@ -46,6 +46,7 @@ import { NiceMode, type TickDatum } from './axisUtil';
 export type AnyTimeInterval = AgTimeInterval | AgTimeIntervalUnit;
 
 export interface GenerateTicksOptions<TScale extends Scale<TDatum, number, TickInterval<TScale>>, TDatum> {
+    locale: string;
     label: ChartAxisLabel;
     scale: TScale;
     domain: TDatum[];
@@ -443,6 +444,7 @@ export function getTimeIntervalTicks<S extends Scale<D, number, TickInterval<S>>
 }
 
 export function timeIntervalMaxLabelSize(
+    locale: string,
     label: ChartAxisLabel,
     primaryLabel: ChartAxisLabel | undefined,
     domain: Date[],
@@ -455,10 +457,10 @@ export function timeIntervalMaxLabelSize(
         return { width: 0, height: 0 };
     }
 
-    const labelFormatter = buildDateFormatter(specifier);
+    const labelFormatter = buildDateFormatter(locale, specifier);
     const hierarchy = timeInterval ? intervalHierarchy(timeInterval) : undefined;
     const primarySpecifier = labelSpecifier(primaryLabel?.format, hierarchy);
-    const primaryLabelFormatter = primarySpecifier ? buildDateFormatter(primarySpecifier) : labelFormatter;
+    const primaryLabelFormatter = primarySpecifier ? buildDateFormatter(locale, primarySpecifier) : labelFormatter;
 
     const d0 = new Date(domain[0]);
     const d1 = new Date(domain.at(-1)!);

--- a/packages/ag-charts-community/src/chart/chartContext.ts
+++ b/packages/ag-charts-community/src/chart/chartContext.ts
@@ -45,7 +45,7 @@ export class ChartContext implements ModuleContext {
 
     readonly callbackCache = new CallbackCache();
     readonly highlightManager = new HighlightManager(this.eventsHub);
-    readonly formatManager = new FormatManager();
+    readonly formatManager = new FormatManager(FormatManager.FALLBACK_LOCALE);
     readonly layoutManager = new LayoutManager(this.eventsHub);
     readonly localeManager = new LocaleManager(this.eventsHub);
     readonly seriesStateManager = new SeriesStateManager();

--- a/packages/ag-charts-community/src/chart/formatter/formatManager.ts
+++ b/packages/ag-charts-community/src/chart/formatter/formatManager.ts
@@ -1,4 +1,5 @@
 import {
+    type LocaleString,
     Logger,
     buildDateFormatter,
     createNumberFormatter,
@@ -56,7 +57,7 @@ export class FormatManager extends Listeners<'format-changed', () => void> {
     );
     formatter: FormatterConfiguration<any> | undefined = undefined;
 
-    constructor(public readonly locale: string) {
+    constructor(public readonly locale: LocaleString) {
         super();
     }
 
@@ -76,7 +77,7 @@ export class FormatManager extends Listeners<'format-changed', () => void> {
     }
 
     static getFormatter(
-        locale: string,
+        locale: LocaleString,
         type: 'number' | 'date' | 'category',
         specifier: string | Partial<Record<AgTimeIntervalUnit, string>>,
         unit?: AgTimeIntervalUnit,

--- a/packages/ag-charts-community/src/chart/formatter/formatManager.ts
+++ b/packages/ag-charts-community/src/chart/formatter/formatManager.ts
@@ -39,6 +39,8 @@ interface FormatParams {
 }
 
 export class FormatManager extends Listeners<'format-changed', () => void> {
+    static readonly FALLBACK_LOCALE = 'en-US';
+
     private readonly formats = new Map<string, ((value: any, _params?: any) => string) | undefined>();
     private readonly dateFormatter = simpleMemorize2(
         (
@@ -49,10 +51,14 @@ export class FormatManager extends Listeners<'format-changed', () => void> {
             truncateDate: FormatParams['truncateDate']
         ) => {
             const mergedFormatter = FormatManager.mergeSpecifiers(propertyFormatter, specifier) ?? defaultTimeFormats;
-            return FormatManager.getFormatter('date', mergedFormatter, unit, style, { truncateDate });
+            return FormatManager.getFormatter(this.locale, 'date', mergedFormatter, unit, style, { truncateDate });
         }
     );
     formatter: FormatterConfiguration<any> | undefined = undefined;
+
+    constructor(public readonly locale: string) {
+        super();
+    }
 
     static mergeSpecifiers(a: Specifier | undefined, ...specifiers: Array<Specifier>): Specifier;
     static mergeSpecifiers(a: Specifier, ...specifiers: Array<Specifier | undefined>): Specifier;
@@ -70,6 +76,7 @@ export class FormatManager extends Listeners<'format-changed', () => void> {
     }
 
     static getFormatter(
+        locale: string,
         type: 'number' | 'date' | 'category',
         specifier: string | Partial<Record<AgTimeIntervalUnit, string>>,
         unit?: AgTimeIntervalUnit,
@@ -89,7 +96,7 @@ export class FormatManager extends Listeners<'format-changed', () => void> {
                     ? specifier?.[unit] ?? defaultTimeFormats[unit]
                     : deriveTimeSpecifier(specifier, unit, truncateDate);
 
-            return buildDateFormatter(fullFormat) as (value: any) => string;
+            return buildDateFormatter(locale, fullFormat) as (value: any) => string;
         }
 
         switch (type) {
@@ -99,7 +106,7 @@ export class FormatManager extends Listeners<'format-changed', () => void> {
                 return createNumberFormatter(options);
             }
             case 'date':
-                return buildDateFormatter(specifier) as (value: any) => string;
+                return buildDateFormatter(locale, specifier) as (value: any) => string;
             case 'category':
                 return (value) => specifier.replace('%s', String(value));
         }
@@ -145,7 +152,7 @@ export class FormatManager extends Listeners<'format-changed', () => void> {
 
         let valueFormatter = this.formats.get(valueSpecifier);
         if (valueFormatter == null) {
-            valueFormatter = FormatManager.getFormatter(params.type, valueSpecifier);
+            valueFormatter = FormatManager.getFormatter(FormatManager.FALLBACK_LOCALE, params.type, valueSpecifier);
             this.formats.set(valueSpecifier, valueFormatter);
         }
         return valueFormatter?.(params.value, params.type === 'number' ? params.fractionDigits : undefined);

--- a/packages/ag-charts-community/src/chart/label.ts
+++ b/packages/ag-charts-community/src/chart/label.ts
@@ -86,6 +86,7 @@ export class Label<TParams = never, TDatum = any>
 
     private _cachedFormatter: FormatterCache | undefined = undefined;
     formatValue(
+        locale: string,
         formatWithContext: ContextFormatter<AgChartLabelFormatterParams<TDatum> & RequireOptional<TParams>>,
         type: 'number' | 'date' | 'category',
         value: any,
@@ -104,7 +105,7 @@ export class Label<TParams = never, TDatum = any>
                 cachedFormatter = {
                     type,
                     format,
-                    formatter: FormatManager.getFormatter(type, format),
+                    formatter: FormatManager.getFormatter(locale, type, format),
                 };
                 this._cachedFormatter = cachedFormatter;
             }

--- a/packages/ag-charts-community/src/chart/label.ts
+++ b/packages/ag-charts-community/src/chart/label.ts
@@ -1,4 +1,4 @@
-import { type RequireOptional, isArray } from 'ag-charts-core';
+import { type LocaleString, type RequireOptional, isArray } from 'ag-charts-core';
 import type {
     AgChartLabelFormatterParams,
     AgChartLabelOptions,
@@ -86,7 +86,7 @@ export class Label<TParams = never, TDatum = any>
 
     private _cachedFormatter: FormatterCache | undefined = undefined;
     formatValue(
-        locale: string,
+        locale: LocaleString,
         formatWithContext: ContextFormatter<AgChartLabelFormatterParams<TDatum> & RequireOptional<TParams>>,
         type: 'number' | 'date' | 'category',
         value: any,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -995,7 +995,7 @@ export abstract class Series<
         const formatInContext = this.callWithContext.bind(this);
 
         const format = (formatParams: FormatterParams<any>) =>
-            label.formatValue(formatInContext, formatParams.type, formatParams.value, params) ??
+            label.formatValue(formatManager.locale, formatInContext, formatParams.type, formatParams.value, params) ??
             formatManager.format(formatInContext, formatParams) ??
             String(value);
 

--- a/packages/ag-charts-community/src/module/axisContext.ts
+++ b/packages/ag-charts-community/src/module/axisContext.ts
@@ -12,6 +12,7 @@ export type ContextFormatter<Params> = (
 
 export interface AxisFormattableLabel<FormatParams extends object, Params extends object = FormatParams> {
     formatValue(
+        locale: string,
         formatInContext: ContextFormatter<FormatParams>,
         type: 'number' | 'date' | 'category',
         value: any,

--- a/packages/ag-charts-core/src/modules/format/timeFormat.test.ts
+++ b/packages/ag-charts-core/src/modules/format/timeFormat.test.ts
@@ -52,7 +52,7 @@ describe('Date/Time Formatting', () => {
 
     describe('buildDateFormatter', () => {
         it.each(cases)('%s', (_, format, expected, date = DEFAULT_DATE) => {
-            const formatter = buildDateFormatter(format);
+            const formatter = buildDateFormatter('en-US', format);
             expect(formatter(date)).toStrictEqual(expected);
         });
     });

--- a/packages/ag-charts-core/src/modules/format/timeFormat.ts
+++ b/packages/ag-charts-core/src/modules/format/timeFormat.ts
@@ -124,7 +124,9 @@ function pad(value: number, size: number, padChar: string) {
     return `${padChar.repeat(size - output.length)}${output}`;
 }
 
-export function buildDateFormatter(formatString: string): FormattingFn {
+export function buildDateFormatter(locale: string, formatString: string): FormattingFn {
+    if (locale !== 'en-US') throw new Error(`unsupported locale ${locale}`);
+
     const formatParts: (LiteralString | [FormattingFn, PaddingString])[] = [];
 
     while (formatString.length > 0) {
@@ -148,7 +150,7 @@ export function buildDateFormatter(formatString: string): FormattingFn {
         if (typeof maybeFormatter === 'function') {
             formatParts.push([maybeFormatter, maybePad]);
         } else if (typeof maybeFormatter === 'string') {
-            const formatter = buildDateFormatter(maybeFormatter);
+            const formatter = buildDateFormatter(locale, maybeFormatter);
             formatParts.push([formatter, maybePad]);
         } else {
             formatParts.push(`${maybePad ?? ''}${maybeFormatterSpecifier}`);

--- a/packages/ag-charts-core/src/modules/format/timeFormat.ts
+++ b/packages/ag-charts-core/src/modules/format/timeFormat.ts
@@ -124,9 +124,9 @@ function pad(value: number, size: number, padChar: string) {
     return `${padChar.repeat(size - output.length)}${output}`;
 }
 
-export function buildDateFormatter(locale: string, formatString: string): FormattingFn {
-    if (locale !== 'en-US') throw new Error(`unsupported locale ${locale}`);
+export type LocaleString = 'en-US';
 
+export function buildDateFormatter(locale: 'en-US', formatString: string): FormattingFn {
     const formatParts: (LiteralString | [FormattingFn, PaddingString])[] = [];
 
     while (formatString.length > 0) {

--- a/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
@@ -158,7 +158,9 @@ export abstract class RadiusAxis<
         const labelX = sideFlag * (this.getTickSize() + this.label.spacing + this.seriesAreaPadding);
 
         const { range, reverse, defaultTickMinSpacing } = this;
+        const { locale } = this.moduleCtx.formatManager;
         const tickGenerationResult = generateTicks({
+            locale,
             scale: this.scale,
             label: this.label,
             interval: this.interval,

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
@@ -44,6 +44,7 @@ export class CrosshairLabelProperties
 
     private _cachedFormatter: FormatterCache | undefined = undefined;
     formatValue(
+        locale: string,
         callWithContext: (
             formatter: (params: AgCrosshairLabelFormatterParams<ContextDefault>) => string | undefined,
             params: AgCrosshairLabelFormatterParams<ContextDefault>
@@ -69,7 +70,7 @@ export class CrosshairLabelProperties
                 cachedFormatter = {
                     type,
                     format,
-                    formatter: FormatManager.getFormatter(type, format),
+                    formatter: FormatManager.getFormatter(locale, type, format),
                 };
                 this._cachedFormatter = cachedFormatter;
             }

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
@@ -7,7 +7,7 @@ import type {
     FormatterParams,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import { type Point, createId, setAttribute } from 'ag-charts-core';
+import { type LocaleString, type Point, createId, setAttribute } from 'ag-charts-core';
 
 const { FormatManager, BaseProperties, Property } = _ModuleSupport;
 
@@ -44,7 +44,7 @@ export class CrosshairLabelProperties
 
     private _cachedFormatter: FormatterCache | undefined = undefined;
     formatValue(
-        locale: string,
+        locale: LocaleString,
         callWithContext: (
             formatter: (params: AgCrosshairLabelFormatterParams<ContextDefault>) => string | undefined,
             params: AgCrosshairLabelFormatterParams<ContextDefault>

--- a/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
@@ -162,7 +162,12 @@ export class AxisTicks {
             };
 
             return (
-                this.label.formatValue((fn, params) => formatWithContext(ctx, fn, params), formatParams, index) ??
+                this.label.formatValue(
+                    formatManager.locale,
+                    (fn, params) => formatWithContext(ctx, fn, params),
+                    formatParams,
+                    index
+                ) ??
                 formatManager.format((fn, params) => formatWithContext(ctx, fn, params), formatParams) ??
                 formatManager.defaultFormat(formatParams)
             );

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -534,6 +534,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         const {
             tickData: { ticks: tickData },
         } = generateTicks({
+            locale: this.ctx.formatManager.locale,
             scale,
             label: this.properties.scale.label,
             interval: this.properties.scale.interval,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-960

Is it not possible to format a date without specifying a locale, because date formats are inherently locale-dependent.

The AG Charts library internally uses the "en-US" locale, but does so implicitly. This PR makes this assumption explicit.