### PR TITLE
AG-16704 Cleanup unnecessary types in `pickManager.ts`

### DIFF
--- a/packages/ag-charts-community/src/chart/series/pickManager.ts
+++ b/packages/ag-charts-community/src/chart/series/pickManager.ts
@@ -40,7 +40,7 @@ function indexOf(candidates: PickedNode[], node: PickedNode | undefined): number
 type TooltipCandidate = { active?: PickedNode; paginationState?: { index: number; length: number } };
 
 /**
- * IPickManager mediates the `active` node state between SeriesAreaManager and ActiveManager.
+ * PickManager mediates the `active` node state between SeriesAreaManager and ActiveManager.
  *
  * It tracks the active node by:
  *
@@ -51,20 +51,7 @@ type TooltipCandidate = { active?: PickedNode; paginationState?: { index: number
  *
  *   3.  Track tooltip candidates (if pagination is enabled).
  */
-export interface IPickManager {
-    onPickedNodesHighlight(pickedNodes: PickedNodes | undefined): PickedNode | undefined;
-    onPickedNodesTooltip(pickedNodes: PickedNodes | undefined): TooltipCandidate;
-    onPickedNodesFocus(pickedFocus: PickFocusOutputs | undefined): void;
-    onPickedNodesAPI(pickedNodes: PickedNodes): PickedNode | undefined;
-    onPickedNodesAPIDebounced(): TooltipCandidate;
-
-    onClearUI(): void;
-    onClearAPI(): void;
-
-    nextCandidate(): TooltipCandidate;
-}
-
-export class PickManager implements IPickManager {
+export class PickManager {
     private candidates: PickedNode[] = [];
 
     private readonly activeState = new StateTracker<PickedNode, ActiveSource>();

--- a/packages/ag-charts-community/src/chart/series/pickManager.ts
+++ b/packages/ag-charts-community/src/chart/series/pickManager.ts
@@ -155,8 +155,7 @@ export class PickManager {
         const { series } = this.focusState;
         this.clear();
         if (series !== undefined && pickedFocus !== undefined) {
-            const { datum, datumIndex } = pickedFocus;
-            this.setSource('focus', { series, datum, datumIndex });
+            this.setSource('focus', pickedFocus.datum);
         }
     }
 

--- a/packages/ag-charts-community/src/chart/series/pickManager.ts
+++ b/packages/ag-charts-community/src/chart/series/pickManager.ts
@@ -8,11 +8,7 @@ import type { DatumIndexType, SeriesNodeDatum } from './seriesTypes';
 
 type ActiveSource = 'highlight' | 'tooltip' | 'focus';
 
-export interface PickedNode {
-    series: UnknownSeries;
-    datum: SeriesNodeDatum<DatumIndexType>;
-    datumIndex: unknown;
-}
+export type PickedNode = SeriesNodeDatum<DatumIndexType>;
 
 export type PickedNodes = {
     matches: PickedNode[];
@@ -20,12 +16,12 @@ export type PickedNodes = {
 };
 
 function getItemId(node: PickedNode): NonNullable<AgActiveItemState['itemId']> {
-    if (node.datum.itemId !== undefined) {
-        return node.datum.itemId;
-    } else if (typeof node.datum.datumIndex === 'number') {
-        return node.datum.datumIndex;
+    if (node.itemId !== undefined) {
+        return node.itemId;
+    } else if (typeof node.datumIndex === 'number') {
+        return node.datumIndex;
     } else {
-        return JSON.stringify(node.datum.datumIndex);
+        return JSON.stringify(node.datumIndex);
     }
 }
 
@@ -96,7 +92,7 @@ export class PickManager {
         } else {
             const seriesId: string = resolved.series.id;
             const itemId: string | number = getItemId(resolved);
-            this.activeManager.update({ type: 'series-node', seriesId, itemId }, resolved.datum);
+            this.activeManager.update({ type: 'series-node', seriesId, itemId }, resolved);
         }
     }
 

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -65,7 +65,7 @@ export interface SeriesAreaChartDependencies {
     fireEvent<TEvent extends TypedEvent>(event: TEvent): void;
     getUpdateType(): ChartUpdateType;
     getTooltipContent: <DatumIndex extends DatumIndexType>(
-        series: UnknownSeries,
+        series: PickedNode['series'],
         datumIndex: DatumIndex,
         removeThisDatum: unknown,
         purpose: 'aria-label' | 'tooltip'
@@ -138,7 +138,7 @@ export class SeriesAreaManager extends BaseManager {
     };
 
     private cachedTooltipContent:
-        | { series: UnknownSeries; datumIndex: unknown; content: TooltipContent[] }
+        | { series: PickedNode['series']; datumIndex: unknown; content: TooltipContent[] }
         | undefined = undefined;
 
     public constructor(private readonly chart: SeriesAreaChartDependencies) {
@@ -328,7 +328,7 @@ export class SeriesAreaManager extends BaseManager {
             const pick = this.pickNodes({ x: event.currentX, y: event.currentY }, 'context-menu');
             if (pick) {
                 this.chart.ctx.highlightManager.updateHighlight(this.id);
-                pickedNode = pick.matches[0].datum;
+                pickedNode = pick.matches[0];
             }
         }
 
@@ -585,11 +585,10 @@ export class SeriesAreaManager extends BaseManager {
         const updated = this.pickManager.onPickedNodesTooltip(pickedNodes);
         if (pickedNodes === undefined || updated.active === undefined) return false;
 
-        const { series, datum } = updated.active;
         const distance = updated.paginationState == null ? pickedNodes.distance : 0;
 
         if (event.type === 'click') {
-            const defaultBehavior = series.fireNodeClickEvent(event.sourceEvent, datum);
+            const defaultBehavior = updated.active.series.fireNodeClickEvent(event.sourceEvent, updated.active);
             if (defaultBehavior) {
                 const next = this.pickManager.nextCandidate();
                 if (next.active !== undefined) {
@@ -613,7 +612,7 @@ export class SeriesAreaManager extends BaseManager {
             // a node.
             event.preventZoomDblClick = distance === 0;
 
-            series.fireNodeDoubleClickEvent(event.sourceEvent, datum);
+            updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, updated.active);
             return true;
         }
 
@@ -760,7 +759,7 @@ export class SeriesAreaManager extends BaseManager {
         // Update the bounds of the focus indicator:
         this.focusIndicator?.update(pick.movedBounds ?? pick.bounds, this.seriesRect, pick.clipFocusBox);
 
-        const tooltipContent = this.getTooltipContent(focus.series, datum.datumIndex, datum, 'aria-label');
+        const tooltipContent = this.getTooltipContent(datum, 'aria-label');
         const keyboardEvent = makeKeyboardPointerEvent(focus.series, hoverRect, pick);
 
         // Update highlight/tooltip for keyboard users:
@@ -887,8 +886,8 @@ export class SeriesAreaManager extends BaseManager {
         const { active, paginationState } = this.pickManager.onPickedNodesAPIDebounced();
         if (active === undefined) return;
 
-        this.chart.ctx.highlightManager.updateHighlight(this.id, active.datum);
-        const refPoint = getDatumRefPoint(active.series, active.datum, undefined);
+        this.chart.ctx.highlightManager.updateHighlight(this.id, active);
+        const refPoint = getDatumRefPoint(active.series, active, undefined);
         if (this.chart.tooltip.enabled) {
             if (!active.series.visible) {
                 this.clearTooltip();
@@ -921,7 +920,7 @@ export class SeriesAreaManager extends BaseManager {
         if (active === undefined) {
             this.chart.ctx.highlightManager.updateHighlight(this.id, undefined, true); // true = delayed
         } else {
-            this.chart.ctx.highlightManager.updateHighlight(this.id, active.datum, false);
+            this.chart.ctx.highlightManager.updateHighlight(this.id, active, false);
         }
     }
 
@@ -956,15 +955,11 @@ export class SeriesAreaManager extends BaseManager {
         }
     }
 
-    private showTooltip(
-        { series, datum, datumIndex }: PickedNode,
-        canvasX: number,
-        canvasY: number,
-        pagination?: TooltipPaginationState
-    ) {
-        const tooltipContent = this.getTooltipContent(series, datumIndex, datum, 'tooltip');
+    private showTooltip(datum: PickedNode, canvasX: number, canvasY: number, pagination?: TooltipPaginationState) {
+        const tooltipContent = this.getTooltipContent(datum, 'tooltip');
         const shouldUpdateTooltip = tooltipContent != null;
         if (shouldUpdateTooltip) {
+            const { series } = datum;
             const meta = TooltipManager.makeTooltipMeta(
                 { type: 'pointermove', canvasX, canvasY },
                 series,
@@ -1078,32 +1073,19 @@ export class SeriesAreaManager extends BaseManager {
         return result;
     }
 
-    private isTooltipEnabled(series: UnknownSeries): boolean {
+    private isTooltipEnabled(series: PickedNode['series']): boolean {
         return series.tooltipEnabled ?? this.chart.tooltip.enabled;
     }
 
     // Do not return undefined tooltip content if we're obtaining it to update the series-area aria-label.
     // (CRT-869, CRT-901, CRT-871, CRT-909).
+    private getTooltipContent(datum: SeriesNodeDatum<DatumIndexType>, purpose: 'aria-label'): TooltipContent[];
+    private getTooltipContent(datum: SeriesNodeDatum<DatumIndexType>, purpose: 'tooltip'): TooltipContent[] | undefined;
     private getTooltipContent(
-        series: UnknownSeries,
-        datumIndex: unknown,
-        datum: SeriesNodeDatum<DatumIndexType>,
-        purpose: 'aria-label'
-    ): TooltipContent[];
-
-    private getTooltipContent(
-        series: UnknownSeries,
-        datumIndex: unknown,
-        datum: SeriesNodeDatum<DatumIndexType>,
-        purpose: 'tooltip'
-    ): TooltipContent[] | undefined;
-
-    private getTooltipContent(
-        series: UnknownSeries,
-        datumIndex: DatumIndexType,
         datum: SeriesNodeDatum<DatumIndexType>,
         purpose: 'aria-label' | 'tooltip'
     ): TooltipContent[] | undefined {
+        const { series, datumIndex } = datum;
         let result: TooltipContent[] | undefined;
 
         if (purpose === 'aria-label' || this.isTooltipEnabled(series)) {
@@ -1179,7 +1161,7 @@ export class SeriesAreaManager extends BaseManager {
             this.onActiveClear();
         } else {
             const picked = this.pickManager.onPickedNodesAPI(desiredPickedNodes);
-            event.setDatum(picked?.datum);
+            event.setDatum(picked);
             this.hoverDevice = 'setState';
             this.activeState.lastActive = { seriesId, itemId };
             if (event.initialState) {
@@ -1201,17 +1183,12 @@ export class SeriesAreaManager extends BaseManager {
             return undefined;
         }
 
-        const desiredDatum: PickedNode['datum'] | undefined = desiredSeries.findNodeDatum(desiredItemId);
+        const desiredDatum: PickedNode | undefined = desiredSeries.findNodeDatum(desiredItemId);
         if (desiredDatum == undefined) {
             Logger.warn(`Cannot find itemId: ${JSON.stringify(desiredItemId)}`);
             return undefined;
         }
 
-        const restoredPick: PickedNode = {
-            datum: desiredDatum,
-            datumIndex: desiredDatum.datumIndex,
-            series: desiredSeries,
-        };
-        return { matches: [restoredPick], distance: 0 };
+        return { matches: [desiredDatum], distance: 0 };
     }
 }

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -45,7 +45,7 @@ import {
     tooltipContentAriaLabel,
 } from '../tooltip/tooltip';
 import type { UpdateOpts } from '../updateService';
-import { type IPickManager, PickManager, type PickedNode, type PickedNodes } from './pickManager';
+import { PickManager, type PickedNode, type PickedNodes } from './pickManager';
 import { type PickFocusInputs, type PickFocusOutputs, type SeriesNodePickIntent, type UnknownSeries } from './series';
 import type { DatumIndexType, SeriesNodeDatum } from './seriesTypes';
 import { getDatumRefPoint } from './util';
@@ -127,7 +127,7 @@ export class SeriesAreaManager extends BaseManager {
      */
     private hoverDevice: HoverDevice = 'pointer';
 
-    private readonly pickManager: IPickManager;
+    private readonly pickManager: PickManager;
 
     private readonly focus = {
         sortedSeries: [] as UnknownSeries[],

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1059,14 +1059,11 @@ export class SeriesAreaManager extends BaseManager {
                 }
 
                 for (const datum of datums) {
-                    const { datumIndex } = datum;
-                    result.matches.push({ series, datum, datumIndex });
+                    result.matches.push(datum);
                 }
             } else if (result == null || result.distance > distance) {
                 // Don't accumulate multiple datums when matching by nearest distance
-                const [datum] = datums;
-                const { datumIndex } = datum;
-                result = { matches: [{ series, datum, datumIndex }], distance };
+                result = { matches: datums, distance };
             }
         }
 

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -7,6 +7,7 @@ import type {
     PointLabelDatum,
     SizedPoint,
 } from 'ag-charts-core';
+import type { AgActiveItemState } from 'ag-charts-types';
 
 import type { BBox } from '../../scene/bbox';
 import type { Group } from '../../scene/group';
@@ -96,6 +97,7 @@ export interface ISeries<TDatumIndex extends DatumIndexType, TDatum, TProps, TLa
     // @todo(AG-13777) - Remove this function (see CartesianSeries.ts)
     minTimeInterval(): number | undefined;
     isPointInArea?(x: number, y: number): boolean;
+    findNodeDatum(itemIdOrIndex: AgActiveItemState['itemId']): SeriesNodeDatum<DatumIndexType> | undefined;
 }
 
 /**

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -402,6 +402,9 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
             formatter = (params) => this.formatLabel(params.value),
         } = label;
         return {
+            series: this,
+            datum: undefined,
+            datumIndex: { type: NodeDataType.Node },
             placement,
             avoidCollisions,
             spacing,

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
@@ -74,7 +74,7 @@ export interface LinearGaugeTargetDatum extends _ModuleSupport.SeriesNodeDatum<L
     label: LinearGaugeTargetDatumLabel;
     style: AgLinearGaugeSeriesStyle;
 }
-export type LinearGaugeLabelDatum = {
+export interface LinearGaugeLabelDatum extends _ModuleSupport.SeriesNodeDatum<LinearGaugeNodeDatumIndex> {
     placement: AgLinearGaugeLabelPlacement;
     avoidCollisions: boolean;
     spacing: number;
@@ -90,7 +90,7 @@ export type LinearGaugeLabelDatum = {
     wrapping: TextWrap;
     overflowStrategy: OverflowStrategy;
     formatter: RichFormatter<AgChartLabelFormatterParams<any>> | undefined;
-};
+}
 
 class LinearGaugeDefaultTargetLabelProperties extends Label<never> {
     @Property


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16704

* Remove `IPickManager` interface (we can just use `PickManager` directly).
* Remove unhelpful `PickedNode` intermediate type