### PR TITLE
Update module imports in docs and gallery examples

### DIFF
--- a/libraries/ag-charts-eslint-rules/rules/module-mappings.mjs
+++ b/libraries/ag-charts-eslint-rules/rules/module-mappings.mjs
@@ -457,9 +457,9 @@ export const bundleContents = new Map([
 // Intrinsic defaults - modules that are expected without explicit options
 export const intrinsicDefaults = {
     // Always expected for any chart
-    always: ['LegendModule'],
+    always: ['LegendModule', 'GradientLegendModule'],
     // Expected when using enterprise features (commonly included for interactivity)
-    enterprise: ['AnimationModule', 'ContextMenuModule', 'CrosshairModule', 'ZoomModule'],
+    enterprise: ['AnimationModule', 'ContextMenuModule', 'CrosshairModule'],
     // Expected for cartesian charts (axis modules)
     cartesian: ['CategoryAxisModule', 'NumberAxisModule', 'TimeAxisModule', 'LogAxisModule'],
     // Expected for polar charts (axis modules)

--- a/packages/ag-charts-website/src/content/docs/accessibility-test/_examples/AG-13668-panToBBox/main.ts
+++ b/packages/ag-charts-website/src/content/docs/accessibility-test/_examples/AG-13668-panToBBox/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/accessibility-test/_examples/keyboard-navigation-with-highlight/main.ts
+++ b/packages/ag-charts-website/src/content/docs/accessibility-test/_examples/keyboard-navigation-with-highlight/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/accessibility-test/_examples/opening-context-menu-second-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/accessibility-test/_examples/opening-context-menu-second-chart/main.ts
@@ -6,8 +6,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ContextMenuModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, data1, data2 } from './data';
 
@@ -19,7 +24,6 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
 ]);
 
 const action = () => console.log('Hello world!');

