### PR TITLE
AG-15850 Remove `itemId` from box-plot node datum

### DIFF
--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -276,7 +276,6 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
     ): BoxPlotNodeDatum {
         return {
             series: this,
-            itemId: ctx.xValues[params.datumIndex],
             datum: params.datum,
             datumIndex: params.datumIndex,
             xKey: ctx.xKey,
@@ -310,7 +309,6 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         // Update datum and index
         mutableNode.datum = params.datum;
         mutableNode.datumIndex = params.datumIndex;
-        mutableNode.itemId = ctx.xValues[params.datumIndex];
         mutableNode.bandwidth = barWidth;
 
         // Update scaledValues in place


### PR DESCRIPTION
We're now using numeric itemIds instead of xKey strings

The culprit is that `xValues[number]` is of type `any` (which annoyingly is assignable to type `never`).