### PR TITLE
Genericise docs-review commands into shared core + thin wrappers

### DIFF
--- a/.rulesync/commands/docs-review.md
+++ b/.rulesync/commands/docs-review.md
@@ -1,1 +1,97 @@
-../../external/prompts/commands/docs-review.md
+---
+targets: ['*']
+description: 'Review documentation pages for technical accuracy and example consistency'
+---
+
+# Documentation Review - AG Charts
+
+You are a technical documentation reviewer for AG Charts. Review documentation pages for technical accuracy and example consistency using the shared three-phase approach.
+
+**Note**: This command validates existing documentation. For creating new documentation pages, use the `/docs-create` command and follow the [Documentation Pages Guide](../../.rulesync/rules/docs-pages.md).
+
+## Product Configuration
+
+### Input Requirements
+
+User provides:
+
+-   Documentation page path: `packages/ag-charts-website/src/content/docs/${pageName}/index.mdoc`
+-   Live dev URL: `https://localhost:4600/charts/javascript/${pageName}/`
+
+### Orchestration Indicator
+
+-   Orchestrator script: `external/prompts/run-docs-review.js`
+
+### File Resolution Rules
+
+For each API/interface mentioned in docs, resolve TypeScript definition files sequentially:
+
+| If docs mention                            | Then check file                                                     |
+| ------------------------------------------ | ------------------------------------------------------------------- |
+| Property path like `series[].type: 'bar'`  | `packages/ag-charts-types/src/series/cartesian/barSeriesOptions.ts` |
+| Property path like `axes[].type: 'number'` | `packages/ag-charts-types/src/axes/axis/axisOptions.ts`             |
+| Interface name like `AgPieSeriesOptions`   | Search `packages/ag-charts-types/src/**/*` for the interface        |
+| Generic config property                    | `packages/ag-charts-types/src/chart/agChartOptions.ts`              |
+| Theme property                             | `packages/ag-charts-types/src/chart/themes/chartTheme.ts`           |
+
+### Implementation Resolution Rules
+
+Map features to source implementation files:
+
+| Feature Category                             | Implementation Path Pattern                                                         |
+| -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Series type: `${type}` (e.g., "bar", "line") | `packages/ag-charts-{community,enterprise}/src/series/cartesian/${type}/*Series.ts` |
+| Series type: pie/donut                       | `packages/ag-charts-community/src/series/polar/pie/*Series.ts`                      |
+| Series/feature module with theme defaults    | `packages/ag-charts-{community,enterprise}/src/**/*Module.ts`                       |
+| Axis feature                                 | `packages/ag-charts-community/src/axes/**/*.ts`                                     |
+| Legend feature                               | `packages/ag-charts-community/src/chart/legend/*.ts`                                |
+| Annotation feature                           | `packages/ag-charts-enterprise/src/features/annotations/**/*.ts`                    |
+| General chart feature                        | Search `packages/ag-charts-{community,enterprise}/src/` using Grep                  |
+
+### Example Path Pattern
+
+`packages/ag-charts-website/src/content/docs/${pageName}/_examples/${exampleName}/`
+
+-   Required: `main.ts`
+-   Optional: `data.ts`, `styles.css`
+
+### Exceptions File Path
+
+`packages/ag-charts-website/src/content/docs/${pageName}/technical-review-exceptions.md`
+
+### Output Paths
+
+-   Review plans: `external/prompts/technical-review-plans/${pageName}.md`
+-   Reports: `packages/ag-charts-website/src/content/docs/${pageName}/reports/technical-review-report.md`
+-   Summary: `reports/docs-review/summary.md`
+
+### Default Value Verification Hierarchy
+
+When checking defaults, always verify against this three-tier hierarchy:
+
+1. **First**: Check `*Module.ts` theme template (actual runtime default)
+2. **Fallback**: Check `@Property` decorator (only if not in theme)
+3. **Verify**: TypeScript comments match the actual runtime default
+
+Theme templates in `*Module.ts` files override decorator defaults and represent actual runtime behaviour. See [Default Values Guide](../../.rulesync/rules/defaults.md) for complete details.
+
+### Product-Specific Conventions
+
+-   **Object Configuration Enablement**: `label: { fontWeight: 'bold' }` implies `enabled: true`
+    -   Applies to: label, marker, tooltip, legend, axes
+    -   Exception: theme.overrides requires explicit `enabled`
+-   **Common Pitfalls**:
+    -   Verify default values against theme templates first, not just `@Property` decorators
+    -   Don't assume similar chart types (pie/donut) behave identically
+    -   Check module files (`*Module.ts`) for actual runtime defaults before documenting
+-   **Known Accepted Patterns** (do NOT flag these as issues):
+    -   `document.getElementById('...').innerHTML = String(value)` for updating slider/control value displays in examples is an established codebase convention used across legend, bars, scatter, bubble, gauge, and scrollbar examples
+-   **Interface Naming Convention**: AG Charts interfaces follow the `Ag*` prefix pattern (e.g., `AgPieSeriesOptions`, `AgChartTheme`). When scanning docs for interface references, match `Ag*Options`, `Ag*Theme`, `Ag*Style`, and similar patterns.
+
+### Phase 3 Notes
+
+AG Charts has ~110 documentation pages. When executing Phase 3 batch processing, use batches of ~10 pages each.
+
+## Review Methodology
+
+**Read and follow all instructions in `external/ag-shared/prompts/commands/docs/_docs-review-core.md` for the review process, applying the product configuration above.**

--- a/.rulesync/commands/release-docs-review.md
+++ b/.rulesync/commands/release-docs-review.md
@@ -1,1 +1,54 @@
-../../external/prompts/commands/release-docs-review.md
+---
+targets: ['*']
+description: 'Review all documentation changes between releases for accuracy and completeness'
+---
+
+# Release Documentation Review - AG Charts
+
+You are an expert documentation reviewer for AG Charts, specialising in release documentation validation and change impact analysis.
+
+## Product Configuration
+
+### Product
+
+-   Name: AG Charts
+-   Docs review command: `/docs-review`
+
+### Paths
+
+-   Docs root: `packages/ag-charts-website/src/content/docs`
+-   Types root: `packages/ag-charts-types/src`
+-   Docs file pattern: `packages/ag-charts-website/src/content/docs/**/*.mdoc`
+-   Examples pattern: `packages/ag-charts-website/src/content/docs/**/_examples/`
+-   Types file pattern: `packages/ag-charts-types/src/**/*.ts`
+
+### Release Branch Pattern
+
+-   Format: `origin/bX.Y.Z`
+-   Discovery command: `git branch -r | grep 'origin/b[0-9]' | sort -V | tail -5`
+
+### Priority Pages
+
+**High priority** (getting started, key features, upgrade guides):
+`quick-start, create-a-basic-chart, installation, key-features, upgrade-to-ag-charts, migration, getting-started`
+
+**Medium priority** (core features):
+`legend, tooltips, themes, series, axes, financial-charts, maps, sparklines`
+
+### Output Paths
+
+-   Reports directory: `reports/`
+-   Filtered task list: `reports/release-docs-review-${PREVIOUS_BRANCH}-${CURRENT_BRANCH}-filtered.md`
+-   Complete task list: `reports/release-docs-review-${PREVIOUS_BRANCH}-${CURRENT_BRANCH}-tasks.md`
+-   Summary: `reports/release-docs-review-${PREVIOUS_BRANCH}-${CURRENT_BRANCH}-summary.md`
+
+### Verification Paths
+
+After each page review, confirm these files exist:
+
+-   `external/prompts/technical-review-plans/${pageName}.md`
+-   `packages/ag-charts-website/src/content/docs/${pageName}/reports/technical-review-report.md`
+
+## Review Methodology
+
+**Read and follow all instructions in `external/ag-shared/prompts/commands/docs/_release-docs-review-core.md` for the review process, applying the product configuration above.**

