### PR TITLE
Fix scheduled benchmark workflow for b13.0.x branches

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,6 +90,10 @@ jobs:
                   elif [[ "${{ github.event_name }}" == "schedule" ]] ; then
                     # For scheduled runs, get the most recent release branch matching exact 'bX.Y.Z' format
                     release=$(git ls-remote --heads origin | grep -E 'refs/heads/b[0-9]+\.[0-9]+\.[0-9]+$' | sort -t '/' -k 3 -V | tail -n 1 | sed 's/.*refs\/heads\///')
+                    # Special case: b13.0.x series uses b13.0.0 as base due to circular dependency issues in b13.0.1+
+                    if [[ "$release" =~ ^b13\.0\.[1-9] ]] ; then
+                      release="b13.0.0"
+                    fi
                     echo "branch=latest" >> $GITHUB_OUTPUT
                     echo "base=$release" >> $GITHUB_OUTPUT
                   else


### PR DESCRIPTION
## Summary
- Add special case handling for b13.0.x series (where x >= 1) to fall back to b13.0.0 as the base for scheduled benchmarks
- The b13.0.1 branch has a circular dependency issue that prevents benchmark data collection, causing the overnight benchmark job to fail

## Test plan
- [x] Verified the regex logic handles edge cases correctly:
  - `b13.0.1` → `b13.0.0` (falls back)
  - `b13.0.0` → `b13.0.0` (unchanged)
  - `b13.1.0` → `b13.1.0` (unchanged)
  - `b12.3.1` → `b12.3.1` (unchanged)
- [ ] Manually trigger the benchmark workflow via workflow_dispatch with `compare-base: b13.0.0` to confirm it works
- [ ] Wait for next scheduled run to verify