### PR TITLE
AG-3390 Handle concatenated JSON output from newer Snyk CLI versions

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = f999ddabe0d121bf65607f7c2bdab710335fab06
-	parent = 85fcaafd3b8fc6487e3a512047c9e957d9f6a66c
+	commit = 4d82650c622e0433d9b58410adc1c88a00608f9d
+	parent = 0b3cdee05c3d3ce3cc5e0dfe040962d49352970f
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/scripts/snyk/snyk-to-ctrf-command.mjs
+++ b/external/ag-shared/scripts/snyk/snyk-to-ctrf-command.mjs
@@ -22,7 +22,20 @@ if (!fs.existsSync(snykPath)) {
 (async () => {
     console.log(`Snyk JSON file: ${snykPath}`);
     const snykJson = fs.readFileSync(snykPath, 'utf-8');
-    const snykData = JSON.parse(snykJson);
+    let snykData;
+    try {
+        snykData = JSON.parse(snykJson);
+    } catch (e) {
+        // Newer Snyk CLI versions append error objects after the main JSON array
+        // when workspace paths fail (e.g. root with "Forbidden"). Extract first document.
+        const position = e.message.match(/at position (\d+)/)?.[1];
+        if (!position) {
+            throw e;
+        }
+
+        console.log(`::warning:: Failed to parse Snyk JSON (${SNYK_JSON_FILE}). Attempting to extract valid JSON portion up to position ${position} (${e.message})`);
+        snykData = JSON.parse(snykJson.slice(0, parseInt(position, 10)));
+    }
     const ctrf = convertToCtrf(snykData);
 
     fs.mkdirSync(path.dirname(ctrfPath), { recursive: true });


### PR DESCRIPTION
## Summary

- Newer Snyk CLI versions (via the floating `snyk/snyk:node` Docker image used by `snyk/actions/node@master`) append workspace error objects as separate JSON documents after the main results array, rather than embedding them within it
- This caused `JSON.parse` to fail with `SyntaxError: Unexpected non-whitespace character after JSON` when the root workspace path (`/github/workspace`) returned a `"Forbidden"` error from the Snyk API
- Fixed by catching the parse error, extracting the byte position from the error message, and re-parsing only the first (valid) JSON document

## Test plan

- [x] Verify the security scan CI job passes on next scheduled run
- [x] Confirm the warning annotation appears in the job log when the truncation fallback is triggered