### PR TITLE
AG-16314 Fix zoom initial event rangeX.min

### DIFF
--- a/packages/ag-charts-community/src/chart/chartContext.ts
+++ b/packages/ag-charts-community/src/chart/chartContext.ts
@@ -141,7 +141,7 @@ export class ChartContext implements ModuleContext {
         this.animationManager = new AnimationManager(this.interactionManager, updateMutex);
         this.dataService = new DataService<any>(this.eventsHub, chart, this.animationManager);
         this.tooltipManager = new TooltipManager(this.eventsHub, this.localeManager, this.domManager, chart.tooltip);
-        this.zoomManager = new ZoomManager(this.eventsHub, fireEvent);
+        this.zoomManager = new ZoomManager(this.eventsHub, this.updateService, fireEvent);
 
         for (const module of ModuleRegistry.listModulesByType(ModuleType.Plugin)) {
             if (!module.chartType || module.chartType === chartType) {

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -37,6 +37,7 @@ import { NonNullableStateTracker } from '../../util/stateTracker';
 import { type CartesianAxisDirection, ChartAxisDirection } from '../chartAxisDirection';
 import { rangeAlignment } from '../rangeAlignment';
 import type { ISeries } from '../series/seriesTypes';
+import type { UpdateService } from '../updateService';
 
 type CoreZoomEntry = ZoomState & { direction: CartesianAxisDirection };
 export type CoreZoomState = Record<AxisID, CoreZoomEntry>;
@@ -152,6 +153,7 @@ export class ZoomManager extends BaseManager {
 
     constructor(
         private readonly eventsHub: EventsHub,
+        updateService: UpdateService,
         private readonly fireChartEvent: <TEvent extends TypedEvent>(event: TEvent) => void
     ) {
         super();
@@ -166,7 +168,9 @@ export class ZoomManager extends BaseManager {
                 }
 
                 this.applyUpdateZoom({ callerId: 'zoom-manager', changeType: 'layoutComplete', changes: {} });
-
+            }),
+            updateService.addListener('update-complete', ({ wasShortcut }) => {
+                if (wasShortcut) return;
                 if (this.didCompleteChange) {
                     this.fireChartEvent<AgZoomEvent>({ type: 'zoom', ...this.getMementoRanges() });
                     this.didCompleteChange = false;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16314

The `layout:complete event` is fired even when an update is shortcut by another update. This shortcut causes the axis scale to not be fully initialised with a domain and so the pixel extents of the scale are unknown.

The update service `update-complete` event allows zoom to check if the update was shortcut and only fire the user's listener after the axis scale domain has been initialised.