### PR TITLE
Add branch context commands for session memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ vite.config.*.timestamp*
 vitest.config.*.timestamp*
 
 # Ignore local AI.
+/.context/
 /.claude/
 /.gemini/
 /.github/prompts/

--- a/.rulesync/commands/git-branch-load-context.md
+++ b/.rulesync/commands/git-branch-load-context.md
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/commands/git/branch-load-context.md

--- a/.rulesync/commands/git-branch-save-context.md
+++ b/.rulesync/commands/git-branch-save-context.md
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/commands/git/branch-save-context.md

--- a/external/ag-shared/prompts/commands/git/branch-load-context.md
+++ b/external/ag-shared/prompts/commands/git/branch-load-context.md
@@ -1,0 +1,87 @@
+---
+targets: ['*']
+description: 'Load branch-specific context from .context/ directory (branch memory)'
+---
+
+# Branch Load Context
+
+Load saved context for the current branch to resume work with full awareness of intent, patterns, and known gaps.
+
+## Usage
+
+`/branch-load-context`
+
+No arguments required - automatically detects current branch.
+
+## Workflow
+
+### STEP 1: Determine Context File Path
+
+```bash
+# Get current branch name
+BRANCH=$(git branch --show-current)
+
+# Get main repo root (works from worktrees)
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir | sed 's/\\.git$//')
+
+# Derive slug with hash suffix to avoid collisions (e.g. feature/foo vs feature-foo)
+SLUG_BASE=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
+HASH=$(echo -n "$BRANCH" | shasum | cut -c1-6)
+SLUG="${SLUG_BASE}-${HASH}"
+
+# Context file path
+CONTEXT_FILE="${MAIN_REPO}.context/${SLUG}.md"
+```
+
+### STEP 2: Load Context
+
+Check if the context file exists:
+
+```bash
+if [ -f "$CONTEXT_FILE" ]; then
+    echo "Found context file: $CONTEXT_FILE"
+else
+    echo "No context file found for branch: $BRANCH"
+fi
+```
+
+### STEP 3: Present Context
+
+If the context file exists, read and present its contents to provide awareness of:
+
+- **Intent**: What this branch is trying to accomplish
+- **Key Patterns**: Code snippets and approaches used in this branch
+- **Known Gaps**: Outstanding issues or areas needing attention
+- **References**: Relevant commands, docs, tickets, or websites
+
+If no context file exists, inform the user:
+
+> No saved context found for branch `{branch}`.
+>
+> Run `/branch-save-context` to create context for this branch.
+
+## Output Format
+
+When context is found, present a summary:
+
+```markdown
+## Branch Context Loaded: {branch}
+
+**Intent**: {summary of intent section}
+
+**Key Patterns**: {count} patterns documented
+
+**Known Gaps**: {count} gaps tracked
+
+**References**: {count} references available
+
+---
+
+{Full context file contents}
+```
+
+## Notes
+
+- Context files are stored in the main repo root, shared across all worktrees
+- Context persists even when worktrees are deleted
+- Files are gitignored - this is personal/local context, not shared

--- a/external/ag-shared/prompts/commands/git/branch-save-context.md
+++ b/external/ag-shared/prompts/commands/git/branch-save-context.md
@@ -1,0 +1,109 @@
+---
+targets: ['*']
+description: 'Save/update branch-specific context to .context/ directory (branch memory)'
+---
+
+# Branch Save Context
+
+Save or update context for the current branch. Keep it concise - only preserve information useful for future sessions.
+
+## Usage
+
+`/branch-save-context`
+
+No arguments required - automatically detects current branch.
+
+## Workflow
+
+### STEP 1: Determine Context File Path
+
+```bash
+# Get current branch name
+BRANCH=$(git branch --show-current)
+
+# Get main repo root (works from worktrees)
+MAIN_REPO=$(git rev-parse --path-format=absolute --git-common-dir | sed 's/\\.git$//')
+
+# Derive slug with hash suffix to avoid collisions (e.g. feature/foo vs feature-foo)
+SLUG_BASE=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
+HASH=$(echo -n "$BRANCH" | shasum | cut -c1-6)
+SLUG="${SLUG_BASE}-${HASH}"
+
+# Context file path
+CONTEXT_FILE="${MAIN_REPO}.context/${SLUG}.md"
+
+# Ensure directory exists
+mkdir -p "${MAIN_REPO}.context"
+```
+
+### STEP 2: Check for Existing Context
+
+If the context file already exists, read its current contents. When updating, **prune resolved items and transient issues**.
+
+### STEP 3: Gather Context Information
+
+Ask the user what to save. Keep responses brief.
+
+**For new context**: What's the branch intent? Any patterns worth remembering?
+
+**For updates**: What changed? Any gaps resolved? New patterns discovered?
+
+### STEP 4: Write Context File
+
+Use this minimal template:
+
+```markdown
+---
+branch: {branch-name}
+updated: {ISO-date}
+---
+
+# {branch-name}
+
+## Intent
+
+{1-2 sentences: what this branch accomplishes}
+
+## Patterns
+
+{Only include if there are reusable code patterns}
+
+## Gaps
+
+{Only persistent gaps - architectural decisions, known limitations}
+
+## References
+
+{Links to ticket, relevant docs}
+```
+
+### STEP 5: Confirm Save
+
+```
+Saved: {context-file-path}
+```
+
+## What to Keep vs Prune
+
+### KEEP (future-relevant)
+
+- High-level intent (stable goal of the branch)
+- Reusable patterns (code you'll copy again)
+- Persistent gaps (architectural decisions pending, known limitations)
+- Reference links (ticket, design docs)
+
+### PRUNE (transient)
+
+- Temporary test failures
+- Build/environment issues
+- Implementation gaps now resolved
+- Debugging notes and scratch work
+- Session-specific troubleshooting
+- Resolved gaps (remove the checkbox, just delete)
+
+## Principles
+
+- **Brevity over completeness** - if in doubt, leave it out
+- **Future self test** - will this help in a new session next week?
+- **No resolved items** - once fixed, remove it entirely
+- **Patterns must be reusable** - don't document one-off code


### PR DESCRIPTION
## Summary

- Add `/branch-load-context` command to load saved context when starting work on a branch
- Add `/branch-save-context` command to persist context between sessions

## Context File Structure

Context files stored at `${MAIN_REPO}/.context/${branch-slug}.md` include:
- **Intent**: what the branch is trying to accomplish
- **Key Patterns**: code snippets and patterns used repeatedly  
- **Known Gaps**: outstanding issues and TODOs
- **References**: links to tickets, commands, docs

## Design Decisions

- Files stored in main repo root (shared across all worktrees)
- Gitignored - personal/local context, not committed
- Branch slug derived from branch name (lowercase, non-alphanumeric → dashes)

## Test plan

- [ ] Run `/git-branch-load-context` on branch without context - should suggest creating
- [ ] Run `/git-branch-save-context` to create context file
- [ ] Run `/git-branch-load-context` again - should load saved context
- [ ] Verify context file at expected path in main repo