--- a/packages/ag-charts-website/src/content/docs/accessibility/_examples/keyboard-navigation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/accessibility/_examples/keyboard-navigation/main.ts
@@ -5,7 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -16,7 +22,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/data-updates/main.ts
@@ -14,10 +14,10 @@ import {
     AgChartOptions,
     AgCharts,
     AgPolarChartOptions,
+    AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
-import { AnimationModule } from 'ag-charts-enterprise';
 
 import { getData, random } from './data';
 
@@ -34,7 +34,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     PieSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 let start = [120, 150, 130, 140, 80];
 let variance = 20;

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/duration/main.ts
@@ -16,10 +16,10 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AgTooltipRendererResult,
+    AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
-import { AnimationModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -34,7 +34,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     PieSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const numFormatter = new Intl.NumberFormat('en-US');
 const tooltip = {

--- a/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
+++ b/packages/ag-charts-website/src/content/docs/animation/_examples/initial-load/main.ts
@@ -16,10 +16,10 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AgTooltipRendererResult,
+    AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
-import { AnimationModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -34,7 +34,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     PieSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const numFormatter = new Intl.NumberFormat('en-US');
 const tooltip = {

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/category-y-axis/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/category-y-axis/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/grouped-category-axis/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/grouped-category-axis/main.ts
@@ -1,5 +1,5 @@
 import { AgMarkerShapeFnParams } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/initial-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/initial-state/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/log-y-axis/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/log-y-axis/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/multiple-axes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/multiple-axes/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/multiple-left-axes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/multiple-left-axes/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/right-y-axis/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/right-y-axis/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-area/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-bar/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-candlestick/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-candlestick/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnnotationsModule, CrosshairModule } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule, OrdinalTimeAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnnotationsModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+    OrdinalTimeAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +18,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     OrdinalTimeAxisModule,
+    ContextMenuModule,
 ]);
 
 const options: AgChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-histogram/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-histogram/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-line/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-scatter/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/simple-scatter/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { femaleHeightWeight, maleHeightWeight } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations-test/_examples/time-axis/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations-test/_examples/time-axis/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/annotations/_examples/annotations-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations/_examples/annotations-customisation/main.ts
@@ -1,6 +1,15 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { AnnotationsModule, CandlestickSeriesModule, OrdinalTimeAxisModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    AnnotationsModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+    OrdinalTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -13,6 +22,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     OrdinalTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/annotations/_examples/annotations-toolbar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations/_examples/annotations-toolbar/main.ts
@@ -5,8 +5,15 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AnnotationsModule, ChartToolbarModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    AnnotationsModule,
+    ChartToolbarModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -19,7 +26,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/annotations/_examples/simple-annotations/main.ts
+++ b/packages/ag-charts-website/src/content/docs/annotations/_examples/simple-annotations/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AnnotationsModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    AnnotationsModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/api-state-test/_examples/initial-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-state-test/_examples/initial-state/main.ts
@@ -1,4 +1,4 @@
-import { AgChartState, AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
+import { AgChartState, AgCharts, AgFinancialChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/api-state-test/_examples/legend-zoom-e2e/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-state-test/_examples/legend-zoom-e2e/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgChartState, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgChartState, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/api-state/_examples/initial-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-state/_examples/initial-state/main.ts
@@ -10,9 +10,11 @@ import {
     AgCartesianSeriesTooltipRendererParams,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -25,6 +27,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const data = getData();
 

--- a/packages/ag-charts-website/src/content/docs/api-state/_examples/legend-state-save-restore/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-state/_examples/legend-state-save-restore/main.ts
@@ -11,9 +11,11 @@ import {
     AgChartState,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -26,6 +28,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const dateFormatter = new Intl.DateTimeFormat('en-GB');
 const tooltip = {

--- a/packages/ag-charts-website/src/content/docs/api-state/_examples/state-save-restore/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-state/_examples/state-save-restore/main.ts
@@ -9,7 +9,7 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/api-state/_examples/state-save-restore/main.ts
+++ b/packages/ag-charts-website/src/content/docs/api-state/_examples/state-save-restore/main.ts
@@ -1,10 +1,15 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartState, AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import {
+    AgChartState,
+    AgCharts,
+    AgFinancialChartOptions,
+    ContextMenuModule,
+    FinancialChartModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 import { AgChartOptions } from 'ag-charts-types';
 
 const data = [

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-changes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/category-changes/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData1, getData2 } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/area-series-test/_examples/continuous-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/axes-cross-lines/_examples/polar-axes-crosslines-angle/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-cross-lines/_examples/polar-axes-crosslines-angle/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarLineSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarLineSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/band-highlight/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/band-highlight/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    BandHighlightModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-custom-label/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-custom-label/main.ts
@@ -4,8 +4,8 @@ import {
     AgCharts,
     AgCrosshairLabelRendererParams,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
@@ -16,7 +16,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const crosshairLabelRenderer = (arrowPosition: 'top' | 'right') => {
     const classList =

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-default-label-custom-css/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-default-label-custom-css/main.ts
@@ -1,5 +1,11 @@
 import { BubbleSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,7 +15,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-default-label-custom-renderer/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-default-label-custom-renderer/main.ts
@@ -10,8 +10,8 @@ import {
     AgCharts,
     AgCrosshairLabelRendererParams,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
@@ -23,7 +23,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     TimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const crosshairLabelRenderer = ({ value }: AgCrosshairLabelRendererParams) => {
     return {

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-format/main.ts
@@ -10,9 +10,9 @@ import {
     AgCharts,
     AgUnitTimeAxisOptions,
     AnimationModule,
-    ZoomModule,
+    ContextMenuModule,
+    CrosshairModule,
 } from 'ag-charts-enterprise';
-import { CrosshairModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -23,7 +23,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-offset/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-label-offset/main.ts
@@ -1,5 +1,11 @@
 import { BubbleSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,7 +15,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-snap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-snap/main.ts
@@ -5,7 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -16,7 +22,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-styles/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/crosshair-styles/main.ts
@@ -1,5 +1,11 @@
 import { BubbleSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,7 +15,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/enabling-crosshairs/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-crosshairs/_examples/enabling-crosshairs/main.ts
@@ -5,8 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, ZoomModule } from 'ag-charts-enterprise';
-import { CrosshairModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -17,7 +22,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-domain/_examples/polar-axis-reversed/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-domain/_examples/polar-axis-reversed/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarAreaSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-labels-test/_examples/axis-label-rotation/main.ts
@@ -4,6 +4,7 @@ import {
     AgCategoryAxisOptions,
     AgCharts,
     AgNumberAxisOptions,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/axis-parent-level-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/axis-parent-level-customisation/main.ts
@@ -5,8 +5,15 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -19,6 +26,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/axis-parent-level/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/axis-parent-level/main.ts
@@ -5,8 +5,15 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -19,6 +26,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/time-vs-unit-time-vs-ordinal-time/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/time-vs-unit-time-vs-ordinal-time/main.ts
@@ -10,9 +10,9 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     OrdinalTimeAxisModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
@@ -24,7 +24,7 @@ ModuleRegistry.registerModules([
     OrdinalTimeAxisModule,
     TimeAxisModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/unit-time-unit/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/unit-time-unit/main.ts
@@ -5,8 +5,15 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -19,6 +26,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-2/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-2/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-4/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-4/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-5/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-5/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-6/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-6/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-7/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-7/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-8/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types-test/_examples/grouped-category-8/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/axes-types/_examples/time-vs-unit-time-vs-ordinal-time/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-types/_examples/time-vs-unit-time-vs-ordinal-time/main.ts
@@ -10,9 +10,9 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     OrdinalTimeAxisModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
@@ -24,7 +24,7 @@ ModuleRegistry.registerModules([
     OrdinalTimeAxisModule,
     TimeAxisModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/background-image/_examples/background-image/main.ts
+++ b/packages/ag-charts-website/src/content/docs/background-image/_examples/background-image/main.ts
@@ -1,9 +1,15 @@
 import { LegendModule, ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, PieSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, PieSeriesModule, ContextMenuModule]);
 const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-vertical/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-vertical/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgChartLegendPosition, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgChartLegendPosition, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/data-per-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/data-per-series/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-number/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-number/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-ordinal-time/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-ordinal-time/main.ts
@@ -1,7 +1,14 @@
 /* @ag-options-extract */
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AgOrdinalTimeAxisOptions } from 'ag-charts-enterprise';
-import { NavigatorModule, OrdinalTimeAxisModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AgOrdinalTimeAxisOptions,
+    ContextMenuModule,
+    NavigatorModule,
+    OrdinalTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -12,6 +19,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     OrdinalTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 
 (window as any).agChartsDebug = 'scene:stats:verbose';

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-time/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-time/main.ts
@@ -1,6 +1,6 @@
 /* @ag-options-extract */
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule, TimeAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +11,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     TimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 
 (window as any).agChartsDebug = 'scene:stats:verbose';

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-unit-time/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/axes-1M-unit-time/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/enterprise-1M-line-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/enterprise-1M-line-series/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-candlestick/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-candlestick/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const INITIAL_POINTS = 100_000;
 const DATA_INTERVAL_MS = 250;

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-ohlc/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-freq-ohlc/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const INITIAL_POINTS = 100_000;
 const DATA_INTERVAL_MS = 250;

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-area-stacked/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-area-stacked/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-area/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-bar-stacked/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-bar-stacked/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-bar/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-line/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-ohlc/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-ohlc/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-range-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-range-area/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-range-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-perf-range-bar/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/multi-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/multi-chart/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/summary/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/summary/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/box-plot-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/box-plot-series-test/_examples/styler-highlight-state/main.ts
@@ -1,4 +1,4 @@
-import { AgBoxPlotSeriesStylerParams, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgBoxPlotSeriesStylerParams, AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/box-plot-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/box-plot-series-test/_examples/styler/main.ts
@@ -1,4 +1,10 @@
-import { AgBoxPlotSeriesStyle, AgBoxPlotSeriesStylerParams, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import {
+    AgBoxPlotSeriesStyle,
+    AgBoxPlotSeriesStylerParams,
+    AgChartOptions,
+    AgCharts,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/box-plot-customisations/main.ts
+++ b/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/box-plot-customisations/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    BoxPlotSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/box-plot-outliers/main.ts
+++ b/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/box-plot-outliers/main.ts
@@ -5,8 +5,14 @@ import {
     NumberAxisModule,
     ScatterSeriesModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    BoxPlotSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getBoxPlotData, getOutliersData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     ScatterSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/horizontal-box-plot/main.ts
+++ b/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/horizontal-box-plot/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    BoxPlotSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/simple-box-plot/main.ts
+++ b/packages/ag-charts-website/src/content/docs/box-plot-series/_examples/simple-box-plot/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    BoxPlotSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-add-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-remove-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-update-value/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series-test/_examples/candlestick-animation-update-value/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/candlestick-series/_examples/candlestick-customisations/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series/_examples/candlestick-customisations/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule, OrdinalTimeAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+    OrdinalTimeAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     OrdinalTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/candlestick-series/_examples/simple-candlestick/main.ts
+++ b/packages/ag-charts-website/src/content/docs/candlestick-series/_examples/simple-candlestick/main.ts
@@ -1,6 +1,13 @@
-import { LegendModule, ModuleRegistry, NumberAxisModule, TimeAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule } from 'ag-charts-enterprise';
+import { LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+    OrdinalTimeAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -10,8 +17,8 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    TimeAxisModule,
-    ZoomModule,
+    OrdinalTimeAxisModule,
+    ContextMenuModule,
 ]);
 
 const options: AgChartOptions = {
@@ -37,16 +44,6 @@ const options: AgChartOptions = {
             closeKey: 'close',
         },
     ],
-    axes: {
-        x: {
-            type: 'time',
-            position: 'bottom',
-        },
-        y: {
-            type: 'number',
-            position: 'left',
-        },
-    },
 };
 
 AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/chord-series/_examples/link-style/main.ts
+++ b/packages/ag-charts-website/src/content/docs/chord-series/_examples/link-style/main.ts
@@ -1,9 +1,15 @@
 // https://www.un.org/development/desa/pd/content/international-migrant-stock
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ChordSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ChordSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, ChordSeriesModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, ChordSeriesModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/chord-series/_examples/node-style/main.ts
+++ b/packages/ag-charts-website/src/content/docs/chord-series/_examples/node-style/main.ts
@@ -1,9 +1,15 @@
 // https://www.un.org/development/desa/pd/content/international-migrant-stock
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ChordSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ChordSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, ChordSeriesModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, ChordSeriesModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/chord-series/_examples/simple-chord/main.ts
+++ b/packages/ag-charts-website/src/content/docs/chord-series/_examples/simple-chord/main.ts
@@ -1,9 +1,15 @@
 // https://www.un.org/development/desa/pd/content/international-migrant-stock
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ChordSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ChordSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, ChordSeriesModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, ChordSeriesModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/cone-funnel-series/_examples/cone-funnel-fills/main.ts
+++ b/packages/ag-charts-website/src/content/docs/cone-funnel-series/_examples/cone-funnel-fills/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ConeFunnelSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ConeFunnelSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/cone-funnel-series/_examples/horizontal-cone-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/docs/cone-funnel-series/_examples/horizontal-cone-funnel/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ConeFunnelSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ConeFunnelSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/cone-funnel-series/_examples/simple-cone-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/docs/cone-funnel-series/_examples/simple-cone-funnel/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ConeFunnelSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ConeFunnelSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/context-menu-test/_examples/ag-16259-showOn/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu-test/_examples/ag-16259-showOn/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-actions/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-actions/main.ts
@@ -5,8 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ContextMenuModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -18,7 +23,6 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
 ]);
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-builtins/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-builtins/main.ts
@@ -10,9 +10,10 @@ import {
     AgCharts,
     AgContextMenuItemLiteral,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { ContextMenuModule, ZoomModule } from 'ag-charts-enterprise';
 
 import { generateCurrencyData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-icons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-icons/main.ts
@@ -1,15 +1,13 @@
 import { LegendModule, ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ContextMenuModule } from 'ag-charts-enterprise';
-
-ModuleRegistry.registerModules([
+import {
+    AgCharts,
+    AgPolarChartOptions,
     AnimationModule,
     ContextMenuModule,
     CrosshairModule,
-    LegendModule,
-    PieSeriesModule,
-    ZoomModule,
-]);
+} from 'ag-charts-enterprise';
+
+ModuleRegistry.registerModules([AnimationModule, ContextMenuModule, CrosshairModule, LegendModule, PieSeriesModule]);
 const DOWNLOAD_URL =
     'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJhZy1pY29uIiBmaWxsPSJub25lIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMS41IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxzdHlsZT4qIHsgdmVjdG9yLWVmZmVjdDogbm9uLXNjYWxpbmctc3Ryb2tlOyB9PC9zdHlsZT48cGF0aCBkPSJNMTIgMTdWMyIvPjxwYXRoIGQ9Im02IDExIDYgNiA2LTYiLz48cGF0aCBkPSJNMTkgMjFINSIvPjwvc3ZnPg==';
 

--- a/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-submenus/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu-submenus/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ContextMenuModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { DataType } from './data';
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu/_examples/context-menu/main.ts
@@ -5,8 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ContextMenuModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
     AnimationModule,
@@ -16,7 +21,6 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/context-menu/_examples/dynamic-context-menu/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu/_examples/dynamic-context-menu/main.ts
@@ -1,7 +1,7 @@
-import { AgCharts, AllEnterpriseModule, ModuleRegistry } from 'ag-charts-enterprise';
+import { AgCharts, AllEnterpriseModule, ContextMenuModule, ModuleRegistry } from 'ag-charts-enterprise';
 import type { AgCartesianChartOptions, AgContextMenuItem } from 'ag-charts-types';
 
-ModuleRegistry.registerModules([AllEnterpriseModule]);
+ModuleRegistry.registerModules([AllEnterpriseModule, ContextMenuModule]);
 
 type DatumType = { sector: string; nyse: number; lse: number; tyo: number };
 

--- a/packages/ag-charts-website/src/content/docs/context-menu/_examples/dynamic-context-menu/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu/_examples/dynamic-context-menu/main.ts
@@ -1,7 +1,21 @@
-import { AgCharts, AllEnterpriseModule, ContextMenuModule, ModuleRegistry } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    ContextMenuModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-enterprise';
 import type { AgCartesianChartOptions, AgContextMenuItem } from 'ag-charts-types';
 
-ModuleRegistry.registerModules([AllEnterpriseModule, ContextMenuModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    NumberAxisModule,
+    CategoryAxisModule,
+    LegendModule,
+    ContextMenuModule,
+]);
 
 type DatumType = { sector: string; nyse: number; lse: number; tyo: number };
 

--- a/packages/ag-charts-website/src/content/docs/context/_examples/currency-converter/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context/_examples/currency-converter/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, TimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule, ContextMenuModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import type { CurrencyConverter } from './currencyConverter';
 import { Currency, makeCurrencyConverter } from './currencyConverter';
@@ -14,7 +20,6 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     TimeAxisModule,
-    ZoomModule,
 ]);
 const options: AgCartesianChartOptions<TradeDatum, CurrencyConverter> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getArgon, getHelium, getOxygen } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/temperatures/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts, AgErrorBarItemStylerParams } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AgErrorBarItemStylerParams, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData, getData2 } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/customisation/main.ts
@@ -5,8 +5,14 @@ import {
     NumberAxisModule,
     ScatterSeriesModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ErrorBarsModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ErrorBarsModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     ScatterSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/double-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/double-error-bars/main.ts
@@ -4,10 +4,10 @@ import {
     AgCharts,
     AgLineSeriesTooltipRendererParams,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    ErrorBarsModule,
 } from 'ag-charts-enterprise';
-import { ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { DataType } from './data';
 import { getData } from './data';
@@ -19,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/error-bars/_examples/single-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars/_examples/single-error-bars/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { ErrorBarsModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ErrorBarsModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     ErrorBarsModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/events/_examples/annotations-event/main.ts
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/annotations-event/main.ts
@@ -5,8 +5,15 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AnnotationsModule, ChartToolbarModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    AnnotationsModule,
+    ChartToolbarModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -19,7 +26,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/events/_examples/zoom-event/main.ts
+++ b/packages/ag-charts-website/src/content/docs/events/_examples/zoom-event/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,6 +24,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/fills/_examples/image-fill-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fills/_examples/image-fill-customisation/main.ts
@@ -1,5 +1,11 @@
 import { BubbleSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -9,7 +15,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-features/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-features/main.ts
@@ -3,7 +3,8 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
+
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-features/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-features/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-styling/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     theme: {

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-styling/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     theme: {

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-types/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-types/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-types/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/chart-types/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/default-configuration/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/default-configuration/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/default-configuration/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-configuration/_examples/default-configuration/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/annotation-save-restore/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/annotation-save-restore/main.ts
@@ -1,4 +1,4 @@
-import { AgChartState, AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
+import { AgChartState, AgCharts, AgFinancialChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/chart-types/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/chart-types/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/e2e-icons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/e2e-icons/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/e2e-toolbar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/e2e-toolbar/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/e2e-zoom-navigator/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/e2e-zoom-navigator/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/readonly/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-test/_examples/readonly/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/annotation-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/annotation-customisation/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/annotation-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/annotation-customisation/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/arrow-drawings/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/arrow-drawings/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/arrow-drawings/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/arrow-drawings/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/fibonacci-tools/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/fibonacci-tools/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/fibonacci-tools/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/fibonacci-tools/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/line-drawings/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/line-drawings/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/line-drawings/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/line-drawings/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/measuring-tools/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/measuring-tools/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/measuring-tools/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/measuring-tools/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/text-annotations/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/text-annotations/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/text-annotations/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts-toolbar/_examples/text-annotations/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts/_examples/financial-charts-showcase/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/_examples/financial-charts-showcase/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/financial-charts/_examples/financial-charts-showcase/main.ts
+++ b/packages/ag-charts-website/src/content/docs/financial-charts/_examples/financial-charts-showcase/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/google-fonts/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/google-fonts/main.ts
@@ -5,7 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
     AnimationModule,
@@ -14,7 +14,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/label-formatters/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/label-formatters/main.ts
@@ -5,7 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -16,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/text-segments/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/text-segments/main.ts
@@ -5,7 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
     AnimationModule,
@@ -14,7 +14,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/formatters/_examples/formatter/main.ts
+++ b/packages/ag-charts-website/src/content/docs/formatters/_examples/formatter/main.ts
@@ -5,7 +5,13 @@ import {
     NumberAxisModule,
     TimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -16,7 +22,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     TimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const magnitudeFormatter = new Intl.NumberFormat('en-US', {
     style: 'decimal',

--- a/packages/ag-charts-website/src/content/docs/funnel-series/_examples/funnel-fills/main.ts
+++ b/packages/ag-charts-website/src/content/docs/funnel-series/_examples/funnel-fills/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { FunnelSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    FunnelSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     FunnelSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/funnel-series/_examples/horizontal-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/docs/funnel-series/_examples/horizontal-funnel/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { FunnelSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    FunnelSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     FunnelSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/funnel-series/_examples/segmented/main.ts
+++ b/packages/ag-charts-website/src/content/docs/funnel-series/_examples/segmented/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { FunnelSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    FunnelSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     FunnelSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/funnel-series/_examples/simple-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/docs/funnel-series/_examples/simple-funnel/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { FunnelSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    FunnelSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     FunnelSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/color-range-with-many-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/color-range-with-many-values/main.ts
@@ -1,6 +1,13 @@
-import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { HeatmapSeriesModule } from 'ag-charts-enterprise';
+import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -8,10 +15,10 @@ ModuleRegistry.registerModules([
     AnimationModule,
     CategoryAxisModule,
     CrosshairModule,
+    GradientLegendModule,
     HeatmapSeriesModule,
-    LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/customising-color-range/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/customising-color-range/main.ts
@@ -1,6 +1,13 @@
-import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { HeatmapSeriesModule } from 'ag-charts-enterprise';
+import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -8,10 +15,10 @@ ModuleRegistry.registerModules([
     AnimationModule,
     CategoryAxisModule,
     CrosshairModule,
+    GradientLegendModule,
     HeatmapSeriesModule,
-    LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/customising-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/customising-labels/main.ts
@@ -1,6 +1,13 @@
-import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { HeatmapSeriesModule } from 'ag-charts-enterprise';
+import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -8,10 +15,10 @@ ModuleRegistry.registerModules([
     AnimationModule,
     CategoryAxisModule,
     CrosshairModule,
+    GradientLegendModule,
     HeatmapSeriesModule,
-    LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend-labels/main.ts
@@ -1,6 +1,13 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     GradientLegendModule,
     HeatmapSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend-position/main.ts
@@ -1,6 +1,13 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     GradientLegendModule,
     HeatmapSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend-size/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend-size/main.ts
@@ -1,6 +1,13 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     GradientLegendModule,
     HeatmapSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/gradient-legend/main.ts
@@ -1,6 +1,13 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     GradientLegendModule,
     HeatmapSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/simple-heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/simple-heatmap/main.ts
@@ -1,6 +1,13 @@
-import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { HeatmapSeriesModule } from 'ag-charts-enterprise';
+import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -8,10 +15,10 @@ ModuleRegistry.registerModules([
     AnimationModule,
     CategoryAxisModule,
     CrosshairModule,
+    GradientLegendModule,
     HeatmapSeriesModule,
-    LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-area/main.ts
@@ -1,4 +1,4 @@
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 // (window as any).agChartsDebug = ['scene:stats', 'data-model', 'data-ref'];

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-bar/main.ts
@@ -1,4 +1,4 @@
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 // (window as any).agChartsDebug = ['scene:stats', 'data-model', 'data-ref'];

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-candlestick/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-candlestick/main.ts
@@ -1,4 +1,4 @@
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 // (window as any).agChartsDebug = ['scene:stats', 'data-model', 'data-ref'];

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-gap-filling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-gap-filling/main.ts
@@ -1,4 +1,4 @@
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-high-volume/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-high-volume/main.ts
@@ -1,4 +1,9 @@
-import { type AgCartesianChartOptions, type AgCartesianSeriesOptions, AgCharts } from 'ag-charts-enterprise';
+import {
+    type AgCartesianChartOptions,
+    type AgCartesianSeriesOptions,
+    AgCharts,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-histogram/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-histogram/main.ts
@@ -1,4 +1,4 @@
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 // (window as any).agChartsDebug = ['scene:stats', 'data-model', 'data-ref'];

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-line/main.ts
@@ -1,4 +1,4 @@
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 // (window as any).agChartsDebug = ['scene:stats', 'data-model', 'data-ref'];

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-multi-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-multi-chart/main.ts
@@ -1,6 +1,6 @@
 // @ag-skip-fws
 // @ag-skip-container-check
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const chartCount = 10;
 const refreshRateInMilliseconds = 50;

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-scatter/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-scatter/main.ts
@@ -1,4 +1,4 @@
-import { type AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 // (window as any).agChartsDebug = ['scene:stats', 'data-model', 'data-ref'];

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-stacked-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-stacked-line/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 // Configuration
 let refreshRateInMilliseconds = 50;

--- a/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-update/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data-test/_examples/high-freq-update/main.ts
@@ -1,4 +1,4 @@
-import { type AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { type AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 (window as any).agChartsDebug = ['scene:stats'];
 

--- a/packages/ag-charts-website/src/content/docs/high-performance-charts/_examples/bubble-scatter/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-performance-charts/_examples/bubble-scatter/main.ts
@@ -11,9 +11,10 @@ import {
     AgCartesianSeriesOptions,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -26,6 +27,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     ScatterSeriesModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 // @ts-expect-error Undocumented option
 window.agChartsDebug = 'scene:stats';

--- a/packages/ag-charts-website/src/content/docs/high-performance-charts/_examples/ordered-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-performance-charts/_examples/ordered-data/main.ts
@@ -15,6 +15,7 @@ import {
     AgCharts,
     AnimationModule,
     CandlestickSeriesModule,
+    ContextMenuModule,
     CrosshairModule,
     NavigatorModule,
     OhlcSeriesModule,
@@ -43,6 +44,7 @@ ModuleRegistry.registerModules([
     TimeAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 // @ts-expect-error Undocumented option
 window.agChartsDebug = 'scene:stats';

--- a/packages/ag-charts-website/src/content/docs/high-performance-charts/_examples/stacked-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/high-performance-charts/_examples/stacked-data/main.ts
@@ -14,6 +14,7 @@ import {
     AgCartesianSeriesOptions,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     NavigatorModule,
     OrdinalTimeAxisModule,
@@ -35,6 +36,7 @@ ModuleRegistry.registerModules([
     TimeAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 // @ts-expect-error Undocumented option
 window.agChartsDebug = 'scene:stats';

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-multiple-series-markers/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-multiple-series-markers/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-multiple-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-multiple-series/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-pie-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-pie-series/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-single-series-item-styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-single-series-item-styler/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-single-series-pattern-fill/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-single-series-pattern-fill/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-single-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/custom-highlight-single-series/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-multiple-series-markers-with-overlap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-multiple-series-markers-with-overlap/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { femaleHeightWeight, maleHeightWeight } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-multiple-series-markers/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-multiple-series-markers/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-multiple-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-multiple-series/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-pie-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-pie-series/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-single-series-markers/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-single-series-markers/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { maleHeightWeight } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-single-series-pattern-fill/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-single-series-pattern-fill/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-single-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/highlight-test/_examples/default-highlight-single-series/main.ts
@@ -1,5 +1,5 @@
 // @ag-skip-fws
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/histogram-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/histogram-series-test/_examples/animation/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/histogram-series/_examples/2d-histogram/main.ts
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/_examples/2d-histogram/main.ts
@@ -1,5 +1,5 @@
 import { HistogramSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,7 +9,7 @@ ModuleRegistry.registerModules([
     HistogramSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/histogram-series/_examples/aggregation-histogram/main.ts
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/_examples/aggregation-histogram/main.ts
@@ -4,8 +4,8 @@ import {
     AgCharts,
     AgHistogramSeriesOptions,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
@@ -16,7 +16,7 @@ ModuleRegistry.registerModules([
     HistogramSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/histogram-series/_examples/irregular-intervals/main.ts
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/_examples/irregular-intervals/main.ts
@@ -1,5 +1,5 @@
 import { HistogramSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,7 +9,7 @@ ModuleRegistry.registerModules([
     HistogramSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/histogram-series/_examples/larger-bin-count/main.ts
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/_examples/larger-bin-count/main.ts
@@ -1,5 +1,5 @@
 import { HistogramSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,7 +9,7 @@ ModuleRegistry.registerModules([
     HistogramSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/histogram-series/_examples/simple/main.ts
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/_examples/simple/main.ts
@@ -1,5 +1,5 @@
 import { HistogramSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,7 +9,7 @@ ModuleRegistry.registerModules([
     HistogramSeriesModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-contain-repeat-x/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-contain-repeat-x/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-contain-width-height/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-contain-width-height/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-contain/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-contain/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-cover-width-height/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-cover-width-height/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-cover/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-cover/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-data-url/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-data-url/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { ImageDataURL, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-none/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-none/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-rotate-repeat/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-rotate-repeat/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-rotate/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-rotate/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-stretch-width-height/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-stretch-width-height/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-stretch/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-stretch/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-url/main.ts
+++ b/packages/ag-charts-website/src/content/docs/image-fill-test/_examples/image-url/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/key-features/_examples/enterprise-features-example/main.ts
+++ b/packages/ag-charts-website/src/content/docs/key-features/_examples/enterprise-features-example/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -12,6 +19,7 @@ ModuleRegistry.registerModules([
     NavigatorModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/key-features/_examples/financial-charts-showcase/main.ts
+++ b/packages/ag-charts-website/src/content/docs/key-features/_examples/financial-charts-showcase/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/key-features/_examples/financial-charts-showcase/main.ts
+++ b/packages/ag-charts-website/src/content/docs/key-features/_examples/financial-charts-showcase/main.ts
@@ -3,7 +3,7 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
 
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/key-features/_examples/map-kitchen-sink/main.ts
+++ b/packages/ag-charts-website/src/content/docs/key-features/_examples/map-kitchen-sink/main.ts
@@ -1,6 +1,10 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
 import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
     MapLineSeriesModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,
@@ -18,7 +22,7 @@ ModuleRegistry.registerModules([
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,
     MapShapeSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const currencyLayers: Record<string, { title: string; fill: string }> = {
     euro: { title: 'Euro', fill: '#3F51B5' },

--- a/packages/ag-charts-website/src/content/docs/key-features/_examples/simple-radial-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/docs/key-features/_examples/simple-radial-gauge/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const performanceStages = ['VERY POOR', 'POOR', 'AVERAGE', 'GOOD', 'VERY GOOD', 'EXCELLENT'].flatMap((item) => [
     '',
     item,

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity/_examples/ordered-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity/_examples/ordered-data/main.ts
@@ -18,13 +18,15 @@ import {
     AgCharts,
     AnimationModule,
     CandlestickSeriesModule,
+    ContextMenuModule,
     CrosshairModule,
+    NavigatorModule,
     OhlcSeriesModule,
     OrdinalTimeAxisModule,
     RangeAreaSeriesModule,
     RangeBarSeriesModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -48,6 +50,7 @@ ModuleRegistry.registerModules([
     TimeAxisModule,
     ZoomModule,
     CategoryAxisModule,
+    ContextMenuModule,
 ]);
 
 let dataLabel = '1K';

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/category-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 import { AgCartesianChartOptions } from 'ag-charts-types';
 
 const data = [

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/continuous-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/easeOut-very-slow/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/easeOut-very-slow/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const STATIONS = [
     'Finsbury\nPark',

--- a/packages/ag-charts-website/src/content/docs/line-series-test/_examples/integrated-category-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/line-series-test/_examples/integrated-category-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 import { AgCartesianChartOptions } from 'ag-charts-types';
 
 function week(id: number) {

--- a/packages/ag-charts-website/src/content/docs/linear-gauge-test/_examples/bar-thickness-horizontal/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge-test/_examples/bar-thickness-horizontal/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgLinearGaugeOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgLinearGaugeOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',

--- a/packages/ag-charts-website/src/content/docs/linear-gauge-test/_examples/bar-thickness-vertical/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge-test/_examples/bar-thickness-vertical/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgLinearGaugeOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgLinearGaugeOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',

--- a/packages/ag-charts-website/src/content/docs/linear-gauge-test/_examples/corner-radius/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge-test/_examples/corner-radius/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgLinearGaugeOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgLinearGaugeOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/bullet/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/bullet/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/corner-radius/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/corner-radius/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     direction: 'horizontal',

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/custom-targets/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/custom-targets/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     direction: 'horizontal',

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/fill-mode/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/fill-mode/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/fill/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/fill/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/horizontal-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/horizontal-linear-gauge/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     direction: 'horizontal',

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/labels/main.ts
@@ -3,13 +3,13 @@ import {
     AgCharts,
     AgLinearGaugeLabelPlacement,
     AgLinearGaugeOptions,
+    AllGaugeModule,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/scale-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/scale-values/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     direction: 'horizontal',

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/segmentation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/segmentation/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/simple-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/simple-linear-gauge/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/targets/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/targets/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/thickness/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/thickness/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgLinearGaugeOptions = {
     type: 'linear-gauge',
     direction: 'horizontal',

--- a/packages/ag-charts-website/src/content/docs/localisation/_examples/custom-text-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/localisation/_examples/custom-text-values/main.ts
@@ -11,9 +11,10 @@ import {
     AgChartOptions,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { ContextMenuModule, ZoomModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
     AnimationModule,

--- a/packages/ag-charts-website/src/content/docs/localisation/_examples/installing-locale/main.ts
+++ b/packages/ag-charts-website/src/content/docs/localisation/_examples/installing-locale/main.ts
@@ -6,8 +6,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ContextMenuModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 import { AG_CHARTS_LOCALE_FR_FR } from 'ag-charts-locale';
 
 ModuleRegistry.registerModules([

--- a/packages/ag-charts-website/src/content/docs/map-lines/_examples/backgrounds/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-lines/_examples/backgrounds/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapLineBackgroundSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapLineBackgroundSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { topology } from './topology';
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapLineBackgroundSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-lines/_examples/heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-lines/_examples/heatmap/main.ts
@@ -1,6 +1,14 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, MapLineSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    MapLineSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { data } from './data';
@@ -12,7 +20,7 @@ ModuleRegistry.registerModules([
     GradientLegendModule,
     MapLineSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-lines/_examples/lines/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-lines/_examples/lines/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapLineSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapLineSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { data } from './data';
@@ -12,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapLineSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-lines/_examples/map-shapes-lines/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-lines/_examples/map-shapes-lines/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapLineSeriesModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapLineSeriesModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { londonBoroughData } from './londonBoroughData';
 import { londonBoroughTopology } from './londonBoroughTopology';
@@ -15,7 +22,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapLineSeriesModule,
     MapShapeSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const sizeDomain = [0, 141537];
 const strokeWidth = 1;

--- a/packages/ag-charts-website/src/content/docs/map-lines/_examples/stroke-width/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-lines/_examples/stroke-width/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapLineSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapLineSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { data } from './data';
@@ -12,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapLineSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-markers/_examples/marker-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-markers/_examples/marker-series/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapMarkerSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapMarkerSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { data } from './data';
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-markers/_examples/marker-size/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-markers/_examples/marker-size/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapMarkerSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapMarkerSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { data } from './data';
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-markers/_examples/markers/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-markers/_examples/markers/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapMarkerSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapMarkerSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { data } from './data';
@@ -12,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-series-test/_examples/heatmap-floating/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-series-test/_examples/heatmap-floating/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { data } from './data';
 import { topology } from './topology';

--- a/packages/ag-charts-website/src/content/docs/map-series-test/_examples/routing/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-series-test/_examples/routing/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { cityData } from './cityData';
 import { cityTopology } from './cityTopology';

--- a/packages/ag-charts-website/src/content/docs/map-shapes/_examples/backgrounds/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-shapes/_examples/backgrounds/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapShapeBackgroundSeriesModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapShapeBackgroundSeriesModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { central, eastern, mountain, pacific } from './data';
 import { topology } from './topology';
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapShapeBackgroundSeriesModule,
     MapShapeSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-shapes/_examples/heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-shapes/_examples/heatmap/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 import { topology } from './topology';
@@ -10,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     MapShapeSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-shapes/_examples/labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-shapes/_examples/labels/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 import { topology } from './topology';
@@ -10,7 +17,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     MapShapeSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/map-shapes/_examples/multiple-series/main.ts
+++ b/packages/ag-charts-website/src/content/docs/map-shapes/_examples/multiple-series/main.ts
@@ -1,11 +1,23 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { central, eastern, mountain, pacific } from './data';
 import { topology } from './topology';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, MapShapeSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    MapShapeSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/maps/_examples/bubble-map/main.ts
+++ b/packages/ag-charts-website/src/content/docs/maps/_examples/bubble-map/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapMarkerSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapMarkerSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { africaData, asiaData, europeData, northAmericaData, oceaniaData, southAmericaData } from './data';
 import { topology } from './topology';
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/maps/_examples/lines/main.ts
+++ b/packages/ag-charts-website/src/content/docs/maps/_examples/lines/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { MapLineSeriesModule, MapMarkerSeriesModule, MapShapeBackgroundSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    MapLineSeriesModule,
+    MapMarkerSeriesModule,
+    MapShapeBackgroundSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { backgroundTopology } from './backgroundTopology';
 import { backgroundTopologyNI } from './backgroundTopologyNI';
@@ -16,7 +24,7 @@ ModuleRegistry.registerModules([
     MapLineSeriesModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/maps/_examples/world-colour-map/main.ts
+++ b/packages/ag-charts-website/src/content/docs/maps/_examples/world-colour-map/main.ts
@@ -1,6 +1,14 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, MapShapeBackgroundSeriesModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    MapShapeBackgroundSeriesModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 import { topology } from './topology';
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     GradientLegendModule,
     MapShapeBackgroundSeriesModule,
     MapShapeSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/navigator/_examples/mini-chart-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/navigator/_examples/mini-chart-styling/main.ts
@@ -5,8 +5,15 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -19,6 +26,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
     day: 'numeric',

--- a/packages/ag-charts-website/src/content/docs/navigator/_examples/mini-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/navigator/_examples/mini-chart/main.ts
@@ -5,8 +5,15 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -19,6 +26,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
     day: 'numeric',

--- a/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator-styling/main.ts
@@ -5,8 +5,15 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -19,6 +26,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator/main.ts
+++ b/packages/ag-charts-website/src/content/docs/navigator/_examples/navigator/main.ts
@@ -5,8 +5,14 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { NavigatorModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     NavigatorModule,
     NumberAxisModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/nightingale-series-test/_examples/styler-and-itemstyler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series-test/_examples/styler-and-itemstyler/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 import {
     AgChartOptions,
     AgRadialSeriesItemStylerParams,

--- a/packages/ag-charts-website/src/content/docs/nightingale-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series-test/_examples/styler-highlight-state/main.ts
@@ -1,4 +1,10 @@
-import { AgChartOptions, AgCharts, AgRadialSeriesStyle, AgRadialSeriesStylerParams } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgRadialSeriesStyle,
+    AgRadialSeriesStylerParams,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/nightingale-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series-test/_examples/styler/main.ts
@@ -1,4 +1,10 @@
-import { AgChartOptions, AgCharts, AgRadialSeriesStyle, AgRadialSeriesStylerParams } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgRadialSeriesStyle,
+    AgRadialSeriesStylerParams,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/axis-label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/axis-label-orientation/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NightingaleSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/category-padding/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/category-padding/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NightingaleSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/group-nightingale/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/group-nightingale/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NightingaleSeriesModule,
-    ZoomModule,
     AngleCategoryAxisModule,
     RadiusNumberAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/inner-radius/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/inner-radius/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NightingaleSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/radius-axis-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/radius-axis-position/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NightingaleSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/simple-nightingale/main.ts
+++ b/packages/ag-charts-website/src/content/docs/nightingale-series/_examples/simple-nightingale/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NightingaleSeriesModule,
-    ZoomModule,
     AngleCategoryAxisModule,
     RadiusNumberAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/ohlc-series/_examples/ohlc-customisations/main.ts
+++ b/packages/ag-charts-website/src/content/docs/ohlc-series/_examples/ohlc-customisations/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { OhlcSeriesModule, OrdinalTimeAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    OhlcSeriesModule,
+    OrdinalTimeAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     OhlcSeriesModule,
     OrdinalTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/ohlc-series/_examples/simple-ohlc/main.ts
+++ b/packages/ag-charts-website/src/content/docs/ohlc-series/_examples/simple-ohlc/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, TimeAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { OhlcSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    OhlcSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     OhlcSeriesModule,
     TimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/overlays/_examples/loading-custom/main.ts
+++ b/packages/ag-charts-website/src/content/docs/overlays/_examples/loading-custom/main.ts
@@ -3,9 +3,9 @@ import {
     AgChartOptions,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     DataSourceModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
@@ -15,7 +15,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/overlays/_examples/loading/main.ts
+++ b/packages/ag-charts-website/src/content/docs/overlays/_examples/loading/main.ts
@@ -3,9 +3,9 @@ import {
     AgChartOptions,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     DataSourceModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
@@ -15,7 +15,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation-donut/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation-donut/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 const data = [
     { asset: 'Stocks', amount: 60000 },

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 const data = [
     { label: 'Android', value: 56.9 },

--- a/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/duplicate-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pie-series-test/_examples/duplicate-labels/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 function getData() {
     return [

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/horizontal-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/horizontal-pyramid/main.ts
@@ -1,10 +1,9 @@
-import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
+    ModuleRegistry,
     AgChartOptions,
     AgCharts,
     AnimationModule,
     ContextMenuModule,
-    CrosshairModule,
     PyramidSeriesModule,
 } from 'ag-charts-enterprise';
 
@@ -12,8 +11,6 @@ import { getData } from './data';
 
 ModuleRegistry.registerModules([
     AnimationModule,
-    CrosshairModule,
-    LegendModule,
     PyramidSeriesModule,
     ContextMenuModule,
 ]);

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/horizontal-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/horizontal-pyramid/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { PyramidSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    PyramidSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, PyramidSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    PyramidSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/horizontal-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/horizontal-pyramid/main.ts
@@ -1,19 +1,15 @@
 import {
-    ModuleRegistry,
     AgChartOptions,
     AgCharts,
     AnimationModule,
     ContextMenuModule,
+    ModuleRegistry,
     PyramidSeriesModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([
-    AnimationModule,
-    PyramidSeriesModule,
-    ContextMenuModule,
-]);
+ModuleRegistry.registerModules([AnimationModule, PyramidSeriesModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-aspect-ratio/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-aspect-ratio/main.ts
@@ -4,14 +4,20 @@ import {
     AgPyramidSeriesOptions,
     AgStandaloneChartOptions,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    PyramidSeriesModule,
 } from 'ag-charts-enterprise';
-import { PyramidSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, PyramidSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    PyramidSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgStandaloneChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-aspect-ratio/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-aspect-ratio/main.ts
@@ -1,23 +1,17 @@
-import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgCharts,
     AgPyramidSeriesOptions,
     AgStandaloneChartOptions,
     AnimationModule,
     ContextMenuModule,
-    CrosshairModule,
+    LegendModule,
+    ModuleRegistry,
     PyramidSeriesModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([
-    AnimationModule,
-    CrosshairModule,
-    LegendModule,
-    PyramidSeriesModule,
-    ContextMenuModule,
-]);
+ModuleRegistry.registerModules([AnimationModule, LegendModule, PyramidSeriesModule, ContextMenuModule]);
 const options: AgStandaloneChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-fills/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-fills/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { PyramidSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    PyramidSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, PyramidSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    PyramidSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-fills/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/pyramid-fills/main.ts
@@ -1,22 +1,16 @@
-import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgChartOptions,
     AgCharts,
     AnimationModule,
     ContextMenuModule,
-    CrosshairModule,
+    LegendModule,
+    ModuleRegistry,
     PyramidSeriesModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([
-    AnimationModule,
-    CrosshairModule,
-    LegendModule,
-    PyramidSeriesModule,
-    ContextMenuModule,
-]);
+ModuleRegistry.registerModules([AnimationModule, LegendModule, PyramidSeriesModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/reverse-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/reverse-pyramid/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { PyramidSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    PyramidSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, PyramidSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    PyramidSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/reverse-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/reverse-pyramid/main.ts
@@ -1,22 +1,16 @@
-import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgChartOptions,
     AgCharts,
     AnimationModule,
     ContextMenuModule,
-    CrosshairModule,
+    LegendModule,
+    ModuleRegistry,
     PyramidSeriesModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([
-    AnimationModule,
-    CrosshairModule,
-    LegendModule,
-    PyramidSeriesModule,
-    ContextMenuModule,
-]);
+ModuleRegistry.registerModules([AnimationModule, LegendModule, PyramidSeriesModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/simple-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/simple-pyramid/main.ts
@@ -1,20 +1,16 @@
 import {
     AgChartOptions,
     AgCharts,
-    LegendModule, ModuleRegistry,
     AnimationModule,
     ContextMenuModule,
+    LegendModule,
+    ModuleRegistry,
     PyramidSeriesModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([
-    AnimationModule,
-    LegendModule,
-    PyramidSeriesModule,
-    ContextMenuModule,
-]);
+ModuleRegistry.registerModules([AnimationModule, LegendModule, PyramidSeriesModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/simple-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/simple-pyramid/main.ts
@@ -1,10 +1,9 @@
-import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgChartOptions,
     AgCharts,
+    LegendModule, ModuleRegistry,
     AnimationModule,
     ContextMenuModule,
-    CrosshairModule,
     PyramidSeriesModule,
 } from 'ag-charts-enterprise';
 
@@ -12,7 +11,6 @@ import { getData } from './data';
 
 ModuleRegistry.registerModules([
     AnimationModule,
-    CrosshairModule,
     LegendModule,
     PyramidSeriesModule,
     ContextMenuModule,

--- a/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/simple-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/docs/pyramid-series/_examples/simple-pyramid/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { PyramidSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    PyramidSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, PyramidSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    PyramidSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/docs/radar-area-series-test/_examples/styler-and-itemstyler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series-test/_examples/styler-and-itemstyler/main.ts
@@ -1,4 +1,10 @@
-import { AgCharts, AgMarkerShapeFn, AgPolarChartOptions, AgRadarAreaSeriesOptions } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgMarkerShapeFn,
+    AgPolarChartOptions,
+    AgRadarAreaSeriesOptions,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radar-area-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series-test/_examples/styler-highlight-state/main.ts
@@ -5,6 +5,7 @@ import {
     AgRadarAreaSeriesStylerParams,
     AgRadarSeriesItemStylerParams,
     AgSeriesMarkerStyle,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/radar-area-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series-test/_examples/styler/main.ts
@@ -1,4 +1,10 @@
-import { AgCharts, AgMarkerShapeFn, AgPolarChartOptions, AgRadarAreaSeriesOptions } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgMarkerShapeFn,
+    AgPolarChartOptions,
+    AgRadarAreaSeriesOptions,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/axis-label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/axis-label-orientation/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarAreaSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/axis-shape/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/axis-shape/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarAreaSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/radius-axis-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/radius-axis-position/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarAreaSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/simple-radar-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-area-series/_examples/simple-radar-area/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     RadarAreaSeriesModule,
-    ZoomModule,
     AngleCategoryAxisModule,
     RadiusNumberAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData1, getData2 } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/styler-and-itemstyler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/styler-and-itemstyler/main.ts
@@ -1,4 +1,10 @@
-import { AgCharts, AgMarkerShapeFn, AgPolarChartOptions, AgRadarLineSeriesOptions } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgMarkerShapeFn,
+    AgPolarChartOptions,
+    AgRadarLineSeriesOptions,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/styler-highlight-state/main.ts
@@ -5,6 +5,7 @@ import {
     AgRadarLineSeriesStylerParams,
     AgRadarSeriesItemStylerParams,
     AgSeriesMarkerStyle,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series-test/_examples/styler/main.ts
@@ -1,4 +1,10 @@
-import { AgCharts, AgMarkerShapeFn, AgPolarChartOptions, AgRadarLineSeriesOptions } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgMarkerShapeFn,
+    AgPolarChartOptions,
+    AgRadarLineSeriesOptions,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/axis-label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/axis-label-orientation/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarLineSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarLineSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/axis-shape/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/axis-shape/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarLineSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarLineSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgPolarChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/radius-axis-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/radius-axis-position/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarLineSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadarLineSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/simple-radar-line/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radar-line-series/_examples/simple-radar-line/main.ts
@@ -4,10 +4,10 @@ import {
     AgCharts,
     AngleCategoryAxisModule,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
@@ -17,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     RadarLineSeriesModule,
-    ZoomModule,
     AngleCategoryAxisModule,
     RadiusNumberAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series-test/_examples/styler-and-itemstyler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series-test/_examples/styler-and-itemstyler/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 import {
     AgChartOptions,
     AgRadialSeriesItemStylerParams,

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series-test/_examples/styler-highlight-state/main.ts
@@ -1,4 +1,10 @@
-import { AgChartOptions, AgCharts, AgRadialSeriesStyle, AgRadialSeriesStylerParams } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgRadialSeriesStyle,
+    AgRadialSeriesStylerParams,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series-test/_examples/styler/main.ts
@@ -1,4 +1,10 @@
-import { AgChartOptions, AgCharts, AgRadialSeriesStyle, AgRadialSeriesStylerParams } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgRadialSeriesStyle,
+    AgRadialSeriesStylerParams,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/axis-angles/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/axis-angles/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialBarSeriesModule,
     RadiusCategoryAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/axis-label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/axis-label-orientation/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialBarSeriesModule,
     RadiusCategoryAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/category-padding/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/category-padding/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialBarSeriesModule,
     RadiusCategoryAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/inner-radius/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/inner-radius/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialBarSeriesModule,
     RadiusCategoryAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/simple-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/simple-radial-bar/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     RadialBarSeriesModule,
-    ZoomModule,
     AngleNumberAxisModule,
     RadiusCategoryAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/stacked-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-bar-series/_examples/stacked-radial-bar/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     RadialBarSeriesModule,
-    ZoomModule,
     AngleNumberAxisModule,
     RadiusCategoryAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/positive-negative-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/positive-negative-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getBaseData, getMixedSignData, getNegativeData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/styler-and-itemstyler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/styler-and-itemstyler/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 import {
     AgChartOptions,
     AgRadialSeriesItemStylerParams,

--- a/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/styler-highlight-state/main.ts
@@ -1,4 +1,10 @@
-import { AgChartOptions, AgCharts, AgRadialSeriesStyle, AgRadialSeriesStylerParams } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgRadialSeriesStyle,
+    AgRadialSeriesStylerParams,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series-test/_examples/styler/main.ts
@@ -1,4 +1,10 @@
-import { AgChartOptions, AgCharts, AgRadialSeriesStyle, AgRadialSeriesStylerParams } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgRadialSeriesStyle,
+    AgRadialSeriesStylerParams,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/axis-label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/axis-label-orientation/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialColumnSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/category-padding/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/category-padding/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialColumnSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/inner-radius/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/inner-radius/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialColumnSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/radius-axis-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/radius-axis-position/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +19,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     RadialColumnSeriesModule,
     RadiusNumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/simple-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/simple-radial-column/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     RadialColumnSeriesModule,
-    ZoomModule,
     AngleCategoryAxisModule,
     RadiusNumberAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/stacked-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-column-series/_examples/stacked-radial-column/main.ts
@@ -1,6 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -9,9 +17,9 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     RadialColumnSeriesModule,
-    ZoomModule,
     AngleCategoryAxisModule,
     RadiusNumberAxisModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/angles/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/angles/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/corner-radius/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/corner-radius/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/custom-targets/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/custom-targets/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/fill-mode/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/fill-mode/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/fill/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/fill/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/labels/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/needle/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/needle/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/scale-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/scale-values/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/segmentation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/segmentation/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/simple-radial-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/simple-radial-gauge/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/targets/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/targets/main.ts
@@ -1,8 +1,14 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgRadialGaugeOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgRadialGaugeOptions,
+    AllGaugeModule,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ZoomModule]);
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule, CrosshairModule, LegendModule, ContextMenuModule]);
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/shared-low-high-match/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/shared-low-high-match/main.ts
@@ -4,6 +4,7 @@ import {
     AgCharts,
     AgRangeAreaSeriesItemStylerParams,
     AgRangeAreaSeriesThemeableOptions,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { type DatumType, getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/styler-and-itemstyler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/styler-and-itemstyler/main.ts
@@ -5,6 +5,7 @@ import {
     type AgRangeAreaSeriesStylerParams,
     type AgSeriesMarkerStyle,
     type AgSeriesMarkerStylerParams,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { type DatumType, getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/styler-highlight-state/main.ts
@@ -5,6 +5,7 @@ import {
     AgRangeAreaSeriesStylerParams,
     AgSeriesMarkerStyle,
     AgSeriesMarkerStylerParams,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { type DatumType, getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series-test/_examples/styler/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgRangeAreaSeriesStyle,
     AgRangeAreaSeriesStylerParams,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { type DatumType, getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/high-low-styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/high-low-styler/main.ts
@@ -4,10 +4,10 @@ import {
     AgCharts,
     AgRangeAreaSeriesItemStylerParams,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    RangeAreaSeriesModule,
 } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
@@ -18,7 +18,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     RangeAreaSeriesModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/multiple-range-areas/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/multiple-range-areas/main.ts
@@ -1,6 +1,13 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule, UnitTimeAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeAreaSeriesModule,
+    UnitTimeAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +18,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     RangeAreaSeriesModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-inverted-style/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-inverted-style/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeAreaSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeAreaSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-labels/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeAreaSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeAreaSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgCartesianChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-missing-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/range-area-missing-data/main.ts
@@ -4,10 +4,10 @@ import {
     AgCharts,
     AgRangeAreaSeriesOptions,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    RangeAreaSeriesModule,
 } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +18,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     RangeAreaSeriesModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-area-series/_examples/simple-range-area/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/_examples/simple-range-area/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeAreaSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     RangeAreaSeriesModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-add-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-remove-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-shuffle-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation-update-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/horizontal-range-bar-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-add-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-remove-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-shuffle-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation-update-data/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/range-bar-animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/styler-and-itemstyler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/styler-and-itemstyler/main.ts
@@ -4,6 +4,7 @@ import {
     AgRangeBarSeriesItemStylerParams,
     AgRangeBarSeriesStyle,
     AgRangeBarSeriesStylerParams,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { type DatumType, getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/styler-highlight-state/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/styler-highlight-state/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgRangeBarSeriesStyle,
     AgRangeBarSeriesStylerParams,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { type DatumType, getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/styler/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series-test/_examples/styler/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgRangeBarSeriesStyle,
     AgRangeBarSeriesStylerParams,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { type DatumType, getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/customising-corner-radius/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/customising-corner-radius/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeBarSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/horizontal-range-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/horizontal-range-bar/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeBarSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/multiple-horizontal-range-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/multiple-horizontal-range-bars/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeBarSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/multiple-range-bars/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/multiple-range-bars/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeBarSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-labels/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeBarSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-missing-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/range-bar-missing-data/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     RangeBarSeriesModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/simple-range-bar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/_examples/simple-range-bar/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     RangeBarSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/range-buttons/_examples/custom-range-buttons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-buttons/_examples/custom-range-buttons/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 const MONTH = 30 * 24 * 60 * 60 * 1000;
 
 const options: AgFinancialChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/range-buttons/_examples/custom-range-buttons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-buttons/_examples/custom-range-buttons/main.ts
@@ -3,7 +3,8 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
+
 const MONTH = 30 * 24 * 60 * 60 * 1000;
 
 const options: AgFinancialChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/range-buttons/_examples/range-buttons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-buttons/_examples/range-buttons/main.ts
@@ -3,7 +3,8 @@ import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartMod
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
+ModuleRegistry.registerModules([FinancialChartModule]);
+
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),
     title: { text: 'Acme Inc.' },

--- a/packages/ag-charts-website/src/content/docs/range-buttons/_examples/range-buttons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-buttons/_examples/range-buttons/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
-import { FinancialChartModule } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule, FinancialChartModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([FinancialChartModule]);
+ModuleRegistry.registerModules([FinancialChartModule, ContextMenuModule]);
 const options: AgFinancialChartOptions = {
     container: document.getElementById('myChart'),
     title: { text: 'Acme Inc.' },

--- a/packages/ag-charts-website/src/content/docs/release-test/_examples/angular-zonejs/main.ts
+++ b/packages/ag-charts-website/src/content/docs/release-test/_examples/angular-zonejs/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 function checkAngularZone(handler: string) {
     if ((globalThis as any).Zone?.current?.name !== 'angular') {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/alignment/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/alignment/main.ts
@@ -4,12 +4,12 @@ import {
     AgFlowProportionChartOptions,
     AgSankeySeriesOptions,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    SankeySeriesModule,
 } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ContextMenuModule]);
 const options: AgFlowProportionChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/label-placement/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/label-placement/main.ts
@@ -4,12 +4,12 @@ import {
     AgFlowProportionChartOptions,
     AgSankeySeriesOptions,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    SankeySeriesModule,
 } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ContextMenuModule]);
 const options: AgFlowProportionChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/link-style/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/link-style/main.ts
@@ -1,9 +1,15 @@
 // Source: https://www.nationalgrideso.com/data-portal
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SankeySeriesModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/node-style/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/node-style/main.ts
@@ -1,9 +1,15 @@
 // Source: https://www.nationalgrideso.com/data-portal
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SankeySeriesModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/simple-sankey/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/simple-sankey/main.ts
@@ -1,9 +1,15 @@
 // Source: https://www.nationalgrideso.com/data-portal
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SankeySeriesModule,
+} from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ContextMenuModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/sorting/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/sorting/main.ts
@@ -4,12 +4,12 @@ import {
     AgFlowProportionChartOptions,
     AgSankeySeriesOptions,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    SankeySeriesModule,
 } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ContextMenuModule]);
 const options: AgFlowProportionChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/vertical-alignment/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/vertical-alignment/main.ts
@@ -4,12 +4,12 @@ import {
     AgFlowProportionChartOptions,
     AgSankeySeriesOptions,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    SankeySeriesModule,
 } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SankeySeriesModule, ContextMenuModule]);
 const options: AgFlowProportionChartOptions = {
     container: document.getElementById('myChart'),
     title: {

--- a/packages/ag-charts-website/src/content/docs/scatter-series-test/_examples/animation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scatter-series-test/_examples/animation/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import {
     getFemaleData,

--- a/packages/ag-charts-website/src/content/docs/sparklines/_examples/sparkline-data-updates/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sparklines/_examples/sparkline-data-updates/main.ts
@@ -1,5 +1,11 @@
 import { AreaSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule, TimeAxisModule } from 'ag-charts-community';
-import { AgCharts, AgSparklineOptions, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgSparklineOptions,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -10,7 +16,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     TimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgSparklineOptions = {

--- a/packages/ag-charts-website/src/content/docs/stylers-test/_examples/item-styler-test/main.ts
+++ b/packages/ag-charts-website/src/content/docs/stylers-test/_examples/item-styler-test/main.ts
@@ -7,6 +7,7 @@ import {
     AgHierarchyChartOptions,
     AgPolarChartOptions,
     AgTopologyChartOptions,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import {

--- a/packages/ag-charts-website/src/content/docs/sunburst-series-test/_examples/org-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series-test/_examples/org-chart/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/color-scale/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/color-scale/main.ts
@@ -1,10 +1,23 @@
-import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import { ModuleRegistry } from 'ag-charts-community';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SunburstSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    GradientLegendModule,
+    SunburstSeriesModule,
+    ContextMenuModule,
+]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend-labels/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     SunburstSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend-position/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     SunburstSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend-size/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend-size/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     SunburstSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/gradient-legend/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     SunburstSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/highlight/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/highlight/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { energyMix } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SunburstSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    SunburstSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: energyMix,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/labels/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SunburstSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    SunburstSeriesModule,
+    ContextMenuModule,
+]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/org-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/org-chart/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SunburstSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    SunburstSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/other-colors/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/other-colors/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SunburstSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    SunburstSeriesModule,
+    ContextMenuModule,
+]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/sizing/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/sizing/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, SunburstSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    SunburstSeriesModule,
+    ContextMenuModule,
+]);
 const gdpFormatter = new Intl.NumberFormat('en-US', {
     useGrouping: true,
     minimumFractionDigits: 2,

--- a/packages/ag-charts-website/src/content/docs/sync-test/_examples/financial-charts-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync-test/_examples/financial-charts-sync/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgFinancialChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgFinancialChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/sync-test/_examples/mixed-series-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync-test/_examples/mixed-series-sync/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getBenchmark1Data, getBenchmark2Data } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/sync-test/_examples/multi-series-horizontal-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync-test/_examples/multi-series-horizontal-sync/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getBenchmark1Data, getBenchmark2Data } from './data';
 import { formatBytes, formatMillis, labelFormatter } from './utils';

--- a/packages/ag-charts-website/src/content/docs/sync-test/_examples/multi-series-implicit-key-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync-test/_examples/multi-series-implicit-key-sync/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getBenchmark1Data, getBenchmark2Data } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/sync-test/_examples/multi-series-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync-test/_examples/multi-series-sync/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getBenchmark1Data, getBenchmark2Data } from './data';
 import { formatBytes, formatMillis, labelFormatter } from './utils';

--- a/packages/ag-charts-website/src/content/docs/sync-test/_examples/secondary-axis-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync-test/_examples/secondary-axis-sync/main.ts
@@ -1,5 +1,5 @@
 /* @ag-options-extract */
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/sync-test/_examples/single-series-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync-test/_examples/single-series-sync/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getBenchmark1Data, getBenchmark2Data } from './data';
 import { formatBytes, formatMillis, labelFormatter } from './utils';

--- a/packages/ag-charts-website/src/content/docs/sync/_examples/axes-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync/_examples/axes-sync/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SyncModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SyncModule,
+} from 'ag-charts-enterprise';
 
 import { currentData, historicalData } from './data';
 
@@ -18,7 +24,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     SyncModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const commonOptions: AgCartesianChartOptions = {
     sync: {

--- a/packages/ag-charts-website/src/content/docs/sync/_examples/basic-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync/_examples/basic-sync/main.ts
@@ -6,8 +6,16 @@ import {
     TimeAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { NavigatorModule, SyncModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    SyncModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { AAPL, MSFT } from './data';
 
@@ -22,6 +30,7 @@ ModuleRegistry.registerModules([
     TimeAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const commonOptions: AgChartOptions = {
     minWidth: 0,

--- a/packages/ag-charts-website/src/content/docs/sync/_examples/group-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync/_examples/group-sync/main.ts
@@ -5,8 +5,16 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgChartOptions, AgCharts, AnimationModule } from 'ag-charts-enterprise';
-import { CrosshairModule, SyncModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SyncModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { costsProductA, costsProductB, salesProductA, salesProductB } from './data';
 
@@ -19,6 +27,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     SyncModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const commonOptions: AgCartesianChartOptions = {
     minWidth: 0,

--- a/packages/ag-charts-website/src/content/docs/sync/_examples/multi-series-sync/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sync/_examples/multi-series-sync/main.ts
@@ -6,8 +6,14 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { SyncModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    SyncModule,
+} from 'ag-charts-enterprise';
 
 import { regionAdata, regionBdata } from './data';
 
@@ -20,7 +26,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     SyncModule,
     UnitTimeAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const commonOptions: AgCartesianChartOptions = {
     sync: { axes: 'xy' },

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/palettes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/palettes/main.ts
@@ -10,8 +10,8 @@ import {
     AgChartTheme,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
@@ -23,7 +23,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const paperTheme: AgChartTheme = {
     palette: {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-parameters/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-parameters/main.ts
@@ -10,10 +10,10 @@ import {
     AgChartTheme,
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
+    ErrorBarsModule,
 } from 'ag-charts-enterprise';
-import { ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -25,7 +25,7 @@ ModuleRegistry.registerModules([
     ErrorBarsModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const paperTheme: AgChartTheme = {
     palette: {

--- a/packages/ag-charts-website/src/content/docs/touch/_examples/long-tap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/touch/_examples/long-tap/main.ts
@@ -5,7 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([
     AnimationModule,
@@ -14,7 +20,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     LineSeriesModule,
     NumberAxisModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/touch/_examples/single-finger-touch-dragging/main.ts
+++ b/packages/ag-charts-website/src/content/docs/touch/_examples/single-finger-touch-dragging/main.ts
@@ -4,9 +4,12 @@ import {
     AgCharts,
     AgTouchOptions,
     AnimationModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
     CrosshairModule,
+    OrdinalTimeAxisModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule, OrdinalTimeAxisModule, ZoomModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,6 +21,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     OrdinalTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgCartesianChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/touch/_examples/two-finger-zoompan/main.ts
+++ b/packages/ag-charts-website/src/content/docs/touch/_examples/two-finger-zoompan/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +17,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/treemap-series-test/_examples/org-chart/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series-test/_examples/org-chart/main.ts
@@ -1,4 +1,4 @@
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/color-scale/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/color-scale/main.ts
@@ -1,10 +1,23 @@
-import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import { ModuleRegistry } from 'ag-charts-community';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    GradientLegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: data,

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend-labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend-labels/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     TreemapSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend-position/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     TreemapSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend-size/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend-size/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     TreemapSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/gradient-legend/main.ts
@@ -1,6 +1,13 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { GradientLegendModule, TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    GradientLegendModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
@@ -9,7 +16,7 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     GradientLegendModule,
     TreemapSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/highlight/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/highlight/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { salesPerformance } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: salesPerformance,

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/labels/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: data,

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/layout/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/layout/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: data,

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/nesting/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/nesting/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data,

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/other-colors/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/other-colors/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: data,

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/simple-treemap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/simple-treemap/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data,

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/sizing/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/sizing/main.ts
@@ -1,10 +1,22 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([AnimationModule, CrosshairModule, LegendModule, TreemapSeriesModule, ZoomModule]);
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    LegendModule,
+    TreemapSeriesModule,
+    ContextMenuModule,
+]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: data,

--- a/packages/ag-charts-website/src/content/docs/ts-generics/_examples/type-tcontext/main.ts
+++ b/packages/ag-charts-website/src/content/docs/ts-generics/_examples/type-tcontext/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, TimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule, ContextMenuModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import type { CurrencyConverter } from './currencyConverter';
 import { Currency, makeCurrencyConverter } from './currencyConverter';
@@ -14,7 +20,6 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     TimeAxisModule,
-    ZoomModule,
 ]);
 const options: AgCartesianChartOptions<TradeDatum, CurrencyConverter> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/customising-connector-lines/main.ts
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/customising-connector-lines/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     WaterfallSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/customising-series-items/main.ts
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/customising-series-items/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     WaterfallSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/horizontal-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/horizontal-waterfall/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     WaterfallSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/simple-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/simple-waterfall/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     WaterfallSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/total-subtotal-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/total-subtotal-values/main.ts
@@ -1,6 +1,12 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
-import { WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,7 +17,7 @@ ModuleRegistry.registerModules([
     LegendModule,
     NumberAxisModule,
     WaterfallSeriesModule,
-    ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom-test/_examples/e2e-zoom-axis-overlap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom-test/_examples/e2e-zoom-axis-overlap/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/zoom-test/_examples/e2e-zoom-crosshairs/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom-test/_examples/e2e-zoom-crosshairs/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/zoom-test/_examples/multiple-zoom-axes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom-test/_examples/multiple-zoom-axes/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/zoom-test/_examples/multitouch-zoompan/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom-test/_examples/multitouch-zoompan/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/zoom-test/_examples/on-data-change/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom-test/_examples/on-data-change/main.ts
@@ -1,6 +1,6 @@
 // @ag-skip-fws
 import type { AgCartesianAxisOptions, AgCartesianChartOptions } from 'ag-charts-enterprise';
-import { AgCharts } from 'ag-charts-enterprise';
+import { AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import type { DatumType } from './data';
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/auto-scaling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/auto-scaling/main.ts
@@ -1,6 +1,15 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule, NavigatorModule, OrdinalTimeAxisModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    CrosshairModule,
+    NavigatorModule,
+    OrdinalTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -13,6 +22,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     OrdinalTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 
 const options: AgCartesianChartOptions = {

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/two-finger-disabled/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/two-finger-disabled/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +17,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-anchor-point/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-anchor-point/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,6 +24,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-async/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-async/main.ts
@@ -9,6 +9,7 @@ import {
 import {
     AgCharts,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     DataSourceModule,
     NavigatorModule,
@@ -27,6 +28,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     TimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-axes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-axes/main.ts
@@ -5,8 +5,14 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,6 +24,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-axis-controls/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-axis-controls/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +17,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-buttons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-buttons/main.ts
@@ -10,9 +10,10 @@ import {
     AgCharts,
     AgZoomButtonsVisible,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
+    ZoomModule,
 } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -24,6 +25,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-context-menu/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-context-menu/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ContextMenuModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-custom-buttons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-custom-buttons/main.ts
@@ -5,8 +5,14 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -18,6 +24,7 @@ ModuleRegistry.registerModules([
     NumberAxisModule,
     UnitTimeAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-min-visible-items/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-min-visible-items/main.ts
@@ -1,7 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ContextMenuModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-pan-key/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-pan-key/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +17,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-scrolling-step/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-scrolling-step/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +17,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-selecting/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom-selecting/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +17,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom/main.ts
+++ b/packages/ag-charts-website/src/content/docs/zoom/_examples/zoom/main.ts
@@ -1,6 +1,12 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
-import { ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
@@ -11,6 +17,7 @@ ModuleRegistry.registerModules([
     LineSeriesModule,
     NumberAxisModule,
     ZoomModule,
+    ContextMenuModule,
 ]);
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
@@ -5,8 +5,7 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
@@ -5,7 +5,13 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-bar/main.ts
@@ -1,5 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-column/main.ts
@@ -5,8 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-column/main.ts
@@ -5,7 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/area-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/area-with-labels/main.ts
@@ -1,5 +1,5 @@
 import { AreaSeriesModule, ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/area-with-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/area-with-markers/main.ts
@@ -5,8 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/area-with-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/area-with-markers/main.ts
@@ -5,7 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/area-with-negative-values/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/area-with-negative-values/main.ts
@@ -1,5 +1,5 @@
 import { AreaSeriesModule, GroupedCategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bar-line-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bar-line-combination/main.ts
@@ -6,7 +6,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bar-line-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bar-line-combination/main.ts
@@ -6,8 +6,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bar-series-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bar-series-error-bars/main.ts
@@ -1,5 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, ErrorBarsModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bar-series-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bar-series-error-bars/main.ts
@@ -1,6 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { ErrorBarsModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bar-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bar-with-labels/main.ts
@@ -1,5 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/box-plot-scatter-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/box-plot-scatter-combination/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BoxPlotSeriesModule } from 'ag-charts-enterprise';
 
 import { getBoxPlotData, getOutliersData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/box-plot-scatter-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/box-plot-scatter-combination/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BoxPlotSeriesModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getBoxPlotData, getOutliersData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-categories/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-categories/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, CategoryAxisModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { days, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-custom-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-custom-markers/main.ts
@@ -1,5 +1,11 @@
 import { BubbleSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AgMarkerShapeFnParams, CrosshairModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgMarkerShapeFnParams,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-custom-svg-patterns/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-custom-svg-patterns/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { asteroid, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-images/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-images/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-labels/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-negative-values/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-negative-values/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-patterns/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-patterns/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/calendar-heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/calendar-heatmap/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    ContextMenuModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/calendar-heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/calendar-heatmap/main.ts
@@ -1,10 +1,9 @@
 import { CategoryAxisModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { HeatmapSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([CategoryAxisModule, HeatmapSeriesModule]);
+ModuleRegistry.registerModules([CategoryAxisModule, GradientLegendModule, HeatmapSeriesModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),

--- a/packages/ag-charts-website/src/content/gallery/_examples/candlestick-hollow/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/candlestick-hollow/main.ts
@@ -1,6 +1,7 @@
 import { ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 import {
+    AgChartOptions,
+    AgCharts,
     BandHighlightModule,
     CandlestickSeriesModule,
     CrosshairModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/candlestick-hollow/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/candlestick-hollow/main.ts
@@ -4,6 +4,7 @@ import {
     AgCharts,
     BandHighlightModule,
     CandlestickSeriesModule,
+    ContextMenuModule,
     CrosshairModule,
     OrdinalTimeAxisModule,
     ZoomModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/candlestick/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/candlestick/main.ts
@@ -1,6 +1,5 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { CandlestickSeriesModule, OrdinalTimeAxisModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, CandlestickSeriesModule, OrdinalTimeAxisModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/candlestick/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/candlestick/main.ts
@@ -1,5 +1,11 @@
 import { LegendModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, CandlestickSeriesModule, OrdinalTimeAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    CandlestickSeriesModule,
+    ContextMenuModule,
+    OrdinalTimeAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/chord-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/chord-customisation/main.ts
@@ -1,6 +1,6 @@
 // Source: https://en.wikipedia.org/wiki/List_of_busiest_passenger_flight_routes
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, ChordSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ChordSeriesModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([ChordSeriesModule]);
 const numberFormatter = new Intl.NumberFormat('en-US', { useGrouping: true });

--- a/packages/ag-charts-website/src/content/gallery/_examples/chord-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/chord-customisation/main.ts
@@ -1,7 +1,6 @@
 // Source: https://en.wikipedia.org/wiki/List_of_busiest_passenger_flight_routes
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { ChordSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ChordSeriesModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([ChordSeriesModule]);
 const numberFormatter = new Intl.NumberFormat('en-US', { useGrouping: true });

--- a/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
@@ -1,7 +1,6 @@
 // Source: https://survey.stackoverflow.co
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { ChordSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ChordSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
@@ -1,6 +1,6 @@
 // Source: https://survey.stackoverflow.co
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, ChordSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ChordSeriesModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/custom-tooltips/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/custom-tooltips/main.ts
@@ -1,5 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgBarSeriesTooltipRendererParams, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgBarSeriesTooltipRendererParams, AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/customised-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/customised-funnel/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, FunnelSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, FunnelSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/customised-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/customised-funnel/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { FunnelSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, FunnelSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/customised-radial-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/customised-radial-gauge/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgGaugeOptions, AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
+import { AgCharts, AgGaugeOptions, AllGaugeModule, ContextMenuModule, ModuleRegistry } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const options: AgGaugeOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/customised-radial-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/customised-radial-gauge/main.ts
@@ -1,5 +1,4 @@
-import { AgCharts, AgGaugeOptions } from 'ag-charts-enterprise';
-import { AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
+import { AgCharts, AgGaugeOptions, AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const options: AgGaugeOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/customised-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/customised-waterfall/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/customised-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/customised-waterfall/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/donut-with-variable-radius/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/donut-with-variable-radius/main.ts
@@ -1,5 +1,5 @@
 import { DonutSeriesModule, LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/fruit-comparison/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/fruit-comparison/main.ts
@@ -14,7 +14,6 @@ import {
     AnimationModule,
     ContextMenuModule,
     CrosshairModule,
-    ZoomModule,
 } from 'ag-charts-enterprise';
 
 import type { DatumType } from './data';
@@ -28,7 +27,6 @@ ModuleRegistry.registerModules([
     CrosshairModule,
     LegendModule,
     NumberAxisModule,
-    ZoomModule,
 ]);
 
 const markingStyle: AgBarSeriesStyle = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/fruit-comparison/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/fruit-comparison/main.ts
@@ -12,10 +12,10 @@ import {
     AgCharts,
     AgContextMenuItem,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
     ZoomModule,
 } from 'ag-charts-enterprise';
-import { ContextMenuModule } from 'ag-charts-enterprise';
 
 import type { DatumType } from './data';
 import { getPersistentMutableData } from './data';

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-bar-line-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-bar-line-combination/main.ts
@@ -7,7 +7,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AgMarkerShapeFnParams, BandHighlightModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AgMarkerShapeFnParams,
+    BandHighlightModule,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-bar-line-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-bar-line-combination/main.ts
@@ -7,8 +7,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AgMarkerShapeFnParams } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AgMarkerShapeFnParams, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-category-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-category-combination/main.ts
@@ -7,7 +7,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-category-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-category-combination/main.ts
@@ -7,8 +7,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-horizontal-bar/main.ts
@@ -5,8 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-horizontal-bar/main.ts
@@ -5,7 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-radial-column/main.ts
@@ -1,6 +1,11 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-radial-column/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     RadialColumnSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-bar/main.ts
@@ -5,7 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    ErrorBarsModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-stacked-bar/main.ts
@@ -5,8 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/heatmap-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/heatmap-with-labels/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    ContextMenuModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/heatmap-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/heatmap-with-labels/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/histogram-scatter-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/histogram-scatter-combination/main.ts
@@ -1,5 +1,5 @@
 import { HistogramSeriesModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/histogram-with-missing-bins/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/histogram-with-missing-bins/main.ts
@@ -1,5 +1,5 @@
 import { HistogramSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/histogram-with-specified-bins/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/histogram-with-specified-bins/main.ts
@@ -1,5 +1,11 @@
 import { HistogramSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AgHistogramSeriesOptions, CrosshairModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AgHistogramSeriesOptions,
+    ContextMenuModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/histogram-with-specified-bins/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/histogram-with-specified-bins/main.ts
@@ -1,6 +1,5 @@
 import { HistogramSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AgHistogramSeriesOptions } from 'ag-charts-enterprise';
-import { CrosshairModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AgHistogramSeriesOptions, CrosshairModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-box-plot/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-box-plot/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    BoxPlotSeriesModule,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-box-plot/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-box-plot/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, BoxPlotSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
@@ -1,4 +1,10 @@
-import { AgCharts, AgLinearGaugeOptions, AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgLinearGaugeOptions,
+    AllGaugeModule,
+    ContextMenuModule,
+    ModuleRegistry,
+} from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const performanceStages = ['VERY POOR', 'POOR', 'AVERAGE', 'GOOD', 'VERY GOOD', 'EXCELLENT'].flatMap((item) => [

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
@@ -1,5 +1,4 @@
-import { AgCharts, AgLinearGaugeOptions } from 'ag-charts-enterprise';
-import { AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
+import { AgCharts, AgLinearGaugeOptions, AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const performanceStages = ['VERY POOR', 'POOR', 'AVERAGE', 'GOOD', 'VERY GOOD', 'EXCELLENT'].flatMap((item) => [

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-scatter-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-scatter-combination/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-scatter-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-scatter-combination/main.ts
@@ -1,6 +1,5 @@
 import { BubbleSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-with-labels/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar-with-labels/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-range-bar/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-waterfall/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-waterfall/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-gaps/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-gaps/main.ts
@@ -5,7 +5,13 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, BandHighlightModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    BandHighlightModule,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-gaps/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-gaps/main.ts
@@ -5,8 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AnimationModule, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AnimationModule, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-labels/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-labels/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-time-axis/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-time-axis/main.ts
@@ -5,8 +5,13 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, CrosshairModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    CrosshairModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/line-with-time-axis/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/line-with-time-axis/main.ts
@@ -9,6 +9,7 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     BandHighlightModule,
+    ContextMenuModule,
     CrosshairModule,
     ZoomModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/log-axis/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/log-axis/main.ts
@@ -1,5 +1,5 @@
 import { LineSeriesModule, LogAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-heatmap-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-heatmap-series/main.ts
@@ -1,5 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgTopologyChartOptions, GradientLegendModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgTopologyChartOptions,
+    ContextMenuModule,
+    GradientLegendModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 import { topology } from './topology';

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-heatmap-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-heatmap-series/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgTopologyChartOptions } from 'ag-charts-enterprise';
-import { GradientLegendModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import { AgCharts, AgTopologyChartOptions, GradientLegendModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
 
 import { data } from './data';
 import { topology } from './topology';

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-kitchen-sink/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-kitchen-sink/main.ts
@@ -2,6 +2,7 @@ import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgCharts,
     AgTopologyChartOptions,
+    ContextMenuModule,
     MapLineSeriesModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-kitchen-sink/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-kitchen-sink/main.ts
@@ -1,6 +1,7 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgTopologyChartOptions } from 'ag-charts-enterprise';
 import {
+    AgCharts,
+    AgTopologyChartOptions,
     MapLineSeriesModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-lines-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-lines-markers/main.ts
@@ -2,6 +2,7 @@ import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgChartOptions,
     AgCharts,
+    ContextMenuModule,
     MapLineBackgroundSeriesModule,
     MapLineSeriesModule,
     MapMarkerSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-lines-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-lines-markers/main.ts
@@ -1,6 +1,7 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 import {
+    AgChartOptions,
+    AgCharts,
     MapLineBackgroundSeriesModule,
     MapLineSeriesModule,
     MapMarkerSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-shapes-lines/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-shapes-lines/main.ts
@@ -1,6 +1,5 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgTopologyChartOptions } from 'ag-charts-enterprise';
-import { MapLineSeriesModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import { AgCharts, AgTopologyChartOptions, MapLineSeriesModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
 
 import { londonBoroughData } from './londonBoroughData';
 import { londonBoroughTopology } from './londonBoroughTopology';

--- a/packages/ag-charts-website/src/content/gallery/_examples/map-shapes-lines/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/map-shapes-lines/main.ts
@@ -1,5 +1,11 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgTopologyChartOptions, MapLineSeriesModule, MapShapeSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgTopologyChartOptions,
+    ContextMenuModule,
+    MapLineSeriesModule,
+    MapShapeSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { londonBoroughData } from './londonBoroughData';
 import { londonBoroughTopology } from './londonBoroughTopology';

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-box-plots/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-box-plots/main.ts
@@ -5,6 +5,7 @@ import {
     AgCharts,
     BandHighlightModule,
     BoxPlotSeriesModule,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-box-plots/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-box-plots/main.ts
@@ -1,6 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgBoxPlotSeriesTooltipRendererParams, AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgBoxPlotSeriesTooltipRendererParams,
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    BoxPlotSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-bubble-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-bubble-series/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getCoffeeIndustryData, getFoodIndustryData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-donuts/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-donuts/main.ts
@@ -1,6 +1,5 @@
 import { DonutSeriesModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgDonutSeriesOptions, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AnimationModule } from 'ag-charts-enterprise';
+import { AgCharts, AgDonutSeriesOptions, AgPolarChartOptions, AnimationModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-donuts/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-donuts/main.ts
@@ -1,5 +1,11 @@
 import { DonutSeriesModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgDonutSeriesOptions, AgPolarChartOptions, AnimationModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgDonutSeriesOptions,
+    AgPolarChartOptions,
+    AnimationModule,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-horizontal-range-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-horizontal-range-bars/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-horizontal-range-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-horizontal-range-bars/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-line-series-large-data/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-line-series-large-data/main.ts
@@ -1,5 +1,5 @@
 import { LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-line-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-line-series/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-line-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-line-series/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-series/main.ts
@@ -2,6 +2,7 @@ import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgCharts,
     AgTopologyChartOptions,
+    ContextMenuModule,
     MapLineSeriesModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-series/main.ts
@@ -1,6 +1,7 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgTopologyChartOptions } from 'ag-charts-enterprise';
 import {
+    AgCharts,
+    AgTopologyChartOptions,
     MapLineSeriesModule,
     MapMarkerSeriesModule,
     MapShapeBackgroundSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-shape-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-shape-series/main.ts
@@ -2,6 +2,7 @@ import { LegendModule, ModuleRegistry } from 'ag-charts-community';
 import {
     AgCharts,
     AgTopologyChartOptions,
+    ContextMenuModule,
     MapShapeBackgroundSeriesModule,
     MapShapeSeriesModule,
     ZoomModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-shape-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-map-shape-series/main.ts
@@ -1,6 +1,11 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgTopologyChartOptions } from 'ag-charts-enterprise';
-import { MapShapeBackgroundSeriesModule, MapShapeSeriesModule, ZoomModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgTopologyChartOptions,
+    MapShapeBackgroundSeriesModule,
+    MapShapeSeriesModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
 
 import { africaData, asiaData, europeData, northAmericaData, oceaniaData, southAmericaData } from './data';
 import { topology } from './topology';

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-nightingale-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-nightingale-series/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-nightingale-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-nightingale-series/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     NightingaleSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-range-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-range-bars/main.ts
@@ -1,5 +1,11 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-range-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-range-bars/main.ts
@@ -1,6 +1,5 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-scatter-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-scatter-series/main.ts
@@ -1,5 +1,5 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/ohlc/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/ohlc/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, CrosshairModule } from 'ag-charts-enterprise';
-import { OhlcSeriesModule, OrdinalTimeAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    CrosshairModule,
+    OhlcSeriesModule,
+    OrdinalTimeAxisModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/ohlc/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/ohlc/main.ts
@@ -2,6 +2,7 @@ import { ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
 import {
     AgCartesianChartOptions,
     AgCharts,
+    ContextMenuModule,
     CrosshairModule,
     OhlcSeriesModule,
     OrdinalTimeAxisModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/pie-in-a-donut/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/pie-in-a-donut/main.ts
@@ -1,5 +1,5 @@
 import { DonutSeriesModule, LegendModule, ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AgPolarSeriesOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions, AgPolarSeriesOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData2020, getData2022 } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/pie-with-variable-radius/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/pie-with-variable-radius/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
-import { AgCharts, AgPieSeriesOptions, AgPolarChartOptions } from 'ag-charts-enterprise';
+import { AgCharts, AgPieSeriesOptions, AgPolarChartOptions, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/radar-area-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/radar-area-with-labels/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     RadarAreaSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/radar-area-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/radar-area-with-labels/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/radar-line-radar-area-nightingale-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/radar-line-radar-area-nightingale-combination/main.ts
@@ -1,6 +1,7 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 import {
+    AgChartOptions,
+    AgCharts,
     AngleCategoryAxisModule,
     NightingaleSeriesModule,
     RadarAreaSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/radar-line-radar-area-nightingale-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/radar-line-radar-area-nightingale-combination/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     NightingaleSeriesModule,
     RadarAreaSeriesModule,
     RadarLineSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/radar-with-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/radar-with-markers/main.ts
@@ -1,6 +1,11 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadarLineSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    RadarLineSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/radar-with-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/radar-with-markers/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleNumberAxisModule,
+    ContextMenuModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-area-difference-inverted-style/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-area-difference-inverted-style/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule, RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-area-difference-inverted-style/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-area-difference-inverted-style/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-area-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-area-with-labels/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule, RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-area-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-area-with-labels/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
@@ -1,6 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, CrosshairModule, RangeBarSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    CrosshairModule,
+    RangeBarSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
@@ -3,6 +3,7 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     BandHighlightModule,
+    ContextMenuModule,
     CrosshairModule,
     RangeBarSeriesModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-nightingale/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-nightingale/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AngleCategoryAxisModule } from 'ag-charts-enterprise';
-import { NightingaleSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    NightingaleSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-nightingale/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-nightingale/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     NightingaleSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-area/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     RadarAreaSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-area/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-with-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-with-markers/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadarLineSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    RadarLineSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-with-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radar-with-markers/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleNumberAxisModule,
+    ContextMenuModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-bar/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-bar/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleNumberAxisModule,
+    ContextMenuModule,
     RadialBarSeriesModule,
     RadiusCategoryAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-column/main.ts
@@ -1,6 +1,11 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { type RevenueData, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/reversed-radial-column/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     RadialColumnSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/sankey-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sankey-customisation/main.ts
@@ -1,6 +1,10 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgFlowProportionChartOptions, AgSankeySeriesTooltipRendererParams } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgFlowProportionChartOptions,
+    AgSankeySeriesTooltipRendererParams,
+    SankeySeriesModule,
+} from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([SankeySeriesModule]);
 const options: AgFlowProportionChartOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/sankey-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sankey-customisation/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgFlowProportionChartOptions,
     AgSankeySeriesTooltipRendererParams,
+    ContextMenuModule,
     SankeySeriesModule,
 } from 'ag-charts-enterprise';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/sankey/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sankey/main.ts
@@ -1,6 +1,6 @@
 // Source: https://medbrane.com/how-many-medical-students-graduate-each-year/
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, SankeySeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, SankeySeriesModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([SankeySeriesModule]);
 const options: AgChartOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/sankey/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sankey/main.ts
@@ -1,7 +1,6 @@
 // Source: https://medbrane.com/how-many-medical-students-graduate-each-year/
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { SankeySeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, SankeySeriesModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([SankeySeriesModule]);
 const options: AgChartOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-series-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-series-error-bars/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { ErrorBarsModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-series-error-bars/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-series-error-bars/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, ErrorBarsModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
@@ -11,6 +11,7 @@ import {
     AgMarkerShapeFnParams,
     AgPath,
     BandHighlightModule,
+    ContextMenuModule,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
@@ -5,8 +5,13 @@ import {
     ScatterSeriesModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AgMarkerShapeFnParams, AgPath } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AgMarkerShapeFnParams,
+    AgPath,
+    BandHighlightModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-labels/main.ts
@@ -4,6 +4,7 @@ import {
     AgCharts,
     AgScatterSeriesTooltipRendererParams,
     AnimationModule,
+    ContextMenuModule,
     CrosshairModule,
 } from 'ag-charts-enterprise';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-labels/main.ts
@@ -1,6 +1,11 @@
 import { LegendModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AgScatterSeriesTooltipRendererParams } from 'ag-charts-enterprise';
-import { AnimationModule, CrosshairModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AgScatterSeriesTooltipRendererParams,
+    AnimationModule,
+    CrosshairModule,
+} from 'ag-charts-enterprise';
 
 import { NameData, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-large-data/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-large-data/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { chromosomes, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-multiple-axes/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-multiple-axes/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { CrosshairModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, CrosshairModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-multiple-axes/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-multiple-axes/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, CrosshairModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule, CrosshairModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-area/main.ts
@@ -1,5 +1,5 @@
 import { AreaSeriesModule, ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-bar/main.ts
@@ -1,5 +1,11 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, BandHighlightModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    BandHighlightModule,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-bar/main.ts
@@ -1,6 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AnimationModule, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AnimationModule, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-box-plot/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-box-plot/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    BoxPlotSeriesModule,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-box-plot/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-box-plot/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, BoxPlotSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, BoxPlotSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-bubble/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-bubble/main.ts
@@ -1,5 +1,5 @@
 import { BubbleSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-bullet/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-bullet/main.ts
@@ -1,4 +1,4 @@
-import { AgCharts, AgGaugeOptions, AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
+import { AgCharts, AgGaugeOptions, AllGaugeModule, ContextMenuModule, ModuleRegistry } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const first: AgGaugeOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-bullet/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-bullet/main.ts
@@ -1,5 +1,4 @@
-import { AgCharts, AgGaugeOptions } from 'ag-charts-enterprise';
-import { AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
+import { AgCharts, AgGaugeOptions, AllGaugeModule, ModuleRegistry } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const first: AgGaugeOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-cone-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-cone-funnel/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { ConeFunnelSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ConeFunnelSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-cone-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-cone-funnel/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, ConeFunnelSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ConeFunnelSeriesModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-donut/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-donut/main.ts
@@ -1,6 +1,5 @@
 import { DonutSeriesModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AnimationModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-donut/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-donut/main.ts
@@ -1,5 +1,5 @@
 import { DonutSeriesModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AnimationModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AnimationModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-funnel/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { FunnelSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, FunnelSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-funnel/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-funnel/main.ts
@@ -1,5 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, FunnelSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, FunnelSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-heatmap/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    ContextMenuModule,
+    GradientLegendModule,
+    HeatmapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-heatmap/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, GradientLegendModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-histogram/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-histogram/main.ts
@@ -1,5 +1,5 @@
 import { HistogramSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-horizontal-bar/main.ts
@@ -1,6 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-horizontal-bar/main.ts
@@ -1,5 +1,11 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    ErrorBarsModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-line/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-line/main.ts
@@ -5,8 +5,7 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-line/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-line/main.ts
@@ -5,7 +5,13 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ErrorBarsModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    ErrorBarsModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import { AgCharts, AgLinearGaugeOptions, AllGaugeModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const options: AgLinearGaugeOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgLinearGaugeOptions, AllGaugeModule } from 'ag-charts-enterprise';
+import { AgCharts, AgLinearGaugeOptions, AllGaugeModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const options: AgLinearGaugeOptions = {

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-nightingale/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-nightingale/main.ts
@@ -4,6 +4,7 @@ import {
     AgCharts,
     AngleCategoryAxisModule,
     AnimationModule,
+    ContextMenuModule,
     NightingaleSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-nightingale/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-nightingale/main.ts
@@ -1,6 +1,7 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
 import {
+    AgChartOptions,
+    AgCharts,
     AngleCategoryAxisModule,
     AnimationModule,
     NightingaleSeriesModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-pie/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-pie/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions, AnimationModule } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions, AnimationModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-pie/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-pie/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AnimationModule } from 'ag-charts-enterprise';
+import { AgCharts, AgPolarChartOptions, AnimationModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-pyramid/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, PyramidSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, PyramidSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-pyramid/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-pyramid/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { PyramidSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, PyramidSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-area/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     RadarAreaSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-area/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarAreaSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleCategoryAxisModule,
+    RadarAreaSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-line/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-line/main.ts
@@ -1,6 +1,11 @@
 import { LegendModule, ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadarLineSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    RadarLineSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-line/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radar-line/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     RadarLineSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-bar/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgPolarChartOptions,
     AngleNumberAxisModule,
+    ContextMenuModule,
     RadialBarSeriesModule,
     RadiusCategoryAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-bar/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgPolarChartOptions } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgCharts,
+    AgPolarChartOptions,
+    AngleNumberAxisModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-column/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleCategoryAxisModule,
+    ContextMenuModule,
     RadialColumnSeriesModule,
     RadiusNumberAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-column/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-column/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AngleCategoryAxisModule, RadialColumnSeriesModule, RadiusNumberAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleCategoryAxisModule,
+    RadialColumnSeriesModule,
+    RadiusNumberAxisModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-gauge/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgGaugeOptions, AllGaugeModule } from 'ag-charts-enterprise';
+import { AgCharts, AgGaugeOptions, AllGaugeModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const performanceStages = ['VERY POOR', 'POOR', 'AVERAGE', 'GOOD', 'VERY GOOD', 'EXCELLENT'].flatMap((item) => [

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-radial-gauge/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgCharts, AgGaugeOptions } from 'ag-charts-enterprise';
-import { AllGaugeModule } from 'ag-charts-enterprise';
+import { AgCharts, AgGaugeOptions, AllGaugeModule } from 'ag-charts-enterprise';
 
 ModuleRegistry.registerModules([AllGaugeModule]);
 const performanceStages = ['VERY POOR', 'POOR', 'AVERAGE', 'GOOD', 'VERY GOOD', 'EXCELLENT'].flatMap((item) => [

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-range-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-range-area/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AnimationModule, RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, AnimationModule, RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-range-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-range-area/main.ts
@@ -1,5 +1,11 @@
 import { ModuleRegistry, NumberAxisModule, UnitTimeAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, AnimationModule, RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    RangeAreaSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-range-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-range-bar/main.ts
@@ -4,6 +4,7 @@ import {
     AgCharts,
     AnimationModule,
     BandHighlightModule,
+    ContextMenuModule,
     OrdinalTimeAxisModule,
     RangeBarSeriesModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-range-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-range-bar/main.ts
@@ -1,6 +1,7 @@
 import { ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
 import {
+    AgCartesianChartOptions,
+    AgCharts,
     AnimationModule,
     BandHighlightModule,
     OrdinalTimeAxisModule,

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-scatter/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-scatter/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry, NumberAxisModule, ScatterSeriesModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-sunburst/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-sunburst/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, SunburstSeriesModule } from 'ag-charts-enterprise';
 
 import { data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-sunburst/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-sunburst/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, SunburstSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, SunburstSeriesModule } from 'ag-charts-enterprise';
 
 import { data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-treemap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-treemap/main.ts
@@ -1,5 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AgTreemapSeriesOptions, TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AgTreemapSeriesOptions,
+    ContextMenuModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-treemap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-treemap/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, AgTreemapSeriesOptions } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, AgTreemapSeriesOptions, TreemapSeriesModule } from 'ag-charts-enterprise';
 
 import { data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-waterfall/main.ts
@@ -1,6 +1,5 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-waterfall/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-waterfall/main.ts
@@ -1,5 +1,11 @@
 import { CategoryAxisModule, LegendModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule, WaterfallSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+    WaterfallSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-area/main.ts
@@ -5,7 +5,7 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-bar-area-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-bar-area-combination/main.ts
@@ -6,7 +6,7 @@ import {
     NumberAxisModule,
     UnitTimeAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-bar/main.ts
@@ -5,7 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-bar/main.ts
@@ -5,8 +5,7 @@ import {
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-horizontal-bar/main.ts
@@ -1,6 +1,5 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgBarSeriesTooltipRendererParams, AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { BandHighlightModule } from 'ag-charts-enterprise';
+import { AgBarSeriesTooltipRendererParams, AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-horizontal-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-horizontal-bar/main.ts
@@ -1,5 +1,11 @@
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgBarSeriesTooltipRendererParams, AgChartOptions, AgCharts, BandHighlightModule } from 'ag-charts-enterprise';
+import {
+    AgBarSeriesTooltipRendererParams,
+    AgChartOptions,
+    AgCharts,
+    BandHighlightModule,
+    ContextMenuModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-radial-bar/main.ts
@@ -1,6 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { AngleNumberAxisModule, RadialBarSeriesModule, RadiusCategoryAxisModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    AngleNumberAxisModule,
+    RadialBarSeriesModule,
+    RadiusCategoryAxisModule,
+} from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/stacked-radial-bar/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/stacked-radial-bar/main.ts
@@ -3,6 +3,7 @@ import {
     AgChartOptions,
     AgCharts,
     AngleNumberAxisModule,
+    ContextMenuModule,
     RadialBarSeriesModule,
     RadiusCategoryAxisModule,
 } from 'ag-charts-enterprise';

--- a/packages/ag-charts-website/src/content/gallery/_examples/step-interpolation-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/step-interpolation-combination/main.ts
@@ -1,6 +1,5 @@
 import { GroupedCategoryAxisModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/step-interpolation-combination/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/step-interpolation-combination/main.ts
@@ -1,5 +1,5 @@
 import { GroupedCategoryAxisModule, LineSeriesModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
-import { AgCartesianChartOptions, AgCharts, RangeAreaSeriesModule } from 'ag-charts-enterprise';
+import { AgCartesianChartOptions, AgCharts, ContextMenuModule, RangeAreaSeriesModule } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-color-range/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-color-range/main.ts
@@ -1,5 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, GradientLegendModule, SunburstSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    ContextMenuModule,
+    GradientLegendModule,
+    SunburstSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-color-range/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-color-range/main.ts
@@ -1,10 +1,9 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, GradientLegendModule, SunburstSeriesModule } from 'ag-charts-enterprise';
 
 import { data } from './data';
 
-ModuleRegistry.registerModules([SunburstSeriesModule]);
+ModuleRegistry.registerModules([GradientLegendModule, SunburstSeriesModule]);
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     data,

--- a/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-nesting/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-nesting/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, SunburstSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, SunburstSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-nesting/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/sunburst-with-nesting/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { SunburstSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, SunburstSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/time-axis-with-irregular-intervals/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/time-axis-with-irregular-intervals/main.ts
@@ -1,5 +1,5 @@
 import { LineSeriesModule, ModuleRegistry, NumberAxisModule, TimeAxisModule } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule } from 'ag-charts-enterprise';
 
 import { data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-color-range/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-color-range/main.ts
@@ -1,5 +1,11 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, GradientLegendModule, TreemapSeriesModule } from 'ag-charts-enterprise';
+import {
+    AgChartOptions,
+    AgCharts,
+    ContextMenuModule,
+    GradientLegendModule,
+    TreemapSeriesModule,
+} from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-color-range/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-color-range/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { GradientLegendModule, TreemapSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, GradientLegendModule, TreemapSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-nesting/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-nesting/main.ts
@@ -1,6 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts } from 'ag-charts-enterprise';
-import { TreemapSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, TreemapSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 

--- a/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-nesting/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-nesting/main.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry } from 'ag-charts-community';
-import { AgChartOptions, AgCharts, TreemapSeriesModule } from 'ag-charts-enterprise';
+import { AgChartOptions, AgCharts, ContextMenuModule, TreemapSeriesModule } from 'ag-charts-enterprise';
 
 import { DataType, data } from './data';
 


### PR DESCRIPTION
- Remove ZoomModule unless necessary (it's not enabled by default)
- Add ContextMenuModule (it's enabled by default) 
- Remove LegendModule from series using `colorKey`
- Add GradientLegendModule to series using `colorKey`
- Combine all enterprise module imports into one import