### PR TITLE
Add GitHub Actions workflow for Codex PR reviews

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,71 @@
+name: PR Review
+
+on:
+    pull_request:
+        types: [opened, ready_for_review]
+    issue_comment:
+        types: [created]
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: 'PR number to review'
+                type: string
+                required: true
+
+env:
+    NX_NO_CLOUD: true
+
+permissions:
+    contents: read
+
+jobs:
+    # Check permissions for issue_comment events
+    check-permissions:
+        runs-on: ubuntu-latest
+        outputs:
+            allowed: ${{ steps.check.outputs.allowed }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Check user permissions
+              id: check
+              uses: ./external/ag-shared/github/actions/check-issue-comment-permissions
+              with:
+                  command: '/pr-review'
+
+    # Run the Codex PR review
+    pr-review:
+        runs-on: ubuntu-latest
+        needs: check-permissions
+        permissions:
+            contents: read
+            pull-requests: write
+            issues: write
+        # Only run if permissions check passed (success) or was skipped (for non-issue_comment events)
+        # For issue_comment, also verify it's on a PR (not a regular issue)
+        if: |
+            needs.check-permissions.result == 'success' && (
+                github.event_name == 'pull_request' ||
+                github.event_name == 'workflow_dispatch' ||
+                (github.event_name == 'issue_comment' && needs.check-permissions.outputs.allowed == 'true' && github.event.issue.pull_request)
+            )
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Run Codex PR Review
+              uses: ./external/ag-shared/github/actions/codex-pr-review
+              with:
+                  openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+                  codex-auth-json-b64: ${{ secrets.CODEX_AUTH_JSON_B64 }}
+                  pr-number: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+                  base-ref: ${{ github.event.pull_request.base.ref || 'latest' }}
+                  head-ref: ${{ github.event.pull_request.head.ref || '' }}
+                  pr-title: ${{ github.event.pull_request.title || '' }}
+                  pr-author: ${{ github.event.pull_request.user.login || '' }}
+                  github-token: ${{ github.token }}
+                  comment-id: ${{ github.event.comment.id }}
+                  inline-comments: 'true'

--- a/.rulesync/commands/pr-review-json.md
+++ b/.rulesync/commands/pr-review-json.md
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/commands/pr/review-json.md

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -1,0 +1,483 @@
+name: codex-pr-review
+description: Run a Codex PR review with complete log suppression - no LLM output appears in workflow logs
+inputs:
+    openai-api-key:
+        description: 'OpenAI API key for Codex CLI (alternative to codex-auth-json-b64)'
+        required: false
+        default: ''
+    codex-auth-json-b64:
+        description: 'Base64-encoded ~/.codex/auth.json for ChatGPT OAuth auth (alternative to openai-api-key)'
+        required: false
+        default: ''
+    pr-number:
+        description: 'PR number to review'
+        required: true
+    prompt-file:
+        description: 'Path to the prompt file'
+        required: false
+        default: 'external/ag-shared/prompts/commands/pr/review.md'
+    github-token:
+        description: 'GitHub token for PR access and commenting'
+        required: true
+    post-comment:
+        description: 'Whether to post the review as a PR comment'
+        required: false
+        default: 'true'
+    inline-comments:
+        description: 'Whether to post inline comments on specific files/lines (requires JSON prompt)'
+        required: false
+        default: 'false'
+    comment-id:
+        description: 'Comment ID to add reactions to (for issue_comment triggers)'
+        required: false
+        default: ''
+    base-ref:
+        description: 'Base branch ref for the PR (e.g., latest, main)'
+        required: false
+        default: ''
+    pr-title:
+        description: 'PR title for review output'
+        required: false
+        default: ''
+    pr-author:
+        description: 'PR author username'
+        required: false
+        default: ''
+    head-ref:
+        description: 'Head branch ref for the PR'
+        required: false
+        default: ''
+outputs:
+    success:
+        description: 'Whether the review completed successfully'
+        value: ${{ steps.verify.outputs.success }}
+    skipped:
+        description: 'Whether the review was skipped due to missing authentication'
+        value: ${{ steps.check-auth.outputs.skipped }}
+runs:
+    using: composite
+    steps:
+        - name: Check Authentication
+          id: check-auth
+          shell: bash
+          env:
+              CODEX_AUTH_JSON_B64: ${{ inputs.codex-auth-json-b64 }}
+              OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+          run: |
+              if [ -z "${CODEX_AUTH_JSON_B64:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+                echo "::warning::Skipping PR review - no authentication configured (set OPENAI_API_KEY or CODEX_AUTH_JSON_B64 secret)"
+                echo "skipped=true" >> $GITHUB_OUTPUT
+              else
+                echo "skipped=false" >> $GITHUB_OUTPUT
+              fi
+
+        - name: React Started
+          if: inputs.comment-id != '' && steps.check-auth.outputs.skipped != 'true'
+          uses: actions/github-script@v7
+          continue-on-error: true
+          env:
+              COMMENT_ID: ${{ inputs.comment-id }}
+          with:
+              github-token: ${{ inputs.github-token }}
+              script: |
+                  await github.rest.reactions.createForIssueComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: parseInt(process.env.COMMENT_ID, 10),
+                    content: 'eyes'
+                  });
+
+        - name: Fetch PR refs
+          if: steps.check-auth.outputs.skipped != 'true'
+          shell: bash
+          run: |
+              # Fetch PR head ref and base branch for git diff access
+              # This allows Codex to use git commands to analyze the PR changes
+              echo "Fetching PR #${{ inputs.pr-number }} refs..."
+              git fetch --no-tags origin \
+                ${{ inputs.base-ref }} \
+                +refs/pull/${{ inputs.pr-number }}/head:refs/remotes/origin/pr/${{ inputs.pr-number }}
+              echo "PR refs fetched successfully"
+
+        - name: Setup Node.js
+          if: steps.check-auth.outputs.skipped != 'true'
+          uses: actions/setup-node@v4
+          with:
+              node-version: '22'
+
+        - name: Install Codex CLI
+          if: steps.check-auth.outputs.skipped != 'true'
+          shell: bash
+          run: npm install -g @openai/codex@latest
+
+        - name: Install and Patch Rulesync
+          if: steps.check-auth.outputs.skipped != 'true'
+          shell: bash
+          run: |
+              # Install rulesync to isolated temp dir to apply patches (avoids workspace dependency conflicts)
+              PATCH_DIR="$(pwd)/external/ag-shared/prompts/patches"
+              if [ -d "$PATCH_DIR" ] && ls "$PATCH_DIR"/rulesync*.patch 1>/dev/null 2>&1; then
+                # Get rulesync version from patch filename (e.g., rulesync+5.2.0.patch -> 5.2.0)
+                PATCH_FILE=$(ls "$PATCH_DIR"/rulesync*.patch | head -1)
+                RULESYNC_VERSION=$(basename "$PATCH_FILE" | sed 's/rulesync+\(.*\)\.patch/\1/')
+                echo "Installing rulesync@$RULESYNC_VERSION with patches..."
+
+                # Create isolated temp directory for rulesync installation
+                RULESYNC_DIR="$(mktemp -d)"
+                cd "$RULESYNC_DIR"
+
+                # Initialize minimal package.json and install rulesync + patch-package
+                echo '{"name":"rulesync-patched","private":true}' > package.json
+                npm install "rulesync@$RULESYNC_VERSION" patch-package
+
+                # Copy patches to temp dir (patch-package requires relative path)
+                cp -r "$PATCH_DIR" ./patches
+                npx patch-package --patch-dir ./patches
+                echo "Patches applied successfully"
+
+                # Export path for setup-prompts.sh to find patched rulesync
+                echo "RULESYNC_BIN=$RULESYNC_DIR/node_modules/.bin/rulesync" >> $GITHUB_ENV
+
+                cd -
+              else
+                echo "No rulesync patches found, using npx default"
+              fi
+
+        - name: Setup Prompts
+          if: steps.check-auth.outputs.skipped != 'true'
+          shell: bash
+          run: |
+              # Generate Codex CLI config if setup script exists
+              if [ -f "./external/ag-shared/scripts/setup-prompts/setup-prompts.sh" ]; then
+                ./external/ag-shared/scripts/setup-prompts/setup-prompts.sh --targets=codexcli --verbose || true
+              fi
+
+        - name: Setup Authentication
+          if: steps.check-auth.outputs.skipped != 'true'
+          shell: bash
+          env:
+              CODEX_AUTH_JSON_B64: ${{ inputs.codex-auth-json-b64 }}
+              OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+          run: |
+              # Prefer auth.json if provided, fall back to API key
+              if [ -n "${CODEX_AUTH_JSON_B64:-}" ]; then
+                echo "Using base64-encoded auth.json for authentication"
+                mkdir -p "$HOME/.codex"
+                echo "$CODEX_AUTH_JSON_B64" | base64 -d > "$HOME/.codex/auth.json"
+                chmod 600 "$HOME/.codex/auth.json"
+              elif [ -n "${OPENAI_API_KEY:-}" ]; then
+                echo "Using OpenAI API key for authentication"
+                # API key already set via env var - Codex will use it
+              fi
+
+        - name: Determine Prompt File
+          if: steps.check-auth.outputs.skipped != 'true'
+          id: prompt
+          shell: bash
+          run: |
+              # Use JSON prompt if inline comments enabled, otherwise use configured prompt
+              if [[ "${{ inputs.inline-comments }}" == "true" ]]; then
+                prompt_file="external/ag-shared/prompts/commands/pr/review-json.md"
+                output_ext="json"
+              else
+                prompt_file="${{ inputs.prompt-file }}"
+                output_ext="md"
+              fi
+              echo "prompt_file=${prompt_file}" >> $GITHUB_OUTPUT
+              echo "output_ext=${output_ext}" >> $GITHUB_OUTPUT
+
+        - name: Run Codex Review
+          if: steps.check-auth.outputs.skipped != 'true'
+          id: codex
+          shell: bash
+          env:
+              OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+              ARGUMENTS: ${{ inputs.pr-number }}
+              BASE_REF: ${{ inputs.base-ref }}
+              HEAD_REF: ${{ inputs.head-ref }}
+              PR_TITLE: ${{ inputs.pr-title }}
+              PR_AUTHOR: ${{ inputs.pr-author }}
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+              GH_TOKEN: ${{ inputs.github-token }}
+          run: |
+              # Output file paths (unique per PR to avoid conflicts)
+              output_file=".codex-review-${{ inputs.pr-number }}.${{ steps.prompt.outputs.output_ext }}"
+              error_file=".codex-error-${{ inputs.pr-number }}.log"
+
+              echo "output_file=${output_file}" >> $GITHUB_OUTPUT
+
+              # Run Codex with ALL output suppressed
+              # - stdin: Prompt file content piped in
+              # - stdout (>/dev/null): Suppresses reasoning/streaming output
+              # - stderr (2>file): Captured to file for debugging, not logged
+              set +e
+              cat "${{ steps.prompt.outputs.prompt_file }}" | codex exec \
+                --output-last-message "${output_file}" \
+                --sandbox read-only \
+                2>"${error_file}" \
+                >/dev/null
+              exit_code=$?
+              set -e
+
+              echo "exit_code=${exit_code}" >> $GITHUB_OUTPUT
+
+              if [ $exit_code -ne 0 ]; then
+                echo "::error::Codex review failed with exit code ${exit_code}"
+                # Show stderr for debugging - contains CLI errors, not review content
+                if [ -f "${error_file}" ] && [ -s "${error_file}" ]; then
+                  echo "::group::Codex CLI Error Output"
+                  cat "${error_file}"
+                  echo "::endgroup::"
+                fi
+              fi
+
+        - name: Verify Output Generated
+          if: steps.check-auth.outputs.skipped != 'true'
+          id: verify
+          shell: bash
+          run: |
+              output_file="${{ steps.codex.outputs.output_file }}"
+              if [ -f "${output_file}" ] && [ -s "${output_file}" ]; then
+                echo "success=true" >> $GITHUB_OUTPUT
+                echo "Review output generated successfully"
+              else
+                echo "success=false" >> $GITHUB_OUTPUT
+                echo "::error::Review output file is missing or empty"
+                exit 1
+              fi
+
+        - name: Post Review Comment
+          if: steps.check-auth.outputs.skipped != 'true' && steps.verify.outputs.success == 'true' && inputs.post-comment == 'true'
+          uses: actions/github-script@v7
+          env:
+              OUTPUT_FILE: ${{ steps.codex.outputs.output_file }}
+              PR_NUMBER: ${{ inputs.pr-number }}
+              INLINE_COMMENTS: ${{ inputs.inline-comments }}
+          with:
+              github-token: ${{ inputs.github-token }}
+              script: |
+                  const fs = require('fs');
+
+                  // Read file content - fs.readFileSync does NOT log content
+                  const rawContent = fs.readFileSync(process.env.OUTPUT_FILE, 'utf8');
+                  const prNumber = parseInt(process.env.PR_NUMBER, 10);
+                  const inlineComments = process.env.INLINE_COMMENTS === 'true';
+                  const commentMarker = '<!-- codex-pr-review -->';
+
+                  let reviewBody;
+                  let inlineReviewComments = [];
+
+                  if (inlineComments) {
+                    // Parse JSON output and create inline comments
+                    let review;
+                    try {
+                      // Handle potential markdown code fences around JSON
+                      let jsonContent = rawContent.trim();
+
+                      // Remove BOM if present
+                      if (jsonContent.charCodeAt(0) === 0xFEFF) {
+                        jsonContent = jsonContent.slice(1);
+                      }
+
+                      // Strip markdown code fences if present
+                      if (jsonContent.startsWith('```json')) {
+                        jsonContent = jsonContent.replace(/^```json\n?/, '').replace(/\n?```$/, '');
+                      } else if (jsonContent.startsWith('```')) {
+                        jsonContent = jsonContent.replace(/^```\n?/, '').replace(/\n?```$/, '');
+                      }
+
+                      // Find the JSON object boundaries (in case there's extra content)
+                      const jsonStart = jsonContent.indexOf('{');
+                      const jsonEnd = jsonContent.lastIndexOf('}');
+                      if (jsonStart !== -1 && jsonEnd !== -1 && jsonEnd > jsonStart) {
+                        jsonContent = jsonContent.slice(jsonStart, jsonEnd + 1);
+                      }
+
+                      review = JSON.parse(jsonContent);
+                    } catch (e) {
+                      console.log(`Failed to parse JSON output: ${e.message}`);
+                      console.log(`Content starts with: ${rawContent.slice(0, 100).replace(/\n/g, '\\n')}`);
+                      console.log(`Content length: ${rawContent.length}`);
+                      reviewBody = rawContent;
+                      review = null;
+                    }
+
+                    if (review) {
+                      // Log parsed review structure for debugging
+                      console.log(`Parsed review: pr_number=${review.pr_number}, findings=${review.findings?.length || 0}`);
+
+                      // Build inline comments for each finding
+                      for (const finding of review.findings || []) {
+                        if (finding.file && finding.line) {
+                          const priorityEmoji = {
+                            'P0': ':x:',
+                            'P1': ':warning:',
+                            'P2': ':information_source:',
+                            'P3': ':bulb:'
+                          }[finding.priority] || ':grey_question:';
+
+                          // GitHub API requires side: 'RIGHT' for inline comments on new file version
+                          const comment = {
+                            path: finding.file,
+                            line: finding.end_line || finding.line,
+                            side: 'RIGHT',
+                            body: `${priorityEmoji} **[${finding.priority}] ${finding.title}**\n\n${finding.description}`
+                          };
+
+                          // For multi-line comments, add start_line and start_side
+                          if (finding.end_line && finding.end_line > finding.line) {
+                            comment.start_line = finding.line;
+                            comment.start_side = 'RIGHT';
+                          }
+
+                          inlineReviewComments.push(comment);
+                        } else {
+                          console.log(`Skipped finding without file/line: ${JSON.stringify(finding)}`);
+                        }
+                      }
+
+                      // Build summary comment body from JSON
+                      const verdictEmoji = review.verdict?.assessment === 'correct' ? ':white_check_mark:' : ':x:';
+                      const totalFindings = (review.stats?.p0_count || 0) + (review.stats?.p1_count || 0) + (review.stats?.p2_count || 0) + (review.stats?.p3_count || 0);
+                      const statsLine = `P0: ${review.stats?.p0_count || 0} | P1: ${review.stats?.p1_count || 0} | P2: ${review.stats?.p2_count || 0} | P3: ${review.stats?.p3_count || 0}`;
+
+                      // Build summary line
+                      const summaryLine = totalFindings === 0
+                        ? `${verdictEmoji} Codex review complete; no issues found`
+                        : `${verdictEmoji} Codex review complete; ${totalFindings} issue${totalFindings === 1 ? '' : 's'} found (${statsLine})`;
+
+                      // Build collapsible details
+                      const requiredActions = review.verdict?.required_actions?.length > 0
+                        ? '**Required Actions:**\n' + review.verdict.required_actions.map(a => `- ${a}`).join('\n')
+                        : '**Required Actions:** None - ready to merge';
+
+                      const findingsNote = inlineReviewComments.length > 0
+                        ? `*${inlineReviewComments.length} inline comments posted.*`
+                        : (totalFindings > 0 ? '*See verdict for details.*' : '*No issues found.*');
+
+                      // Build diff stats line if available
+                      const diffStatsLine = review.diff_stats
+                        ? `**Diff:** ${review.diff_stats.files_changed} file${review.diff_stats.files_changed === 1 ? '' : 's'} changed, +${review.diff_stats.lines_added} -${review.diff_stats.lines_removed}`
+                        : '';
+
+                      // Build body using array join to avoid YAML parsing issues with angle brackets
+                      reviewBody = [
+                        summaryLine,
+                        '',
+                        '\x3Cdetails\x3E',
+                        '\x3Csummary\x3EView full review\x3C/summary\x3E',
+                        '',
+                        `# ${review.pr_title}`,
+                        '',
+                        `**PR:** ${review.pr_url}`,
+                        `**Author:** ${review.author} | **Base:** ${review.base_branch} \u2190 **Head:** ${review.head_branch}`,
+                        diffStatsLine,
+                        '',
+                        '# Summary',
+                        '',
+                        review.summary,
+                        '',
+                        '# Findings',
+                        '',
+                        statsLine,
+                        '',
+                        findingsNote,
+                        '',
+                        '# Verdict',
+                        '',
+                        `**Assessment:** ${review.verdict?.assessment || 'unknown'}`,
+                        `**Confidence:** ${review.verdict?.confidence || 'N/A'}`,
+                        '',
+                        review.verdict?.justification || '',
+                        '',
+                        requiredActions,
+                        '',
+                        '\x3C/details\x3E'
+                      ].join('\n');
+                    }
+                  } else {
+                    // Use raw markdown content
+                    reviewBody = rawContent;
+                  }
+
+                  // Post inline comments as a review if we have any
+                  if (inlineReviewComments.length > 0) {
+                    try {
+                      // Get the PR head SHA for the review
+                      const { data: pr } = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: prNumber
+                      });
+
+                      await github.rest.pulls.createReview({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: prNumber,
+                        commit_id: pr.head.sha,
+                        event: 'COMMENT',
+                        comments: inlineReviewComments
+                      });
+                      console.log(`Posted ${inlineReviewComments.length} inline comments on commit ${pr.head.sha}`);
+                    } catch (e) {
+                      console.log(`Failed to post inline comments: ${e.message}`);
+                      // Fall back to including findings in the summary comment
+                      reviewBody += '\n\n---\n\n**Note:** Failed to post inline comments. Findings listed above.';
+                    }
+                  }
+
+                  // Find existing bot comment to update (avoid duplicates)
+                  const { data: comments } = await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    per_page: 100
+                  });
+
+                  const existingComment = comments.find(c =>
+                    c.user.type === 'Bot' && c.body.includes(commentMarker)
+                  );
+
+                  const body = `${commentMarker}\n${reviewBody}\n`;
+
+                  if (existingComment) {
+                    await github.rest.issues.updateComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: existingComment.id,
+                      body: body
+                    });
+                    console.log('Updated existing review comment');
+                  } else {
+                    await github.rest.issues.createComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: prNumber,
+                      body: body
+                    });
+                    console.log('Created new review comment');
+                  }
+
+        - name: React Success
+          if: steps.check-auth.outputs.skipped != 'true' && inputs.comment-id != '' && steps.verify.outputs.success == 'true'
+          uses: actions/github-script@v7
+          continue-on-error: true
+          env:
+              COMMENT_ID: ${{ inputs.comment-id }}
+          with:
+              github-token: ${{ inputs.github-token }}
+              script: |
+                  await github.rest.reactions.createForIssueComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: parseInt(process.env.COMMENT_ID, 10),
+                    content: '+1'
+                  });
+
+        - name: Cleanup Sensitive Files
+          if: always()
+          shell: bash
+          run: |
+              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log"
+              # Also clean up auth.json if we created it
+              rm -f "$HOME/.codex/auth.json"

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -90,13 +90,23 @@ runs:
         - name: Fetch PR refs
           if: steps.check-auth.outputs.skipped != 'true'
           shell: bash
