### PR TITLE
AG-NONE Rename Zoom Types

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -22,7 +22,7 @@ import type {
     OptionsDefs,
     RequireOptional,
     Scale,
-    ZoomState,
+    ZoomMinMax,
 } from 'ag-charts-core';
 import type { AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
@@ -43,7 +43,7 @@ import { rangeAlignment } from '../rangeAlignment';
 import type { ISeries } from '../series/seriesTypes';
 import type { UpdateService } from '../updateService';
 
-type CoreZoomEntry = ZoomState & { direction: CartesianAxisDirection };
+type CoreZoomEntry = ZoomMinMax & { direction: CartesianAxisDirection };
 export type CoreZoomState = Record<AxisID, CoreZoomEntry>;
 export type CoreZoomStateSafeRetrieval = { readonly [K in AxisID]: CoreZoomEntry | undefined };
 
@@ -90,7 +90,7 @@ export type UpdateZoomSourcing = {
     source: AgZoomEventSource;
     sourceDetail: ZoomEventSourceDetail;
 };
-export type UpdateZoomChanges = Record<AxisID, ZoomState | undefined>;
+export type UpdateZoomChanges = Record<AxisID, ZoomMinMax | undefined>;
 export type UpdateZoomParams = UpdateZoomSourcing & {
     isReset: boolean;
     changes: UpdateZoomChanges;
@@ -227,8 +227,8 @@ export class ZoomManager extends BaseManager {
 
     // FIXME: should be private
     public toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): AxisZoomState | undefined {
-        let x: ZoomState | undefined;
-        let y: ZoomState | undefined;
+        let x: ZoomMinMax | undefined;
+        let y: ZoomMinMax | undefined;
 
         // Use the zoom on the primary (first) axis in each direction
         for (const id of strictObjectKeys(coreZoom)) {
@@ -486,7 +486,7 @@ export class ZoomManager extends BaseManager {
         return this.toAxisZoomState(this.state);
     }
 
-    public getAxisZoom(axisId: AxisID): ZoomState {
+    public getAxisZoom(axisId: AxisID): ZoomMinMax {
         return this.state[axisId] ?? { min: 0, max: 1 };
     }
 
@@ -649,15 +649,15 @@ export class ZoomManager extends BaseManager {
         return changeAccepted;
     }
 
-    public getRange(axisId: AxisID, ratio: ZoomState): AgZoomRange | undefined {
+    public getRange(axisId: AxisID, ratio: ZoomMinMax): AgZoomRange | undefined {
         return this.getRangeAxis(this.findAxis(axisId), ratio);
     }
 
-    private getRangeDirection(direction: CartesianAxisDirection, ratio: ZoomState): AgZoomRange | undefined {
+    private getRangeDirection(direction: CartesianAxisDirection, ratio: ZoomMinMax): AgZoomRange | undefined {
         return this.getRangeAxis(this.getPrimaryAxis(direction), ratio);
     }
 
-    private getRangeAxis(axis: CartesianAxisLike | undefined, ratio: ZoomState | undefined): AgZoomRange | undefined {
+    private getRangeAxis(axis: CartesianAxisLike | undefined, ratio: ZoomMinMax | undefined): AgZoomRange | undefined {
         if (!axis || !ratio || (!ContinuousScale.is(axis.scale) && !DiscreteTimeScale.is(axis.scale))) return;
 
         const extents = this.getDomainPixelExtents(axis);
@@ -679,15 +679,15 @@ export class ZoomManager extends BaseManager {
         return { start, end };
     }
 
-    public rangeToRatio(axisId: AxisID, range: AgZoomRange): ZoomState | undefined {
+    public rangeToRatio(axisId: AxisID, range: AgZoomRange): ZoomMinMax | undefined {
         return this.rangeToRatioAxis(this.findAxis(axisId), range);
     }
 
-    public rangeToRatioDirection(direction: CartesianAxisDirection, range: AgZoomRange): ZoomState | undefined {
+    public rangeToRatioDirection(direction: CartesianAxisDirection, range: AgZoomRange): ZoomMinMax | undefined {
         return this.rangeToRatioAxis(this.getPrimaryAxis(direction), range);
     }
 
-    private rangeToRatioAxis(axis: CartesianAxisLike | undefined, range: AgZoomRange): ZoomState | undefined {
+    private rangeToRatioAxis(axis: CartesianAxisLike | undefined, range: AgZoomRange): ZoomMinMax | undefined {
         if (!axis) return;
 
         const extents = this.getDomainPixelExtents(axis);

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -14,7 +14,6 @@ import {
 } from 'ag-charts-core';
 import type {
     AxisID,
-    AxisZoomState,
     BoxBounds,
     CartesianAxisDirection,
     DeepReadonly,
@@ -23,6 +22,7 @@ import type {
     RequireOptional,
     Scale,
     ZoomMinMax,
+    ZoomState,
 } from 'ag-charts-core';
 import type { AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
@@ -196,7 +196,7 @@ export class ZoomManager extends BaseManager {
     }
 
     // FIXME: should be private
-    public toCoreZoomState(axisZoom: DeepReadonly<AxisZoomState>): CoreZoomState {
+    public toCoreZoomState(axisZoom: DeepReadonly<ZoomState>): CoreZoomState {
         const result: CoreZoomState = {};
         let ids: AxisID[];
         const { state } = this;
@@ -226,7 +226,7 @@ export class ZoomManager extends BaseManager {
     }
 
     // FIXME: should be private
-    public toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): AxisZoomState | undefined {
+    public toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): ZoomState | undefined {
         let x: ZoomMinMax | undefined;
         let y: ZoomMinMax | undefined;
 
@@ -354,7 +354,7 @@ export class ZoomManager extends BaseManager {
         return this.zoomModule;
     }
 
-    public updateZoom({ source, sourceDetail }: UpdateZoomSourcing, newZoom?: AxisZoomState): boolean {
+    public updateZoom({ source, sourceDetail }: UpdateZoomSourcing, newZoom?: ZoomState): boolean {
         const changes = this.toCoreZoomState(newZoom ?? {});
         return this.updateChanges({ source, sourceDetail, changes, isReset: false });
     }
@@ -423,7 +423,7 @@ export class ZoomManager extends BaseManager {
             return false;
         }
 
-        const newZoom: AxisZoomState = calcPanToBBoxRatios(seriesRect, zoom, target);
+        const newZoom: ZoomState = calcPanToBBoxRatios(seriesRect, zoom, target);
         const changes = this.toCoreZoomState(newZoom);
         return this.updateChanges({
             source: 'user-interaction',
@@ -482,7 +482,7 @@ export class ZoomManager extends BaseManager {
         this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio }, isReset: false });
     }
 
-    public getZoom(): AxisZoomState | undefined {
+    public getZoom(): ZoomState | undefined {
         return this.toAxisZoomState(this.state);
     }
 
@@ -613,7 +613,7 @@ export class ZoomManager extends BaseManager {
             stateAsDefinedZoom(): DefinedZoomState {
                 return definedZoomState(zoomManager.toAxisZoomState(event.state));
             },
-            constrainZoom(restrictions: AxisZoomState): void {
+            constrainZoom(restrictions: ZoomState): void {
                 this.constrainChanges(zoomManager.toCoreZoomState(restrictions));
             },
             constrainChanges(restrictions: ZoomChangeState): void {

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -226,7 +226,7 @@ export class ZoomManager extends BaseManager {
     }
 
     // FIXME: should be private
-    public toAxisZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): ZoomState | undefined {
+    public toZoomState(coreZoom: DeepReadonly<CoreZoomStateSafeRetrieval>): ZoomState | undefined {
         let x: ZoomMinMax | undefined;
         let y: ZoomMinMax | undefined;
 
@@ -483,7 +483,7 @@ export class ZoomManager extends BaseManager {
     }
 
     public getZoom(): ZoomState | undefined {
-        return this.toAxisZoomState(this.state);
+        return this.toZoomState(this.state);
     }
 
     public getAxisZoom(axisId: AxisID): ZoomMinMax {
@@ -611,7 +611,7 @@ export class ZoomManager extends BaseManager {
             x,
             y,
             stateAsDefinedZoom(): DefinedZoomState {
-                return definedZoomState(zoomManager.toAxisZoomState(event.state));
+                return definedZoomState(zoomManager.toZoomState(event.state));
             },
             constrainZoom(restrictions: ZoomState): void {
                 this.constrainChanges(zoomManager.toCoreZoomState(restrictions));

--- a/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
@@ -1,5 +1,5 @@
 import { ChartUpdateType, CleanupRegistry } from 'ag-charts-core';
-import type { ZoomState } from 'ag-charts-core';
+import type { ZoomMinMax } from 'ag-charts-core';
 
 import type { EventsHub } from '../../core/eventsHub';
 import type { DataService } from '../data/dataService';
@@ -11,7 +11,7 @@ import type { AxisLike, ChartLike, UpdateProcessor } from './processor';
 export class DataWindowProcessor<D extends object> implements UpdateProcessor {
     private dirtyZoom = false;
     private dirtyDataSource = false;
-    private readonly lastAxisZooms = new Map<string, ZoomState>();
+    private readonly lastAxisZooms = new Map<string, ZoomMinMax>();
 
     private readonly cleanup = new CleanupRegistry();
 
@@ -88,7 +88,7 @@ export class DataWindowProcessor<D extends object> implements UpdateProcessor {
         return this.chart.axes.find((axis) => axis.type === 'time');
     }
 
-    private shouldRefresh(event: UpdateCompleteEvent, axis: AxisLike, zoom: ZoomState) {
+    private shouldRefresh(event: UpdateCompleteEvent, axis: AxisLike, zoom: ZoomMinMax) {
         if (event.apiUpdate) return true;
         if (this.dirtyDataSource) return true;
         if (!this.dirtyZoom) return false;
@@ -103,7 +103,7 @@ export class DataWindowProcessor<D extends object> implements UpdateProcessor {
         return true;
     }
 
-    private getAxisWindow(axis: AxisLike, zoom: ZoomState) {
+    private getAxisWindow(axis: AxisLike, zoom: ZoomMinMax) {
         const { domain } = axis.scale;
 
         if (!zoom || domain.length === 0 || Number.isNaN(Number(domain[0]))) return;

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -5,8 +5,8 @@ import type {
     DeepReadonly,
     DefinedZoomState,
     Scale,
-    ZoomState,
-    ZoomStateDirection,
+    ZoomMinMax,
+    ZoomMinMaxDirection,
 } from 'ag-charts-core';
 import { EventEmitter } from 'ag-charts-core';
 import type {
@@ -187,7 +187,7 @@ export interface ZoomLoadMementoEvent {
 }
 
 export type ZoomChangeState = {
-    readonly [K in AxisID]: Readonly<ZoomStateDirection> | undefined;
+    readonly [K in AxisID]: Readonly<ZoomMinMaxDirection> | undefined;
 };
 
 export type ZoomEventSourceDetail =
@@ -230,8 +230,8 @@ export interface ZoomChangeRequestEvent {
     readonly isReset: boolean;
     readonly changedAxes: readonly AxisID[];
     readonly state: ZoomChangeState;
-    readonly x?: Readonly<ZoomState>;
-    readonly y?: Readonly<ZoomState>;
+    readonly x?: Readonly<ZoomMinMax>;
+    readonly y?: Readonly<ZoomMinMax>;
     stateAsDefinedZoom(): DefinedZoomState; // do not use (legacy zoom-state)
     constrainZoom(zoom: AxisZoomState): void; // do not use (legacy zoom-state)
     constrainChanges(changes: ZoomChangeState): void;
@@ -240,7 +240,7 @@ export interface ZoomChangeRequestEvent {
 export interface ZoomChangeCompleteEvent {
     readonly source: AgZoomEventSource;
     readonly sourceDetail: ZoomEventSourceDetail;
-    readonly x?: Readonly<ZoomState>;
+    readonly x?: Readonly<ZoomMinMax>;
 }
 
 export interface ZoomPanStartEvent {

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -1,12 +1,12 @@
 import type {
     AxisID,
-    AxisZoomState,
     ChartAxisDirection,
     DeepReadonly,
     DefinedZoomState,
     Scale,
     ZoomMinMax,
     ZoomMinMaxDirection,
+    ZoomState,
 } from 'ag-charts-core';
 import { EventEmitter } from 'ag-charts-core';
 import type {
@@ -233,7 +233,7 @@ export interface ZoomChangeRequestEvent {
     readonly x?: Readonly<ZoomMinMax>;
     readonly y?: Readonly<ZoomMinMax>;
     stateAsDefinedZoom(): DefinedZoomState; // do not use (legacy zoom-state)
-    constrainZoom(zoom: AxisZoomState): void; // do not use (legacy zoom-state)
+    constrainZoom(zoom: ZoomState): void; // do not use (legacy zoom-state)
     constrainChanges(changes: ZoomChangeState): void;
 }
 

--- a/packages/ag-charts-community/src/util/panToBBox.ts
+++ b/packages/ag-charts-community/src/util/panToBBox.ts
@@ -45,7 +45,7 @@ function panAxesUnnormalized(
     return clamp(worldMin, viewportMin + diff, worldMax);
 }
 
-// The calculations of the new desired viewport (i.e. ZoomState) is done in pixel coords (unnormalised).
+// The calculations of the new desired viewport (i.e. ZoomMinMax) is done in pixel coords (unnormalised).
 // The desired (x, y) for the new viewport is found, the pixel coords are converted into normalized values
 export function calcPanToBBoxRatios(
     viewportBBox: BoxBounds,

--- a/packages/ag-charts-core/src/utils/zoomUtils.ts
+++ b/packages/ag-charts-core/src/utils/zoomUtils.ts
@@ -12,7 +12,7 @@ export interface DefinedZoomState {
     y: ZoomMinMax;
 }
 
-export interface AxisZoomState {
+export interface ZoomState {
     x?: ZoomMinMax;
     y?: ZoomMinMax;
     autoScaleYAxis?: boolean;
@@ -21,7 +21,7 @@ export interface AxisZoomState {
 export const UNIT_MIN = 0;
 export const UNIT_MAX = 1;
 
-export function definedZoomState(zoom?: AxisZoomState): DefinedZoomState {
+export function definedZoomState(zoom?: ZoomState): DefinedZoomState {
     return {
         x: { min: zoom?.x?.min ?? UNIT_MIN, max: zoom?.x?.max ?? UNIT_MAX },
         y: { min: zoom?.y?.min ?? UNIT_MIN, max: zoom?.y?.max ?? UNIT_MAX },

--- a/packages/ag-charts-core/src/utils/zoomUtils.ts
+++ b/packages/ag-charts-core/src/utils/zoomUtils.ts
@@ -1,20 +1,20 @@
-export interface ZoomState {
+export interface ZoomMinMax {
     min: number;
     max: number;
 }
 
-export interface ZoomStateDirection extends ZoomState {
+export interface ZoomMinMaxDirection extends ZoomMinMax {
     direction: 'x' | 'y';
 }
 
 export interface DefinedZoomState {
-    x: ZoomState;
-    y: ZoomState;
+    x: ZoomMinMax;
+    y: ZoomMinMax;
 }
 
 export interface AxisZoomState {
-    x?: ZoomState;
-    y?: ZoomState;
+    x?: ZoomMinMax;
+    y?: ZoomMinMax;
     autoScaleYAxis?: boolean;
 }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -953,7 +953,7 @@ export class Zoom extends AbstractModuleInstance {
         // TODO: constrainZoom should operate on a partial CoreZoomState instead of DefinedZoomState.
         // For compatibility, we calculate the final DefinedZoomState for constrainZoom to continue to work without
         // breaking thebehaviour.
-        const partialZoom = this.ctx.zoomManager.toAxisZoomState(changes) ?? {};
+        const partialZoom = this.ctx.zoomManager.toZoomState(changes) ?? {};
         const currentZoom = definedZoomState(this.ctx.zoomManager.getZoom());
         this.updateZoom(sourcing, {
             x: partialZoom.x ?? currentZoom.x,

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -1,5 +1,5 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { AxisID, CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { AxisID, CartesianAxisDirection, DefinedZoomState, ZoomMinMax } from 'ag-charts-core';
 import {
     AbstractModuleInstance,
     ActionOnSet,
@@ -907,7 +907,7 @@ export class Zoom extends AbstractModuleInstance {
     };
     private isAxisZoomValid(
         direction: CartesianAxisDirection,
-        axisZoom: ZoomState,
+        axisZoom: ZoomMinMax,
         options?: { directional?: boolean }
     ) {
         const {
@@ -1005,7 +1005,7 @@ export class Zoom extends AbstractModuleInstance {
         sourcing: _ModuleSupport.UpdateZoomSourcing,
         axisId: AxisID,
         direction: CartesianAxisDirection,
-        axisZoom: ZoomState | undefined,
+        axisZoom: ZoomMinMax | undefined,
         validOptions?: { directional?: boolean }
     ) {
         const {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAutoScale.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAutoScale.ts
@@ -1,6 +1,6 @@
 import type { AgZoomAutoScaling } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import type { CartesianAxisDirection, DeepRequired, ZoomState } from 'ag-charts-core';
+import type { CartesianAxisDirection, DeepRequired, ZoomMinMax } from 'ag-charts-core';
 import {
     BaseProperties,
     ChartAxisDirection,
@@ -109,11 +109,11 @@ export class ZoomAutoScaler {
         }
     }
 
-    private getAutoScaleYZoom(zoomX: ZoomState): ZoomState | undefined {
+    private getAutoScaleYZoom(zoomX: ZoomMinMax): ZoomMinMax | undefined {
         if (!this.enabled) return;
 
         const { padding } = this.properties;
-        let yZoom: ZoomState | undefined;
+        let yZoom: ZoomMinMax | undefined;
         if (this.deps.enableIndependentAxes) {
             yZoom = this.primaryAxisZoom(ChartAxisDirection.Y, zoomX, { padding });
         } else {
@@ -155,7 +155,7 @@ export class ZoomAutoScaler {
         yAxis: CartesianAxisLike,
         zoom: { min: number; max: number },
         padding: number
-    ): ZoomState | undefined {
+    ): ZoomMinMax | undefined {
         // Because xScale is only updated after a chart update, working out a visible range
         // will be calculated with unpredictable - but always accurate - numbers
         // However, floating point rounding causes issues when doing that
@@ -236,9 +236,9 @@ export class ZoomAutoScaler {
 
     private primaryAxisZoom(
         direction: CartesianAxisDirection,
-        zoom: ZoomState,
+        zoom: ZoomMinMax,
         { padding = 0 } = {}
-    ): ZoomState | undefined {
+    ): ZoomMinMax | undefined {
         const crossDirection = direction === ChartAxisDirection.X ? ChartAxisDirection.Y : ChartAxisDirection.X;
 
         const xAxis = this.zoomManager.getPrimaryAxis(crossDirection);
@@ -251,9 +251,9 @@ export class ZoomAutoScaler {
 
     private combinedAxisZoom(
         direction: CartesianAxisDirection,
-        zoom: ZoomState,
+        zoom: ZoomMinMax,
         { padding = 0 } = {}
-    ): ZoomState | undefined {
+    ): ZoomMinMax | undefined {
         const axes = this.zoomManager.getAxes();
         const crossDirection = direction === ChartAxisDirection.X ? ChartAxisDirection.Y : ChartAxisDirection.X;
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -1,6 +1,6 @@
 import type { AgZoomAnchorPoint } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState } from 'ag-charts-core';
-import type { AxisZoomState, BoxBounds, DefinedZoomState, ZoomMinMax } from 'ag-charts-core';
+import type { BoxBounds, DefinedZoomState, ZoomMinMax, ZoomState } from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
 import { constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
@@ -14,7 +14,7 @@ export class ZoomAxisDragger {
         direction: ChartAxisDirection,
         anchor: AgZoomAnchorPoint,
         bbox: BoxBounds,
-        zoom?: AxisZoomState,
+        zoom?: ZoomState,
         axisZoom?: ZoomMinMax
     ): ZoomMinMax {
         // Store the initial zoom state, merged with the state for this axis

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -1,6 +1,6 @@
 import type { AgZoomAnchorPoint } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState } from 'ag-charts-core';
-import type { AxisZoomState, BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { AxisZoomState, BoxBounds, DefinedZoomState, ZoomMinMax } from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
 import { constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
@@ -15,8 +15,8 @@ export class ZoomAxisDragger {
         anchor: AgZoomAnchorPoint,
         bbox: BoxBounds,
         zoom?: AxisZoomState,
-        axisZoom?: ZoomState
-    ): ZoomState {
+        axisZoom?: ZoomMinMax
+    ): ZoomMinMax {
         // Store the initial zoom state, merged with the state for this axis
         this.oldZoom ??= definedZoomState(
             direction === ChartAxisDirection.X ? { ...zoom, x: axisZoom } : { ...zoom, y: axisZoom }
@@ -40,7 +40,7 @@ export class ZoomAxisDragger {
         }
     }
 
-    private updateZoom(direction: ChartAxisDirection, anchor: AgZoomAnchorPoint, bbox: BoxBounds): ZoomState {
+    private updateZoom(direction: ChartAxisDirection, anchor: AgZoomAnchorPoint, bbox: BoxBounds): ZoomMinMax {
         const { coords, oldZoom } = this;
 
         let newZoom = definedZoomState(oldZoom);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomOnDataChange.ts
@@ -4,8 +4,8 @@ import type {
     CleanupRegistry,
     DeepRequired,
     DefinedZoomState,
-    ZoomState,
-    ZoomStateDirection,
+    ZoomMinMax,
+    ZoomMinMaxDirection,
 } from 'ag-charts-core';
 import { BaseProperties, ChartAxisDirection, Logger, Property, clamp, definedZoomState } from 'ag-charts-core';
 import type { AgZoomOnDataChange, AgZoomOnDataChangeStrategy } from 'ag-charts-types';
@@ -51,7 +51,7 @@ function shouldStickToEnd(properties: ZoomOnDataChangeProperties, zoom: DefinedZ
     return properties.stickToEnd && zoom.x.max === 1;
 }
 
-function toVisibleMinMax(axisId: AxisID, domainMinMax: DomainMinMax, ratios: ZoomState): VisibleMinMax {
+function toVisibleMinMax(axisId: AxisID, domainMinMax: DomainMinMax, ratios: ZoomMinMax): VisibleMinMax {
     const { domainMin, domainMax } = domainMinMax;
     const span = domainMax - domainMin;
     return {
@@ -61,7 +61,7 @@ function toVisibleMinMax(axisId: AxisID, domainMinMax: DomainMinMax, ratios: Zoo
     };
 }
 
-function fromVisibleMinMax(domainMinMax: DomainMinMax, visibleMinMax: VisibleMinMax): ZoomStateDirection {
+function fromVisibleMinMax(domainMinMax: DomainMinMax, visibleMinMax: VisibleMinMax): ZoomMinMaxDirection {
     const { domainMin, domainMax } = domainMinMax;
     const { visibleMin, visibleMax } = visibleMinMax;
     const span = domainMax - domainMin;
@@ -153,7 +153,7 @@ export class ZoomOnDataChange {
 
         switch (desiredChanges.type) {
             case 'domain': {
-                const changes: { [K in AxisID]: Readonly<ZoomStateDirection> } = {};
+                const changes: { [K in AxisID]: Readonly<ZoomMinMaxDirection> } = {};
                 for (const entry of desiredChanges.domains) {
                     const domainMinMax: DomainMinMax | undefined = this.computeDomainMinMax(entry.axisId);
                     if (domainMinMax) {
@@ -225,7 +225,7 @@ export class ZoomOnDataChange {
         const domainMinMax: DomainMinMax | undefined = this.computeDomainMinMax(axisId);
         if (!domainMinMax) return;
 
-        const ratios: ZoomState = this.ctx.zoomManager.getAxisZoom(axisId);
+        const ratios: ZoomMinMax = this.ctx.zoomManager.getAxisZoom(axisId);
         if (!ratios) return;
 
         const { visibleMin, visibleMax } = toVisibleMinMax(axisId, domainMinMax, ratios);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
@@ -1,5 +1,5 @@
 import { definedZoomState } from 'ag-charts-core';
-import type { AxisZoomState, BoxBounds, DefinedZoomState } from 'ag-charts-core';
+import type { BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
 
 import type { ZoomRect } from './scenes/zoomRect';
 import type { ZoomCoords, ZoomProperties } from './zoomTypes';
@@ -26,7 +26,7 @@ export class ZoomSelector {
         this.updateRect(bbox);
     }
 
-    stop(innerBBox?: BoxBounds, bbox?: BoxBounds, currentZoom?: AxisZoomState): DefinedZoomState | undefined {
+    stop(innerBBox?: BoxBounds, bbox?: BoxBounds, currentZoom?: ZoomState): DefinedZoomState | undefined {
         let zoom = definedZoomState();
 
         if (!innerBBox || !bbox) return zoom;
@@ -124,7 +124,7 @@ export class ZoomSelector {
         }
     }
 
-    private createZoomFromCoords(bbox: BoxBounds, currentZoom?: AxisZoomState) {
+    private createZoomFromCoords(bbox: BoxBounds, currentZoom?: ZoomState) {
         const oldZoom = definedZoomState(currentZoom);
         const normal = this.getNormalisedDimensions();
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomToolbar.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, type AgZoomButtonValue, _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { AxisID, CartesianAxisDirection, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { AxisID, CartesianAxisDirection, DefinedZoomState, ZoomMinMax } from 'ag-charts-core';
 import {
     ActionOnSet,
     BaseProperties,
@@ -95,7 +95,7 @@ export class ZoomToolbar extends BaseProperties {
             sourcing: _ModuleSupport.UpdateZoomSourcing,
             axisId: AxisID,
             direction: CartesianAxisDirection,
-            partialZoom: ZoomState | undefined
+            partialZoom: ZoomMinMax | undefined
         ) => void,
         private readonly resetZoom: (sourceDetail: _ModuleSupport.ZoomEventSourceDetail) => void,
         private readonly isZoomValid: (zoom: DefinedZoomState) => boolean
@@ -274,7 +274,7 @@ export class ZoomToolbar extends BaseProperties {
         props: ZoomProperties,
         axisId: AxisID,
         direction: CartesianAxisDirection,
-        zoom: ZoomState
+        zoom: ZoomMinMax
     ) {
         const { isScalingX, isScalingY, scrollingStep } = props;
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
@@ -1,5 +1,5 @@
 import type { _Widget } from 'ag-charts-community';
-import type { AxisZoomState, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { AxisZoomState, DefinedZoomState, ZoomMinMax } from 'ag-charts-core';
 
 // clientXY  (unit: px)          :  Touch screen points.
 // normalXY  (unit: N/A - ratio) :  Touch normalised points in [0, N] range.
@@ -9,13 +9,13 @@ type ZoomTwoFingersTouchStart = { readonly origins: [Origin, Origin] };
 const N = 1_000_000;
 
 // Interpolate `a` from [Rx, Rw] to [min, max]
-function clientToNormal({ min, max }: ZoomState, a: number, Rx: number, Rw: number): number {
+function clientToNormal({ min, max }: ZoomMinMax, a: number, Rx: number, Rw: number): number {
     if (Rw === 0) return 0; // don't divide by 0.
     return N * (((a - Rx) / Rw) * (max - min) + min);
 }
 
 // See AG-13737 for explanation.
-function solveTwoUnknowns(x1: number, x2: number, a1: number, a2: number, Rx: number, Rw: number): ZoomState {
+function solveTwoUnknowns(x1: number, x2: number, a1: number, a2: number, Rx: number, Rw: number): ZoomMinMax {
     // The math expects x1 <= x2 (and a1 <= a2).
     // If x1 > x2, then the gesture will be reversed (i.e. fingers moving closer would zoom in).
     [x1, x2] = [Math.min(x1, x2), Math.max(x1, x2)];
@@ -171,8 +171,8 @@ function twitchTolerantZoomPan2(
     previousKey2: keyof typeof previous,
     Rx: number,
     Rw: number,
-    initialZoom: ZoomState
-): ZoomState {
+    initialZoom: ZoomMinMax
+): ZoomMinMax {
     if (x1 == x2) {
         // pan-only mode:
         const xn1 = clientToNormal(initialZoom, a1, Rx, Rw);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomTwoFingers.ts
@@ -1,5 +1,5 @@
 import type { _Widget } from 'ag-charts-community';
-import type { AxisZoomState, DefinedZoomState, ZoomMinMax } from 'ag-charts-core';
+import type { DefinedZoomState, ZoomMinMax, ZoomState } from 'ag-charts-core';
 
 // clientXY  (unit: px)          :  Touch screen points.
 // normalXY  (unit: N/A - ratio) :  Touch normalised points in [0, N] range.
@@ -51,7 +51,7 @@ export class ZoomTwoFingers {
     private readonly initialZoom: DefinedZoomState = { x: { min: 0, max: 1 }, y: { min: 0, max: 1 } };
     private readonly previous = { a1: Number.NaN, a2: Number.NaN, b1: Number.NaN, b2: Number.NaN };
 
-    start(event: _Widget.TouchWidgetEvent<'touchstart'>, target: _Widget.Widget, zoom: AxisZoomState): boolean {
+    start(event: _Widget.TouchWidgetEvent<'touchstart'>, target: _Widget.Widget, zoom: ZoomState): boolean {
         if (event.sourceEvent.targetTouches.length !== 2) return false;
         event.sourceEvent.preventDefault();
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomUtils.ts
@@ -1,5 +1,5 @@
 import { type AgZoomAnchorPoint, _ModuleSupport } from 'ag-charts-community';
-import type { BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { BoxBounds, DefinedZoomState, ZoomMinMax } from 'ag-charts-core';
 import { UNIT_MAX, UNIT_MIN, clamp, definedZoomState, isNumberEqual, jsonDiff } from 'ag-charts-core';
 
 export const UNIT_SIZE = UNIT_MAX - UNIT_MIN;
@@ -17,7 +17,7 @@ export function dy(zoom: DefinedZoomState) {
     return zoom.y.max - zoom.y.min;
 }
 
-function isZoomRangeEqual(left: ZoomState, right: ZoomState) {
+function isZoomRangeEqual(left: ZoomMinMax, right: ZoomMinMax) {
     return isNumberEqual(left.min, right.min) && isNumberEqual(left.max, right.max);
 }
 
@@ -86,11 +86,11 @@ export function scaleZoomCenter(zoom: DefinedZoomState, sx: number, sy: number):
  * Scale a single zoom axis about its anchor.
  */
 export function scaleZoomAxisWithAnchor(
-    newState: ZoomState,
-    oldState: ZoomState,
+    newState: ZoomMinMax,
+    oldState: ZoomMinMax,
     anchor: AgZoomAnchorPoint,
     origin?: number
-): ZoomState {
+): ZoomMinMax {
     const { min, max } = oldState;
     const center = min + (max - min) / 2;
     const diff = newState.max - newState.min;
@@ -109,7 +109,7 @@ export function scaleZoomAxisWithAnchor(
     }
 }
 
-export function scaleZoomAxisWithPoint(newState: ZoomState, oldState: ZoomState, origin: number) {
+export function scaleZoomAxisWithPoint(newState: ZoomMinMax, oldState: ZoomMinMax, origin: number) {
     const newDelta = newState.max - newState.min;
     const oldDelta = oldState.max - oldState.min;
     const scaledOrigin = origin * (1 - (oldDelta - newDelta));


### PR DESCRIPTION
The current names are sort of confusing.

* `DefinedZoomState` sounds like a defined version of `ZoomState` (but it's not, it's defined version of `AxisZoomState`).
* `definedZoomState()` sounds like it takes a `ZoomState` type input (but it doesn't, it takes a `AxisZoomState`).
* `AxisZoomState` sounds like the state of a specific axis (but it's not, it's the state of both axes).
* `ZoomState` sounds like the full state of the viewport (but it's not, it's only the state of a specific axis).

New Type Names:
* `ZoomState` -> `ZoomMinMax`
* `ZoomStateDirection` -> `ZoomMinMaxDirection`
* `DefinedZoomState` -> _unchanged_
* `AxisZoomState` -> `ZoomState`