### PR TITLE
AG-NONE Move `definedZoomState` to ag-charts-core

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,13 +1,6 @@
 import {
-    type AxisID,
-    type BoxBounds,
-    type CartesianAxisDirection,
     ChartAxisDirection,
-    type DeepReadonly,
     Logger,
-    type OptionsDefs,
-    type RequireOptional,
-    type Scale,
     ScaleAlignment,
     attachDescription,
     deepClone,
@@ -18,17 +11,26 @@ import {
     strictObjectKeys,
     validate,
 } from 'ag-charts-core';
+import type {
+    AxisID,
+    AxisZoomState,
+    BoxBounds,
+    CartesianAxisDirection,
+    DeepReadonly,
+    DefinedZoomState,
+    OptionsDefs,
+    RequireOptional,
+    Scale,
+    ZoomState,
+} from 'ag-charts-core';
 import type { AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
 import type {
-    AxisZoomState,
-    DefinedZoomState,
     EventsHub,
     ZoomChangeRequestEvent,
     ZoomChangeState,
     ZoomEventSourceDetail,
     ZoomMemento,
-    ZoomState,
 } from '../../core/eventsHub';
 import { ContinuousScale } from '../../scale/continuousScale';
 import { DiscreteTimeScale } from '../../scale/discreteTimeScale';

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -6,6 +6,7 @@ import {
     deepClone,
     deepFreeze,
     defined,
+    definedZoomState,
     isFiniteNumber,
     isObject,
     strictObjectKeys,
@@ -282,7 +283,7 @@ export class ZoomManager extends BaseManager {
 
         // Migration from older versions can be implemented here.
 
-        const zoom = this.getDefinedZoom();
+        const zoom = definedZoomState(this.getZoom());
         if (memento?.rangeX) {
             zoom.x = this.rangeToRatioDirection(ChartAxisDirection.X, memento.rangeX) ?? { min: 0, max: 1 };
         } else if (memento?.ratioX) {
@@ -574,7 +575,7 @@ export class ZoomManager extends BaseManager {
     }
 
     private getMementoRanges() {
-        const zoom = this.getDefinedZoom();
+        const zoom = definedZoomState(this.getZoom());
         const memento: RequireOptional<ZoomMemento> & {
             ratioX: Required<AgZoomRatio>;
             ratioY: Required<AgZoomRatio>;
@@ -755,13 +756,5 @@ export class ZoomManager extends BaseManager {
         if (!isFiniteNumber(d0) || !isFiniteNumber(d1)) return;
 
         return [d0, d1];
-    }
-
-    private getDefinedZoom(): DefinedZoomState {
-        const zoom = this.getZoom();
-        return {
-            x: { min: zoom?.x?.min ?? 0, max: zoom?.x?.max ?? 1 },
-            y: { min: zoom?.y?.min ?? 0, max: zoom?.y?.max ?? 1 },
-        };
     }
 }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -611,9 +611,7 @@ export class ZoomManager extends BaseManager {
             x,
             y,
             stateAsDefinedZoom(): DefinedZoomState {
-                const { x: x2 = { min: 0, max: 1 }, y: y2 = { min: 0, max: 1 } } =
-                    zoomManager.toAxisZoomState(event.state) ?? {};
-                return { x: x2, y: y2 };
+                return definedZoomState(zoomManager.toAxisZoomState(event.state));
             },
             constrainZoom(restrictions: AxisZoomState): void {
                 this.constrainChanges(zoomManager.toCoreZoomState(restrictions));

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -544,9 +544,9 @@ export class ZoomManager extends BaseManager {
             yVisibleRange = nextZoom.y;
         }
 
-        const xZoom: ZoomState = { min: xVisibleRange[0], max: xVisibleRange[1] };
-        const yZoom: ZoomState = { min: yVisibleRange?.[0] ?? 0, max: yVisibleRange?.[1] ?? 1 };
-        return { x: xZoom, y: yZoom };
+        const x = { min: xVisibleRange[0], max: xVisibleRange[1] };
+        const y = yVisibleRange ? { min: yVisibleRange[0], max: yVisibleRange[1] } : undefined;
+        return definedZoomState({ x, y });
     }
 
     public isVisibleItemsCountAtLeast(

--- a/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
@@ -1,6 +1,7 @@
 import { ChartUpdateType, CleanupRegistry } from 'ag-charts-core';
+import type { ZoomState } from 'ag-charts-core';
 
-import type { EventsHub, ZoomState } from '../../core/eventsHub';
+import type { EventsHub } from '../../core/eventsHub';
 import type { DataService } from '../data/dataService';
 import type { AnimationManager } from '../interaction/animationManager';
 import type { ZoomManager } from '../interaction/zoomManager';

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -1,4 +1,13 @@
-import type { AxisID, ChartAxisDirection, DeepReadonly, Scale } from 'ag-charts-core';
+import type {
+    AxisID,
+    AxisZoomState,
+    ChartAxisDirection,
+    DeepReadonly,
+    DefinedZoomState,
+    Scale,
+    ZoomState,
+    ZoomStateDirection,
+} from 'ag-charts-core';
 import { EventEmitter } from 'ag-charts-core';
 import type {
     AgAnnotation,
@@ -248,26 +257,6 @@ export interface HighlightNodeDatum<I extends DatumIndexType = DatumIndexType> e
     readonly aggregatedValue?: number;
     readonly domain?: [number, number];
     readonly legendItemName?: string;
-}
-
-export interface ZoomState {
-    min: number;
-    max: number;
-}
-
-export interface ZoomStateDirection extends ZoomState {
-    direction: 'x' | 'y';
-}
-
-export interface DefinedZoomState {
-    x: ZoomState;
-    y: ZoomState;
-}
-
-export interface AxisZoomState {
-    x?: ZoomState;
-    y?: ZoomState;
-    autoScaleYAxis?: boolean;
 }
 
 export interface AxisLayout {

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -64,11 +64,9 @@ export { stackCartesianSeries } from './chart/cartesianUtil';
 export { CartesianCrossLine } from './chart/crossline/cartesianCrossLine';
 export type {
     AxisLayout,
-    AxisZoomState,
     ContextMenuEvent,
     DataModelDiff,
     DataModelDiffEvent,
-    DefinedZoomState,
     EventsHub,
     EventsHubMap,
     HighlightChangeEvent,
@@ -84,8 +82,6 @@ export type {
     ZoomLoadMementoEvent,
     ZoomPanStartEvent,
     ZoomSaveMementoEvent,
-    ZoomState,
-    ZoomStateDirection,
 } from './core/eventsHub';
 export { ChartOptions } from './module/optionsModule';
 export type { AxisBandDatum, AxisContext, AxisFormattableLabel } from './module/axisContext';

--- a/packages/ag-charts-core/src/main.ts
+++ b/packages/ag-charts-core/src/main.ts
@@ -93,6 +93,7 @@ export * from './utils/value';
 export * from './utils/validation';
 export * as Vec2 from './utils/vector';
 export * as Vec4 from './utils/vector4';
+export * from './utils/zoomUtils';
 export * from './utils/fill';
 export * from './utils/bezier';
 export * from './utils/labelPlacement';

--- a/packages/ag-charts-core/src/utils/zoomUtils.ts
+++ b/packages/ag-charts-core/src/utils/zoomUtils.ts
@@ -1,0 +1,29 @@
+export interface ZoomState {
+    min: number;
+    max: number;
+}
+
+export interface ZoomStateDirection extends ZoomState {
+    direction: 'x' | 'y';
+}
+
+export interface DefinedZoomState {
+    x: ZoomState;
+    y: ZoomState;
+}
+
+export interface AxisZoomState {
+    x?: ZoomState;
+    y?: ZoomState;
+    autoScaleYAxis?: boolean;
+}
+
+export const UNIT_MIN = 0;
+export const UNIT_MAX = 1;
+
+export function definedZoomState(zoom?: AxisZoomState): DefinedZoomState {
+    return {
+        x: { min: zoom?.x?.min ?? UNIT_MIN, max: zoom?.x?.max ?? UNIT_MAX },
+        y: { min: zoom?.y?.min ?? UNIT_MIN, max: zoom?.y?.max ?? UNIT_MAX },
+    };
+}

--- a/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
+++ b/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
@@ -11,6 +11,7 @@ import {
     Property,
     type Scale,
     arraysEqual,
+    definedZoomState,
     findMinMax,
     isDate,
     isDefined,
@@ -20,7 +21,6 @@ import {
 } from 'ag-charts-core';
 
 import { readDatum } from '../../utils/datum';
-import { definedZoomState } from '../zoom/zoomUtils';
 
 const { CartesianAxis, ContinuousScale, TimeScale, UnitTimeScale, TooltipManager } = _ModuleSupport;
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { CartesianAxisDirection, ZoomState } from 'ag-charts-core';
+import type { CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
 import {
     AbstractModuleInstance,
     ActionOnSet,
@@ -12,7 +12,6 @@ import {
     entries,
     roundTo,
 } from 'ag-charts-core';
-import type { DefinedZoomState } from 'ag-charts-core';
 import { UNIT_MAX, UNIT_MIN, definedZoomState } from 'ag-charts-core';
 import type { AgZoomAnchorPoint, AgZoomAxisDraggingMode } from 'ag-charts-types';
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { CartesianAxisDirection } from 'ag-charts-core';
+import type { CartesianAxisDirection, ZoomState } from 'ag-charts-core';
 import {
     AbstractModuleInstance,
     ActionOnSet,
@@ -12,6 +12,8 @@ import {
     entries,
     roundTo,
 } from 'ag-charts-core';
+import type { DefinedZoomState } from 'ag-charts-core';
+import { UNIT_MAX, UNIT_MIN, definedZoomState } from 'ag-charts-core';
 import type { AgZoomAnchorPoint, AgZoomAxisDraggingMode } from 'ag-charts-types';
 
 import { ZoomRect } from './scenes/zoomRect';
@@ -26,16 +28,13 @@ import { ZoomScroller } from './zoomScroller';
 import { ZoomSelector } from './zoomSelector';
 import { ZoomToolbar } from './zoomToolbar';
 import { ZoomTwoFingers } from './zoomTwoFingers';
-import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
+import type { ZoomProperties } from './zoomTypes';
 import {
     DEFAULT_ANCHOR_POINT_X,
     DEFAULT_ANCHOR_POINT_Y,
-    UNIT_MAX,
-    UNIT_MIN,
     UNIT_SIZE,
     ZOOM_VALID_CHECK_DEBOUNCE,
     constrainZoom,
-    definedZoomState,
     dx,
     dy,
     isMaxZoom,
@@ -908,7 +907,7 @@ export class Zoom extends AbstractModuleInstance {
     };
     private isAxisZoomValid(
         direction: CartesianAxisDirection,
-        axisZoom: _ModuleSupport.ZoomState,
+        axisZoom: ZoomState,
         options?: { directional?: boolean }
     ) {
         const {
@@ -1006,7 +1005,7 @@ export class Zoom extends AbstractModuleInstance {
         sourcing: _ModuleSupport.UpdateZoomSourcing,
         axisId: AxisID,
         direction: CartesianAxisDirection,
-        axisZoom: _ModuleSupport.ZoomState | undefined,
+        axisZoom: ZoomState | undefined,
         validOptions?: { directional?: boolean }
     ) {
         const {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,18 +1,19 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { AxisID, CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
 import {
     AbstractModuleInstance,
     ActionOnSet,
-    type AxisID,
     ChartAxisDirection,
     ChartUpdateType,
     Property,
     ProxyProperty,
+    UNIT_MAX,
+    UNIT_MIN,
     debounce,
+    definedZoomState,
     entries,
     roundTo,
 } from 'ag-charts-core';
-import { UNIT_MAX, UNIT_MIN, definedZoomState } from 'ag-charts-core';
 import type { AgZoomAnchorPoint, AgZoomAxisDraggingMode } from 'ag-charts-types';
 
 import { ZoomRect } from './scenes/zoomRect';

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAutoScale.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAutoScale.ts
@@ -1,6 +1,6 @@
 import type { AgZoomAutoScaling } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import type { CartesianAxisDirection, DeepRequired } from 'ag-charts-core';
+import type { CartesianAxisDirection, DeepRequired, ZoomState } from 'ag-charts-core';
 import {
     BaseProperties,
     ChartAxisDirection,
@@ -11,7 +11,6 @@ import {
     strictObjectKeys,
 } from 'ag-charts-core';
 
-type ZoomState = _ModuleSupport.ZoomState;
 type CartesianAxisLike = ReturnType<_ModuleSupport.ZoomManager['getAxes']>[number];
 type ZoomAutoScalingOpts = DeepRequired<AgZoomAutoScaling>;
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -1,9 +1,10 @@
-import type { AgZoomAnchorPoint } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import { ChartAxisDirection } from 'ag-charts-core';
+import type { AgZoomAnchorPoint } from 'ag-charts-community';
+import { ChartAxisDirection, definedZoomState } from 'ag-charts-core';
+import type { AxisZoomState, DefinedZoomState, ZoomState } from 'ag-charts-core';
 
-import type { DefinedZoomState, ZoomCoords } from './zoomTypes';
-import { constrainZoom, definedZoomState, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
+import type { ZoomCoords } from './zoomTypes';
+import { constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
 
 export class ZoomAxisDragger {
     private coords?: ZoomCoords;
@@ -14,9 +15,9 @@ export class ZoomAxisDragger {
         direction: ChartAxisDirection,
         anchor: AgZoomAnchorPoint,
         bbox: _ModuleSupport.BBox,
-        zoom?: _ModuleSupport.AxisZoomState,
-        axisZoom?: _ModuleSupport.ZoomState
-    ): _ModuleSupport.ZoomState {
+        zoom?: AxisZoomState,
+        axisZoom?: ZoomState
+    ): ZoomState {
         // Store the initial zoom state, merged with the state for this axis
         this.oldZoom ??= definedZoomState(
             direction === ChartAxisDirection.X ? { ...zoom, x: axisZoom } : { ...zoom, y: axisZoom }
@@ -40,11 +41,7 @@ export class ZoomAxisDragger {
         }
     }
 
-    private updateZoom(
-        direction: ChartAxisDirection,
-        anchor: AgZoomAnchorPoint,
-        bbox: _ModuleSupport.BBox
-    ): _ModuleSupport.ZoomState {
+    private updateZoom(direction: ChartAxisDirection, anchor: AgZoomAnchorPoint, bbox: _ModuleSupport.BBox): ZoomState {
         const { coords, oldZoom } = this;
 
         let newZoom = definedZoomState(oldZoom);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -1,7 +1,6 @@
-import { _ModuleSupport } from 'ag-charts-community';
 import type { AgZoomAnchorPoint } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState } from 'ag-charts-core';
-import type { AxisZoomState, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { AxisZoomState, BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
 import { constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
@@ -14,7 +13,7 @@ export class ZoomAxisDragger {
         event: { offsetX: number; offsetY: number },
         direction: ChartAxisDirection,
         anchor: AgZoomAnchorPoint,
-        bbox: _ModuleSupport.BBox,
+        bbox: BoxBounds,
         zoom?: AxisZoomState,
         axisZoom?: ZoomState
     ): ZoomState {
@@ -41,7 +40,7 @@ export class ZoomAxisDragger {
         }
     }
 
-    private updateZoom(direction: ChartAxisDirection, anchor: AgZoomAnchorPoint, bbox: _ModuleSupport.BBox): ZoomState {
+    private updateZoom(direction: ChartAxisDirection, anchor: AgZoomAnchorPoint, bbox: BoxBounds): ZoomState {
         const { coords, oldZoom } = this;
 
         let newZoom = definedZoomState(oldZoom);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
@@ -1,13 +1,13 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import type { AgSeriesAreaContextMenuActionEvent } from 'ag-charts-community';
-import type { Point } from 'ag-charts-core';
+import type { DefinedZoomState, Point } from 'ag-charts-core';
+import { definedZoomState } from 'ag-charts-core';
 
-import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
+import type { ZoomProperties } from './zoomTypes';
 import {
     UNIT_SIZE,
     canResetZoom,
     constrainZoom,
-    definedZoomState,
     dx,
     dy,
     isZoomEqual,

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
@@ -10,11 +10,10 @@ import {
     constrainZoom,
     dx,
     dy,
-    isZoomEqual,
+    isMaxZoom,
     pointToRatio,
     scaleZoomCenter,
     translateZoom,
-    unitZoomState,
 } from './zoomUtils';
 
 const { userInteraction } = _ModuleSupport;
@@ -53,7 +52,7 @@ export class ZoomContextMenu {
             return this.iterateFindNextZoomAtPoint(origin) != null;
         };
         const shouldEnablePanToHere = () => {
-            return !isZoomEqual(definedZoomState(this.zoomManager.getZoom()), unitZoomState());
+            return !isMaxZoom(definedZoomState(this.zoomManager.getZoom()));
         };
         const removeListener = this.eventsHub.on('context-menu:setup', (event) => {
             contextMenuRegistry.builtins.items['zoom-to-cursor'].enabled = shouldEnableZoomToHere(event);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
@@ -1,6 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import type { AgSeriesAreaContextMenuActionEvent } from 'ag-charts-community';
-import type { DefinedZoomState, Point } from 'ag-charts-core';
+import type { BoxBounds, DefinedZoomState, Point } from 'ag-charts-core';
 import { definedZoomState } from 'ag-charts-core';
 
 import type { ZoomProperties } from './zoomTypes';
@@ -25,7 +25,7 @@ export class ZoomContextMenu {
         private readonly contextMenuRegistry: _ModuleSupport.ContextMenuRegistry,
         private readonly zoomManager: _ModuleSupport.ZoomManager,
         private readonly getModuleProperties: () => ZoomProperties,
-        private readonly getRect: () => _ModuleSupport.BBox | undefined,
+        private readonly getRect: () => BoxBounds | undefined,
         private readonly updateZoom: (sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedZoomState) => void,
         private readonly isZoomValid: (zoom: DefinedZoomState) => boolean
     ) {}

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
@@ -1,17 +1,19 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import type { AxisID, CleanupRegistry, DeepRequired } from 'ag-charts-core';
-import { BaseProperties, ChartAxisDirection, Logger, Property, clamp } from 'ag-charts-core';
+import type {
+    AxisID,
+    CleanupRegistry,
+    DeepRequired,
+    DefinedZoomState,
+    ZoomState,
+    ZoomStateDirection,
+} from 'ag-charts-core';
+import { BaseProperties, ChartAxisDirection, Logger, Property, clamp, definedZoomState } from 'ag-charts-core';
 import type { AgZoomOnDataChange, AgZoomOnDataChangeStrategy } from 'ag-charts-types';
-
-import { definedZoomState } from './zoomUtils';
 
 const { userInteraction } = _ModuleSupport;
 
-type DefinedZoomState = _ModuleSupport.DefinedZoomState;
 type ModuleContext = Pick<_ModuleSupport.ModuleContext, 'eventsHub' | 'zoomManager' | 'axisManager'>;
 type ZoomChangeState = _ModuleSupport.ZoomChangeState;
-type ZoomState = _ModuleSupport.ZoomState;
-type ZoomStateDirection = _ModuleSupport.ZoomStateDirection;
 
 // All axes scale-types can have their minimums & maximums represented as a number.
 // * For category-scales, it's indices.

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
@@ -1,5 +1,13 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { ChartAxisDirection, UNIT_MAX, UNIT_MIN, definedZoomState, entries, getWindow } from 'ag-charts-core';
+import {
+    type BoxBounds,
+    ChartAxisDirection,
+    UNIT_MAX,
+    UNIT_MIN,
+    definedZoomState,
+    entries,
+    getWindow,
+} from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
 import { constrainZoom, dx, dy, pointToRatio, translateZoom } from './zoomUtils';
@@ -166,7 +174,7 @@ export class ZoomPanner {
         return this.direction == null || this.direction === ChartAxisDirection.Y;
     }
 
-    translateZooms(bbox: _ModuleSupport.BBox, currentZooms: StateRetrieval, deltaX: number, deltaY: number) {
+    translateZooms(bbox: BoxBounds, currentZooms: StateRetrieval, deltaX: number, deltaY: number) {
         const offset = pointToRatio(bbox, bbox.x + Math.abs(deltaX), bbox.y + bbox.height - Math.abs(deltaY));
 
         const offsetX = Math.sign(deltaX) * offset.x;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
@@ -1,8 +1,8 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { ChartAxisDirection, entries, getWindow } from 'ag-charts-core';
+import { ChartAxisDirection, UNIT_MAX, UNIT_MIN, definedZoomState, entries, getWindow } from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
-import { UNIT_MAX, UNIT_MIN, constrainZoom, definedZoomState, dx, dy, pointToRatio, translateZoom } from './zoomUtils';
+import { constrainZoom, dx, dy, pointToRatio, translateZoom } from './zoomUtils';
 
 type State = _ModuleSupport.CoreZoomState;
 type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScrollPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScrollPanner.ts
@@ -1,5 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState, entries } from 'ag-charts-core';
+import type { BoxBounds } from 'ag-charts-core';
 
 import { constrainZoom, dx, pointToRatio, translateZoom } from './zoomUtils';
 
@@ -9,12 +10,12 @@ type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;
 const DELTA_SCALE = 200;
 
 export class ZoomScrollPanner {
-    update(event: { deltaX: number }, step: number, bbox: _ModuleSupport.BBox, zooms: StateRetrieval): State {
+    update(event: { deltaX: number }, step: number, bbox: BoxBounds, zooms: StateRetrieval): State {
         const deltaX = event.deltaX * step * DELTA_SCALE;
         return this.translateZooms(bbox, zooms, deltaX);
     }
 
-    private translateZooms(bbox: _ModuleSupport.BBox, currentZooms: StateRetrieval, deltaX: number) {
+    private translateZooms(bbox: BoxBounds, currentZooms: StateRetrieval, deltaX: number) {
         const newZooms: State = {};
 
         const offset = pointToRatio(bbox, bbox.x + Math.abs(deltaX), 0);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScrollPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScrollPanner.ts
@@ -1,7 +1,7 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { ChartAxisDirection, entries } from 'ag-charts-core';
+import { ChartAxisDirection, definedZoomState, entries } from 'ag-charts-core';
 
-import { constrainZoom, definedZoomState, dx, pointToRatio, translateZoom } from './zoomUtils';
+import { constrainZoom, dx, pointToRatio, translateZoom } from './zoomUtils';
 
 type State = _ModuleSupport.CoreZoomState;
 type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
@@ -1,6 +1,6 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState, entries } from 'ag-charts-core';
-import type { DefinedZoomState } from 'ag-charts-core';
+import type { BoxBounds, DefinedZoomState } from 'ag-charts-core';
 
 import type { ZoomProperties } from './zoomTypes';
 import { constrainAxis, constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
@@ -9,12 +9,7 @@ type State = _ModuleSupport.CoreZoomState;
 type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;
 
 export class ZoomScroller {
-    updateAxes(
-        event: _Widget.WheelWidgetEvent,
-        props: ZoomProperties,
-        bbox: _ModuleSupport.BBox,
-        zooms: StateRetrieval
-    ): State {
+    updateAxes(event: _Widget.WheelWidgetEvent, props: ZoomProperties, bbox: BoxBounds, zooms: StateRetrieval): State {
         const sourceEvent = event.sourceEvent;
         const newZooms: State = {};
         const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
@@ -57,7 +52,7 @@ export class ZoomScroller {
     update(
         event: _Widget.WheelWidgetEvent,
         props: ZoomProperties,
-        bbox: _ModuleSupport.BBox,
+        bbox: BoxBounds,
         oldZoom: DefinedZoomState
     ): DefinedZoomState | undefined {
         const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
@@ -1,16 +1,9 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import { ChartAxisDirection, entries } from 'ag-charts-core';
+import { ChartAxisDirection, definedZoomState, entries } from 'ag-charts-core';
+import type { DefinedZoomState } from 'ag-charts-core';
 
-import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
-import {
-    constrainAxis,
-    constrainZoom,
-    definedZoomState,
-    dx,
-    dy,
-    pointToRatio,
-    scaleZoomAxisWithAnchor,
-} from './zoomUtils';
+import type { ZoomProperties } from './zoomTypes';
+import { constrainAxis, constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
 
 type State = _ModuleSupport.CoreZoomState;
 type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
@@ -1,4 +1,3 @@
-import type { _ModuleSupport } from 'ag-charts-community';
 import { definedZoomState } from 'ag-charts-core';
 import type { AxisZoomState, BoxBounds, DefinedZoomState } from 'ag-charts-core';
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
@@ -1,17 +1,10 @@
 import type { _ModuleSupport } from 'ag-charts-community';
+import { definedZoomState } from 'ag-charts-core';
+import type { AxisZoomState, DefinedZoomState } from 'ag-charts-core';
 
 import type { ZoomRect } from './scenes/zoomRect';
-import type { DefinedZoomState, ZoomCoords, ZoomProperties } from './zoomTypes';
-import {
-    constrainZoom,
-    definedZoomState,
-    dx,
-    dy,
-    multiplyZoom,
-    pointToRatio,
-    scaleZoom,
-    translateZoom,
-} from './zoomUtils';
+import type { ZoomCoords, ZoomProperties } from './zoomTypes';
+import { constrainZoom, dx, dy, multiplyZoom, pointToRatio, scaleZoom, translateZoom } from './zoomUtils';
 
 // "Re-rewind, when the crowd say..."
 export class ZoomSelector {
@@ -37,7 +30,7 @@ export class ZoomSelector {
     stop(
         innerBBox?: _ModuleSupport.BBox,
         bbox?: _ModuleSupport.BBox,
-        currentZoom?: _ModuleSupport.AxisZoomState
+        currentZoom?: AxisZoomState
     ): DefinedZoomState | undefined {
         let zoom = definedZoomState();
 
@@ -136,7 +129,7 @@ export class ZoomSelector {
         }
     }
 
-    private createZoomFromCoords(bbox: _ModuleSupport.BBox, currentZoom?: _ModuleSupport.AxisZoomState) {
+    private createZoomFromCoords(bbox: _ModuleSupport.BBox, currentZoom?: AxisZoomState) {
         const oldZoom = definedZoomState(currentZoom);
         const normal = this.getNormalisedDimensions();
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
@@ -1,6 +1,6 @@
 import type { _ModuleSupport } from 'ag-charts-community';
 import { definedZoomState } from 'ag-charts-core';
-import type { AxisZoomState, DefinedZoomState } from 'ag-charts-core';
+import type { AxisZoomState, BoxBounds, DefinedZoomState } from 'ag-charts-core';
 
 import type { ZoomRect } from './scenes/zoomRect';
 import type { ZoomCoords, ZoomProperties } from './zoomTypes';
@@ -18,7 +18,7 @@ export class ZoomSelector {
         this.rect.visible = false;
     }
 
-    update(event: { currentX: number; currentY: number }, props: ZoomProperties, bbox?: _ModuleSupport.BBox): void {
+    update(event: { currentX: number; currentY: number }, props: ZoomProperties, bbox?: BoxBounds): void {
         const canvasX = event.currentX + (bbox?.x ?? 0);
         const canvasY = event.currentY + (bbox?.y ?? 0);
         this.rect.visible = true;
@@ -27,11 +27,7 @@ export class ZoomSelector {
         this.updateRect(bbox);
     }
 
-    stop(
-        innerBBox?: _ModuleSupport.BBox,
-        bbox?: _ModuleSupport.BBox,
-        currentZoom?: AxisZoomState
-    ): DefinedZoomState | undefined {
+    stop(innerBBox?: BoxBounds, bbox?: BoxBounds, currentZoom?: AxisZoomState): DefinedZoomState | undefined {
         let zoom = definedZoomState();
 
         if (!innerBBox || !bbox) return zoom;
@@ -63,7 +59,7 @@ export class ZoomSelector {
         return this.rect.visible && this.rect.width > 0 && this.rect.height > 0;
     }
 
-    private updateCoords(x: number, y: number, props: ZoomProperties, bbox?: _ModuleSupport.BBox): void {
+    private updateCoords(x: number, y: number, props: ZoomProperties, bbox?: BoxBounds): void {
         if (!this.coords) {
             this.coords = { x1: x, y1: y, x2: x, y2: y };
             return;
@@ -102,7 +98,7 @@ export class ZoomSelector {
         }
     }
 
-    private updateRect(bbox?: _ModuleSupport.BBox): void {
+    private updateRect(bbox?: BoxBounds): void {
         if (!bbox) return;
 
         const { rect } = this;
@@ -129,7 +125,7 @@ export class ZoomSelector {
         }
     }
 
-    private createZoomFromCoords(bbox: _ModuleSupport.BBox, currentZoom?: AxisZoomState) {
+    private createZoomFromCoords(bbox: BoxBounds, currentZoom?: AxisZoomState) {
         const oldZoom = definedZoomState(currentZoom);
         const normal = this.getNormalisedDimensions();
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -30,7 +30,6 @@ import {
     scaleZoom,
     scaleZoomAxisWithAnchor,
     translateZoom,
-    unitZoomState,
 } from './zoomUtils';
 
 const { userInteraction, NativeWidget, Toolbar } = _ModuleSupport;
@@ -233,7 +232,7 @@ export class ZoomToolbar extends BaseProperties {
                     enabled = zoom.x.max < UNIT_MAX;
                     break;
                 case 'zoom-out':
-                    enabled = !isZoomEqual(zoom, unitZoomState());
+                    enabled = !isMaxZoom(zoom);
                     break;
                 case 'zoom-in':
                     enabled = this.isZoomValid(

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomButtonValue, _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { AxisID, CartesianAxisDirection } from 'ag-charts-core';
+import type { AxisID, CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
 import {
     ActionOnSet,
     BaseProperties,
@@ -8,22 +8,22 @@ import {
     PropertiesArray,
     Property,
     ToolbarButtonProperties,
+    UNIT_MAX,
+    UNIT_MIN,
     createElement,
     debounce,
+    definedZoomState,
     entries,
 } from 'ag-charts-core';
 
-import type { DefinedZoomState, ZoomProperties } from './zoomTypes';
+import type { ZoomProperties } from './zoomTypes';
 import {
     DEFAULT_ANCHOR_POINT_X,
     DEFAULT_ANCHOR_POINT_Y,
-    UNIT_MAX,
-    UNIT_MIN,
     ZOOM_VALID_CHECK_DEBOUNCE,
     canResetZoom,
     constrainAxis,
     constrainZoom,
-    definedZoomState,
     dx,
     isMaxZoom,
     isZoomEqual,
@@ -96,7 +96,7 @@ export class ZoomToolbar extends BaseProperties {
             sourcing: _ModuleSupport.UpdateZoomSourcing,
             axisId: AxisID,
             direction: CartesianAxisDirection,
-            partialZoom: _ModuleSupport.ZoomState | undefined
+            partialZoom: ZoomState | undefined
         ) => void,
         private readonly resetZoom: (sourceDetail: _ModuleSupport.ZoomEventSourceDetail) => void,
         private readonly isZoomValid: (zoom: DefinedZoomState) => boolean
@@ -275,7 +275,7 @@ export class ZoomToolbar extends BaseProperties {
         props: ZoomProperties,
         axisId: AxisID,
         direction: CartesianAxisDirection,
-        zoom: _ModuleSupport.ZoomState
+        zoom: ZoomState
     ) {
         const { isScalingX, isScalingY, scrollingStep } = props;
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
@@ -1,11 +1,9 @@
 import type { _ModuleSupport, _Widget } from 'ag-charts-community';
+import type { AxisZoomState, DefinedZoomState, ZoomState } from 'ag-charts-core';
 
 // clientXY  (unit: px)          :  Touch screen points.
 // normalXY  (unit: N/A - ratio) :  Touch normalised points in [0, N] range.
 type Origin = { identifier: number; normalX: number; normalY: number };
-type ZoomState = _ModuleSupport.ZoomState;
-type AxisZoomState = _ModuleSupport.AxisZoomState;
-type DefinedZoomState = _ModuleSupport.DefinedZoomState;
 type ZoomTwoFingersTouchStart = { readonly origins: [Origin, Origin] };
 
 const N = 1_000_000;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
@@ -1,4 +1,4 @@
-import type { _ModuleSupport, _Widget } from 'ag-charts-community';
+import type { _Widget } from 'ag-charts-community';
 import type { AxisZoomState, DefinedZoomState, ZoomState } from 'ag-charts-core';
 
 // clientXY  (unit: px)          :  Touch screen points.

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
@@ -1,4 +1,4 @@
-import type { AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
+import type { AgZoomAnchorPoint } from 'ag-charts-community';
 
 export type ZoomCoords = {
     x1: number;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTypes.ts
@@ -1,7 +1,5 @@
 import type { AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
 
-export type DefinedZoomState = _ModuleSupport.DefinedZoomState;
-
 export type ZoomCoords = {
     x1: number;
     y1: number;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -1,6 +1,6 @@
 import { type AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
 import type { BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
-import { UNIT_MAX, UNIT_MIN, clamp, isNumberEqual, jsonDiff } from 'ag-charts-core';
+import { UNIT_MAX, UNIT_MIN, clamp, definedZoomState, isNumberEqual, jsonDiff } from 'ag-charts-core';
 
 export const UNIT_SIZE = UNIT_MAX - UNIT_MIN;
 export const DEFAULT_ANCHOR_POINT_X: AgZoomAnchorPoint = 'end';
@@ -8,10 +8,6 @@ export const DEFAULT_ANCHOR_POINT_Y: AgZoomAnchorPoint = 'middle';
 export const ZOOM_VALID_CHECK_DEBOUNCE = 300;
 
 const constrain = (value: number, min = UNIT_MIN, max = UNIT_MAX) => clamp(min, value, max);
-
-export function unitZoomState(): DefinedZoomState {
-    return { x: { min: UNIT_MIN, max: UNIT_MAX }, y: { min: UNIT_MIN, max: UNIT_MAX } };
-}
 
 export function dx(zoom: DefinedZoomState) {
     return zoom.x.max - zoom.x.min;
@@ -30,7 +26,7 @@ export function isZoomEqual(left: DefinedZoomState, right: DefinedZoomState) {
 }
 
 export function isMaxZoom(zoom: DefinedZoomState) {
-    return isZoomEqual(zoom, unitZoomState());
+    return isZoomEqual(zoom, definedZoomState());
 }
 
 /**

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -1,10 +1,7 @@
 import { type AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
-import { type BoxBounds, clamp, isNumberEqual, jsonDiff } from 'ag-charts-core';
+import type { BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import { UNIT_MAX, UNIT_MIN, clamp, isNumberEqual, jsonDiff } from 'ag-charts-core';
 
-import type { DefinedZoomState } from './zoomTypes';
-
-export const UNIT_MIN = 0;
-export const UNIT_MAX = 1;
 export const UNIT_SIZE = UNIT_MAX - UNIT_MIN;
 export const DEFAULT_ANCHOR_POINT_X: AgZoomAnchorPoint = 'end';
 export const DEFAULT_ANCHOR_POINT_Y: AgZoomAnchorPoint = 'middle';
@@ -24,7 +21,7 @@ export function dy(zoom: DefinedZoomState) {
     return zoom.y.max - zoom.y.min;
 }
 
-function isZoomRangeEqual(left: _ModuleSupport.ZoomState, right: _ModuleSupport.ZoomState) {
+function isZoomRangeEqual(left: ZoomState, right: ZoomState) {
     return isNumberEqual(left.min, right.min) && isNumberEqual(left.max, right.max);
 }
 
@@ -34,13 +31,6 @@ export function isZoomEqual(left: DefinedZoomState, right: DefinedZoomState) {
 
 export function isMaxZoom(zoom: DefinedZoomState) {
     return isZoomEqual(zoom, unitZoomState());
-}
-
-export function definedZoomState(zoom?: _ModuleSupport.AxisZoomState): DefinedZoomState {
-    return {
-        x: { min: zoom?.x?.min ?? UNIT_MIN, max: zoom?.x?.max ?? UNIT_MAX },
-        y: { min: zoom?.y?.min ?? UNIT_MIN, max: zoom?.y?.max ?? UNIT_MAX },
-    };
 }
 
 /**
@@ -100,11 +90,11 @@ export function scaleZoomCenter(zoom: DefinedZoomState, sx: number, sy: number):
  * Scale a single zoom axis about its anchor.
  */
 export function scaleZoomAxisWithAnchor(
-    newState: _ModuleSupport.ZoomState,
-    oldState: _ModuleSupport.ZoomState,
+    newState: ZoomState,
+    oldState: ZoomState,
     anchor: AgZoomAnchorPoint,
     origin?: number
-): _ModuleSupport.ZoomState {
+): ZoomState {
     const { min, max } = oldState;
     const center = min + (max - min) / 2;
     const diff = newState.max - newState.min;
@@ -123,11 +113,7 @@ export function scaleZoomAxisWithAnchor(
     }
 }
 
-export function scaleZoomAxisWithPoint(
-    newState: _ModuleSupport.ZoomState,
-    oldState: _ModuleSupport.ZoomState,
-    origin: number
-) {
+export function scaleZoomAxisWithPoint(newState: ZoomState, oldState: ZoomState, origin: number) {
     const newDelta = newState.max - newState.min;
     const oldDelta = oldState.max - oldState.min;
     const scaledOrigin = origin * (1 - (oldDelta - newDelta));


### PR DESCRIPTION
**Key Changes:**
* Move these const/functions to `ag-charts-core`:
  * `UNIT_MIN`
  * `UNIT_MAX`
  * `definedZoomState`
* Move these types to `ag-charts-core`:
  * `ZoomState`
  * `ZoomStateDirection`
  * `DefinedZoomState`
  * `AxisZoomState`
* Use `definedZoomState` in `zoomManager.ts`
* Remove `unitZoomState()` (just use `isMaxZoom()` instead)
* Replace `_ModuleSupport.BBox` (`ag-chart-community`) with `BoxBounds` (`ag-charts-core`) in some places.