### PR TITLE
AG-15850 Add tests label `formatter` and `itemStyler` callbacks

### DIFF
--- a/packages/ag-charts-community/src/chart/test/freezableMock.ts
+++ b/packages/ag-charts-community/src/chart/test/freezableMock.ts
@@ -112,6 +112,9 @@ export type MockErrorBarStyler<TDatum, TContext> = NonNullablePath<
 export type MockChartLabelFormatter<TDatum, TContext> = NonNullable<
     NonNullable<AgChartLabelOptions<TDatum, TContext>['formatter']>
 >;
+export type MockChartLabelItemStyler<TDatum, TContext> = NonNullable<
+    NonNullable<AgChartLabelOptions<TDatum, TContext>['itemStyler']>
+>;
 export type MockAnnotationsListener<TDatum, TContext> = NonNullable<
     AgBaseChartListeners<TDatum, TContext>['annotations']
 >;
@@ -184,6 +187,7 @@ export type MockAPICallback<TDatum, TContext> =
     | MockTooltipRenderer<TDatum, TContext>
     | MockErrorBarStyler<TDatum, TContext>
     | MockChartLabelFormatter<TDatum, TContext>
+    | MockChartLabelItemStyler<TDatum, TContext>
     | MockAnnotationsListener<TDatum, TContext>
     | MockZoomListener<TDatum, TContext>
     | MockGetDataCallback<TDatum, TContext>

