### PR TITLE
AG-16803 Add debug tracing for Chart.update() loops

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -650,7 +650,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
     private readonly _performUpdateNotify = new AsyncAwaitQueue();
     private performUpdateType: ChartUpdateType = ChartUpdateType.NONE;
     private runningUpdateType: ChartUpdateType = ChartUpdateType.NONE;
-
+    private currentProcessingUpdateType: ChartUpdateType = ChartUpdateType.NONE;
     private updateShortcutCount = 0;
     private readonly seriesToUpdate: Set<ISeries<any, any, any>> = new Set();
     private readonly updateMutex = new Mutex();
@@ -703,6 +703,18 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
             let stack = new Error('Stack trace for update tracking').stack ?? '<unknown>';
             stack = stack.replaceAll(/\([^)]*/g, '');
             this.updateRequestors[stack] = type;
+
+            if (this.currentProcessingUpdateType !== ChartUpdateType.NONE && this.currentProcessingUpdateType >= type) {
+                this.debug.group(
+                    `Chart.update() - ⚠️ received update for earlier update stage ${ChartUpdateType[type]} ⚠️`,
+                    () => {
+                        this.debug(
+                            `Current processing update type: ${ChartUpdateType[this.currentProcessingUpdateType]}`
+                        );
+                        this.debug('Update from: ', stack);
+                    }
+                );
+            }
         }
 
         if (type < this.performUpdateType) {
@@ -724,7 +736,10 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
 
     private async tryPerformUpdate(count: number) {
         try {
-            await this.performUpdate(count);
+            const status = `${ChartUpdateType[this.performUpdateType]} ${this.updateShortcutCount > 0 ? '⚠️ redo #' + this.updateShortcutCount + ' ⚠️ ' : ''}`;
+            await this.debug.group(`Chart.performUpdate() ${status}`, async () => {
+                await this.performUpdate(count);
+            });
         } catch (error: any) {
             Logger.error('update error', error, error.stack);
         }
@@ -748,6 +763,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         this.performUpdateType = ChartUpdateType.NONE;
         this.seriesToUpdate.clear();
         this.runningUpdateType = performUpdateType;
+        this.currentProcessingUpdateType = performUpdateType;
 
         if (this.updateShortcutCount === 0 && performUpdateType < ChartUpdateType.SCENE_RENDER) {
             ctx.animationManager.startBatch(this._performUpdateSkipAnimations);
@@ -872,6 +888,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
                 // Do nothing.
                 this.updateShortcutCount = 0;
                 this.updateRequestors = {};
+                this.currentProcessingUpdateType = ChartUpdateType.NONE;
                 this._performUpdateSkipAnimations = false;
                 ctx.animationManager.endBatch();
         }
@@ -946,7 +963,12 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         }
 
         if (this.performUpdateType <= checkUpdateType) {
-            this.debug('Chart.checkUpdateShortcut() - BLOCKED AT: ', ChartUpdateType[checkUpdateType]);
+            this.debug(
+                'Chart.checkUpdateShortcut() - BLOCKED AT: ',
+                ChartUpdateType[checkUpdateType],
+                ' BY REQUEST FOR: ',
+                ChartUpdateType[this.performUpdateType]
+            );
 
             // A previous step modified series state, and we need to re-run this or an earlier step before rendering.
             this.updateShortcutCount++;
@@ -954,6 +976,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         }
 
         this.debug('Chart.checkUpdateShortcut() - PROCEEDING TO: ', ChartUpdateType[checkUpdateType]);
+        this.currentProcessingUpdateType = checkUpdateType;
 
         return false;
     }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -1,5 +1,6 @@
 import {
     ChartAxisDirection,
+    Debug,
     Logger,
     ScaleAlignment,
     attachDescription,
@@ -155,6 +156,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
     private independentAxes = false;
     private navigatorModule = false;
     private zoomModule = false;
+    private readonly debug = Debug.create(true, 'zoom');
 
     // The initial state memento can not be restored until the chart has performed its first layout. Instead save it as
     // pending and restore then delete it on the first layout.
@@ -687,6 +689,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const state = this.state;
         let constrainedState: typeof state | undefined;
 
+        const debug = this.debug;
         const zoomManager = this;
         const event = {
             source,
@@ -704,6 +707,9 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
                 this.constrainChanges(zoomManager.toCoreZoomState(restrictions));
             },
             constrainChanges(restrictions: ZoomChangeState): void {
+                if (debug.check()) {
+                    debug('ZoomManager.constrainChanges()', state, '->', restrictions, new Error().stack);
+                }
                 constrainedState ??= deepClone(state);
                 for (const id of strictObjectKeys(restrictions)) {
                     const src = restrictions[id];

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -668,7 +668,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
 
         const delta = zoom[axis].max - zoom[axis].min;
         const minDelta = 1 / this.lastRestoredRequiredRange;
-        if (delta <= minDelta) return;
+        if (delta <= minDelta) return; // FAILING HERE!
 
         event.constrainZoom({
             ...zoom,
@@ -719,13 +719,11 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
 
         this.eventsHub.emit('zoom:change-request', event);
 
-        let wasChangeConstrained = false;
         if (constrainedState && !areEqualCoreZooms(state, constrainedState)) {
-            wasChangeConstrained = true;
             this.state = constrainedState;
         }
 
-        const changeAccepted: boolean = changedAxes.length > 0 || wasChangeConstrained;
+        const changeAccepted: boolean = !areEqualCoreZooms(oldState, this.state);
         if (changeAccepted) {
             const acceptedZoom = this.getZoom() ?? {};
             this.eventsHub.emit('zoom:change-complete', { source, sourceDetail, x: acceptedZoom.x });

--- a/packages/ag-charts-core/src/logging/logger.ts
+++ b/packages/ag-charts-core/src/logging/logger.ts
@@ -51,11 +51,25 @@ export function reset() {
     doOnceCache.clear();
 }
 
+function isPromise(value: unknown): value is Promise<unknown> {
+    return typeof value === 'object' && value !== null && 'then' in value;
+}
+
 export function logGroup<T>(name: string, cb: () => T): T {
     console.groupCollapsed(name);
+    let syncCleanup = true;
     try {
-        return cb();
+        const result = cb();
+        if (isPromise(result)) {
+            syncCleanup = false;
+            return result.finally(() => {
+                console.groupEnd();
+            }) as T;
+        }
+        return result;
     } finally {
-        console.groupEnd();
+        if (syncCleanup) {
+            console.groupEnd();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add instrumentation to `Chart.update()` to trace sources of update loop restarts when `window.agChartsDebug = 'chart'` is enabled
- Fix `logGroup` to handle async callbacks properly (defer `console.groupEnd()` until promise resolves)
- Improve zoom change acceptance logic to compare old vs new state directly

## Test plan
- [ ] Enable `window.agChartsDebug = 'chart'` in a chart example and verify debug groups appear in the console
- [ ] Verify that update loop warnings highlight earlier-stage re-requests during processing
- [ ] Confirm no regressions in zoom behaviour