### PR TITLE
AG-8627 Use branded AxisID string

### DIFF
--- a/packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/packages/ag-charts-community/src/chart/chartAxis.ts
@@ -1,4 +1,4 @@
-import type { Scale } from 'ag-charts-core';
+import type { AxisID, Scale } from 'ag-charts-core';
 import type {
     AgAxisLabelFormatterParams,
     AgAxisLabelStylerParams,
@@ -124,7 +124,7 @@ export interface ChartAxis {
     gridLength: number;
     gridLine: AxisGridLine;
     gridPadding: number;
-    id: string;
+    id: AxisID;
     interactionEnabled: boolean;
     interval: AxisInterval;
     keys: string[];

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,4 +1,5 @@
 import {
+    type AxisID,
     type BoxBounds,
     Logger,
     type OptionsDefs,
@@ -10,7 +11,6 @@ import {
     isFiniteNumber,
     isObject,
     validate,
-    type AxisID,
 } from 'ag-charts-core';
 import type { AgAutoScaledAxes, AgZoomEvent, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -10,6 +10,7 @@ import {
     isFiniteNumber,
     isObject,
     validate,
+    type AxisID,
 } from 'ag-charts-core';
 import type { AgAutoScaledAxes, AgZoomEvent, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
@@ -41,7 +42,7 @@ export type ZoomMemento = {
 };
 
 export type CartesianAxisLike = {
-    id: string;
+    id: AxisID;
     direction: CartesianAxisDirection;
     visibleRange: [number, number];
     scale: Scale<any, any>;
@@ -293,7 +294,7 @@ export class ZoomManager extends BaseManager {
         this.applyChanges(callerId);
     }
 
-    public updateAxisZoom(callerId: string, axisId: string, newZoom?: ZoomState) {
+    public updateAxisZoom(callerId: string, axisId: AxisID, newZoom?: ZoomState) {
         this.axisZoomManagers.get(axisId)?.updateZoom(callerId, newZoom);
         this.applyChanges(callerId);
     }
@@ -310,7 +311,7 @@ export class ZoomManager extends BaseManager {
         });
     }
 
-    public resetAxisZoom(callerId: string, axisId: string) {
+    public resetAxisZoom(callerId: string, axisId: AxisID) {
         const axisZoomManager = this.axisZoomManagers.get(axisId);
         const direction = axisZoomManager?.direction;
         if (direction == null) return;
@@ -325,7 +326,7 @@ export class ZoomManager extends BaseManager {
         }
     }
 
-    public setAxisManuallyAdjusted(_callerId: string, axisId: string) {
+    public setAxisManuallyAdjusted(_callerId: string, axisId: AxisID) {
         const direction = this.axisZoomManagers.get(axisId)?.direction;
         if (direction !== ChartAxisDirection.Y) return;
         this.autoScaleYAxis.manuallyAdjusted = true;
@@ -427,11 +428,11 @@ export class ZoomManager extends BaseManager {
         }
     }
 
-    public getAxisZoom(axisId: string): ZoomState {
+    public getAxisZoom(axisId: AxisID | CartesianAxisDirection): ZoomState {
         return this.axisZoomManagers.get(axisId)?.getZoom() ?? { min: 0, max: 1 };
     }
 
-    public getAxisZooms(): Record<string, { direction: CartesianAxisDirection; zoom: ZoomState }> {
+    public getAxisZooms(): Record<AxisID, { direction: CartesianAxisDirection; zoom: ZoomState }> {
         const axes: Record<string, { direction: CartesianAxisDirection; zoom: ZoomState }> = {};
         for (const [axisId, axis] of this.axisZoomManagers.entries()) {
             axes[axisId] = {

--- a/packages/ag-charts-community/src/chart/update/processor.ts
+++ b/packages/ag-charts-community/src/chart/update/processor.ts
@@ -1,4 +1,4 @@
-import type { Scale } from 'ag-charts-core';
+import type { AxisID, Scale } from 'ag-charts-core';
 
 import type { Group } from '../../scene/group';
 import type { Padding } from '../../util/padding';
@@ -13,7 +13,7 @@ export interface ChartLike {
 }
 
 export interface AxisLike {
-    id: string;
+    id: AxisID;
     type: string;
     scale: Scale<any, any>;
 }

--- a/packages/ag-charts-community/src/module/axisContext.ts
+++ b/packages/ag-charts-community/src/module/axisContext.ts
@@ -1,4 +1,4 @@
-import type { BoxBounds, Point, Scale } from 'ag-charts-core';
+import type { AxisID, BoxBounds, Point, Scale } from 'ag-charts-core';
 import type { AgCartesianAxisPosition, FormatterParams, TextOrSegments } from 'ag-charts-types';
 
 import type { ChartAxisDirection } from '../chart/chartAxisDirection';
@@ -27,7 +27,7 @@ export interface AxisBandDatum {
 
 export interface AxisContext {
     context?: unknown;
-    axisId: string;
+    axisId: AxisID;
     continuous: boolean;
     direction: ChartAxisDirection;
     position?: AgCartesianAxisPosition;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomAxisDraggingMode, _ModuleSupport, _Widget } from 'ag-charts-community';
-import { AbstractModuleInstance, debounce, entries, roundTo, type AxisID } from 'ag-charts-core';
+import { AbstractModuleInstance, type AxisID, debounce, entries, roundTo } from 'ag-charts-core';
 
 import { ZoomRect } from './scenes/zoomRect';
 import { ZoomAxisDragger } from './zoomAxisDragger';

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomAxisDraggingMode, _ModuleSupport, _Widget } from 'ag-charts-community';
-import { AbstractModuleInstance, debounce, entries, roundTo } from 'ag-charts-core';
+import { AbstractModuleInstance, debounce, entries, roundTo, type AxisID } from 'ag-charts-core';
 
 import { ZoomRect } from './scenes/zoomRect';
 import { ZoomAxisDragger } from './zoomAxisDragger';
@@ -34,7 +34,7 @@ const { ActionOnSet, ChartAxisDirection, ChartUpdateType, Property, InteractionS
 type SeriesAreaHoverEvent = _ModuleSupport.SeriesAreaHoverEvent;
 type SeriesAreaClickEvent = _ModuleSupport.SeriesAreaClickEvent;
 
-type AxisHit = { axisId: string; direction: _ModuleSupport.ChartAxisDirection };
+type AxisHit = { axisId: AxisID; direction: _ModuleSupport.ChartAxisDirection };
 
 const round = (value: number) => roundTo(value, 10);
 
@@ -514,7 +514,7 @@ export class Zoom extends AbstractModuleInstance {
         this.ctx.tooltipManager.removeTooltip(TOOLTIP_ID);
     }
 
-    private onAxisDoubleClick(id: string) {
+    private onAxisDoubleClick(id: AxisID) {
         const {
             enabled,
             enableDoubleClickToReset,
@@ -552,7 +552,7 @@ export class Zoom extends AbstractModuleInstance {
     }
 
     private onAxisDragMove(
-        axisId: string,
+        axisId: AxisID,
         direction: _ModuleSupport.ChartAxisDirection,
         event: _Widget.DragWidgetEvent<'drag-move'>
     ) {
@@ -673,7 +673,7 @@ export class Zoom extends AbstractModuleInstance {
     }
 
     private onAxisWheel(
-        axisId: string,
+        axisId: AxisID,
         axisDirection: _ModuleSupport.ChartAxisDirection,
         event: _ModuleSupport.WheelWidgetEvent
     ) {
@@ -997,7 +997,7 @@ export class Zoom extends AbstractModuleInstance {
     }
 
     private updateAxisZoom(
-        axisId: string,
+        axisId: AxisID,
         direction: _ModuleSupport.CartesianAxisDirection,
         axisZoom: _ModuleSupport.ZoomState | undefined,
         validOptions?: { directional?: boolean }

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomDOMProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomDOMProxy.ts
@@ -1,5 +1,5 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import { type BaseStyleTypeMap, boxEmpty, type AxisID } from 'ag-charts-core';
+import { type AxisID, type BaseStyleTypeMap, boxEmpty } from 'ag-charts-core';
 
 const { ChartAxisDirection } = _ModuleSupport;
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomDOMProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomDOMProxy.ts
@@ -1,28 +1,28 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import { type BaseStyleTypeMap, boxEmpty } from 'ag-charts-core';
+import { type BaseStyleTypeMap, boxEmpty, type AxisID } from 'ag-charts-core';
 
 const { ChartAxisDirection } = _ModuleSupport;
 
-type AxisHit = { axisId: string; direction: _ModuleSupport.ChartAxisDirection };
+type AxisHit = { axisId: AxisID; direction: _ModuleSupport.ChartAxisDirection };
 
 type AxesHandlers = {
     onAxisDragStart: (direction: _ModuleSupport.ChartAxisDirection) => void;
     onAxisDragMove: (
-        id: string,
+        id: AxisID,
         direction: _ModuleSupport.ChartAxisDirection,
         event: _Widget.DragWidgetEvent<'drag-move'>
     ) => void;
     onAxisDragEnd: () => void;
-    onAxisDoubleClick: (id: string, direction: _ModuleSupport.ChartAxisDirection) => void;
+    onAxisDoubleClick: (id: AxisID, direction: _ModuleSupport.ChartAxisDirection) => void;
     onAxisWheel: (
-        id: string,
+        id: AxisID,
         direction: _ModuleSupport.ChartAxisDirection,
         event: _ModuleSupport.WheelWidgetEvent
     ) => void;
 };
 
 type ProxyAxis = {
-    axisId: string;
+    axisId: AxisID;
     direction: _ModuleSupport.ChartAxisDirection;
     div: _Widget.NativeWidget<HTMLDivElement>;
     bounds?: _ModuleSupport.BBox;
@@ -194,7 +194,7 @@ export class ZoomDOMProxy {
 
     private initAxis(
         ctx: Pick<_ModuleSupport.ModuleContext, 'proxyInteractionService' | 'localeManager'>,
-        axisId: string,
+        axisId: AxisID,
         handlers: AxesHandlers,
         direction: _ModuleSupport.ChartAxisDirection
     ): ProxyAxis {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomButtonValue, _ModuleSupport, _Widget } from 'ag-charts-community';
-import { CleanupRegistry, createElement, debounce, entries, type AxisID } from 'ag-charts-core';
+import { type AxisID, CleanupRegistry, createElement, debounce, entries } from 'ag-charts-core';
 
 import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
 import {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomButtonValue, _ModuleSupport, _Widget } from 'ag-charts-community';
-import { CleanupRegistry, createElement, debounce, entries } from 'ag-charts-core';
+import { CleanupRegistry, createElement, debounce, entries, type AxisID } from 'ag-charts-core';
 
 import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
 import {
@@ -90,7 +90,7 @@ export class ZoomToolbar extends BaseProperties {
         private readonly canResetZoom: (zoom: Readonly<DefinedZoomState>) => boolean,
         private readonly updateZoom: (zoom: DefinedZoomState) => void,
         private readonly updateAxisZoom: (
-            axisId: string,
+            axisId: AxisID,
             direction: _ModuleSupport.CartesianAxisDirection,
             partialZoom: _ModuleSupport.ZoomState | undefined
         ) => void,
@@ -266,7 +266,7 @@ export class ZoomToolbar extends BaseProperties {
     private onButtonPressAxis(
         event: { value: AgZoomButtonValue },
         props: ZoomProperties,
-        axisId: string,
+        axisId: AxisID,
         direction: _ModuleSupport.CartesianAxisDirection,
         zoom: _ModuleSupport.ZoomState
     ) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
@@ -1,4 +1,5 @@
 import type { AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
+import type { AxisID } from 'ag-charts-core';
 
 export interface DefinedZoomState extends _ModuleSupport.AxisZoomState {
     x: _ModuleSupport.ZoomState;
@@ -13,7 +14,7 @@ export type ZoomCoords = {
 };
 
 export type AxisZoomStates = Record<
-    string,
+    AxisID,
     { direction: _ModuleSupport.ChartAxisDirection; zoom: _ModuleSupport.ZoomState }
 >;
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-8627

This enforce better type-safety (general-purpose strings cannot be passed as params to functions that require an axis ID).