### PR TITLE
Remove direnv configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-# Allow multiple Claude accounts to be used; use an ag-grid account for this repo.
-export CLAUDE_CONFIG_DIR=~/.claude-ag-grid

--- a/external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh
+++ b/external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh
@@ -95,21 +95,6 @@ install_nx() {
     return 0
 }
 
-opt_enable_direnv() {
-    if ! command -v direnv &> /dev/null; then
-        log_info "direnv is not installed, skipping enablement"
-        return 0
-    fi
-
-    if direnv allow; then
-        log_info "direnv enabled successfully"
-        return 0
-    else
-        log_error "Failed to enable direnv"
-        return 2
-    fi
-}
-
 # Function to install yarn and initial dependencies
 install_yarn() {
     # Create .yarnrc to ignore engine checks
@@ -256,10 +241,6 @@ main() {
         if ! install_dependencies; then
             exit 2
         fi
-    fi
-
-    if ! opt_enable_direnv; then
-        exit 2
     fi
 
     # Verify nx is available after installation


### PR DESCRIPTION
Remove `.envrc` and the `opt_enable_direnv()` function from the cloud install script. The direnv setup was for personal multi-account Claude configuration and isn't used by the team.