### PR TITLE
Update chart axis documentation and examples

### DIFF
--- a/tools/prompts/commands/spruce-example/core-rules.md
+++ b/tools/prompts/commands/spruce-example/core-rules.md
@@ -46,7 +46,7 @@ Gallery examples are used by thousands of developers who:
 
 ## ⚠️ Required Fields
 
--   **`axes[].type`** - MUST always be specified for every axis configuration
+-   **`axes.*.type`** - MUST always be specified for every axis configuration (axes are now a dictionary/object: `axes: { x: { type: 'category' }, y: { type: 'number' } }`)
 -   All TypeScript types must be properly defined - NEVER use `any`
 -   Use specific chart types (`AgCartesianChartOptions`, `AgPolarChartOptions`, etc.) instead of generic `AgChartOptions` to avoid compiler errors
 
@@ -90,7 +90,7 @@ Gallery examples are used by thousands of developers who:
 2.  ✅ Example MUST generate without warnings
 3.  ✅ **Validation MUST pass** (`yarn nx run ag-charts-website-gallery_[example-name]_main.ts:typecheck`) - **DO NOT SKIP THIS**
 4.  ✅ Thumbnail generation MUST succeed (`yarn nx generate-thumbnails`)
-5.  ✅ All `axes[].type` fields MUST be specified
+5.  ✅ All `axes.*.type` fields MUST be specified (axes use dictionary format: `axes: { x: {...}, y: {...} }`)
 
 ### Failure Conditions (STOP IMMEDIATELY):
 

--- a/tools/prompts/commands/spruce-example/features/axes.md
+++ b/tools/prompts/commands/spruce-example/features/axes.md
@@ -8,9 +8,9 @@ _Apply: 6 minutes, Impact: VERY HIGH_ ⭐ **STRONGLY RECOMMENDED**
 
 ```typescript
 // Add visual depth with alternating background bands
-axes: [
-    {
-        type: 'number', // ⚠️ REQUIRED - axes[].type must always be specified
+axes: {
+    y: {
+        type: 'number', // ⚠️ REQUIRED - axes.*.type must always be specified
         position: 'left',
         gridLine: {
             style: [
@@ -26,7 +26,7 @@ axes: [
             ],
         },
     },
-];
+};
 ```
 
 ### Why this matters
@@ -44,16 +44,16 @@ _Apply: 4 minutes, Impact: HIGH_ ⭐ **RECOMMENDED**
 
 ```typescript
 // Add interactive hover highlighting to axis bands
-axes: [
-    {
-        type: 'category', // ⚠️ REQUIRED - always specify axes[].type
+axes: {
+    x: {
+        type: 'category', // ⚠️ REQUIRED - always specify axes.*.type
         position: 'bottom',
         bandHighlight: {
             enabled: true,
             // Don't set fill - theme provides appropriate highlight color
         },
     },
-];
+};
 ```
 
 ### Visual Benefits
@@ -81,18 +81,18 @@ const options = {
                 year: 'numeric',
             }), // Applied to all x-values (dates)
     },
