### PR TITLE
Fix CI benchmark failures on macOS

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -88,8 +88,8 @@ jobs:
                     echo "branch=latest" >> $GITHUB_OUTPUT
                     echo "base=b11.3.1" >> $GITHUB_OUTPUT
                   elif [[ "${{ github.event_name }}" == "schedule" ]] ; then
-                    # For scheduled runs, get the most recent branch matching 'b' followed by semver (e.g. b1.2.3)
-                    release=$(git ls-remote --heads origin 'b[0-9]*\.[0-9]*\.[0-9]*' | sort -t '/' -k 2 -V | tail -n 1 | sed 's/.*refs\/heads\///')
+                    # For scheduled runs, get the most recent release branch matching exact 'bX.Y.Z' format
+                    release=$(git ls-remote --heads origin | grep -E 'refs/heads/b[0-9]+\.[0-9]+\.[0-9]+$' | sort -t '/' -k 3 -V | tail -n 1 | sed 's/.*refs\/heads\///')
                     echo "branch=latest" >> $GITHUB_OUTPUT
                     echo "base=$release" >> $GITHUB_OUTPUT
                   else

--- a/tools/benchmark/collect-version-benchmark.sh
+++ b/tools/benchmark/collect-version-benchmark.sh
@@ -124,8 +124,9 @@ fi
 cleanup() {
     log_info "Cleaning up"
     run_silent git add ${data_file}
-    run_silent git restore --source HEAD -- ${included_files[@]}
-    run_silent git clean -fd
+    run_silent git checkout HEAD -- ${included_files[@]}
+    run_silent git reset HEAD -- ${included_files[@]}
+    run_silent git clean -fd -- ${included_files[@]}
 }
 
 prebuild() {
@@ -210,14 +211,16 @@ trap 'cleanup' ERR EXIT
 prebuild
 for version in "${versions[@]}"; do
     # Checkout files in the specified input file set (removing any files that have been added since then)
-    run_silent git restore --source "$version" -- ${included_files[@]}
+    # Note: Using git checkout instead of git restore to handle case-sensitive filename changes on macOS
+    run_silent git checkout "$version" -- ${included_files[@]}
     build ${version}
     # Benchmark
     benchmark ${version}
-    # Remove any untracked files created during this benchmark run
-    run_silent git clean -fd
-    # Reset the working tree state
-    run_silent git restore --source HEAD -- ${included_files[@]}
+    # Reset the working tree and staging area to HEAD state
+    run_silent git checkout HEAD -- ${included_files[@]}
+    run_silent git reset HEAD -- ${included_files[@]}
+    # Remove any files that don't exist in HEAD (e.g., files only in old versions)
+    run_silent git clean -fd -- ${included_files[@]}
 done
 
 if $($failed) ; then 


### PR DESCRIPTION
- Replace `git restore` with `git checkout` to handle case-sensitive
  filename renames (e.g., geoJson.ts → geojson.ts) on macOS
  case-insensitive filesystem
- Fix release branch selection to use strict regex pattern, excluding
  branches like `test/b13.0.0-crt-regression-tests`