--- a/external/ag-shared/prompts/commands/docs/_docs-review-core.md
+++ b/external/ag-shared/prompts/commands/docs/_docs-review-core.md
@@ -1,0 +1,384 @@
+# Documentation Review Core Methodology
+
+This file contains the shared documentation review methodology. It is included by product-specific wrapper prompts that provide configuration (paths, conventions, resolution rules).
+
+## Required Product Configuration
+
+The product wrapper that references this file MUST define these sections (referenced by exact name below):
+
+-   **Input Requirements** — documentation page path pattern, dev URL
+-   **File Resolution Rules** — table mapping documentation references to TypeScript definition files
+-   **Implementation Resolution Rules** — table mapping features to source implementation files
+-   **Example Path Pattern** — directory layout for examples
+-   **Exceptions File Path** — location of the per-page exceptions file
+-   **Output Paths** — where review plans, reports, and summaries are written
+-   **Default Value Verification Hierarchy** — how runtime defaults are resolved in the product
+-   **Product-Specific Conventions** — accepted patterns, known pitfalls, enablement conventions
+
+Optional sections:
+
+-   **Orchestration Indicator** — if the product has a batch orchestration script, name it here so Strict Mode can be detected
+
+## Execution Mode Detection
+
+Check for any of these indicators:
+
+-   "EXECUTION CONTEXT: ORCHESTRATED" in the prompt
+-   Session ID provided
+-   Invoked via the orchestrator script named in **Orchestration Indicator** (if provided)
+
+**If found**: **STRICT MODE** - All MCP tools REQUIRED. If ANY tool is missing, STOP immediately with error message: `ERROR: Cannot proceed in orchestrated mode - missing required MCP tool [name]`. Do NOT attempt review or fallbacks.
+
+**If not found**: **ADAPTIVE MODE** - Check available tools. If claude-in-chrome or Task tool unavailable, display degraded mode warning and request explicit user confirmation before proceeding.
+
+### Degraded Mode Warning Template
+
+```
+[WARNING] DEGRADED MODE DETECTED
+
+Missing capabilities:
+- Browser automation (claude-in-chrome)
+- Example testing delegation (Task tool)
+
+Limitations:
+- Static code analysis only for examples
+- No automated screenshots
+- No runtime behavior validation
+- No interactive testing
+
+Still included:
+- Full API and TypeScript validation
+- Configuration consistency checking
+- Static example code analysis
+- Documentation accuracy assessment
+
+Continue in degraded mode? (Please confirm explicitly)
+```
+
+## Mode Adaptations Reference
+
+| Capability            | STRICT/Full Mode                                | ADAPTIVE/Degraded Mode                       |
+| --------------------- | ----------------------------------------------- | -------------------------------------------- |
+| **Tool Requirements** | claude-in-chrome + Task tool (REQUIRED)         | Read/Write only (optional tools unavailable) |
+| **Example Testing**   | Delegate to example-tester agent via Task tool  | Static code analysis of example files        |
+| **Visual Testing**    | Full screenshot capture + interaction testing   | Skip with warning marker                     |
+| **Report Markers**    | `[PASSED]`, `[WARNING]`, `[CRITICAL]`           | Prefix with "STATIC ANALYSIS ONLY"           |
+| **Visual Evidence**   | Reference screenshots by filename               | Note "[SKIPPED] VISUAL TESTING"              |
+| **Interaction Tests** | Test all interactive features described in docs | Mark "Unable to verify (requires browser)"   |
+
+Apply these adaptations throughout all phases based on detected mode.
+
+## Three-Phase Review Process
+
+### Phase 1: Create Review Plan
+
+**Goal**: Analyse documentation and create structured validation plan using mechanical file resolution.
+
+#### Step 1: Discover Files to Review
+
+**A. Read documentation page**: Use the path pattern from **Input Requirements** in the product configuration.
+
+**B. Extract API surface systematically**:
+
+1. **Scan for code blocks** containing configuration objects to extract property names
+2. **Extract interface references** from docs (look for product-specific interface naming patterns)
+3. **List all example references** (pattern: `<framework-example.*example='${exampleName}'`)
+4. **Note chart/component types mentioned** (e.g., "bar", "line", "pie", "scatter")
+
+**C. Resolve TypeScript definition files**: Apply the **File Resolution Rules** table in the product configuration sequentially for each API/interface mentioned in docs.
+
+**D. Resolve implementation files**: Apply the **Implementation Resolution Rules** table in the product configuration based on feature/type.
+
+**E. Resolve example files**: Use the **Example Path Pattern** in the product configuration. For each example name extracted:
+
+-   Check the required file (typically `main.ts`)
+-   Check optional files (`data.ts`, `styles.css`, etc.) if they exist
+
+**F. Check for exceptions file**: Look at the path specified in **Exceptions File Path** in the product configuration.
+
+#### Step 2: Create Structured Plan
+
+Document all discovered files and create validation tasks in the review plan output location (see **Output Paths** in product configuration):
+
+1. **List TypeScript definitions to verify** (with full paths from Step 1C)
+2. **List implementation files to cross-check** (with full paths from Step 1D)
+3. **List module files to check for theme template defaults** (with full paths from Step 1D)
+4. **List examples to test** with:
+    - Example name and path
+    - What the docs claim it demonstrates
+    - Key configurations mentioned in docs
+    - Expected behaviours described
+5. **List interactive features** to test (mode-dependent)
+6. **List visual states** to capture (full mode only)
+
+**Output**: Write to the review plans path specified in **Output Paths**.
+
+### Phase 2: Execute Review
+
+**Prerequisites**:
+
+-   The review plan output file must exist and have been updated with the review plan from Step 1.
+
+**Goal**: Validate technical accuracy, example consistency, and content quality.
+
+1. **Clean reports directory**: Delete existing files in the reports directory for this page (see **Output Paths** in product configuration).
+
+2. **Technical Accuracy Review** (always performed in all modes):
+
+    > **Default Value Verification**: When checking defaults, always verify against the hierarchy described in the **Default Value Verification Hierarchy** in the product configuration. Theme/module defaults override decorator defaults and represent actual runtime behaviour.
+
+    - Verify APIs against TypeScript definitions using paths from **File Resolution Rules**
+    - Check implementations using paths from **Implementation Resolution Rules**
+    - Validate default values using the hierarchy from product configuration
+    - Verify code snippets work correctly
+    - Document findings with:
+        - Status indicators: `[CRITICAL]`, `[WARNING]`, or `[PASSED]`
+        - Specific file:line locations
+        - Code examples showing incorrect vs correct
+        - For defaults: Show all layers of the verification hierarchy
+
+3. **Example Testing** (mode-dependent, see Mode Adaptations table):
+
+    **Full Mode**: Delegate to example-tester agent via Task tool with:
+
+    - Example path and expected behaviours from documentation
+    - Specific features that should be visible/testable
+    - Configuration patterns mentioned in docs
+    - Structure agent findings by example as returned
+
+    > **Note**: Full Mode example testing requires a product-specific `example-tester` sub-agent. If the product has not configured one, fall back to Degraded Mode for example testing.
+
+    **Degraded Mode**: For each example, perform static analysis:
+
+    - Read source files from the **Example Path Pattern**
+    - Extract documentation claims about the example
+    - Validate: configuration consistency, API usage, property validation, data compatibility, best practices
+    - Report format:
+
+    ```
+    #### [Example Name] - STATIC ANALYSIS ONLY
+    **Location**: `_examples/[example-name]/`
+
+    [PASSED] **Configuration Verified**: [list validated configurations]
+
+    [CRITICAL] **Configuration Issues**:
+    - **Issue**: [Specific mismatch]
+    - **Documentation claims**: [What docs say]
+    - **Actual code**: [What's in example]
+    - **Fix Required**: [Specific action]
+
+    [WARNING] **Unable to Verify (requires browser)**: Runtime behavior, Visual rendering, Interactive features, Tooltip content
+    ```
+
+4. **Visual & Interaction Testing** (mode-dependent, see Mode Adaptations table):
+
+    **Full Mode**: Perform screenshot capture and interaction testing. Navigate to dev URL (from **Input Requirements**), test interactive features, save screenshots to designated directories.
+
+    **Degraded Mode**: Add section noting:
+
+    ```
+    ### Visual & Interaction Testing
+    [SKIPPED] - claude-in-chrome unavailable
+
+    Could not verify: Screenshot capture, Runtime rendering, Interactive features, Tooltip behavior, Responsive layout
+
+    Manual verification recommended for critical visual features.
+    ```
+
+5. **Content Quality** (always performed):
+    - Completeness of feature coverage
+    - Accuracy against code analysis (static or runtime based on mode)
+    - Missing documentation for discovered features
+
+**Output**: Write to the reports path specified in **Output Paths** (see Report Structure below).
+
+### Phase 3: Generate Summary
+
+**Goal**: Aggregate findings from all reviewed pages.
+
+Process page reports in batches to avoid context limits:
+
+1. Process ~10 pages per batch → temporary `batch-summary-{n}.json`
+2. Aggregate batch summaries → final report
+3. Identify patterns and prioritise recommendations
+
+**Output**: Write to the summary path specified in **Output Paths**.
+
+## Report Structure Requirements (Phase 2)
+
+All reports must include these sections in order. Use the specified structure and include all required elements.
+
+### 1. Executive Summary
+
+Required elements:
+
+-   Brief assessment of page
+-   Review mode indicator (Full MCP / Degraded)
+-   Overall status: `[CRITICAL ISSUES]`, `[ISSUES FOUND]`, or `[ALL PASSED]`
+-   Issue counts by category: Technical Accuracy, Example Consistency (note if static only), Visual/Interaction (or SKIPPED), Content Quality
+
+### 2. Review Limitations (if in degraded mode)
+
+List what was skipped (browser testing, screenshots, interactions) and what was completed (static analysis, configuration verification, API validation).
+
+### 3. Known Exceptions
+
+List exceptions from the exceptions file (see **Exceptions File Path** in product configuration) if any exist, or note if no exceptions file found.
+
+### 4. Technical Accuracy Issues
+
+Structure each finding as:
+
+-   Status indicator: `[PASSED]`, `[WARNING]`, or `[CRITICAL]`
+-   Specific file:line reference
+-   Code comparison (incorrect → correct)
+-   Implementation file reference
+
+Example:
+
+```
+[CRITICAL] **Default Value Mismatch** at `index.mdoc:45`
+- Docs claim: `spacing: 10` (default)
+- Decorator default: `spacing: number = 1` (Properties.ts:95)
+- Theme/module default: `spacing: 20` (Module.ts:51) <-- Actual runtime default
+- TypeScript comment: `spacing: 10` (Options.ts:74) <-- Stale
+- Fix: Update documentation and TypeScript comment to reflect runtime default of 20
+```
+
+### 5. Example Consistency Issues
+
+Structure findings by example with clear headers. Include appropriate status labels (CRITICAL FAILURE, DOCUMENTATION MISMATCH, etc.). Provide specific fix instructions.
+
+-   **Full mode**: Include example-tester agent findings verbatim
+-   **Degraded mode**: Include static analysis findings with "STATIC ANALYSIS ONLY" labels
+
+### 6. Visual and Interaction Testing Results
+
+-   **Full mode**: Reference specific screenshots as evidence (e.g., "See `reports/screenshots/tooltip-hover.png`")
+-   **Degraded mode**: Note "[SKIPPED] VISUAL TESTING - claude-in-chrome unavailable"
+-   List any console errors found through static analysis
+
+### 7. Content Quality Issues
+
+Document:
+
+-   Missing property documentation
+-   Incomplete feature coverage
+-   Unclear explanations
+-   Gaps between implementation and documentation
+
+### 8. Recommendations
+
+Organise by priority with specific fix instructions:
+
+```
+### High Priority (Critical Fixes Required)
+1. **[Specific Issue]**:
+   - [Specific fix instruction]
+   - Update file: `[exact file path]` at line [X]
+
+### Medium Priority
+[List medium priority fixes]
+
+### Low Priority
+[List low priority improvements]
+```
+
+### 9. Summary
+
+Overall assessment including:
+
+-   Files requiring updates (with full paths)
+-   Evidence locations (screenshots, test results if available)
+-   Any limitations due to degraded mode
+-   Next steps
+
+## Documentation Style Principles
+
+When reviewing documentation, apply these principles to avoid over-documentation:
+
+### Do NOT Recommend Adding:
+
+1. **Default values in prose** - Don't add sentences like "The default value is X" unless the default is surprising or essential for understanding. Users can check the API Reference for defaults.
+
+2. **Redundant enablement explanations** - If something is enabled by default, don't explain how to enable it. Only document how to disable.
+
+    - Bad: "The toolbar can be enabled by setting `enabled: true`, or disabled by setting `enabled: false`"
+    - Good: "The toolbar is enabled by default. Use `enabled: false` to disable."
+
+3. **New sections for minor properties** - Not every property needs its own documentation section. Properties like `spacing`, `padding`, or simple numeric values are adequately covered in the API Reference.
+
+4. **Implementation details** - Don't document internal behaviour like callback return value handling, fallback mechanisms, or edge case handling unless it's essential for correct usage.
+
+5. **Verbose explanations** - Keep documentation concise. If something can be explained in one sentence, don't use three.
+
+### Example Titles
+
+Example titles should describe what the example demonstrates, not just the chart/component type:
+
+-   Bad: "Overlapping Series" (describes the data, not the feature)
+-   Good: "Simple Highlight" (describes what's being demonstrated)
+-   Bad: "Bar Chart with Tooltip" (generic)
+-   Good: "Custom Tooltip Content" (specific feature demonstrated)
+
+### When Flagging Issues
+
+Only flag documentation as incomplete if:
+
+-   A **primary feature** is undocumented (not minor styling properties)
+-   The documentation is **factually incorrect** (wrong API names, broken examples)
+-   An example **doesn't match** what the documentation claims it shows
+-   There's a **critical default** that affects common use cases
+
+Do NOT flag:
+
+-   Missing documentation for every property (that's what API Reference is for)
+-   Missing default value mentions
+-   Opportunities to add more detail to already-clear explanations
+
+## Language Conventions
+
+Documentation must follow these spelling and language conventions:
+
+| Content Type                  | Language                              | Examples                                                      |
+| ----------------------------- | ------------------------------------- | ------------------------------------------------------------- |
+| **Documentation text**        | UK/British English                    | colour, centre, behaviour, customisation, visualise, minimise |
+| **Code comments in examples** | UK/British English                    | `// Customise the colour`                                     |
+| **API option names**          | US English (as defined in TypeScript) | `color`, `center`, `behavior`                                 |
+| **JSDoc comments**            | UK/British English                    | `/** Customises the series colour. */`                        |
+
+**Key Spelling Differences to Check**:
+
+-   colour (UK) vs color (US) - use UK in prose, US in API names
+-   centre (UK) vs center (US) - use UK in prose, US in API names
+-   behaviour (UK) vs behavior (US) - use UK in prose
+-   customisation (UK) vs customization (US) - use UK
+-   visualise (UK) vs visualize (US) - use UK
+-   minimise (UK) vs minimize (US) - use UK
+-   licence (UK noun) vs license (US) - use UK in prose
+-   organisation (UK) vs organization (US) - use UK
+-   cancelled (UK) vs canceled (US) - use UK
+-   labelling (UK) vs labeling (US) - use UK
+
+**Grammar Checks**:
+
+-   Consistent tense usage (prefer present tense)
+-   Subject-verb agreement
+-   Proper punctuation (Oxford comma optional but be consistent)
+-   Correct use of articles (a/an/the)
+-   No sentence fragments in explanatory text
+
+## Tool Usage by Phase
+
+| Phase              | Required Tools | Mode-Dependent Tools                                        |
+| ------------------ | -------------- | ----------------------------------------------------------- |
+| Phase 1            | Read, Write    | -                                                           |
+| Phase 2 (Full)     | Read, Write    | Task, claude-in-chrome (navigate, screenshot, interactions) |
+| Phase 2 (Degraded) | Read, Write    | -                                                           |
+| Phase 3            | Read, Write    | -                                                           |
+
+## Usage
+
+1. **Phase 1**: Provide page path → receive review plan
+2. **Phase 2**: Provide page path → receive detailed report (with mode-appropriate validations)
+3. **Phase 3**: Run after all pages reviewed → receive summary report

--- a/external/ag-shared/prompts/commands/docs/_release-docs-review-core.md
+++ b/external/ag-shared/prompts/commands/docs/_release-docs-review-core.md
@@ -135,7 +135,7 @@ Find all modified examples and their associated documentation pages:
 
 ```bash
 # Get list of modified examples (substitute DOCS_PATH from product config)
-git diff --name-only $PREVIOUS_BRANCH $CURRENT_BRANCH -- '${DOCS_PATH}/**/_examples/' | \
+git diff --name-only $PREVIOUS_BRANCH $CURRENT_BRANCH -- '${DOCS_PATH}/**/_examples/**' | \
   grep -E '/_examples/' | \
   sed "s|${DOCS_PATH}/||" | \
   sed 's|/_examples/.*||' | \
@@ -514,7 +514,7 @@ Generate two task lists using the paths from **Output Paths** in the product con
 **Create the filtered list:**
 
 ```bash
-cat > ${FILTERED_LIST} << 'EOF'
+cat > ${FILTERED_LIST} << EOF
 # Release Documentation Review (Filtered)
 
 ## Summary
@@ -534,10 +534,10 @@ Pages are prioritised by risk score (0-100) based on:
 - Content type (new sections, warnings)
 - Page importance (from **Priority Pages** configuration)
 
-- **Critical (80-100)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 80' | wc -l) pages
-- **High (60-79)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 60 && $2 < 80' | wc -l) pages
-- **Medium (40-59)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 40 && $2 < 60' | wc -l) pages
-- **Low (0-39)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 < 40' | wc -l) pages
+- **Critical (80-100)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '\$2 >= 80' | wc -l) pages
+- **High (60-79)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '\$2 >= 60 && \$2 < 80' | wc -l) pages
+- **Medium (40-59)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '\$2 >= 40 && \$2 < 60' | wc -l) pages
+- **Low (0-39)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '\$2 < 40' | wc -l) pages
 
 ## Skipped Pages
 