-    axes: [
-        {
+    axes: {
+        y: {
             type: 'number', // ⚠️ REQUIRED field
             position: 'left',
             // Automatically uses root formatter.y
         },
-        {
+        x: {
             type: 'time', // ⚠️ REQUIRED field
             position: 'bottom',
             // Automatically uses root formatter.x
         },
-    ],
+    },
     series: [
         // All series labels and tooltips also use root formatters
     ],
@@ -102,8 +102,8 @@ const options = {
 ### Only use axis-specific formatters when they differ:
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number', // ⚠️ REQUIRED field
         position: 'left',
         label: {
@@ -111,7 +111,7 @@ axes: [
             formatter: (params) => `${params.value}%`, // Specific to percentage axis
         },
     },
-];
+};
 ```
 
 ### 🎨 NEW: Axis Label Item Styler (b12.2.0)
@@ -120,8 +120,8 @@ _Apply: 6 minutes, Impact: MEDIUM_
 
 ```typescript
 // Style specific axis labels based on value or position
-axes: [
-    {
+axes: {
+    y: {
         type: 'number', // ⚠️ REQUIRED field
         position: 'left',
         label: {
@@ -149,7 +149,7 @@ axes: [
             },
         },
     },
-];
+};
 ```
 
 ### Use Cases for Label Stylers
@@ -164,8 +164,8 @@ axes: [
 _Apply: 6 minutes, Impact: HIGH_
 
 ```typescript
-axes: [
-    {
+axes: {
+    x: {
         type: 'time',
         position: 'bottom',
         label: {
@@ -181,7 +181,7 @@ axes: [
             ],
         },
     },
-];
+};
 ```
 
 ### Why this matters
@@ -195,8 +195,8 @@ axes: [
 _Apply: 5 minutes, Impact: MEDIUM_
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number',
         position: 'left',
         crossAt: {
@@ -204,14 +204,14 @@ axes: [
             sticky: true, // Keep the horizontal axis locked to domain 0
         },
     },
-    {
+    x: {
         type: 'time',
         position: 'bottom',
         crossAt: {
             value: new Date('2025-01-01'),
         },
     },
-];
+};
 ```
 
 ### When to use crossAt
@@ -226,20 +226,20 @@ _Apply: 2 minutes, Impact: Medium_
 
 ```typescript
 // For continuous axes (number, time, log), control axis range padding
-axes: [
-    {
+axes: {
+    y: {
         type: 'number', // ⚠️ REQUIRED field
         position: 'left',
         nice: false, // ✅ Data fits exactly to min/max (no padding)
         // Default nice: true adds padding for round numbers
     },
-    {
+    x: {
         type: 'time', // ⚠️ REQUIRED field
         position: 'bottom',
         nice: false, // ✅ Time scale starts/ends at data boundaries
         // Useful for showing exact date ranges
     },
-];
+};
 ```
 
 ### When to use `nice: false`
@@ -260,8 +260,8 @@ axes: [
 _Apply: 10 minutes, Impact: HIGH_
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number', // ⚠️ REQUIRED field
         position: 'left',
         nice: false, // ✅ Data fits snugly to scale (no extra padding)
@@ -276,7 +276,7 @@ axes: [
         gridLine: { style: [{ lineDash: [2, 3] }] }, // Don't set stroke color
         tick: { width: 1 }, // Don't set stroke color
     },
-    {
+    x: {
         type: 'category', // ⚠️ REQUIRED field
         position: 'bottom',
         bandHighlight: {
@@ -288,7 +288,7 @@ axes: [
             // ❌ Don't set fontSize
         },
     },
-];
+};
 ```
 
 ## 🎨 Advanced Grid Line Styling
@@ -323,8 +323,8 @@ gridLine: {
 }
 
 // BEST PRACTICE: Combine with bandHighlight for maximum impact
-axes: [
-    {
+axes: {
+    x: {
         type: 'category', // ⚠️ REQUIRED field
         position: 'bottom',
         gridLine: {
@@ -337,7 +337,7 @@ axes: [
             enabled: true,
         },
     },
-];
+};
 ```
 
 ### Visual Impact
@@ -363,8 +363,8 @@ Creates a layered visual experience where:
 ### Financial Charts
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number',
         position: 'left',
         label: {
@@ -377,7 +377,7 @@ axes: [
             ],
         },
     },
-];
+};
 ```
 
 ### Financial Chart Axis Positioning Convention
@@ -387,8 +387,8 @@ _Apply: 2 minutes, Impact: VERY HIGH for financial data_ ⭐⭐ **INDUSTRY STAND
 For financial and monetary data, follow standard industry conventions:
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number',
         position: 'right', // ✅ PREFERRED for price/monetary values
         label: {
@@ -404,12 +404,12 @@ axes: [
             ],
         },
     },
-    {
+    x: {
         type: 'time',
         position: 'bottom',
         // Date/time axis configuration
     },
-];
+};
 ```
 
 ### Why right-side positioning for financial data:
@@ -436,8 +436,8 @@ axes: [
 ### Time Series
 
 ```typescript
-axes: [
-    {
+axes: {
+    x: {
         type: 'time',
         position: 'bottom',
         nice: false, // Exact date range
@@ -451,14 +451,14 @@ axes: [
             },
         },
     },
-];
+};
 ```
 
 ### Category Axes with Many Items
 
 ```typescript
-axes: [
-    {
+axes: {
+    x: {
         type: 'category',
         position: 'bottom',
         bandHighlight: { enabled: true },
@@ -467,7 +467,7 @@ axes: [
             autoRotate: true, // Automatic rotation when needed
         },
     },
-];
+};
 ```
 
 ## ⚠️ Special Considerations for Radial/Polar Charts
@@ -478,23 +478,23 @@ Radial and polar charts can quickly become cluttered. Follow these guidelines:
 
 ```typescript
 // ❌ AVOID - Too many axis elements in radial charts
-axes: [
-    {
+axes: {
+    angle: {
         type: 'angle-category',
         gridLine: { enabled: true, style: [...] }, // Often clutters
         label: { enabled: true, formatter: ... },  // Can overlap
         crossLines: [...],                          // Usually overkill
     },
-    {
+    radius: {
         type: 'radius-number',
         gridLine: { enabled: true },               // Multiple circles can overwhelm
         label: { enabled: true },                  // Often unnecessary
     },
-];
+};
 
 // ✅ BETTER - Minimal, focused approach
-axes: [
-    {
+axes: {
+    angle: {
         type: 'angle-category',
         gridLine: { enabled: false },              // Clean look
         label: {
@@ -502,7 +502,7 @@ axes: [
             // Keep labels short to avoid overlap
         },
     },
-    {
+    radius: {
         type: 'radius-number',
         gridLine: {
             enabled: true,
@@ -510,7 +510,7 @@ axes: [
         },
         label: { enabled: false },                 // Often not needed
     },
-];
+};
 ```
 
 ### Guidelines for Radial/Polar Charts:

--- a/tools/prompts/commands/spruce-example/features/enterprise.md
+++ b/tools/prompts/commands/spruce-example/features/enterprise.md
@@ -11,8 +11,8 @@ _Apply: 8 minutes, Impact: MEDIUM_ ⭐ **RECOMMENDED for data-heavy charts**
 ### Basic Crosshairs
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number', // Required field
         position: 'left',
         crosshair: {
@@ -23,14 +23,14 @@ axes: [
             },
         },
     },
-    {
+    x: {
         type: 'category', // Required field
         position: 'bottom',
         crosshair: {
             enabled: true,
         },
     },
-];
+};
 ```
 
 ### Advanced Crosshair Configuration

--- a/tools/prompts/commands/spruce-example/features/recent-features.md
+++ b/tools/prompts/commands/spruce-example/features/recent-features.md
@@ -89,8 +89,8 @@ formatter: {
         { text: ' %', opacity: 0.7 },
     ],
 },
-axes: [
-    {
+axes: {
+    x: {
         type: 'time',
         position: 'bottom',
         label: {
@@ -100,7 +100,7 @@ axes: [
             ],
         },
     },
-];
+};
 ```
 
 _Scope_: Works for axes, labels, navigator mini-chart labels, and chart-level captions.
