### PR TITLE
AG-3390 - Add release branch to node_modules cache key if on release

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -92,6 +92,7 @@ runs:
                   echo "NX_BASE=${branch}" >> $GITHUB_ENV
                 fi
                 echo "type=release" >> $GITHUB_OUTPUT
+                echo "release_branch=${branch}" >> $GITHUB_OUTPUT
               else
                 # PR
                 echo "base=origin/${{ inputs.base_ref }}" >> $GITHUB_OUTPUT
@@ -102,6 +103,10 @@ runs:
                 elif [[ ${{ inputs.fetch_base }} == 'full' ]] ; then
                   git fetch origin ${{ inputs.base_ref }}
                 fi
+
+                if [[ "${{inputs.base_ref}}" =~ b[0-9][0-9]\..+ ]] ; then
+                  echo "release_branch=${{ inputs.base_ref }}" >> $GITHUB_OUTPUT
+                fi
               fi
 
               cat $GITHUB_OUTPUT
@@ -111,6 +116,8 @@ runs:
           if: inputs.cache_mode == 'ro'
           id: cache_ro
           uses: actions/cache/restore@v4
+          env:
+              NODE_MODULES_HASH: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'libraries/*/package.json', 'external/*/package.json') }}
           with:
               path: |
                   node_modules/
@@ -118,14 +125,17 @@ runs:
                   plugins/*/node_modules/
                   libraries/*/node_modules/
                   external/*/node_modules/
-              key: node_modules-${{ runner.os }}-${{hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'libraries/*/package.json', 'external/*/package.json')}}
-              restore-keys: node_modules-${{ runner.os }}- # Take any latest cache if failed to find it for current yarn.lock
+              key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, env.NODE_MODULES_HASH) || env.NODE_MODULES_HASH }}
+              restore-keys: ${{ steps.nx_config.outputs.release_branch && format('node_modules-{0}-release-{1}-', runner.os, steps.nx_config.outputs.release_branch) || format('node_modules-{0}-', runner.os) }}
+              # For releases add release branch to key, otherwise take any latest cache if failed to find it for current yarn.lock
               # fail-on-cache-miss: true
 
         - name: Cache node_modules
           if: inputs.cache_mode == 'rw'
           id: cache_rw
           uses: actions/cache@v4
+          env:
+              NODE_MODULES_HASH: ${{ hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'libraries/*/package.json', 'external/*/package.json') }}
           with:
               path: |
                   node_modules/
@@ -133,8 +143,9 @@ runs:
                   plugins/*/node_modules/
                   libraries/*/node_modules/
                   external/*/node_modules/
-              key: node_modules-${{ runner.os }}-${{hashFiles('yarn.lock','patches/*.patch', 'packages/*/package.json', 'plugins/*/package.json', 'libraries/*/package.json', 'external/*/package.json')}}
-              restore-keys: node_modules-${{ runner.os }}- # Take any latest cache if failed to find it for current yarn.lock
+              key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, env.NODE_MODULES_HASH) || env.NODE_MODULES_HASH }}
+              restore-keys: ${{ steps.nx_config.outputs.release_branch && format('node_modules-{0}-release-{1}-', runner.os, steps.nx_config.outputs.release_branch) || format('node_modules-{0}-', runner.os) }}
+              # For releases add release branch to key, otherwise take any latest cache if failed to find it for current yarn.lock
 
         - name: Cache Nx
           if: inputs.cache_mode == 'rw' && inputs.nx_restore != 'false'


### PR DESCRIPTION
Branch is based on `github.ref_name` (current branch) if it exists, otherwise `inputs.base_ref` (PR target branches)

From https://github.com/ag-grid/ag-charts/pull/5740