@@ -890,7 +890,7 @@ Format:
 
 3. **Review Scope Management**:
 
-    - For large releases (>50 pages after filtering), consider batching reviews
+    - For large releases (>50 pages after filtering), use wave-based parallelism (launch multiple single-page sub-agents concurrently) rather than batching
     - Prioritise based on user-facing importance (getting started, key features, upgrade guides)
     - Start with largest changes first (they often reveal patterns)
     - Skip generated or auto-updated sections if identified

--- a/external/ag-shared/prompts/commands/docs/_release-docs-review-core.md
+++ b/external/ag-shared/prompts/commands/docs/_release-docs-review-core.md
@@ -1,0 +1,941 @@
+# Release Documentation Review Core Methodology
+
+This file contains the shared release documentation review methodology. It is included by product-specific wrapper prompts that provide configuration (paths, page lists, branch patterns).
+
+## Required Product Configuration
+
+The product wrapper that references this file MUST define these sections (referenced by exact name below):
+
+-   **Product** — product name, docs review command name
+-   **Paths** — docs root, types root, docs file pattern, examples pattern, types file pattern
+-   **Release Branch Pattern** — branch naming format, discovery command
+-   **Priority Pages** — high-priority and medium-priority page lists
+-   **Output Paths** — reports directory, filtered/complete task list paths, summary path
+-   **Verification Paths** — files to confirm exist after each page review
+
+## Help
+
+If the user provides a command option of `help`:
+
+-   Explain how to use this prompt.
+-   Explain if they are missing any prerequisites or tooling requirements.
+-   DO NOT proceed, exit the prompt immediately after these steps.
+
+## Prerequisite - Determine Branches to Compare
+
+**Checklist:**
+
+-   [ ] Are you given multiple branches as command options?
+        → Compare these two as previous and current releases respectively.
+-   [ ] Are you given a single branch as command option?
+        → Compare this branch against the highest-numbered release branch matching the **Release Branch Pattern**.
+-   [ ] Are you given no command options?
+        → Compare the current branch against the highest-numbered release branch, or the previous highest if already on a release branch.
+
+If you are uncertain about which branches to compare, **halt and ask the user to clarify before continuing.**
+
+## Task Overview
+
+Perform a comprehensive documentation review for all docs pages that have been modified or affected by API changes between release branches. This includes:
+
+1. Directly modified documentation pages
+2. Pages containing modified examples
+3. Pages referencing modified public APIs
+
+## Critical Requirements
+
+**READ THIS FIRST - MANDATORY EXECUTION RULES:**
+
+### Rule 1: Use SlashCommand Tool for ALL Reviews
+
+**MANDATORY:** When executing documentation reviews (Step 8), you MUST:
+
+-   Use: `SlashCommand` tool with the docs review command specified in **Product** configuration
+-   DO NOT: Create custom review prompts for sub-agents
+-   DO NOT: Perform reviews manually
+-   DO NOT: Implement alternative review methods
+
+**Why:** The docs review command follows a standardised three-phase process with specific output formats and quality checks. Custom implementations bypass this standard.
+
+**Verification:** After each review, confirm the files specified in **Verification Paths** exist.
+
+### Rule 2: One Page Per Sub-Agent - NO BATCHING
+
+**MANDATORY:** When spawning sub-agents (Step 8), you MUST:
+
+-   SPAWN: One sub-agent per documentation page
+-   DO NOT: Batch multiple pages into one sub-agent
+-   DO NOT: Ask one sub-agent to review 10, 20, or any N>1 pages
+-   DO NOT: Create "batches" for efficiency
+
+**Why:** Batching causes:
+
+1. Inconsistent review depth (later pages get less attention)
+2. Context overflow and token exhaustion
+3. Non-standard report locations and formats
+4. Inability to track per-page completion
+
+**Correct Pattern:**
+
+```
+Task 1: Review page-name-1 → /docs-review page-name-1
+Task 2: Review page-name-2 → /docs-review page-name-2
+Task 3: Review page-name-3 → /docs-review page-name-3
+```
+
+**Incorrect Pattern:**
+
+```
+Task 1: Review pages 1-20 → DO NOT DO THIS
+```
+
+### Rule 3: Parallel Execution for Efficiency
+
+**RECOMMENDED:** Launch sub-agents in parallel:
+
+-   USE: Single message with multiple Task tool calls
+-   LAUNCH: 10-20 agents concurrently (one per page)
+-   MONITOR: Wait for all agents to complete before aggregating
+
+**Example:** For 50 pages, launch in 3 waves of ~17 agents each.
+
+## Workflow
+
+### Step 1: Identify Previous Release Branch
+
+Determine the previous release branch to compare against using the checklist above.
+
+Execute the discovery command from the **Release Branch Pattern** in the product configuration to list recent release branches, then store the branches for comparison:
+
+```bash
+export PREVIOUS_BRANCH=<previous_branch>
+export CURRENT_BRANCH=<current_branch or HEAD>
+```
+
+### Step 2: Identify Modified Documentation Pages
+
+Find all directly modified documentation files using the **Paths** → Docs file pattern from the product configuration:
+
+```bash
+# Get list of modified docs files (substitute DOCS_PATH from product config Paths → Docs root)
+git diff --name-only $PREVIOUS_BRANCH $CURRENT_BRANCH -- '${DOCS_PATH}/**/*.mdoc' | \
+  grep -E '\.mdoc$' | \
+  sed "s|${DOCS_PATH}/||" | \
+  sed 's|/index\.mdoc$||' | \
+  sort -u > modified-docs.txt
+
+echo "Found $(wc -l < modified-docs.txt) directly modified documentation pages"
+```
+
+> **Note**: Replace `${DOCS_PATH}` with the actual docs root path from the product configuration **Paths** section (e.g., `packages/ag-charts-website/src/content/docs`).
+
+### Step 3: Identify Modified Examples
+
+Find all modified examples and their associated documentation pages:
+
+```bash
+# Get list of modified examples (substitute DOCS_PATH from product config)
+git diff --name-only $PREVIOUS_BRANCH $CURRENT_BRANCH -- '${DOCS_PATH}/**/_examples/' | \
+  grep -E '/_examples/' | \
+  sed "s|${DOCS_PATH}/||" | \
+  sed 's|/_examples/.*||' | \
+  sort -u > examples-docs.txt
+
+echo "Found $(wc -l < examples-docs.txt) docs pages with modified examples"
+```
+
+### Step 4: Identify Modified Public APIs
+
+Analyse changes to public APIs and find documentation pages that reference them:
+
+```bash
+# Get list of modified type files (substitute TYPES_PATH from product config Paths → Types root)
+git diff --name-only $PREVIOUS_BRANCH $CURRENT_BRANCH -- '${TYPES_PATH}/' | \
+  grep -E '\.(ts|d\.ts)$' > modified-types.txt
+
+# Extract modified interface/type names
+for file in $(cat modified-types.txt); do
+  git diff $PREVIOUS_BRANCH $CURRENT_BRANCH -- "$file" | \
+    grep -E '^[+-](export )?(interface|type|class|enum) ' | \
+    sed -E 's/^[+-](export )?(interface|type|class|enum) ([A-Za-z0-9]+).*/\3/' | \
+    sort -u
+done > modified-api-names.txt
+
+# For each modified API, find docs that reference it
+> api-affected-docs.txt
+for api_name in $(cat modified-api-names.txt); do
+  grep -r "$api_name" ${DOCS_PATH}/ --include="*.mdoc" | \
+    sed "s|${DOCS_PATH}/||" | \
+    sed 's|/index\.mdoc:.*||' | \
+    sort -u >> api-affected-docs.txt
+done
+
+sort -u api-affected-docs.txt -o api-affected-docs.txt
+echo "Found $(wc -l < api-affected-docs.txt) docs pages referencing modified APIs"
+```
+
+### Step 5: Consolidate Affected Documentation Pages
+
+Combine all identified pages into a single list:
+
+```bash
+cat modified-docs.txt examples-docs.txt api-affected-docs.txt | \
+  sort -u > all-affected-docs.txt
+
+TOTAL_PAGES=$(wc -l < all-affected-docs.txt)
+echo "Total documentation pages requiring review: $TOTAL_PAGES"
+
+# Keep examples-docs.txt and api-affected-docs.txt for filtering step
+rm modified-docs.txt modified-types.txt modified-api-names.txt
+```
+
+### Step 6: Filter Trivial Changes
+
+Many documentation changes are trivial formatting standardisation that don't require review. Filter these out to focus on substantive changes.
+
+First, get diff statistics for all pages:
+
+```bash
+# Get diff statistics for each page (substitute DOCS_PATH from product config)
+cat all-affected-docs.txt | while read page; do
+  file="${DOCS_PATH}/${page}/index.mdoc"
+  stats=$(git diff $PREVIOUS_BRANCH $CURRENT_BRANCH --shortstat -- "$file" 2>/dev/null)
+  if [ -n "$stats" ]; then
+    insertions=$(echo "$stats" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
+    deletions=$(echo "$stats" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
+    total=$((insertions + deletions))
+    echo "$total,$insertions,$deletions,$page"
+  fi
+done | sort -t',' -k1 -nr > /tmp/diff-stats.txt
+```
+
+Then, categorise changes using Python. The script uses these variables from the product configuration:
+
+| Script Variable        | Product Config Section                |
+| ---------------------- | ------------------------------------- |
+| `DOCS_PATH`            | **Paths** → Docs root                |
+| `high_priority_pages`  | **Priority Pages** → High priority   |
+| `medium_priority_pages`| **Priority Pages** → Medium priority |
+| `file_path` template   | **Paths** → Docs root + `/{page}/index.mdoc` |
+| Trivial-change patterns| Generic (no product substitution needed) |
+
+> **Substitute the values below** from the product configuration before executing.
+
+````python
+#!/usr/bin/env python3
+import subprocess
+import re
+
+categories = {
+    'SKIP_TRIVIAL': [],
+    'SKIP_TEST_NEW': [],
+    'REVIEW_NEEDED': []
+}
+
+# Load pages with example changes
+example_pages = set()
+try:
+    with open('examples-docs.txt', 'r') as f:
+        example_pages = set(line.strip() for line in f if line.strip())
+except FileNotFoundError:
+    pass
+
+# Load pages with API changes
+api_pages = set()
+try:
+    with open('api-affected-docs.txt', 'r') as f:
+        api_pages = set(line.strip() for line in f if line.strip())
+except FileNotFoundError:
+    pass
+
+def calculate_risk_score(page, total_lines, has_examples, has_api_changes, file_path, prev_branch, curr_branch):
+    '''
+    Calculate risk score (0-100) based on multiple factors.
+    Higher score = higher priority for review.
+    '''
+    score = 0
+
+    # Factor 1: Change source (0-40 points)
+    if has_api_changes:
+        score += 25  # API changes are high risk
+    if has_examples:
+        score += 25  # Example changes are high risk
+
+    # Factor 2: Change magnitude (0-25 points)
+    if total_lines > 200:
+        score += 25
+    elif total_lines > 100:
+        score += 20
+    elif total_lines > 50:
+        score += 15
+    elif total_lines > 20:
+        score += 10
+    elif total_lines > 0:
+        score += 5
+
+    # Factor 3: Content type analysis (0-20 points)
+    result = subprocess.run(
+        ['git', 'diff', prev_branch, curr_branch, '--', file_path],
+        capture_output=True, text=True
+    )
+    diff = result.stdout
+
+    # Check for high-risk content changes
+    if '{% warning %}' in diff or '{% note %}' in diff:
+        score += 8  # New warnings/notes are important
+    if re.search(r'\+##[^#]', diff):  # New sections (but not subsections)
+        score += 12  # New major sections are high priority
+
+    # Factor 4: Page importance (0-15 points)
+    # SUBSTITUTE these lists from the product configuration Priority Pages section
+    high_priority_pages = [
+        # *** REPLACE with values from product config Priority Pages → High priority ***
+    ]
+    medium_priority_pages = [
+        # *** REPLACE with values from product config Priority Pages → Medium priority ***
+    ]
+
+    if any(p in page for p in high_priority_pages):
+        score += 15
+    elif any(p in page for p in medium_priority_pages):
+        score += 10
+    elif page.endswith('-test'):
+        score -= 10  # Test pages are lower priority
+
+    return min(100, max(0, score))  # Clamp to 0-100
+
+def is_trivial_change(page, file_path, prev_branch, curr_branch):
+    '''
+    Determine if a change is trivial (formatting only).
+    Returns True only if ALL changes match known trivial patterns.
+    Errs on the side of reviewing when uncertain.
+    '''
+    # First check: ignore whitespace-only changes
+    result_ws = subprocess.run(
+        ['git', 'diff', '-w', '--ignore-blank-lines', prev_branch, curr_branch, '--', file_path],
+        capture_output=True, text=True
+    )
+
+    # If no diff after ignoring whitespace, it's purely whitespace changes
+    if not result_ws.stdout.strip():
+        return True
+
+    # Get full diff for detailed analysis
+    result = subprocess.run(
+        ['git', 'diff', prev_branch, curr_branch, '--', file_path],
+        capture_output=True, text=True
+    )
+    diff = result.stdout
+
+    # Extract all added lines (excluding diff metadata)
+    added_lines = []
+    for line in diff.split('\n'):
+        if line.startswith('+') and not line.startswith('+++'):
+            added_lines.append(line[1:])  # Remove the '+' prefix
+
+    # If no added lines, skip (only deletions)
+    if not added_lines:
+        return False
+
+    # Define trivial change patterns (whitelist approach)
+    trivial_patterns = [
+        # Code block metadata additions
+        r'^\s*```\w+\s+format="snippet"\s*$',
+        r'^\s*```\w+\s+format="generated"\s*$',
+        # Frontmatter changes (within --- blocks at file start)
+        r'^\s*enterprise:\s*(true|false)\s*$',
+        r'^\s*title:\s*[\'"].*[\'\"]\s*$',
+        # Empty lines or pure whitespace
+        r'^\s*$',
+        # Opening/closing braces for code wrapping (but be conservative)
+        r'^\s*\{\s*$',
+        r'^\s*\}\s*$',
+    ]
+
+    # Check if ALL added lines match trivial patterns
+    all_trivial = True
+    for added_line in added_lines:
+        line_is_trivial = False
+        for pattern in trivial_patterns:
+            if re.match(pattern, added_line):
+                line_is_trivial = True
+                break
+
+        if not line_is_trivial:
+            all_trivial = False
+            break
+
+    # Additional check: look for substantive content changes
+    has_substantive = (
+        '##' in '\n'.join(added_lines) or  # New sections
+        '{% warning %}' in diff or  # New warnings
+        '{% note %}' in diff or  # New notes
+        re.search(r'\+\s*[A-Z][a-z]+.*\w+', diff)  # New prose content
+    )
+
+    return all_trivial and not has_substantive
+
+# SUBSTITUTE DOCS_PATH from the product configuration Paths → Docs root
+DOCS_PATH = '*** REPLACE with Paths → Docs root from product config ***'
+
+with open('/tmp/diff-stats.txt', 'r') as f:
+    for line in f:
+        parts = line.strip().split(',')
+        total, insertions, deletions, page = int(parts[0]), int(parts[1]), int(parts[2]), parts[3]
+
+        file_path = f"{DOCS_PATH}/{page}/index.mdoc"
+
+        has_examples = page in example_pages
+        has_api = page in api_pages
+
+        # CRITICAL: Pages with example or API changes must ALWAYS be reviewed
+        # even if their .mdoc files have trivial or no changes
+        if has_examples or has_api:
+            risk_score = calculate_risk_score(page, total, has_examples, has_api, file_path, '$PREVIOUS_BRANCH', '$CURRENT_BRANCH')
+            categories['REVIEW_NEEDED'].append((risk_score, total, page))
+        # Categorize based on .mdoc file changes
+        elif page.endswith('-test') and deletions == 0:
+            # New test pages with no deletions
+            categories['SKIP_TEST_NEW'].append((0, total, page))
+        elif is_trivial_change(page, file_path, '$PREVIOUS_BRANCH', '$CURRENT_BRANCH'):
+            # Only trivial formatting changes
+            categories['SKIP_TRIVIAL'].append((0, total, page))
+        else:
+            # Everything else needs review (err on the side of reviewing)
+            risk_score = calculate_risk_score(page, total, has_examples, has_api, file_path, '$PREVIOUS_BRANCH', '$CURRENT_BRANCH')
+            categories['REVIEW_NEEDED'].append((risk_score, total, page))
+
+# Output results sorted by risk score (descending) for REVIEW_NEEDED
+for category, pages in categories.items():
+    if category == 'REVIEW_NEEDED':
+        for risk_score, total, page in sorted(pages, key=lambda x: (-x[0], -x[1])):
+            print(f"{category},{risk_score},{total},{page}")
+    else:
+        for risk_score, total, page in pages:
+            print(f"{category},{risk_score},{total},{page}")
+````
+
+Save this as `/tmp/categorize.py` and run:
+
+```bash
+python3 /tmp/categorize.py > /tmp/categorized-docs.txt
+
+# Generate summary with risk score statistics
+echo "=== Filtering Results ==="
+echo "SKIP_TRIVIAL: $(grep -c '^SKIP_TRIVIAL,' /tmp/categorized-docs.txt) pages"
+echo "SKIP_TEST_NEW: $(grep -c '^SKIP_TEST_NEW,' /tmp/categorized-docs.txt) pages"
+echo "REVIEW_NEEDED: $(grep -c '^REVIEW_NEEDED,' /tmp/categorized-docs.txt) pages"
+echo ""
+echo "=== Risk Score Distribution (REVIEW_NEEDED pages) ==="
+echo "Critical (80-100): $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 80' | wc -l) pages"
+echo "High (60-79): $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 60 && $2 < 80' | wc -l) pages"
+echo "Medium (40-59): $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 40 && $2 < 60' | wc -l) pages"
+echo "Low (0-39): $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 < 40' | wc -l) pages"
+
+# Clean up tracking files after categorisation
+rm examples-docs.txt api-affected-docs.txt
+```
+
+**Risk Scoring System (0-100):**
+
+Pages requiring review are prioritised by risk score based on multiple factors:
+
+1. **Change Source (0-40 points)**:
+
+    - API changes: +25 points (may require doc updates)
+    - Example changes: +25 points (code users copy must be correct)
+    - Both API and examples: +50 points (maximum source risk)
+
+2. **Change Magnitude (0-25 points)**:
+
+    - > 200 lines: +25 points
+    - 100-200 lines: +20 points
+    - 50-100 lines: +15 points
+    - 20-50 lines: +10 points
+    - <20 lines: +5 points
+
+3. **Content Type (0-20 points)**:
+
+    - New major sections (`## Heading`): +12 points
+    - New warnings/notes: +8 points
+
+4. **Page Importance (0-15 points)**:
+    - High priority (from **Priority Pages** → High priority): +15 points
+    - Medium priority (from **Priority Pages** → Medium priority): +10 points
+    - Test pages: -10 points (lower priority)
+
+**Risk Levels**:
+
+-   **Critical (80-100)**: Review first - high impact/high risk changes
+-   **High (60-79)**: Review early - significant changes or important pages
+-   **Medium (40-59)**: Standard review - moderate impact
+-   **Low (0-39)**: Review when time permits - minor changes or less critical pages
+
+**Trivial Change Detection Strategy:**
+
+The filtering uses a **whitelist approach** with the following criteria:
+
+1. **Example/API Change Override**: Pages with modified examples or API references are **ALWAYS** marked for review (with appropriate risk score), regardless of their docs file changes. This is critical because:
+
+    - Example changes may affect documentation accuracy even without docs file changes
+    - API changes may require documentation updates even if not yet applied
+    - These changes indicate functional updates that need validation
+
+2. **Whitespace-only changes**: For remaining pages, diff with `-w --ignore-blank-lines` to catch pure whitespace
+
+3. **Known trivial patterns**: ALL added lines must match one of:
+
+    - Code block metadata: `format="snippet"` or `format="generated"` attributes
+    - Frontmatter changes: `enterprise:`, `title:` fields
+    - Structural wrapping: `{` or `}` for code snippet wrapping
+    - Empty lines
+
+4. **No substantive content**: Must not contain:
+    - New sections (`##` headings)
+    - New warnings or notes (`{% warning %}`, `{% note %}`)
+    - New prose content (sentences starting with capital letters)
+
+**Conservative Approach**: If **any** line doesn't match a known trivial pattern, the page is marked for review. This errs on the side of over-reviewing rather than missing substantive changes.
+
+**Test Page Pattern:**
+
+-   Pages ending in `-test` with only additions (no deletions)
+-   These are new test documentation pages that don't affect main documentation
+
+### Step 7: Create Review Task Lists
+
+Generate two task lists using the paths from **Output Paths** in the product configuration:
+
+1. **Filtered list**: Only pages needing substantive review
+2. **Complete list**: All modified pages (for reference)
+
+> **Note**: In the bash below, substitute `${FILTERED_LIST}` and `${COMPLETE_LIST}` with the filtered and complete task list paths from **Output Paths**. Substitute `${DOCS_PATH}` with the docs root from **Paths**. Substitute the `/docs-review` command references with the docs review command from **Product** configuration.
+
+**Create the filtered list:**
+
+```bash
+cat > ${FILTERED_LIST} << 'EOF'
+# Release Documentation Review (Filtered)
+
+## Summary
+
+- Previous Release: ${PREVIOUS_BRANCH}
+- Current Release: ${CURRENT_BRANCH}
+- Total Pages Modified: $(wc -l < all-affected-docs.txt)
+- Pages Requiring Review: $(grep -c '^REVIEW_NEEDED,' /tmp/categorized-docs.txt)
+- Pages Skipped (Trivial): $(grep -c '^SKIP_TRIVIAL,' /tmp/categorized-docs.txt)
+- Pages Skipped (Test): $(grep -c '^SKIP_TEST_NEW,' /tmp/categorized-docs.txt)
+
+## Risk Score Distribution
+
+Pages are prioritised by risk score (0-100) based on:
+- Change source (examples/API changes)
+- Change magnitude (lines changed)
+- Content type (new sections, warnings)
+- Page importance (from **Priority Pages** configuration)
+
+- **Critical (80-100)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 80' | wc -l) pages
+- **High (60-79)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 60 && $2 < 80' | wc -l) pages
+- **Medium (40-59)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 40 && $2 < 60' | wc -l) pages
+- **Low (0-39)**: $(grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 < 40' | wc -l) pages
+
+## Skipped Pages
+
+### Trivial Formatting Changes
+EOF
+
+grep '^SKIP_TRIVIAL,' /tmp/categorized-docs.txt | cut -d',' -f4 | while read page; do
+  echo "- ${page}" >> ${FILTERED_LIST}
+done
+
+cat >> ${FILTERED_LIST} << 'EOF'
+
+### New Test Pages
+EOF
+
+grep '^SKIP_TEST_NEW,' /tmp/categorized-docs.txt | cut -d',' -f4 | while read page; do
+  echo "- ${page}" >> ${FILTERED_LIST}
+done
+
+cat >> ${FILTERED_LIST} << 'EOF'
+
+## Pages Requiring Review
+
+Review in order of risk score (highest priority first).
+
+### Critical Priority (Risk: 80-100)
+
+EOF
+
+# Add critical risk pages
+grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 80' | while IFS=',' read category risk_score total_lines page; do
+  cat >> ${FILTERED_LIST} << ENDTASK
+- [ ] **${page}** - Risk: ${risk_score} (${total_lines} lines)
+  - Command: \`/docs-review ${DOCS_PATH}/${page}/index.mdoc\`
+
+ENDTASK
+done
+
+cat >> ${FILTERED_LIST} << 'EOF'
+
+### High Priority (Risk: 60-79)
+
+EOF
+
+# Add high risk pages
+grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 60 && $2 < 80' | while IFS=',' read category risk_score total_lines page; do
+  cat >> ${FILTERED_LIST} << ENDTASK
+- [ ] **${page}** - Risk: ${risk_score} (${total_lines} lines)
+  - Command: \`/docs-review ${DOCS_PATH}/${page}/index.mdoc\`
+
+ENDTASK
+done
+
+cat >> ${FILTERED_LIST} << 'EOF'
+
+### Medium Priority (Risk: 40-59)
+
+EOF
+
+# Add medium risk pages
+grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 >= 40 && $2 < 60' | while IFS=',' read category risk_score total_lines page; do
+  cat >> ${FILTERED_LIST} << ENDTASK
+- [ ] **${page}** - Risk: ${risk_score} (${total_lines} lines)
+  - Command: \`/docs-review ${DOCS_PATH}/${page}/index.mdoc\`
+
+ENDTASK
+done
+
+cat >> ${FILTERED_LIST} << 'EOF'
+
+### Low Priority (Risk: 0-39)
+
+EOF
+
+# Add low risk pages
+grep '^REVIEW_NEEDED,' /tmp/categorized-docs.txt | awk -F',' '$2 < 40' | while IFS=',' read category risk_score total_lines page; do
+  cat >> ${FILTERED_LIST} << ENDTASK
+- [ ] **${page}** - Risk: ${risk_score} (${total_lines} lines)
+  - Command: \`/docs-review ${DOCS_PATH}/${page}/index.mdoc\`
+
+ENDTASK
+done
+```
+
+**Create the complete list** (for reference):
+
+```bash
+# Create complete unfiltered task list (substitute COMPLETE_LIST and DOCS_PATH from product config)
+cat all-affected-docs.txt | while read page; do
+  cat >> ${COMPLETE_LIST} << ENDTASK
+- [ ] **${page}**
+  - Command: \`/docs-review ${DOCS_PATH}/${page}/index.mdoc\`
+
+ENDTASK
+done
+```
+
+**Use the filtered list** for actual reviews unless there's reason to suspect the filtering missed something important.
+
+### Step 8: Execute Documentation Reviews
+
+**CRITICAL REQUIREMENTS:**
+
+1. **ONE PAGE PER SUB-AGENT - NO BATCHING**
+2. **MUST USE SlashCommand TOOL - NO CUSTOM IMPLEMENTATIONS**
+
+#### Execution Pattern
+
+For each documentation page in the **filtered task list**, spawn a dedicated sub-agent that:
+
+1. **Reviews exactly ONE page** (no batching allowed)
+2. **Uses the SlashCommand tool** to invoke the docs review command from **Product** configuration
+3. **Validates the review outputs** (files specified in **Verification Paths**)
+
+#### Sub-Agent Prompt Template
+
+Each sub-agent must receive this strict prompt (substitute product-specific values):
+
+```
+You are reviewing the [PAGE_NAME] documentation page for [PRODUCT_NAME] release from [PREVIOUS_BRANCH] to [CURRENT_BRANCH].
+
+STRICT REQUIREMENTS:
+
+1. MANDATORY: Use SlashCommand tool to invoke the docs review command
+   - Execute: SlashCommand with command "/docs-review [DOCS_PATH]/[PAGE_NAME]/index.mdoc"
+   - DO NOT create custom review implementations
+   - DO NOT perform manual reviews
+   - DO NOT skip the SlashCommand tool
+
+2. Single Page Only
+   - Review ONLY: [PAGE_NAME]
+   - DO NOT review multiple pages
+   - DO NOT batch reviews
+
+3. Verify Outputs
+   - After the review completes, confirm the verification files exist
+   - If files are missing, report failure
+
+4. Return Summary
+   - Report review status (PASSED / ISSUES FOUND / FAILED)
+   - List critical issues if any found
+   - Confirm SlashCommand was used
+
+Execute the review now.
+```
+
+#### Parallel Execution Strategy
+
+Launch all sub-agents in parallel for maximum efficiency:
+
+1. **Read the filtered task list** to get all pages requiring review
+2. **Create one Task per page** in a single message (multiple tool calls)
+3. **Monitor completion** of all agents
+4. **Validate outputs** from each agent
+
+#### Implementation Example
+
+```bash
+# Read filtered task list (substitute the filtered task list path from Output Paths)
+PAGES=$(grep "^- \[ \]" ${FILTERED_LIST} | \
+        grep -oP '\*\*\K[^*]+' | head -10)
+
+# For each page, spawn a dedicated agent
+# (In practice, you'll use multiple Task tool calls in one message)
+```
+
+#### Validation After Execution
+
+After all agents complete, verify:
+
+1. Each agent used SlashCommand tool (check agent outputs)
+2. Each page has the review files specified in **Verification Paths**
+3. No agent reviewed multiple pages (batching violation)
+
+**If validation fails:**
+
+-   Identify which pages were not properly reviewed
+-   Identify which agents didn't use SlashCommand
+-   Re-launch failed agents with corrected strict prompts
+
+#### Handling Large Page Counts
+
+For releases with many pages (e.g., 50+):
+
+1. **Launch in waves** if needed (e.g., 20 agents at a time)
+2. **Prioritise by risk score** (Critical → High → Medium → Low)
+3. **Monitor token usage** across agents
+4. **Wait for wave completion** before launching next wave
+
+**Note**: Use the filtered list by default. Only review skipped pages if:
+
+-   You find issues in related pages that suggest skipped pages may be affected
+-   The release is high-risk and requires maximum thoroughness
+-   Stakeholders specifically request full coverage
+
+### Step 9: Generate Summary Report
+
+After all individual page reviews are complete:
+
+1. **Aggregate findings** from all technical review reports
+2. **Identify patterns** across multiple pages
+3. **Prioritise issues** by severity and frequency
+4. **Generate release readiness assessment**
+
+Write the final summary to the summary path from **Output Paths** in the product configuration.
+
+## Output Format
+
+### Filtered Task List (Primary Output)
+
+Write to the filtered task list path from **Output Paths**.
+
+This is the **primary list to use for reviews**. It excludes trivial formatting changes and focuses on substantive updates.
+
+Format:
+
+```markdown
+# Release Documentation Review (Filtered)
+
+## Summary
+
+-   Previous Release: ${PREVIOUS_BRANCH}
+-   Current Release: ${CURRENT_BRANCH}
+-   Total Pages Modified: ${TOTAL_MODIFIED}
+-   Pages Requiring Review: ${REVIEW_NEEDED_COUNT}
+-   Pages Skipped (Trivial): ${SKIP_TRIVIAL_COUNT}
+-   Pages Skipped (Test): ${SKIP_TEST_COUNT}
+
+## Risk Score Distribution
+
+Pages are prioritised by risk score (0-100) based on:
+-   Change source (examples/API changes)
+-   Change magnitude (lines changed)
+-   Content type (new sections, warnings)
+-   Page importance (from **Priority Pages** configuration)
+
+-   **Critical (80-100)**: ${CRITICAL_COUNT} pages
+-   **High (60-79)**: ${HIGH_COUNT} pages
+-   **Medium (40-59)**: ${MEDIUM_COUNT} pages
+-   **Low (0-39)**: ${LOW_COUNT} pages
+
+## Analysis Summary
+
+After analysing all modified documentation pages, categorised by change type.
+
+### Skipped: Trivial Formatting Changes
+
+These pages only have code formatting standardisation:
+
+-   page-1
+-   page-2
+
+### Skipped: New Test Pages
+
+New test documentation pages (all additions):
+
+-   test-page-1
+-   test-page-2
+
+### Pages Requiring Review
+
+-   [ ] **page-name**: /docs-review command...
+```
+
+### Complete Task List (Reference)
+
+Write to the complete task list path from **Output Paths**.
+
+This list includes **all** modified pages without filtering. Use for reference or when maximum thoroughness is required.
+
+Format:
+
+```markdown
+# Release Documentation Review Tasks (Complete)
+
+## Summary
+
+-   Previous Release: ${PREVIOUS_BRANCH}
+-   Current Release: ${CURRENT_BRANCH}
+-   Total Pages Modified: ${TOTAL_PAGES}
+-   Direct Doc Changes: ${DIRECT_COUNT}
+-   Example Changes: ${EXAMPLE_COUNT}
+-   API Impact: ${API_COUNT}
+
+## All Modified Pages
+
+-   [ ] page-1: /docs-review command...
+-   [ ] page-2: /docs-review command...
+```
+
+### Final Summary Report
+
+Write to the summary path from **Output Paths**.
+
+Format:
+
+```markdown
+# Release Documentation Review Summary
+
+## Executive Summary
+
+[Brief overview of documentation status for release]
+
+## Review Statistics
+
+-   Total Pages Reviewed: X
+-   Pages with Issues: Y
+-   Critical Issues: Z
+-   Estimated Fix Time: N hours
+
+## Critical Issues Requiring Immediate Fix
+
+[List of blocking documentation issues]
+
+## Pattern Analysis
+
+[Common issues found across multiple pages]
+
+## Recommendations
+
+[Prioritised list of documentation updates needed]
+
+## Release Risk Assessment
+
+[Overall documentation readiness: Low/Medium/High]
+```
+
+## Important Considerations
+
+1. **Filtering and Triage**:
+
+    - **Use the filtered list by default** - it uses risk scoring + conservative whitelist approach
+    - **Risk scores (0-100) prioritise review order**: Critical (80-100) → High (60-79) → Medium (40-59) → Low (0-39)
+    - **Example/API changes override all filtering**: Pages with modified examples or API references are ALWAYS reviewed, even if docs file changes are trivial or absent
+    - **Whitespace-only changes** are automatically detected with `git diff -w`
+    - **Trivial patterns** are explicitly whitelisted (code block metadata, frontmatter, structural wrapping)
+    - **Conservative by design**: Any line that doesn't match a known trivial pattern → mark for review
+    - New test pages (ending in `-test` with only additions) are skipped by default
+    - If filtering reduces review load by >20%, mention this efficiency gain in reports
+    - Review skipped pages only if issues found in related pages suggest impact
+
+2. **Change Impact Analysis with Risk Scoring**:
+
+    - **Change source** (40 points max): Example/API changes score highest
+    - **Change magnitude** (25 points max): Larger changes = higher risk
+    - **Content type** (20 points max): New sections/warnings increase risk
+    - **Page importance** (15 points max): Pages listed in **Priority Pages** score highest
+    - **Combined scores** guide review order - tackle high-risk pages first
+    - Pages with >100 lines changed likely have major feature updates
+
+3. **Review Scope Management**:
+
+    - For large releases (>50 pages after filtering), consider batching reviews
+    - Prioritise based on user-facing importance (getting started, key features, upgrade guides)
+    - Start with largest changes first (they often reveal patterns)
+    - Skip generated or auto-updated sections if identified
+
+4. **Quality Gates**:
+    - All HIGH priority issues must be resolved before release
+    - MEDIUM priority issues should be documented in release notes
+    - LOW priority issues can be addressed post-release
+    - Formatting-only changes don't block releases
+
+## Execution Tips
+
+### Mandatory Practices
+
+-   **Always run the filtering step (Step 6)** before creating task lists - it typically saves 20-40% of review effort
+-   **ONE PAGE PER SUB-AGENT** - Never batch multiple pages into a single agent
+-   **USE SlashCommand TOOL** - Always invoke the docs review command via SlashCommand, never create custom review implementations
+-   **Validate outputs** - After reviews, confirm plan and report files exist at standard locations
+
+### Performance Optimisation
+
+-   **Launch agents in parallel** - Use single message with multiple Task tool calls for maximum efficiency
+-   **Batch API calls, not reviews** - Launch 10-20 agents concurrently, but each reviews only ONE page
+-   **Monitor completion** - Track which agents finish and which pages remain
+-   **Cache git operations** - Store diff results in `/tmp/diff-stats.txt` and `/tmp/categorized-docs.txt`
+
+### Quality Assurance
+
+-   **Verify SlashCommand usage** - Check agent outputs confirm they used SlashCommand tool
+-   **Validate standard outputs** - Ensure review plan and report files are in correct locations
+-   **Check for batching violations** - Confirm no agent reviewed multiple pages
+-   **Example validation** - If Step 3 found example changes, verify examples run correctly before reviewing docs
+
+### Progress Tracking
+
+-   **Provide status updates** - Report completion progress for long-running reviews (e.g., "35/77 pages reviewed")
+-   **Identify failures early** - If agents don't use SlashCommand or output goes to wrong location, stop and fix
+-   **Wave-based execution** - For 50+ pages, review in waves of 15-20 agents each
+
+## Benefits of Filtering
+
+Typical filtering results across releases:
+
+-   **Trivial formatting changes**: 5-10% of modified pages (pure formatting standardisation)
+-   **New test pages**: 10-15% of modified pages (test documentation that doesn't affect main docs)
+-   **Total efficiency gain**: 20-30% reduction in review workload while maintaining quality
+
+Remember: This comprehensive review with intelligent filtering ensures documentation quality matches code quality for the release while optimising reviewer time.

--- a/external/ag-shared/prompts/guides/docs-review-integration.md
+++ b/external/ag-shared/prompts/guides/docs-review-integration.md
@@ -1,0 +1,238 @@
+# Docs Review Integration Guide
+
+This guide covers how to integrate the shared docs review methodology into any AG product repo (ag-grid, ag-studio, etc.).
+
+## Architecture
+
+The shared docs review uses an **inverted reference pattern** (same as PR reviews):
+
+-   **Core files** (`external/ag-shared/prompts/commands/docs/_docs-review-core.md` and `_release-docs-review-core.md`): Generic workflow methodology, report structure, quality standards
+-   **Thin wrappers** (plain files in each repo's `.rulesync/commands/`): Product configuration block + single reference line to the core
+
+The LLM reads the product configuration first, then follows the core methodology, substituting product values at runtime. No build-time templating required.
+
+## Prerequisites
+
+-   The repo already uses `external/ag-shared/` as a git subrepo
+-   The repo already uses rulesync and the `setup-prompts.sh` pipeline
+-   No private prompts repo is required — all product-specific files are plain files in `.rulesync/`
+
+## Step 1: Pull the Latest ag-shared
+
+```bash
+git subrepo pull external/ag-shared
+```
+
+This brings in the core files:
+
+-   `external/ag-shared/prompts/commands/docs/_docs-review-core.md`
+-   `external/ag-shared/prompts/commands/docs/_release-docs-review-core.md`
+
+## Step 2: Create the Product Configuration Wrapper for `/docs-review`
+
+Create `.rulesync/commands/docs-review.md` as a plain file. Sections marked with a "Required" note must be present — the core methodology references these by exact name.
+
+```markdown
+---
+targets: ['*']
+description: 'Review documentation pages for technical accuracy and example consistency'
+---
+
+# Documentation Review - [Product Name]
+
+You are a technical documentation reviewer for [Product Name].
+
+## Product Configuration
+
+### Input Requirements
+> Required — referenced by exact name in the core methodology.
+
+User provides:
+- Documentation page path: `[path to docs]/${pageName}/index.mdoc`
+- Live dev URL: `[dev server URL]/${pageName}/`
+
+### Orchestration Indicator
+- Orchestrator script: `[path to orchestrator, if any]`
+
+### File Resolution Rules
+> Required — referenced by exact name in the core methodology.
+
+Map documentation references to TypeScript definition files:
+
+| If docs mention           | Then check file                          |
+| ------------------------- | ---------------------------------------- |
+| [Pattern for your product] | [Path to types package]                 |
+| Interface name like `XxxOptions` | Search `[types path]/**/*`        |
+| Generic config property   | `[path to main options file]`            |
+
+### Implementation Resolution Rules
+> Required — referenced by exact name in the core methodology.
+
+Map features to source implementation files:
+
+| Feature Category | Implementation Path Pattern |
+| ---------------- | --------------------------- |
+| [Your feature categories] | [Your source paths]    |
+
+### Example Path Pattern
+> Required — referenced by exact name in the core methodology.
+
+`[docs path]/${pageName}/_examples/${exampleName}/`
+- Required: `main.ts`
+- Optional: `data.ts`, `styles.css`
+
+### Exceptions File Path
+`[docs path]/${pageName}/technical-review-exceptions.md`
+
+### Output Paths
+> Required — referenced by exact name in the core methodology.
+
+- Review plans: `[plans path]/${pageName}.md`
+- Reports: `[docs path]/${pageName}/reports/technical-review-report.md`
+- Summary: `reports/docs-review/summary.md`
+
+### Default Value Verification Hierarchy
+> Required — referenced by exact name in the core methodology.
+> Describe how default values are resolved in your product's architecture.
+> For AG Charts this is: Module theme template -> @Property decorator -> TypeScript comments
+> For AG Grid this might be: ColDef defaults -> GridOptions defaults -> etc.
+
+### Product-Specific Conventions
+- [List any API conventions specific to your product]
+- [Known accepted patterns that should NOT be flagged]
+
+## Review Methodology
+
+**Read and follow all instructions in `external/ag-shared/prompts/commands/docs/_docs-review-core.md` for the review process, applying the product configuration above.**
+```
+
+## Step 3: Create the Product Configuration Wrapper for `/release-docs-review`
+
+Create `.rulesync/commands/release-docs-review.md` as a plain file:
+
+```markdown
+---
+targets: ['*']
+description: 'Review all documentation changes between releases for accuracy and completeness'
+---
+
+# Release Documentation Review - [Product Name]
+
+You are an expert documentation reviewer for [Product Name], specialising in
+release documentation validation.
+
+## Product Configuration
+
+### Product
+> Required — referenced by exact name in the core methodology.
+
+- Name: [Product Name]
+- Docs review command: `/docs-review`
+
+### Paths
+> Required — referenced by exact name in the core methodology.
+- Docs root: `[path to docs content]`
+- Types root: `[path to public types package]`
+- Docs file pattern: `[docs root]/**/*.mdoc`
+- Examples pattern: `[docs root]/**/_examples/`
+- Types file pattern: `[types root]/**/*.ts`
+
+### Release Branch Pattern
+> Required — referenced by exact name in the core methodology.
+
+- Format: `[your branch naming pattern, e.g. origin/bX.Y.Z]`
+- Discovery command: `[shell command to list recent release branches]`
+
+### Priority Pages
+> Required — referenced by exact name in the core methodology.
+
+**High priority** (getting started, key features, upgrade guides):
+`[comma-separated list of high-priority page names]`
+
+**Medium priority** (core features):
+`[comma-separated list of medium-priority page names]`
+
+### Output Paths
+> Required — referenced by exact name in the core methodology.
+
+- Reports directory: `reports/`
+- Filtered task list: `reports/release-docs-review-${PREVIOUS}-${CURRENT}-filtered.md`
+- Complete task list: `reports/release-docs-review-${PREVIOUS}-${CURRENT}-tasks.md`
+- Summary: `reports/release-docs-review-${PREVIOUS}-${CURRENT}-summary.md`
+
+### Verification Paths
+After each page review, confirm these files exist:
+- `[plans path]/${pageName}.md`
+- `[docs path]/${pageName}/reports/technical-review-report.md`
+
+## Review Methodology
+
+**Read and follow all instructions in `external/ag-shared/prompts/commands/docs/_release-docs-review-core.md` for the review process, applying the product configuration above.**
+```
+
+## Step 4: Create Product-Specific Documentation Rules
+
+The shared core handles the review workflow, but each product needs rules describing its documentation conventions. Create these in `.rulesync/rules/` (or `external/prompts/guides/`).
+
+**Recommended supporting rules:**
+
+These files are not referenced by the review core but provide context that improves review quality.
+
+-   **`docs-pages.md`** — comprehensive guide to your documentation system: page types and standard structures, Markdoc/MDX component reference, content patterns, example integration conventions
+-   **`docs-checklist.md`** — pre-submission quality checklist: content structure requirements, technical accuracy checks, example validation commands, framework compatibility checks
+
+**Optional:**
+
+-   **`playbook-docs.md`** — quick-reference workflow for docs changes
+-   **`example-tester.md`** (sub-agent in `.rulesync/subagents/`) — if you want Full Mode interactive review (build, test, and validate examples). Without this, `/docs-review` operates in Adaptive/Degraded mode (static analysis only), which is still useful.
+
+Use the AG Charts versions as a reference for structure and level of detail.
+
+## Step 5: Verify File Placement
+
+Confirm the files are in the correct locations (all plain files, no symlinks needed):
+
+```
+.rulesync/
+├── commands/
+│   ├── docs-review.md           ← plain file (Step 2)
+│   └── release-docs-review.md   ← plain file (Step 3)
+└── rules/
+    ├── docs-pages.md            ← plain file (Step 4)
+    └── docs-checklist.md        ← plain file (Step 4)
+```
+
+## Step 6: Regenerate Tool Config
+
+```bash
+./external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+```
+
+Verify the commands appear in `.claude/commands/`:
+
+```bash
+ls -la .claude/commands/docs-review.md .claude/commands/release-docs-review.md
+```
+
+## Step 7: Test
+
+1. Run `/docs-review [path-to-a-docs-page]` and confirm the LLM reads both your wrapper and the core
+2. Check that the report references your product's file paths (not AG Charts paths)
+3. Run `/release-docs-review` with two release branches and confirm page discovery works with your paths
+
+## Adoption Checklist
+
+-   [ ] `git subrepo pull external/ag-shared` completed
+-   [ ] `.rulesync/commands/docs-review.md` created as plain file with all REQUIRED sections
+-   [ ] `.rulesync/commands/release-docs-review.md` created as plain file with all REQUIRED sections
+-   [ ] `.rulesync/rules/docs-pages.md` created (or equivalent)
+-   [ ] `.rulesync/rules/docs-checklist.md` created (or equivalent)
+-   [ ] `setup-prompts.sh` run successfully
+-   [ ] `/docs-review` tested on a real page
+-   [ ] `/release-docs-review` tested between two branches
+
+## Notes
+
+-   **Batch orchestration**: The core methodology covers single-page and release-diff reviews. Batch orchestration across all pages (like AG Charts' `run-docs-review.js`) is product-specific. Start with manual page-by-page invocation.
+-   **Estimated adoption effort**: ~2-3 hours per repo.
+-   **Section names are normative**: The core references wrapper sections by exact name. Renaming sections in either wrapper or core silently breaks cross-referencing.

--- a/external/ag-shared/prompts/guides/setup-prompts.md
+++ b/external/ag-shared/prompts/guides/setup-prompts.md
@@ -70,3 +70,15 @@ npx patch-package rulesync
 ```
 
 This updates `patches/rulesync+*.patch` (which symlinks to `external/ag-shared/prompts/patches/`).
+
+## Shared Prompt Conventions
+
+When using the inverted reference pattern (shared core + thin wrapper), follow these rules to avoid silent breakage.
+
+### Section names are normative contracts
+
+Heading names in the wrapper are referenced by exact name in the core. Adding suffixes like `(REQUIRED)` or other annotations to heading text in templates or guides will break the exact-name contract silently at runtime. Treat section headings as API identifiers — rename them only with the same care as renaming a function.
+
+### Preserve executable content during genericisation
+
+When migrating product-specific prompts to shared cores, bash scripts and procedural subsections are often generic despite appearing product-specific (they only contain path references that can be parameterised). Always diff the original vs genericised output section-by-section to catch accidentally dropped content.


### PR DESCRIPTION
## Summary

- Migrate `/docs-review` and `/release-docs-review` to a shared core methodology in `external/ag-shared/` with product-specific thin wrappers in `.rulesync/commands/`
- Restore Step 7 bash script, Step 8 subsections (Implementation Example, Validation After Execution), and Risk Score Distribution that were dropped during genericisation
- Add interface naming convention and Phase 3 page count hint to AG Charts wrapper
- Add integration guide for adopting the shared docs review in other AG repos
- Fix template headings in integration guide to avoid breaking exact-name contracts