### PR TITLE
CRT-1049 Fix waterfall tooltip showing stale content on subtotal/total bars

### DIFF
--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -320,6 +320,7 @@ export class Tooltip extends BaseProperties {
         if (element != null && content != null && content.length !== 0) {
             const html = tooltipHtml(this.localeManager, content, this.mode, this.pagination ? pagination : undefined);
             if (html == null) {
+                element.innerHTML = '';
                 this.toggle(false);
                 return;
             }

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -10,6 +10,7 @@ import {
 } from 'ag-charts-community';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
+    deproxy,
     expectWarningsCalls,
     extractImageData,
     setupMockCanvas,
@@ -19,6 +20,7 @@ import {
 } from 'ag-charts-community-test';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
+import type { WaterfallSeries } from './waterfallSeries';
 
 describe('WaterfallSeries', () => {
     setupMockConsole();
@@ -766,6 +768,90 @@ describe('WaterfallSeries', () => {
 
             expectWarningsCalls().toMatchInlineSnapshot(`[]`);
             await compare();
+        });
+    });
+
+    describe('CRT-1049: tooltip content for subtotal and total nodes', () => {
+        const WATERFALL_TOTALS_OPTIONS: AgCartesianChartOptions = {
+            data: [
+                { year: '2020', spending: 10 },
+                { year: '2021', spending: 20 },
+                { year: '2022', spending: 30 },
+                { year: '2023', spending: -20 },
+                { year: '2024', spending: -30 },
+                { year: '2025', spending: 40 },
+                { year: '2026', spending: -30 },
+                { year: '2027', spending: 40 },
+                { year: '2028', spending: 50 },
+            ],
+            series: [
+                {
+                    type: 'waterfall',
+                    xKey: 'year',
+                    yKey: 'spending',
+                    totals: [
+                        { totalType: 'subtotal', index: 2, axisLabel: 'Subtotal 1' },
+                        { totalType: 'subtotal', index: 5, axisLabel: 'Subtotal 2' },
+                        { totalType: 'total', index: 8, axisLabel: 'Total' },
+                    ],
+                },
+            ],
+        };
+
+        it('should return valid tooltip content for subtotal nodes', async () => {
+            const options = { ...WATERFALL_TOTALS_OPTIONS };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const series = chart.series[0] as WaterfallSeries;
+
+            // Index 3 is the first subtotal (after data indices 0, 1, 2)
+            const subtotalContent = series.getTooltipContent(3);
+            expect(subtotalContent).toBeDefined();
+            expect(subtotalContent?.type).toBe('structured');
+            if (subtotalContent?.type === 'structured') {
+                expect(subtotalContent.data?.[0].missing).not.toBe(true);
+            }
+        });
+
+        it('should return valid tooltip content for total nodes', async () => {
+            const options = { ...WATERFALL_TOTALS_OPTIONS };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const series = chart.series[0] as WaterfallSeries;
+
+            // Last index is the total node
+            const nodeData = series['contextNodeData']?.nodeData;
+            const totalIndex = nodeData ? nodeData.length - 1 : -1;
+            const totalContent = series.getTooltipContent(totalIndex);
+            expect(totalContent).toBeDefined();
+            expect(totalContent?.type).toBe('structured');
+            if (totalContent?.type === 'structured') {
+                expect(totalContent.data?.[0].missing).not.toBe(true);
+            }
+        });
+
+        it('should return valid tooltip content for regular data nodes', async () => {
+            const options = { ...WATERFALL_TOTALS_OPTIONS };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const series = chart.series[0] as WaterfallSeries;
+
+            // Index 0 is the first regular data node
+            const regularContent = series.getTooltipContent(0);
+            expect(regularContent).toBeDefined();
+            expect(regularContent?.type).toBe('structured');
+            if (regularContent?.type === 'structured') {
+                expect(regularContent.data?.[0].missing).not.toBe(true);
+            }
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -972,7 +972,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
                         label: yName,
                         fallbackLabel: yKey,
                         value: this.getAxisValueText(yAxis, 'tooltip', total, datum, yKey, legendItemName),
-                        missing: _ModuleSupport.isTooltipValueMissing(yValue),
+                        missing: _ModuleSupport.isTooltipValueMissing(total),
                     },
                 ],
             },


### PR DESCRIPTION
## Summary
- Fix waterfall subtotal/total bars displaying stale tooltip content from the previously hovered bar
- The raw y-value (`yRaw`) is `undefined` for artificial subtotal/total nodes, causing the tooltip data to be marked as `missing: true` and `tooltipHtml` to return `undefined`
- Changed the missing flag to use the computed `total` value instead of `yRaw`
- Added defence-in-depth: clear tooltip `innerHTML` when `tooltipHtml` returns `undefined` to prevent stale content on reposition calls

## Test plan
- [x] Added 3 new tests verifying tooltip content for subtotal, total, and regular data nodes
- [x] All 42 waterfall tests pass (39 existing + 3 new)
- [x] All 2899 community tests pass
- [ ] Manual: hover bars then subtotal/total bars on the [waterfall total-subtotal-values example](https://ag-grid.com/charts/javascript/waterfall-series/#total--subtotal-values) to verify correct tooltip content