### PR TITLE
Address docs-review PR review feedback

### DIFF
--- a/.rulesync/README.md
+++ b/.rulesync/README.md
@@ -139,15 +139,15 @@ Rules load automatically when you edit files matching their glob patterns.
 
 ### Documentation and Examples
 
-| Rule                             | Activates on                                      | Description                                 |
-| -------------------------------- | ------------------------------------------------- | ------------------------------------------- |
-| 🟢 `docs-pages`                  | `**/docs/**/*.mdoc`, `**/docs/**/_examples/**`    | Creating high-quality documentation pages   |
-| 🟢 `docs-checklist`              | `**/docs/**/*.mdoc`                               | Pre-submission documentation checklist      |
-| 🟢 `examples`                    | `**/_examples/**`, `**/gallery/**`                | Working with examples in AG Charts          |
-| 🟢 `examples-framework-patterns` | `**/_examples/**`, `**/generate-example-files/**` | React, Angular, Vue transformation patterns |
+| Rule                             | Activates on                                           | Description                                        |
+| -------------------------------- | ------------------------------------------------------ | -------------------------------------------------- |
+| 🟢 `docs-pages`                  | `**/docs/**/*.mdoc`, `**/docs/**/_examples/**`         | Creating high-quality documentation pages          |
+| 🟢 `docs-checklist`              | `**/docs/**/*.mdoc`                                    | Pre-submission documentation checklist             |
+| 🟢 `examples`                    | `**/_examples/**`, `**/gallery/**`                     | Working with examples in AG Charts                 |
+| 🟢 `examples-framework-patterns` | `**/_examples/**`, `**/generate-example-files/**`      | React, Angular, Vue transformation patterns        |
 | 🔵 `website-astro-pages`         | `**/src/pages/**/*.astro`, `**/src/layouts/**/*.astro` | Astro page patterns, layouts, and code conventions |
-| 🔵 `website-browser-testing`     | `**/src/pages/**/*.astro`, `**/src/layouts/**/*.astro` | Chrome DevTools MCP browser testing workflow |
-| 🔵 `website-css`                 | `**/src/pages-styles/**/*.scss`, design-system     | CSS architecture, design system, and styling |
+| 🔵 `website-browser-testing`     | `**/src/pages/**/*.astro`, `**/src/layouts/**/*.astro` | Chrome DevTools MCP browser testing workflow       |
+| 🔵 `website-css`                 | `**/src/pages-styles/**/*.scss`, design-system         | CSS architecture, design system, and styling       |
 
 ### Playbooks
 

--- a/.rulesync/commands/docs-review.md
+++ b/.rulesync/commands/docs-review.md
@@ -15,8 +15,9 @@ You are a technical documentation reviewer for AG Charts. Review documentation p
 
 User provides:
 
--   Documentation page path: `packages/ag-charts-website/src/content/docs/${pageName}/index.mdoc`
--   Live dev URL: `https://localhost:4600/charts/javascript/${pageName}/`
+-   Page name or full path (e.g., `bar-series` or `packages/ag-charts-website/src/content/docs/bar-series/index.mdoc`)
+
+Resolve page name to: `packages/ag-charts-website/src/content/docs/${pageName}/index.mdoc`
 
 ### Orchestration Indicator
 
@@ -57,12 +58,12 @@ Map features to source implementation files:
 
 ### Exceptions File Path
 
-`packages/ag-charts-website/src/content/docs/${pageName}/technical-review-exceptions.md`
+`external/prompts/technical-review-exceptions/${pageName}.md`
 
 ### Output Paths
 
 -   Review plans: `external/prompts/technical-review-plans/${pageName}.md`
--   Reports: `packages/ag-charts-website/src/content/docs/${pageName}/reports/technical-review-report.md`
+-   Reports: `reports/docs-review/${pageName}.md`
 -   Summary: `reports/docs-review/summary.md`
 
 ### Default Value Verification Hierarchy

--- a/.rulesync/commands/release-docs-review.md
+++ b/.rulesync/commands/release-docs-review.md
@@ -47,7 +47,7 @@ You are an expert documentation reviewer for AG Charts, specialising in release 
 After each page review, confirm these files exist:
 
 -   `external/prompts/technical-review-plans/${pageName}.md`
--   `packages/ag-charts-website/src/content/docs/${pageName}/reports/technical-review-report.md`
+-   `reports/docs-review/${pageName}.md`
 
 ## Review Methodology
 

--- a/packages/ag-charts-website/src/content/docs/line-series/technical-review-exceptions.md
+++ b/packages/ag-charts-website/src/content/docs/line-series/technical-review-exceptions.md
@@ -1,5 +1,0 @@
-# Technical Review Exceptions
-
-## Line Series Stacking
-
--   Support for stacking is deliberately not documented as it is not a common use case.


### PR DESCRIPTION
Follow-up to #6226 addressing review comments:

- Simplify input requirements to accept just page name instead of requiring full path + dev URL
- Move exceptions file path from website docs to `external/prompts/technical-review-exceptions/`
- Consolidate report output to `reports/docs-review/${pageName}.md`
- Update stale report path in `release-docs-review.md`