### PR TITLE
AG-16452 Add browser benchmark harness via Playwright

### DIFF
--- a/.rulesync/rules/benchmarks.md
+++ b/.rulesync/rules/benchmarks.md
@@ -34,3 +34,14 @@ This guide covers running and creating performance benchmarks for AG Charts.
 3. Add `/* @ag-options-extract */` and `/* @ag-options-end */` comments around the options object in the example's `main.ts`.
 4. Add example dependency to `benchmark.dependsOn` array in the package's `project.json`: `ag-charts-website-benchmarks_${exampleName}_main.ts:generate-example`.
 5. Run `yarn nx benchmark ag-charts-{community,enterprise} -- -t "test pattern"` to verify.
+
+## Browser Benchmarks
+
+Browser benchmarks run the docs-page benchmark examples in headless Chromium via Playwright, producing real canvas rendering measurements (unlike Jest/jsdom benchmarks which skip canvas).
+
+-   **Run**: `yarn nx browser-benchmark ag-charts-website` (requires `yarn nx dev` running separately), or `tools/benchmark/run-browser-benchmarks.sh` (manages dev server lifecycle for CI).
+-   **Script**: `tools/benchmark/browser-benchmark.ts` — discovers examples from `_examples/`, launches Playwright, collects results.
+-   **Output**: `reports/browser-benchmarks/results.json` (combined JSON report).
+-   **Auto-run**: Examples use `?benchmark=true` query param to trigger automatic benchmark execution.
+-   **`#e2e=true` gotcha**: Do NOT add `#e2e=true` to benchmark URLs — each example guards `initBenchmark()` with `if (!window.location.hash.includes('e2e=true'))`, so the hash suppresses benchmark initialisation.
+-   **Excluded examples**: `summary` (static comparison dashboard, no `getBenchmarkConfig()`) and `high-freq-high-volume` (streaming demo using animation-loop pattern, no `initBenchmark()`).

--- a/packages/ag-charts-website/.gitignore
+++ b/packages/ag-charts-website/.gitignore
@@ -11,6 +11,9 @@ search-output/
 # Generated technical review reports
 src/content/docs/**/reports/
 
