### PR TITLE
CRT-1026 Fix area series warning on stackGroup option

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeriesProperties.ts
@@ -33,6 +33,9 @@ export class AreaSeriesProperties extends CartesianSeriesProperties<AgAreaSeries
     yFilterKey: string | undefined;
 
     @Property
+    stackGroup?: string;
+
+    @Property
     normalizedTo?: number;
 
     @Property


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1026