### PR TITLE
Remove orphaned highlight style types from ag-charts-types

### DIFF
--- a/packages/ag-charts-types/src/series/seriesOptions.ts
+++ b/packages/ag-charts-types/src/series/seriesOptions.ts
@@ -1,23 +1,6 @@
 import type { AgSeriesListeners } from '../chart/eventOptions';
-import type { AxisValue, ContextDefault, DatumDefault, InteractionRange, Opacity, PixelSize } from '../chart/types';
+import type { AxisValue, ContextDefault, DatumDefault, InteractionRange, Opacity } from '../chart/types';
 import type { FillOptions, LineDashOptions, StrokeOptions } from './cartesian/commonOptions';
-
-export type AgSeriesHighlightMarkerStyle = FillOptions & StrokeOptions;
-
-export interface AgSeriesHighlightSeriesStyle {
-    enabled?: boolean;
-    /** The opacity of the whole series (area line, area fill, labels and markers, if any) when another chart series or another stack level in the same area series is highlighted by hovering a data point or a legend item. Use `undefined` or `1` for no dimming. */
-    dimOpacity?: Opacity;
-    /** The stroke width of the area line when one of the markers is tapped or hovered over, or when a tooltip is shown for a data point, even when series markers are disabled. Use `undefined` for no highlight. */
-    strokeWidth?: PixelSize;
-}
-
-export interface AgSeriesHighlightStyle {
-    /** Highlight style used for an individual item within a series. */
-    item?: AgSeriesHighlightMarkerStyle;
-    /** Highlight style used for whole series when a series or legend item is hovered. */
-    series?: AgSeriesHighlightSeriesStyle;
-}
 
 export interface AgMultiSeriesHighlightOptions<
     ItemHighlightStyleOptions,

--- a/packages/ag-charts-types/src/series/topology/mapLineOptions.ts
+++ b/packages/ag-charts-types/src/series/topology/mapLineOptions.ts
@@ -7,7 +7,6 @@ import type {
     AgBaseSeriesOptions,
     AgBaseSeriesThemeableOptions,
     AgMultiSeriesHighlightOptions,
-    AgSeriesHighlightStyle,
 } from '../seriesOptions';
 
 export type AgMapLineSeriesTooltipRendererParams<
@@ -17,8 +16,6 @@ export type AgMapLineSeriesTooltipRendererParams<
     AgMapLineSeriesOptionsKeys<TDatum> &
     AgMapLineSeriesOptionsNames &
     AgMapLineSeriesStyle;
-
-export type AgMapLineSeriesHighlightStyle<_TDatum> = AgSeriesHighlightStyle & StrokeOptions;
 
 export type AgMapLineSeriesStyle = StrokeOptions & LineDashOptions;
 

--- a/packages/ag-charts-types/src/series/topology/mapMarkerOptions.ts
+++ b/packages/ag-charts-types/src/series/topology/mapMarkerOptions.ts
@@ -17,7 +17,6 @@ import type {
     AgBaseSeriesThemeableOptions,
     AgHighlightStyleOptions,
     AgMultiSeriesHighlightOptions,
-    AgSeriesHighlightStyle,
 } from '../seriesOptions';
 
 export interface AgMapMarkerSeriesTooltipRendererParams<TDatum, TContext = ContextDefault>
@@ -25,8 +24,6 @@ export interface AgMapMarkerSeriesTooltipRendererParams<TDatum, TContext = Conte
         AgMapMarkerSeriesOptionsKeys<TDatum>,
         AgMapMarkerSeriesOptionsNames,
         AgMapMarkerSeriesStyle {}
-
-export type AgMapMarkerSeriesHighlightStyle<_TDatum> = AgSeriesHighlightStyle & FillOptions & StrokeOptions;
 
 export type AgMapMarkerSeriesLabelFormatterParams<TDatum = DatumDefault> = AgMapMarkerSeriesOptionsKeys<TDatum> &
     AgMapMarkerSeriesOptionsNames;

--- a/packages/ag-charts-types/src/series/topology/mapShapeOptions.ts
+++ b/packages/ag-charts-types/src/series/topology/mapShapeOptions.ts
@@ -8,7 +8,6 @@ import type {
     AgBaseSeriesThemeableOptions,
     AgHighlightStyleOptions,
     AgMultiSeriesHighlightOptions,
-    AgSeriesHighlightStyle,
 } from '../seriesOptions';
 
 export interface AgMapShapeSeriesTooltipRendererParams<TDatum, TContext = ContextDefault>
@@ -16,8 +15,6 @@ export interface AgMapShapeSeriesTooltipRendererParams<TDatum, TContext = Contex
         AgMapShapeSeriesOptionsKeys<TDatum>,
         AgMapShapeSeriesOptionsNames,
         AgMapShapeSeriesStyle {}
-
-export type AgMapShapeSeriesHighlightStyle<_TDatum> = AgSeriesHighlightStyle & FillOptions & StrokeOptions;
 
 export type AgMapShapeSeriesStyle = FillOptions & StrokeOptions & LineDashOptions;
 


### PR DESCRIPTION
## Summary

- Removes `AgSeriesHighlightStyle`, `AgSeriesHighlightSeriesStyle`, and `AgSeriesHighlightMarkerStyle` from `seriesOptions.ts`
- Removes `AgMapLineSeriesHighlightStyle`, `AgMapMarkerSeriesHighlightStyle`, and `AgMapShapeSeriesHighlightStyle` from the map series options files
- Cleans up the now-unused `AgSeriesHighlightStyle` import from the three map series files and the unused `PixelSize` import from `seriesOptions.ts`

These types were exported as public API but never actually referenced in the `AgChartOptions` type hierarchy. All series define their `highlight` property using `AgMultiSeriesHighlightOptions` with series-specific style types instead.

## Test plan

- [x] `yarn nx build:types ag-charts-types` passes