### PR TITLE
Update spruce-example docs for b13.0.0 API changes

### DIFF
--- a/tools/prompts/commands/spruce-example/core-rules.md
+++ b/tools/prompts/commands/spruce-example/core-rules.md
@@ -71,6 +71,8 @@ Gallery examples are used by thousands of developers who:
 -   **Custom tooltip HTML via `renderer()`** - use multiple `data[]` elements instead (simpler + better styling)
 -   **Tooltip renderers without `heading`** - ALWAYS include `heading` property to avoid empty lines at the top of tooltips
 -   **Use deprecated `highlightStyle`** - use the newer `highlight.*` options instead
+-   **Use deprecated `highlighted` boolean** - callback params now use `highlightState` string instead (`'highlighted-item'`, `'highlighted-series'`, etc.)
+-   **Use deprecated `itemId` for series item types** - use `itemType` instead (for waterfall, range-area, range-bar, OHLC series)
 -   **Add no-op formatters** - NEVER use formatters that just call `toLocaleString()` without additional formatting
 -   **Use deeply nested formatters** - ALWAYS prefer root-level `formatter.x` and `formatter.y` over duplicating formatters
 -   **Over-decorate radial/polar charts** - Avoid adding cross lines, excessive grid lines, or axis labels unless absolutely necessary
@@ -275,6 +277,81 @@ series: [
     },
 ];
 ```
+
+### ❌ `highlighted` boolean → ✅ Use `highlightState` string:
+
+```typescript
+// ❌ DEPRECATED - Do not use
+series: [
+    {
+        styler: (params) => {
+            if (params.highlighted) {
+                return { strokeWidth: 3 };
+            }
+            return {};
+        },
+    },
+];
+
+// ✅ MODERN - Use this instead
+series: [
+    {
+        styler: (params) => {
+            if (params.highlightState === 'highlighted-item') {
+                return { strokeWidth: 3 };
+            }
+            return {};
+        },
+    },
+];
+```
+
+**Available `highlightState` values:**
+- `'highlighted-item'`: The directly hovered item
+- `'highlighted-series'`: The series containing the hovered item
+- `'unhighlighted-item'`: Other items not hovered
+- `'unhighlighted-series'`: Other series not containing hovered item
+- `'highlighted-branch'`: For hierarchical series (treemap/sunburst) - nodes sharing same root branch
+- `'unhighlighted-branch'`: For hierarchical series - nodes in different branches
+- `'none'`: Default state
+
+### ❌ `itemId` → ✅ Use `itemType` for series item classification:
+
+```typescript
+// ❌ DEPRECATED - Do not use (for waterfall, range-area, range-bar, OHLC series)
+series: [
+    {
+        type: 'range-area',
+        label: {
+            formatter: ({ itemId, value }) => `${itemId === 'high' ? 'High' : 'Low'}: ${value}`,
+        },
+        styler: ({ itemId }) => {
+            if (itemId === 'high') {
+                return { lineDash: [6, 3] };
+            }
+            return {};
+        },
+    },
+];
+
+// ✅ MODERN - Use this instead
+series: [
+    {
+        type: 'range-area',
+        label: {
+            formatter: ({ itemType, value }) => `${itemType === 'high' ? 'High' : 'Low'}: ${value}`,
+        },
+        styler: ({ itemType }) => {
+            if (itemType === 'high') {
+                return { lineDash: [6, 3] };
+            }
+            return {};
+        },
+    },
+];
+```
+
+**Note:** `itemId` is still valid for legend events and other contexts where it refers to legend item identifiers, not series datum types.
 
 ### Other deprecated patterns to avoid:
 

--- a/tools/prompts/commands/spruce-example/core-rules.md
+++ b/tools/prompts/commands/spruce-example/core-rules.md
@@ -307,13 +307,14 @@ series: [
 ```
 
 **Available `highlightState` values:**