@@ -110,8 +110,8 @@ _Scope_: Works for axes, labels, navigator mini-chart labels, and chart-level ca
 _New Mar 2025 • Apply: 4 minutes • Impact: MEDIUM_
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number',
         position: 'left',
         crossAt: {
@@ -119,12 +119,12 @@ axes: [
             sticky: true, // Keep origin locked to the plotted domain
         },
     },
-    {
+    x: {
         type: 'time',
         position: 'bottom',
         crossAt: { value: new Date('2025-01-01') },
     },
-];
+};
 ```
 
 _Use for_: Center-origin charts, quadrant layouts, and custom axis intersections without manual offsets.
@@ -197,8 +197,8 @@ _Replaces: Repetitive itemStyler implementations, manual series state management
 _New Jan 2025 • Apply: 5 minutes • Impact: MEDIUM_
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number', // Required
         position: 'left',
         label: {
@@ -216,7 +216,7 @@ axes: [
             },
         },
     },
-];
+};
 ```
 
 _Replaces: Complex label formatter workarounds, custom label rendering_
@@ -692,8 +692,8 @@ _Replaces: Static chart loading and manual animation implementations_
 _New May 2023 • Apply: 8 minutes • Impact: Medium_
 
 ```typescript
-axes: [
-    {
+axes: {
+    y: {
         type: 'number', // Required
         position: 'left',
         title: {
@@ -703,7 +703,7 @@ axes: [
             },
         },
     },
-];
+};
 ```
 
 _Replaces: Static axis titles and manual title generation logic_
@@ -713,8 +713,8 @@ _Replaces: Static axis titles and manual title generation logic_
 _New Apr 2023 • Apply: 4 minutes • Impact: Low_
 
 ```typescript
-axes: [
-    {
+axes: {
+    x: {
         type: 'category', // Required
         position: 'bottom',
         label: {
@@ -724,7 +724,7 @@ axes: [
             // Don't set color - theme handles label colors
         },
     },
-];
+};
 ```
 
 _Note: Only use rotation if labels truly overlap, otherwise leave default_

