### PR TITLE
AG-16239: Add high-frequency data benchmarks for bar, candlestick, OHLC, and line series

### DIFF
--- a/packages/ag-charts-community/benchmarks/highFrequencyDataBar.test.ts
+++ b/packages/ag-charts-community/benchmarks/highFrequencyDataBar.test.ts
@@ -1,0 +1,197 @@
+import type { AgCartesianChartOptions } from 'ag-charts-types';
+
+import { benchmark, setupBenchmark } from './benchmark';
+
+describe('high-frequency data bar benchmark', () => {
+    const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-bar');
+
+    type Datum = {
+        timestamp: number;
+        price: number;
+        volume: number;
+    };
+
+    const INITIAL_POINTS = 100_000;
+    const BATCH_SIZE = 100;
+    const DATA_INTERVAL_MS = 250;
+    const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
+    const BASE_PRICE = 100;
+
+    class HighFrequencyBarDataGenerator {
+        private index = 0;
+        private price = BASE_PRICE;
+
+        reset() {
+            this.index = 0;
+            this.price = BASE_PRICE;
+        }
+
+        take(count: number): Datum[] {
+            const batch: Datum[] = [];
+            for (let i = 0; i < count; i++) {
+                batch.push(this.next());
+            }
+            return batch;
+        }
+
+        private next(): Datum {
+            const index = this.index++;
+            const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+            const drift = Math.sin(index / 12) * 0.7 + Math.cos(index / 24) * 0.4;
+            this.price = Number((this.price + drift).toFixed(2));
+            return {
+                timestamp,
+                price: this.price,
+                volume: 600 + Math.round((Math.sin(index / 8) + 1) * 220),
+            };
+        }
+    }
+
+    const barDataGenerator = new HighFrequencyBarDataGenerator();
+
+    let data: Datum[] = [];
+
+    function createSeedData(count: number): Datum[] {
+        barDataGenerator.reset();
+        return barDataGenerator.take(count);
+    }
+
+    function createBatch(count: number): Datum[] {
+        return barDataGenerator.take(count);
+    }
+
+    beforeEach(() => {
+        data = createSeedData(INITIAL_POINTS);
+    });
+
+    describe('applyTransaction updates', () => {
+        beforeEach(async () => {
+            ctx.options.data = data;
+            await ctx.create();
+        });
+
+        benchmark(
+            '1x append batch (100 points)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const append = createBatch(BATCH_SIZE);
+                data = data.concat(append);
+                await (ctx.chart as any).applyTransaction({ append });
+            },
+            15_000
+        );
+
+        benchmark(
+            '10x append batch (1k points total)',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const append = createBatch(BATCH_SIZE);
+                data = data.concat(append);
+                await (ctx.chart as any).applyTransaction({ append });
+            },
+            30_000
+        );
+
+        benchmark(
+            '1x remove batch (100 points)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                data = data.slice(BATCH_SIZE);
+                await (ctx.chart as any).applyTransaction({ remove });
+            },
+            15_000
+        );
+
+        benchmark(
+            '1x rolling window update (append + remove)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            15_000
+        );
+
+        benchmark(
+            '10x rolling window update (append + remove)',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            '50x rolling window update (append + remove)',
+            ctx.repeatCount(50),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            60_000
+        );
+    });
+
+    describe('different batch sizes', () => {
+        beforeEach(async () => {
+            ctx.options.data = data;
+            await ctx.create();
+        });
+
+        benchmark(
+            'applyTransaction - 10 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 10;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            'applyTransaction - 500 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 500;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            'applyTransaction - 1000 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 1000;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+    });
+});

--- a/packages/ag-charts-community/benchmarks/highFrequencyDataBar.test.ts
+++ b/packages/ag-charts-community/benchmarks/highFrequencyDataBar.test.ts
@@ -101,7 +101,7 @@ describeWhenSupported('high-frequency data bar benchmark', () => {
 
         benchmark(
             '1x remove batch (100 points)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);
@@ -113,7 +113,7 @@ describeWhenSupported('high-frequency data bar benchmark', () => {
 
         benchmark(
             '1x rolling window update (append + remove)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);

--- a/packages/ag-charts-community/benchmarks/highFrequencyDataBar.test.ts
+++ b/packages/ag-charts-community/benchmarks/highFrequencyDataBar.test.ts
@@ -1,8 +1,13 @@
+import { describe as jestDescribe } from '@jest/globals';
+
 import type { AgCartesianChartOptions } from 'ag-charts-types';
 
 import { benchmark, setupBenchmark } from './benchmark';
+import { isAtOrAfterVersion } from './compatibility';
 
-describe('high-frequency data bar benchmark', () => {
+const describeWhenSupported = isAtOrAfterVersion(12, 3, 0) ? jestDescribe : jestDescribe.skip;
+
+describeWhenSupported('high-frequency data bar benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-bar');
 
     type Datum = {

--- a/packages/ag-charts-community/benchmarks/highFrequencyDataLine.test.ts
+++ b/packages/ag-charts-community/benchmarks/highFrequencyDataLine.test.ts
@@ -98,7 +98,7 @@ describeWhenSupported('high-frequency data line benchmark', () => {
 
         benchmark(
             '1x remove batch (100 points)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);
@@ -110,7 +110,7 @@ describeWhenSupported('high-frequency data line benchmark', () => {
 
         benchmark(
             '1x rolling window update (append + remove)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);

--- a/packages/ag-charts-community/benchmarks/highFrequencyDataLine.test.ts
+++ b/packages/ag-charts-community/benchmarks/highFrequencyDataLine.test.ts
@@ -1,11 +1,14 @@
-import { beforeEach, describe } from '@jest/globals';
+import { describe as jestDescribe } from '@jest/globals';
 
-import { AgCartesianChartOptions } from 'ag-charts-types';
+import type { AgCartesianChartOptions } from 'ag-charts-types';
 
 import { benchmark, setupBenchmark } from './benchmark';
+import { isAtOrAfterVersion } from './compatibility';
 
-describe('high-frequency data benchmark', () => {
-    const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-high-volume');
+const describeWhenSupported = isAtOrAfterVersion(12, 3, 0) ? jestDescribe : jestDescribe.skip;
+
+describeWhenSupported('high-frequency data line benchmark', () => {
+    const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-line');
 
     type Datum = {
         timestamp: number;
@@ -17,39 +20,50 @@ describe('high-frequency data benchmark', () => {
     const DATA_INTERVAL_MS = 250;
     const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
 
-    let data: Datum[] = [];
-    let nextIndex = 0;
+    class HighFrequencyLineDataGenerator {
+        private index = 0;
 
-    function generateDatum(index: number): Datum {
-        const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
-        const trend = Math.sin(index / 240) * 40 + Math.cos(index / 80) * 25;
-        const volatility = Math.sin(index / 15) * 5;
-        const baseline = 1_000 + index * 0.02;
-        return {
-            timestamp,
-            value: Number((baseline + trend + volatility).toFixed(2)),
-        };
+        reset() {
+            this.index = 0;
+        }
+
+        take(count: number): Datum[] {
+            const batch: Datum[] = [];
+            for (let i = 0; i < count; i++) {
+                batch.push(this.next());
+            }
+            return batch;
+        }
+
+        private next(): Datum {
+            const index = this.index++;
+            const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+            const trend = Math.sin(index / 240) * 40 + Math.cos(index / 80) * 25;
+            const volatility = Math.sin(index / 15) * 5;
+            const baseline = 1_000 + index * 0.02;
+
+            return {
+                timestamp,
+                value: Number((baseline + trend + volatility).toFixed(2)),
+            };
+        }
     }
 
+    const lineDataGenerator = new HighFrequencyLineDataGenerator();
+
+    let data: Datum[] = [];
+
     function createSeedData(count: number): Datum[] {
-        const result: Datum[] = [];
-        for (let i = 0; i < count; i++) {
-            result.push(generateDatum(i));
-        }
-        return result;
+        lineDataGenerator.reset();
+        return lineDataGenerator.take(count);
     }
 
     function createBatch(count: number): Datum[] {
-        const batch: Datum[] = [];
-        for (let i = 0; i < count; i++) {
-            batch.push(generateDatum(nextIndex++));
-        }
-        return batch;
+        return lineDataGenerator.take(count);
     }
 
     beforeEach(() => {
         data = createSeedData(INITIAL_POINTS);
-        nextIndex = data.length;
     });
 
     describe('applyTransaction updates', () => {
@@ -147,10 +161,7 @@ describe('high-frequency data benchmark', () => {
             async () => {
                 const batchSize = 10;
                 const remove = data.slice(0, batchSize);
-                const append: Datum[] = [];
-                for (let i = 0; i < batchSize; i++) {
-                    append.push(generateDatum(nextIndex++));
-                }
+                const append = createBatch(batchSize);
                 data = data.slice(batchSize).concat(append);
                 await (ctx.chart as any).applyTransaction({ append, remove });
             },
@@ -164,10 +175,7 @@ describe('high-frequency data benchmark', () => {
             async () => {
                 const batchSize = 500;
                 const remove = data.slice(0, batchSize);
-                const append: Datum[] = [];
-                for (let i = 0; i < batchSize; i++) {
-                    append.push(generateDatum(nextIndex++));
-                }
+                const append = createBatch(batchSize);
                 data = data.slice(batchSize).concat(append);
                 await (ctx.chart as any).applyTransaction({ append, remove });
             },
@@ -181,10 +189,7 @@ describe('high-frequency data benchmark', () => {
             async () => {
                 const batchSize = 1000;
                 const remove = data.slice(0, batchSize);
-                const append: Datum[] = [];
-                for (let i = 0; i < batchSize; i++) {
-                    append.push(generateDatum(nextIndex++));
-                }
+                const append = createBatch(batchSize);
                 data = data.slice(batchSize).concat(append);
                 await (ctx.chart as any).applyTransaction({ append, remove });
             },

--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -89,7 +89,8 @@
         "ag-charts-website-benchmarks_large-scale-multi-series_main.ts:generate-example",
         "ag-charts-website-benchmarks_multi-series_main.ts:generate-example",
         "ag-charts-website-benchmarks_resize_main.ts:generate-example",
-        "ag-charts-website-benchmarks_high-freq-high-volume_main.ts:generate-example"
+        "ag-charts-website-benchmarks_high-freq-high-volume_main.ts:generate-example",
+        "ag-charts-website-benchmarks_high-freq-bar_main.ts:generate-example"
       ]
     },
     "pack": {

--- a/packages/ag-charts-community/project.json
+++ b/packages/ag-charts-community/project.json
@@ -89,7 +89,7 @@
         "ag-charts-website-benchmarks_large-scale-multi-series_main.ts:generate-example",
         "ag-charts-website-benchmarks_multi-series_main.ts:generate-example",
         "ag-charts-website-benchmarks_resize_main.ts:generate-example",
-        "ag-charts-website-benchmarks_high-freq-high-volume_main.ts:generate-example",
+        "ag-charts-website-benchmarks_high-freq-line_main.ts:generate-example",
         "ag-charts-website-benchmarks_high-freq-bar_main.ts:generate-example"
       ]
     },

--- a/packages/ag-charts-enterprise/benchmarks/highFrequencyDataCandlestick.test.ts
+++ b/packages/ag-charts-enterprise/benchmarks/highFrequencyDataCandlestick.test.ts
@@ -1,0 +1,211 @@
+import type { AgCartesianChartOptions } from 'ag-charts-types';
+
+import { benchmark, setupBenchmark } from './benchmark';
+
+describe('high-frequency data candlestick benchmark', () => {
+    const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-candlestick', { isEnterprise: true });
+
+    type Datum = {
+        timestamp: number;
+        open: number;
+        high: number;
+        low: number;
+        close: number;
+        volume: number;
+    };
+
+    const INITIAL_POINTS = 100_000;
+    const BATCH_SIZE = 100;
+    const DATA_INTERVAL_MS = 250;
+    const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
+    const BASE_PRICE = 100;
+
+    class HighFrequencyCandlestickGenerator {
+        private index = 0;
+        private price = BASE_PRICE;
+
+        reset() {
+            this.index = 0;
+            this.price = BASE_PRICE;
+        }
+
+        take(count: number): Datum[] {
+            const batch: Datum[] = [];
+            for (let i = 0; i < count; i++) {
+                batch.push(this.next());
+            }
+            return batch;
+        }
+
+        private next(): Datum {
+            const index = this.index++;
+            const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+            const drift = Math.sin(index / 12) * 0.7 + Math.cos(index / 24) * 0.4;
+            this.price = Number((this.price + drift).toFixed(2));
+
+            // Generate realistic OHLC data with some volatility
+            const volatility = 0.5 + Math.sin(index / 20) * 0.3;
+            const open = this.price;
+            const close = Number((open + Math.sin(index / 5) * volatility).toFixed(2));
+            const high = Number(Math.max(open, close, open + Math.abs(Math.cos(index / 7)) * volatility).toFixed(2));
+            const low = Number(Math.min(open, close, open - Math.abs(Math.sin(index / 9)) * volatility).toFixed(2));
+
+            return {
+                timestamp,
+                open,
+                high,
+                low,
+                close,
+                volume: 600 + Math.round((Math.sin(index / 8) + 1) * 220),
+            };
+        }
+    }
+
+    const candlestickGenerator = new HighFrequencyCandlestickGenerator();
+
+    let data: Datum[] = [];
+
+    function createSeedData(count: number): Datum[] {
+        candlestickGenerator.reset();
+        return candlestickGenerator.take(count);
+    }
+
+    function createBatch(count: number): Datum[] {
+        return candlestickGenerator.take(count);
+    }
+
+    beforeEach(() => {
+        data = createSeedData(INITIAL_POINTS);
+    });
+
+    describe('applyTransaction updates', () => {
+        beforeEach(async () => {
+            ctx.options.data = data;
+            await ctx.create();
+        });
+
+        benchmark(
+            '1x append batch (100 points)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const append = createBatch(BATCH_SIZE);
+                data = data.concat(append);
+                await (ctx.chart as any).applyTransaction({ append });
+            },
+            15_000
+        );
+
+        benchmark(
+            '10x append batch (1k points total)',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const append = createBatch(BATCH_SIZE);
+                data = data.concat(append);
+                await (ctx.chart as any).applyTransaction({ append });
+            },
+            30_000
+        );
+
+        benchmark(
+            '1x remove batch (100 points)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                data = data.slice(BATCH_SIZE);
+                await (ctx.chart as any).applyTransaction({ remove });
+            },
+            15_000
+        );
+
+        benchmark(
+            '1x rolling window update (append + remove)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            15_000
+        );
+
+        benchmark(
+            '10x rolling window update (append + remove)',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            '50x rolling window update (append + remove)',
+            ctx.repeatCount(50),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            60_000
+        );
+    });
+
+    describe('different batch sizes', () => {
+        beforeEach(async () => {
+            ctx.options.data = data;
+            await ctx.create();
+        });
+
+        benchmark(
+            'applyTransaction - 10 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 10;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            'applyTransaction - 500 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 500;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            'applyTransaction - 1000 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 1000;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+    });
+});

--- a/packages/ag-charts-enterprise/benchmarks/highFrequencyDataCandlestick.test.ts
+++ b/packages/ag-charts-enterprise/benchmarks/highFrequencyDataCandlestick.test.ts
@@ -1,8 +1,12 @@
+import { describe as jestDescribe } from '@jest/globals';
+
 import type { AgCartesianChartOptions } from 'ag-charts-types';
 
-import { benchmark, setupBenchmark } from './benchmark';
+import { benchmark, isAtOrAfterVersion, setupBenchmark } from './benchmark';
 
-describe('high-frequency data candlestick benchmark', () => {
+const describeWhenSupported = isAtOrAfterVersion(12, 3, 0) ? jestDescribe : jestDescribe.skip;
+
+describeWhenSupported('high-frequency data candlestick benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-candlestick', { isEnterprise: true });
 
     type Datum = {

--- a/packages/ag-charts-enterprise/benchmarks/highFrequencyDataCandlestick.test.ts
+++ b/packages/ag-charts-enterprise/benchmarks/highFrequencyDataCandlestick.test.ts
@@ -114,7 +114,7 @@ describeWhenSupported('high-frequency data candlestick benchmark', () => {
 
         benchmark(
             '1x remove batch (100 points)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);
@@ -126,7 +126,7 @@ describeWhenSupported('high-frequency data candlestick benchmark', () => {
 
         benchmark(
             '1x rolling window update (append + remove)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);

--- a/packages/ag-charts-enterprise/benchmarks/highFrequencyDataOhlc.test.ts
+++ b/packages/ag-charts-enterprise/benchmarks/highFrequencyDataOhlc.test.ts
@@ -1,0 +1,210 @@
+import type { AgCartesianChartOptions } from 'ag-charts-types';
+
+import { benchmark, setupBenchmark } from './benchmark';
+
+describe('high-frequency data ohlc benchmark', () => {
+    const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-ohlc', { isEnterprise: true });
+
+    type Datum = {
+        timestamp: number;
+        open: number;
+        high: number;
+        low: number;
+        close: number;
+        volume: number;
+    };
+
+    const INITIAL_POINTS = 100_000;
+    const BATCH_SIZE = 100;
+    const DATA_INTERVAL_MS = 250;
+    const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
+    const BASE_PRICE = 100;
+
+    class HighFrequencyOhlcGenerator {
+        private index = 0;
+        private price = BASE_PRICE;
+
+        reset() {
+            this.index = 0;
+            this.price = BASE_PRICE;
+        }
+
+        take(count: number): Datum[] {
+            const batch: Datum[] = [];
+            for (let i = 0; i < count; i++) {
+                batch.push(this.next());
+            }
+            return batch;
+        }
+
+        private next(): Datum {
+            const index = this.index++;
+            const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+            const drift = Math.sin(index / 12) * 0.7 + Math.cos(index / 24) * 0.4;
+            this.price = Number((this.price + drift).toFixed(2));
+
+            const volatility = 0.5 + Math.sin(index / 20) * 0.3;
+            const open = this.price;
+            const close = Number((open + Math.sin(index / 5) * volatility).toFixed(2));
+            const high = Number(Math.max(open, close, open + Math.abs(Math.cos(index / 7)) * volatility).toFixed(2));
+            const low = Number(Math.min(open, close, open - Math.abs(Math.sin(index / 9)) * volatility).toFixed(2));
+
+            return {
+                timestamp,
+                open,
+                high,
+                low,
+                close,
+                volume: 600 + Math.round((Math.sin(index / 8) + 1) * 220),
+            };
+        }
+    }
+
+    const ohlcGenerator = new HighFrequencyOhlcGenerator();
+
+    let data: Datum[] = [];
+
+    function createSeedData(count: number): Datum[] {
+        ohlcGenerator.reset();
+        return ohlcGenerator.take(count);
+    }
+
+    function createBatch(count: number): Datum[] {
+        return ohlcGenerator.take(count);
+    }
+
+    beforeEach(() => {
+        data = createSeedData(INITIAL_POINTS);
+    });
+
+    describe('applyTransaction updates', () => {
+        beforeEach(async () => {
+            ctx.options.data = data;
+            await ctx.create();
+        });
+
+        benchmark(
+            '1x append batch (100 points)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const append = createBatch(BATCH_SIZE);
+                data = data.concat(append);
+                await (ctx.chart as any).applyTransaction({ append });
+            },
+            15_000
+        );
+
+        benchmark(
+            '10x append batch (1k points total)',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const append = createBatch(BATCH_SIZE);
+                data = data.concat(append);
+                await (ctx.chart as any).applyTransaction({ append });
+            },
+            30_000
+        );
+
+        benchmark(
+            '1x remove batch (100 points)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                data = data.slice(BATCH_SIZE);
+                await (ctx.chart as any).applyTransaction({ remove });
+            },
+            15_000
+        );
+
+        benchmark(
+            '1x rolling window update (append + remove)',
+            ctx,
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            15_000
+        );
+
+        benchmark(
+            '10x rolling window update (append + remove)',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            '50x rolling window update (append + remove)',
+            ctx.repeatCount(50),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const remove = data.slice(0, BATCH_SIZE);
+                const append = createBatch(BATCH_SIZE);
+                data = data.slice(BATCH_SIZE).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            60_000
+        );
+    });
+
+    describe('different batch sizes', () => {
+        beforeEach(async () => {
+            ctx.options.data = data;
+            await ctx.create();
+        });
+
+        benchmark(
+            'applyTransaction - 10 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 10;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            'applyTransaction - 500 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 500;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+
+        benchmark(
+            'applyTransaction - 1000 points rolling window',
+            ctx.repeatCount(10),
+            { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
+            async () => {
+                const batchSize = 1000;
+                const remove = data.slice(0, batchSize);
+                const append = createBatch(batchSize);
+                data = data.slice(batchSize).concat(append);
+                await (ctx.chart as any).applyTransaction({ append, remove });
+            },
+            30_000
+        );
+    });
+});

--- a/packages/ag-charts-enterprise/benchmarks/highFrequencyDataOhlc.test.ts
+++ b/packages/ag-charts-enterprise/benchmarks/highFrequencyDataOhlc.test.ts
@@ -113,7 +113,7 @@ describeWhenSupported('high-frequency data ohlc benchmark', () => {
 
         benchmark(
             '1x remove batch (100 points)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);
@@ -125,7 +125,7 @@ describeWhenSupported('high-frequency data ohlc benchmark', () => {
 
         benchmark(
             '1x rolling window update (append + remove)',
-            ctx,
+            ctx.repeatCount(1),
             { expectedRelativeMB: 0.5, expectedCanvasCount: 2, autoSnapshot: false },
             async () => {
                 const remove = data.slice(0, BATCH_SIZE);

--- a/packages/ag-charts-enterprise/benchmarks/highFrequencyDataOhlc.test.ts
+++ b/packages/ag-charts-enterprise/benchmarks/highFrequencyDataOhlc.test.ts
@@ -1,8 +1,12 @@
+import { describe as jestDescribe } from '@jest/globals';
+
 import type { AgCartesianChartOptions } from 'ag-charts-types';
 
-import { benchmark, setupBenchmark } from './benchmark';
+import { benchmark, isAtOrAfterVersion, setupBenchmark } from './benchmark';
 
-describe('high-frequency data ohlc benchmark', () => {
+const describeWhenSupported = isAtOrAfterVersion(12, 3, 0) ? jestDescribe : jestDescribe.skip;
+
+describeWhenSupported('high-frequency data ohlc benchmark', () => {
     const ctx = setupBenchmark<AgCartesianChartOptions>('high-freq-ohlc', { isEnterprise: true });
 
     type Datum = {

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -99,7 +99,8 @@
         "ag-charts-website-benchmarks_high-perf-line_main.ts:generate-example",
         "ag-charts-website-benchmarks_high-perf-ohlc_main.ts:generate-example",
         "ag-charts-website-benchmarks_high-perf-range-area_main.ts:generate-example",
-        "ag-charts-website-benchmarks_high-perf-range-bar_main.ts:generate-example"
+        "ag-charts-website-benchmarks_high-perf-range-bar_main.ts:generate-example",
+        "ag-charts-website-benchmarks_high-freq-candlestick_main.ts:generate-example"
       ]
     },
     "pack": {

--- a/packages/ag-charts-enterprise/project.json
+++ b/packages/ag-charts-enterprise/project.json
@@ -100,7 +100,8 @@
         "ag-charts-website-benchmarks_high-perf-ohlc_main.ts:generate-example",
         "ag-charts-website-benchmarks_high-perf-range-area_main.ts:generate-example",
         "ag-charts-website-benchmarks_high-perf-range-bar_main.ts:generate-example",
-        "ag-charts-website-benchmarks_high-freq-candlestick_main.ts:generate-example"
+        "ag-charts-website-benchmarks_high-freq-candlestick_main.ts:generate-example",
+        "ag-charts-website-benchmarks_high-freq-ohlc_main.ts:generate-example"
       ]
     },
     "pack": {

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-bar/index.html
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-bar/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-bar/main.ts
@@ -1,0 +1,78 @@
+/* @ag-options-extract */
+import { AgChartOptions, AgCharts } from 'ag-charts-community';
+
+const INITIAL_POINTS = 100_000;
+const DATA_INTERVAL_MS = 250;
+const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
+const BASE_PRICE = 100;
+
+type Datum = {
+    timestamp: number;
+    price: number;
+    volume: number;
+};
+
+class HighFrequencyBarDataGenerator {
+    private index = 0;
+    private price = BASE_PRICE;
+
+    reset() {
+        this.index = 0;
+        this.price = BASE_PRICE;
+    }
+
+    take(count: number): Datum[] {
+        const batch: Datum[] = [];
+        for (let i = 0; i < count; i++) {
+            batch.push(this.next());
+        }
+        return batch;
+    }
+
+    private next(): Datum {
+        const index = this.index++;
+        const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+        const drift = Math.sin(index / 12) * 0.7 + Math.cos(index / 24) * 0.4;
+        this.price = Number((this.price + drift).toFixed(2));
+        return {
+            timestamp,
+            price: this.price,
+            volume: 600 + Math.round((Math.sin(index / 8) + 1) * 220),
+        };
+    }
+}
+
+const dataGenerator = new HighFrequencyBarDataGenerator();
+dataGenerator.reset();
+const data = dataGenerator.take(INITIAL_POINTS);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data,
+    animation: { enabled: false },
+    legend: { enabled: false },
+    axes: [
+        {
+            type: 'time',
+            position: 'bottom',
+            label: { format: '%H:%M:%S' },
+        },
+        {
+            type: 'number',
+            position: 'left',
+            label: {
+                formatter: (params) => `$${params.value.toFixed(2)}`,
+            },
+        },
+    ],
+    series: [
+        {
+            type: 'bar',
+            xKey: 'timestamp',
+            yKey: 'price',
+        },
+    ],
+};
+/* @ag-options-end */
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-candlestick/index.html
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-candlestick/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-candlestick/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-candlestick/main.ts
@@ -1,0 +1,94 @@
+/* @ag-options-extract */
+import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+
+const INITIAL_POINTS = 100_000;
+const DATA_INTERVAL_MS = 250;
+const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
+const BASE_PRICE = 100;
+
+type Datum = {
+    timestamp: number;
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+    volume: number;
+};
+
+class HighFrequencyCandlestickGenerator {
+    private index = 0;
+    private price = BASE_PRICE;
+
+    reset() {
+        this.index = 0;
+        this.price = BASE_PRICE;
+    }
+
+    take(count: number): Datum[] {
+        const batch: Datum[] = [];
+        for (let i = 0; i < count; i++) {
+            batch.push(this.next());
+        }
+        return batch;
+    }
+
+    private next(): Datum {
+        const index = this.index++;
+        const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+        const drift = Math.sin(index / 12) * 0.7 + Math.cos(index / 24) * 0.4;
+        this.price = Number((this.price + drift).toFixed(2));
+
+        const volatility = 0.5 + Math.sin(index / 20) * 0.3;
+        const open = this.price;
+        const close = Number((open + Math.sin(index / 5) * volatility).toFixed(2));
+        const high = Number(Math.max(open, close, open + Math.abs(Math.cos(index / 7)) * volatility).toFixed(2));
+        const low = Number(Math.min(open, close, open - Math.abs(Math.sin(index / 9)) * volatility).toFixed(2));
+
+        return {
+            timestamp,
+            open,
+            high,
+            low,
+            close,
+            volume: 600 + Math.round((Math.sin(index / 8) + 1) * 220),
+        };
+    }
+}
+
+const dataGenerator = new HighFrequencyCandlestickGenerator();
+dataGenerator.reset();
+const data = dataGenerator.take(INITIAL_POINTS);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data,
+    animation: { enabled: false },
+    legend: { enabled: false },
+    axes: [
+        {
+            type: 'time',
+            position: 'bottom',
+            label: { format: '%H:%M:%S' },
+        },
+        {
+            type: 'number',
+            position: 'left',
+            label: {
+                formatter: (params) => `$${params.value.toFixed(2)}`,
+            },
+        },
+    ],
+    series: [
+        {
+            type: 'candlestick',
+            xKey: 'timestamp',
+            openKey: 'open',
+            highKey: 'high',
+            lowKey: 'low',
+            closeKey: 'close',
+        },
+    ],
+};
+/* @ag-options-end */
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-line/index.html
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-line/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-line/main.ts
@@ -1,0 +1,75 @@
+/* @ag-options-extract */
+import { AgChartOptions, AgCharts } from 'ag-charts-community';
+
+const INITIAL_POINTS = 100_000;
+const DATA_INTERVAL_MS = 250;
+const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
+
+type Datum = {
+    timestamp: number;
+    value: number;
+};
+
+class HighFrequencyLineDataGenerator {
+    private index = 0;
+
+    reset() {
+        this.index = 0;
+    }
+
+    take(count: number): Datum[] {
+        const batch: Datum[] = [];
+        for (let i = 0; i < count; i++) {
+            batch.push(this.next());
+        }
+        return batch;
+    }
+
+    private next(): Datum {
+        const index = this.index++;
+        const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+        const trend = Math.sin(index / 240) * 40 + Math.cos(index / 80) * 25;
+        const volatility = Math.sin(index / 15) * 5;
+        const baseline = 1_000 + index * 0.02;
+
+        return {
+            timestamp,
+            value: Number((baseline + trend + volatility).toFixed(2)),
+        };
+    }
+}
+
+const dataGenerator = new HighFrequencyLineDataGenerator();
+dataGenerator.reset();
+const data = dataGenerator.take(INITIAL_POINTS);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data,
+    animation: { enabled: false },
+    legend: { enabled: false },
+    axes: [
+        {
+            type: 'time',
+            position: 'bottom',
+            label: { format: '%H:%M:%S' },
+        },
+        {
+            type: 'number',
+            position: 'left',
+            title: { text: 'Value' },
+        },
+    ],
+    series: [
+        {
+            type: 'line',
+            xKey: 'timestamp',
+            yKey: 'value',
+            marker: { enabled: false },
+            strokeWidth: 1,
+        },
+    ],
+};
+/* @ag-options-end */
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-ohlc/index.html
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-ohlc/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-ohlc/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-ohlc/main.ts
@@ -1,0 +1,94 @@
+/* @ag-options-extract */
+import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+
+const INITIAL_POINTS = 100_000;
+const DATA_INTERVAL_MS = 250;
+const START_TIMESTAMP = Date.UTC(2024, 0, 1, 0, 0, 0);
+const BASE_PRICE = 100;
+
+type Datum = {
+    timestamp: number;
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+    volume: number;
+};
+
+class HighFrequencyOhlcGenerator {
+    private index = 0;
+    private price = BASE_PRICE;
+
+    reset() {
+        this.index = 0;
+        this.price = BASE_PRICE;
+    }
+
+    take(count: number): Datum[] {
+        const batch: Datum[] = [];
+        for (let i = 0; i < count; i++) {
+            batch.push(this.next());
+        }
+        return batch;
+    }
+
+    private next(): Datum {
+        const index = this.index++;
+        const timestamp = START_TIMESTAMP + index * DATA_INTERVAL_MS;
+        const drift = Math.sin(index / 12) * 0.7 + Math.cos(index / 24) * 0.4;
+        this.price = Number((this.price + drift).toFixed(2));
+
+        const volatility = 0.5 + Math.sin(index / 20) * 0.3;
+        const open = this.price;
+        const close = Number((open + Math.sin(index / 5) * volatility).toFixed(2));
+        const high = Number(Math.max(open, close, open + Math.abs(Math.cos(index / 7)) * volatility).toFixed(2));
+        const low = Number(Math.min(open, close, open - Math.abs(Math.sin(index / 9)) * volatility).toFixed(2));
+
+        return {
+            timestamp,
+            open,
+            high,
+            low,
+            close,
+            volume: 600 + Math.round((Math.sin(index / 8) + 1) * 220),
+        };
+    }
+}
+
+const dataGenerator = new HighFrequencyOhlcGenerator();
+dataGenerator.reset();
+const data = dataGenerator.take(INITIAL_POINTS);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data,
+    animation: { enabled: false },
+    legend: { enabled: false },
+    axes: [
+        {
+            type: 'time',
+            position: 'bottom',
+            label: { format: '%H:%M:%S' },
+        },
+        {
+            type: 'number',
+            position: 'left',
+            label: {
+                formatter: (params) => `$${params.value.toFixed(2)}`,
+            },
+        },
+    ],
+    series: [
+        {
+            type: 'ohlc',
+            xKey: 'timestamp',
+            openKey: 'open',
+            highKey: 'high',
+            lowKey: 'low',
+            closeKey: 'close',
+        },
+    ],
+};
+/* @ag-options-end */
+
+AgCharts.create(options);


### PR DESCRIPTION
This PR adds comprehensive benchmarks for high-frequency data scenarios across multiple chart series types.

## Changes
- Added high-frequency data benchmarks for bar series (community)
- Added high-frequency data benchmarks for candlestick series (enterprise)
- Added high-frequency data benchmarks for OHLC series (enterprise)
- Updated high-frequency data benchmarks for line series (community)
- Added corresponding example files for all benchmark types
- Updated project.json configurations for benchmark example generation

## Reviewers
This PR should be reviewed by the Charts dev team as it focuses on benchmark additions and library functionality.