### PR TITLE
Remove ./test export from ag-charts-server-side

### DIFF
--- a/packages/ag-charts-server-side/package.json
+++ b/packages/ag-charts-server-side/package.json
@@ -10,11 +10,6 @@
       "import": "./dist/package/main.esm.mjs",
       "require": "./dist/package/main.cjs.js",
       "types": "./dist/types/src/main.d.ts"
-    },
-    "./test": {
-      "import": "./dist/package/test/index.esm.mjs",
-      "require": "./dist/package/test/index.cjs.js",
-      "types": "./dist/types/src/test/index.d.ts"
     }
   },
   "repository": {

--- a/packages/ag-charts-server-side/project.json
+++ b/packages/ag-charts-server-side/project.json
@@ -17,15 +17,13 @@
     },
     "build:types": {
       "options": {
-        "main": "{projectRoot}/src/main.ts",
-        "additionalEntryPoints": ["{projectRoot}/src/test/index.ts"]
+        "main": "{projectRoot}/src/main.ts"
       }
     },
     "build:package": {
       "dependsOn": ["^build:types", "^build:package"],
       "options": {
         "main": "{projectRoot}/src/main.ts",
-        "additionalEntryPoints": ["{projectRoot}/src/test/index.ts"],
         "external": ["ag-charts-community", "ag-charts-core", "jsdom", "skia-canvas"],
         "platform": "node"
       }


### PR DESCRIPTION
## Summary
- Remove the `./test` subpath export from `ag-charts-server-side` package.json
- Remove `additionalEntryPoints` for the test entry from both `build:types` and `build:package` targets in project.json
- Source files in `src/test/` are kept for internal use

## Test plan
- [ ] `yarn nx build:types ag-charts-server-side` succeeds
- [ ] `yarn nx build:package ag-charts-server-side` succeeds
- [ ] `dist/package/test/` is no longer generated