--- a/tools/prompts/commands/spruce-example/features/theme-overrides.md
+++ b/tools/prompts/commands/spruce-example/features/theme-overrides.md
@@ -90,14 +90,14 @@ theme: {
 
 ```typescript
 // Note: Axes typically configured directly, not through overrides
-axes: [
-    {
+axes: {
+    x: {
         type: 'category', // Required field
         position: 'bottom',
         bandHighlight: { enabled: true },
         // Don't set label fontSize - theme handles it
     },
-    {
+    y: {
         type: 'number', // Required field
         position: 'left',
         gridLine: {
@@ -107,7 +107,7 @@ axes: [
             ],
         },
     },
-];
+};
 ```
 
 ### 3. Complex Shared Behaviors

--- a/tools/prompts/commands/spruce-example/troubleshooting.md
+++ b/tools/prompts/commands/spruce-example/troubleshooting.md
@@ -50,24 +50,24 @@ const options: AgChartOptions = { ... };
 // ✅ Specific types
 import { AgCartesianChartOptions } from 'ag-charts-enterprise';
 const options: AgCartesianChartOptions = {
-    axes: [...],  // Now properly typed
+    axes: { x: {...}, y: {...} },  // Now properly typed
     series: [...]
 };
 ```
 
-### Always Specify axes[].type
+### Always Specify axes.*.type
 
 ```typescript
-axes: [
-    {
+axes: {
+    x: {
         type: 'category', // ⚠️ REQUIRED
         position: 'bottom',
     },
-    {
+    y: {
         type: 'number', // ⚠️ REQUIRED
         position: 'left',
     },
-];
+};
 ```
 
 ## 🎯 When Things Fail

--- a/tools/prompts/commands/spruce-example/troubleshooting.md
+++ b/tools/prompts/commands/spruce-example/troubleshooting.md
@@ -55,7 +55,7 @@ const options: AgCartesianChartOptions = {
 };
 ```
 
-### Always Specify axes.*.type
+### Always Specify axes.\*.type
 
 ```typescript
 axes: {

--- a/tools/prompts/guides/docs-pages.md
+++ b/tools/prompts/guides/docs-pages.md
@@ -441,10 +441,10 @@ Display code snippets with syntax highlighting.
         { type: 'bar', xKey: 'quarter', yKey: 'iphone', yName: 'iPhone', fill: '#007bff', stacked: true },
         { type: 'bar', xKey: 'quarter', yKey: 'mac', yName: 'Mac', fill: '#28a745', stacked: true },
     ],
-    axes: [
-        { type: 'category', position: 'bottom' },
-        { type: 'number', position: 'left' },
-    ],
+    axes: {
+        x: { type: 'category', position: 'bottom' },
+        y: { type: 'number', position: 'left' },
+    },
     legend: { enabled: true },
 }
 ```
@@ -797,12 +797,12 @@ A category axis is used to display distinct categories or groups of data in a ch
 
 ```js format="snippet"
 {
-    axes: [
-        {
+    axes: {
+        x: {
             type: 'category',
             position: 'bottom',
         },
-    ],
+    },
 }
 ```
 ````
@@ -979,10 +979,10 @@ See the [Default Values Guide](./defaults.md) for complete details.
     series: [
         { type: 'bar', xKey: 'month', yKey: 'sales', yName: 'Sales', fill: '#007bff', stacked: true },
     ],
-    axes: [
-        { type: 'category', position: 'bottom' },
-        { type: 'number', position: 'left' },
-    ],
+    axes: {
+        x: { type: 'category', position: 'bottom' },
+        y: { type: 'number', position: 'left' },
+    },
 }
 ```
 


### PR DESCRIPTION
Major changes to axes specification: axes are now a dictionary/object instead of an array.

Old format: axes: [{ type: 'number', position: 'left' }, ...]
New format: axes: { y: { type: 'number', position: 'left' }, ... }

Updated all examples and instructions in:
- tools/prompts/commands/spruce-example/features/axes.md
- tools/prompts/commands/spruce-example/core-rules.md
- tools/prompts/commands/spruce-example/features/enterprise.md
- tools/prompts/commands/spruce-example/features/recent-features.md
- tools/prompts/commands/spruce-example/features/theme-overrides.md
- tools/prompts/commands/spruce-example/troubleshooting.md
- tools/prompts/guides/docs-pages.md