### PR TITLE
AG-10228 Partially expand `defaults` context-menu literal

### DIFF
--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -13,12 +13,11 @@ import {
     callWithContext,
     clamp,
     createElement,
-    deepClone,
     getIconClassNames,
     toPlainText,
 } from 'ag-charts-core';
 
-import { ContextMenuItem, expandItems } from './contextMenuItem';
+import { ContextMenuItem, expandBuiltinLists, expandItems } from './contextMenuItem';
 import { DEFAULT_CONTEXT_MENU_CLASS } from './contextMenuStyles';
 
 type ContextMenuEvent = _ModuleSupport.ContextMenuEvent;
@@ -134,7 +133,7 @@ export class ContextMenu extends AbstractModuleInstance {
     private makeGetItemsParams(event: ContextMenuEvent): AgContextMenuGetItemsParams {
         const { showOn } = event;
         const { context } = this.ctx.chartService; // TODO: callWithContext
-        const defaultItems: AgContextMenuItem[] = deepClone([...this.items]);
+        const defaultItems: AgContextMenuItem[] = expandBuiltinLists(this.items, this.ctx.contextMenuRegistry);
         switch (showOn) {
             case 'always':
             case 'series-area':

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -133,7 +133,7 @@ export class ContextMenu extends AbstractModuleInstance {
     private makeGetItemsParams(event: ContextMenuEvent): AgContextMenuGetItemsParams {
         const { showOn } = event;
         const { context } = this.ctx.chartService; // TODO: callWithContext
-        const defaultItems: AgContextMenuItem[] = expandBuiltinLists(this.items, this.ctx.contextMenuRegistry);
+        const defaultItems: AgContextMenuItem[] = expandBuiltinLists(showOn, this.items, this.ctx.contextMenuRegistry);
         switch (showOn) {
             case 'always':
             case 'series-area':

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
@@ -80,9 +80,12 @@ export function expandBuiltinLists(
     }
 
     return unfiltered.filter((it) => {
-        const showOn: AgContextMenuItemShowOn | undefined =
-            typeof it === 'string' ? registry.builtins.items[it].showOn : it.showOn;
-        return showsFor(showOn ?? 'always', showing);
+        if (typeof it === 'string') {
+            const showOn = registry.builtins.items[it].showOn ?? 'always';
+            return registry.isVisible(it) && showsFor(showOn, showing);
+        } else {
+            return showsFor(it.showOn ?? 'always', showing);
+        }
     });
 }
 

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
@@ -8,6 +8,7 @@ import type {
 import { isKeyOf } from 'ag-charts-core';
 
 type Options = Partial<_ModuleSupport.ContextMenuItemContractNonRecursive>;
+type AgContextMenuItem_NoLists = Exclude<AgContextMenuItem, keyof _ModuleSupport.ContextMenuBuiltins['lists']>;
 
 function showsFor(showOn: AgContextMenuItemShowOn, showing: AgContextMenuItemShowOn): boolean {
     if (showOn === 'always') return true;
@@ -59,6 +60,24 @@ function expandBuiltin(
     } else {
         appendBuiltinItem(showing, registry, keyword, result);
     }
+}
+
+export function expandBuiltinLists(
+    items: readonly Readonly<AgContextMenuItem>[],
+    registry: _ModuleSupport.ContextMenuRegistry
+): AgContextMenuItem_NoLists[] {
+    const result: AgContextMenuItem_NoLists[] = [];
+    const { builtins } = registry;
+    for (const it of items) {
+        if (typeof it === 'string' && isKeyOf(it, builtins.lists)) {
+            for (const listItem of builtins.lists[it]) {
+                result.push(listItem);
+            }
+        } else {
+            result.push(it);
+        }
+    }
+    return result;
 }
 
 export function expandItems(

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
@@ -63,21 +63,27 @@ function expandBuiltin(
 }
 
 export function expandBuiltinLists(
+    showing: AgContextMenuItemShowOn,
     items: readonly Readonly<AgContextMenuItem>[],
     registry: _ModuleSupport.ContextMenuRegistry
 ): AgContextMenuItem_NoLists[] {
-    const result: AgContextMenuItem_NoLists[] = [];
+    const unfiltered: AgContextMenuItem_NoLists[] = [];
     const { builtins } = registry;
     for (const it of items) {
         if (typeof it === 'string' && isKeyOf(it, builtins.lists)) {
             for (const listItem of builtins.lists[it]) {
-                result.push(listItem);
+                unfiltered.push(listItem);
             }
         } else {
-            result.push(it);
+            unfiltered.push(it);
         }
     }
-    return result;
+
+    return unfiltered.filter((it) => {
+        const showOn: AgContextMenuItemShowOn | undefined =
+            typeof it === 'string' ? registry.builtins.items[it].showOn : it.showOn;
+        return showsFor(showOn ?? 'always', showing);
+    });
 }
 
 export function expandItems(


### PR DESCRIPTION
Changes the value of the `defaultItems` (from `getItem()` dynamic context menu).
```
 from:
  ['defaults']
 to:
  ['download', 'zoom-to-cursor', 'pan-to-cursor', 'reset-zoom', 'toggle-series-visibility', 'toggle-other-series']
```