### PR TITLE
fix rulesync skills installation

### DIFF
--- a/.rulesync/skills/estimate-jira
+++ b/.rulesync/skills/estimate-jira
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/skills/estimate-jira/

--- a/.rulesync/skills/estimate-jira.md
+++ b/.rulesync/skills/estimate-jira.md
@@ -1,1 +1,0 @@
-../../external/ag-shared/prompts/skills/estimate-jira/SKILL.md

--- a/.rulesync/skills/jira-create
+++ b/.rulesync/skills/jira-create
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/skills/jira-create/

--- a/.rulesync/skills/jira-create.md
+++ b/.rulesync/skills/jira-create.md
@@ -1,1 +1,0 @@
-../../external/ag-shared/prompts/skills/jira-create/SKILL.md

--- a/.rulesync/skills/optimize-series
+++ b/.rulesync/skills/optimize-series
@@ -1,0 +1,1 @@
+../../external/prompts/skills/optimize-series/

--- a/.rulesync/skills/optimize-series.md
+++ b/.rulesync/skills/optimize-series.md
@@ -1,1 +1,0 @@
-../../external/prompts/skills/optimize-series/SKILL.md

--- a/.rulesync/skills/plunker
+++ b/.rulesync/skills/plunker
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/skills/plunker/

--- a/.rulesync/skills/plunker.md
+++ b/.rulesync/skills/plunker.md
@@ -1,1 +1,0 @@
-../../external/ag-shared/prompts/skills/plunker/SKILL.md

--- a/.rulesync/skills/spruce-docs
+++ b/.rulesync/skills/spruce-docs
@@ -1,0 +1,1 @@
+../../external/prompts/skills/spruce-docs/

--- a/.rulesync/skills/spruce-docs.md
+++ b/.rulesync/skills/spruce-docs.md
@@ -1,1 +1,0 @@
-../../external/prompts/skills/spruce-docs/SKILL.md

--- a/.rulesync/skills/spruce-example
+++ b/.rulesync/skills/spruce-example
@@ -1,0 +1,1 @@
+../../external/prompts/skills/spruce-example/

--- a/.rulesync/skills/spruce-example.md
+++ b/.rulesync/skills/spruce-example.md
@@ -1,1 +1,0 @@
-../../external/prompts/skills/spruce-example/SKILL.md

--- a/external/ag-shared/prompts/guides/rulesync.md
+++ b/external/ag-shared/prompts/guides/rulesync.md
@@ -144,6 +144,10 @@ ln -s ../../external/prompts/agents/visual-qa.md visual-qa.md
 
 # From .rulesync/rules/
 ln -s ../../external/ag-shared/prompts/guides/code-quality.md code-quality.md
+
+# From .rulesync/skills/ (NOTE: skills use directory symlinks, not file symlinks)
+ln -s ../../external/ag-shared/prompts/skills/estimate-jira/ estimate-jira
+ln -s ../../external/prompts/skills/spruce-example/ spruce-example
 ```
 
 ## Verification

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -422,7 +422,7 @@ generate_config() {
     local exit_code=0
     output=$($rulesync_cmd generate \
         --targets="$targets" \
-        --features="rules,ignore,mcp,commands,subagents" \
+        --features="rules,ignore,mcp,commands,subagents,skills" \
         --delete 2>&1) || exit_code=$?
 
     if [[ $exit_code -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Add `skills` feature to rulesync generate command in `setup-prompts.sh`
- Change skill symlinks from file-based (`*.md` → `SKILL.md`) to directory-based (rulesync expects skills as directories containing `SKILL.md`)
- Document correct skills symlink pattern in rulesync guide

## Test plan
- [x] Run `./external/ag-shared/scripts/setup-prompts/setup-prompts.sh --verbose`
- [x] Verify `.claude/skills/` directory is created with 6 skill directories
- [x] Confirm rulesync output shows "Successfully loaded 6 rulesync skills"