### PR TITLE
CRT-992 - Avoid GroupedCategory forcing animation skip on initial load + no-op updates.

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -111,7 +111,7 @@ class DepthProperties extends BaseProperties {
     tick = new DepthTickProperties();
 }
 
-export class GroupedCategoryAxis extends CategoryAxis {
+export class GroupedCategoryAxis extends CategoryAxis<GroupedCategoryScale<string[]>> {
     static override readonly className = 'GroupedCategoryAxis';
     static override readonly type = 'grouped-category' as const;
 
@@ -440,9 +440,10 @@ export class GroupedCategoryAxis extends CategoryAxis {
     override update() {
         if (!this.computedLayout) return;
 
-        // Category axis isn't animatable
-        // As most super methods aren't called, we need to do this manually
-        this.moduleCtx.animationManager.skipCurrentBatch();
+        // Skip animations only when the domain changes (not on initial load or other updates)
+        if (!this.scale.animatable) {
+            this.moduleCtx.animationManager.skipCurrentBatch();
+        }
 
         const { tickScale, tick, gridLine, gridLength, visibleRange, tickTreeLayout } = this;
         if (!tickTreeLayout) return;

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -23,7 +23,7 @@ import {
     datumKeys,
 } from './dataModel';
 
-const MAX_ANIMATABLE_NODES = 1000;
+export const MAX_ANIMATABLE_NODES = 1000;
 
 function combineIntervalBandResults(
     bandResults: unknown[],

--- a/packages/ag-charts-community/src/chart/interaction/animationManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/animationManager.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../motion/animation';
 import { Animation } from '../../motion/animation';
 import type { Mutex } from '../../util/mutex';
+import { MAX_ANIMATABLE_NODES } from '../data/processors';
 import { AnimationBatch } from './animationBatch';
 import { InteractionManager, InteractionState } from './interactionManager';
 
@@ -32,7 +33,7 @@ function validAnimationDuration(testee?: number) {
  */
 export class AnimationManager {
     public defaultDuration = 1000;
-    public maxAnimatableItems = Infinity;
+    public maxAnimatableItems = MAX_ANIMATABLE_NODES;
 
     private batch = new AnimationBatch(this.defaultDuration * 1.5);
 

--- a/packages/ag-charts-community/src/scale/groupedCategoryScale.ts
+++ b/packages/ag-charts-community/src/scale/groupedCategoryScale.ts
@@ -2,9 +2,36 @@ import type { DomainWithMetadata, NormalizedDomain } from 'ag-charts-core';
 
 import { CategoryScale } from './categoryScale';
 
+// Matches MAX_ANIMATABLE_NODES in processors.ts - domains larger than this won't animate anyway
+const MAX_ANIMATABLE_NODES = 1000;
+
 export class GroupedCategoryScale<D, I = number> extends CategoryScale<D, I> {
     static override is(value: unknown): value is GroupedCategoryScale<any, any> {
         return value instanceof GroupedCategoryScale;
+    }
+
+    private previousDomainJson: string | undefined = undefined;
+
+    /** Whether the current domain update is animatable (initial load or no domain change). */
+    animatable = true;
+
+    override set domain(values: D[]) {
+        // Track domain changes to determine if animations should be skipped.
+        // For large domains, skip JSON.stringify overhead since series won't animate anyway.
+        if (values.length <= MAX_ANIMATABLE_NODES) {
+            const currentDomainJson = JSON.stringify(values);
+            this.animatable = this.previousDomainJson === undefined || this.previousDomainJson === currentDomainJson;
+            this.previousDomainJson = currentDomainJson;
+        } else {
+            this.animatable = this.previousDomainJson === undefined;
+            this.previousDomainJson = '';
+        }
+
+        super.domain = values;
+    }
+
+    override get domain(): D[] {
+        return super.domain;
     }
 
     override normalizeDomains(...domains: DomainWithMetadata<D>[]): NormalizedDomain<D> {

--- a/packages/ag-charts-enterprise/src/features/animation/animationModule.ts
+++ b/packages/ag-charts-enterprise/src/features/animation/animationModule.ts
@@ -16,7 +16,6 @@ export const AnimationModule: PluginModuleDefinition<AgAnimationOptions> = {
     },
     themeTemplate: {
         enabled: true,
-        maxAnimatableItems: 1000,
     },
 
     create: (ctx) => new Animation(ctx),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-992