--- a/packages/ag-charts-enterprise/src/__snapshots__/callbacks.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/__snapshots__/callbacks.test.ts.snap
@@ -1,0 +1,2656 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AG-15850 labels area formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "seriesId": "AreaSeries-1",
+      "value": 10,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "seriesId": "AreaSeries-1",
+      "value": 20,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels area itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "myValue",
+      "itemType": undefined,
+      "legendItemName": undefined,
+      "padding": 8,
+      "seriesId": "AreaSeries-1",
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "myValue",
+      "itemType": undefined,
+      "legendItemName": undefined,
+      "padding": 8,
+      "seriesId": "AreaSeries-1",
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels bar formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "seriesId": "BarSeries-1",
+      "value": 10,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "seriesId": "BarSeries-1",
+      "value": 20,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels bar itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "myValue",
+      "itemType": undefined,
+      "legendItemName": "myCategory",
+      "padding": 8,
+      "seriesId": "BarSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yKey": "myValue",
+      "yName": "myValue",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "myValue",
+      "itemType": undefined,
+      "legendItemName": "myCategory",
+      "padding": 8,
+      "seriesId": "BarSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yKey": "myValue",
+      "yName": "myValue",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels bubble formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "labelKey": undefined,
+      "labelName": undefined,
+      "legendItemName": undefined,
+      "seriesId": "BubbleSeries-1",
+      "sizeKey": "mySize",
+      "sizeName": undefined,
+      "value": 5,
+      "xKey": "myValue",
+      "xName": undefined,
+      "yKey": "myValue2",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "labelKey": undefined,
+      "labelName": undefined,
+      "legendItemName": undefined,
+      "seriesId": "BubbleSeries-1",
+      "sizeKey": "mySize",
+      "sizeName": undefined,
+      "value": 10,
+      "xKey": "myValue",
+      "xName": undefined,
+      "yKey": "myValue2",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels bubble itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "myValue2",
+      "itemType": undefined,
+      "labelKey": undefined,
+      "labelName": undefined,
+      "legendItemName": undefined,
+      "padding": 8,
+      "seriesId": "BubbleSeries-1",
+      "sizeKey": "mySize",
+      "sizeName": undefined,
+      "xKey": "myValue",
+      "xName": undefined,
+      "yKey": "myValue2",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels chord formatter 1`] = `
+[
+  [
+    {
+      "datum": {},
+      "fromKey": "myFrom",
+      "seriesId": "ChordSeries-1",
+      "size": 5,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+      "value": "myNode1",
+    },
+  ],
+  [
+    {
+      "datum": {},
+      "fromKey": "myFrom",
+      "seriesId": "ChordSeries-1",
+      "size": 8,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+      "value": "myNode2",
+    },
+  ],
+  [
+    {
+      "datum": {},
+      "fromKey": "myFrom",
+      "seriesId": "ChordSeries-1",
+      "size": 3,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+      "value": "myNode3",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels chord itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "fromKey": "myFrom",
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "ChordSeries-1",
+      "size": 5,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "fromKey": "myFrom",
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "ChordSeries-1",
+      "size": 8,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "fromKey": "myFrom",
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "ChordSeries-1",
+      "size": 3,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels donut formatter 1`] = `
+[
+  [
+    {
+      "angleKey": "myValue",
+      "angleName": undefined,
+      "calloutLabelKey": "myCategory",
+      "calloutLabelName": undefined,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemKey": undefined,
+      "radiusKey": undefined,
+      "radiusName": undefined,
+      "sectorLabelKey": undefined,
+      "sectorLabelName": undefined,
+      "seriesId": "DonutSeries-1",
+      "value": "CatA",
+    },
+  ],
+  [
+    {
+      "angleKey": "myValue",
+      "angleName": undefined,
+      "calloutLabelKey": "myCategory",
+      "calloutLabelName": undefined,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemKey": undefined,
+      "radiusKey": undefined,
+      "radiusName": undefined,
+      "sectorLabelKey": undefined,
+      "sectorLabelName": undefined,
+      "seriesId": "DonutSeries-1",
+      "value": "CatB",
+    },
+  ],
+  [
+    {
+      "angleKey": "myValue",
+      "angleName": undefined,
+      "calloutLabelKey": "myCategory",
+      "calloutLabelName": undefined,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemKey": undefined,
+      "radiusKey": undefined,
+      "radiusName": undefined,
+      "sectorLabelKey": undefined,
+      "sectorLabelName": undefined,
+      "seriesId": "DonutSeries-1",
+      "value": "CatA",
+    },
+  ],
+  [
+    {
+      "angleKey": "myValue",
+      "angleName": undefined,
+      "calloutLabelKey": "myCategory",
+      "calloutLabelName": undefined,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemKey": undefined,
+      "radiusKey": undefined,
+      "radiusName": undefined,
+      "sectorLabelKey": undefined,
+      "sectorLabelName": undefined,
+      "seriesId": "DonutSeries-1",
+      "value": "CatB",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels donut itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": 0,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "DonutSeries-1",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": 1,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "DonutSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels funnel formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "itemId": "myValue",
+      "seriesId": "FunnelSeries-1",
+      "stageKey": "myCategory",
+      "value": 10,
+      "valueKey": "myValue",
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "itemId": "myValue",
+      "seriesId": "FunnelSeries-1",
+      "stageKey": "myCategory",
+      "value": 20,
+      "valueKey": "myValue",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels funnel itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "myCategory",
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "FunnelSeries-1",
+      "stageKey": "myCategory",
+      "valueKey": "myValue",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "myCategory",
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "FunnelSeries-1",
+      "stageKey": "myCategory",
+      "valueKey": "myValue",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels histogram formatter 1`] = `
+[
+  [
+    {
+      "datum": [
+        1,
+      ],
+      "seriesId": "HistogramSeries-1",
+      "value": 1,
+      "xKey": "myValue",
+      "xName": undefined,
+      "yKey": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": [
+        1,
+      ],
+      "seriesId": "HistogramSeries-1",
+      "value": 1,
+      "xKey": "myValue",
+      "xName": undefined,
+      "yKey": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": [
+        1,
+      ],
+      "seriesId": "HistogramSeries-1",
+      "value": 1,
+      "xKey": "myValue",
+      "xName": undefined,
+      "yKey": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": [
+        1,
+      ],
+      "seriesId": "HistogramSeries-1",
+      "value": 1,
+      "xKey": "myValue",
+      "xName": undefined,
+      "yKey": undefined,
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels histogram itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": [],
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "HistogramSeries-1",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": [
+        1,
+      ],
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "HistogramSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels line formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "seriesId": "LineSeries-1",
+      "value": 10,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "seriesId": "LineSeries-1",
+      "value": 20,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels line itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "legendItemName": undefined,
+      "padding": 8,
+      "seriesId": "LineSeries-1",
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "legendItemName": undefined,
+      "padding": 8,
+      "seriesId": "LineSeries-1",
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels linear-gauge formatter 1`] = `
+[
+  [
+    {
+      "datum": undefined,
+      "seriesId": "LinearGaugeSeries-1",
+      "value": 40,
+    },
+  ],
+  [
+    {
+      "datum": undefined,
+      "seriesId": "LinearGaugeSeries-1",
+      "value": 40,
+    },
+  ],
+  [
+    {
+      "datum": undefined,
+      "seriesId": "LinearGaugeSeries-1",
+      "value": 40,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels linear-gauge itemStyler 1`] = `[]`;
+
+exports[`AG-15850 labels map-line formatter 1`] = `
+[
+  [
+    {
+      "colorKey": undefined,
+      "colorName": undefined,
+      "datum": {
+        "myId": "myLine",
+        "myValue": 10,
+      },
+      "idKey": "myId",
+      "idName": undefined,
+      "labelKey": "myId",
+      "labelName": undefined,
+      "seriesId": "MapLineSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": undefined,
+      "value": "myLine",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels map-line itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "MapLineSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels map-marker formatter 1`] = `
+[
+  [
+    {
+      "colorKey": undefined,
+      "colorName": undefined,
+      "datum": {
+        "myId": "myPoly",
+        "myLat": 0.5,
+        "myLon": 0.5,
+      },
+      "idKey": undefined,
+      "idName": undefined,
+      "labelKey": "myId",
+      "labelName": undefined,
+      "latitudeKey": "myLat",
+      "latitudeName": undefined,
+      "longitudeKey": "myLon",
+      "longitudeName": undefined,
+      "seriesId": "MapMarkerSeries-1",
+      "sizeKey": undefined,
+      "sizeName": undefined,
+      "value": "myPoly",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels map-marker itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "MapMarkerSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels map-shape formatter 1`] = `
+[
+  [
+    {
+      "colorKey": "myValue",
+      "colorName": undefined,
+      "datum": {
+        "myId": "myPoly",
+        "myValue": 10,
+      },
+      "idKey": "myId",
+      "idName": undefined,
+      "labelKey": "myId",
+      "labelName": undefined,
+      "seriesId": "MapShapeSeries-1",
+      "value": "myPoly",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels map-shape itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": "bold",
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "MapShapeSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels pyramid formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "seriesId": "PyramidSeries-1",
+      "stageKey": "myCategory",
+      "value": 10,
+      "valueKey": "myValue",
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "seriesId": "PyramidSeries-1",
+      "stageKey": "myCategory",
+      "value": 20,
+      "valueKey": "myValue",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels pyramid itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "PyramidSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radars formatter 1`] = `
+[
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadarLineSeries-1",
+      "value": 10,
+    },
+  ],
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadarLineSeries-1",
+      "value": 20,
+    },
+  ],
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadarLineSeries-1",
+      "value": 10,
+    },
+  ],
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadarLineSeries-1",
+      "value": 20,
+    },
+  ],
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadarLineSeries-1",
+      "value": 10,
+    },
+  ],
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadarLineSeries-1",
+      "value": 20,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radars itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "RadarLineSeries-1",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "RadarLineSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radial-bar formatter 1`] = `
+[
+  [
+    {
+      "angleKey": "myValue",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue2",
+      "radiusName": undefined,
+      "seriesId": "RadialBarSeries-1",
+      "value": 10,
+    },
+  ],
+  [
+    {
+      "angleKey": "myValue",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue2",
+      "radiusName": undefined,
+      "seriesId": "RadialBarSeries-1",
+      "value": 20,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radial-bar itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "RadialBarSeries-1",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "RadialBarSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radial-column formatter 1`] = `
+[
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadialColumnSeries-1",
+      "value": 10,
+    },
+  ],
+  [
+    {
+      "angleKey": "myCategory",
+      "angleName": undefined,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "legendItemName": undefined,
+      "radiusKey": "myValue",
+      "radiusName": undefined,
+      "seriesId": "RadialColumnSeries-1",
+      "value": 20,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radial-column itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "RadialColumnSeries-1",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "RadialColumnSeries-1",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radial-gauge formatter 1`] = `
+[
+  [
+    {
+      "datum": undefined,
+      "seriesId": "RadialGaugeSeries-1",
+      "value": 70,
+    },
+  ],
+  [
+    {
+      "datum": undefined,
+      "seriesId": "RadialGaugeSeries-1",
+      "value": 70,
+    },
+  ],
+  [
+    {
+      "datum": undefined,
+      "seriesId": "RadialGaugeSeries-1",
+      "value": 70,
+    },
+  ],
+  [
+    {
+      "datum": undefined,
+      "seriesId": "RadialGaugeSeries-1",
+      "value": 70,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels radial-gauge itemStyler 1`] = `[]`;
+
+exports[`AG-15850 labels range-area formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "itemType": "high",
+      "legendItemName": undefined,
+      "seriesId": "RangeAreaSeries-1",
+      "value": 10,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "itemType": "low",
+      "legendItemName": undefined,
+      "seriesId": "RangeAreaSeries-1",
+      "value": 7,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "itemType": "high",
+      "legendItemName": undefined,
+      "seriesId": "RangeAreaSeries-1",
+      "value": 20,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "itemType": "low",
+      "legendItemName": undefined,
+      "seriesId": "RangeAreaSeries-1",
+      "value": 14,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels range-area itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "high",
+      "legendItemName": undefined,
+      "padding": 10,
+      "seriesId": "RangeAreaSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "low",
+      "legendItemName": undefined,
+      "padding": 10,
+      "seriesId": "RangeAreaSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "high",
+      "legendItemName": undefined,
+      "padding": 10,
+      "seriesId": "RangeAreaSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "low",
+      "legendItemName": undefined,
+      "padding": 10,
+      "seriesId": "RangeAreaSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels range-bar formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "itemType": "low",
+      "legendItemName": undefined,
+      "seriesId": "RangeBarSeries-1",
+      "value": 7,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "itemType": "high",
+      "legendItemName": undefined,
+      "seriesId": "RangeBarSeries-1",
+      "value": 10,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "itemType": "low",
+      "legendItemName": undefined,
+      "seriesId": "RangeBarSeries-1",
+      "value": 14,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "itemType": "high",
+      "legendItemName": undefined,
+      "seriesId": "RangeBarSeries-1",
+      "value": 20,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yHighKey": "myValue",
+      "yHighName": undefined,
+      "yLowKey": "myValue2",
+      "yLowName": undefined,
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels range-bar itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "low",
+      "legendItemName": undefined,
+      "padding": 6,
+      "seriesId": "RangeBarSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "mySize": 5,
+        "myValue": 10,
+        "myValue2": 7,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "high",
+      "legendItemName": undefined,
+      "padding": 6,
+      "seriesId": "RangeBarSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "low",
+      "legendItemName": undefined,
+      "padding": 6,
+      "seriesId": "RangeBarSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "white",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "mySize": 10,
+        "myValue": 20,
+        "myValue2": 14,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "high",
+      "legendItemName": undefined,
+      "padding": 6,
+      "seriesId": "RangeBarSeries-1",
+      "xKey": "myCategory",
+      "xName": "myCategory",
+      "yHighKey": "myValue",
+      "yHighName": "myValue",
+      "yLowKey": "myValue2",
+      "yLowName": "myValue2",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels sankey formatter 1`] = `
+[
+  [
+    {
+      "datum": {},
+      "fromKey": "myFrom",
+      "seriesId": "SankeySeries-1",
+      "size": 5,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+      "value": "myNode1",
+    },
+  ],
+  [
+    {
+      "datum": {},
+      "fromKey": "myFrom",
+      "seriesId": "SankeySeries-1",
+      "size": 5,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+      "value": "myNode2",
+    },
+  ],
+  [
+    {
+      "datum": {},
+      "fromKey": "myFrom",
+      "seriesId": "SankeySeries-1",
+      "size": 3,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+      "value": "myNode3",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels sankey itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "fromKey": "myFrom",
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "SankeySeries-1",
+      "size": 5,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": undefined,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "fromKey": "myFrom",
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": undefined,
+      "padding": 8,
+      "seriesId": "SankeySeries-1",
+      "size": 3,
+      "sizeKey": "mySize",
+      "toKey": "myTo",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels sunburst formatter 1`] = `
+[
+  [
+    {
+      "childrenKey": "children",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "datum": {
+        "children": [
+          {
+            "myLabel": "LabA",
+            "myValue": 10,
+          },
+          {
+            "myLabel": "LabB",
+            "myValue": 20,
+          },
+        ],
+        "myLabel": "root",
+      },
+      "depth": 0,
+      "labelKey": "myLabel",
+      "secondaryLabelKey": undefined,
+      "seriesId": "SunburstSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": undefined,
+      "value": "root",
+    },
+  ],
+  [
+    {
+      "childrenKey": "children",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "datum": {
+        "myLabel": "LabA",
+        "myValue": 10,
+      },
+      "depth": 1,
+      "labelKey": "myLabel",
+      "secondaryLabelKey": undefined,
+      "seriesId": "SunburstSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": undefined,
+      "value": "LabA",
+    },
+  ],
+  [
+    {
+      "childrenKey": "children",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "datum": {
+        "myLabel": "LabB",
+        "myValue": 20,
+      },
+      "depth": 1,
+      "labelKey": "myLabel",
+      "secondaryLabelKey": undefined,
+      "seriesId": "SunburstSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": undefined,
+      "value": "LabB",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels sunburst itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "childrenKey": "children",
+      "color": "white",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "cornerRadius": 4,
+      "datum": {
+        "children": [
+          {
+            "myLabel": "LabA",
+            "myValue": 10,
+          },
+          {
+            "myLabel": "LabB",
+            "myValue": 20,
+          },
+        ],
+        "myLabel": "root",
+      },
+      "depth": 0,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 14,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "0",
+      "itemType": undefined,
+      "labelKey": "myLabel",
+      "padding": 8,
+      "secondaryLabelKey": undefined,
+      "seriesId": "SunburstSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": "myValue",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "childrenKey": "children",
+      "color": "white",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "cornerRadius": 4,
+      "datum": {
+        "myLabel": "LabA",
+        "myValue": 10,
+      },
+      "depth": 1,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 14,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "0;0",
+      "itemType": undefined,
+      "labelKey": "myLabel",
+      "padding": 8,
+      "secondaryLabelKey": undefined,
+      "seriesId": "SunburstSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": "myValue",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "childrenKey": "children",
+      "color": "white",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "cornerRadius": 4,
+      "datum": {
+        "myLabel": "LabB",
+        "myValue": 20,
+      },
+      "depth": 1,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 14,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "0;1",
+      "itemType": undefined,
+      "labelKey": "myLabel",
+      "padding": 8,
+      "secondaryLabelKey": undefined,
+      "seriesId": "SunburstSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": "myValue",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels treemap formatter 1`] = `
+[
+  [
+    {
+      "childrenKey": "children",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "datum": {
+        "myLabel": "LabA",
+        "myValue": 10,
+      },
+      "depth": 1,
+      "labelKey": "myLabel",
+      "secondaryLabelKey": undefined,
+      "seriesId": "TreemapSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": undefined,
+      "value": "LabA",
+    },
+  ],
+  [
+    {
+      "childrenKey": "children",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "datum": {
+        "myLabel": "LabB",
+        "myValue": 20,
+      },
+      "depth": 1,
+      "labelKey": "myLabel",
+      "secondaryLabelKey": undefined,
+      "seriesId": "TreemapSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": undefined,
+      "value": "LabB",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels treemap itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "childrenKey": "children",
+      "color": "white",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "cornerRadius": 4,
+      "datum": {
+        "myLabel": "LabA",
+        "myValue": 10,
+      },
+      "depth": 1,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 18,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "0;0",
+      "itemType": undefined,
+      "labelKey": "myLabel",
+      "padding": 8,
+      "secondaryLabelKey": undefined,
+      "seriesId": "TreemapSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": "myValue",
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "childrenKey": "children",
+      "color": "white",
+      "colorKey": undefined,
+      "colorName": undefined,
+      "cornerRadius": 4,
+      "datum": {
+        "myLabel": "LabB",
+        "myValue": 20,
+      },
+      "depth": 1,
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 18,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": "0;1",
+      "itemType": undefined,
+      "labelKey": "myLabel",
+      "padding": 8,
+      "secondaryLabelKey": undefined,
+      "seriesId": "TreemapSeries-1",
+      "sizeKey": "myValue",
+      "sizeName": "myValue",
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels waterfall formatter 1`] = `
+[
+  [
+    {
+      "datum": {
+        "myCategory": "CatA",
+        "myValue": 10,
+      },
+      "itemType": "positive",
+      "seriesId": "WaterfallSeries-1",
+      "value": 10,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatB",
+        "myValue": -5,
+      },
+      "itemType": "negative",
+      "seriesId": "WaterfallSeries-1",
+      "value": -5,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "datum": {
+        "myCategory": "CatC",
+        "myValue": 15,
+      },
+      "itemType": "positive",
+      "seriesId": "WaterfallSeries-1",
+      "value": 15,
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+]
+`;
+
+exports[`AG-15850 labels waterfall itemStyler 1`] = `
+[
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatA",
+        "myValue": 10,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "positive",
+      "padding": 6,
+      "seriesId": "WaterfallSeries-1",
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatB",
+        "myValue": -5,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "negative",
+      "padding": 6,
+      "seriesId": "WaterfallSeries-1",
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+  [
+    {
+      "border": {
+        "enabled": false,
+        "stroke": "rgba(70, 70, 70, 0.08)",
+        "strokeOpacity": undefined,
+        "strokeWidth": 1,
+      },
+      "color": "#464646",
+      "cornerRadius": 4,
+      "datum": {
+        "myCategory": "CatC",
+        "myValue": 15,
+      },
+      "enabled": true,
+      "fill": undefined,
+      "fillOpacity": undefined,
+      "fontFamily": "Verdana, sans-serif",
+      "fontSize": 12,
+      "fontStyle": undefined,
+      "fontWeight": 400,
+      "highlightState": "none",
+      "itemId": undefined,
+      "itemType": "positive",
+      "padding": 6,
+      "seriesId": "WaterfallSeries-1",
+      "xKey": "myCategory",
+      "xName": undefined,
+      "yKey": "myValue",
+      "yName": undefined,
+    },
+  ],
+]
+`;

--- a/packages/ag-charts-enterprise/src/callbacks.test.ts
+++ b/packages/ag-charts-enterprise/src/callbacks.test.ts
@@ -617,6 +617,11 @@ describe('AG-15850 labels', () => {
         mockItemStyler = newFreezableMock<D, C, ItemStyler>();
     });
 
+    afterEach(() => {
+        chart?.destroy();
+        (chart as unknown) = undefined;
+    });
+
     async function createChart<O extends AgChartOptions>(opts: O): Promise<void> {
         prepareEnterpriseTestOptions(opts);
         chart = AgCharts.create(opts);

--- a/packages/ag-charts-enterprise/src/callbacks.test.ts
+++ b/packages/ag-charts-enterprise/src/callbacks.test.ts
@@ -45,7 +45,7 @@ import {
     setupMockConsole,
     waitForChartStability,
 } from 'ag-charts-community-test';
-import type { AgDataSourceCallbackParams } from 'ag-charts-types';
+import type { AgCartesianChartOptions, AgDataSourceCallbackParams } from 'ag-charts-types';
 
 import { prepareEnterpriseTestOptions } from './test/utils';
 
@@ -552,12 +552,68 @@ describe('AG-15850 labels', () => {
     type C = unknown;
     type Formatter = MockChartLabelFormatter<D, C>;
     type ItemStyler = MockChartLabelItemStyler<D, C>;
-    let chart: AgChartInstance;
+
+    let chart: AgChartInstance<AgGaugeOptions | AgChartOptions<D, C>>;
     let mockFormatter: ReturnType<typeof newFreezableMock<D, C, Formatter>>;
     let mockItemStyler: ReturnType<typeof newFreezableMock<D, C, ItemStyler>>;
 
+    const basicData = [
+        { myCategory: 'CatA', myValue: 10, myValue2: 7, mySize: 5 },
+        { myCategory: 'CatB', myValue: 20, myValue2: 14, mySize: 10 },
+    ];
+
+    const hierarchyData = [
+        {
+            myLabel: 'root',
+            children: [
+                { myLabel: 'LabA', myValue: 10 },
+                { myLabel: 'LabB', myValue: 20 },
+            ],
+        },
+    ];
+
+    const flowData = [
+        { myFrom: 'myNode1', myTo: 'myNode2', mySize: 5 },
+        { myFrom: 'myNode2', myTo: 'myNode3', mySize: 3 },
+    ];
+
+    const geoJson = {
+        type: 'FeatureCollection',
+        features: [
+            {
+                type: 'Feature',
+                properties: { name: 'myPoly' },
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                        [
+                            [0, 0],
+                            [1, 0],
+                            [1, 1],
+                            [0, 1],
+                            [0, 0],
+                        ],
+                    ],
+                },
+            },
+            {
+                type: 'Feature',
+                properties: { name: 'myLine' },
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [
+                        [0, 0],
+                        [1, 0],
+                        [1, 1],
+                        [0, 1],
+                    ],
+                },
+            },
+        ],
+    };
+
     beforeEach(() => {
-        mockFormatter = newFreezableMock<D, C, Formatter>();
+        mockFormatter = newFreezableMock<D, C, Formatter>((p) => `${p.value}`);
         mockItemStyler = newFreezableMock<D, C, ItemStyler>();
     });
 
@@ -567,23 +623,58 @@ describe('AG-15850 labels', () => {
         await waitForChartStability(chart);
     }
 
+    async function createGauge<O extends AgGaugeOptions>(opts: O): Promise<void> {
+        prepareEnterpriseTestOptions(opts);
+        chart = AgCharts.createGauge(opts);
+        await waitForChartStability(chart);
+    }
+
     describe('sankey', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: flowData,
+                series: [
+                    {
+                        type: 'sankey',
+                        fromKey: 'myFrom',
+                        toKey: 'myTo',
+                        sizeKey: 'mySize',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
             expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
         });
 
-        test('itemStyler', () => {
+        // Ignore the test for now; circular itemStyler param object (`nodeDatum`)
+        xtest('itemStyler', () => {
             expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
         });
     });
 
     describe('chord', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: flowData,
+                series: [
+                    {
+                        type: 'chord',
+                        fromKey: 'myFrom',
+                        toKey: 'myTo',
+                        sizeKey: 'mySize',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -596,8 +687,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('pyramid', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'pyramid',
+                        valueKey: 'myValue',
+                        stageKey: 'myCategory',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -610,8 +714,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('funnel', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart<AgCartesianChartOptions<D, C>>({
+                data: basicData,
+                series: [
+                    {
+                        type: 'funnel',
+                        valueKey: 'myValue',
+                        stageKey: 'myCategory',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -624,8 +741,24 @@ describe('AG-15850 labels', () => {
     });
 
     describe('map-shape', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: [{ myId: 'myPoly', myValue: 10 }],
+                topology: geoJson,
+                series: [
+                    {
+                        type: 'map-shape',
+                        colorKey: 'myValue',
+                        labelKey: 'myId',
+                        idKey: 'myId',
+                        label: {
+                            enabled: true,
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -638,8 +771,28 @@ describe('AG-15850 labels', () => {
     });
 
     describe('map-marker', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                topology: geoJson,
+                data: [{ myId: 'myPoly', myLat: 0.5, myLon: 0.5 }],
+                series: [
+                    {
+                        type: 'map-shape-background',
+                    },
+                    {
+                        type: 'map-marker',
+                        latitudeKey: 'myLat',
+                        longitudeKey: 'myLon',
+                        labelKey: 'myId',
+                        size: 50,
+                        label: {
+                            enabled: true,
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -651,9 +804,24 @@ describe('AG-15850 labels', () => {
         });
     });
 
-    describe('marker-line', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+    describe('map-line', () => {
+        beforeEach(async () => {
+            await createChart({
+                data: [{ myId: 'myLine', myValue: 10 }],
+                topology: geoJson,
+                series: [
+                    {
+                        type: 'map-line',
+                        idKey: 'myId',
+                        labelKey: 'myId',
+                        sizeKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -666,8 +834,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('sunburst', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: hierarchyData,
+                series: [
+                    {
+                        type: 'sunburst',
+                        labelKey: 'myLabel',
+                        sizeKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -680,8 +861,23 @@ describe('AG-15850 labels', () => {
     });
 
     describe('treemap', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: hierarchyData,
+                series: [
+                    {
+                        type: 'treemap',
+                        labelKey: 'myLabel',
+                        sizeKey: 'myValue',
+                        tile: {
+                            label: {
+                                formatter: mockFormatter.frozen,
+                                itemStyler: mockItemStyler.frozen,
+                            },
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -694,8 +890,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('line', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'line',
+                        xKey: 'myCategory',
+                        yKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -708,8 +917,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('area', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'area',
+                        xKey: 'myCategory',
+                        yKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -722,8 +944,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('bar', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'bar',
+                        xKey: 'myCategory',
+                        yKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -736,8 +971,22 @@ describe('AG-15850 labels', () => {
     });
 
     describe('range-area', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'range-area',
+                        xKey: 'myCategory',
+                        yLowKey: 'myValue2',
+                        yHighKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -750,8 +999,22 @@ describe('AG-15850 labels', () => {
     });
 
     describe('range-bar', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'range-bar',
+                        xKey: 'myCategory',
+                        yLowKey: 'myValue2',
+                        yHighKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -764,8 +1027,22 @@ describe('AG-15850 labels', () => {
     });
 
     describe('bubble', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'bubble',
+                        xKey: 'myValue',
+                        yKey: 'myValue2',
+                        sizeKey: 'mySize',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -778,8 +1055,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('donut', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'donut',
+                        angleKey: 'myValue',
+                        calloutLabelKey: 'myCategory',
+                        calloutLabel: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -792,8 +1082,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('radial-bar', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'radial-bar',
+                        angleKey: 'myValue',
+                        radiusKey: 'myValue2',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -806,8 +1109,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('radial-column', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'radial-column',
+                        angleKey: 'myCategory',
+                        radiusKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -820,8 +1136,21 @@ describe('AG-15850 labels', () => {
     });
 
     describe('radars', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: basicData,
+                series: [
+                    {
+                        type: 'radar-line',
+                        angleKey: 'myCategory',
+                        radiusKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -834,8 +1163,15 @@ describe('AG-15850 labels', () => {
     });
 
     describe('radial-gauge', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createGauge({
+                type: 'radial-gauge',
+                value: 70,
+                label: {
+                    formatter: mockFormatter.frozen,
+                    itemStyler: mockItemStyler.frozen,
+                },
+            });
         });
 
         test('formatter', () => {
@@ -848,8 +1184,15 @@ describe('AG-15850 labels', () => {
     });
 
     describe('linear-gauge', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createGauge({
+                type: 'linear-gauge',
+                value: 40,
+                label: {
+                    formatter: mockFormatter.frozen,
+                    itemStyler: mockItemStyler.frozen,
+                },
+            });
         });
 
         test('formatter', () => {
@@ -862,8 +1205,41 @@ describe('AG-15850 labels', () => {
     });
 
     describe('waterfall', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: [
+                    { myCategory: 'CatA', myValue: 10 },
+                    { myCategory: 'CatB', myValue: -5 },
+                    { myCategory: 'CatC', myValue: 15 },
+                ],
+                series: [
+                    {
+                        type: 'waterfall',
+                        xKey: 'myCategory',
+                        yKey: 'myValue',
+                        item: {
+                            positive: {
+                                label: {
+                                    formatter: mockFormatter.frozen,
+                                    itemStyler: mockItemStyler.frozen,
+                                },
+                            },
+                            negative: {
+                                label: {
+                                    formatter: mockFormatter.frozen,
+                                    itemStyler: mockItemStyler.frozen,
+                                },
+                            },
+                            total: {
+                                label: {
+                                    formatter: mockFormatter.frozen,
+                                    itemStyler: mockItemStyler.frozen,
+                                },
+                            },
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {
@@ -876,22 +1252,20 @@ describe('AG-15850 labels', () => {
     });
 
     describe('histogram', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
-        });
-
-        test('formatter', () => {
-            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
-        });
-
-        test('itemStyler', () => {
-            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
-        });
-    });
-
-    describe('box-plot', () => {
-        beforeEach(() => {
-            throw new Error('Not Yet Implemented');
+        beforeEach(async () => {
+            await createChart({
+                data: [{ myValue: 1 }, { myValue: 2 }, { myValue: 3 }, { myValue: 4 }],
+                series: [
+                    {
+                        type: 'histogram',
+                        xKey: 'myValue',
+                        label: {
+                            formatter: mockFormatter.frozen,
+                            itemStyler: mockItemStyler.frozen,
+                        },
+                    },
+                ],
+            });
         });
 
         test('formatter', () => {

--- a/packages/ag-charts-enterprise/src/callbacks.test.ts
+++ b/packages/ag-charts-enterprise/src/callbacks.test.ts
@@ -27,6 +27,7 @@ import {
     type MockChartClickListener,
     type MockChartDblClickListener,
     type MockChartLabelFormatter,
+    type MockChartLabelItemStyler,
     type MockChartSeriesVisibilityChangeListener,
     type MockContextMenuAction,
     type MockGetDataCallback,
@@ -539,6 +540,366 @@ describe('AG-13024 API context gauges', () => {
             options.context = rootContext;
             chart = await createChart(options);
             chartLabelFormatter.expect().toHaveBeenCalledTimes(3).withContext(rootContext);
+        });
+    });
+});
+
+describe('AG-15850 labels', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    type D = unknown;
+    type C = unknown;
+    type Formatter = MockChartLabelFormatter<D, C>;
+    type ItemStyler = MockChartLabelItemStyler<D, C>;
+    let chart: AgChartInstance;
+    let mockFormatter: ReturnType<typeof newFreezableMock<D, C, Formatter>>;
+    let mockItemStyler: ReturnType<typeof newFreezableMock<D, C, ItemStyler>>;
+
+    beforeEach(() => {
+        mockFormatter = newFreezableMock<D, C, Formatter>();
+        mockItemStyler = newFreezableMock<D, C, ItemStyler>();
+    });
+
+    async function createChart<O extends AgChartOptions>(opts: O): Promise<void> {
+        prepareEnterpriseTestOptions(opts);
+        chart = AgCharts.create(opts);
+        await waitForChartStability(chart);
+    }
+
+    describe('sankey', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('chord', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('pyramid', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('funnel', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('map-shape', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('map-marker', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('marker-line', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('sunburst', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('treemap', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('line', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('area', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('bar', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('range-area', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('range-bar', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('bubble', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('donut', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('radial-bar', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('radial-column', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('radars', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('radial-gauge', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('linear-gauge', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('waterfall', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('histogram', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
+        });
+    });
+
+    describe('box-plot', () => {
+        beforeEach(() => {
+            throw new Error('Not Yet Implemented');
+        });
+
+        test('formatter', () => {
+            expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
+        });
+
+        test('itemStyler', () => {
+            expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/callbacks.test.ts
+++ b/packages/ag-charts-enterprise/src/callbacks.test.ts
@@ -652,8 +652,7 @@ describe('AG-15850 labels', () => {
             expect(mockFormatter.mock.mock.calls).toMatchSnapshot();
         });
 
-        // Ignore the test for now; circular itemStyler param object (`nodeDatum`)
-        xtest('itemStyler', () => {
+        test('itemStyler', () => {
             expect(mockItemStyler.mock.mock.calls).toMatchSnapshot();
         });
     });

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
@@ -9,6 +9,7 @@ import {
 } from 'ag-charts-community';
 import {
     Logger,
+    type RequireOptional,
     TextMeasurer,
     cachedTextMeasurer,
     calcLineHeight,
@@ -732,7 +733,12 @@ export class SankeySeries extends FlowProportionSeries<
         const activeHighlightDatum = this.getHighlightedDatum();
         opts.labelSelection.each((label, datum) => {
             const { x, y, textAlign, text, datumIndex, nodeDatum } = datum;
-            const params: AgSankeySeriesLabelFormatterParams = datum;
+            const params: RequireOptional<AgSankeySeriesLabelFormatterParams> = {
+                fromKey: this.properties.fromKey,
+                size: datum.size,
+                sizeKey: this.properties.sizeKey,
+                toKey: this.properties.toKey,
+            };
 
             const isHighlight = this.isLabelHighlighted(nodeDatum, activeHighlightDatum);
             const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15850
https://ag-grid.atlassian.net/browse/AG-16652 (Sub-Task)

These tests will check for breaking changes to the `itemId` property in the callbacks.

Tests added:
```
AG-15850 labels
  sankey
    formatter
    itemStyler
  chord
    formatter
    itemStyler
  pyramid
    formatter
    itemStyler
  funnel
    formatter
    itemStyler
  map-shape
    formatter
    itemStyler
  map-marker
    formatter
    itemStyler
  map-line
    formatter
    itemStyler
  sunburst
    formatter
    itemStyler
  treemap
    formatter
    itemStyler
  line
    formatter
    itemStyler
  area
    formatter
    itemStyler
  bar
    formatter
    itemStyler
  range-area
    formatter
    itemStyler
  range-bar
    formatter
    itemStyler
  bubble
    formatter
    itemStyler
  donut
    formatter
    itemStyler
  radial-bar
    formatter
    itemStyler
  radial-column
    formatter
    itemStyler
  radars
    formatter
    itemStyler
  radial-gauge
    formatter
    itemStyler
  linear-gauge
    formatter
    itemStyler
  waterfall
    formatter
    itemStyler
  histogram
    formatter
    itemStyler
```