### PR TITLE
CRT-1040 Fix line series fade animation reading stale highlight opacity

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -224,7 +224,7 @@ export function prepareLinePathPropertyAnimation(
     if (visibleToggleMode === 'fade') {
         return {
             fromFn(path: Path, datum) {
-                const opacity = status === 'added' ? 0 : path.opacity;
+                const opacity = status === 'added' ? 0 : 1;
                 const segments = status === 'removed' ? path.previousDatum ?? datum : datum;
                 return { ...result.fromFn(path, datum), opacity, segments };
             },


### PR DESCRIPTION
## Summary
- Fix line series legend toggle causing other series to fade in from dimmed opacity
- The fade animation `fromFn` in `prepareLinePathPropertyAnimation()` was reading `path.opacity` from the DOM node, which contained a stale highlight-dimmed value (~0.2) set by `updatePathNodes()` during legend hover
- Changed to use a fixed starting opacity value (`0` for added, `1` otherwise) instead of reading from the DOM

## Test plan
- [x] `yarn nx test ag-charts-community --testPathPattern="lineSeries"` — 168 tests pass, 123 snapshots match
- [ ] Manual: open `line-with-time-axis` gallery example, toggle series off then on, confirm other series do not fade in