### PR TITLE
AG-16074 - Address PR review feedback from #5700

### DIFF
--- a/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
@@ -881,7 +881,6 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
 
         // Determine the most conservative strategy across all changes
         let preserveSortOrders = true;
-        let preserveDomainRanges = true;
 
         for (const changeDesc of changeDescs) {
             const { indexMap } = changeDesc;
@@ -890,26 +889,22 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                 // Update-only: Values changed but indices stable
                 // DOMAIN_RANGES must be cleared (values changed)
                 // Sort orders can be preserved if only values changed, not keys
-                preserveDomainRanges = false;
                 // Sort orders depend on values, so mark dirty but don't clear
             } else if (isAppendOnly(indexMap)) {
                 // Append-only: New items at end, no index shifts
                 // DOMAIN_RANGES must be rebuilt to include new values
                 // Existing sort orders remain valid for their ranges
-                preserveDomainRanges = false;
             } else {
                 // Rolling window: Indices shift predictably
                 // Complex pattern: Full invalidation for safety
                 // Both caches must be cleared
                 preserveSortOrders = false;
-                preserveDomainRanges = false;
             }
         }
 
         // Apply invalidation strategy
-        if (!preserveDomainRanges) {
-            this.markDomainRangesDirty(processedData[DOMAIN_RANGES]);
-        }
+        // Domain ranges are always invalidated for all change types (update-only, append-only, rolling window)
+        this.markDomainRangesDirty(processedData[DOMAIN_RANGES]);
 
         if (!preserveSortOrders) {
             // Complex patterns: Full invalidation needed

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -851,27 +851,27 @@ export abstract class CartesianSeries<
         const crossAxisValues = this.keysOrValues(crossAxisKey);
 
         const sortOrder = this.sortOrder(crossAxisKey);
-        if (sortOrder == null) {
-            const allAxisValues = axisKeys.map((axisKey) => this.keysOrValues(axisKey));
-
-            let axisMin = Infinity;
-            let axisMax = -Infinity;
-            for (const [i, crossAxisValue] of crossAxisValues.entries()) {
-                const [x0, x1] = this.xCoordinateRange(crossAxisValue, 0, i);
-                if (x1 < r0 || x0 > r1) continue;
-
-                for (let j = 0; j < axisKeys.length; j++) {
-                    const axisValue = allAxisValues[j][i];
-                    axisMin = Math.min(axisMin, axisValue);
-                    axisMax = Math.max(axisMax, axisValue);
-                }
-            }
-
-            return axisMin > axisMax ? [Number.NaN, Number.NaN] : [axisMin, axisMax];
-        } else {
+        if (sortOrder != null) {
             const crossAxisRange = this.visibleRangeIndices(crossAxisKey, visibleRange, indices, { sortOrder });
             return dataModel!.getDomainBetweenRange(this, axisKeys, crossAxisRange, processedData!);
         }
+
+        const allAxisValues = axisKeys.map((axisKey) => this.keysOrValues(axisKey));
+
+        let axisMin = Infinity;
+        let axisMax = -Infinity;
+        for (const [i, crossAxisValue] of crossAxisValues.entries()) {
+            const [x0, x1] = this.xCoordinateRange(crossAxisValue, 0, i);
+            if (x1 < r0 || x0 > r1) continue;
+
+            for (let j = 0; j < axisKeys.length; j++) {
+                const axisValue = allAxisValues[j][i];
+                axisMin = Math.min(axisMin, axisValue);
+                axisMax = Math.max(axisMax, axisValue);
+            }
+        }
+
+        return axisMin > axisMax ? [Number.NaN, Number.NaN] : [axisMin, axisMax];
     }
 
     protected domainForClippedRange(direction: ChartAxisDirection, axisKeys: string[], crossAxisKey: string) {


### PR DESCRIPTION
This PR addresses the review feedback from PR #5700:

1. **incrementalProcessor.ts**: Removed redundant `preserveDomainRanges` variable that was always set to `false` in all branches. Domain ranges are now always invalidated directly.

2. **cartesianSeries.ts**: Restored the early-return pattern in `domainForVisibleRange` method - checking `sortOrder != null` first and returning early, keeping the longer fallback block unindented for better readability.

Addresses comments from @lsjroberts on PR #5700.