### PR TITLE
CRT-1029 Default wheel event listeners to passive

### DIFF
--- a/packages/ag-charts-community/src/widget/widgetListenerHTML.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerHTML.ts
@@ -29,7 +29,9 @@ export class WidgetListenerHTML {
                 this.dispatch(type, target, widgetEvent);
             };
             const opts: AddEventListenerOptions = {};
-            if (type.startsWith('touch')) opts.passive = false;
+            if (type.startsWith('touch') || type === 'wheel') {
+                opts.passive = false;
+            }
             this.initSourceHandler(type, sourceHandler);
             target.getElement().addEventListener(type, sourceHandler, opts);
         }


### PR DESCRIPTION
## Summary
- Default wheel event listeners to `{ passive: true }` in the widget listener infrastructure, eliminating the Chrome verbose-level violation warning for charts that don't need `preventDefault()` (funnel, pie, basic cartesian, etc.)
- Allow callers to opt into non-passive via `addListener(type, handler, { passive: false })`, which re-registers the native listener
- Zoom module explicitly requests non-passive since it needs `preventDefault()` for scroll/pan behaviour

## Test plan
- [x] `yarn nx build:types ag-charts-community` passes
- [x] `yarn nx lint ag-charts-community` passes
- [x] `yarn nx lint ag-charts-enterprise` passes
- [x] `yarn nx test ag-charts-community` passes (95 suites, 2899 tests)
- [x] `yarn nx test ag-charts-enterprise` passes (66 suites, 1568 tests)
- [ ] Manual: open funnel example in Chrome with verbose console — no wheel violation warning
- [ ] Manual: open a zoom-enabled chart — zoom scroll/pan still works