### PR TITLE
Simplify Codex PR review to API-key-only auth with failure detection

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -60,7 +60,6 @@ jobs:
               uses: ./external/ag-shared/github/actions/codex-pr-review
               with:
                   openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-                  codex-auth-json-b64: ${{ secrets.CODEX_AUTH_JSON_B64 }}
                   pr-number: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
                   base-ref: ${{ github.event.pull_request.base.ref || 'latest' }}
                   head-ref: ${{ github.event.pull_request.head.ref || '' }}

--- a/.rulesync/README.md
+++ b/.rulesync/README.md
@@ -139,15 +139,15 @@ Rules load automatically when you edit files matching their glob patterns.
 
 ### Documentation and Examples
 
-| Rule                             | Activates on                                      | Description                                 |
-| -------------------------------- | ------------------------------------------------- | ------------------------------------------- |
-| 🟢 `docs-pages`                  | `**/docs/**/*.mdoc`, `**/docs/**/_examples/**`    | Creating high-quality documentation pages   |
-| 🟢 `docs-checklist`              | `**/docs/**/*.mdoc`                               | Pre-submission documentation checklist      |
-| 🟢 `examples`                    | `**/_examples/**`, `**/gallery/**`                | Working with examples in AG Charts          |
-| 🟢 `examples-framework-patterns` | `**/_examples/**`, `**/generate-example-files/**` | React, Angular, Vue transformation patterns |
+| Rule                             | Activates on                                           | Description                                        |
+| -------------------------------- | ------------------------------------------------------ | -------------------------------------------------- |
+| 🟢 `docs-pages`                  | `**/docs/**/*.mdoc`, `**/docs/**/_examples/**`         | Creating high-quality documentation pages          |
+| 🟢 `docs-checklist`              | `**/docs/**/*.mdoc`                                    | Pre-submission documentation checklist             |
+| 🟢 `examples`                    | `**/_examples/**`, `**/gallery/**`                     | Working with examples in AG Charts                 |
+| 🟢 `examples-framework-patterns` | `**/_examples/**`, `**/generate-example-files/**`      | React, Angular, Vue transformation patterns        |
 | 🔵 `website-astro-pages`         | `**/src/pages/**/*.astro`, `**/src/layouts/**/*.astro` | Astro page patterns, layouts, and code conventions |
-| 🔵 `website-browser-testing`     | `**/src/pages/**/*.astro`, `**/src/layouts/**/*.astro` | Chrome DevTools MCP browser testing workflow |
-| 🔵 `website-css`                 | `**/src/pages-styles/**/*.scss`, design-system     | CSS architecture, design system, and styling |
+| 🔵 `website-browser-testing`     | `**/src/pages/**/*.astro`, `**/src/layouts/**/*.astro` | Chrome DevTools MCP browser testing workflow       |
+| 🔵 `website-css`                 | `**/src/pages-styles/**/*.scss`, design-system         | CSS architecture, design system, and styling       |
 
 ### Playbooks
 

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -11,7 +11,7 @@ description: Run a Codex PR review with complete log suppression - no LLM output
 # 5. POST RESULTS: Create/update summary comment (<!-- codex-pr-review --> marker)
 #    and post new inline comments on specific file/line locations
 # 6. REACT COMPLETE: Remove 👀 from PR description, add 👍 (no findings) or 👎 (has findings)
-# 7. CLEANUP FILES: Remove sensitive review output and auth files
+# 7. CLEANUP FILES: Remove sensitive review output files
 #
 # Re-review behaviour:
 # - Summary comment is updated in-place (found via marker)
@@ -31,11 +31,7 @@ description: Run a Codex PR review with complete log suppression - no LLM output
 #
 inputs:
     openai-api-key:
-        description: 'OpenAI API key for Codex CLI (alternative to codex-auth-json-b64)'
-        required: false
-        default: ''
-    codex-auth-json-b64:
-        description: 'Base64-encoded ~/.codex/auth.json for ChatGPT OAuth auth (alternative to openai-api-key)'
+        description: 'OpenAI API key for Codex CLI authentication (also set as CODEX_API_KEY for codex exec)'
         required: false
         default: ''
     pr-number:
@@ -90,11 +86,10 @@ runs:
           id: check-auth
           shell: bash
           env:
-              CODEX_AUTH_JSON_B64: ${{ inputs.codex-auth-json-b64 }}
               OPENAI_API_KEY: ${{ inputs.openai-api-key }}
           run: |
-              if [ -z "${CODEX_AUTH_JSON_B64:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
-                echo "::warning::Skipping PR review - no authentication configured (set OPENAI_API_KEY or CODEX_AUTH_JSON_B64 secret)"
+              if [ -z "${OPENAI_API_KEY:-}" ]; then
+                echo "::warning::Skipping PR review - no authentication configured (set OPENAI_API_KEY secret)"
                 echo "skipped=true" >> $GITHUB_OUTPUT
               else
                 echo "skipped=false" >> $GITHUB_OUTPUT
@@ -278,24 +273,6 @@ runs:
                 ./external/ag-shared/scripts/setup-prompts/setup-prompts.sh --targets=codexcli --verbose || true
               fi
 
-        - name: Setup Authentication
-          if: steps.check-auth.outputs.skipped != 'true'
-          shell: bash
-          env:
-              CODEX_AUTH_JSON_B64: ${{ inputs.codex-auth-json-b64 }}
-              OPENAI_API_KEY: ${{ inputs.openai-api-key }}
-          run: |
-              # Prefer auth.json if provided, fall back to API key
-              if [ -n "${CODEX_AUTH_JSON_B64:-}" ]; then
-                echo "Using base64-encoded auth.json for authentication"
-                mkdir -p "$HOME/.codex"
-                echo "$CODEX_AUTH_JSON_B64" | base64 -d > "$HOME/.codex/auth.json"
-                chmod 600 "$HOME/.codex/auth.json"
-              elif [ -n "${OPENAI_API_KEY:-}" ]; then
-                echo "Using OpenAI API key for authentication"
-                # API key already set via env var - Codex will use it
-              fi
-
         - name: Determine Prompt File
           if: steps.check-auth.outputs.skipped != 'true'
           id: prompt
@@ -318,6 +295,7 @@ runs:
           shell: bash
           env:
               OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+              CODEX_API_KEY: ${{ inputs.openai-api-key }}
               ARGUMENTS: ${{ inputs.pr-number }}
               BASE_REF: ${{ inputs.base-ref }}
               HEAD_REF: ${{ inputs.head-ref }}
@@ -349,6 +327,12 @@ runs:
 
               if [ $exit_code -ne 0 ]; then
                 echo "::error::Codex review failed with exit code ${exit_code}"
+
+                # Check if error is authentication-related
+                if [ -f "${error_file}" ] && grep -qE "(invalid_api_key|token_expired|refresh_token_reused|401 Unauthorized|Incorrect API key|Your access token could not be refreshed|exceeded retry limit.*401)" "${error_file}"; then
+                  echo "::error::Authentication failure detected — the OPENAI_API_KEY secret is likely invalid, expired, or has insufficient permissions. Verify the secret in repo/org settings."
+                fi
+
                 # Show stderr for debugging - contains CLI errors, not review content
                 if [ -f "${error_file}" ] && [ -s "${error_file}" ]; then
                   echo "::group::Codex CLI Error Output"
@@ -690,5 +674,3 @@ runs:
           shell: bash
           run: |
               rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log"
-              # Also clean up auth.json if we created it
-              rm -f "$HOME/.codex/auth.json"


### PR DESCRIPTION
## Summary

- Remove OAuth `codex-auth-json-b64` authentication path, simplifying to API-key-only auth
- Set `CODEX_API_KEY` alongside `OPENAI_API_KEY` for `codex exec` compatibility
- Add stderr pattern matching to detect and surface auth failures with a prominent `::error::` annotation
- Clean up related workflow inputs and README table alignment