### PR TITLE
AG-16099 QA Feedback: Remove 'reset' from AgZoomEventSource

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -89,6 +89,7 @@ export type UpdateZoomSourcing = {
 };
 export type UpdateZoomChanges = Record<AxisID, ZoomState | undefined>;
 export type UpdateZoomParams = UpdateZoomSourcing & {
+    isReset: boolean;
     changes: UpdateZoomChanges;
 };
 
@@ -294,7 +295,12 @@ export class ZoomManager extends BaseManager {
 
         const changes = this.toCoreZoomState(zoom);
         this.lastRestoredState = deepFreeze(deepClone(changes));
-        this.updateChanges({ source: 'user-interaction', sourceDetail: 'internal-restoreMemento', changes });
+        this.updateChanges({
+            source: 'user-interaction',
+            sourceDetail: 'internal-restoreMemento',
+            changes,
+            isReset: false,
+        });
     }
 
     private findAxis(axisId: AxisID): CartesianAxisLike | undefined {
@@ -321,7 +327,7 @@ export class ZoomManager extends BaseManager {
         this.state = changes;
         this.lastRestoredState = refreshCoreState(nextAxes, this.lastRestoredState);
 
-        this.updateChanges({ source: 'chart-update', sourceDetail: 'internal-setAxes', changes });
+        this.updateChanges({ source: 'chart-update', sourceDetail: 'internal-setAxes', changes, isReset: false });
     }
 
     public setIndependentAxes(independent = true) {
@@ -346,7 +352,7 @@ export class ZoomManager extends BaseManager {
 
     public updateZoom({ source, sourceDetail }: UpdateZoomSourcing, newZoom?: AxisZoomState): boolean {
         const changes = this.toCoreZoomState(newZoom ?? {});
-        return this.updateChanges({ source, sourceDetail, changes });
+        return this.updateChanges({ source, sourceDetail, changes, isReset: false });
     }
 
     private computeChangedAxesIds(newState: UpdateZoomChanges): readonly AxisID[] {
@@ -367,7 +373,7 @@ export class ZoomManager extends BaseManager {
     }
 
     public updateChanges(params: UpdateZoomParams): boolean {
-        const { source, sourceDetail, changes } = params;
+        const { source, sourceDetail, isReset, changes } = params;
         validateChanges(changes);
 
         const changedAxes = this.computeChangedAxesIds(changes);
@@ -381,15 +387,20 @@ export class ZoomManager extends BaseManager {
         }
         this.state = newState;
 
-        return this.dispatch(source, sourceDetail, changedAxes);
+        return this.dispatch(source, sourceDetail, changedAxes, isReset);
     }
 
-    public resetZoom(sourceDetail: ZoomEventSourceDetail) {
-        this.updateChanges({ source: 'reset', sourceDetail, changes: this.getRestoredZoom() });
+    public resetZoom({ source, sourceDetail }: UpdateZoomSourcing) {
+        this.updateChanges({ source, sourceDetail, changes: this.getRestoredZoom(), isReset: true });
     }
 
-    public resetAxisZoom(sourceDetail: ZoomEventSourceDetail, axisId: AxisID) {
-        this.updateChanges({ source: 'reset', sourceDetail, changes: { [axisId]: this.getRestoredZoom()[axisId] } });
+    public resetAxisZoom({ source, sourceDetail }: UpdateZoomSourcing, axisId: AxisID) {
+        this.updateChanges({
+            source,
+            sourceDetail,
+            changes: { [axisId]: this.getRestoredZoom()[axisId] },
+            isReset: true,
+        });
     }
 
     public panToBBox(seriesRect: BBox, target: BoxBounds): boolean {
@@ -410,7 +421,12 @@ export class ZoomManager extends BaseManager {
 
         const newZoom: AxisZoomState = calcPanToBBoxRatios(seriesRect, zoom, target);
         const changes = this.toCoreZoomState(newZoom);
-        return this.updateChanges({ source: 'user-interaction', sourceDetail: 'internal-panToBBox', changes });
+        return this.updateChanges({
+            source: 'user-interaction',
+            sourceDetail: 'internal-panToBBox',
+            changes,
+            isReset: false,
+        });
     }
 
     // Fire this event to signal to listeners that the view is changing through a zoom and/or pan change.
@@ -439,7 +455,7 @@ export class ZoomManager extends BaseManager {
         const ratio = this.rangeToRatioAxis(axis, { start });
         if (!ratio) return;
 
-        this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio } });
+        this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio }, isReset: false });
     }
 
     public updateWith(
@@ -459,7 +475,7 @@ export class ZoomManager extends BaseManager {
         const ratio = this.rangeToRatioAxis(axis, { start, end });
         if (!ratio) return;
 
-        this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio } });
+        this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio }, isReset: false });
     }
 
     public getZoom(): AxisZoomState | undefined {
@@ -574,7 +590,8 @@ export class ZoomManager extends BaseManager {
     private dispatch(
         source: AgZoomEventSource,
         sourceDetail: ZoomEventSourceDetail,
-        changedAxes: readonly AxisID[]
+        changedAxes: readonly AxisID[],
+        isReset: boolean
     ): boolean {
         const { x, y } = this.getZoom() ?? {};
         const state = this.state;
@@ -583,6 +600,7 @@ export class ZoomManager extends BaseManager {
         const event = {
             source,
             sourceDetail,
+            isReset,
             changedAxes,
             state,
             x,

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -218,6 +218,7 @@ export type ZoomEventSourceDetail =
 export interface ZoomChangeRequestEvent {
     readonly source: AgZoomEventSource;
     readonly sourceDetail: ZoomEventSourceDetail;
+    readonly isReset: boolean;
     readonly changedAxes: readonly AxisID[];
     readonly state: ZoomChangeState;
     readonly x?: Readonly<ZoomState>;

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -75,7 +75,7 @@ export class Ranges extends AbstractModuleInstance {
 
         const sourcing = userInteraction(`zoom-range-button-${index}`);
         if (value == null) {
-            zoomManager.resetZoom(sourcing.sourceDetail);
+            zoomManager.resetZoom(sourcing);
         } else if (typeof value === 'number') {
             zoomManager.extendToEnd(sourcing, ChartAxisDirection.X, value);
         } else if (Array.isArray(value)) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -514,7 +514,7 @@ export class Zoom extends AbstractModuleInstance {
         if (!enabled || !enableDoubleClickToReset || !this.isState(InteractionState.ZoomClickable)) return;
 
         this.previousAxisZoomValid = { [ChartAxisDirection.X]: true, [ChartAxisDirection.Y]: true };
-        zoomManager.resetAxisZoom('zoom-axis-dblclick', id);
+        zoomManager.resetAxisZoom({ source: 'user-interaction', sourceDetail: 'zoom-axis-dblclick' }, id);
     }
 
     private onAxisDragStart(direction: ChartAxisDirection) {
@@ -930,7 +930,7 @@ export class Zoom extends AbstractModuleInstance {
     private resetZoom(sourceDetail: _ModuleSupport.ZoomEventSourceDetail) {
         this.previousZoomValid = true;
         this.previousAxisZoomValid = { [ChartAxisDirection.X]: true, [ChartAxisDirection.Y]: true };
-        this.ctx.zoomManager.resetZoom(sourceDetail);
+        this.ctx.zoomManager.resetZoom({ source: 'user-interaction', sourceDetail });
     }
 
     public updateSyncZoom(zoom: DefinedZoomState) {
@@ -1013,7 +1013,7 @@ export class Zoom extends AbstractModuleInstance {
         if (!this.isAxisZoomValid(direction, axisZoom, validOptions)) return false;
 
         const { source, sourceDetail } = sourcing;
-        zoomManager.updateChanges({ source, sourceDetail, changes: { [axisId]: axisZoom } });
+        zoomManager.updateChanges({ source, sourceDetail, changes: { [axisId]: axisZoom }, isReset: false });
         return true;
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAutoScale.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAutoScale.ts
@@ -81,12 +81,13 @@ export class ZoomAutoScaler implements ZoomAutoScaleChangeListener {
                 source: 'chart-update',
                 sourceDetail: 'internal-autoScaling',
                 changes: this.autoScaleYZoom() ?? {},
+                isReset: false,
             });
         }
     }
 
     private onChangeRequest(event: _ModuleSupport.ZoomChangeRequestEvent) {
-        if (event.source == 'reset') {
+        if (event.isReset) {
             for (const id of event.changedAxes) {
                 if (event.state[id]?.direction === ChartAxisDirection.Y) {
                     this.manuallyAdjusted = false;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
@@ -115,7 +115,7 @@ export class ZoomContextMenu {
     }
 
     private onResetZoom(_actionEvent: AgSeriesAreaContextMenuActionEvent) {
-        this.zoomManager.resetZoom('contextmenu-reset');
+        this.zoomManager.resetZoom(userInteraction('contextmenu-reset'));
     }
 
     private iterateFindNextZoomAtPoint(origin: Point) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
@@ -5,6 +5,8 @@ import type { AgZoomOnDataChange, AgZoomOnDataChangeStrategy } from 'ag-charts-t
 
 import { definedZoomState } from './zoomUtils';
 
+const { userInteraction } = _ModuleSupport;
+
 type DefinedZoomState = _ModuleSupport.DefinedZoomState;
 type ModuleContext = Pick<_ModuleSupport.ModuleContext, 'eventsHub' | 'zoomManager' | 'axisManager'>;
 type ZoomChangeState = _ModuleSupport.ZoomChangeState;
@@ -186,7 +188,7 @@ export class ZoomOnDataChange {
 
         switch (this.properties.strategy) {
             case 'reset':
-                return this.ctx.zoomManager.resetZoom('onDataChange-reset');
+                return this.ctx.zoomManager.resetZoom(userInteraction('onDataChange-reset'));
             case 'preserveRatios':
                 return; // do nothing (keep ZoomManager min/max ratios unchanged).
             case 'preserveDomain':

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -64,7 +64,7 @@ export interface AgAnnotationsEvent<TContext = ContextDefault> {
     context?: TContext;
 }
 
-export type AgZoomEventSource = 'user-interaction' | 'reset' | 'chart-update' | 'data-update' | 'sync';
+export type AgZoomEventSource = 'user-interaction' | 'chart-update' | 'data-update' | 'sync';
 
 export interface AgZoomEvent<TContext = ContextDefault> {
     type: 'zoom';


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16099

Refactor ZoomChangeRequestEvent to include an `isReset` property (required by the zoomAutoScale module to know whether to clear the `manuallyAdjusted` state).