### PR TITLE
AG-NONE Rename `DefinedZoomState` and `AxisZoomState`

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -14,14 +14,14 @@ import {
 } from 'ag-charts-core';
 import type {
     AxisID,
-    AxisZoomState,
     BoxBounds,
     CartesianAxisDirection,
     DeepReadonly,
-    DefinedZoomState,
+    DefinedViewportState,
     OptionsDefs,
     RequireOptional,
     Scale,
+    ViewportState,
     ZoomState,
 } from 'ag-charts-core';
 import type { AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
@@ -196,7 +196,7 @@ export class ZoomManager extends BaseManager {
     }
 
     // FIXME: should be private
-    public toCoreZoomState(axisZoom: DeepReadonly<AxisZoomState>): CoreZoomState {
+    public toCoreZoomState(axisZoom: DeepReadonly<ViewportState>): CoreZoomState {
         const result: CoreZoomState = {};
         let ids: AxisID[];
         const { state } = this;
@@ -226,7 +226,7 @@ export class ZoomManager extends BaseManager {
     }
 
     // FIXME: should be private
-    public toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): AxisZoomState | undefined {
+    public toViewportState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): ViewportState | undefined {
         let x: ZoomState | undefined;
         let y: ZoomState | undefined;
 
@@ -354,7 +354,7 @@ export class ZoomManager extends BaseManager {
         return this.zoomModule;
     }
 
-    public updateZoom({ source, sourceDetail }: UpdateZoomSourcing, newZoom?: AxisZoomState): boolean {
+    public updateZoom({ source, sourceDetail }: UpdateZoomSourcing, newZoom?: ViewportState): boolean {
         const changes = this.toCoreZoomState(newZoom ?? {});
         return this.updateChanges({ source, sourceDetail, changes, isReset: false });
     }
@@ -423,7 +423,7 @@ export class ZoomManager extends BaseManager {
             return false;
         }
 
-        const newZoom: AxisZoomState = calcPanToBBoxRatios(seriesRect, zoom, target);
+        const newZoom: ViewportState = calcPanToBBoxRatios(seriesRect, zoom, target);
         const changes = this.toCoreZoomState(newZoom);
         return this.updateChanges({
             source: 'user-interaction',
@@ -482,8 +482,8 @@ export class ZoomManager extends BaseManager {
         this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio }, isReset: false });
     }
 
-    public getZoom(): AxisZoomState | undefined {
-        return this.toAxisZoomState(this.state);
+    public getZoom(): ViewportState | undefined {
+        return this.toViewportState(this.state);
     }
 
     public getAxisZoom(axisId: AxisID): ZoomState {
@@ -530,10 +530,10 @@ export class ZoomManager extends BaseManager {
     }
 
     public constrainZoomToItemCount(
-        zoom: DefinedZoomState,
+        zoom: DefinedViewportState,
         minVisibleItems: number,
         shouldAutoscale: boolean
-    ): DefinedZoomState {
+    ): DefinedViewportState {
         let xVisibleRange: [number, number] = [zoom.x.min, zoom.x.max];
         let yVisibleRange: [number, number] | undefined = shouldAutoscale ? undefined : [zoom.y.min, zoom.y.max];
         for (const series of this.getBoundSeries()) {
@@ -550,7 +550,7 @@ export class ZoomManager extends BaseManager {
     }
 
     public isVisibleItemsCountAtLeast(
-        zoom: DefinedZoomState,
+        zoom: DefinedViewportState,
         minVisibleItems: number,
         opts: { autoScaleYAxis: boolean; includeYVisibleRange: boolean }
     ): boolean {
@@ -610,10 +610,10 @@ export class ZoomManager extends BaseManager {
             state,
             x,
             y,
-            stateAsDefinedZoom(): DefinedZoomState {
-                return definedZoomState(zoomManager.toAxisZoomState(event.state));
+            stateAsDefinedZoom(): DefinedViewportState {
+                return definedZoomState(zoomManager.toViewportState(event.state));
             },
-            constrainZoom(restrictions: AxisZoomState): void {
+            constrainZoom(restrictions: ViewportState): void {
                 this.constrainChanges(zoomManager.toCoreZoomState(restrictions));
             },
             constrainChanges(restrictions: ZoomChangeState): void {

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -1,10 +1,10 @@
 import type {
     AxisID,
-    AxisZoomState,
     ChartAxisDirection,
     DeepReadonly,
-    DefinedZoomState,
+    DefinedViewportState,
     Scale,
+    ViewportState,
     ZoomState,
     ZoomStateDirection,
 } from 'ag-charts-core';
@@ -180,7 +180,7 @@ export interface ZoomLoadMementoEvent {
     // Note: `zoom` is intentionally mutable. At the time of writing, only one feature (autoScaling) depends on zoom
     // memento events, so it's safe because we do not have multiple writers. We may need to consider adding a
     // `constrain()` method to this event.
-    zoom: DefinedZoomState;
+    zoom: DefinedViewportState;
     readonly memento: DeepReadonly<ZoomMemento> | undefined;
     readonly navigatorModule: boolean;
     readonly zoomModule: boolean;
@@ -232,8 +232,8 @@ export interface ZoomChangeRequestEvent {
     readonly state: ZoomChangeState;
     readonly x?: Readonly<ZoomState>;
     readonly y?: Readonly<ZoomState>;
-    stateAsDefinedZoom(): DefinedZoomState; // do not use (legacy zoom-state)
-    constrainZoom(zoom: AxisZoomState): void; // do not use (legacy zoom-state)
+    stateAsDefinedZoom(): DefinedViewportState; // do not use (legacy zoom-state)
+    constrainZoom(zoom: ViewportState): void; // do not use (legacy zoom-state)
     constrainChanges(changes: ZoomChangeState): void;
 }
 

--- a/packages/ag-charts-core/src/utils/zoomUtils.ts
+++ b/packages/ag-charts-core/src/utils/zoomUtils.ts
@@ -7,12 +7,12 @@ export interface ZoomStateDirection extends ZoomState {
     direction: 'x' | 'y';
 }
 
-export interface DefinedZoomState {
+export interface DefinedViewportState {
     x: ZoomState;
     y: ZoomState;
 }
 
-export interface AxisZoomState {
+export interface ViewportState {
     x?: ZoomState;
     y?: ZoomState;
     autoScaleYAxis?: boolean;
@@ -21,7 +21,7 @@ export interface AxisZoomState {
 export const UNIT_MIN = 0;
 export const UNIT_MAX = 1;
 
-export function definedZoomState(zoom?: AxisZoomState): DefinedZoomState {
+export function definedZoomState(zoom?: ViewportState): DefinedViewportState {
     return {
         x: { min: zoom?.x?.min ?? UNIT_MIN, max: zoom?.x?.max ?? UNIT_MAX },
         y: { min: zoom?.y?.min ?? UNIT_MIN, max: zoom?.y?.max ?? UNIT_MAX },

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { CartesianAxisDirection, DefinedViewportState, ZoomState } from 'ag-charts-core';
 import {
     AbstractModuleInstance,
     ActionOnSet,
@@ -854,13 +854,13 @@ export class Zoom extends AbstractModuleInstance {
         return this.shouldFlipXY ? this.anchorPointX : this.anchorPointY;
     }
 
-    private constrainZoom(newZoom: DefinedZoomState) {
+    private constrainZoom(newZoom: DefinedViewportState) {
         return this.ctx.zoomManager.constrainZoomToItemCount(newZoom, this.minVisibleItems, this.autoScaler.enabled);
     }
 
     private previousZoomValid = true;
     private isZoomValid(
-        newZoom: DefinedZoomState,
+        newZoom: DefinedViewportState,
         options?: { directional?: boolean; includeYVisibleRange?: boolean }
     ) {
         const {
@@ -944,15 +944,15 @@ export class Zoom extends AbstractModuleInstance {
         this.ctx.zoomManager.resetZoom({ source: 'user-interaction', sourceDetail });
     }
 
-    public updateSyncZoom(zoom: DefinedZoomState) {
+    public updateSyncZoom(zoom: DefinedViewportState) {
         this.updateZoom({ source: 'sync', sourceDetail: 'internal-updateSyncZoom' }, zoom);
     }
 
     private updateChanges(sourcing: _ModuleSupport.UpdateZoomSourcing, changes: _ModuleSupport.CoreZoomState) {
-        // TODO: constrainZoom should operate on a partial CoreZoomState instead of DefinedZoomState.
-        // For compatibility, we calculate the final DefinedZoomState for constrainZoom to continue to work without
+        // TODO: constrainZoom should operate on a partial CoreZoomState instead of DefinedViewportState.
+        // For compatibility, we calculate the final DefinedViewportState for constrainZoom to continue to work without
         // breaking thebehaviour.
-        const partialZoom = this.ctx.zoomManager.toAxisZoomState(changes) ?? {};
+        const partialZoom = this.ctx.zoomManager.toViewportState(changes) ?? {};
         const currentZoom = definedZoomState(this.ctx.zoomManager.getZoom());
         this.updateZoom(sourcing, {
             x: partialZoom.x ?? currentZoom.x,
@@ -960,7 +960,7 @@ export class Zoom extends AbstractModuleInstance {
         });
     }
 
-    private updateZoom(sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedZoomState) {
+    private updateZoom(sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedViewportState) {
         if (this.enableIndependentAxes) {
             this.updatePrimaryAxisZooms(sourcing, zoom);
         } else {
@@ -970,7 +970,7 @@ export class Zoom extends AbstractModuleInstance {
 
     private updateUnifiedZoom(
         sourcing: _ModuleSupport.UpdateZoomSourcing,
-        zoom: DefinedZoomState,
+        zoom: DefinedViewportState,
         validOptions?: { directional?: boolean }
     ) {
         zoom = this.constrainZoom(zoom);
@@ -985,14 +985,14 @@ export class Zoom extends AbstractModuleInstance {
         return true;
     }
 
-    private updatePrimaryAxisZooms(sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedZoomState) {
+    private updatePrimaryAxisZooms(sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedViewportState) {
         this.updatePrimaryAxisZoom(sourcing, zoom, ChartAxisDirection.X);
         this.updatePrimaryAxisZoom(sourcing, zoom, ChartAxisDirection.Y);
     }
 
     private updatePrimaryAxisZoom(
         sourcing: _ModuleSupport.UpdateZoomSourcing,
-        zoom: DefinedZoomState,
+        zoom: DefinedViewportState,
         direction: CartesianAxisDirection
     ) {
         const axisId = this.ctx.zoomManager.getPrimaryAxisId(direction);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -1,20 +1,20 @@
 import type { AgZoomAnchorPoint } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState } from 'ag-charts-core';
-import type { AxisZoomState, BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { BoxBounds, DefinedViewportState, ViewportState, ZoomState } from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
 import { constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
 
 export class ZoomAxisDragger {
     private coords?: ZoomCoords;
-    private oldZoom?: DefinedZoomState;
+    private oldZoom?: DefinedViewportState;
 
     update(
         event: { offsetX: number; offsetY: number },
         direction: ChartAxisDirection,
         anchor: AgZoomAnchorPoint,
         bbox: BoxBounds,
-        zoom?: AxisZoomState,
+        zoom?: ViewportState,
         axisZoom?: ZoomState
     ): ZoomState {
         // Store the initial zoom state, merged with the state for this axis

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomContextMenu.ts
@@ -1,6 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import type { AgSeriesAreaContextMenuActionEvent } from 'ag-charts-community';
-import type { BoxBounds, DefinedZoomState, Point } from 'ag-charts-core';
+import type { BoxBounds, DefinedViewportState, Point } from 'ag-charts-core';
 import { definedZoomState } from 'ag-charts-core';
 
 import type { ZoomProperties } from './zoomTypes';
@@ -26,8 +26,8 @@ export class ZoomContextMenu {
         private readonly zoomManager: _ModuleSupport.ZoomManager,
         private readonly getModuleProperties: () => ZoomProperties,
         private readonly getRect: () => BoxBounds | undefined,
-        private readonly updateZoom: (sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedZoomState) => void,
-        private readonly isZoomValid: (zoom: DefinedZoomState) => boolean
+        private readonly updateZoom: (sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedViewportState) => void,
+        private readonly isZoomValid: (zoom: DefinedViewportState) => boolean
     ) {}
 
     public registerActions(enabled: boolean | undefined) {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
@@ -3,7 +3,7 @@ import type {
     AxisID,
     CleanupRegistry,
     DeepRequired,
-    DefinedZoomState,
+    DefinedViewportState,
     ZoomState,
     ZoomStateDirection,
 } from 'ag-charts-core';
@@ -43,11 +43,11 @@ type DesiredStickToEnd = {
 
 type DesiredChanges = DesiredDomains | DesiredStickToEnd;
 
-function shouldIgnoreDataUpdate(zoom: DefinedZoomState): boolean {
+function shouldIgnoreDataUpdate(zoom: DefinedViewportState): boolean {
     return zoom.x.min === 0 && zoom.x.max === 1 && zoom.y.min === 0 && zoom.y.max === 1;
 }
 
-function shouldStickToEnd(properties: ZoomOnDataChangeProperties, zoom: DefinedZoomState): boolean {
+function shouldStickToEnd(properties: ZoomOnDataChangeProperties, zoom: DefinedViewportState): boolean {
     return properties.stickToEnd && zoom.x.max === 1;
 }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
@@ -1,6 +1,6 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState, entries } from 'ag-charts-core';
-import type { BoxBounds, DefinedZoomState } from 'ag-charts-core';
+import type { BoxBounds, DefinedViewportState } from 'ag-charts-core';
 
 import type { ZoomProperties } from './zoomTypes';
 import { constrainAxis, constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
@@ -53,8 +53,8 @@ export class ZoomScroller {
         event: _Widget.WheelWidgetEvent,
         props: ZoomProperties,
         bbox: BoxBounds,
-        oldZoom: DefinedZoomState
-    ): DefinedZoomState | undefined {
+        oldZoom: DefinedViewportState
+    ): DefinedViewportState | undefined {
         const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
 
         const canvasX = event.offsetX + bbox.x;
@@ -83,7 +83,7 @@ export class ZoomScroller {
         return newZoom;
     }
 
-    updateDelta(delta: number, props: ZoomProperties, oldZoom: DefinedZoomState): DefinedZoomState {
+    updateDelta(delta: number, props: ZoomProperties, oldZoom: DefinedViewportState): DefinedViewportState {
         const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
 
         // Scale the zoom bounding box

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
@@ -1,5 +1,5 @@
 import { definedZoomState } from 'ag-charts-core';
-import type { AxisZoomState, BoxBounds, DefinedZoomState } from 'ag-charts-core';
+import type { BoxBounds, DefinedViewportState, ViewportState } from 'ag-charts-core';
 
 import type { ZoomRect } from './scenes/zoomRect';
 import type { ZoomCoords, ZoomProperties } from './zoomTypes';
@@ -11,8 +11,8 @@ export class ZoomSelector {
 
     constructor(
         private readonly rect: ZoomRect,
-        private readonly getZoom: () => DefinedZoomState,
-        private readonly isZoomValid: (zoom: DefinedZoomState) => boolean
+        private readonly getZoom: () => DefinedViewportState,
+        private readonly isZoomValid: (zoom: DefinedViewportState) => boolean
     ) {
         this.rect.visible = false;
     }
@@ -26,7 +26,7 @@ export class ZoomSelector {
         this.updateRect(bbox);
     }
 
-    stop(innerBBox?: BoxBounds, bbox?: BoxBounds, currentZoom?: AxisZoomState): DefinedZoomState | undefined {
+    stop(innerBBox?: BoxBounds, bbox?: BoxBounds, currentZoom?: ViewportState): DefinedViewportState | undefined {
         let zoom = definedZoomState();
 
         if (!innerBBox || !bbox) return zoom;
@@ -124,7 +124,7 @@ export class ZoomSelector {
         }
     }
 
-    private createZoomFromCoords(bbox: BoxBounds, currentZoom?: AxisZoomState) {
+    private createZoomFromCoords(bbox: BoxBounds, currentZoom?: ViewportState) {
         const oldZoom = definedZoomState(currentZoom);
         const normal = this.getNormalisedDimensions();
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomButtonValue, _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { AxisID, CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { AxisID, CartesianAxisDirection, DefinedViewportState, ZoomState } from 'ag-charts-core';
 import {
     ActionOnSet,
     BaseProperties,
@@ -86,12 +86,12 @@ export class ZoomToolbar extends BaseProperties {
 
     private readonly cleanup = new CleanupRegistry();
 
-    private previousZoom?: DefinedZoomState;
+    private previousZoom?: DefinedViewportState;
 
     constructor(
         private readonly ctx: _ModuleSupport.ModuleContext,
         private readonly getModuleProperties: () => ZoomProperties,
-        private readonly updateZoom: (sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedZoomState) => void,
+        private readonly updateZoom: (sourcing: _ModuleSupport.UpdateZoomSourcing, zoom: DefinedViewportState) => void,
         private readonly updateAxisZoom: (
             sourcing: _ModuleSupport.UpdateZoomSourcing,
             axisId: AxisID,
@@ -99,7 +99,7 @@ export class ZoomToolbar extends BaseProperties {
             partialZoom: ZoomState | undefined
         ) => void,
         private readonly resetZoom: (sourceDetail: _ModuleSupport.ZoomEventSourceDetail) => void,
-        private readonly isZoomValid: (zoom: DefinedZoomState) => boolean
+        private readonly isZoomValid: (zoom: DefinedViewportState) => boolean
     ) {
         super();
 
@@ -210,7 +210,7 @@ export class ZoomToolbar extends BaseProperties {
         trailing: true,
     });
     private toggleButtons() {
-        const zoom: Readonly<DefinedZoomState> = definedZoomState(this.ctx.zoomManager.getZoom());
+        const zoom: Readonly<DefinedViewportState> = definedZoomState(this.ctx.zoomManager.getZoom());
 
         // Only change the buttons if zoom has changed to prevent churn
         if (this.previousZoom && isZoomEqual(this.previousZoom, zoom)) return;
@@ -360,7 +360,11 @@ export class ZoomToolbar extends BaseProperties {
         this.updateZoom(userInteraction(`zoom-button-${event.value}`), constrainZoom(zoom));
     }
 
-    private getNextZoomStateUnified(button: 'zoom-in' | 'zoom-out', oldZoom: DefinedZoomState, props: ZoomProperties) {
+    private getNextZoomStateUnified(
+        button: 'zoom-in' | 'zoom-out',
+        oldZoom: DefinedViewportState,
+        props: ZoomProperties
+    ) {
         const { isScalingX, isScalingY, scrollingStep } = props;
 
         const scale = button === 'zoom-in' ? 1 - scrollingStep : 1 + scrollingStep;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
@@ -1,5 +1,6 @@
 import type { _Widget } from 'ag-charts-community';
 import type { ViewportState, DefinedViewportState, ZoomState } from 'ag-charts-core';
+import { definedZoomState } from 'ag-charts-core';
 
 // clientXY  (unit: px)          :  Touch screen points.
 // normalXY  (unit: N/A - ratio) :  Touch normalised points in [0, N] range.
@@ -48,7 +49,7 @@ export class ZoomTwoFingers {
             { identifier: 0, normalX: Number.NaN, normalY: Number.NaN },
         ],
     };
-    private readonly initialZoom: DefinedViewportState = { x: { min: 0, max: 1 }, y: { min: 0, max: 1 } };
+    private readonly initialZoom: DefinedViewportState = definedZoomState(undefined);
     private readonly previous = { a1: Number.NaN, a2: Number.NaN, b1: Number.NaN, b2: Number.NaN };
 
     start(event: _Widget.TouchWidgetEvent<'touchstart'>, target: _Widget.Widget, zoom: ViewportState): boolean {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
@@ -1,5 +1,5 @@
 import type { _Widget } from 'ag-charts-community';
-import type { AxisZoomState, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { ViewportState, DefinedViewportState, ZoomState } from 'ag-charts-core';
 
 // clientXY  (unit: px)          :  Touch screen points.
 // normalXY  (unit: N/A - ratio) :  Touch normalised points in [0, N] range.
@@ -48,10 +48,10 @@ export class ZoomTwoFingers {
             { identifier: 0, normalX: Number.NaN, normalY: Number.NaN },
         ],
     };
-    private readonly initialZoom: DefinedZoomState = { x: { min: 0, max: 1 }, y: { min: 0, max: 1 } };
+    private readonly initialZoom: DefinedViewportState = { x: { min: 0, max: 1 }, y: { min: 0, max: 1 } };
     private readonly previous = { a1: Number.NaN, a2: Number.NaN, b1: Number.NaN, b2: Number.NaN };
 
-    start(event: _Widget.TouchWidgetEvent<'touchstart'>, target: _Widget.Widget, zoom: AxisZoomState): boolean {
+    start(event: _Widget.TouchWidgetEvent<'touchstart'>, target: _Widget.Widget, zoom: ViewportState): boolean {
         if (event.sourceEvent.targetTouches.length !== 2) return false;
         event.sourceEvent.preventDefault();
 
@@ -91,7 +91,7 @@ export class ZoomTwoFingers {
         return true;
     }
 
-    update(event: _Widget.TouchWidgetEvent<'touchmove'>, target: _Widget.Widget): DefinedZoomState {
+    update(event: _Widget.TouchWidgetEvent<'touchmove'>, target: _Widget.Widget): DefinedViewportState {
         event.sourceEvent.preventDefault();
 
         const targetTouches = Array.from(event.sourceEvent.targetTouches);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
-import type { BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { BoxBounds, DefinedViewportState, ZoomState } from 'ag-charts-core';
 import { UNIT_MAX, UNIT_MIN, clamp, isNumberEqual, jsonDiff } from 'ag-charts-core';
 
 export const UNIT_SIZE = UNIT_MAX - UNIT_MIN;
@@ -9,15 +9,15 @@ export const ZOOM_VALID_CHECK_DEBOUNCE = 300;
 
 const constrain = (value: number, min = UNIT_MIN, max = UNIT_MAX) => clamp(min, value, max);
 
-export function unitZoomState(): DefinedZoomState {
+export function unitZoomState(): DefinedViewportState {
     return { x: { min: UNIT_MIN, max: UNIT_MAX }, y: { min: UNIT_MIN, max: UNIT_MAX } };
 }
 
-export function dx(zoom: DefinedZoomState) {
+export function dx(zoom: DefinedViewportState) {
     return zoom.x.max - zoom.x.min;
 }
 
-export function dy(zoom: DefinedZoomState) {
+export function dy(zoom: DefinedViewportState) {
     return zoom.y.max - zoom.y.min;
 }
 
@@ -25,11 +25,11 @@ function isZoomRangeEqual(left: ZoomState, right: ZoomState) {
     return isNumberEqual(left.min, right.min) && isNumberEqual(left.max, right.max);
 }
 
-export function isZoomEqual(left: DefinedZoomState, right: DefinedZoomState) {
+export function isZoomEqual(left: DefinedViewportState, right: DefinedViewportState) {
     return isZoomRangeEqual(left.x, right.x) && isZoomRangeEqual(left.y, right.y);
 }
 
-export function isMaxZoom(zoom: DefinedZoomState) {
+export function isMaxZoom(zoom: DefinedViewportState) {
     return isZoomEqual(zoom, unitZoomState());
 }
 
@@ -53,7 +53,7 @@ export function pointToRatio(bbox: BoxBounds, x: number, y: number): { x: number
 /**
  * Translate a zoom bounding box by shifting all points by the given x & y amounts.
  */
-export function translateZoom(zoom: DefinedZoomState, x: number, y: number): DefinedZoomState {
+export function translateZoom(zoom: DefinedViewportState, x: number, y: number): DefinedViewportState {
     return {
         x: { min: zoom.x.min + x, max: zoom.x.max + x },
         y: { min: zoom.y.min + y, max: zoom.y.max + y },
@@ -63,7 +63,7 @@ export function translateZoom(zoom: DefinedZoomState, x: number, y: number): Def
 /**
  * Scale a zoom bounding box from the top left corner.
  */
-export function scaleZoom(zoom: DefinedZoomState, sx: number, sy: number): DefinedZoomState {
+export function scaleZoom(zoom: DefinedViewportState, sx: number, sy: number): DefinedViewportState {
     return {
         x: { min: zoom.x.min, max: zoom.x.min + dx(zoom) * sx },
         y: { min: zoom.y.min, max: zoom.y.min + dy(zoom) * sy },
@@ -73,7 +73,7 @@ export function scaleZoom(zoom: DefinedZoomState, sx: number, sy: number): Defin
 /**
  * Scale a zoom bounding box from the center.
  */
-export function scaleZoomCenter(zoom: DefinedZoomState, sx: number, sy: number): DefinedZoomState {
+export function scaleZoomCenter(zoom: DefinedViewportState, sx: number, sy: number): DefinedViewportState {
     const dx_ = dx(zoom);
     const dy_ = dy(zoom);
 
@@ -125,7 +125,7 @@ export function scaleZoomAxisWithPoint(newState: ZoomState, oldState: ZoomState,
     return { min, max };
 }
 
-export function multiplyZoom(zoom: DefinedZoomState, nx: number, ny: number) {
+export function multiplyZoom(zoom: DefinedViewportState, nx: number, ny: number) {
     return {
         x: { min: zoom.x.min * nx, max: zoom.x.max * nx },
         y: { min: zoom.y.min * ny, max: zoom.y.max * ny },
@@ -135,7 +135,7 @@ export function multiplyZoom(zoom: DefinedZoomState, nx: number, ny: number) {
 /**
  * Constrain a zoom bounding box such that no corner exceeds an edge while maintaining the same width and height.
  */
-export function constrainZoom(zoom: DefinedZoomState): DefinedZoomState {
+export function constrainZoom(zoom: DefinedViewportState): DefinedViewportState {
     return {
         x: constrainAxis(zoom.x),
         y: constrainAxis(zoom.y),


### PR DESCRIPTION
It's sort of confusing names.

"DefinedZoomState" sounds like a defined version of "ZoomState" (but it's not, it's defined version of "AxisZoomState").

"AxisZoomState" sounds like the state of a specific axis (but it's not, it's the state of both axes).