+# Generated benchmark reports
+reports/
+
 src/content/gallery/_examples/*/tsconfig*.json
 
 # Algolia search output

--- a/packages/ag-charts-website/project.json
+++ b/packages/ag-charts-website/project.json
@@ -247,6 +247,16 @@
           "args": ["--verbose"]
         }
       }
+    },
+    "browser-benchmark": {
+      "command": "tsx ../../tools/benchmark/browser-benchmark.ts",
+      "dependsOn": ["^build", "generate-examples"],
+      "outputs": ["{workspaceRoot}/reports/browser-benchmarks/results.json"],
+      "cache": false,
+      "parallelism": false,
+      "options": {
+        "cwd": "{projectRoot}"
+      }
     }
   },
   "implicitDependencies": [

--- a/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
@@ -483,7 +483,8 @@ class BenchmarkUI {
         results: BenchmarkResult[],
         formatTestCase: (testCase: string) => string,
         version: string,
-        metadata?: Record<string, unknown>
+        metadata?: Record<string, unknown>,
+        onExport?: () => void
     ): void {
         if (!this.resultsElement) return;
 
@@ -575,58 +576,8 @@ class BenchmarkUI {
 
         // Add export functionality
         const exportButton = document.getElementById('exportBenchmarkResults');
-        if (exportButton) {
-            exportButton.addEventListener('click', () => {
-                // Capture environment details at export time
-                const chartElement = document.getElementById('myChart');
-                const chartRect = chartElement?.getBoundingClientRect();
-
-                // Derive parameter keys from results
-                const parameterKeys: string[] = [];
-                for (const r of results) {
-                    for (const key of Object.keys(r.params)) {
-                        if (!parameterKeys.includes(key)) {
-                            parameterKeys.push(key);
-                        }
-                    }
-                }
-
-                const exportData = {
-                    version,
-                    parameterKeys,
-                    environment: {
-                        viewport: {
-                            width: window.innerWidth,
-                            height: window.innerHeight,
-                        },
-                        chart: chartRect
-                            ? {
-                                  width: Math.round(chartRect.width),
-                                  height: Math.round(chartRect.height),
-                              }
-                            : null,
-                        devicePixelRatio: window.devicePixelRatio,
-                    },
-                    metadata: metadata || {},
-                    results: results.map((r) => ({
-                        testCase: formatTestCase(r.testCase),
-                        params: r.params,
-                        averageTime: r.averageTime,
-                        minTime: r.minTime,
-                        maxTime: r.maxTime,
-                        sampleCount: r.sampleCount,
-                        timings: r.timings,
-                    })),
-                };
-                const json = JSON.stringify(exportData, null, 2);
-                const blob = new Blob([json], { type: 'application/json' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = `benchmark-results-${new Date().toISOString()}.json`;
-                a.click();
-                URL.revokeObjectURL(url);
-            });
+        if (exportButton && onExport) {
+            exportButton.addEventListener('click', onExport);
         }
 
         // Log to console
@@ -746,11 +697,14 @@ class BenchmarkRunner {
             }
 
             this.displayResults();
+            (window as any).__benchmarkResults = this.buildExportData();
         } catch (error) {
             console.error('Benchmark error:', error);
             this.ui.showError(`Benchmark failed: ${error}`);
+            (window as any).__benchmarkError = String(error);
         } finally {
             this.isRunning = false;
+            (window as any).__benchmarkComplete = true;
             this.currentTestCase = null;
             this.currentVariant = null;
             this.ui.setRunButtonEnabled(true);
@@ -865,16 +819,72 @@ class BenchmarkRunner {
         );
     }
 
+    private formatTestCase(testCase: string): string {
+        const tc = this.config.testCases.find((t) => t.id === testCase);
+        return tc?.label || testCase;
+    }
+
+    private buildExportData() {
+        const chartElement = document.getElementById('myChart');
+        const chartRect = chartElement?.getBoundingClientRect();
+
+        // Derive parameter keys from results
+        const parameterKeys: string[] = [];
+        for (const r of this.results) {
+            for (const key of Object.keys(r.params)) {
+                if (!parameterKeys.includes(key)) {
+                    parameterKeys.push(key);
+                }
+            }
+        }
+
+        return {
+            version: this.version,
+            parameterKeys,
+            environment: {
+                viewport: {
+                    width: window.innerWidth,
+                    height: window.innerHeight,
+                },
+                chart: chartRect
+                    ? {
+                          width: Math.round(chartRect.width),
+                          height: Math.round(chartRect.height),
+                      }
+                    : null,
+                devicePixelRatio: window.devicePixelRatio,
+            },
+            metadata: this.config.metadata || {},
+            results: this.results.map((r) => ({
+                testCase: this.formatTestCase(r.testCase),
+                params: r.params,
+                averageTime: r.averageTime,
+                minTime: r.minTime,
+                maxTime: r.maxTime,
+                sampleCount: r.sampleCount,
+                timings: r.timings,
+            })),
+        };
+    }
+
     private displayResults(): void {
         this.updateProgress(true);
         this.ui.displayResults(
             this.results,
-            (testCase) => {
-                const tc = this.config.testCases.find((t) => t.id === testCase);
-                return tc?.label || testCase;
-            },
+            (testCase) => this.formatTestCase(testCase),
             this.version,
-            this.config.metadata
+            this.config.metadata,
+            () => {
+                const exportData = this.buildExportData();
+                const json = JSON.stringify(exportData, null, 2);
+                const blob = new Blob([json], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `benchmark-results-${new Date().toISOString()}.json`;
+                a.click();
+                URL.revokeObjectURL(url);
+            }
         );
     }
 }

--- a/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
@@ -482,8 +482,8 @@ class BenchmarkUI {
     displayResults(
         results: BenchmarkResult[],
         formatTestCase: (testCase: string) => string,
-        version: string,
-        metadata?: Record<string, unknown>,
+        _version: string,
+        _metadata?: Record<string, unknown>,
         onExport?: () => void
     ): void {
         if (!this.resultsElement) return;

--- a/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
@@ -574,10 +574,12 @@ class BenchmarkUI {
 
         this.resultsElement.innerHTML = html;
 
-        // Add export functionality
+        // Add export functionality (remove button if no handler provided)
         const exportButton = document.getElementById('exportBenchmarkResults');
         if (exportButton && onExport) {
             exportButton.addEventListener('click', onExport);
+        } else if (exportButton) {
+            exportButton.remove();
         }
 
         // Log to console

--- a/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/benchmarkHarness.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+
 /**
  * Full benchmark harness implementation that gets compiled to benchmarkHarness.js
  * and included in generated examples that define getBenchmarkConfig().

--- a/tools/benchmark/browser-benchmark.ts
+++ b/tools/benchmark/browser-benchmark.ts
@@ -61,7 +61,7 @@ async function main() {
     const argv = await yargs(hideBin(process.argv))
         .option('base-url', {
             type: 'string',
-            default: 'http://localhost:4600/charts',
+            default: 'https://localhost:4600/charts',
             describe: 'Base URL of the dev server',
         })
         .option('output', {
@@ -155,7 +155,7 @@ async function main() {
             }
 
             // Wait for benchmark completion
-            await page.waitForFunction(() => (window as any).__benchmarkComplete === true, {
+            await page.waitForFunction(() => (window as any).__benchmarkComplete === true, undefined, {
                 timeout: argv.timeout,
                 polling: 1_000,
             });

--- a/tools/benchmark/browser-benchmark.ts
+++ b/tools/benchmark/browser-benchmark.ts
@@ -155,7 +155,7 @@ async function main() {
             }
 
             // Wait for benchmark completion
-            await page.waitForFunction(() => (window as any).__benchmarkComplete === true, undefined, {
+            await page.waitForFunction(() => (window as any).__benchmarkComplete === true, {
                 timeout: argv.timeout,
                 polling: 1_000,
             });

--- a/tools/benchmark/browser-benchmark.ts
+++ b/tools/benchmark/browser-benchmark.ts
@@ -1,0 +1,235 @@
+/* eslint-disable no-console */
+
+/**
+ * Browser-based benchmark runner using Playwright.
+ *
+ * Launches headless Chromium, navigates to each benchmark example on the dev server,
+ * waits for completion, extracts structured results, and writes a combined JSON report.
+ *
+ * Usage:
+ *   npx tsx tools/benchmark/browser-benchmark.ts [options]
+ *
+ * Requires a running dev server (yarn nx dev) or use the CI wrapper script.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+const EXAMPLES_DIR = path.resolve(__dirname, '../../packages/ag-charts-website/src/content/docs/benchmarks/_examples');
+
+// Examples that don't use the standard benchmark harness
+const EXCLUDED_EXAMPLES = new Set([
+    'summary', // Static comparison dashboard — no getBenchmarkConfig()
+    'high-freq-high-volume', // Streaming demo using animation-loop pattern — no initBenchmark()
+]);
+
+interface BenchmarkExampleResult {
+    status: 'success' | 'error' | 'timeout';
+    data?: Record<string, unknown>;
+    error?: string;
+    durationMs: number;
+}
+
+interface BenchmarkReport {
+    timestamp: string;
+    environment: {
+        viewport: { width: number; height: number };
+        devicePixelRatio: number;
+        browser: string;
+    };
+    summary: {
+        total: number;
+        success: number;
+        error: number;
+        timeout: number;
+        totalDurationMs: number;
+    };
+    examples: Record<string, BenchmarkExampleResult>;
+}
+
+function discoverExamples(): string[] {
+    const entries = fs.readdirSync(EXAMPLES_DIR, { withFileTypes: true });
+    return entries
+        .filter((e) => e.isDirectory() && !EXCLUDED_EXAMPLES.has(e.name))
+        .map((e) => e.name)
+        .sort();
+}
+
+async function main() {
+    const argv = await yargs(hideBin(process.argv))
+        .option('base-url', {
+            type: 'string',
+            default: 'http://localhost:4600/charts',
+            describe: 'Base URL of the dev server',
+        })
+        .option('output', {
+            type: 'string',
+            default: 'reports/browser-benchmarks/results.json',
+            describe: 'Output file path for the combined JSON report',
+        })
+        .option('examples', {
+            type: 'string',
+            default: '',
+            describe: 'Comma-separated list of example names to run (default: all)',
+        })
+        .option('timeout', {
+            type: 'number',
+            default: 300_000,
+            describe: 'Per-example timeout in milliseconds',
+        })
+        .option('viewport', {
+            type: 'string',
+            default: '800x600',
+            describe: 'Viewport dimensions (WxH)',
+        })
+        .option('dpr', {
+            type: 'number',
+            default: 2,
+            describe: 'Device pixel ratio',
+        })
+        .strict()
+        .help()
+        .parse();
+
+    const [vpWidth, vpHeight] = argv.viewport.split('x').map(Number);
+    if (!vpWidth || !vpHeight) {
+        console.error(`Invalid viewport format: ${argv.viewport}. Expected WxH (e.g. 800x600)`);
+        process.exit(1);
+    }
+
+    // Discover and filter examples
+    let exampleNames = discoverExamples();
+    if (argv.examples) {
+        const filter = new Set(argv.examples.split(',').map((s) => s.trim()));
+        const unknown = [...filter].filter((name) => !exampleNames.includes(name));
+        if (unknown.length > 0) {
+            console.error(`Unknown example(s): ${unknown.join(', ')}`);
+            console.error(`Available: ${exampleNames.join(', ')}`);
+            process.exit(1);
+        }
+        exampleNames = exampleNames.filter((name) => filter.has(name));
+    }
+
+    console.log(`Running ${exampleNames.length} benchmark example(s)`);
+    console.log(`Base URL: ${argv['base-url']}`);
+    console.log(`Viewport: ${vpWidth}x${vpHeight} @ ${argv.dpr}x DPR`);
+    console.log(`Timeout: ${argv.timeout}ms per example`);
+    console.log();
+
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+        viewport: { width: vpWidth, height: vpHeight },
+        deviceScaleFactor: argv.dpr,
+    });
+
+    const report: BenchmarkReport = {
+        timestamp: new Date().toISOString(),
+        environment: {
+            viewport: { width: vpWidth, height: vpHeight },
+            devicePixelRatio: argv.dpr,
+            browser: 'chromium',
+        },
+        summary: { total: exampleNames.length, success: 0, error: 0, timeout: 0, totalDurationMs: 0 },
+        examples: {},
+    };
+
+    const overallStart = Date.now();
+
+    for (const name of exampleNames) {
+        const url = `${argv['base-url']}/vanilla/benchmarks/examples/${name}?benchmark=true`;
+        console.log(`[${name}] Navigating to ${url}`);
+
+        const page = await context.newPage();
+        const pageErrors: string[] = [];
+        page.on('pageerror', (err) => pageErrors.push(String(err)));
+
+        const exampleStart = Date.now();
+        let result: BenchmarkExampleResult;
+
+        try {
+            const response = await page.goto(url, { waitUntil: 'load', timeout: 30_000 });
+            if (!response || response.status() >= 400) {
+                throw new Error(`HTTP ${response?.status() ?? 'no response'} for ${url}`);
+            }
+
+            // Wait for benchmark completion
+            await page.waitForFunction(() => (window as any).__benchmarkComplete === true, undefined, {
+                timeout: argv.timeout,
+                polling: 1_000,
+            });
+
+            // Extract results
+            const benchmarkError = await page.evaluate(() => (window as any).__benchmarkError);
+            if (benchmarkError) {
+                result = {
+                    status: 'error',
+                    error: benchmarkError,
+                    durationMs: Date.now() - exampleStart,
+                };
+            } else {
+                const data = await page.evaluate(() => (window as any).__benchmarkResults);
+                result = {
+                    status: 'success',
+                    data,
+                    durationMs: Date.now() - exampleStart,
+                };
+            }
+        } catch (error: unknown) {
+            const isTimeout =
+                error instanceof Error && (error.message.includes('Timeout') || error.name === 'TimeoutError');
+            result = {
+                status: isTimeout ? 'timeout' : 'error',
+                error: String(error),
+                durationMs: Date.now() - exampleStart,
+            };
+        }
+
+        if (pageErrors.length > 0) {
+            result.error = [result.error, ...pageErrors.map((e) => `[page error] ${e}`)].filter(Boolean).join('\n');
+            if (result.status === 'success') {
+                // Page errors during a "success" run are notable but don't change status
+                console.warn(`[${name}] Completed with page errors: ${pageErrors.length}`);
+            }
+        }
+
+        report.examples[name] = result;
+        report.summary[result.status]++;
+
+        const statusIcon = result.status === 'success' ? '\u2713' : result.status === 'timeout' ? '\u23F1' : '\u2717';
+        const duration = (result.durationMs / 1000).toFixed(1);
+        console.log(`[${name}] ${statusIcon} ${result.status} (${duration}s)`);
+
+        if (result.status !== 'success') {
+            console.error(`[${name}] ${result.error}`);
+        }
+
+        await page.close();
+    }
+
+    report.summary.totalDurationMs = Date.now() - overallStart;
+
+    await browser.close();
+
+    // Write report
+    const outputPath = path.resolve(argv.output);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, JSON.stringify(report, null, 2) + '\n');
+
+    console.log();
+    console.log(`Report written to ${outputPath}`);
+    console.log(
+        `Summary: ${report.summary.success} success, ${report.summary.error} error, ${report.summary.timeout} timeout (${(report.summary.totalDurationMs / 1000).toFixed(1)}s total)`
+    );
+
+    // Exit with non-zero if any failures
+    if (report.summary.error > 0 || report.summary.timeout > 0) {
+        process.exit(1);
+    }
+}
+
+main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(2);
+});

--- a/tools/benchmark/run-browser-benchmarks.sh
+++ b/tools/benchmark/run-browser-benchmarks.sh
@@ -44,6 +44,8 @@ cleanup() {
         kill "$SERVER_PID" 2>/dev/null || true
         wait "$SERVER_PID" 2>/dev/null || true
     fi
+    # Kill any orphaned Astro child process (Nx wraps the actual server)
+    pkill -f "astro dev --port=${PORT}" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 

--- a/tools/benchmark/run-browser-benchmarks.sh
+++ b/tools/benchmark/run-browser-benchmarks.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# CI wrapper for browser-based benchmarks.
+# Starts the Astro dev server, waits for it, runs the Playwright benchmark script,
+# and cleans up the server on exit.
+#
+# Usage:
+#   ./tools/benchmark/run-browser-benchmarks.sh [--port PORT] [-- extra args for browser-benchmark.ts]
+#
+# Examples:
+#   ./tools/benchmark/run-browser-benchmarks.sh
+#   ./tools/benchmark/run-browser-benchmarks.sh --port 4602
+#   ./tools/benchmark/run-browser-benchmarks.sh -- --examples simple-chart --timeout 60000
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PORT="${PORT:-4601}"
+SERVER_PID=""
+EXTRA_ARGS=()
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            EXTRA_ARGS=("$@")
+            break
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+cleanup() {
+    if [[ -n "$SERVER_PID" ]]; then
+        echo "Stopping dev server (PID $SERVER_PID)..."
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+echo "Starting dev server on port $PORT..."
+cd "$REPO_ROOT"
+PORT="$PORT" npx nx dev ag-charts-website &
+SERVER_PID=$!
+
+echo "Waiting for dev server at http://localhost:$PORT..."
+npx wait-on "http-get://localhost:$PORT/charts/" --timeout 120000
+
+echo "Dev server ready. Running browser benchmarks..."
+npx tsx tools/benchmark/browser-benchmark.ts \
+    --base-url "http://localhost:$PORT/charts" \
+    "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"


### PR DESCRIPTION
Fix #AG-16452

Adds a Playwright-based browser benchmark harness that drives headless Chromium to run benchmark examples and collect structured JSON results.

**Changes:**
- **benchmarkHarness.ts**: Expose `window.__benchmarkComplete`, `window.__benchmarkResults`, and `window.__benchmarkError` for programmatic result extraction. Extract `buildExportData()` method (DRY with export button handler).
- **tools/benchmark/browser-benchmark.ts**: Standalone Playwright script that discovers benchmark examples, navigates to each with `?benchmark=true`, waits for completion, and writes a combined report to `reports/browser-benchmarks/results.json`.
- **tools/benchmark/run-browser-benchmarks.sh**: CI wrapper that manages dev server lifecycle (start, wait, run, cleanup).
- **project.json**: New `browser-benchmark` Nx target.