### PR TITLE
Add benchmark counts and full tables to Slack notifications

### DIFF
--- a/tools/benchmark/format-slack-message.js
+++ b/tools/benchmark/format-slack-message.js
@@ -232,6 +232,17 @@ blocks.push(
 // ```bash
 // SLACK_CHANNEL='a' SLACK_ICON='a' SLACK_USERNAME='a' ./tools/benchmark/format-slack-message.js | pbcopy
 // ```
+const fullTimingTable = formatFullSection(
+    rankedByTime,
+    ['pctTimeChange', 'beforeMs', 'afterMs'],
+    ['%', 'Before (ms)', 'After (ms)']
+);
+const fullMemoryTable = formatFullSection(
+    rankedByMemory,
+    ['pctMemoryChange', 'beforeMB', 'afterMB'],
+    ['%', 'Before (MB)', 'After (MB)']
+);
+
 const slackMessage = {
     channel,
     username,
@@ -240,15 +251,19 @@ const slackMessage = {
     attachments: [
         {
             color: '#36a64f',
-            title: 'Full Timing Results',
-            text: `\`\`\`\n${formatFullSection(rankedByTime, ['pctTimeChange', 'beforeMs', 'afterMs'], ['%', 'Before (ms)', 'After (ms)'])}\`\`\``,
+            title: `Full Timing Results (${rankedByTime.length} benchmarks)`,
+            text: `\`\`\`\n${fullTimingTable}\`\`\``,
             fallback: 'Full timing benchmark results',
+            mrkdwn_in: ['text'],
+            collapsed: true,
         },
         {
             color: '#2196F3',
-            title: 'Full Memory Results',
-            text: `\`\`\`\n${formatFullSection(rankedByMemory, ['pctMemoryChange', 'beforeMB', 'afterMB'], ['%', 'Before (MB)', 'After (MB)'])}\`\`\``,
+            title: `Full Memory Results (${rankedByMemory.length} benchmarks)`,
+            text: `\`\`\`\n${fullMemoryTable}\`\`\``,
             fallback: 'Full memory benchmark results',
+            mrkdwn_in: ['text'],
+            collapsed: true,
         },
     ],
 };

--- a/tools/benchmark/format-slack-message.js
+++ b/tools/benchmark/format-slack-message.js
@@ -96,7 +96,8 @@ function formatFullSection(data, headers, headerLabels) {
     const labels = ['Test', ...(headerLabels || dataKeys)];
 
     // Calculate column widths
-    const maxWidth = 80;
+    // Reduced from 80 to 77 to fit within Slack attachment display width
+    const maxWidth = 77;
     const padding = 2; // Space between columns
     const colWidths = labels.map((h) => h.length);
     for (const row of rows) {


### PR DESCRIPTION
This PR enhances the benchmark CI Slack notifications by:

- **Fixed table width**: Reduced maxWidth from 80 to 77 to prevent column wrapping in Slack attachments
- **Collapsed attachments**: Added collapsed: true to minimize attachment preview in Slack