+          env:
+              PR_NUMBER: ${{ inputs.pr-number }}
+              BASE_REF: ${{ inputs.base-ref }}
           run: |
               # Fetch PR head ref and base branch for git diff access
               # This allows Codex to use git commands to analyze the PR changes
-              echo "Fetching PR #${{ inputs.pr-number }} refs..."
+
+              # Validate PR number is numeric to prevent shell injection
+              if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+                echo "::error::Invalid PR number: must be numeric"
+                exit 1
+              fi
+
+              echo "Fetching PR #${PR_NUMBER} refs..."
               git fetch --no-tags origin \
-                ${{ inputs.base-ref }} \
-                +refs/pull/${{ inputs.pr-number }}/head:refs/remotes/origin/pr/${{ inputs.pr-number }}
+                "${BASE_REF}" \
+                "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}"
               echo "PR refs fetched successfully"
 
         - name: Setup Node.js
@@ -296,7 +306,6 @@ runs:
                       review = JSON.parse(jsonContent);
                     } catch (e) {
                       console.log(`Failed to parse JSON output: ${e.message}`);
-                      console.log(`Content starts with: ${rawContent.slice(0, 100).replace(/\n/g, '\\n')}`);
                       console.log(`Content length: ${rawContent.length}`);
                       reviewBody = rawContent;
                       review = null;

--- a/external/ag-shared/prompts/commands/pr/_review-core.md
+++ b/external/ag-shared/prompts/commands/pr/_review-core.md
@@ -1,0 +1,155 @@
+# PR Review Core Instructions
+
+This file contains the shared review methodology. It is included by format-specific prompts.
+
+## Help
+
+If the user provides a command option of `help`:
+
+-   Explain how to use this prompt.
+-   Explain if they are missing any prerequisites or tooling requirements.
+-   DO NOT proceed, exit the prompt immediately after these steps.
+
+## 1. Prerequisites
+
+-   **CI Environment (preferred)**: PR refs pre-fetched, use `git diff` commands
+-   **Local Environment (fallback)**: GitHub CLI (`gh`) available for PR access
+
+## 2. Context
+
+-   This is a monorepo with multiple packages.
+-   Release branches are named `bX.Y.Z` (semantic versioning).
+-   The main branch is `latest`.
+
+## 3. Review Focus
+
+Focus on issues that impact:
+
+-   **Correctness**: Does the code work as intended? Are there logic errors?
+-   **Performance**: Any performance regressions or inefficiencies?
+-   **Security**: Any vulnerabilities introduced?
+-   **Maintainability**: Is the code readable and maintainable?
+-   **Developer Experience**: Any DX issues (confusing APIs, poor error messages)?
+
+### What to Flag
+
+-   Flag only **actionable issues introduced by the pull request**
+-   Provide a short, direct explanation for each issue
+-   **Cite the affected file and line number** from the diff
+-   Prioritise severe issues over minor ones
+
+### What NOT to Flag
+
+-   Style issues handled by linters/formatters
+-   Issues in code not modified by this PR
+-   Nit-level comments unless they block understanding of the diff
+-   Hypothetical issues that are unlikely to occur
+
+### Repository-Specific Guidelines
+
+Before reviewing, check for a `## Review guidelines` section in `CLAUDE.md` or `AGENTS.md`.
+Apply any repo-specific rules found (e.g., "Don't log PII", "Verify auth middleware wraps routes").
+
+## 4. Workflow
+
+1. Determine the PR number from `$ARGUMENTS` (required in CI, optional locally).
+2. Determine if running in CI (PR refs pre-fetched) or locally (use `gh` CLI).
+3. Fetch the PR diff and metadata using the appropriate method (see sections below).
+4. Analyse the changes and identify issues.
+5. Output the review in the format specified by the calling prompt.
+
+### CI Environment (Sandboxed - No Network Access)
+
+In CI, PR refs are pre-fetched by the workflow. Use git commands with these environment variables:
+- `$ARGUMENTS` - PR number
+- `$BASE_REF` - Target branch (e.g., `latest`, `main`)
+- `$HEAD_REF` - Source branch name (may be empty)
+- `$PR_TITLE` - PR title from GitHub (may be empty, fall back to first commit message)
+- `$PR_AUTHOR` - PR author username (may be empty)
+
+```bash
+# Get PR diff (three-dot = what PR introduces, same as GitHub's PR view)
+git diff origin/${BASE_REF}...origin/pr/$ARGUMENTS
+
+# Get head commit SHA
+git rev-parse origin/pr/$ARGUMENTS
+
+# List changed files
+git diff --name-only origin/${BASE_REF}...origin/pr/$ARGUMENTS
+
+# Get all commit messages in the PR (for context)
+git log --format="%s" origin/${BASE_REF}..origin/pr/$ARGUMENTS
+```
+
+**Why three-dot (`...`)?** GitHub uses three-dot comparison for PR diffs. This shows changes since the branches diverged (merge-base), focusing on "what the PR introduces" rather than comparing current branch states. See [GitHub Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests).
+
+**IMPORTANT**: Use `$PR_TITLE` for the PR title if available. Only fall back to git commit messages if `$PR_TITLE` is empty. The PR URL follows the pattern: `https://github.com/{owner}/{repo}/pull/{PR_NUMBER}`
+
+### Local Environment (With Network Access)
+
+When `gh` CLI is available and network-accessible, use the commands in Section 8.
+
+```bash
+# Get PR diff
+PAGER='' gh pr diff $ARGUMENTS
+
+# Get PR metadata (title, author, head SHA)
+PAGER='' gh pr view $ARGUMENTS --json title,author,headRefOid,baseRefName,headRefName,url
+```
+
+## 5. Priority Definitions
+
+| Priority | Meaning                          | Examples                                                       |
+| -------- | -------------------------------- | -------------------------------------------------------------- |
+| **P0**   | Critical - Must fix before merge | Security vulnerabilities, data loss, crashes, breaking changes |
+| **P1**   | High - Should fix before merge   | Logic errors, significant bugs, missing error handling         |
+| **P2**   | Medium - Consider fixing         | Minor bugs, performance concerns, maintainability issues       |
+| **P3**   | Low - Optional (count only)      | Documentation, minor style, suggestions                        |
+
+## 6. Confidence Score Guidelines
+
+| Score   | Meaning                                     |
+| ------- | ------------------------------------------- |
+| 0.9-1.0 | Very confident - Clear evidence for verdict |
+| 0.7-0.8 | Confident - Minor uncertainties             |
+| 0.5-0.6 | Moderate - Some aspects unclear             |
+| < 0.5   | Low confidence - Significant uncertainty    |
+
+## 7. Line Number Guidelines
+
+**IMPORTANT**: Line numbers must reference the line number in the NEW (changed) version of the file, not the old version. This is the line number shown with `+` prefix in the diff.
+
+To find the correct line number:
+1. Look at the diff hunk header: `@@ -old_start,old_count +new_start,new_count @@`
+2. Count lines from `new_start` for added/modified lines
+3. Only reference lines that are actually changed (added or modified) in this PR
+
+## 8. Using GitHub CLI (Local Only)
+
+These commands require network access and won't work in sandboxed CI environments:
+
+```bash
+# View PR details
+PAGER='' gh pr view {PR_NUMBER}
+
+# View PR diff
+PAGER='' gh pr diff {PR_NUMBER}
+
+# Get head commit SHA
+PAGER='' gh pr view {PR_NUMBER} --json headRefOid -q '.headRefOid'
+
+# View PR files changed
+PAGER='' gh pr view {PR_NUMBER} --json files
+
+# Get current branch's PR
+PAGER='' gh pr view
+```
+
+## 9. Environment Detection
+
+To determine which method to use:
+
+1. **Check `CI` environment variable**: If `CI=true` is set, use git diff commands (network is restricted)
+2. **Fallback**: Check for pre-fetched refs with `git rev-parse origin/pr/$ARGUMENTS 2>/dev/null`
+   - If successful: Use git diff commands
+   - If fails: Use `gh` CLI commands

--- a/external/ag-shared/prompts/commands/pr/review-json.md
+++ b/external/ag-shared/prompts/commands/pr/review-json.md
@@ -1,0 +1,134 @@
+---
+targets: ['*']
+description: 'Review pull requests with structured JSON output for inline commenting'
+---
+
+# PR Review Instructions (JSON Output)
+
+You are acting as a reviewer for a proposed code change. Your goal is to identify issues that could impact the quality, correctness, or safety of the codebase.
+
+**Read and follow all instructions in `external/ag-shared/prompts/commands/pr/_review-core.md` for the review methodology.**
+
+## Output Format
+
+**CRITICAL**: Output ONLY valid JSON. No markdown code fences, no explanatory text before or after. The output must be parseable by `JSON.parse()`.
+
+```json
+{
+  "pr_number": 123,
+  "pr_title": "Fix bug in chart rendering",
+  "pr_url": "https://github.com/owner/repo/pull/123",
+  "author": "username",
+  "base_branch": "latest",
+  "head_branch": "feature-branch",
+  "commit_sha": "abc123def456...",
+  "summary": "Brief 1-2 sentence summary of what this PR does",
+  "findings": [
+    {
+      "priority": "P0",
+      "file": "src/chart/series.ts",
+      "line": 42,
+      "end_line": 48,
+      "title": "Issue title",
+      "description": "Detailed explanation of the issue"
+    }
+  ],
+  "verdict": {
+    "assessment": "correct",
+    "confidence": 0.85,
+    "justification": "Brief reason for the verdict",
+    "required_actions": ["Action 1", "Action 2"]
+  },
+  "stats": {
+    "p0_count": 0,
+    "p1_count": 1,
+    "p2_count": 2,
+    "p3_count": 3
+  },
+  "diff_stats": {
+    "files_changed": 5,
+    "lines_added": 150,
+    "lines_removed": 20
+  }
+}
+```
+
+### Field Definitions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pr_number` | number | The PR number |
+| `pr_title` | string | The PR title |
+| `pr_url` | string | Full URL to the PR |
+| `author` | string | PR author's username |
+| `base_branch` | string | Target branch (e.g., "latest") |
+| `head_branch` | string | Source branch |
+| `commit_sha` | string | Full SHA of the head commit (for inline comments) |
+| `summary` | string | 1-2 sentence summary of the PR |
+| `findings` | array | List of issues found |
+| `findings[].priority` | string | "P0", "P1", "P2", or "P3" |
+| `findings[].file` | string | Relative file path from repo root |
+| `findings[].line` | number | Line number in the NEW version of the file |
+| `findings[].end_line` | number | Optional end line for multi-line issues |
+| `findings[].title` | string | Short issue title |
+| `findings[].description` | string | Detailed explanation |
+| `verdict.assessment` | string | "correct" or "incorrect" |
+| `verdict.confidence` | number | 0.0 to 1.0 |
+| `verdict.justification` | string | Brief reason for verdict |
+| `verdict.required_actions` | array | List of required fixes, or empty array |
+| `stats` | object | Count of issues by priority |
+| `diff_stats` | object | Statistics about the diff analyzed |
+| `diff_stats.files_changed` | number | Number of files changed in the PR |
+| `diff_stats.lines_added` | number | Number of lines added (+) |
+| `diff_stats.lines_removed` | number | Number of lines removed (-) |
+
+## Example Output
+
+```json
+{
+  "pr_number": 5990,
+  "pr_title": "Fix tooltip positioning in polar charts",
+  "pr_url": "https://github.com/ag-grid/ag-charts/pull/5990",
+  "author": "developer123",
+  "base_branch": "latest",
+  "head_branch": "fix/tooltip-polar",
+  "commit_sha": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0",
+  "summary": "Fixes tooltip positioning issues in polar charts by correctly calculating the angle-based offset.",
+  "findings": [
+    {
+      "priority": "P1",
+      "file": "packages/ag-charts-community/src/chart/tooltip/tooltip.ts",
+      "line": 142,
+      "end_line": 145,
+      "title": "Missing null check for polar axis",
+      "description": "The polarAxis could be undefined for non-polar series, which would cause a runtime error when accessing polarAxis.angle."
+    },
+    {
+      "priority": "P2",
+      "file": "packages/ag-charts-community/src/chart/tooltip/tooltip.ts",
+      "line": 150,
+      "title": "Magic number should be a constant",
+      "description": "The offset value 15 should be extracted to a named constant for clarity and maintainability."
+    }
+  ],
+  "verdict": {
+    "assessment": "incorrect",
+    "confidence": 0.85,
+    "justification": "The fix addresses the main issue but introduces a potential null reference error that must be fixed before merge.",
+    "required_actions": [
+      "Add null check for polarAxis before accessing its properties"
+    ]
+  },
+  "stats": {
+    "p0_count": 0,
+    "p1_count": 1,
+    "p2_count": 1,
+    "p3_count": 0
+  },
+  "diff_stats": {
+    "files_changed": 2,
+    "lines_added": 45,
+    "lines_removed": 12
+  }
+}
+```

--- a/external/ag-shared/prompts/commands/pr/review.md
+++ b/external/ag-shared/prompts/commands/pr/review.md
@@ -1,68 +1,15 @@
 ---
 targets: ['*']
-description: 'Review pull requests with Codex-style analysis and structured findings'
+description: 'Review pull requests with Markdown output'
 ---
 
-# PR Review Instructions
+# PR Review Instructions (Markdown Output)
 
 You are acting as a reviewer for a proposed code change. Your goal is to identify issues that could impact the quality, correctness, or safety of the codebase.
 
-## Help
+**Read and follow all instructions in `external/ag-shared/prompts/commands/pr/_review-core.md` for the review methodology.**
 
-If the user provides a command option of `help`:
-
--   Explain how to use this prompt.
--   Explain if they are missing any prerequisites or tooling requirements.
--   DO NOT proceed, exit the prompt immediately after these steps.
-
-## 1. Prerequisites
-
--   GitHub CLI (`gh`) must be available to fetch PR details.
-
-## 2. Context
-
--   This is a monorepo with multiple packages.
--   Release branches are named `bX.Y.Z` (semantic versioning).
--   The main branch is `latest`.
-
-## 3. Review Focus
-
-Focus on issues that impact:
-
--   **Correctness**: Does the code work as intended? Are there logic errors?
--   **Performance**: Any performance regressions or inefficiencies?
--   **Security**: Any vulnerabilities introduced?
--   **Maintainability**: Is the code readable and maintainable?
--   **Developer Experience**: Any DX issues (confusing APIs, poor error messages)?
-
-### What to Flag
-
--   Flag only **actionable issues introduced by the pull request**
--   Provide a short, direct explanation for each issue
--   **Cite the affected file and line range** (e.g., `src/chart/series.ts:42-48`)
--   Prioritise severe issues over minor ones
-
-### What NOT to Flag
-
--   Style issues handled by linters/formatters
--   Issues in code not modified by this PR
--   Nit-level comments unless they block understanding of the diff
--   Hypothetical issues that are unlikely to occur
-
-### Repository-Specific Guidelines
-
-Before reviewing, check for a `## Review guidelines` section in `CLAUDE.md` or `AGENTS.md`.
-Apply any repo-specific rules found (e.g., "Don't log PII", "Verify auth middleware wraps routes").
-
-## 4. Workflow
-
-1. If `$ARGUMENTS` is provided, review that PR number.
-2. Otherwise, review the current branch's open PR (use `gh pr view`).
-3. Fetch the PR diff using `gh pr diff {PR_NUMBER}`.
-4. Analyse the changes and identify issues.
-5. Output the review in the format specified below.
-
-## 5. Output Format
+## Output Format
 
 Output the review directly to the terminal using this Markdown structure:
 
@@ -111,38 +58,4 @@ _{N} low-priority issues omitted._
 {Concise justification for the verdict - 1-2 sentences}
 
 **Required Actions:** {Bulleted list of required fixes, or "None - ready to merge"}
-```
-
-### Priority Definitions
-
-| Priority | Meaning                          | Examples                                                       |
-| -------- | -------------------------------- | -------------------------------------------------------------- |
-| **P0**   | Critical - Must fix before merge | Security vulnerabilities, data loss, crashes, breaking changes |
-| **P1**   | High - Should fix before merge   | Logic errors, significant bugs, missing error handling         |
-| **P2**   | Medium - Consider fixing         | Minor bugs, performance concerns, maintainability issues       |
-| **P3**   | Low - Optional (count only)      | Documentation, minor style, suggestions                        |
-
-### Confidence Score Guidelines
-
-| Score   | Meaning                                     |
-| ------- | ------------------------------------------- |
-| 0.9-1.0 | Very confident - Clear evidence for verdict |
-| 0.7-0.8 | Confident - Minor uncertainties             |
-| 0.5-0.6 | Moderate - Some aspects unclear             |
-| < 0.5   | Low confidence - Significant uncertainty    |
-
-## 6. Using GitHub CLI
-
-```bash
-# View PR details
-PAGER='' gh pr view {PR_NUMBER}
-
-# View PR diff
-PAGER='' gh pr diff {PR_NUMBER}
-
-# View PR files changed
-PAGER='' gh pr view {PR_NUMBER} --json files
-
-# Get current branch's PR
-PAGER='' gh pr view
 ```

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -389,6 +389,18 @@ copy_extra_configs() {
     fi
 }
 
+# Get rulesync command - prefer patched versions over npx (which downloads fresh unpatched)
+# Priority: RULESYNC_BIN env var > local node_modules > npx fallback
+get_rulesync_cmd() {
+    if [[ -n "${RULESYNC_BIN:-}" && -x "$RULESYNC_BIN" ]]; then
+        echo "$RULESYNC_BIN"
+    elif [[ -x "$REPO_ROOT/node_modules/.bin/rulesync" ]]; then
+        echo "$REPO_ROOT/node_modules/.bin/rulesync"
+    else
+        echo "npx rulesync"
+    fi
+}
+
 # Generate rulesync configuration
 generate_config() {
     local targets="$1"
@@ -401,10 +413,14 @@ generate_config() {
         echo ""
     fi
 
+    # Prefer local rulesync (with patches applied) over npx (downloads fresh unpatched version)
+    local rulesync_cmd
+    rulesync_cmd=$(get_rulesync_cmd)
+
     # Run rulesync and capture output + exit code
     local output
     local exit_code=0
-    output=$(npx rulesync generate \
+    output=$($rulesync_cmd generate \
         --targets="$targets" \
         --features="rules,ignore,mcp,commands,subagents" \
         --delete 2>&1) || exit_code=$?

--- a/external/ag-shared/scripts/setup-prompts/verify-rulesync.sh
+++ b/external/ag-shared/scripts/setup-prompts/verify-rulesync.sh
@@ -270,11 +270,16 @@ build_expected_inventory() {
     done
 
     # Commands (claudecode only - goes to commands/)
+    # Skip files with _ prefix as they are internal helper files (e.g., _review-core.md)
     if [[ "$TARGET" == "claudecode" ]] && [[ -d "$REPO_ROOT/.rulesync/commands" ]]; then
         for cmd_file in "$REPO_ROOT/.rulesync/commands/"*.md; do
             if [[ -f "$cmd_file" ]]; then
                 local basename
                 basename=$(basename "$cmd_file")
+                # Skip internal helper files (prefixed with _)
+                if [[ "$basename" == _* ]]; then
+                    continue
+                fi
                 EXPECTED_FILES+=("commands/$basename")
             fi
         done
@@ -429,6 +434,7 @@ verify_content() {
     done
 
     # Verify commands content (claudecode only)
+    # Skip files with _ prefix as they are internal helper files (e.g., _review-core.md)
     if [[ "$TARGET" == "claudecode" ]] && [[ -d "$REPO_ROOT/.rulesync/commands" ]]; then
         for cmd_file in "$REPO_ROOT/.rulesync/commands/"*.md; do
             if [[ ! -f "$cmd_file" ]]; then
@@ -437,6 +443,10 @@ verify_content() {
 
             local basename
             basename=$(basename "$cmd_file")
+            # Skip internal helper files (prefixed with _)
+            if [[ "$basename" == _* ]]; then
+                continue
+            fi
             local source_file
             source_file=$(resolve_symlink "$cmd_file")
             local output_file="$temp_output/commands/$basename"

--- a/external/ag-shared/scripts/sync-rulesync/sync-rulesync.sh
+++ b/external/ag-shared/scripts/sync-rulesync/sync-rulesync.sh
@@ -238,6 +238,7 @@ apply_remove_stale_symlinks() {
 }
 
 # Check for missing symlinks in .rulesync/commands/ that should exist based on source files
+# Skip files with _ prefix as they are internal helper files (e.g., _review-core.md)
 check_missing_rulesync_symlinks() {
     local commands_dir="$REPO_ROOT/.rulesync/commands"
     local missing_count=0
@@ -255,6 +256,11 @@ check_missing_rulesync_symlinks() {
             local rel_path="${source_file#$shared_commands/}"
             local dir_name=$(dirname "$rel_path")
             local file_name=$(basename "$rel_path")
+
+            # Skip internal helper files (prefixed with _)
+            if [[ "$file_name" == _* ]]; then
+                continue
+            fi
 
             # Compute expected symlink name: dir/file.md -> dir-file.md
             local symlink_name="${dir_name}-${file_name}"
@@ -299,6 +305,7 @@ check_missing_rulesync_symlinks() {
 }
 
 # Create missing symlinks in .rulesync/commands/
+# Skip files with _ prefix as they are internal helper files (e.g., _review-core.md)
 apply_create_missing_symlinks() {
     local commands_dir="$REPO_ROOT/.rulesync/commands"
 
@@ -315,6 +322,11 @@ apply_create_missing_symlinks() {
             local rel_path="${source_file#$shared_commands/}"
             local dir_name=$(dirname "$rel_path")
             local file_name=$(basename "$rel_path")
+
+            # Skip internal helper files (prefixed with _)
+            if [[ "$file_name" == _* ]]; then
+                continue
+            fi
 
             local symlink_name="${dir_name}-${file_name}"
             local symlink_path="$commands_dir/$symlink_name"


### PR DESCRIPTION
## Summary
- Adds a reusable composite action (`codex-pr-review`) in ag-shared for running Codex PR reviews
- Adds a workflow in ag-charts that triggers on PR events, `/pr-review` comments, and manual dispatch
- Implements complete log suppression to ensure no LLM feedback appears in workflow logs

## Log Suppression Techniques
1. `>/dev/null 2>&1` redirects all Codex CLI stdout/stderr
2. Review content stays in file, never echoed to shell
3. `fs.readFileSync()` in JavaScript doesn't log file contents
4. Sensitive files cleaned up after posting

## Triggers
- `pull_request: [opened, ready_for_review, synchronize]` - Auto-review
- `issue_comment: /pr-review` - Manual via comment
- `workflow_dispatch` - Manual with PR number input

## Required Setup
- Add `OPENAI_API_KEY` secret to the repository

## Test plan
- [ ] Test `/pr-review` comment trigger on a test PR
- [ ] Verify review posts as PR comment
- [ ] Verify GitHub Actions logs contain NO review content
- [ ] Test `workflow_dispatch` with PR number