### PR TITLE
AG-16615 Rollback tooltip intent filtering

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1005,7 +1005,6 @@ export class SeriesAreaManager extends BaseManager {
         // Iterate through series in reverse, as later declared series appears on top of earlier
         // declared series.
         const reverseSeries = [...this.series].reverse();
-        const isTooltipIntent = intent === 'tooltip';
 
         const clickIntent = intent === 'event' || intent === 'context-menu';
         const tooltipIntent = intent === 'tooltip' || intent === 'highlight-tooltip';
@@ -1019,7 +1018,6 @@ export class SeriesAreaManager extends BaseManager {
         const { x, y } = point;
         const seriesContainingPoint = new Set<UnknownSeries>();
         for (const series of reverseSeries) {
-            if (isTooltipIntent && !this.isTooltipEnabled(series)) continue;
             if (series.visible && series.contentGroup.visible && getIntentRange(series) === 'area') {
                 if (series.isPointInArea?.(x, y)) {
                     seriesContainingPoint.add(series);
@@ -1032,7 +1030,6 @@ export class SeriesAreaManager extends BaseManager {
         let result: PickedNodes | undefined;
         for (const series of reverseSeries) {
             if (!series.visible || !series.contentGroup.visible) continue;
-            if (isTooltipIntent && !this.isTooltipEnabled(series)) continue;
 
             // If we found series with 'area' range containing the point, prefer those series.
             if (hasSeriesContainingPoint) {

--- a/packages/ag-charts-website/e2e/tooltip.spec.ts
+++ b/packages/ag-charts-website/e2e/tooltip.spec.ts
@@ -56,7 +56,7 @@ test.describe('tooltip', () => {
         });
     });
 
-    test('nearest tooltip ignores disabled series', async ({ page }) => {
+    test.skip('nearest tooltip ignores disabled series', async ({ page }) => {
         await gotoExample(page, toExamplePageUrl('tooltips-test', 'e2e-tooltip-nearest', 'vanilla').url);
 
         const point = await getScatterCanvasPoint(page);


### PR DESCRIPTION
## Summary
- Rolls back the tooltip intent filtering introduced in AG-16615 in `seriesAreaManager.ts`

## Test plan
- [ ] Verify tooltip behaviour works correctly without the intent filtering
- [ ] Run `yarn nx test ag-charts-community`