### PR TITLE
AG-16613 - Add formatting and tooltip support for null category keys

### DIFF
--- a/packages/ag-charts-community/src/chart/callbacks.test.ts
+++ b/packages/ag-charts-community/src/chart/callbacks.test.ts
@@ -467,6 +467,105 @@ describe('AG-15283 context precedence', () => {
     });
 });
 
+describe('AG-16613 null category callbacks', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let chart: Chart;
+
+    afterEach(() => {
+        if (chart) {
+            chart.destroy();
+            (chart as unknown) = undefined;
+        }
+    });
+
+    const nullCategoryData = [
+        { quarter: null, Toyota: 120000 },
+        { quarter: 'q2', Toyota: 150000 },
+        { quarter: 'q3', Toyota: 170000 },
+    ];
+
+    test('tooltipRenderer receives null xValue', async () => {
+        const tooltipRenderer = jest.fn(() => '');
+        chart = await createChart({
+            data: nullCategoryData,
+            series: [
+                {
+                    type: 'bar',
+                    xKey: 'quarter',
+                    yKey: 'Toyota',
+                    allowNullKeys: true,
+                    tooltip: { renderer: tooltipRenderer },
+                } as any,
+            ],
+            axes: {
+                x: { type: 'category', position: 'bottom' },
+                y: { type: 'number', position: 'left' },
+            },
+        });
+
+        // Hover over the first bar (null category)
+        await hoverAction(130, 300)(chart);
+        await waitForChartStability(chart);
+
+        expect(tooltipRenderer).toHaveBeenCalled();
+        const callWithNullDatum = tooltipRenderer.mock.calls.find((c: any[]) => c[0]?.datum?.quarter === null);
+        expect(callWithNullDatum).toBeDefined();
+    });
+
+    test('itemStyler receives null datum', async () => {
+        const itemStyler = jest.fn(() => undefined);
+        chart = await createChart({
+            data: nullCategoryData,
+            series: [
+                {
+                    type: 'bar',
+                    xKey: 'quarter',
+                    yKey: 'Toyota',
+                    allowNullKeys: true,
+                    itemStyler,
+                } as any,
+            ],
+            axes: {
+                x: { type: 'category', position: 'bottom' },
+                y: { type: 'number', position: 'left' },
+            },
+        });
+
+        expect(itemStyler).toHaveBeenCalled();
+        const callWithNullDatum = itemStyler.mock.calls.find((c: any[]) => c[0]?.datum?.quarter === null);
+        expect(callWithNullDatum).toBeDefined();
+    });
+
+    test('axisLabelFormatter called with value: null', async () => {
+        const axisLabelFormatter = jest.fn();
+        chart = await createChart({
+            data: nullCategoryData,
+            series: [
+                {
+                    type: 'bar',
+                    xKey: 'quarter',
+                    yKey: 'Toyota',
+                    allowNullKeys: true,
+                } as any,
+            ],
+            axes: {
+                x: {
+                    type: 'category',
+                    position: 'bottom',
+                    label: { formatter: axisLabelFormatter },
+                },
+                y: { type: 'number', position: 'left' },
+            },
+        });
+
+        expect(axisLabelFormatter).toHaveBeenCalled();
+        const callWithNull = axisLabelFormatter.mock.calls.find((c: any[]) => c[0]?.value === null);
+        expect(callWithNull).toBeDefined();
+    });
+});
+
 describe('callback cache', () => {
     let chart: AgChartInstance;
     setupMockConsole();

--- a/packages/ag-charts-community/src/chart/formatter/formatManager.test.ts
+++ b/packages/ag-charts-community/src/chart/formatter/formatManager.test.ts
@@ -6,6 +6,7 @@ import type { AgCartesianChartOptions, AgChartInstance, AgPolarChartOptions } fr
 import { AgCharts } from '../../api/agCharts';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
+    expectWarningsCalls,
     extractImageData,
     hoverAction,
     prepareTestOptions,
@@ -253,5 +254,390 @@ describe('Format Manager', () => {
 
         const element = getDocument('body').getElementsByClassName('ag-charts-tooltip')[0];
         expect(element.textContent).toMatchInlineSnapshot(`"product Apple iPhone iPhone 140.000 growth 5.000000"`);
+    });
+
+    describe('AG-16613 null/undefined category value formatting', () => {
+        // Cartesian series configurations with standard xKey/yKey pattern
+        const CARTESIAN_SERIES = [
+            { type: 'bar' as const, xKey: 'product', yKey: 'value' },
+            { type: 'line' as const, xKey: 'product', yKey: 'value' },
+            { type: 'area' as const, xKey: 'product', yKey: 'value' },
+            { type: 'scatter' as const, xKey: 'product', yKey: 'value' },
+        ];
+
+        // Bubble requires sizeKey
+        const BUBBLE_SERIES = { type: 'bubble' as const, xKey: 'product', yKey: 'value', sizeKey: 'size' };
+
+        // Test cases for null/undefined handling
+        const NULL_KEY_CASES: Array<{
+            name: string;
+            nullValue: null | undefined;
+            allowNullKeys: boolean;
+            expectWarning: boolean;
+        }> = [
+            { name: 'null allowed', nullValue: null, allowNullKeys: true, expectWarning: false },
+            { name: 'undefined allowed', nullValue: undefined, allowNullKeys: true, expectWarning: false },
+            { name: 'null rejected', nullValue: null, allowNullKeys: false, expectWarning: true },
+            { name: 'undefined rejected', nullValue: undefined, allowNullKeys: false, expectWarning: true },
+        ];
+
+        const SERIES_ID_MAP: Record<string, string> = {
+            bar: 'BarSeries',
+            line: 'LineSeries',
+            area: 'AreaSeries',
+            scatter: 'ScatterSeries',
+        };
+
+        function formatNullValue(value: unknown): string {
+            if (value === null) return 'NULL';
+            if (value === undefined) return 'UNDEF';
+            return String(value);
+        }
+
+        describe.each(CARTESIAN_SERIES)('$type series', ({ type, xKey, yKey }) => {
+            const seriesIdPrefix = SERIES_ID_MAP[type];
+
+            it.each(NULL_KEY_CASES)(
+                'chart-level formatter.x: $name',
+                async ({ nullValue, allowNullKeys, expectWarning }) => {
+                    const xFormatter = jest.fn((params: { value: unknown }) => formatNullValue(params.value));
+
+                    const options: AgCartesianChartOptions = {
+                        data: [
+                            { [xKey]: nullValue, [yKey]: 140 },
+                            { [xKey]: 'Mac', [yKey]: 20 },
+                        ],
+                        series: [{ type, xKey, yKey, allowNullKeys } as any],
+                        formatter: { x: xFormatter },
+                    };
+
+                    chart = AgCharts.create(prepareTestOptions(options));
+                    await waitForChartStability(chart);
+
+                    if (expectWarning) {
+                        const valueType = nullValue === null ? 'object' : 'undefined';
+                        // Different series types may emit different numbers of warnings (xKey, xValue, etc.)
+                        // Verify at least one warning contains the expected pattern
+                        expectWarningsCalls().toEqual(
+                            expect.arrayContaining([
+                                expect.arrayContaining([
+                                    expect.stringMatching(
+                                        new RegExp(
+                                            `invalid value of type \\[${valueType}\\] for \\[${seriesIdPrefix}-1 / xValue\\] ignored:`
+                                        )
+                                    ),
+                                ]),
+                            ])
+                        );
+                    }
+
+                    const calls = xFormatter.mock.calls.map((c: [{ value: unknown }]) => c[0].value);
+                    if (allowNullKeys) {
+                        expect(calls).toContain(nullValue);
+                    } else {
+                        expect(calls).not.toContain(nullValue);
+                    }
+                    expect(calls).toContain('Mac');
+                }
+            );
+
+            it('axis label formatter receives null value when allowNullKeys is true', async () => {
+                const axisFormatter = jest.fn((params: { value: unknown }) =>
+                    params.value === null ? 'NULL' : String(params.value)
+                );
+
+                const options: AgCartesianChartOptions = {
+                    data: [
+                        { [xKey]: null, [yKey]: 140 },
+                        { [xKey]: 'Mac', [yKey]: 20 },
+                    ],
+                    series: [{ type, xKey, yKey, allowNullKeys: true } as any],
+                    axes: {
+                        x: { type: 'category', position: 'bottom', label: { formatter: axisFormatter } },
+                        y: { type: 'number', position: 'left' },
+                    },
+                };
+
+                chart = AgCharts.create(prepareTestOptions(options));
+                await waitForChartStability(chart);
+
+                expect(axisFormatter).toHaveBeenCalledWith(expect.objectContaining({ value: null }));
+            });
+
+            it('domain includes null when allowNullKeys is true', async () => {
+                const xFormatter = jest.fn();
+
+                const options: AgCartesianChartOptions = {
+                    data: [
+                        { [xKey]: 'iPhone', [yKey]: 140 },
+                        { [xKey]: null, [yKey]: 100 },
+                        { [xKey]: 'Mac', [yKey]: 20 },
+                    ],
+                    series: [{ type, xKey, yKey, allowNullKeys: true } as any],
+                    formatter: { x: xFormatter },
+                };
+
+                chart = AgCharts.create(prepareTestOptions(options));
+                await waitForChartStability(chart);
+
+                const callWithDomain = xFormatter.mock.calls.find(
+                    (c: [{ domain: unknown[] }]) => Array.isArray(c[0].domain) && c[0].domain.length === 3
+                );
+                expect(callWithDomain).toBeDefined();
+                expect(callWithDomain[0].domain).toContain(null);
+                expect(callWithDomain[0].domain).toContain('iPhone');
+                expect(callWithDomain[0].domain).toContain('Mac');
+            });
+        });
+
+        describe('bubble series', () => {
+            const { type, xKey, yKey, sizeKey } = BUBBLE_SERIES;
+
+            it.each(NULL_KEY_CASES)(
+                'chart-level formatter.x: $name',
+                async ({ nullValue, allowNullKeys, expectWarning }) => {
+                    const xFormatter = jest.fn((params: { value: unknown }) => formatNullValue(params.value));
+
+                    const options: AgCartesianChartOptions = {
+                        data: [
+                            { [xKey]: nullValue, [yKey]: 140, [sizeKey]: 10 },
+                            { [xKey]: 'Mac', [yKey]: 20, [sizeKey]: 5 },
+                        ],
+                        series: [{ type, xKey, yKey, sizeKey, allowNullKeys } as any],
+                        formatter: { x: xFormatter },
+                    };
+
+                    chart = AgCharts.create(prepareTestOptions(options));
+                    await waitForChartStability(chart);
+
+                    if (expectWarning) {
+                        const valueType = nullValue === null ? 'object' : 'undefined';
+                        expectWarningsCalls().toEqual(
+                            expect.arrayContaining([
+                                expect.arrayContaining([
+                                    expect.stringMatching(
+                                        new RegExp(
+                                            `invalid value of type \\[${valueType}\\] for \\[BubbleSeries-1 / xValue\\] ignored:`
+                                        )
+                                    ),
+                                ]),
+                            ])
+                        );
+                    }
+
+                    const calls = xFormatter.mock.calls.map((c: [{ value: unknown }]) => c[0].value);
+                    if (allowNullKeys) {
+                        expect(calls).toContain(nullValue);
+                    } else {
+                        expect(calls).not.toContain(nullValue);
+                    }
+                    expect(calls).toContain('Mac');
+                }
+            );
+
+            it('domain includes null when allowNullKeys is true', async () => {
+                const xFormatter = jest.fn();
+
+                const options: AgCartesianChartOptions = {
+                    data: [
+                        { [xKey]: 'iPhone', [yKey]: 140, [sizeKey]: 10 },
+                        { [xKey]: null, [yKey]: 100, [sizeKey]: 8 },
+                        { [xKey]: 'Mac', [yKey]: 20, [sizeKey]: 5 },
+                    ],
+                    series: [{ type, xKey, yKey, sizeKey, allowNullKeys: true } as any],
+                    formatter: { x: xFormatter },
+                };
+
+                chart = AgCharts.create(prepareTestOptions(options));
+                await waitForChartStability(chart);
+
+                const callWithDomain = xFormatter.mock.calls.find(
+                    (c: [{ domain: unknown[] }]) => Array.isArray(c[0].domain) && c[0].domain.length === 3
+                );
+                expect(callWithDomain).toBeDefined();
+                expect(callWithDomain[0].domain).toContain(null);
+            });
+        });
+
+        // Bar-specific tests for tooltip and label formatting (these use specific hover positions)
+        describe('bar series tooltip and label formatting', () => {
+            it('formats tooltip heading for null category when allowNullKeys is true', async () => {
+                const xFormatter = jest.fn((params: { value: unknown }) =>
+                    params.value === null ? 'No Product' : String(params.value)
+                );
+
+                const options: AgCartesianChartOptions = {
+                    data: [
+                        { product: null, value: 140 },
+                        { product: 'Mac', value: 20 },
+                    ],
+                    series: [{ type: 'bar', xKey: 'product', yKey: 'value', allowNullKeys: true } as any],
+                    formatter: { x: xFormatter },
+                };
+
+                chart = AgCharts.create(prepareTestOptions(options));
+                await waitForChartStability(chart);
+
+                await hoverAction(200, 200)(chart);
+                await waitForChartStability(chart);
+
+                const element = getDocument('body').getElementsByClassName('ag-charts-tooltip')[0];
+                expect(element?.textContent).toContain('No Product');
+            });
+
+            it('calls formatter.x for tooltip with null category when allowNullKeys is true', async () => {
+                const xFormatter = jest.fn((params: { value: unknown; source: string }) => {
+                    if (params.source === 'tooltip' && params.value === null) {
+                        return 'Tooltip Null';
+                    }
+                    return params.value === null ? 'NULL' : String(params.value);
+                });
+
+                const options: AgCartesianChartOptions = {
+                    data: [
+                        { product: null, value: 140 },
+                        { product: 'Mac', value: 20 },
+                    ],
+                    series: [{ type: 'bar', xKey: 'product', yKey: 'value', allowNullKeys: true } as any],
+                    formatter: { x: xFormatter },
+                };
+
+                chart = AgCharts.create(prepareTestOptions(options));
+                await waitForChartStability(chart);
+
+                await hoverAction(200, 200)(chart);
+                await waitForChartStability(chart);
+
+                const tooltipCalls = xFormatter.mock.calls.filter(
+                    (c: [{ source: string; value: unknown }]) => c[0].source === 'tooltip' && c[0].value === null
+                );
+                expect(tooltipCalls.length).toBeGreaterThan(0);
+            });
+
+            it('calls series label formatter for data with null category when allowNullKeys is true', async () => {
+                const labelFormatter = jest.fn((params: { value: unknown }) =>
+                    params.value === null ? 'NULL' : String(params.value)
+                );
+
+                const options: AgCartesianChartOptions = {
+                    data: [
+                        { product: null, value: 140 },
+                        { product: 'Mac', value: 20 },
+                    ],
+                    series: [
+                        {
+                            type: 'bar',
+                            xKey: 'product',
+                            yKey: 'value',
+                            allowNullKeys: true,
+                            label: { enabled: true, formatter: labelFormatter },
+                        } as any,
+                    ],
+                };
+
+                chart = AgCharts.create(prepareTestOptions(options));
+                await waitForChartStability(chart);
+
+                expect(labelFormatter).toHaveBeenCalledTimes(2);
+                const formatterDatums = labelFormatter.mock.calls.map((c: any[]) => c[0].datum?.product);
+                expect(formatterDatums).toContain(null);
+                expect(formatterDatums).toContain('Mac');
+            });
+        });
+
+        // Polar series tests (pie, donut) using legendItemKey
+        // Note: Pie/donut series emit warnings for both legendItemKey and legendItemValue
+        const POLAR_SERIES = [
+            { type: 'pie' as const, legendItemKey: 'product', angleKey: 'value' },
+            { type: 'donut' as const, legendItemKey: 'product', angleKey: 'value' },
+        ];
+
+        describe.each(POLAR_SERIES)('$type series', ({ type, legendItemKey, angleKey }) => {
+            const seriesIdPrefix = type === 'pie' ? 'PieSeries' : 'DonutSeries';
+
+            describe('null category key', () => {
+                it('should reject null category key with warning', async () => {
+                    const options: AgPolarChartOptions = {
+                        data: [
+                            { [legendItemKey]: null, [angleKey]: 140 },
+                            { [legendItemKey]: 'Mac', [angleKey]: 20 },
+                        ],
+                        series: [{ type, legendItemKey, angleKey } as any],
+                    };
+
+                    chart = AgCharts.create(prepareTestOptions(options));
+                    await waitForChartStability(chart);
+
+                    // Pie/donut emit warnings for both legendItemKey and legendItemValue
+                    expectWarningsCalls().toEqual([
+                        [
+                            `AG Charts - invalid value of type [object] for [${seriesIdPrefix}-1 / legendItemKey] ignored:`,
+                            '[null]',
+                        ],
+                        [
+                            `AG Charts - invalid value of type [object] for [${seriesIdPrefix}-1 / legendItemValue] ignored:`,
+                            '[null]',
+                        ],
+                    ]);
+                });
+
+                it('should accept null category key when allowNullKeys is true', async () => {
+                    const options: AgPolarChartOptions = {
+                        data: [
+                            { [legendItemKey]: null, [angleKey]: 140 },
+                            { [legendItemKey]: 'Mac', [angleKey]: 20 },
+                        ],
+                        series: [{ type, legendItemKey, angleKey, allowNullKeys: true } as any],
+                    };
+
+                    chart = AgCharts.create(prepareTestOptions(options));
+                    await waitForChartStability(chart);
+
+                    expectWarningsCalls().toEqual([]);
+                });
+            });
+
+            describe('undefined category key', () => {
+                it('should reject undefined category key with warning', async () => {
+                    const options: AgPolarChartOptions = {
+                        data: [
+                            { [legendItemKey]: undefined, [angleKey]: 140 },
+                            { [legendItemKey]: 'Mac', [angleKey]: 20 },
+                        ],
+                        series: [{ type, legendItemKey, angleKey } as any],
+                    };
+
+                    chart = AgCharts.create(prepareTestOptions(options));
+                    await waitForChartStability(chart);
+
+                    // Pie/donut emit warnings for both legendItemKey and legendItemValue
+                    expectWarningsCalls().toEqual([
+                        [
+                            `AG Charts - invalid value of type [undefined] for [${seriesIdPrefix}-1 / legendItemKey] ignored:`,
+                            '[undefined]',
+                        ],
+                        [
+                            `AG Charts - invalid value of type [undefined] for [${seriesIdPrefix}-1 / legendItemValue] ignored:`,
+                            '[undefined]',
+                        ],
+                    ]);
+                });
+
+                it('should accept undefined category key when allowNullKeys is true', async () => {
+                    const options: AgPolarChartOptions = {
+                        data: [
+                            { [legendItemKey]: undefined, [angleKey]: 140 },
+                            { [legendItemKey]: 'Mac', [angleKey]: 20 },
+                        ],
+                        series: [{ type, legendItemKey, angleKey, allowNullKeys: true } as any],
+                    };
+
+                    chart = AgCharts.create(prepareTestOptions(options));
+                    await waitForChartStability(chart);
+
+                    expectWarningsCalls().toEqual([]);
+                });
+            });
+        });
     });
 });

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.test.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.test.ts
@@ -416,6 +416,72 @@ describe('Tooltip', () => {
         });
     });
 
