### PR TITLE
AG-8627 Standardise `ZoomManager` update flow

### DIFF
--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -66,7 +66,7 @@ export class CartesianChart extends Chart {
         this.syncAxisChanges(newValue, oldValue);
 
         if (this.ctx != null) {
-            this.ctx.zoomManager.updateAxes(newValue);
+            this.ctx.zoomManager.setAxes(newValue);
         }
     }
 

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,6 +1,7 @@
 import {
     type AxisID,
     type BoxBounds,
+    type DeepReadonly,
     Logger,
     type OptionsDefs,
     type RequireOptional,
@@ -14,13 +15,19 @@ import {
 } from 'ag-charts-core';
 import type { AgAutoScaledAxes, AgZoomEvent, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
-import type { AxisZoomState, EventsHub, ZoomState } from '../../core/eventsHub';
+import type {
+    AxisZoomState,
+    EventsHub,
+    ZoomChangeRequestedEvent,
+    ZoomChangeType,
+    ZoomState,
+} from '../../core/eventsHub';
+import { deepClone } from '../../module-support';
 import { ContinuousScale } from '../../scale/continuousScale';
 import { DiscreteTimeScale } from '../../scale/discreteTimeScale';
 import type { BBox } from '../../scene/bbox';
 import { BaseManager } from '../../util/baseManager';
-import { deepClone } from '../../util/json';
-import { objectsEqual } from '../../util/object';
+import { objectsEqual, strictObjectKeys } from '../../util/object';
 import type { TypedEvent } from '../../util/observable';
 import { calcPanToBBoxRatios } from '../../util/panToBBox';
 import { NonNullableStateTracker } from '../../util/stateTracker';
@@ -33,6 +40,10 @@ export interface DefinedZoomState {
     y: ZoomState;
 }
 
+type CoreZoomEntry = ZoomState & { direction: CartesianAxisDirection };
+export type CoreZoomState = Record<AxisID, CoreZoomEntry>;
+export type CoreZoomStateSafeRetrieval = { readonly [K in AxisID]: CoreZoomEntry | undefined };
+
 export type ZoomMemento = {
     rangeX?: AgZoomRange;
     rangeY?: AgZoomRange;
@@ -41,9 +52,12 @@ export type ZoomMemento = {
     autoScaledAxes?: AgAutoScaledAxes;
 };
 
-export type CartesianAxisLike = {
+export type SimpleAxis = {
     id: AxisID;
     direction: CartesianAxisDirection;
+};
+
+export type CartesianAxisLike = SimpleAxis & {
     visibleRange: [number, number];
     scale: Scale<any, any>;
     range: [number, number];
@@ -56,6 +70,7 @@ class ZoomManagerAutoScaleAxis {
     enabled = false;
     padding = 0;
     manuallyAdjusted = false;
+    lastAutoScaleYAxis = true;
 }
 
 const rangeValidator = (axis?: CartesianAxisLike) =>
@@ -65,6 +80,30 @@ const rangeValidator = (axis?: CartesianAxisLike) =>
         return value < options.end;
     }, `to be less than end`);
 
+function validateChanges(changes: UpdateZoomParams['changes']): void {
+    for (const axisId of strictObjectKeys(changes)) {
+        const zoom = changes[axisId];
+        if (!zoom) continue;
+
+        const { min, max } = zoom;
+
+        if (min < 0 || max > 1) {
+            Logger.warnOnce(
+                `Attempted to update axis (${axisId}) zoom to an invalid ratio of [{ min: ${min}, max: ${max} }], expecting a ratio of 0 to 1. Ignoring.`
+            );
+
+            // Remove invalid zoom state for this axis
+            delete changes[axisId];
+        }
+    }
+}
+
+type UpdateZoomParams = {
+    callerId: string;
+    changes: Record<AxisID, ZoomState>;
+    changeType: ZoomChangeType;
+};
+
 /**
  * Manages the current zoom state for a chart. Tracks the requested zoom from distinct dependents
  * and handles conflicting zoom requests.
@@ -72,14 +111,12 @@ const rangeValidator = (axis?: CartesianAxisLike) =>
 export class ZoomManager extends BaseManager {
     public mementoOriginatorKey = 'zoom' as const;
 
-    private readonly axisZoomManagers = new Map<string, AxisZoomManager>();
-    private readonly state = new NonNullableStateTracker<AxisZoomState>({}, 'initial');
-
+    private readonly state = new NonNullableStateTracker<CoreZoomStateSafeRetrieval>({}, 'initial');
     private readonly axes: CartesianAxisLike[] = [];
     private didLayoutAxes = false;
 
     private readonly autoScaleYAxis = new ZoomManagerAutoScaleAxis();
-    private lastRestoredState: AxisZoomState | undefined = undefined;
+    private lastRestoredState: CoreZoomStateSafeRetrieval | undefined = undefined;
     private independentAxes = false;
     private navigatorModule = false;
     private zoomModule = false;
@@ -112,9 +149,55 @@ export class ZoomManager extends BaseManager {
                     this.restoreMemento(pendingMemento.version, pendingMemento.mementoVersion, pendingMemento.memento);
                 }
 
-                this.autoScaleYZoom('zoom-manager');
+                this.autoScaleYZoom('zoom-manager', 'layoutComplete');
             })
         );
+    }
+
+    private toCoreZoomState(axisZoom: DeepReadonly<AxisZoomState>): CoreZoomState {
+        const result: CoreZoomState = {};
+        let ids: AxisID[];
+
+        if (this.independentAxes) {
+            const xId = this.getPrimaryAxisId(ChartAxisDirection.X);
+            const yId = this.getPrimaryAxisId(ChartAxisDirection.Y);
+            ids = [];
+            if (xId) ids.push(xId);
+            if (yId) ids.push(yId);
+        } else {
+            ids = strictObjectKeys(this.state.stateValue);
+        }
+
+        for (const id of ids) {
+            for (const direction of [ChartAxisDirection.X, ChartAxisDirection.Y] as const) {
+                const zoom = axisZoom[direction];
+                if (zoom) {
+                    const { min, max } = zoom;
+                    result[id] = { min, max, direction };
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): AxisZoomState | undefined {
+        let x: ZoomState | undefined;
+        let y: ZoomState | undefined;
+
+        // Use the zoom on the primary (first) axis in each direction
+        for (const id of strictObjectKeys(coreZoom)) {
+            const { min, max, direction } = coreZoom[id]!;
+            if (direction === ChartAxisDirection.X) {
+                x ??= { min, max };
+            } else if (direction === ChartAxisDirection.Y) {
+                y ??= { min, max };
+            }
+        }
+
+        if (x || y) {
+            return { x, y };
+        }
     }
 
     public createMemento() {
@@ -147,8 +230,6 @@ export class ZoomManager extends BaseManager {
     }
 
     public restoreMemento(version: string, mementoVersion: string, memento: ZoomMemento | undefined) {
-        const { independentAxes } = this;
-
         if (!this.axes || !this.didLayoutAxes) {
             this.pendingMemento = { version, mementoVersion, memento };
             return;
@@ -157,7 +238,7 @@ export class ZoomManager extends BaseManager {
 
         // Migration from older versions can be implemented here.
 
-        const zoom: AxisZoomState = this.getDefinedZoom();
+        const zoom: DefinedZoomState & Pick<AxisZoomState, 'autoScaleYAxis'> = this.getDefinedZoom();
 
         if (memento?.rangeX) {
             zoom.x = this.rangeToRatio(memento.rangeX, ChartAxisDirection.X) ?? { min: 0, max: 1 };
@@ -191,41 +272,30 @@ export class ZoomManager extends BaseManager {
             zoom.autoScaleYAxis = yAutoScale;
         }
 
-        this.lastRestoredState = zoom;
-
-        if (independentAxes !== true) {
-            this.updateZoom('zoom-manager', zoom);
-            return;
-        }
-
-        const primaryX = this.getPrimaryAxis(ChartAxisDirection.X);
-        const primaryY = this.getPrimaryAxis(ChartAxisDirection.Y);
-
-        for (const axis of [primaryX, primaryY]) {
-            if (!axis) continue;
-            this.updateAxisZoom('zoom-manager', axis.id, zoom[axis.direction as keyof DefinedZoomState]);
-        }
+        const changes = this.toCoreZoomState(zoom);
+        this.lastRestoredState = changes;
+        this.autoScaleYAxis.lastAutoScaleYAxis = zoom.autoScaleYAxis ?? false;
+        this.applyUpdateZoom({ callerId: 'zoom-manager', changeType: 'restoreMemento', changes });
     }
 
-    public updateAxes(nextAxes: Array<CartesianAxisLike | CartesianAxisDirection>) {
-        const { axes, axisZoomManagers } = this;
-
-        const existingZoomManagers = new Map(axisZoomManagers);
-        axisZoomManagers.clear();
-
+    public setAxes(nextAxes: Array<CartesianAxisLike> | Array<SimpleAxis>) {
+        const { axes } = this;
         axes.length = 0;
         for (const axis of nextAxes) {
-            if (typeof axis === 'string') {
-                axisZoomManagers.set(axis, existingZoomManagers.get(axis) ?? new AxisZoomManager(axis));
-            } else {
+            if ('range' in axis) {
                 axes.push(axis);
-                axisZoomManagers.set(axis.id, existingZoomManagers.get(axis.id) ?? new AxisZoomManager(axis));
             }
         }
 
-        if (this.state.size > 0 && axes.length > 0) {
-            this.updateZoom(this.state.stateId(), this.state.stateValue());
+        const callerId = this.state.stateId();
+        const oldState = this.state.stateValue();
+        const changes: CoreZoomState = {};
+        for (const { id, direction } of nextAxes) {
+            const { min, max } = oldState[id] ?? { min: 0, max: 1 };
+            changes[id] = { min, max, direction };
         }
+        this.state.set(callerId, changes);
+        this.applyUpdateZoom({ callerId, changeType: 'setAxes', changes });
     }
 
     public setIndependentAxes(independent = true) {
@@ -237,7 +307,7 @@ export class ZoomManager extends BaseManager {
         this.autoScaleYAxis.padding = padding;
 
         if (enabled) {
-            this.autoScaleYZoom('toggle-auto-scale');
+            this.autoScaleYZoom('toggle-auto-scale', 'update');
         }
     }
 
@@ -258,84 +328,86 @@ export class ZoomManager extends BaseManager {
     }
 
     public updateZoom(callerId: string, newZoom?: AxisZoomState) {
-        if (newZoom?.x && (newZoom.x.min < 0 || newZoom.x.max > 1)) {
-            Logger.warnOnce(
-                `Attempted to update x-axis zoom to an invalid ratio of [{ min: ${newZoom.x.min}, max: ${newZoom.x.max} }], expecting a ratio of 0 to 1, ignoring.`
-            );
-            newZoom.x = undefined;
-        }
+        this.updateChanges(callerId, this.toCoreZoomState(newZoom ?? {}));
+    }
 
-        if (newZoom?.y && (newZoom.y.min < 0 || newZoom.y.max > 1)) {
-            Logger.warnOnce(
-                `Attempted to update y-axis zoom to an invalid ratio of [{ min: ${newZoom.y.min}, max: ${newZoom.y.max} }], expecting a ratio of 0 to 1, ignoring.`
-            );
-            newZoom.y = undefined;
-        }
+    public updateAxisZoom(callerId: string, axisId: AxisID, newZoom?: ZoomState) {
+        const changes = { [axisId]: newZoom ?? this.getAxisZoom(axisId) };
+        this.updateChanges(callerId, changes);
+    }
 
-        if (this.axisZoomManagers.size === 0) {
-            const stateId = this.state.stateId();
-            if (stateId === 'initial' || stateId === callerId) {
-                this.state.set(callerId, newZoom);
+    public updateChanges(callerId: string, changes: UpdateZoomParams['changes']) {
+        this.applyUpdateZoom({ callerId, changeType: 'update', changes });
+    }
+
+    private computeChangedAxesIds(newState: UpdateZoomParams['changes']): readonly AxisID[] {
+        const result: AxisID[] = [];
+        const oldState = this.state.stateValue();
+        for (const id of strictObjectKeys(newState)) {
+            const newAxisState = newState[id];
+            const oldAxisState = oldState[id];
+            if (
+                oldAxisState == undefined ||
+                oldAxisState.min !== newAxisState.min ||
+                oldAxisState.max !== newAxisState.max
+            ) {
+                result.push(id);
             }
-            return;
         }
+        return result;
+    }
 
-        this.state.set(callerId, newZoom);
+    private applyUpdateZoom(
+        { callerId, changeType, changes }: UpdateZoomParams,
+        autoScaleYAxis?: boolean // TODO(olegat) move to enterprise
+    ) {
+        validateChanges(changes);
 
-        const autoScaleYAxis = newZoom?.autoScaleYAxis;
+        autoScaleYAxis ??= this.autoScaleYAxis.enabled && !this.autoScaleYAxis.manuallyAdjusted;
+
+        const changedAxes = this.computeChangedAxesIds(changes);
+        const newState: CoreZoomStateSafeRetrieval = deepClone(this.state.stateValue());
+        for (const id of changedAxes) {
+            const axis = newState[id];
+            if (axis != undefined) {
+                axis.min = changes[id].min;
+                axis.max = changes[id].max;
+            }
+        }
+        this.state.set(callerId, newState);
+
         if (autoScaleYAxis != null) {
             this.autoScaleYAxis.manuallyAdjusted = !autoScaleYAxis;
         }
 
-        for (const axis of this.axisZoomManagers.values()) {
-            axis.updateZoom(callerId, newZoom?.[axis.direction]);
-        }
-
-        this.applyChanges(callerId);
-    }
-
-    public updateAxisZoom(callerId: string, axisId: AxisID, newZoom?: ZoomState) {
-        this.axisZoomManagers.get(axisId)?.updateZoom(callerId, newZoom);
-        this.applyChanges(callerId);
+        this.dispatch(callerId, changeType, changedAxes);
     }
 
     public resetZoom(callerId: string) {
         this.autoScaleYAxis.manuallyAdjusted = false;
 
-        // TODO: Move `zoomUtils.ts` to community and use `definedZoomState()` here.
-        const zoom = this.getRestoredZoom();
-        this.updateZoom(callerId, {
-            x: { min: zoom?.x?.min ?? 0, max: zoom?.x?.max ?? 1 },
-            y: { min: zoom?.y?.min ?? 0, max: zoom?.y?.max ?? 1 },
-            autoScaleYAxis: zoom?.autoScaleYAxis ?? true,
-        });
+        const { lastAutoScaleYAxis } = this.autoScaleYAxis;
+        const changes = this.toCoreZoomState(this.getRestoredZoom());
+        this.applyUpdateZoom({ callerId, changeType: 'reset', changes }, lastAutoScaleYAxis);
     }
 
     public resetAxisZoom(callerId: string, axisId: AxisID) {
-        const axisZoomManager = this.axisZoomManagers.get(axisId);
-        const direction = axisZoomManager?.direction;
+        const direction = this.state.stateValue()[axisId]?.direction;
         if (direction == null) return;
         const restoredZoom = this.getRestoredZoom();
+        let lastAutoScaleYAxis: boolean | undefined;
         if (direction === ChartAxisDirection.Y) {
-            const autoScaleYAxis = restoredZoom?.autoScaleYAxis ?? true;
-            this.autoScaleYAxis.manuallyAdjusted = !autoScaleYAxis;
+            lastAutoScaleYAxis = restoredZoom?.autoScaleYAxis ?? true;
+            this.autoScaleYAxis.manuallyAdjusted = !lastAutoScaleYAxis;
         }
-        for (const axis of this.axes) {
-            if (axis.direction !== direction) continue;
-            this.updateAxisZoom(callerId, axis.id, restoredZoom?.[direction] ?? { min: 0, max: 1 });
-        }
+        const changes = this.toCoreZoomState({ [direction]: restoredZoom[direction] });
+        this.applyUpdateZoom({ callerId, changeType: 'reset', changes });
     }
 
     public setAxisManuallyAdjusted(_callerId: string, axisId: AxisID) {
-        const direction = this.axisZoomManagers.get(axisId)?.direction;
+        const direction = this.state.stateValue()[axisId]?.direction;
         if (direction !== ChartAxisDirection.Y) return;
         this.autoScaleYAxis.manuallyAdjusted = true;
-    }
-
-    public updatePrimaryAxisZoom(callerId: string, direction: CartesianAxisDirection, newZoom?: ZoomState) {
-        const primaryAxis = this.getPrimaryAxis(direction);
-        if (!primaryAxis) return;
-        this.updateAxisZoom(callerId, primaryAxis.id, newZoom);
     }
 
     public panToBBox(callerId: string, seriesRect: BBox, target: BoxBounds): boolean {
@@ -355,13 +427,8 @@ export class ZoomManager extends BaseManager {
         }
 
         const newZoom: AxisZoomState = calcPanToBBoxRatios(seriesRect, zoom, target);
-
-        if (this.independentAxes) {
-            this.updatePrimaryAxisZoom(callerId, ChartAxisDirection.X, newZoom.x);
-            this.updatePrimaryAxisZoom(callerId, ChartAxisDirection.Y, newZoom.y);
-        } else {
-            this.updateZoom(callerId, newZoom);
-        }
+        const changes = this.toCoreZoomState(newZoom);
+        this.applyUpdateZoom({ callerId, changeType: 'panToBBox', changes });
         return true;
     }
 
@@ -411,40 +478,26 @@ export class ZoomManager extends BaseManager {
     }
 
     public getZoom(): AxisZoomState | undefined {
-        let x: ZoomState | undefined;
-        let y: ZoomState | undefined;
-
-        // Use the zoom on the primary (first) axis in each direction
-        for (const axis of this.axisZoomManagers.values()) {
-            if (axis.direction === ChartAxisDirection.X) {
-                x ??= axis.getZoom();
-            } else if (axis.direction === ChartAxisDirection.Y) {
-                y ??= axis.getZoom();
-            }
-        }
-
-        if (x || y) {
-            return { x, y };
-        }
+        return this.toAxisZoomState(this.state.stateValue());
     }
 
-    public getAxisZoom(axisId: AxisID | CartesianAxisDirection): ZoomState {
-        return this.axisZoomManagers.get(axisId)?.getZoom() ?? { min: 0, max: 1 };
+    public getAxisZoom(axisId: AxisID): ZoomState {
+        return this.state.stateValue()[axisId] ?? { min: 0, max: 1 };
     }
 
-    public getAxisZooms(): Record<AxisID, { direction: CartesianAxisDirection; zoom: ZoomState }> {
-        const axes: Record<string, { direction: CartesianAxisDirection; zoom: ZoomState }> = {};
-        for (const [axisId, axis] of this.axisZoomManagers.entries()) {
-            axes[axisId] = {
-                direction: axis.direction,
-                zoom: axis.getZoom(),
-            };
-        }
-        return axes;
+    public getAxisZooms(): CoreZoomStateSafeRetrieval {
+        return this.state.stateValue();
     }
 
-    public getRestoredZoom(): AxisZoomState | undefined {
-        return this.lastRestoredState;
+    public getRestoredZoom() {
+        // TODO: Move `zoomUtils.ts` to community and use `definedZoomState()` here.
+        const zoom = this.toAxisZoomState(this.lastRestoredState ?? {});
+        const newZoom = {
+            x: { min: zoom?.x?.min ?? 0, max: zoom?.x?.max ?? 1 },
+            y: { min: zoom?.y?.min ?? 0, max: zoom?.y?.max ?? 1 },
+            autoScaleYAxis: zoom?.autoScaleYAxis ?? true,
+        };
+        return newZoom;
     }
 
     public getPrimaryAxisId(direction: CartesianAxisDirection) {
@@ -569,47 +622,30 @@ export class ZoomManager extends BaseManager {
         }
     }
 
-    private autoScaleYZoom(callerId: string, applyChanges = true) {
-        const { independentAxes } = this;
-
+    private autoScaleYZoom(callerId: string, changeType: ZoomChangeType | undefined, apply = true) {
         const zoom = this.getZoom();
         if (zoom?.x == null) return;
 
         const zoomY = this.getAutoScaleYZoom(zoom.x);
         if (zoomY == null || objectsEqual(zoom.y, zoomY)) return;
 
-        if (independentAxes) {
-            const primaryAxis = this.getPrimaryAxis(ChartAxisDirection.Y);
-            const primaryAxisManager = primaryAxis == null ? undefined : this.axisZoomManagers.get(primaryAxis.id);
-            primaryAxisManager?.updateZoom('zoom-manager', zoomY);
-        } else {
-            for (const axisZoomManager of this.axisZoomManagers.values()) {
-                if (axisZoomManager.direction === ChartAxisDirection.Y) {
-                    axisZoomManager.updateZoom('zoom-manager', zoomY);
-                }
-            }
-        }
-
-        if (applyChanges) {
-            this.applyChanges(callerId);
+        if (changeType && apply) {
+            const changes = this.toCoreZoomState({ y: zoomY });
+            this.applyUpdateZoom({ callerId, changeType, changes });
         }
     }
 
-    private applyChanges(callerId: string) {
-        this.autoScaleYZoom(callerId, false);
+    private dispatch(callerId: string, changeType: ZoomChangeType, changedAxes: readonly AxisID[]) {
+        this.autoScaleYZoom(callerId, undefined, false);
 
-        const changed = Array.from(this.axisZoomManagers.values(), (axis) => axis.applyChanges()).includes(true);
-
-        if (!changed) {
+        if (changedAxes.length === 0) {
             return;
         }
 
-        const axes: Record<string, ZoomState | undefined> = {};
-        for (const [axisId, axis] of this.axisZoomManagers.entries()) {
-            axes[axisId] = axis.getZoom();
-        }
-
-        this.eventsHub.emit('zoom:change-request', { ...this.getZoom(), axes, callerId });
+        const { x, y } = this.getZoom() ?? {};
+        const state = this.state.stateValue();
+        const newEvent: ZoomChangeRequestedEvent = { callerId, changeType, changedAxes, state, x, y };
+        this.eventsHub.emit('zoom:change-request', newEvent);
     }
 
     private getRangeDirection(ratio: ZoomState, direction: CartesianAxisDirection): AgZoomRange | undefined {
@@ -855,47 +891,5 @@ export class ZoomManager extends BaseManager {
         if (min > max) return;
 
         return { min, max };
-    }
-}
-
-class AxisZoomManager {
-    public readonly direction: CartesianAxisDirection;
-    private currentZoom: ZoomState;
-    private readonly state: NonNullableStateTracker<ZoomState>;
-
-    constructor(axis: CartesianAxisDirection | CartesianAxisLike) {
-        let min: number;
-        let max: number;
-        if (typeof axis === 'string') {
-            this.direction = axis;
-            min = 0;
-            max = 1;
-        } else {
-            this.direction = axis.direction;
-            [min = 0, max = 1] = axis.visibleRange;
-        }
-
-        this.state = new NonNullableStateTracker({ min, max }, 'initial');
-        this.currentZoom = this.state.stateValue();
-    }
-
-    public updateZoom(callerId: string, newZoom?: ZoomState) {
-        this.state.set(callerId, newZoom);
-    }
-
-    public getZoom() {
-        return deepClone(this.state.stateValue());
-    }
-
-    public hasChanges(): boolean {
-        const currentZoom = this.currentZoom;
-        const pendingZoom = this.state.stateValue();
-        return currentZoom.min !== pendingZoom.min || currentZoom.max !== pendingZoom.max;
-    }
-
-    public applyChanges(): boolean {
-        const hasChanges = this.hasChanges();
-        this.currentZoom = this.state.stateValue();
-        return hasChanges;
     }
 }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -367,7 +367,7 @@ export class ZoomManager extends BaseManager {
 
         // TODO(olegat) move to enterprise
         if (this.autoScaleYAxis.enabled && !this.autoScaleYAxis.manuallyAdjusted) {
-            changes = this.autoScaleYZoom(callerId, changeType, false) ?? changes;
+            changes = this.autoScaleYZoom(callerId, changeType, false, changes) ?? changes;
         }
 
         const changedAxes = this.computeChangedAxesIds(changes);
@@ -427,8 +427,7 @@ export class ZoomManager extends BaseManager {
 
         const newZoom: AxisZoomState = calcPanToBBoxRatios(seriesRect, zoom, target);
         const changes = this.toCoreZoomState(newZoom);
-        this.applyUpdateZoom({ callerId, changeType: 'panToBBox', changes });
-        return true;
+        return this.applyUpdateZoom({ callerId, changeType: 'panToBBox', changes });
     }
 
     // Fire this event to signal to listeners that the view is changing through a zoom and/or pan change.
@@ -621,14 +620,31 @@ export class ZoomManager extends BaseManager {
         }
     }
 
-    private autoScaleYZoom(callerId: string, changeType: ZoomChangeType | undefined, apply = true) {
+    private autoScaleYZoom(
+        callerId: string,
+        changeType: ZoomChangeType | undefined,
+        apply = true,
+        changes?: UpdateZoomChanges
+    ) {
         const zoom = this.getZoom();
+        if (zoom && changes) {
+            // The `zoom` is outdated, let's patch in the updates from `changes`.
+            const state = this.state.stateValue();
+            for (const dir of ['x', 'y'] as const) {
+                for (const id of strictObjectKeys(changes)) {
+                    if (state[id]?.direction === dir) {
+                        zoom[dir] = changes[id];
+                        break;
+                    }
+                }
+            }
+        }
         if (zoom?.x == null) return;
 
         const zoomY = this.getAutoScaleYZoom(zoom.x);
         if (zoomY == null || objectsEqual(zoom.y, zoomY)) return;
 
-        const changes = this.toCoreZoomState({ x: zoom.x, y: zoomY });
+        changes = this.toCoreZoomState({ x: zoom.x, y: zoomY });
         if (changeType && apply) {
             this.applyUpdateZoom({ callerId, changeType, changes });
         }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -79,7 +79,7 @@ const rangeValidator = (axis?: CartesianAxisLike) =>
         return value < options.end;
     }, `to be less than end`);
 
-function validateChanges(changes: UpdateZoomParams['changes']): void {
+function validateChanges(changes: UpdateZoomChanges): void {
     for (const axisId of strictObjectKeys(changes)) {
         const zoom = changes[axisId];
         if (!zoom) continue;
@@ -97,9 +97,10 @@ function validateChanges(changes: UpdateZoomParams['changes']): void {
     }
 }
 
+type UpdateZoomChanges = Record<AxisID, ZoomState>;
 type UpdateZoomParams = {
     callerId: string;
-    changes: Record<AxisID, ZoomState>;
+    changes: UpdateZoomChanges;
     changeType: ZoomChangeType;
 };
 
@@ -340,11 +341,11 @@ export class ZoomManager extends BaseManager {
         return this.updateChanges(callerId, changes);
     }
 
-    public updateChanges(callerId: string, changes: UpdateZoomParams['changes']): boolean {
+    public updateChanges(callerId: string, changes: UpdateZoomChanges): boolean {
         return this.applyUpdateZoom({ callerId, changeType: 'update', changes });
     }
 
-    private computeChangedAxesIds(newState: UpdateZoomParams['changes']): readonly AxisID[] {
+    private computeChangedAxesIds(newState: UpdateZoomChanges): readonly AxisID[] {
         const result: AxisID[] = [];
         const oldState = this.state.stateValue();
         for (const id of strictObjectKeys(newState)) {

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -22,11 +22,11 @@ import type {
     ZoomChangeType,
     ZoomState,
 } from '../../core/eventsHub';
-import { deepClone } from '../../module-support';
 import { ContinuousScale } from '../../scale/continuousScale';
 import { DiscreteTimeScale } from '../../scale/discreteTimeScale';
 import type { BBox } from '../../scene/bbox';
 import { BaseManager } from '../../util/baseManager';
+import { deepClone } from '../../util/json';
 import { objectsEqual, strictObjectKeys } from '../../util/object';
 import type { TypedEvent } from '../../util/observable';
 import { calcPanToBBoxRatios } from '../../util/panToBBox';

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -70,7 +70,6 @@ class ZoomManagerAutoScaleAxis {
     enabled = false;
     padding = 0;
     manuallyAdjusted = false;
-    lastAutoScaleYAxis = true;
 }
 
 const rangeValidator = (axis?: CartesianAxisLike) =>
@@ -276,7 +275,9 @@ export class ZoomManager extends BaseManager {
 
         const changes = this.toCoreZoomState(zoom);
         this.lastRestoredState = changes;
-        this.autoScaleYAxis.lastAutoScaleYAxis = zoom.autoScaleYAxis ?? false;
+        if (zoom.autoScaleYAxis != undefined) {
+            this.autoScaleYAxis.manuallyAdjusted = !zoom.autoScaleYAxis;
+        }
         this.applyUpdateZoom({ callerId: 'zoom-manager', changeType: 'restoreMemento', changes });
     }
 
@@ -359,14 +360,11 @@ export class ZoomManager extends BaseManager {
         return result;
     }
 
-    private applyUpdateZoom(
-        { callerId, changeType, changes }: UpdateZoomParams,
-        autoScaleYAxis?: boolean // TODO(olegat) move to enterprise
-    ): boolean {
+    private applyUpdateZoom({ callerId, changeType, changes }: UpdateZoomParams): boolean {
         validateChanges(changes);
 
-        autoScaleYAxis ??= this.autoScaleYAxis.enabled && !this.autoScaleYAxis.manuallyAdjusted;
-        if (autoScaleYAxis) {
+        // TODO(olegat) move to enterprise
+        if (this.autoScaleYAxis.enabled && !this.autoScaleYAxis.manuallyAdjusted) {
             changes = this.autoScaleYZoom(callerId, changeType, false) ?? changes;
         }
 
@@ -386,10 +384,8 @@ export class ZoomManager extends BaseManager {
 
     public resetZoom(callerId: string) {
         this.autoScaleYAxis.manuallyAdjusted = false;
-
-        const { lastAutoScaleYAxis } = this.autoScaleYAxis;
         const changes = this.toCoreZoomState(this.getRestoredZoom());
-        this.applyUpdateZoom({ callerId, changeType: 'reset', changes }, lastAutoScaleYAxis);
+        this.applyUpdateZoom({ callerId, changeType: 'reset', changes });
     }
 
     public resetAxisZoom(callerId: string, axisId: AxisID) {

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -157,6 +157,7 @@ export class ZoomManager extends BaseManager {
     private toCoreZoomState(axisZoom: DeepReadonly<AxisZoomState>): CoreZoomState {
         const result: CoreZoomState = {};
         let ids: AxisID[];
+        const state = this.state.stateValue();
 
         if (this.independentAxes) {
             const xId = this.getPrimaryAxisId(ChartAxisDirection.X);
@@ -165,11 +166,12 @@ export class ZoomManager extends BaseManager {
             if (xId) ids.push(xId);
             if (yId) ids.push(yId);
         } else {
-            ids = strictObjectKeys(this.state.stateValue);
+            ids = strictObjectKeys(state);
         }
 
         for (const id of ids) {
-            for (const direction of [ChartAxisDirection.X, ChartAxisDirection.Y] as const) {
+            const { direction } = state[id] ?? {};
+            if (direction != undefined) {
                 const zoom = axisZoom[direction];
                 if (zoom) {
                     const { min, max } = zoom;

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -378,10 +378,6 @@ export class ZoomManager extends BaseManager {
         }
         this.state.set(callerId, newState);
 
-        if (autoScaleYAxis != null) {
-            this.autoScaleYAxis.manuallyAdjusted = !autoScaleYAxis;
-        }
-
         this.dispatch(callerId, changeType, changedAxes);
     }
 

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -630,7 +630,7 @@ export class ZoomManager extends BaseManager {
         if (zoom && changes) {
             // The `zoom` is outdated, let's patch in the updates from `changes`.
             const state = this.state.stateValue();
-            for (const dir of ['x', 'y'] as const) {
+            for (const dir of [ChartAxisDirection.X, ChartAxisDirection.Y] as const) {
                 for (const id of strictObjectKeys(changes)) {
                     if (state[id]?.direction === dir) {
                         zoom[dir] = changes[id];

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -329,17 +329,17 @@ export class ZoomManager extends BaseManager {
         return this.zoomModule;
     }
 
-    public updateZoom(callerId: string, newZoom?: AxisZoomState) {
-        this.updateChanges(callerId, this.toCoreZoomState(newZoom ?? {}));
+    public updateZoom(callerId: string, newZoom?: AxisZoomState): boolean {
+        return this.updateChanges(callerId, this.toCoreZoomState(newZoom ?? {}));
     }
 
-    public updateAxisZoom(callerId: string, axisId: AxisID, newZoom?: ZoomState) {
+    public updateAxisZoom(callerId: string, axisId: AxisID, newZoom?: ZoomState): boolean {
         const changes = { [axisId]: newZoom ?? this.getAxisZoom(axisId) };
-        this.updateChanges(callerId, changes);
+        return this.updateChanges(callerId, changes);
     }
 
-    public updateChanges(callerId: string, changes: UpdateZoomParams['changes']) {
-        this.applyUpdateZoom({ callerId, changeType: 'update', changes });
+    public updateChanges(callerId: string, changes: UpdateZoomParams['changes']): boolean {
+        return this.applyUpdateZoom({ callerId, changeType: 'update', changes });
     }
 
     private computeChangedAxesIds(newState: UpdateZoomParams['changes']): readonly AxisID[] {
@@ -362,7 +362,7 @@ export class ZoomManager extends BaseManager {
     private applyUpdateZoom(
         { callerId, changeType, changes }: UpdateZoomParams,
         autoScaleYAxis?: boolean // TODO(olegat) move to enterprise
-    ) {
+    ): boolean {
         validateChanges(changes);
 
         autoScaleYAxis ??= this.autoScaleYAxis.enabled && !this.autoScaleYAxis.manuallyAdjusted;
@@ -378,7 +378,7 @@ export class ZoomManager extends BaseManager {
         }
         this.state.set(callerId, newState);
 
-        this.dispatch(callerId, changeType, changedAxes);
+        return this.dispatch(callerId, changeType, changedAxes);
     }
 
     public resetZoom(callerId: string) {
@@ -633,17 +633,18 @@ export class ZoomManager extends BaseManager {
         }
     }
 
-    private dispatch(callerId: string, changeType: ZoomChangeType, changedAxes: readonly AxisID[]) {
+    private dispatch(callerId: string, changeType: ZoomChangeType, changedAxes: readonly AxisID[]): boolean {
         this.autoScaleYZoom(callerId, undefined, false);
 
         if (changedAxes.length === 0) {
-            return;
+            return false;
         }
 
         const { x, y } = this.getZoom() ?? {};
         const state = this.state.stateValue();
         const newEvent: ZoomChangeRequestedEvent = { callerId, changeType, changedAxes, state, x, y };
         this.eventsHub.emit('zoom:change-request', newEvent);
+        return true;
     }
 
     private getRangeDirection(ratio: ZoomState, direction: CartesianAxisDirection): AgZoomRange | undefined {

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -366,6 +366,9 @@ export class ZoomManager extends BaseManager {
         validateChanges(changes);
 
         autoScaleYAxis ??= this.autoScaleYAxis.enabled && !this.autoScaleYAxis.manuallyAdjusted;
+        if (autoScaleYAxis) {
+            changes = this.autoScaleYZoom(callerId, changeType, false) ?? changes;
+        }
 
         const changedAxes = this.computeChangedAxesIds(changes);
         const newState: CoreZoomStateSafeRetrieval = deepClone(this.state.stateValue());
@@ -627,15 +630,14 @@ export class ZoomManager extends BaseManager {
         const zoomY = this.getAutoScaleYZoom(zoom.x);
         if (zoomY == null || objectsEqual(zoom.y, zoomY)) return;
 
+        const changes = this.toCoreZoomState({ x: zoom.x, y: zoomY });
         if (changeType && apply) {
-            const changes = this.toCoreZoomState({ y: zoomY });
             this.applyUpdateZoom({ callerId, changeType, changes });
         }
+        return changes;
     }
 
     private dispatch(callerId: string, changeType: ZoomChangeType, changedAxes: readonly AxisID[]): boolean {
-        this.autoScaleYZoom(callerId, undefined, false);
-
         if (changedAxes.length === 0) {
             return false;
         }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -182,7 +182,8 @@ export class ZoomManager extends BaseManager {
         return result;
     }
 
-    private toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): AxisZoomState | undefined {
+    // FIXME: should be private
+    public toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): AxisZoomState | undefined {
         let x: ZoomState | undefined;
         let y: ZoomState | undefined;
 

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -1,4 +1,4 @@
-import type { Scale } from 'ag-charts-core';
+import type { AxisID, Scale } from 'ag-charts-core';
 import { EventEmitter } from 'ag-charts-core';
 import type { AgAnnotation, AgContextMenuItemShowOn, AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
 
@@ -119,9 +119,13 @@ export interface SeriesKeyNavZoomEvent {
     readonly widgetEvent: KeyboardWidgetEvent<'keydown'>;
 }
 
+export type ZoomChangeType = 'layoutComplete' | 'panToBBox' | 'reset' | 'restoreMemento' | 'update' | 'setAxes';
+
 export interface ZoomChangeRequestedEvent extends AxisZoomState {
     readonly callerId: string;
-    readonly axes: Record<string, Readonly<ZoomState> | undefined>;
+    readonly changeType: ZoomChangeType;
+    readonly changedAxes: readonly AxisID[];
+    readonly state: { readonly [K in AxisID]: Readonly<ZoomState> | undefined };
     readonly x?: Readonly<ZoomState>;
     readonly y?: Readonly<ZoomState>;
 }

--- a/packages/ag-charts-enterprise/src/charts/topologyChart.ts
+++ b/packages/ag-charts-enterprise/src/charts/topologyChart.ts
@@ -1,4 +1,5 @@
 import { _ModuleSupport } from 'ag-charts-community';
+import { type AxisID, createId } from 'ag-charts-core';
 import type { AgTopologyChartOptions } from 'ag-charts-types';
 
 const { Chart, MercatorScale, ChartAxisDirection, Property } = _ModuleSupport;
@@ -18,6 +19,8 @@ function isTopologySeries(
 export class TopologyChart extends Chart {
     static readonly className = 'TopologyChart';
     static readonly type = 'topology' as const;
+    private readonly xAxis = { id: createId<AxisID>(_ModuleSupport.Axis), direction: ChartAxisDirection.X } as const;
+    private readonly yAxis = { id: createId<AxisID>(_ModuleSupport.Axis), direction: ChartAxisDirection.Y } as const;
 
     @Property
     topology?: _ModuleSupport.FeatureCollection;
@@ -25,7 +28,7 @@ export class TopologyChart extends Chart {
     constructor(options: _ModuleSupport.ChartOptions, resources?: _ModuleSupport.TransferableResources) {
         super(options, resources);
 
-        this.ctx.zoomManager.updateAxes([ChartAxisDirection.X, ChartAxisDirection.Y]);
+        this.ctx.zoomManager.setAxes([this.xAxis, this.yAxis]);
     }
 
     override getChartType() {
@@ -88,8 +91,8 @@ export class TopologyChart extends Chart {
             const x1 = viewBoxOriginX + viewBoxWidth;
             const y1 = viewBoxOriginY + viewBoxHeight;
 
-            const xZoom = this.ctx.zoomManager.getAxisZoom(ChartAxisDirection.X);
-            const yZoom = this.ctx.zoomManager.getAxisZoom(ChartAxisDirection.Y);
+            const xZoom = this.ctx.zoomManager.getAxisZoom(this.xAxis.id);
+            const yZoom = this.ctx.zoomManager.getAxisZoom(this.yAxis.id);
             const xSpan = (x1 - x0) / (xZoom.max - xZoom.min);
             const xStart = x0 - xSpan * xZoom.min;
             const ySpan = (y1 - y0) / (1 - yZoom.min - (1 - yZoom.max));

--- a/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/navigatorDOMProxy.ts
@@ -93,7 +93,7 @@ export class NavigatorDOMProxy {
         const { _min: min, _max: max } = this;
         if (min == null || max == null) return;
 
-        return this.ctx.zoomManager.updateZoom('navigator', { x: { min, max } });
+        this.ctx.zoomManager.updateZoom('navigator', { x: { min, max } });
     }
 
     updateBounds(bounds: BoxBounds): void {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomAxisDraggingMode, _ModuleSupport, _Widget } from 'ag-charts-community';
-import { AbstractModuleInstance, type AxisID, debounce, roundTo, entries } from 'ag-charts-core';
+import { AbstractModuleInstance, type AxisID, debounce, entries, roundTo } from 'ag-charts-core';
 
 import { ZoomRect } from './scenes/zoomRect';
 import { ZoomAxisDragger } from './zoomAxisDragger';
@@ -719,8 +719,8 @@ export class Zoom extends AbstractModuleInstance {
             for (const [axisId, { direction, min, max }] of entries(newZooms)) {
                 const constrainedZoom =
                     direction === ChartAxisDirection.X
-                    ? this.constrainZoom({ x: { min, max }, y: { min: UNIT_MAX, max: UNIT_MAX } }).x
-                : {min, max};
+                        ? this.constrainZoom({ x: { min, max }, y: { min: UNIT_MAX, max: UNIT_MAX } }).x
+                        : { min, max };
                 updated &&= this.updateAxisZoom(
                     axisId,
                     direction as _ModuleSupport.CartesianAxisDirection,

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -721,11 +721,7 @@ export class Zoom extends AbstractModuleInstance {
                     direction === ChartAxisDirection.X
                         ? this.constrainZoom({ x: { min, max }, y: { min: UNIT_MAX, max: UNIT_MAX } }).x
                         : { min, max };
-                updated &&= this.updateAxisZoom(
-                    axisId,
-                    direction,
-                    constrainedZoom
-                );
+                updated &&= this.updateAxisZoom(axisId, direction, constrainedZoom);
             }
         } else {
             const newZoom = scroller.update(event, props, seriesRect, this.getZoom());

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomAxisDraggingMode, _ModuleSupport, _Widget } from 'ag-charts-community';
-import { AbstractModuleInstance, type AxisID, debounce, entries, roundTo } from 'ag-charts-core';
+import { AbstractModuleInstance, type AxisID, debounce, roundTo } from 'ag-charts-core';
 
 import { ZoomRect } from './scenes/zoomRect';
 import { ZoomAxisDragger } from './zoomAxisDragger';
@@ -660,9 +660,7 @@ export class Zoom extends AbstractModuleInstance {
         event.sourceEvent.preventDefault();
 
         const newZooms = scrollPanner.update(event, scrollingStep, seriesRect, zoomManager.getAxisZooms());
-        for (const [axisId, { direction, zoom }] of entries(newZooms)) {
-            this.updateAxisZoom(axisId, direction as _ModuleSupport.CartesianAxisDirection, zoom);
-        }
+        this.ctx.zoomManager.updateChanges('zoom', newZooms);
     }
 
     private onWheelScrolling(event: _Widget.WheelWidgetEvent) {
@@ -718,21 +716,11 @@ export class Zoom extends AbstractModuleInstance {
 
         if (enableIndependentAxes === true) {
             const newZooms = scroller.updateAxes(event, props, seriesRect, zoomManager.getAxisZooms());
-            for (const [axisId, { direction, zoom: axisZoom }] of entries(newZooms)) {
-                const constrainedZoom =
-                    direction === ChartAxisDirection.X
-                        ? this.constrainZoom({ x: axisZoom, y: { min: UNIT_MAX, max: UNIT_MAX } }).x
-                        : axisZoom;
-                updated &&= this.updateAxisZoom(
-                    axisId,
-                    direction as _ModuleSupport.CartesianAxisDirection,
-                    constrainedZoom
-                );
-            }
+            this.ctx.zoomManager.updateChanges('zoom', newZooms);
         } else {
             const newZoom = scroller.update(event, props, seriesRect, this.getZoom());
             if (newZoom == null) return;
-            updated = this.updateUnifiedZoom(newZoom, { directional: true });
+            this.ctx.zoomManager.updateZoom('zoom', newZoom);
         }
 
         isZoomCapped ||= event.deltaY < 0 && !updated;
@@ -829,11 +817,7 @@ export class Zoom extends AbstractModuleInstance {
         if (!seriesRect) return;
 
         const newZooms = panner.translateZooms(seriesRect, zoomManager.getAxisZooms(), event.deltaX, event.deltaY);
-
-        for (const [axisId, { direction, zoom }] of entries(newZooms)) {
-            this.updateAxisZoom(axisId, direction as _ModuleSupport.CartesianAxisDirection, zoom);
-        }
-
+        this.ctx.zoomManager.updateChanges('zoom', newZooms);
         tooltipManager.updateTooltip(TOOLTIP_ID);
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -712,15 +712,15 @@ export class Zoom extends AbstractModuleInstance {
 
         if (!seriesRect) return;
 
-        let updated = true;
+        let updated: boolean;
 
         if (enableIndependentAxes === true) {
             const newZooms = scroller.updateAxes(event, props, seriesRect, zoomManager.getAxisZooms());
-            this.ctx.zoomManager.updateChanges('zoom', newZooms);
+            updated = this.ctx.zoomManager.updateChanges('zoom', newZooms);
         } else {
             const newZoom = scroller.update(event, props, seriesRect, this.getZoom());
             if (newZoom == null) return;
-            this.ctx.zoomManager.updateZoom('zoom', newZoom);
+            updated = this.ctx.zoomManager.updateZoom('zoom', newZoom);
         }
 
         isZoomCapped ||= event.deltaY < 0 && !updated;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomAxisDraggingMode, _ModuleSupport, _Widget } from 'ag-charts-community';
-import { AbstractModuleInstance, type AxisID, debounce, roundTo } from 'ag-charts-core';
+import { AbstractModuleInstance, type AxisID, debounce, roundTo, entries } from 'ag-charts-core';
 
 import { ZoomRect } from './scenes/zoomRect';
 import { ZoomAxisDragger } from './zoomAxisDragger';
@@ -660,7 +660,7 @@ export class Zoom extends AbstractModuleInstance {
         event.sourceEvent.preventDefault();
 
         const newZooms = scrollPanner.update(event, scrollingStep, seriesRect, zoomManager.getAxisZooms());
-        this.ctx.zoomManager.updateChanges('zoom', newZooms);
+        this.updateChanges(newZooms);
     }
 
     private onWheelScrolling(event: _Widget.WheelWidgetEvent) {
@@ -712,15 +712,25 @@ export class Zoom extends AbstractModuleInstance {
 
         if (!seriesRect) return;
 
-        let updated: boolean;
+        let updated = true;
 
         if (enableIndependentAxes === true) {
             const newZooms = scroller.updateAxes(event, props, seriesRect, zoomManager.getAxisZooms());
-            updated = this.ctx.zoomManager.updateChanges('zoom', newZooms);
+            for (const [axisId, { direction, min, max }] of entries(newZooms)) {
+                const constrainedZoom =
+                    direction === ChartAxisDirection.X
+                    ? this.constrainZoom({ x: { min, max }, y: { min: UNIT_MAX, max: UNIT_MAX } }).x
+                : {min, max};
+                updated &&= this.updateAxisZoom(
+                    axisId,
+                    direction as _ModuleSupport.CartesianAxisDirection,
+                    constrainedZoom
+                );
+            }
         } else {
             const newZoom = scroller.update(event, props, seriesRect, this.getZoom());
             if (newZoom == null) return;
-            updated = this.ctx.zoomManager.updateZoom('zoom', newZoom);
+            updated = this.updateUnifiedZoom(newZoom, { directional: true });
         }
 
         isZoomCapped ||= event.deltaY < 0 && !updated;
@@ -817,7 +827,7 @@ export class Zoom extends AbstractModuleInstance {
         if (!seriesRect) return;
 
         const newZooms = panner.translateZooms(seriesRect, zoomManager.getAxisZooms(), event.deltaX, event.deltaY);
-        this.ctx.zoomManager.updateChanges('zoom', newZooms);
+        this.updateChanges(newZooms);
         tooltipManager.updateTooltip(TOOLTIP_ID);
     }
 
@@ -946,6 +956,10 @@ export class Zoom extends AbstractModuleInstance {
 
     public updateSyncZoom(zoom: DefinedZoomState) {
         this.updateZoom(zoom);
+    }
+
+    private updateChanges(changes: _ModuleSupport.CoreZoomState) {
+        this.updateZoom(definedZoomState(this.ctx.zoomManager.toAxisZoomState(changes)));
     }
 
     private updateZoom(zoom: DefinedZoomState) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -959,7 +959,15 @@ export class Zoom extends AbstractModuleInstance {
     }
 
     private updateChanges(changes: _ModuleSupport.CoreZoomState) {
-        this.updateZoom(definedZoomState(this.ctx.zoomManager.toAxisZoomState(changes)));
+        // TODO: constrainZoom should operate on a partial CoreZoomState instead of DefinedZoomState.
+        // For compatibility, we calculate the final DefinedZoomState for constrainZoom to continue to work without
+        // breaking thebehaviour.
+        const partialZoom = this.ctx.zoomManager.toAxisZoomState(changes) ?? {};
+        const currentZoom = definedZoomState(this.ctx.zoomManager.getZoom());
+        this.updateZoom({
+            x: partialZoom.x ?? currentZoom.x,
+            y: partialZoom.y ?? currentZoom.y,
+        });
     }
 
     private updateZoom(zoom: DefinedZoomState) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -723,7 +723,7 @@ export class Zoom extends AbstractModuleInstance {
                         : { min, max };
                 updated &&= this.updateAxisZoom(
                     axisId,
-                    direction as _ModuleSupport.CartesianAxisDirection,
+                    direction,
                     constrainedZoom
                 );
             }

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
@@ -1,8 +1,11 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import { entries, getWindow } from 'ag-charts-core';
 
-import type { AxisZoomStates, ZoomCoords } from './zoomTypes';
+import type { ZoomCoords } from './zoomTypes';
 import { UNIT_MAX, UNIT_MIN, constrainZoom, definedZoomState, dx, dy, pointToRatio, translateZoom } from './zoomUtils';
+
+type State = _ModuleSupport.CoreZoomState;
+type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;
 
 export interface ZoomPanUpdate {
     type: 'update';
@@ -163,24 +166,27 @@ export class ZoomPanner {
         return this.direction == null || this.direction === _ModuleSupport.ChartAxisDirection.Y;
     }
 
-    translateZooms(bbox: _ModuleSupport.BBox, currentZooms: AxisZoomStates, deltaX: number, deltaY: number) {
+    translateZooms(bbox: _ModuleSupport.BBox, currentZooms: StateRetrieval, deltaX: number, deltaY: number) {
         const offset = pointToRatio(bbox, bbox.x + Math.abs(deltaX), bbox.y + bbox.height - Math.abs(deltaY));
 
         const offsetX = Math.sign(deltaX) * offset.x;
         const offsetY = -Math.sign(deltaY) * offset.y;
 
-        const newZooms: AxisZoomStates = {};
+        const newZooms: State = {};
 
-        for (const [axisId, { direction, zoom: currentZoom }] of entries(currentZooms)) {
+        for (const [axisId, currentZoom] of entries(currentZooms)) {
+            if (currentZoom == null) continue;
             // Skip panning axes that are fully zoomed out to prevent floating point issues
-            if (currentZoom && currentZoom.min === UNIT_MIN && currentZoom.max === UNIT_MAX) {
+            if (currentZoom.min === UNIT_MIN && currentZoom.max === UNIT_MAX) {
                 continue;
             }
+            const { direction } = currentZoom;
 
             let zoom = definedZoomState({ [direction]: currentZoom });
             zoom = constrainZoom(translateZoom(zoom, offsetX * dx(zoom), offsetY * dy(zoom)));
 
-            newZooms[axisId] = { direction, zoom: zoom[direction as _ModuleSupport.CartesianAxisDirection] };
+            const { min, max } = zoom[direction];
+            newZooms[axisId] = { direction, min, max };
         }
 
         return newZooms;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScrollPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScrollPanner.ts
@@ -1,29 +1,32 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import { entries } from 'ag-charts-core';
 
-import type { AxisZoomStates } from './zoomTypes';
 import { constrainZoom, definedZoomState, dx, pointToRatio, translateZoom } from './zoomUtils';
+
+type State = _ModuleSupport.CoreZoomState;
+type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;
 
 const DELTA_SCALE = 200;
 
 export class ZoomScrollPanner {
-    update(event: { deltaX: number }, step: number, bbox: _ModuleSupport.BBox, zooms: AxisZoomStates): AxisZoomStates {
+    update(event: { deltaX: number }, step: number, bbox: _ModuleSupport.BBox, zooms: StateRetrieval): State {
         const deltaX = event.deltaX * step * DELTA_SCALE;
         return this.translateZooms(bbox, zooms, deltaX);
     }
 
-    private translateZooms(bbox: _ModuleSupport.BBox, currentZooms: AxisZoomStates, deltaX: number) {
-        const newZooms: AxisZoomStates = {};
+    private translateZooms(bbox: _ModuleSupport.BBox, currentZooms: StateRetrieval, deltaX: number) {
+        const newZooms: State = {};
 
         const offset = pointToRatio(bbox, bbox.x + Math.abs(deltaX), 0);
         const offsetX = deltaX < 0 ? -offset.x : offset.x;
 
-        for (const [axisId, { direction, zoom: currentZoom }] of entries(currentZooms)) {
-            if (direction !== _ModuleSupport.ChartAxisDirection.X) continue;
+        for (const [axisId, value] of entries(currentZooms)) {
+            if (value?.direction !== _ModuleSupport.ChartAxisDirection.X) continue;
+            const { direction, min, max } = value;
 
-            let zoom = definedZoomState({ x: currentZoom });
+            let zoom = definedZoomState({ x: { min, max } });
             zoom = constrainZoom(translateZoom(zoom, offsetX * dx(zoom), 0));
-            newZooms[axisId] = { direction, zoom: zoom.x };
+            newZooms[axisId] = { direction, min: zoom.x.min, max: zoom.x.max };
         }
 
         return newZooms;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
@@ -1,7 +1,7 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
 import { entries } from 'ag-charts-core';
 
-import type { AxisZoomStates, DefinedZoomState, ZoomProperties } from './zoomTypes';
+import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
 import {
     constrainAxis,
     constrainZoom,
@@ -12,15 +12,18 @@ import {
     scaleZoomAxisWithAnchor,
 } from './zoomUtils';
 
+type State = _ModuleSupport.CoreZoomState;
+type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;
+
 export class ZoomScroller {
     updateAxes(
         event: _Widget.WheelWidgetEvent,
         props: ZoomProperties,
         bbox: _ModuleSupport.BBox,
-        zooms: AxisZoomStates
-    ): AxisZoomStates {
+        zooms: StateRetrieval
+    ): State {
         const sourceEvent = event.sourceEvent;
-        const newZooms: AxisZoomStates = {};
+        const newZooms: State = {};
         const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
 
         // Convert the cursor position to coordinates as a ratio of 0 to 1
@@ -30,19 +33,20 @@ export class ZoomScroller {
             sourceEvent.offsetY ?? sourceEvent.clientY
         );
 
-        for (const [axisId, { direction, zoom }] of entries(zooms)) {
-            if (zoom == null) continue;
+        for (const [axisId, value] of entries(zooms)) {
+            if (value == null) continue;
+            const { direction, min, max } = value;
 
-            let newZoom = { ...zoom };
+            let newZoom = { min, max };
 
-            const delta = scrollingStep * event.deltaY * (zoom.max - zoom.min);
+            const delta = scrollingStep * event.deltaY * (max - min);
 
             if (direction === _ModuleSupport.ChartAxisDirection.X && isScalingX) {
                 newZoom.max += delta;
-                newZoom = scaleZoomAxisWithAnchor(newZoom, zoom, anchorPointX, origin.x);
+                newZoom = scaleZoomAxisWithAnchor(newZoom, value, anchorPointX, origin.x);
             } else if (direction === _ModuleSupport.ChartAxisDirection.Y && isScalingY) {
                 newZoom.max += delta;
-                newZoom = scaleZoomAxisWithAnchor(newZoom, zoom, anchorPointY, origin.y);
+                newZoom = scaleZoomAxisWithAnchor(newZoom, value, anchorPointY, origin.y);
             } else {
                 continue;
             }
@@ -50,7 +54,8 @@ export class ZoomScroller {
             // @todo(AG-15397) - We don't have a way to normalize this zoom yet, so we'll just discard the zoom event
             if (newZoom.max < newZoom.min) continue;
 
-            newZooms[axisId] = { direction, zoom: constrainAxis(newZoom) };
+            const constrained = constrainAxis(newZoom);
+            newZooms[axisId] = { direction, min: constrained.min, max: constrained.max };
         }
 
         return newZooms;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -250,9 +250,10 @@ export class ZoomToolbar extends BaseProperties {
 
         if (props.independentAxes && button.value !== 'reset') {
             const axisZooms = this.ctx.zoomManager.getAxisZooms();
-            for (const [axisId, { direction, zoom }] of entries(axisZooms)) {
-                if (zoom == null) continue;
-                this.onButtonPressAxis(button, props, axisId, direction, zoom);
+            for (const [axisId, value] of entries(axisZooms)) {
+                if (value == null) continue;
+                const { direction, min, max } = value;
+                this.onButtonPressAxis(button, props, axisId, direction, { min, max });
             }
         } else {
             this.onButtonPressUnified(button, props);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
@@ -1,5 +1,4 @@
 import type { AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
-import type { AxisID } from 'ag-charts-core';
 
 export interface DefinedZoomState extends _ModuleSupport.AxisZoomState {
     x: _ModuleSupport.ZoomState;
@@ -12,11 +11,6 @@ export type ZoomCoords = {
     x2: number;
     y2: number;
 };
-
-export type AxisZoomStates = Record<
-    AxisID,
-    { direction: _ModuleSupport.ChartAxisDirection; zoom: _ModuleSupport.ZoomState }
->;
 
 export interface ZoomProperties {
     anchorPointX: AgZoomAnchorPoint;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8627

> [!IMPORTANT]
> All update branches now lead to `ZoomManager.applyUpdateChanges`

There were four permutations of ZoomManager updates:
1.  `independentAxes: true`  / `update` (both X & Y)
2.  `independentAxes: true`  / `updateAxis` (specific AxisID)
3.  `independentAxes: false` / `update` (both X & Y)
4.  `independentAxes: false` / `updateAxis` (specific AxisID)

This is very difficult to maintain, because the number of permutations will grow
exponentially as we add more options like `independentAxes`. Therefore this
commit standardises these permutations into one update flow:
1.  Update a list of AxisIDs

The permutations are mapped as follows:
1.  `independentAxes: true`  / `update`       -> AxisIDs = primaryX, primaryY
3.  `independentAxes: true`  / `updateAxis`   -> AxisIDs = single input axis
4.  `independentAxes: false` / `update` -> AxisIDs = all axes in internal state
5.  `independentAxes: false` / `updateAxis`   -> AxisIDs = all axes in direction of input axis