### PR TITLE
AG-8627 Split `zoom:change` into 2 event types

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -386,7 +386,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
                 ctx.domManager.setDataBoolean('animating', false);
                 ctx.domManager.setDataNumber('animationTimeMs', ctx.animationManager.getCumulativeAnimationTime());
             }),
-            ctx.eventsHub.on('zoom:change-requested', () => {
+            ctx.eventsHub.on('zoom:change-request', () => {
                 for (const s of this.series) {
                     (s as any).animationState?.transition('updateData');
                 }

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -386,7 +386,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
                 ctx.domManager.setDataBoolean('animating', false);
                 ctx.domManager.setDataNumber('animationTimeMs', ctx.animationManager.getCumulativeAnimationTime());
             }),
-            ctx.eventsHub.on('zoom:change', () => {
+            ctx.eventsHub.on('zoom:change-requested', () => {
                 for (const s of this.series) {
                     (s as any).animationState?.transition('updateData');
                 }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -100,6 +100,9 @@ export class ZoomManager extends BaseManager {
         super();
 
         this.cleanup.register(
+            eventsHub.on('zoom:change-completed', () => {
+                this.fireChartEvent<AgZoomEvent>({ type: 'zoom', ...this.getMementoRanges() });
+            }),
             eventsHub.on('layout:complete', () => {
                 this.didLayoutAxes = true;
 
@@ -605,14 +608,7 @@ export class ZoomManager extends BaseManager {
             axes[axisId] = axis.getZoom();
         }
 
-        this.eventsHub.emit('zoom:change', { ...this.getZoom(), axes, callerId });
-        this.eventsHub.on('layout:complete', this.boundFireOnceChartEvent);
-    }
-
-    private readonly boundFireOnceChartEvent = this.fireOnceChartEvent.bind(this);
-    private fireOnceChartEvent() {
-        this.fireChartEvent<AgZoomEvent>({ type: 'zoom', ...this.getMementoRanges() });
-        this.eventsHub.off('layout:complete', this.boundFireOnceChartEvent);
+        this.eventsHub.emit('zoom:change-requested', { ...this.getZoom(), axes, callerId });
     }
 
     private getRangeDirection(ratio: ZoomState, direction: ChartAxisDirection): AgZoomRange | undefined {

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -100,7 +100,7 @@ export class ZoomManager extends BaseManager {
         super();
 
         this.cleanup.register(
-            eventsHub.on('zoom:change-completed', () => {
+            eventsHub.on('zoom:change-complete', () => {
                 this.fireChartEvent<AgZoomEvent>({ type: 'zoom', ...this.getMementoRanges() });
             }),
             eventsHub.on('layout:complete', () => {
@@ -608,7 +608,7 @@ export class ZoomManager extends BaseManager {
             axes[axisId] = axis.getZoom();
         }
 
-        this.eventsHub.emit('zoom:change-requested', { ...this.getZoom(), axes, callerId });
+        this.eventsHub.emit('zoom:change-request', { ...this.getZoom(), axes, callerId });
     }
 
     private getRangeDirection(ratio: ZoomState, direction: ChartAxisDirection): AgZoomRange | undefined {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -228,7 +228,7 @@ export class SeriesAreaManager extends BaseManager {
             chart.ctx.eventsHub.on('layout:complete', (event) => this.layoutComplete(event)),
             chart.ctx.updateService.addListener('pre-scene-render', () => this.preSceneRender()),
             chart.ctx.updateService.addListener('update-complete', () => this.updateComplete()),
-            chart.ctx.eventsHub.on('zoom:change', () => this.clearAll()),
+            chart.ctx.eventsHub.on('zoom:change-requested', () => this.clearAll()),
             chart.ctx.eventsHub.on('zoom:pan-start', () => this.clearAll())
         );
         if (seriesDragInterpreter) {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -228,7 +228,7 @@ export class SeriesAreaManager extends BaseManager {
             chart.ctx.eventsHub.on('layout:complete', (event) => this.layoutComplete(event)),
             chart.ctx.updateService.addListener('pre-scene-render', () => this.preSceneRender()),
             chart.ctx.updateService.addListener('update-complete', () => this.updateComplete()),
-            chart.ctx.eventsHub.on('zoom:change-requested', () => this.clearAll()),
+            chart.ctx.eventsHub.on('zoom:change-request', () => this.clearAll()),
             chart.ctx.eventsHub.on('zoom:pan-start', () => this.clearAll())
         );
         if (seriesDragInterpreter) {

--- a/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
@@ -28,7 +28,7 @@ export class DataWindowProcessor<D extends object> implements UpdateProcessor {
             this.eventsHub.on('data:load', () => this.onDataLoad()),
             this.eventsHub.on('data:error', () => this.onDataError()),
             this.updateService.addListener('update-complete', (e) => this.onUpdateComplete(e)),
-            this.eventsHub.on('zoom:change-requested', () => this.onZoomChange())
+            this.eventsHub.on('zoom:change-request', () => this.onZoomChange())
         );
     }
 

--- a/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
@@ -28,7 +28,7 @@ export class DataWindowProcessor<D extends object> implements UpdateProcessor {
             this.eventsHub.on('data:load', () => this.onDataLoad()),
             this.eventsHub.on('data:error', () => this.onDataError()),
             this.updateService.addListener('update-complete', (e) => this.onUpdateComplete(e)),
-            this.eventsHub.on('zoom:change', () => this.onZoomChange())
+            this.eventsHub.on('zoom:change-requested', () => this.onZoomChange())
         );
     }
 

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -53,8 +53,8 @@ export interface EventsHubMap {
     'series-area:click': SeriesAreaClickEvent;
     'series:redo': null;
     'series:undo': null;
-    'zoom:change-requested': ZoomChangeRequestedEvent;
-    'zoom:change-completed': null;
+    'zoom:change-request': ZoomChangeRequestedEvent;
+    'zoom:change-complete': null;
     'zoom:pan-start': ZoomPanStartEvent;
 }
 

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -53,7 +53,8 @@ export interface EventsHubMap {
     'series-area:click': SeriesAreaClickEvent;
     'series:redo': null;
     'series:undo': null;
-    'zoom:change': ZoomChangeEvent;
+    'zoom:change-requested': ZoomChangeRequestedEvent;
+    'zoom:change-completed': null;
     'zoom:pan-start': ZoomPanStartEvent;
 }
 
@@ -118,7 +119,7 @@ export interface SeriesKeyNavZoomEvent {
     readonly widgetEvent: KeyboardWidgetEvent<'keydown'>;
 }
 
-export interface ZoomChangeEvent extends AxisZoomState {
+export interface ZoomChangeRequestedEvent extends AxisZoomState {
     readonly callerId: string;
     readonly axes: Record<string, Readonly<ZoomState> | undefined>;
     readonly x?: Readonly<ZoomState>;

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -486,7 +486,7 @@ export class Annotations extends AbstractModuleInstance {
             ctx.eventsHub.on('annotations:restore', this.onRestoreAnnotations.bind(this)),
             ctx.eventsHub.on('layout:complete', this.onLayoutComplete.bind(this)),
             ctx.updateService.addListener('pre-scene-render', this.onPreRender.bind(this)),
-            ctx.eventsHub.on('zoom:change-requested', () => this.onResize()),
+            ctx.eventsHub.on('zoom:change-request', () => this.onResize()),
             ctx.eventsHub.on('dom:resize', () => this.onResize()),
 
             // Toolbar

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -486,7 +486,7 @@ export class Annotations extends AbstractModuleInstance {
             ctx.eventsHub.on('annotations:restore', this.onRestoreAnnotations.bind(this)),
             ctx.eventsHub.on('layout:complete', this.onLayoutComplete.bind(this)),
             ctx.updateService.addListener('pre-scene-render', this.onPreRender.bind(this)),
-            ctx.eventsHub.on('zoom:change', () => this.onResize()),
+            ctx.eventsHub.on('zoom:change-requested', () => this.onResize()),
             ctx.eventsHub.on('dom:resize', () => this.onResize()),
 
             // Toolbar

--- a/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
@@ -43,7 +43,7 @@ export class AxisButton extends AbstractModuleInstance {
             ctx.widgets.seriesDragInterpreter?.events.on('click', (e) => this.onClick(e)),
             ctx.eventsHub.on('series:focus-change', () => this.onKeyPress()),
             ctx.eventsHub.on('zoom:pan-start', () => this.hide()),
-            ctx.eventsHub.on('zoom:change-requested', () => this.hide()),
+            ctx.eventsHub.on('zoom:change-request', () => this.hide()),
             () => this.destroyElements(),
             () => this.button.destroy()
         );

--- a/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
@@ -43,7 +43,7 @@ export class AxisButton extends AbstractModuleInstance {
             ctx.widgets.seriesDragInterpreter?.events.on('click', (e) => this.onClick(e)),
             ctx.eventsHub.on('series:focus-change', () => this.onKeyPress()),
             ctx.eventsHub.on('zoom:pan-start', () => this.hide()),
-            ctx.eventsHub.on('zoom:change', () => this.hide()),
+            ctx.eventsHub.on('zoom:change-requested', () => this.hide()),
             () => this.destroyElements(),
             () => this.button.destroy()
         );

--- a/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
+++ b/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
@@ -91,7 +91,7 @@ export class BandHighlight extends AbstractModuleInstance {
             eventsHub.on('layout:complete', (event) => this.layout(event)),
             eventsHub.on('series:focus-change', () => this.onKeyPress()),
             eventsHub.on('zoom:pan-start', () => this.clearAllHighlight()),
-            eventsHub.on('zoom:change', () => this.clearAllHighlight()),
+            eventsHub.on('zoom:change-requested', () => this.clearAllHighlight()),
             eventsHub.on('dom:resize', () => this.clearAllHighlight()),
             eventsHub.on('axis:change', () => this.axisChange())
         );

--- a/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
+++ b/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
@@ -91,7 +91,7 @@ export class BandHighlight extends AbstractModuleInstance {
             eventsHub.on('layout:complete', (event) => this.layout(event)),
             eventsHub.on('series:focus-change', () => this.onKeyPress()),
             eventsHub.on('zoom:pan-start', () => this.clearAllHighlight()),
-            eventsHub.on('zoom:change-requested', () => this.clearAllHighlight()),
+            eventsHub.on('zoom:change-request', () => this.clearAllHighlight()),
             eventsHub.on('dom:resize', () => this.clearAllHighlight()),
             eventsHub.on('axis:change', () => this.axisChange())
         );

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -82,7 +82,7 @@ export class Crosshair extends AbstractModuleInstance {
             ctx.widgets.seriesWidget.addListener('mouseleave', () => this.onMouseOut()),
             ctx.eventsHub.on('series:focus-change', () => this.onKeyPress()),
             ctx.eventsHub.on('zoom:pan-start', () => this.onMouseOut()),
-            ctx.eventsHub.on('zoom:change', () => this.onMouseOut()),
+            ctx.eventsHub.on('zoom:change-requested', () => this.onMouseOut()),
             ctx.eventsHub.on('highlight:change', (event) => this.onHighlightChange(event)),
             ctx.eventsHub.on('layout:complete', (event) => this.layout(event)),
             () => {

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -82,7 +82,7 @@ export class Crosshair extends AbstractModuleInstance {
             ctx.widgets.seriesWidget.addListener('mouseleave', () => this.onMouseOut()),
             ctx.eventsHub.on('series:focus-change', () => this.onKeyPress()),
             ctx.eventsHub.on('zoom:pan-start', () => this.onMouseOut()),
-            ctx.eventsHub.on('zoom:change-requested', () => this.onMouseOut()),
+            ctx.eventsHub.on('zoom:change-request', () => this.onMouseOut()),
             ctx.eventsHub.on('highlight:change', (event) => this.onHighlightChange(event)),
             ctx.eventsHub.on('layout:complete', (event) => this.layout(event)),
             () => {

--- a/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
@@ -172,7 +172,7 @@ export class Navigator extends AbstractModuleInstance {
         this.updateZoom();
     }
 
-    private onZoomChange(event: _ModuleSupport.ZoomChangeEvent) {
+    private onZoomChange(event: _ModuleSupport.ZoomChangeRequestedEvent) {
         const { x: xZoom } = event;
         if (!xZoom) return;
 

--- a/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
@@ -70,7 +70,7 @@ export class Navigator extends AbstractModuleInstance {
             ctx.eventsHub.on('locale:change', () => this.updateZoom()),
             ctx.layoutManager.registerElement(_ModuleSupport.LayoutElement.Navigator, (e) => this.onLayoutStart(e)),
             ctx.eventsHub.on('layout:complete', (e) => this.onLayoutComplete(e)),
-            ctx.eventsHub.on('zoom:change', (event) => this.onZoomChange(event))
+            ctx.eventsHub.on('zoom:change-requested', (event) => this.onZoomChange(event))
         );
 
         this.domProxy = new NavigatorDOMProxy(ctx, this);

--- a/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigator.ts
@@ -70,7 +70,7 @@ export class Navigator extends AbstractModuleInstance {
             ctx.eventsHub.on('locale:change', () => this.updateZoom()),
             ctx.layoutManager.registerElement(_ModuleSupport.LayoutElement.Navigator, (e) => this.onLayoutStart(e)),
             ctx.eventsHub.on('layout:complete', (e) => this.onLayoutComplete(e)),
-            ctx.eventsHub.on('zoom:change-requested', (event) => this.onZoomChange(event))
+            ctx.eventsHub.on('zoom:change-request', (event) => this.onZoomChange(event))
         );
 
         this.domProxy = new NavigatorDOMProxy(ctx, this);

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -31,7 +31,7 @@ export class Ranges extends AbstractModuleInstance {
         this.cleanup.register(
             this.toolbar.addToolbarListener('button-pressed', this.onButtonPress.bind(this)),
             ctx.layoutManager.registerElement(LayoutElement.ToolbarBottom, this.onLayoutStart.bind(this)),
-            ctx.eventsHub.on('zoom:change', this.onZoomChanged.bind(this)),
+            ctx.eventsHub.on('zoom:change-requested', this.onZoomChanged.bind(this)),
             this.teardown.bind(this)
         );
     }

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -31,7 +31,7 @@ export class Ranges extends AbstractModuleInstance {
         this.cleanup.register(
             this.toolbar.addToolbarListener('button-pressed', this.onButtonPress.bind(this)),
             ctx.layoutManager.registerElement(LayoutElement.ToolbarBottom, this.onLayoutStart.bind(this)),
-            ctx.eventsHub.on('zoom:change-requested', this.onZoomChanged.bind(this)),
+            ctx.eventsHub.on('zoom:change-request', this.onZoomChanged.bind(this)),
             this.teardown.bind(this)
         );
     }

--- a/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
+++ b/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
@@ -121,7 +121,7 @@ export class ChartSync extends BaseProperties implements ModuleInstance, AgChart
     private enabledZoomSync() {
         const { eventsHub } = this.moduleContext;
         this.disableZoomSync?.(); // Cleanup any existing listeners.
-        this.disableZoomSync = eventsHub.on('zoom:change-requested', this.onZoom.bind(this));
+        this.disableZoomSync = eventsHub.on('zoom:change-request', this.onZoom.bind(this));
     }
 
     private onZoom() {

--- a/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
+++ b/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
@@ -121,7 +121,7 @@ export class ChartSync extends BaseProperties implements ModuleInstance, AgChart
     private enabledZoomSync() {
         const { eventsHub } = this.moduleContext;
         this.disableZoomSync?.(); // Cleanup any existing listeners.
-        this.disableZoomSync = eventsHub.on('zoom:change', this.onZoom.bind(this));
+        this.disableZoomSync = eventsHub.on('zoom:change-requested', this.onZoom.bind(this));
     }
 
     private onZoom() {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -254,7 +254,7 @@ export class Zoom extends AbstractModuleInstance {
             ctx.widgets.seriesWidget.addListener('touchcancel', (event) => this.onTouchEnd(event)),
             ctx.updateService.addListener('process-data', (event) => this.onProcessData(event)),
             ctx.eventsHub.on('layout:complete', (event) => this.onLayoutComplete(event)),
-            ctx.eventsHub.on('zoom:change-requested', (event) => this.onZoomChangeRequested(event)),
+            ctx.eventsHub.on('zoom:change-request', (event) => this.onZoomChangeRequested(event)),
             ctx.eventsHub.on('zoom:pan-start', (event) => this.onZoomPanStart(event)),
             this.panner.addListener('update', (event) => this.onPanUpdate(event)),
             () => this.teardown()
@@ -798,7 +798,7 @@ export class Zoom extends AbstractModuleInstance {
 
         if (this.wasZoomChangeRequested) {
             this.wasZoomChangeRequested = false;
-            this.ctx.eventsHub.emit('zoom:change-completed', null);
+            this.ctx.eventsHub.emit('zoom:change-complete', null);
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -208,6 +208,7 @@ export class Zoom extends AbstractModuleInstance {
         this.isFirstWheelEvent = true;
         this.wasFirstWheelEventZoomCapped = undefined;
     }, 100);
+    private wasZoomChangeRequested = false;
 
     constructor(private readonly ctx: _ModuleSupport.ModuleContext) {
         super();
@@ -253,7 +254,7 @@ export class Zoom extends AbstractModuleInstance {
             ctx.widgets.seriesWidget.addListener('touchcancel', (event) => this.onTouchEnd(event)),
             ctx.updateService.addListener('process-data', (event) => this.onProcessData(event)),
             ctx.eventsHub.on('layout:complete', (event) => this.onLayoutComplete(event)),
-            ctx.eventsHub.on('zoom:change', (event) => this.onZoomChange(event)),
+            ctx.eventsHub.on('zoom:change-requested', (event) => this.onZoomChangeRequested(event)),
             ctx.eventsHub.on('zoom:pan-start', (event) => this.onZoomPanStart(event)),
             this.panner.addListener('update', (event) => this.onPanUpdate(event)),
             () => this.teardown()
@@ -794,9 +795,16 @@ export class Zoom extends AbstractModuleInstance {
         if (this.enableAxisDragging) {
             this.toggleAxisDraggingCursorsDebounced();
         }
+
+        if (this.wasZoomChangeRequested) {
+            this.wasZoomChangeRequested = false;
+            this.ctx.eventsHub.emit('zoom:change-completed', null);
+        }
     }
 
-    private onZoomChange(event: _ModuleSupport.ZoomChangeEvent) {
+    private onZoomChangeRequested(event: _ModuleSupport.ZoomChangeRequestedEvent) {
+        this.wasZoomChangeRequested = true;
+
         if (event.callerId !== 'zoom') {
             this.panner.stopInteractions();
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8627

-   `zoom:change-requested` (same as old `zoom:change`).
-   `zoom:change-completed` (emitted by zoom.ts when change is done).