### PR TITLE
Add /worktree-clean command and migrate rules to skills

### DIFF
--- a/.rulesync/commands/git-worktree-clean.md
+++ b/.rulesync/commands/git-worktree-clean.md
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/commands/git/worktree-clean.md

--- a/.rulesync/skills/dev-server
+++ b/.rulesync/skills/dev-server
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/skills/dev-server/

--- a/.rulesync/skills/releases/SKILL.md
+++ b/.rulesync/skills/releases/SKILL.md
@@ -1,8 +1,7 @@
 ---
-root: false
 targets: ['*']
-description: 'Release conventions and guidelines for AG Charts'
-globs: ['**/*']
+name: releases
+description: 'Release conventions and guidelines. Use when preparing releases, naming branches, or understanding release constraints.'
 ---
 
 # Releases Guide

--- a/.rulesync/skills/technology-stack/SKILL.md
+++ b/.rulesync/skills/technology-stack/SKILL.md
@@ -1,8 +1,7 @@
 ---
-root: false
 targets: ['*']
-description: 'Technology stack and architectural constraints for AG Charts'
-globs: ['**/*']
+name: technology-stack
+description: 'Technology stack and architectural constraints. Use when choosing technologies, adding dependencies, or understanding zero-dependency requirements.'
 ---
 
 # AG Charts Technology Stack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,13 @@ This file provides guidance to AI Agents when working with code in this reposito
 -   **Yarn and Nx based repo:** Use Yarn for package management and Nx for build and test orchestration.
 -   **Main constraint:** Community and enterprise runtime bundles stay dependency-free beyond AG Charts code.
 -   **Default branch:** Target `latest`; follow release/JIRA naming conventions below for topic branches.
--   **Build monitoring:** Check `node_modules/.cache/ag-watch-status.json` to monitor watch state (`yarn nx dev`) and build health (see [Development Server Guide](.rulesync/rules/dev-server.md)).
+-   **Build monitoring:** Check `node_modules/.cache/ag-watch-status.json` to monitor watch state (`yarn nx dev`) and build health (see [Development Server Skill](.rulesync/skills/dev-server/SKILL.md)).
 -   **Formatting:** Run `yarn nx format` from the repo root before proposing commits.
 -   **Typechecking:** Run `yarn nx build:types <package>` from the repo root before proposing commits.
 -   **Linting:** Run `yarn nx lint <package>` from the repo root before proposing commits.
 -   **Baseline verification:** Expect to run `yarn nx test ag-charts-community`, `yarn nx test ag-charts-enterprise`, and `yarn nx e2e ag-charts-website` after meaningful chart changes.
 -   **Test verification patterns:** When writing or modifying tests, review similar tests to ensure consistent verification patterns (see [Testing Guide](.rulesync/rules/testing.md)).
--   **Technology stack:** Review the [technology stack rules](.rulesync/rules/technology-stack.md) for architectural decisions before introducing new patterns.
+-   **Technology stack:** Review the [technology stack skill](.rulesync/skills/technology-stack/SKILL.md) for architectural decisions before introducing new patterns.
 
 ## Specialized Guides
 
@@ -43,9 +43,9 @@ For detailed information on specific topics, consult these guides:
 -   **[JIRA Guide](.rulesync/rules/jira.md)** - JIRA ticket search and creation guidelines
 -   **[Code Quality Guide](.rulesync/rules/code-quality.md)** - Code bloat avoidance, comments, and review practices
 -   **[Default Values Guide](.rulesync/rules/defaults.md)** - Understanding the three-tier default system and theme configuration
--   **[Development Server Guide](.rulesync/rules/dev-server.md)** - Dev server setup and build watch monitoring
+-   **[Development Server Skill](.rulesync/skills/dev-server/SKILL.md)** - Dev server setup and build watch monitoring
 -   **[Benchmarks Guide](.rulesync/rules/benchmarks.md)** - Running and creating performance benchmarks
--   **[Releases Guide](.rulesync/rules/releases.md)** - Release conventions and guidelines
+-   **[Releases Skill](.rulesync/skills/releases/SKILL.md)** - Release conventions and guidelines
 -   **[Series Guide](.rulesync/rules/series.md)** - Series development architecture and patterns
 -   **[Data Model Guide](.rulesync/rules/data-model.md)** - Data processing principles
 
@@ -57,12 +57,12 @@ AG Charts is a sophisticated TypeScript monorepo providing canvas-based JavaScri
 
 **Key Constraint:** The main AG Charts libraries must have ZERO third-party runtime dependencies.
 
