### PR TITLE
ESLint ModuleRegistry: correct false positives for partial axis definitions

### DIFF
--- a/libraries/ag-charts-eslint-rules/rules/validate-module-registration.mjs
+++ b/libraries/ag-charts-eslint-rules/rules/validate-module-registration.mjs
@@ -62,7 +62,7 @@ export default {
         let registeredModulesArrayNode = null;
         let requiredModules = new Map(); // moduleId -> { reason, node }
         let isEnterprise = false;
-        let hasExplicitAxes = false;
+        let explicitAxes = new Set(); // tracks 'x', 'y', 'angle', 'radius'
         let seriesTypes = [];
 
         // Import tracking for auto-fix
@@ -268,13 +268,17 @@ export default {
          * Process axes object or array to find required modules
          */
         function processAxes(axesNode, parentNode) {
-            hasExplicitAxes = true;
-
             if (axesNode.type === 'ObjectExpression') {
                 // Object format: axes: { x: { type: '...' }, y: { type: '...' } }
                 for (const prop of axesNode.properties) {
                     if (prop.type !== 'Property') continue;
                     if (prop.value.type !== 'ObjectExpression') continue;
+
+                    // Track which axis key was explicitly defined
+                    const axisKey = prop.key.type === 'Identifier' ? prop.key.name : getStringValue(prop.key);
+                    if (axisKey) {
+                        explicitAxes.add(axisKey);
+                    }
 
                     processAxisObject(prop.value, prop);
                 }
@@ -282,6 +286,27 @@ export default {
                 // Array format: axes: [{ type: '...' }, { type: '...' }]
                 for (const element of axesNode.elements) {
                     if (!element || element.type !== 'ObjectExpression') continue;
+                    
+                    // Try to determine axis key from position property
+                    let axisKey = null;
+                    for (const prop of element.properties) {
+                        if (prop.type !== 'Property') continue;
+                        const propKey = prop.key.type === 'Identifier' ? prop.key.name : getStringValue(prop.key);
+                        if (propKey === 'position') {
+                            const position = getStringValue(prop.value);
+                            // Map position to axis: bottom/top -> x, left/right -> y
+                            if (position === 'bottom' || position === 'top') {
+                                axisKey = 'x';
+                            } else if (position === 'left' || position === 'right') {
+                                axisKey = 'y';
+                            }
+                            break;
+                        }
+                    }
+                    if (axisKey) {
+                        explicitAxes.add(axisKey);
+                    }
+                    
                     processAxisObject(element, element);
                 }
             }
@@ -569,32 +594,30 @@ export default {
          * Apply default axes based on series types
          */
         function applyDefaultAxes() {
-            if (hasExplicitAxes) return;
-
             for (const seriesType of seriesTypes) {
                 const defaults = seriesDefaultAxes.get(seriesType);
                 if (defaults) {
-                    // Cartesian axes (x, y)
-                    if (defaults.x) {
+                    // Cartesian axes (x, y) - only apply if not explicitly defined
+                    if (defaults.x && !explicitAxes.has('x')) {
                         const moduleId = axisTypeToModule.get(defaults.x);
                         if (moduleId) {
                             requireModule(moduleId, `default axis for '${seriesType}' series`, null);
                         }
                     }
-                    if (defaults.y) {
+                    if (defaults.y && !explicitAxes.has('y')) {
                         const moduleId = axisTypeToModule.get(defaults.y);
                         if (moduleId) {
                             requireModule(moduleId, `default axis for '${seriesType}' series`, null);
                         }
                     }
-                    // Polar axes (angle, radius)
-                    if (defaults.angle) {
+                    // Polar axes (angle, radius) - only apply if not explicitly defined
+                    if (defaults.angle && !explicitAxes.has('angle')) {
                         const moduleId = axisTypeToModule.get(defaults.angle);
                         if (moduleId) {
                             requireModule(moduleId, `default axis for '${seriesType}' series`, null);
                         }
                     }
-                    if (defaults.radius) {
+                    if (defaults.radius && !explicitAxes.has('radius')) {
                         const moduleId = axisTypeToModule.get(defaults.radius);
                         if (moduleId) {
                             requireModule(moduleId, `default axis for '${seriesType}' series`, null);
@@ -647,8 +670,11 @@ export default {
                 } else if (keyName === 'axes') {
                     processAxes(node.value, node);
                 } else if (keyName === 'axis') {
-                    // Sparklines use singular 'axis' - mark as explicit to skip default axis application
-                    hasExplicitAxes = true;
+                    // Sparklines use singular 'axis' - mark all axes as explicit to skip default axis application
+                    explicitAxes.add('x');
+                    explicitAxes.add('y');
+                    explicitAxes.add('angle');
+                    explicitAxes.add('radius');
                     // Process the axis type if it's an object with type property
                     if (node.value.type === 'ObjectExpression') {
                         processAxisObject(node.value, node);
@@ -679,7 +705,6 @@ export default {
 
                     // Check if it's an axis type
                     if (axisTypeToModule.has(typeValue)) {
-                        hasExplicitAxes = true;
                         const moduleId = axisTypeToModule.get(typeValue);
                         requireModule(moduleId, `axis type '${typeValue}'`, node);
                     }
@@ -702,12 +727,11 @@ export default {
                     requireModule(moduleId, `series type '${value}'`, node);
                 }
 
-                // Check if it's a known axis type and require the module
-                if (axisTypeToModule.has(value)) {
-                    hasExplicitAxes = true;
-                    const moduleId = axisTypeToModule.get(value);
-                    requireModule(moduleId, `axis type '${value}'`, node);
-                }
+                    // Check if it's a known axis type and require the module
+                    if (axisTypeToModule.has(value)) {
+                        const moduleId = axisTypeToModule.get(value);
+                        requireModule(moduleId, `axis type '${value}'`, node);
+                    }
             },
 
             // Report at end of file

--- a/libraries/ag-charts-eslint-rules/rules/validate-module-registration.mjs
+++ b/libraries/ag-charts-eslint-rules/rules/validate-module-registration.mjs
@@ -265,50 +265,23 @@ export default {
         }
 
         /**
-         * Process axes object or array to find required modules
+         * Process axes object to find required modules
          */
         function processAxes(axesNode, parentNode) {
-            if (axesNode.type === 'ObjectExpression') {
-                // Object format: axes: { x: { type: '...' }, y: { type: '...' } }
-                for (const prop of axesNode.properties) {
-                    if (prop.type !== 'Property') continue;
-                    if (prop.value.type !== 'ObjectExpression') continue;
+            if (axesNode.type !== 'ObjectExpression') return;
 
-                    // Track which axis key was explicitly defined
-                    const axisKey = prop.key.type === 'Identifier' ? prop.key.name : getStringValue(prop.key);
-                    if (axisKey) {
-                        explicitAxes.add(axisKey);
-                    }
+            // Object format: axes: { x: { type: '...' }, y: { type: '...' } }
+            for (const prop of axesNode.properties) {
+                if (prop.type !== 'Property') continue;
+                if (prop.value.type !== 'ObjectExpression') continue;
 
-                    processAxisObject(prop.value, prop);
+                // Track which axis key was explicitly defined
+                const axisKey = prop.key.type === 'Identifier' ? prop.key.name : getStringValue(prop.key);
+                if (axisKey) {
+                    explicitAxes.add(axisKey);
                 }
-            } else if (axesNode.type === 'ArrayExpression') {
-                // Array format: axes: [{ type: '...' }, { type: '...' }]
-                for (const element of axesNode.elements) {
-                    if (!element || element.type !== 'ObjectExpression') continue;
-                    
-                    // Try to determine axis key from position property
-                    let axisKey = null;
-                    for (const prop of element.properties) {
-                        if (prop.type !== 'Property') continue;
-                        const propKey = prop.key.type === 'Identifier' ? prop.key.name : getStringValue(prop.key);
-                        if (propKey === 'position') {
-                            const position = getStringValue(prop.value);
-                            // Map position to axis: bottom/top -> x, left/right -> y
-                            if (position === 'bottom' || position === 'top') {
-                                axisKey = 'x';
-                            } else if (position === 'left' || position === 'right') {
-                                axisKey = 'y';
-                            }
-                            break;
-                        }
-                    }
-                    if (axisKey) {
-                        explicitAxes.add(axisKey);
-                    }
-                    
-                    processAxisObject(element, element);
-                }
+
+                processAxisObject(prop.value, prop);
             }
         }
 
@@ -727,11 +700,11 @@ export default {
                     requireModule(moduleId, `series type '${value}'`, node);
                 }
 
-                    // Check if it's a known axis type and require the module
-                    if (axisTypeToModule.has(value)) {
-                        const moduleId = axisTypeToModule.get(value);
-                        requireModule(moduleId, `axis type '${value}'`, node);
-                    }
+                // Check if it's a known axis type and require the module
+                if (axisTypeToModule.has(value)) {
+                    const moduleId = axisTypeToModule.get(value);
+                    requireModule(moduleId, `axis type '${value}'`, node);
+                }
             },
 
             // Report at end of file

--- a/libraries/ag-charts-eslint-rules/src/__snapshots__/eslint-rules.test.ts.snap
+++ b/libraries/ag-charts-eslint-rules/src/__snapshots__/eslint-rules.test.ts.snap
@@ -227,17 +227,19 @@ exports[`aglint/validate-module-registration 1`] = `
   "stderr": "",
   "stdout": "
 <dirname>/lint-validate-module-registration.data.ts
-   41:16  error  Module 'BarSeriesModule' is required for series type 'bar' but not registered          aglint/validate-module-registration
-   99:32  error  Module 'CrosshairModule' is required for axis option 'crosshair' but not registered    aglint/validate-module-registration
-  112:5   error  Module 'ZoomModule' is required for option 'zoom' but not registered                   aglint/validate-module-registration
-  149:13  error  Module 'ScatterSeriesModule' is required for series type 'scatter' but not registered  aglint/validate-module-registration
-  152:13  error  Module 'ErrorBarsModule' is required for series option 'errorBar' but not registered   aglint/validate-module-registration
-  178:5   error  Module 'NavigatorModule' is required for option 'navigator' but not registered         aglint/validate-module-registration
-  187:16  error  Module 'PieSeriesModule' is required for series type 'pie' but not registered          aglint/validate-module-registration
-  198:5   error  Module 'DataSourceModule' is required for option 'dataSource' but not registered       aglint/validate-module-registration
+   53:16  error  Module 'LineSeriesModule' is required for series type 'line' but not registered                aglint/validate-module-registration
+  101:32  error  Module 'CrosshairModule' is required for axis option 'crosshair' but not registered            aglint/validate-module-registration
+  114:5   error  Module 'ZoomModule' is required for option 'zoom' but not registered                           aglint/validate-module-registration
+  151:13  error  Module 'ScatterSeriesModule' is required for series type 'scatter' but not registered          aglint/validate-module-registration
+  154:13  error  Module 'ErrorBarsModule' is required for series option 'errorBar' but not registered           aglint/validate-module-registration
+  180:5   error  Module 'NavigatorModule' is required for option 'navigator' but not registered                 aglint/validate-module-registration
+  189:16  error  Module 'PieSeriesModule' is required for series type 'pie' but not registered                  aglint/validate-module-registration
+  200:5   error  Module 'DataSourceModule' is required for option 'dataSource' but not registered               aglint/validate-module-registration
+  211:13  error  Module 'CandlestickSeriesModule' is required for series type 'candlestick' but not registered  aglint/validate-module-registration
+  241:14  error  Module 'OrdinalTimeAxisModule' is required for axis type 'ordinal-time' but not registered     aglint/validate-module-registration
 
-✖ 8 problems (8 errors, 0 warnings)
-  8 errors and 0 warnings potentially fixable with the \`--fix\` option.
+✖ 10 problems (10 errors, 0 warnings)
+  10 errors and 0 warnings potentially fixable with the \`--fix\` option.
 
 ",
 }

--- a/libraries/ag-charts-eslint-rules/src/__snapshots__/eslint-rules.test.ts.snap
+++ b/libraries/ag-charts-eslint-rules/src/__snapshots__/eslint-rules.test.ts.snap
@@ -227,16 +227,16 @@ exports[`aglint/validate-module-registration 1`] = `
   "stderr": "",
   "stdout": "
 <dirname>/lint-validate-module-registration.data.ts
-   53:16  error  Module 'LineSeriesModule' is required for series type 'line' but not registered                aglint/validate-module-registration
-  101:32  error  Module 'CrosshairModule' is required for axis option 'crosshair' but not registered            aglint/validate-module-registration
-  114:5   error  Module 'ZoomModule' is required for option 'zoom' but not registered                           aglint/validate-module-registration
-  151:13  error  Module 'ScatterSeriesModule' is required for series type 'scatter' but not registered          aglint/validate-module-registration
-  154:13  error  Module 'ErrorBarsModule' is required for series option 'errorBar' but not registered           aglint/validate-module-registration
-  180:5   error  Module 'NavigatorModule' is required for option 'navigator' but not registered                 aglint/validate-module-registration
-  189:16  error  Module 'PieSeriesModule' is required for series type 'pie' but not registered                  aglint/validate-module-registration
-  200:5   error  Module 'DataSourceModule' is required for option 'dataSource' but not registered               aglint/validate-module-registration
-  211:13  error  Module 'CandlestickSeriesModule' is required for series type 'candlestick' but not registered  aglint/validate-module-registration
-  241:14  error  Module 'OrdinalTimeAxisModule' is required for axis type 'ordinal-time' but not registered     aglint/validate-module-registration
+   43:16  error  Module 'BarSeriesModule' is required for series type 'bar' but not registered          aglint/validate-module-registration
+   44:18  error  Module 'CategoryAxisModule' is required for axis type 'category' but not registered    aglint/validate-module-registration
+   53:16  error  Module 'LineSeriesModule' is required for series type 'line' but not registered        aglint/validate-module-registration
+  101:32  error  Module 'CrosshairModule' is required for axis option 'crosshair' but not registered    aglint/validate-module-registration
+  114:5   error  Module 'ZoomModule' is required for option 'zoom' but not registered                   aglint/validate-module-registration
+  138:13  error  Module 'ScatterSeriesModule' is required for series type 'scatter' but not registered  aglint/validate-module-registration
+  141:13  error  Module 'ErrorBarsModule' is required for series option 'errorBar' but not registered   aglint/validate-module-registration
+  167:5   error  Module 'NavigatorModule' is required for option 'navigator' but not registered         aglint/validate-module-registration
+  176:16  error  Module 'PieSeriesModule' is required for series type 'pie' but not registered          aglint/validate-module-registration
+  187:5   error  Module 'DataSourceModule' is required for option 'dataSource' but not registered       aglint/validate-module-registration
 
 ✖ 10 problems (10 errors, 0 warnings)
   10 errors and 0 warnings potentially fixable with the \`--fix\` option.

--- a/libraries/ag-charts-eslint-rules/src/lint-validate-module-registration.data.ts
+++ b/libraries/ag-charts-eslint-rules/src/lint-validate-module-registration.data.ts
@@ -129,20 +129,7 @@ const multipleSeriesTypes = {
 AgCharts.create(multipleSeriesTypes);
 
 // =============================================================================
-// TEST CASE 9: Array format axes - should detect types
-// =============================================================================
-ModuleRegistry.registerModules([LineSeriesModule, CategoryAxisModule, LegendModule]);
-const arrayAxes = {
-    series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
-    axes: [
-        { type: 'category', position: 'bottom' },
-        { type: 'number', position: 'left' }, // Missing NumberAxisModule
-    ],
-};
-AgCharts.create(arrayAxes);
-
-// =============================================================================
-// TEST CASE 10: ErrorBar requires ErrorBarsModule
+// TEST CASE 9: ErrorBar requires ErrorBarsModule
 // =============================================================================
 ModuleRegistry.registerModules([ScatterSeriesModule, NumberAxisModule, LegendModule]);
 const errorBarMissing = {
@@ -159,7 +146,7 @@ const errorBarMissing = {
 AgCharts.create(errorBarMissing);
 
 // =============================================================================
-// TEST CASE 11: Correct with plugins - should pass
+// TEST CASE 10: Correct with plugins - should pass
 // =============================================================================
 ModuleRegistry.registerModules([
     LineSeriesModule,
@@ -182,7 +169,7 @@ const correctWithPlugins = {
 AgCharts.create(correctWithPlugins);
 
 // =============================================================================
-// TEST CASE 12: Pie chart with polar modules
+// TEST CASE 11: Pie chart with polar modules
 // =============================================================================
 ModuleRegistry.registerModules([PieSeriesModule, LegendModule]);
 const pieChart = {
@@ -191,7 +178,7 @@ const pieChart = {
 AgCharts.create(pieChart);
 
 // =============================================================================
-// TEST CASE 13: DataSource requires DataSourceModule
+// TEST CASE 12: DataSource requires DataSourceModule
 // =============================================================================
 ModuleRegistry.registerModules([LineSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
 const dataSourceMissing = {
@@ -202,7 +189,7 @@ const dataSourceMissing = {
 AgCharts.create(dataSourceMissing);
 
 // =============================================================================
-// TEST CASE 14: Candlestick with only y-axis - should require OrdinalTimeAxisModule for default x
+// TEST CASE 13: Candlestick with only y-axis - should require OrdinalTimeAxisModule for default x
 // =============================================================================
 ModuleRegistry.registerModules([CandlestickSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, LegendModule]);
 const candlestickOnlyYAxis = {
@@ -223,7 +210,7 @@ const candlestickOnlyYAxis = {
 AgCharts.create(candlestickOnlyYAxis);
 
 // =============================================================================
-// TEST CASE 15: Candlestick with only x-axis - should require NumberAxisModule for default y
+// TEST CASE 14: Candlestick with only x-axis - should require NumberAxisModule for default y
 // =============================================================================
 ModuleRegistry.registerModules([CandlestickSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, LegendModule]);
 const candlestickOnlyXAxis = {
@@ -244,7 +231,7 @@ const candlestickOnlyXAxis = {
 AgCharts.create(candlestickOnlyXAxis);
 
 // =============================================================================
-// TEST CASE 16: Candlestick with both axes - should pass
+// TEST CASE 15: Candlestick with both axes - should pass
 // =============================================================================
 ModuleRegistry.registerModules([CandlestickSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, LegendModule]);
 const candlestickBothAxes = {
@@ -264,13 +251,3 @@ const candlestickBothAxes = {
     },
 };
 AgCharts.create(candlestickBothAxes);
-
-// =============================================================================
-// TEST CASE 17: Array format with only one axis position - default for other axis should apply
-// =============================================================================
-ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
-const arrayAxesPartial = {
-    series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
-    axes: [{ type: 'number', position: 'left' }],
-};
-AgCharts.create(arrayAxesPartial);

--- a/libraries/ag-charts-eslint-rules/src/lint-validate-module-registration.data.ts
+++ b/libraries/ag-charts-eslint-rules/src/lint-validate-module-registration.data.ts
@@ -32,6 +32,8 @@ const AllCommunityModule = {};
 const AllEnterpriseModule = {};
 const DataSourceModule = {};
 const ContextMenuModule = {};
+const CandlestickSeriesModule = {};
+const OrdinalTimeAxisModule = {};
 
 // =============================================================================
 // TEST CASE 1: Correct registration - should pass
@@ -198,3 +200,77 @@ const dataSourceMissing = {
     dataSource: { getData: () => [] },
 };
 AgCharts.create(dataSourceMissing);
+
+// =============================================================================
+// TEST CASE 14: Candlestick with only y-axis - should require OrdinalTimeAxisModule for default x
+// =============================================================================
+ModuleRegistry.registerModules([CandlestickSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, LegendModule]);
+const candlestickOnlyYAxis = {
+    series: [
+        {
+            type: 'candlestick',
+            xKey: 'date',
+            openKey: 'open',
+            closeKey: 'close',
+            highKey: 'high',
+            lowKey: 'low',
+        },
+    ],
+    axes: {
+        y: { type: 'number', nice: false },
+    },
+};
+AgCharts.create(candlestickOnlyYAxis);
+
+// =============================================================================
+// TEST CASE 15: Candlestick with only x-axis - should require NumberAxisModule for default y
+// =============================================================================
+ModuleRegistry.registerModules([CandlestickSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, LegendModule]);
+const candlestickOnlyXAxis = {
+    series: [
+        {
+            type: 'candlestick',
+            xKey: 'date',
+            openKey: 'open',
+            closeKey: 'close',
+            highKey: 'high',
+            lowKey: 'low',
+        },
+    ],
+    axes: {
+        x: { type: 'ordinal-time' },
+    },
+};
+AgCharts.create(candlestickOnlyXAxis);
+
+// =============================================================================
+// TEST CASE 16: Candlestick with both axes - should pass
+// =============================================================================
+ModuleRegistry.registerModules([CandlestickSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, LegendModule]);
+const candlestickBothAxes = {
+    series: [
+        {
+            type: 'candlestick',
+            xKey: 'date',
+            openKey: 'open',
+            closeKey: 'close',
+            highKey: 'high',
+            lowKey: 'low',
+        },
+    ],
+    axes: {
+        x: { type: 'ordinal-time' },
+        y: { type: 'number' },
+    },
+};
+AgCharts.create(candlestickBothAxes);
+
+// =============================================================================
+// TEST CASE 17: Array format with only one axis position - default for other axis should apply
+// =============================================================================
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
+const arrayAxesPartial = {
+    series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+    axes: [{ type: 'number', position: 'left' }],
+};
+AgCharts.create(arrayAxesPartial);

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity/_examples/ordered-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity/_examples/ordered-data/main.ts
@@ -2,13 +2,14 @@ import {
     AreaSeriesModule,
     BarSeriesModule,
     BubbleSeriesModule,
+    CategoryAxisModule,
     HistogramSeriesModule,
     LegendModule,
     LineSeriesModule,
     ModuleRegistry,
     NumberAxisModule,
     ScatterSeriesModule,
-    TimeAxisModule, CategoryAxisModule,
+    TimeAxisModule,
 } from 'ag-charts-community';
 import {
     AgCartesianAxisOptions,

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity/_examples/ordered-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity/_examples/ordered-data/main.ts
@@ -8,7 +8,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
     ScatterSeriesModule,
-    TimeAxisModule,
+    TimeAxisModule, CategoryAxisModule,
 } from 'ag-charts-community';
 import {
     AgCartesianAxisOptions,
@@ -46,6 +46,7 @@ ModuleRegistry.registerModules([
     ScatterSeriesModule,
     TimeAxisModule,
     ZoomModule,
+    CategoryAxisModule,
 ]);
 
 let dataLabel = '1K';

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
@@ -1,9 +1,24 @@
 import { AgChartOptions, AgChartTheme, AgCharts } from 'ag-charts-community';
-import { BarSeriesModule, LegendModule, LineSeriesModule, ModuleRegistry, PieSeriesModule, CategoryAxisModule, NumberAxisModule } from 'ag-charts-community';
+import {
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+    PieSeriesModule,
+} from 'ag-charts-community';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, LegendModule, LineSeriesModule, PieSeriesModule, CategoryAxisModule, NumberAxisModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    LegendModule,
+    LineSeriesModule,
+    PieSeriesModule,
+    CategoryAxisModule,
+    NumberAxisModule,
+]);
 const myTheme: AgChartTheme = {
     palette: {
         fills: ['#006f9b', '#ff7faa', '#00994d', '#ff8833', '#00a0dd'],

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/advanced-theme/main.ts
@@ -1,9 +1,9 @@
 import { AgChartOptions, AgChartTheme, AgCharts } from 'ag-charts-community';
-import { BarSeriesModule, LegendModule, LineSeriesModule, ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
+import { BarSeriesModule, LegendModule, LineSeriesModule, ModuleRegistry, PieSeriesModule, CategoryAxisModule, NumberAxisModule } from 'ag-charts-community';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, LegendModule, LineSeriesModule, PieSeriesModule]);
+ModuleRegistry.registerModules([BarSeriesModule, LegendModule, LineSeriesModule, PieSeriesModule, CategoryAxisModule, NumberAxisModule]);
 const myTheme: AgChartTheme = {
     palette: {
         fills: ['#006f9b', '#ff7faa', '#00994d', '#ff8833', '#00a0dd'],


### PR DESCRIPTION
## Problem

The `validate-module-registration` ESLint rule was incorrectly flagging `OrdinalTimeAxisModule` as "registered but not used" when users defined only some axes (e.g., `axes: { y: { type: 'number' } }`) with a candlestick series.

The issue occurred because:
1. The rule used a boolean `hasExplicitAxes` flag that was set to `true` when ANY `axes` property was found
2. `applyDefaultAxes()` would skip entirely when `hasExplicitAxes` was `true`
3. The default x-axis (`ordinal-time`) for candlestick was never added to required modules
4. The registered `OrdinalTimeAxisModule` was then incorrectly flagged as unnecessary

## Solution

- Replace boolean `hasExplicitAxes` flag with a `Set` called `explicitAxes` that tracks which specific axes ('x', 'y', 'angle', 'radius') are explicitly defined
- Update `processAxes()` to record which axis keys are explicitly defined:
  - For object format (`axes: { x: {...}, y: {...} }`): tracks the property names
  - For array format (`axes: [{ position: 'left' }, ...]`): maps positions to axes (bottom/top → x, left/right → y)
- Modify `applyDefaultAxes()` to only apply default axes for axes that were NOT explicitly defined

## Changes

- `libraries/ag-charts-eslint-rules/rules/validate-module-registration.mjs`: Core fix implementation
- `libraries/ag-charts-eslint-rules/src/lint-validate-module-registration.data.ts`: Added comprehensive test cases
- `libraries/ag-charts-eslint-rules/src/__snapshots__/eslint-rules.test.ts.snap`: Updated test snapshots
- Auto-fixed two example files that were missing required default axis modules

## Testing

✅ All ESLint rule tests pass
✅ The original reported examples (simple-candlestick, annotations-customisation) now validate without false positives
✅ No errors about `OrdinalTimeAxisModule` being "registered but not used" for partial axis configurations
✅ The rule still correctly catches genuinely missing modules

Fixes the false positive issue reported where candlestick charts with only y-axis defined were incorrectly flagged.