+    describe('AG-16613 allowNullKeys', () => {
+        it('should show xValue row for null category key when allowNullKeys is true', async () => {
+            chart = await createChart({
+                data: [
+                    { x: 'A', y: 10 },
+                    { x: null, y: 20 },
+                    { x: 'B', y: 15 },
+                ],
+                axes: {
+                    x: { type: 'category', position: 'bottom' },
+                    y: { type: 'number', position: 'left' },
+                },
+                series: [
+                    {
+                        type: 'bubble',
+                        xKey: 'x',
+                        xName: 'Category',
+                        yKey: 'y',
+                        yName: 'Value',
+                        sizeKey: 'y',
+                        sizeName: 'Size',
+                        allowNullKeys: true,
+                    } as any,
+                ],
+            });
+            // Hover over the middle bubble (null category key)
+            await hoverAction(400, 200)(chart);
+            await waitForChartStability(chart);
+
+            const element = Array.from(getDocument('body').getElementsByClassName('ag-charts-tooltip')).at(0);
+            const content = element?.textContent ?? '';
+            // Should show Category row even though value is null
+            expect(content).toContain('Category');
+            expect(content).toContain('Value');
+        });
+
+        it('should call axis formatter with actual null value (not "null" string) when allowNullKeys is true', async () => {
+            const formatterMock = jest.fn((params: { value: unknown }) =>
+                params.value === null ? 'NULL' : String(params.value)
+            );
+            chart = await createChart({
+                data: [
+                    { x: 'A', y: 10 },
+                    { x: null, y: 20 },
+                    { x: 'B', y: 15 },
+                ],
+                axes: {
+                    x: {
+                        type: 'category',
+                        position: 'bottom',
+                        label: { formatter: formatterMock },
+                    },
+                    y: { type: 'number', position: 'left' },
+                },
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y', allowNullKeys: true } as any],
+            });
+            await waitForChartStability(chart);
+
+            // Verify formatter was called with actual null value (not string "null")
+            expect(formatterMock).toHaveBeenCalledWith(expect.objectContaining({ value: null }));
+            // Verify formatter was NOT called with string "null"
+            const calls = formatterMock.mock.calls.map((c: [{ value: unknown }]) => c[0].value);
+            expect(calls).not.toContain('null');
+        });
+    });
+
     describe('AG-16272 Missing Values', () => {
         it('should not show rows for series with missing data in shared tooltips', async () => {
             chart = await createChart({

--- a/packages/ag-charts-community/src/chart/tooltip/tooltipContent.test.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltipContent.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { isTooltipValueMissing } from './tooltipContent';
+
+describe('tooltipContent', () => {
+    describe('isTooltipValueMissing', () => {
+        it('should return true for null by default', () => {
+            expect(isTooltipValueMissing(null)).toBe(true);
+        });
+
+        it('should return true for undefined by default', () => {
+            expect(isTooltipValueMissing(undefined)).toBe(true);
+        });
+
+        it('should return false for null when allowNull is true', () => {
+            expect(isTooltipValueMissing(null, true)).toBe(false);
+        });
+
+        it('should return false for undefined when allowNull is true', () => {
+            expect(isTooltipValueMissing(undefined, true)).toBe(false);
+        });
+
+        it('should return true for null when allowNull is false', () => {
+            expect(isTooltipValueMissing(null, false)).toBe(true);
+        });
+
+        it('should return true for NaN regardless of allowNull', () => {
+            expect(isTooltipValueMissing(Number.NaN)).toBe(true);
+            expect(isTooltipValueMissing(Number.NaN, true)).toBe(true);
+            expect(isTooltipValueMissing(Number.NaN, false)).toBe(true);
+        });
+
+        it('should return true for Infinity regardless of allowNull', () => {
+            expect(isTooltipValueMissing(Infinity)).toBe(true);
+            expect(isTooltipValueMissing(Infinity, true)).toBe(true);
+            expect(isTooltipValueMissing(-Infinity, true)).toBe(true);
+        });
+
+        it('should return false for valid string values', () => {
+            expect(isTooltipValueMissing('test')).toBe(false);
+            expect(isTooltipValueMissing('')).toBe(false);
+        });
+
+        it('should return false for valid number values', () => {
+            expect(isTooltipValueMissing(0)).toBe(false);
+            expect(isTooltipValueMissing(42)).toBe(false);
+            expect(isTooltipValueMissing(-1)).toBe(false);
+        });
+
+        it('should return false for Date values', () => {
+            expect(isTooltipValueMissing(new Date())).toBe(false);
+        });
+
+        it('should return false for objects and arrays', () => {
+            expect(isTooltipValueMissing({})).toBe(false);
+            expect(isTooltipValueMissing([])).toBe(false);
+        });
+    });
+});

--- a/packages/ag-charts-community/src/chart/tooltip/tooltipContent.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltipContent.ts
@@ -55,10 +55,9 @@ function textOrSegmentsIsDefined(value: TextOrSegments | undefined): value is Te
  * Only null, undefined, NaN, and Infinity are considered missing.
  * Strings, Dates, and other non-numeric values are valid for category/time axes.
  */
-export function isTooltipValueMissing(value: any): boolean {
-    if (value == null) return true;
-    if (typeof value === 'number' && !Number.isFinite(value)) return true;
-    return false;
+export function isTooltipValueMissing(value: any, allowNull: boolean = false): boolean {
+    if (value == null) return !allowNull;
+    return typeof value === 'number' && !Number.isFinite(value);
 }
 
 /**

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -289,34 +289,41 @@ export abstract class Node<TDatum = unknown> {
 
     batchedUpdate(fn: () => void) {
         this.batchLevel++;
-        fn();
-        this.batchLevel--;
-        if (this.batchLevel === 0 && this.batchDirty) {
-            this.markDirty();
-            this.batchDirty = false;
+        try {
+            fn();
+        } finally {
+            this.batchLevel--;
+            if (this.batchLevel === 0 && this.batchDirty) {
+                this.markDirty();
+                this.batchDirty = false;
+            }
         }
     }
 
     setProperties<T extends Node>(this: T, styles: { [K in keyof T]?: T[K] }) {
         this.batchLevel++;
-        assignIfNotStrictlyEqual(this, styles);
-        this.batchLevel--;
-
-        if (this.batchLevel === 0 && this.batchDirty) {
-            this.markDirty();
-            this.batchDirty = false;
+        try {
+            assignIfNotStrictlyEqual(this, styles);
+        } finally {
+            this.batchLevel--;
+            if (this.batchLevel === 0 && this.batchDirty) {
+                this.markDirty();
+                this.batchDirty = false;
+            }
         }
         return this;
     }
 
     setPropertiesWithKeys<T extends Node>(this: T, styles: { [K in keyof T]?: T[K] }, keys: readonly string[]) {
         this.batchLevel++;
-        assignIfNotStrictlyEqual(this, styles, keys);
-        this.batchLevel--;
-
-        if (this.batchLevel === 0 && this.batchDirty) {
-            this.markDirty();
-            this.batchDirty = false;
+        try {
+            assignIfNotStrictlyEqual(this, styles, keys);
+        } finally {
+            this.batchLevel--;
+            if (this.batchLevel === 0 && this.batchDirty) {
+                this.markDirty();
+                this.batchDirty = false;
+            }
         }
         return this;
     }


### PR DESCRIPTION
## Summary
- Add formatManager tests for null category value formatting
- Add tooltipContent support and tests for null key display
- Fix Node batching to not break on exceptions during node processing
- Add callback tests for null key scenarios

## Stack
This is PR 3 of 4 in a stacked PR series:
1. Foundation (#6050) → `latest`
2. Community Series (#6051) → PR 1
3. **Formatting & UI** (this PR) → PR 2
4. Enterprise Series → this PR

## Test plan
- [x] `yarn nx build:types ag-charts-community` passes
- [x] `yarn nx lint ag-charts-community` passes
- [ ] `yarn nx test ag-charts-community` passes