-See the [Technology Stack](.rulesync/rules/technology-stack.md) for detailed information about preferred technologies and architectural constraints.
+See the [Technology Stack Skill](.rulesync/skills/technology-stack/SKILL.md) for detailed information about preferred technologies and architectural constraints.
 
 ## Repository Conventions
 
 -   The main branch of this repo is `latest`
--   Release branch names are of the form `b12.0.0` (see [Releases Guide](.rulesync/rules/releases.md))
+-   Release branch names are of the form `b12.0.0` (see [Releases Skill](.rulesync/skills/releases/SKILL.md))
 -   JIRA-related branch should be named of the form `ag-12345/${kebabCaseChangeSummary}`
 -   **Language conventions:** UK/British English for documentation text, comments, and JSDocs; US English for API option names (see [Documentation Pages Guide](.rulesync/rules/docs-pages.md#language-conventions))
 
@@ -101,6 +101,7 @@ NOTE: These are only intended for agentic tools that don't support custom slash 
 -   `/fixup` - execute `external/prompts/commands/fixup.md` for quick fixes to common issues.
 -   `/split` - execute `external/prompts/commands/split.md` to split large changes into smaller commits.
 -   `/previs` - execute `external/prompts/commands/previs.md` to run PREVis visual quality evaluation.
+-   `/worktree-clean` - execute `external/ag-shared/prompts/commands/git/worktree-clean.md` to clean worktree branch by resetting to origin/latest.
 
 ## Architecture
 

--- a/external/ag-shared/prompts/commands/git/worktree-clean.md
+++ b/external/ag-shared/prompts/commands/git/worktree-clean.md
@@ -1,0 +1,78 @@
+---
+targets: ['*']
+description: 'Clean worktree by fetching and hard-resetting to origin/latest (or specified branch)'
+---
+
+# Worktree Clean
+
+Clean up a worktree branch by fetching fresh state from origin and hard-resetting to a target branch.
+
+## Usage
+
+`/worktree-clean [branch]`
+
+**Arguments:**
+
+-   `branch` (optional): Target branch to reset to. Default: `origin/latest`
+
+## Help
+
+If the user provides `help` as an argument:
+
+-   Explain how to use this command
+-   Explain prerequisites
+-   DO NOT proceed, exit immediately
+
+## Prerequisites
+
+1. **Git CLI** must be available
+2. **Working directory** should be a git worktree (not the main repository)
+3. **No critical uncommitted changes** - warn user if dirty
+
+## Workflow
+
+### STEP 1: Verify Environment
+
+```bash
+# Check if we're in a git worktree
+git rev-parse --is-inside-work-tree || exit 1
+
+# Check for uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+    echo "WARNING: Uncommitted changes detected"
+    git status --short
+fi
+```
+
+If uncommitted changes exist, **STOP** and ask user for confirmation before proceeding.
+
+### STEP 2: Fetch Fresh State
+
+```bash
+# Fetch latest from origin
+git fetch origin
+```
+
+### STEP 3: Hard Reset to Target
+
+```bash
+# Default to origin/latest if no argument provided
+TARGET_BRANCH="${ARGUMENTS:-origin/latest}"
+
+# Hard reset to target
+git reset --hard "$TARGET_BRANCH"
+```
+
+### STEP 4: Verify Clean State
+
+```bash
+# Show current state
+git log --oneline -1
+git status
+```
+
+## Definition of Done
+
+-   [ ] Working tree is clean
+-   [ ] HEAD matches target branch
+-   [ ] User informed of reset result

--- a/external/ag-shared/prompts/skills/dev-server/SKILL.md
+++ b/external/ag-shared/prompts/skills/dev-server/SKILL.md
@@ -1,8 +1,7 @@
 ---
-root: false
 targets: ['*']
-description: 'Development server setup and build watch monitoring'
-globs: ['**/*']
+name: dev-server
+description: 'Development server setup and build watch monitoring. Use when starting dev work, checking build status, or troubleshooting the dev server.'
 ---
 
 # Development Server Guide

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -389,19 +389,41 @@ copy_extra_configs() {
     fi
 }
 
-# Reset AGENTS.md to remove any noise from rulesync
-# Most users don't need to see rulesync changes to AGENTS.md
+# Check if AGENTS.md had changes before rulesync ran
+# Call this BEFORE running rulesync to detect pre-existing user edits
+check_agents_md_before() {
+    AGENTS_MD_WAS_DIRTY="false"
+    local agents_file="$REPO_ROOT/AGENTS.md"
+
+    if [[ -f "$agents_file" ]] && git -C "$REPO_ROOT" ls-files --error-unmatch "AGENTS.md" &>/dev/null 2>&1; then
+        if ! git -C "$REPO_ROOT" diff --quiet "AGENTS.md" 2>/dev/null; then
+            AGENTS_MD_WAS_DIRTY="true"
+        fi
+    fi
+}
+
+# Reset AGENTS.md to remove rulesync noise, but only if it wasn't already dirty
+# This preserves intentional user edits while cleaning up rulesync-generated changes
 reset_agents_md() {
     local verbose="$1"
     local agents_file="$REPO_ROOT/AGENTS.md"
 
-    if [[ -f "$agents_file" ]] && git -C "$REPO_ROOT" ls-files --error-unmatch "AGENTS.md" &>/dev/null; then
-        # File is tracked by git - reset it
+    # If AGENTS.md was already dirty before rulesync, don't touch it
+    if [[ "$AGENTS_MD_WAS_DIRTY" == "true" ]]; then
+        if [[ "$verbose" == "true" ]]; then
+            echo -e "${YELLOW}!${NC} AGENTS.md had pre-existing changes, preserving them"
+        fi
+        return 0
+    fi
+
+    if [[ -f "$agents_file" ]] && git -C "$REPO_ROOT" ls-files --error-unmatch "AGENTS.md" &>/dev/null 2>&1; then
+        # File is tracked by git - check if rulesync modified it
         if git -C "$REPO_ROOT" diff --quiet "AGENTS.md" 2>/dev/null; then
             # No changes - nothing to reset
             return 0
         fi
 
+        # Changes are from rulesync only - safe to reset
         git -C "$REPO_ROOT" checkout -- "AGENTS.md" 2>/dev/null || true
         if [[ "$verbose" == "true" ]]; then
             echo -e "${GREEN}✓${NC} Reset AGENTS.md to clean state"
@@ -543,6 +565,11 @@ main() {
     # Setup prompts repository (graceful - doesn't fail on errors)
     setup_prompts_repo || true
 
+    # Check AGENTS.md state before rulesync (to preserve pre-existing user edits)
+    if [[ "$postinstall" == "true" ]]; then
+        check_agents_md_before
+    fi
+
     case $mode in
         list)
             print_detected_tools_verbose
@@ -552,14 +579,14 @@ main() {
                 echo -e "${BLUE}Generating for all supported tools...${NC}"
             fi
             generate_config "*" "$verbose"
-            # Reset AGENTS.md in postinstall mode to avoid noise
+            # Reset AGENTS.md in postinstall mode to avoid noise (only if it wasn't already dirty)
             if [[ "$postinstall" == "true" ]]; then
                 reset_agents_md "$verbose"
             fi
             ;;
         custom)
             generate_config "$custom_targets" "$verbose"
-            # Reset AGENTS.md in postinstall mode to avoid noise
+            # Reset AGENTS.md in postinstall mode (only if it wasn't already dirty)
             if [[ "$postinstall" == "true" ]]; then
                 reset_agents_md "$verbose"
             fi
@@ -580,7 +607,7 @@ main() {
             fi
 
             generate_config "$detected" "$verbose"
-            # Reset AGENTS.md in postinstall mode to avoid noise
+            # Reset AGENTS.md in postinstall mode (only if it wasn't already dirty)
             if [[ "$postinstall" == "true" ]]; then
                 reset_agents_md "$verbose"
             fi

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -389,46 +389,56 @@ copy_extra_configs() {
     fi
 }
 
-# Check if AGENTS.md had changes before rulesync ran
-# Call this BEFORE running rulesync to detect pre-existing user edits
-check_agents_md_before() {
-    AGENTS_MD_WAS_DIRTY="false"
+# Stash AGENTS.md changes before rulesync runs
+# This preserves user edits that would otherwise be overwritten
+stash_agents_md() {
+    AGENTS_MD_STASH_FILE=""
     local agents_file="$REPO_ROOT/AGENTS.md"
 
     if [[ -f "$agents_file" ]] && git -C "$REPO_ROOT" ls-files --error-unmatch "AGENTS.md" &>/dev/null 2>&1; then
         if ! git -C "$REPO_ROOT" diff --quiet "AGENTS.md" 2>/dev/null; then
-            AGENTS_MD_WAS_DIRTY="true"
+            # AGENTS.md has local changes - stash them
+            AGENTS_MD_STASH_FILE=$(mktemp)
+            git -C "$REPO_ROOT" diff "AGENTS.md" > "$AGENTS_MD_STASH_FILE"
         fi
     fi
 }
 
-# Reset AGENTS.md to remove rulesync noise, but only if it wasn't already dirty
-# This preserves intentional user edits while cleaning up rulesync-generated changes
-reset_agents_md() {
+# Reset AGENTS.md and restore any stashed user changes
+# This removes rulesync noise while preserving intentional user edits
+restore_agents_md() {
     local verbose="$1"
     local agents_file="$REPO_ROOT/AGENTS.md"
 
-    # If AGENTS.md was already dirty before rulesync, don't touch it
-    if [[ "$AGENTS_MD_WAS_DIRTY" == "true" ]]; then
-        if [[ "$verbose" == "true" ]]; then
-            echo -e "${YELLOW}!${NC} AGENTS.md had pre-existing changes, preserving them"
-        fi
-        return 0
-    fi
-
     if [[ -f "$agents_file" ]] && git -C "$REPO_ROOT" ls-files --error-unmatch "AGENTS.md" &>/dev/null 2>&1; then
-        # File is tracked by git - check if rulesync modified it
-        if git -C "$REPO_ROOT" diff --quiet "AGENTS.md" 2>/dev/null; then
-            # No changes - nothing to reset
-            return 0
+        # Reset to HEAD (removes all changes including rulesync noise)
+        if ! git -C "$REPO_ROOT" diff --quiet "AGENTS.md" 2>/dev/null; then
+            git -C "$REPO_ROOT" checkout -- "AGENTS.md" 2>/dev/null || true
         fi
 
-        # Changes are from rulesync only - safe to reset
-        git -C "$REPO_ROOT" checkout -- "AGENTS.md" 2>/dev/null || true
-        if [[ "$verbose" == "true" ]]; then
+        # Restore stashed user changes if any
+        if [[ -n "$AGENTS_MD_STASH_FILE" && -f "$AGENTS_MD_STASH_FILE" && -s "$AGENTS_MD_STASH_FILE" ]]; then
+            if git -C "$REPO_ROOT" apply --check "$AGENTS_MD_STASH_FILE" 2>/dev/null; then
+                git -C "$REPO_ROOT" apply "$AGENTS_MD_STASH_FILE" 2>/dev/null
+                if [[ "$verbose" == "true" ]]; then
+                    echo -e "${GREEN}✓${NC} Restored local AGENTS.md changes"
+                fi
+            else
+                # Patch doesn't apply cleanly - save for manual recovery
+                local backup_file="$REPO_ROOT/.agents-md-stash.patch"
+                cp "$AGENTS_MD_STASH_FILE" "$backup_file"
+                echo -e "${YELLOW}!${NC} Could not cleanly restore AGENTS.md changes"
+                echo -e "${YELLOW}!${NC} Your changes saved to: $backup_file"
+            fi
+            rm -f "$AGENTS_MD_STASH_FILE"
+            AGENTS_MD_STASH_FILE=""
+        elif [[ "$verbose" == "true" ]]; then
             echo -e "${GREEN}✓${NC} Reset AGENTS.md to clean state"
         fi
     fi
+
+    # Cleanup stash file if still exists
+    [[ -n "$AGENTS_MD_STASH_FILE" && -f "$AGENTS_MD_STASH_FILE" ]] && rm -f "$AGENTS_MD_STASH_FILE"
 }
 
 # Get rulesync command - prefer patched versions over npx (which downloads fresh unpatched)
@@ -565,9 +575,9 @@ main() {
     # Setup prompts repository (graceful - doesn't fail on errors)
     setup_prompts_repo || true
 
-    # Check AGENTS.md state before rulesync (to preserve pre-existing user edits)
+    # Stash AGENTS.md changes before rulesync (to preserve user edits)
     if [[ "$postinstall" == "true" ]]; then
-        check_agents_md_before
+        stash_agents_md
     fi
 
     case $mode in
@@ -581,14 +591,14 @@ main() {
             generate_config "*" "$verbose"
             # Reset AGENTS.md in postinstall mode to avoid noise (only if it wasn't already dirty)
             if [[ "$postinstall" == "true" ]]; then
-                reset_agents_md "$verbose"
+                restore_agents_md "$verbose"
             fi
             ;;
         custom)
             generate_config "$custom_targets" "$verbose"
             # Reset AGENTS.md in postinstall mode (only if it wasn't already dirty)
             if [[ "$postinstall" == "true" ]]; then
-                reset_agents_md "$verbose"
+                restore_agents_md "$verbose"
             fi
             ;;
         auto)
@@ -609,7 +619,7 @@ main() {
             generate_config "$detected" "$verbose"
             # Reset AGENTS.md in postinstall mode (only if it wasn't already dirty)
             if [[ "$postinstall" == "true" ]]; then
-                reset_agents_md "$verbose"
+                restore_agents_md "$verbose"
             fi
             ;;
     esac

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -389,6 +389,26 @@ copy_extra_configs() {
     fi
 }
 
+# Reset AGENTS.md to remove any noise from rulesync
+# Most users don't need to see rulesync changes to AGENTS.md
+reset_agents_md() {
+    local verbose="$1"
+    local agents_file="$REPO_ROOT/AGENTS.md"
+
+    if [[ -f "$agents_file" ]] && git -C "$REPO_ROOT" ls-files --error-unmatch "AGENTS.md" &>/dev/null; then
+        # File is tracked by git - reset it
+        if git -C "$REPO_ROOT" diff --quiet "AGENTS.md" 2>/dev/null; then
+            # No changes - nothing to reset
+            return 0
+        fi
+
+        git -C "$REPO_ROOT" checkout -- "AGENTS.md" 2>/dev/null || true
+        if [[ "$verbose" == "true" ]]; then
+            echo -e "${GREEN}✓${NC} Reset AGENTS.md to clean state"
+        fi
+    fi
+}
+
 # Get rulesync command - prefer patched versions over npx (which downloads fresh unpatched)
 # Priority: RULESYNC_BIN env var > local node_modules > npx fallback
 get_rulesync_cmd() {
@@ -480,6 +500,7 @@ main() {
     local mode="auto"
     local custom_targets=""
     local verbose="false"
+    local postinstall="false"
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -499,6 +520,12 @@ main() {
                 ;;
             --verbose|-v)
                 verbose="true"
+                shift
+                ;;
+            --postinstall)
+                # When run via postinstall, reset AGENTS.md after rulesync
+                # to avoid confusing noise for most users
+                postinstall="true"
                 shift
                 ;;
             --help|-h)
@@ -525,9 +552,17 @@ main() {
                 echo -e "${BLUE}Generating for all supported tools...${NC}"
             fi
             generate_config "*" "$verbose"
+            # Reset AGENTS.md in postinstall mode to avoid noise
+            if [[ "$postinstall" == "true" ]]; then
+                reset_agents_md "$verbose"
+            fi
             ;;
         custom)
             generate_config "$custom_targets" "$verbose"
+            # Reset AGENTS.md in postinstall mode to avoid noise
+            if [[ "$postinstall" == "true" ]]; then
+                reset_agents_md "$verbose"
+            fi
             ;;
         auto)
             local detected
@@ -545,6 +580,10 @@ main() {
             fi
 
             generate_config "$detected" "$verbose"
+            # Reset AGENTS.md in postinstall mode to avoid noise
+            if [[ "$postinstall" == "true" ]]; then
+                reset_agents_md "$verbose"
+            fi
             ;;
     esac
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall:nx-daemon-reset-metadata": "(test -e .nx/workspace-data/ && rm -rf .nx/workspace-data/) || echo \"Nx workspace not found\"",
     "postinstall:plugin-build": "nx run-many -p tag:plugin -t build",
     "postinstall:nx-daemon-restart": "(test -e .nx/workspace-data/d/server-process.json && nx daemon --stop) || echo \"Nx Daemon not running\"",
-    "postinstall:setup-prompts": "./external/ag-shared/scripts/setup-prompts/setup-prompts.sh"
+    "postinstall:setup-prompts": "./external/ag-shared/scripts/setup-prompts/setup-prompts.sh --postinstall"
   },
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary
- Add `/worktree-clean` command for resetting worktree branches to `origin/latest` (or specified branch)
- Migrate `dev-server`, `releases`, and `technology-stack` from rules to skills to reduce redundant context loading (they had `globs: ['**/*']` causing them to load for all files)
- Add `--postinstall` flag to `setup-prompts.sh` to reset `AGENTS.md` after rulesync runs during `yarn install`

## Test plan
- [ ] Verify `/worktree-clean` command works in a fresh worktree
- [ ] Verify skill symlinks resolve correctly: `ls -la .rulesync/skills/`
- [ ] Run `yarn install` and confirm AGENTS.md is not modified