### PR TITLE
AG-16713 Listen for `active:update` events in SeriesAreaManager

### DIFF
--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -1243,7 +1243,6 @@ export class Legend extends BaseProperties {
         };
 
         const updateManagers = (opts: InternalUpdateOpts | undefined): void => {
-            this.ctx.highlightManager.updateHighlight(this.id, opts?.nodeDatum);
             if (opts === undefined) {
                 this.ctx.activeManager.clear();
             } else {
@@ -1251,6 +1250,7 @@ export class Legend extends BaseProperties {
                 const itemId = opts.itemId;
                 this.ctx.activeManager.update({ type: 'legend', seriesId, itemId }, undefined);
             }
+            this.ctx.highlightManager.updateHighlight(this.id, opts?.nodeDatum);
         };
 
         const highlightNodeDatum = (opts: InternalUpdateOpts | undefined): void => {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1116,7 +1116,7 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     private onActiveUpdate(activeItem: AgActiveItemState | undefined): void {
-        if (activeItem?.type === 'legend') {
+        if (this.hoverDevice === 'setState' && activeItem?.type === 'legend') {
             this.clearHighlight();
             this.clearTooltip();
         }

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -169,6 +169,7 @@ export class SeriesAreaManager extends BaseManager {
             containerWidget.addListener('dblclick', (event, current) => this.onClick(event, current)),
             chart.ctx.animationManager.addListener('animation-start', () => this.onAnimationStart()),
             chart.ctx.eventsHub.on('active:load-memento', (event) => this.onActiveLoadMemento(event)),
+            chart.ctx.eventsHub.on('active:update', (event) => this.onActiveUpdate(event)),
             chart.ctx.eventsHub.on('dom:resize', () => this.clearAll()),
             chart.ctx.eventsHub.on('highlight:change', (event) => this.changeHighlightDatum(event)),
             chart.ctx.eventsHub.on('layout:complete', (event) => this.layoutComplete(event)),
@@ -1111,6 +1112,13 @@ export class SeriesAreaManager extends BaseManager {
                 return this.onActiveDatum(event.activeItem, event);
             default:
                 return event.activeItem?.type satisfies undefined;
+        }
+    }
+
+    private onActiveUpdate(activeItem: AgActiveItemState | undefined): void {
+        if (activeItem?.type === 'legend') {
+            this.clearHighlight();
+            this.clearTooltip();
         }
     }
 

--- a/packages/ag-charts-website/e2e/state.spec.ts
+++ b/packages/ag-charts-website/e2e/state.spec.ts
@@ -569,6 +569,37 @@ test.describe('state', () => {
                 });
             });
 
+            test.describe('legend hover clears active active from setState-series-node', () => {
+                test('screenshots', async ({ page }) => {
+                    await pickDatum(page, { country: 'UK', year: '2023' });
+                    await expect(canvas).toHaveScreenshot('line-example-canvas-active-UK-2023.png');
+
+                    await hoverOnUKLegend(page);
+                    await expect(canvas).toHaveScreenshot('line-example-canvas-active-UK-Legend.png');
+                });
+
+                test('states', async ({ page }) => {
+                    let state: AgChartState;
+
+                    state = await getChartState(page);
+                    expect(state.active?.activeItem).toBeUndefined();
+
+                    await pickDatum(page, { country: 'UK', year: '2023' });
+                    state = await getChartState(page);
+                    expect(state.active).toEqual({
+                        // frozen: false, // undocumented
+                        activeItem: { type: 'series-node', itemId: 13, seriesId: 'LineSeries-2' },
+                    });
+
+                    await hoverOnUKLegend(page);
+                    state = await getChartState(page);
+                    expect(state.active).toEqual({
+                        // frozen: false, // undocumented
+                        activeItem: { type: 'legend', itemId: 'UK', seriesId: 'LineSeries-2' },
+                    });
+                });
+            });
+
             /* // undocumented: frozen
             test.describe('frozen chart ignores mouse events', () => {
                 test('screenshots', async ({ page }) => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16713

Bugfix: Clears series-area highlight state on legend highlight state change