### PR TITLE
Disable CodeQL trap caching - generating 520MB cache entries on EVERY run.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,7 @@ jobs:
                   config-file: ./.github/codeql/codeql-config-pr.yml
                   languages: ${{ matrix.language }}
                   build-mode: ${{ matrix.build-mode }}
+                  trap-caching: false
 
             - name: Initialize CodeQL (latest)
               uses: github/codeql-action/init@v3
@@ -65,6 +66,7 @@ jobs:
                   config-file: ./.github/codeql/codeql-config-latest.yml
                   languages: ${{ matrix.language }}
                   build-mode: ${{ matrix.build-mode }}
+                  trap-caching: false
 
             - name: Perform CodeQL Analysis
               uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
See https://github.com/github/codeql-action/issues/2030