-- `'highlighted-item'`: The directly hovered item
-- `'highlighted-series'`: The series containing the hovered item
-- `'unhighlighted-item'`: Other items not hovered
-- `'unhighlighted-series'`: Other series not containing hovered item
-- `'highlighted-branch'`: For hierarchical series (treemap/sunburst) - nodes sharing same root branch
-- `'unhighlighted-branch'`: For hierarchical series - nodes in different branches
-- `'none'`: Default state
+
+-   `'highlighted-item'`: The directly hovered item
+-   `'highlighted-series'`: The series containing the hovered item
+-   `'unhighlighted-item'`: Other items not hovered
+-   `'unhighlighted-series'`: Other series not containing hovered item
+-   `'highlighted-branch'`: For hierarchical series (treemap/sunburst) - nodes sharing same root branch
+-   `'unhighlighted-branch'`: For hierarchical series - nodes in different branches
+-   `'none'`: Default state
 
 ### ❌ `itemId` → ✅ Use `itemType` for series item classification:
 

--- a/tools/prompts/commands/spruce-example/features/axes.md
+++ b/tools/prompts/commands/spruce-example/features/axes.md
@@ -274,18 +274,21 @@ axes: {
 ```
 
 **Difference from `min`/`max`:**
-- `min`/`max`: Hard bounds that take priority - axis will never go beyond these values
-- `preferredMin`/`preferredMax`: Soft bounds that can be extended by data or `nice` option
+
+-   `min`/`max`: Hard bounds that take priority - axis will never go beyond these values
+-   `preferredMin`/`preferredMax`: Soft bounds that can be extended by data or `nice` option
 
 **When to use `preferredMin`/`preferredMax`:**
-- ✅ When you want a suggested range but allow data to extend beyond it
-- ✅ For axes where you want to start near zero but allow negative values if data has them
-- ✅ When `nice: true` should be able to round beyond your preferred bounds
+
+-   ✅ When you want a suggested range but allow data to extend beyond it
+-   ✅ For axes where you want to start near zero but allow negative values if data has them
+-   ✅ When `nice: true` should be able to round beyond your preferred bounds
 
 **When to use `min`/`max` instead:**
-- ✅ When you need strict bounds that must never be exceeded
-- ✅ For percentage axes that must stay 0-100
-- ✅ When you need guaranteed axis limits regardless of data
+
+-   ✅ When you need strict bounds that must never be exceeded
+-   ✅ For percentage axes that must stay 0-100
+-   ✅ When you need guaranteed axis limits regardless of data
 
 ## 📏 Axis Enhancement
 
@@ -520,19 +523,22 @@ axes: {
 ```
 
 **Wrapping Options:**
-- `'always'`: Always wrap text to fit within `maxWidth`
-- `'hyphenate'`: Similar to `'always'`, but inserts a hyphen (`-`) if forced to wrap mid-word
-- `'on-space'` (default): Only wrap on whitespace. If no space available and `maxWidth` can't be satisfied, text will be truncated
-- `'never'`: Disable text wrapping
+
+-   `'always'`: Always wrap text to fit within `maxWidth`
+-   `'hyphenate'`: Similar to `'always'`, but inserts a hyphen (`-`) if forced to wrap mid-word
+-   `'on-space'` (default): Only wrap on whitespace. If no space available and `maxWidth` can't be satisfied, text will be truncated
+-   `'never'`: Disable text wrapping
 
 **Truncate:**
-- When `truncate: true`, text that exceeds available space will be truncated with an ellipsis (`...`)
-- Works in combination with `wrapping` - if wrapping can't fit the text, truncation applies
+
+-   When `truncate: true`, text that exceeds available space will be truncated with an ellipsis (`...`)
+-   Works in combination with `wrapping` - if wrapping can't fit the text, truncation applies
 
 **Use Cases:**
-- ✅ Long category names that need to fit in limited space
-- ✅ Multi-level grouped categories where labels can be lengthy
-- ✅ Responsive charts where label space varies
+
+-   ✅ Long category names that need to fit in limited space
+-   ✅ Multi-level grouped categories where labels can be lengthy
+-   ✅ Responsive charts where label space varies
 
 ## ⚠️ Special Considerations for Radial/Polar Charts
 

--- a/tools/prompts/commands/spruce-example/features/axes.md
+++ b/tools/prompts/commands/spruce-example/features/axes.md
@@ -255,6 +255,38 @@ axes: {
 -   ✅ When axis labels should be "nice" values (0, 50, 100 vs 0, 47, 94)
 -   ✅ For better readability with clean axis tick values
 
+## 🎯 Preferred Min/Max (Soft Bounds)
+
+_New Nov 2024 • Apply: 3 minutes • Impact: MEDIUM_
+
+```typescript
+axes: {
+    y: {
+        type: 'number', // ⚠️ REQUIRED field
+        position: 'left',
+        preferredMin: 0, // Soft lower bound - can be extended by data or nice
+        preferredMax: 100, // Soft upper bound - can be extended by data or nice
+        // These are "preferred" values that will be used unless:
+        // - Data extends beyond them
+        // - nice: true rounds beyond them
+    },
+}
+```
+
+**Difference from `min`/`max`:**
+- `min`/`max`: Hard bounds that take priority - axis will never go beyond these values
+- `preferredMin`/`preferredMax`: Soft bounds that can be extended by data or `nice` option
+
+**When to use `preferredMin`/`preferredMax`:**
+- ✅ When you want a suggested range but allow data to extend beyond it
+- ✅ For axes where you want to start near zero but allow negative values if data has them
+- ✅ When `nice: true` should be able to round beyond your preferred bounds
+
+**When to use `min`/`max` instead:**
+- ✅ When you need strict bounds that must never be exceeded
+- ✅ For percentage axes that must stay 0-100
+- ✅ When you need guaranteed axis limits regardless of data
+
 ## 📏 Axis Enhancement
 
 _Apply: 10 minutes, Impact: HIGH_
@@ -469,6 +501,38 @@ axes: {
     },
 };
 ```
+
+### 📋 Grouped Category Axis Label Options
+
+_New Nov 2024 • Apply: 4 minutes • Impact: MEDIUM_
+
+```typescript
+axes: {
+    x: {
+        type: 'grouped-category',
+        position: 'bottom',
+        label: {
+            wrapping: 'on-space', // 'always' | 'hyphenate' | 'on-space' | 'never'
+            truncate: true, // Add ellipsis when text is truncated
+        },
+    },
+}
+```
+
+**Wrapping Options:**
+- `'always'`: Always wrap text to fit within `maxWidth`
+- `'hyphenate'`: Similar to `'always'`, but inserts a hyphen (`-`) if forced to wrap mid-word
+- `'on-space'` (default): Only wrap on whitespace. If no space available and `maxWidth` can't be satisfied, text will be truncated
+- `'never'`: Disable text wrapping
+
+**Truncate:**
+- When `truncate: true`, text that exceeds available space will be truncated with an ellipsis (`...`)
+- Works in combination with `wrapping` - if wrapping can't fit the text, truncation applies
+
+**Use Cases:**
+- ✅ Long category names that need to fit in limited space
+- ✅ Multi-level grouped categories where labels can be lengthy
+- ✅ Responsive charts where label space varies
 
 ## ⚠️ Special Considerations for Radial/Polar Charts
 

--- a/tools/prompts/commands/spruce-example/features/recent-features.md
+++ b/tools/prompts/commands/spruce-example/features/recent-features.md
@@ -457,10 +457,11 @@ zoom: {
 ```
 
 **Strategy Options:**
-- `'preserveDomain'` (default): Keep current zoom domain when data changes
-- `'reset'`: Reset zoom to show all data when data changes
-- `'resize'`: Adjust zoom to fit new data range while maintaining zoom level
-- `'preserveData'`: Keep zoom focused on existing data points
+
+-   `'preserveDomain'` (default): Keep current zoom domain when data changes
+-   `'reset'`: Reset zoom to show all data when data changes
+-   `'resize'`: Adjust zoom to fit new data range while maintaining zoom level
+-   `'preserveData'`: Keep zoom focused on existing data points
 
 _Use for_: Live data updates where you want to control how zoom behaves when new data arrives.
 
@@ -476,7 +477,7 @@ series: [
         labelKey: 'name',
         styler: (params) => {
             const { highlightState } = params;
-            
+
             // Differentiate between directly hovered items and branch items
             if (highlightState === 'highlighted-item') {
                 return { strokeWidth: 3 }; // Directly hovered
@@ -494,11 +495,12 @@ series: [
 ```
 
 **Available States:**
-- `'highlighted-item'`: The directly hovered node
-- `'highlighted-branch'`: Nodes sharing the same root branch as the hovered item
-- `'unhighlighted-branch'`: Nodes in different branches
-- `'unhighlighted-item'`: Other items not in the hovered branch
-- `'none'`: Default state
+
+-   `'highlighted-item'`: The directly hovered node
+-   `'highlighted-branch'`: Nodes sharing the same root branch as the hovered item
+-   `'unhighlighted-branch'`: Nodes in different branches
+-   `'unhighlighted-item'`: Other items not in the hovered branch
+-   `'none'`: Default state
 
 _Use for_: Treemap and sunburst charts where you want to highlight related nodes in the same hierarchy branch.
 
@@ -511,26 +513,27 @@ series: [
     {
         type: 'bar',
         xKey: 'category',
-        yKey: 'value',
-        xKeyAxis: 'x', // Default: 'x'
-        yKeyAxis: 'y2', // Bind to secondary y-axis
+        yKey: 'volume',
+        xKeyAxis: 'category', // Default: 'x'
+        yKeyAxis: 'volume', // Bind to volume axis
     },
     {
         type: 'line',
         xKey: 'category',
-        yKey: 'percentage',
-        xKeyAxis: 'x', // Same x-axis
-        yKeyAxis: 'y', // Primary y-axis
+        yKey: 'price',
+        xKeyAxis: 'category', // Same x-axis
+        yKeyAxis: 'price', // Bind to price axis
     },
 ],
 axes: {
-    x: { type: 'category', position: 'bottom' },
-    y: { type: 'number', position: 'left' },
-    y2: { type: 'number', position: 'right' }, // Secondary axis
+    category: { type: 'category', position: 'bottom' },
+    price: { type: 'number', position: 'left' },
+    volume: { type: 'number', position: 'right' }, // Secondary axis
 }
 ```
 
 **Polar Series:**
+
 ```typescript
 series: [
     {
@@ -540,7 +543,7 @@ series: [
         angleKeyAxis: 'angle', // Default: 'angle'
         radiusKeyAxis: 'radius', // Default: 'radius'
     },
-]
+];
 ```
 
 _Use for_: Multi-axis charts where different series need to be bound to different axes, or polar charts with multiple angle/radius axes.

--- a/tools/prompts/commands/spruce-example/features/recent-features.md
+++ b/tools/prompts/commands/spruce-example/features/recent-features.md
@@ -176,9 +176,9 @@ series: [
         type: 'line',
         styler: (params) => {
             // Access series-level properties
-            const { seriesId, seriesName, highlighted } = params;
+            const { seriesId, seriesName, highlightState } = params;
 
-            if (highlighted) {
+            if (highlightState === 'highlighted-series') {
                 return {
                     strokeWidth: 3,
                     // Don't hardcode colors - let theme handle it
@@ -261,15 +261,15 @@ series: [
         xKey: 'date',
         yLowKey: 'low',
         yHighKey: 'high',
-        styler: ({ itemId }) => {
-            if (itemId === 'high') {
+        styler: ({ itemType }) => {
+            if (itemType === 'high') {
                 return { lineDash: [6, 3] };
             }
             return {};
         },
         label: {
             enabled: true,
-            formatter: ({ itemId, value }) => `${itemId === 'high' ? 'High' : 'Low'}: ${value.toFixed(0)}`,
+            formatter: ({ itemType, value }) => `${itemType === 'high' ? 'High' : 'Low'}: ${value.toFixed(0)}`,
         },
         invertedStyle: {
             fillOpacity: 0.35, // Theme picks fill color
@@ -285,7 +285,7 @@ series: [
 ];
 ```
 
-_Takeaway_: Use `styler`, `itemId` aware label callbacks, and `invertedStyle` to emphasise band flips without resorting to manual fills.
+_Takeaway_: Use `styler`, `itemType` aware label callbacks, and `invertedStyle` to emphasise band flips without resorting to manual fills.
 
 ### 🪵 Range Bar Styling Hooks
 
@@ -300,11 +300,11 @@ series: [
         yHighKey: 'finish',
         direction: 'horizontal',
         cornerRadius: 8,
-        styler: ({ highlighted }) => (highlighted ? { strokeWidth: 2 } : {}),
+        styler: ({ highlightState }) => (highlightState === 'highlighted-item' ? { strokeWidth: 2 } : {}),
         label: {
             enabled: true,
             placement: 'outside',
-            formatter: ({ itemId, value }) => `${itemId === 'high' ? 'Finish' : 'Start'}: ${value}`,
+            formatter: ({ itemType, value }) => `${itemType === 'high' ? 'Finish' : 'Start'}: ${value}`,
         },
     },
 ];
@@ -322,7 +322,7 @@ series: [
         type: 'box-plot',
         xKey: 'group',
         yNameKey: 'label',
-        styler: ({ highlighted }) => (highlighted ? { strokeWidth: 3 } : {}),
+        styler: ({ highlightState }) => (highlightState === 'highlighted-item' ? { strokeWidth: 3 } : {}),
         cap: { strokeWidth: 2 },
         whisker: { strokeWidth: 1 },
         legendItemName: 'Distribution',
@@ -362,7 +362,7 @@ series: [
         type: 'radar-line',
         angleKey: 'metric',
         radiusKey: 'score',
-        styler: ({ highlighted }) => (highlighted ? { strokeWidth: 4 } : {}),
+        styler: ({ highlightState }) => (highlightState === 'highlighted-item' ? { strokeWidth: 4 } : {}),
         highlight: {
             series: {
                 item: { strokeWidth: 3 },
@@ -442,6 +442,108 @@ const chart = AgCharts.createFinancialChart({
 ```
 
 _Best for_: Tailoring toolbars to analyst workflows (earnings windows, YTD, custom presets).
+
+### 🔄 Zoom Data Change Strategy
+
+_New Nov 2024 • Apply: 3 minutes • Impact: MEDIUM_
+
+```typescript
+zoom: {
+    enabled: true,
+    onDataChange: {
+        strategy: 'preserveDomain', // 'preserveDomain' | 'reset' | 'resize' | 'preserveData'
+    },
+}
+```
+
+**Strategy Options:**
+- `'preserveDomain'` (default): Keep current zoom domain when data changes
+- `'reset'`: Reset zoom to show all data when data changes
+- `'resize'`: Adjust zoom to fit new data range while maintaining zoom level
+- `'preserveData'`: Keep zoom focused on existing data points
+
+_Use for_: Live data updates where you want to control how zoom behaves when new data arrives.
+
+### 🌳 Hierarchy Highlight States
+
+_New Nov 2024 • Apply: 5 minutes • Impact: MEDIUM_
+
+```typescript
+series: [
+    {
+        type: 'treemap',
+        sizeKey: 'value',
+        labelKey: 'name',
+        styler: (params) => {
+            const { highlightState } = params;
+            
+            // Differentiate between directly hovered items and branch items
+            if (highlightState === 'highlighted-item') {
+                return { strokeWidth: 3 }; // Directly hovered
+            }
+            if (highlightState === 'highlighted-branch') {
+                return { strokeWidth: 2, opacity: 0.8 }; // Same branch
+            }
+            if (highlightState === 'unhighlighted-branch') {
+                return { opacity: 0.3 }; // Different branch
+            }
+            return {};
+        },
+    },
+];
+```
+
+**Available States:**
+- `'highlighted-item'`: The directly hovered node
+- `'highlighted-branch'`: Nodes sharing the same root branch as the hovered item
+- `'unhighlighted-branch'`: Nodes in different branches
+- `'unhighlighted-item'`: Other items not in the hovered branch
+- `'none'`: Default state
+
+_Use for_: Treemap and sunburst charts where you want to highlight related nodes in the same hierarchy branch.
+
+### 📊 Series Axis Binding
+
+_New Nov 2024 • Apply: 4 minutes • Impact: MEDIUM_
+
+```typescript
+series: [
+    {
+        type: 'bar',
+        xKey: 'category',
+        yKey: 'value',
+        xKeyAxis: 'x', // Default: 'x'
+        yKeyAxis: 'y2', // Bind to secondary y-axis
+    },
+    {
+        type: 'line',
+        xKey: 'category',
+        yKey: 'percentage',
+        xKeyAxis: 'x', // Same x-axis
+        yKeyAxis: 'y', // Primary y-axis
+    },
+],
+axes: {
+    x: { type: 'category', position: 'bottom' },
+    y: { type: 'number', position: 'left' },
+    y2: { type: 'number', position: 'right' }, // Secondary axis
+}
+```
+
+**Polar Series:**
+```typescript
+series: [
+    {
+        type: 'pie',
+        angleKey: 'category',
+        valueKey: 'value',
+        angleKeyAxis: 'angle', // Default: 'angle'
+        radiusKeyAxis: 'radius', // Default: 'radius'
+    },
+]
+```
+
+_Use for_: Multi-axis charts where different series need to be bound to different axes, or polar charts with multiple angle/radius axes.
 
 ## 🆕 Recently Added Features (Past 6 Months)
 

--- a/tools/prompts/commands/spruce-example/features/tooltips.md
+++ b/tools/prompts/commands/spruce-example/features/tooltips.md
@@ -260,6 +260,59 @@ const options: AgChartOptions = {
 };
 ```
 
+## 🎨 Tooltip Symbol Customization
+
+_New Nov 2024 • Apply: 5 minutes • Impact: MEDIUM_
+
+Customize the marker and line symbols shown in tooltips for better visual distinction:
+
+```typescript
+tooltip: {
+    renderer: (params) => {
+        return {
+            heading: params.datum.category,
+            title: params.yName || 'Series',
+            symbol: {
+                marker: {
+                    enabled: true,
+                    shape: 'circle', // 'circle' | 'square' | 'diamond' | 'plus' | 'cross' | 'triangle'
+                    // Don't set fill/stroke - theme handles colors
+                },
+                line: {
+                    enabled: true,
+                    strokeWidth: 2,
+                    lineDash: [4, 2], // Optional dashed line
+                    // Don't set stroke - theme handles colors
+                },
+            },
+            data: [
+                { label: 'Value', value: params.value },
+            ],
+        };
+    },
+}
+```
+
+**Symbol Options:**
+- `marker`: Configure the marker symbol shown next to series name
+  - `enabled`: Toggle marker visibility
+  - `shape`: Marker shape (circle, square, diamond, plus, cross, triangle, or custom function)
+- `line`: Configure the line symbol shown for line/area series
+  - `enabled`: Toggle line visibility
+  - `strokeWidth`: Line thickness
+  - `lineDash`: Optional dash pattern
+
+**Use Cases:**
+- ✅ Differentiate series visually in shared tooltips
+- ✅ Match tooltip symbols to series marker styles
+- ✅ Create consistent visual language between chart and tooltip
+- ✅ Improve accessibility by providing visual cues alongside text
+
+**Theme Compatibility:**
+- Colors are automatically handled by the theme
+- Works seamlessly in light/dark modes
+- Don't hardcode fill/stroke colors - let theme manage them
+
 ## Pro Tip for Complex Data
 
 When dealing with grouped data (like player wins/losses), the shared tooltip automatically groups all series at the same x-position, making it perfect for comparative analysis. This is why examples like `stacked-horizontal-bar` are so effective - users can instantly see all three players' performance for any given year.

--- a/tools/prompts/commands/spruce-example/features/tooltips.md
+++ b/tools/prompts/commands/spruce-example/features/tooltips.md
@@ -294,24 +294,27 @@ tooltip: {
 ```
 
 **Symbol Options:**
-- `marker`: Configure the marker symbol shown next to series name
-  - `enabled`: Toggle marker visibility
-  - `shape`: Marker shape (circle, square, diamond, plus, cross, triangle, or custom function)
-- `line`: Configure the line symbol shown for line/area series
-  - `enabled`: Toggle line visibility
-  - `strokeWidth`: Line thickness
-  - `lineDash`: Optional dash pattern
+
+-   `marker`: Configure the marker symbol shown next to series name
+    -   `enabled`: Toggle marker visibility
+    -   `shape`: Marker shape (circle, square, diamond, plus, cross, triangle, or custom function)
+-   `line`: Configure the line symbol shown for line/area series
+    -   `enabled`: Toggle line visibility
+    -   `strokeWidth`: Line thickness
+    -   `lineDash`: Optional dash pattern
 
 **Use Cases:**
-- ✅ Differentiate series visually in shared tooltips
-- ✅ Match tooltip symbols to series marker styles
-- ✅ Create consistent visual language between chart and tooltip
-- ✅ Improve accessibility by providing visual cues alongside text
+
+-   ✅ Differentiate series visually in shared tooltips
+-   ✅ Match tooltip symbols to series marker styles
+-   ✅ Create consistent visual language between chart and tooltip
+-   ✅ Improve accessibility by providing visual cues alongside text
 
 **Theme Compatibility:**
-- Colors are automatically handled by the theme
-- Works seamlessly in light/dark modes
-- Don't hardcode fill/stroke colors - let theme manage them
+
+-   Colors are automatically handled by the theme
+-   Works seamlessly in light/dark modes
+-   Don't hardcode fill/stroke colors - let theme manage them
 
 ## Pro Tip for Complex Data
 

--- a/tools/prompts/guides/examples.md
+++ b/tools/prompts/guides/examples.md
@@ -42,6 +42,64 @@ Example paths are mapped from repo paths:
 -   If a TData type is useful for the example, `data.ts` should also declare this.
 -   For deeper architectural context, see the main AGENTS.md file for Documentation Resources.
 
+## Module Registration
+
+_New Nov 2024 • Required for all examples_
+
+Examples must explicitly register the modules they use. This ensures proper tree-shaking and module loading:
+
+```typescript
+import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AnimationModule, BandHighlightModule } from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+// Register all required modules BEFORE creating the chart
+ModuleRegistry.registerModules([
+    AnimationModule,
+    BandHighlightModule,
+    BarSeriesModule,
+    CategoryAxisModule,
+    NumberAxisModule,
+]);
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    // ... rest of options
+};
+
+const chart = AgCharts.create(options);
+```
+
+**Common Modules:**
+
+**From `ag-charts-community`:**
+- `BarSeriesModule`, `LineSeriesModule`, `AreaSeriesModule`, `ScatterSeriesModule`
+- `CategoryAxisModule`, `NumberAxisModule`, `TimeAxisModule`
+- `PieSeriesModule`, `DonutSeriesModule`, `RadarSeriesModule`
+- `ChartModule` (if using standalone chart types)
+
+**From `ag-charts-enterprise`:**
+- `AnimationModule` (for animations)
+- `BandHighlightModule` (for axis band highlighting)
+- `ZoomModule` (for zoom functionality)
+- `NavigatorModule` (for navigator mini-chart)
+- Enterprise series modules (e.g., `WaterfallSeriesModule`, `BoxPlotSeriesModule`)
+
+**Best Practices:**
+- ✅ Register modules at the top of `main.ts`, before chart creation
+- ✅ Only import and register modules actually used by the example
+- ✅ Group community and enterprise imports separately for clarity
+- ✅ Use specific series/axis modules rather than importing everything
+
+**Why This Matters:**
+- Enables proper tree-shaking in production builds
+- Ensures modules are loaded before chart creation
+- Prevents runtime errors from missing module registrations
+- Improves bundle size by only including used modules
+
 ## Framework Generation
 
 Examples written in vanilla TypeScript are automatically transformed into React, Angular, and Vue variants. Understanding how this transformation works is essential for creating examples that work across all frameworks.

--- a/tools/prompts/guides/examples.md
+++ b/tools/prompts/guides/examples.md
@@ -76,29 +76,33 @@ const chart = AgCharts.create(options);
 **Common Modules:**
 
 **From `ag-charts-community`:**
-- `BarSeriesModule`, `LineSeriesModule`, `AreaSeriesModule`, `ScatterSeriesModule`
-- `CategoryAxisModule`, `NumberAxisModule`, `TimeAxisModule`
-- `PieSeriesModule`, `DonutSeriesModule`, `RadarSeriesModule`
-- `ChartModule` (if using standalone chart types)
+
+-   `BarSeriesModule`, `LineSeriesModule`, `AreaSeriesModule`, `ScatterSeriesModule`
+-   `CategoryAxisModule`, `NumberAxisModule`, `TimeAxisModule`
+-   `PieSeriesModule`, `DonutSeriesModule`, `RadarSeriesModule`
+-   `ChartModule` (if using standalone chart types)
 
 **From `ag-charts-enterprise`:**
-- `AnimationModule` (for animations)
-- `BandHighlightModule` (for axis band highlighting)
-- `ZoomModule` (for zoom functionality)
-- `NavigatorModule` (for navigator mini-chart)
-- Enterprise series modules (e.g., `WaterfallSeriesModule`, `BoxPlotSeriesModule`)
+
+-   `AnimationModule` (for animations)
+-   `BandHighlightModule` (for axis band highlighting)
+-   `ZoomModule` (for zoom functionality)
+-   `NavigatorModule` (for navigator mini-chart)
+-   Enterprise series modules (e.g., `WaterfallSeriesModule`, `BoxPlotSeriesModule`)
 
 **Best Practices:**
-- ✅ Register modules at the top of `main.ts`, before chart creation
-- ✅ Only import and register modules actually used by the example
-- ✅ Group community and enterprise imports separately for clarity
-- ✅ Use specific series/axis modules rather than importing everything
+
+-   ✅ Register modules at the top of `main.ts`, before chart creation
+-   ✅ Only import and register modules actually used by the example
+-   ✅ Group community and enterprise imports separately for clarity
+-   ✅ Use specific series/axis modules rather than importing everything
 
 **Why This Matters:**
-- Enables proper tree-shaking in production builds
-- Ensures modules are loaded before chart creation
-- Prevents runtime errors from missing module registrations
-- Improves bundle size by only including used modules
+
+-   Enables proper tree-shaking in production builds
+-   Ensures modules are loaded before chart creation
+-   Prevents runtime errors from missing module registrations
+-   Improves bundle size by only including used modules
 
 ## Framework Generation
 


### PR DESCRIPTION
## Summary

Updates the `/spruce-example` command and related guides to reflect API changes made since b12.3.1:

### Key Changes

1. **`itemId` → `itemType`**: Updated all series callback examples (waterfall, range-area, range-bar, OHLC) to use the new `itemType` parameter instead of deprecated `itemId`
2. **`highlighted` → `highlightState`**: Updated all styler examples to use `highlightState` string instead of deprecated `highlighted` boolean
3. **New axis options**: Added documentation for `preferredMin`/`preferredMax` (soft bounds) and grouped-category axis `wrapping`/`truncate` options
4. **Tooltip symbol customization**: Added new section documenting `symbol` option with `marker` and `line` configuration
5. **Module registration**: Added section to examples guide documenting the new `ModuleRegistry.registerModules()` pattern required for all examples
6. **New features**: Added documentation for zoom `onDataChange` strategy, hierarchy highlight states, and series axis binding

### Files Updated

- `tools/prompts/commands/spruce-example/features/recent-features.md`
- `tools/prompts/commands/spruce-example/features/axes.md`
- `tools/prompts/commands/spruce-example/features/tooltips.md`
- `tools/prompts/commands/spruce-example/core-rules.md`
- `tools/prompts/guides/examples.md`

All changes maintain backward compatibility notes where appropriate and include code examples showing the correct modern patterns.