### PR TITLE
AG-16832 Tighten aggregation thresholds and add regression tests

### DIFF
--- a/packages/ag-charts-community/src/chart/series/aggregationManager.test.ts
+++ b/packages/ag-charts-community/src/chart/series/aggregationManager.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { type AggregationFilterBase, AggregationManager } from './aggregationManager';
+
+interface MockFilter extends AggregationFilterBase {
+    maxRange: number;
+}
+
+function createMockFilters(): MockFilter[] {
+    return [{ maxRange: 100 }, { maxRange: 500 }, { maxRange: 1000 }];
+}
+
+function seedFilters(manager: AggregationManager<MockFilter>, dataLength: number): void {
+    // Set _dataLength first (this discards any existing filters, which is fine for seeding).
+    manager.markStale(dataLength);
+    // Then populate filters via aggregate.
+    manager.aggregate({ computeFull: () => createMockFilters(), targetRange: 0 });
+}
+
+describe('AggregationManager', () => {
+    describe('markStale()', () => {
+        it('should discard filters on large increase (1000 -> 5000)', () => {
+            const manager = new AggregationManager<MockFilter>();
+            seedFilters(manager, 1000);
+            expect(manager.filters).toBeDefined();
+
+            manager.markStale(5000);
+            expect(manager.filters).toBeUndefined();
+        });
+
+        it('should discard filters on large decrease (10000 -> 1000)', () => {
+            const manager = new AggregationManager<MockFilter>();
+            seedFilters(manager, 10000);
+            expect(manager.filters).toBeDefined();
+
+            manager.markStale(1000);
+            expect(manager.filters).toBeUndefined();
+        });
+
+        it('should preserve filters on small change (1000 -> 1200)', () => {
+            const manager = new AggregationManager<MockFilter>();
+            seedFilters(manager, 1000);
+            expect(manager.filters).toBeDefined();
+
+            manager.markStale(1200);
+            expect(manager.filters).toBeDefined();
+        });
+
+        it('should discard filters on exact 2x boundary (1000 -> 2000)', () => {
+            const manager = new AggregationManager<MockFilter>();
+            seedFilters(manager, 1000);
+            expect(manager.filters).toBeDefined();
+
+            manager.markStale(2000);
+            expect(manager.filters).toBeUndefined();
+        });
+
+        it('should discard filters on exact 0.5x boundary (2000 -> 1000)', () => {
+            const manager = new AggregationManager<MockFilter>();
+            seedFilters(manager, 2000);
+            expect(manager.filters).toBeDefined();
+
+            manager.markStale(1000);
+            expect(manager.filters).toBeUndefined();
+        });
+
+        it('should discard filters on first call (initial state)', () => {
+            const manager = new AggregationManager<MockFilter>();
+            manager.aggregate({ computeFull: () => createMockFilters(), targetRange: 0 });
+            expect(manager.filters).toBeDefined();
+
+            manager.markStale(1000);
+            expect(manager.filters).toBeUndefined();
+        });
+
+        it('should discard filters at every >=2x step in a multi-step drift sequence', () => {
+            const manager = new AggregationManager<MockFilter>();
+
+            // Step 1: initial seed at 1000
+            seedFilters(manager, 1000);
+
+            // Step 2: 1000 -> 10000 (10x increase) — must discard
+            manager.aggregate({ computeFull: () => createMockFilters(), targetRange: 0 });
+            manager.markStale(10000);
+            expect(manager.filters).toBeUndefined();
+
+            // Step 3: 10000 -> 1000 (10x decrease) — must discard
+            manager.aggregate({ computeFull: () => createMockFilters(), targetRange: 0 });
+            manager.markStale(1000);
+            expect(manager.filters).toBeUndefined();
+
+            // Step 4: 1000 -> 100000 (100x increase) — must discard
+            manager.aggregate({ computeFull: () => createMockFilters(), targetRange: 0 });
+            manager.markStale(100000);
+            expect(manager.filters).toBeUndefined();
+
+            // Step 5: 100000 -> 1000 (100x decrease) — must discard
+            manager.aggregate({ computeFull: () => createMockFilters(), targetRange: 0 });
+            manager.markStale(1000);
+            expect(manager.filters).toBeUndefined();
+        });
+
+        it('should mark existing filters as stale on small change', () => {
+            const manager = new AggregationManager<MockFilter>();
+            seedFilters(manager, 1000);
+
+            manager.markStale(1200);
+            const filters = manager.filters as (MockFilter & { stale?: boolean })[];
+            expect(filters).toBeDefined();
+            expect(filters.every((f) => f.stale === true)).toBe(true);
+        });
+    });
+});

--- a/packages/ag-charts-community/src/chart/series/aggregationManager.ts
+++ b/packages/ag-charts-community/src/chart/series/aggregationManager.ts
@@ -110,22 +110,20 @@ export class AggregationManager<TFilter extends AggregationFilterBase> {
 
     /**
      * Mark filters as stale or discard them based on data size change.
-     * When data size changes significantly (>10x), filters are discarded to prevent
+     * When data size changes significantly (>=2x), filters are discarded to prevent
      * incorrect array reuse.
      */
     markStale(dataLength: number): void {
         const ratio = this._dataLength > 0 ? dataLength / this._dataLength : 0;
-        if (ratio > 10 || ratio < 0.1 || this._dataLength === 0) {
+        if (ratio >= 2 || ratio <= 0.5 || this._dataLength === 0) {
             this._filters = undefined;
-            this._dataLength = dataLength;
         } else if (this._filters) {
             for (const f of this._filters) {
                 (f as TFilter & { stale?: boolean }).stale = true;
             }
-        } else {
-            this._dataLength = dataLength;
         }
 
+        this._dataLength = dataLength;
         this.executor.cancel();
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
@@ -1823,6 +1823,12 @@ describe('LineSeries', () => {
     });
 
     describe('aggregation data size transitions', () => {
+        const getNodeDataCount = () => {
+            const chartInstance = deproxy(chart);
+            const series = chartInstance.series[0] as any;
+            return series.contextNodeData?.nodeData?.length ?? 0;
+        };
+
         it('should render consistent node count after data size transitions (small -> large -> small)', async () => {
             const smallData = Array.from({ length: 100 }, (_, i) => ({ x: i, y: Math.random() * 100 }));
             const largeData = Array.from({ length: 10000 }, (_, i) => ({ x: i, y: Math.random() * 100 }));
@@ -1835,12 +1841,6 @@ describe('LineSeries', () => {
             prepareTestOptions(options);
             chart = AgCharts.create(options);
             await waitForChartStability(chart);
-
-            const getNodeDataCount = () => {
-                const chartInstance = deproxy(chart);
-                const series = chartInstance.series[0] as any;
-                return series.contextNodeData?.nodeData?.length ?? 0;
-            };
 
             const initialNodeCount = getNodeDataCount();
             expect(initialNodeCount).toBeGreaterThan(0);
@@ -1857,6 +1857,42 @@ describe('LineSeries', () => {
             const finalNodeCount = getNodeDataCount();
 
             expect(finalNodeCount).toBe(initialNodeCount);
+        });
+
+        it('should render correct node count after multi-step data size transitions', async () => {
+            const data1K = Array.from({ length: 1000 }, (_, i) => ({ x: i, y: Math.sin(i / 10) * 100 }));
+            const data10K = Array.from({ length: 10000 }, (_, i) => ({ x: i, y: Math.sin(i / 10) * 100 }));
+            const data100K = Array.from({ length: 100000 }, (_, i) => ({ x: i, y: Math.sin(i / 10) * 100 }));
+
+            const options: AgCartesianChartOptions = {
+                data: data1K,
+                series: [{ type: 'line', xKey: 'x', yKey: 'y', marker: { enabled: true } }],
+            };
+
+            prepareTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const baseline1K = getNodeDataCount();
+            expect(baseline1K).toBeGreaterThan(0);
+
+            // 1K -> 10K
+            await chart.update({ ...options, data: data10K });
+            await waitForChartStability(chart);
+
+            // 10K -> 1K (should match baseline)
+            await chart.update({ ...options, data: data1K });
+            await waitForChartStability(chart);
+            expect(getNodeDataCount()).toBe(baseline1K);
+
+            // 1K -> 100K
+            await chart.update({ ...options, data: data100K });
+            await waitForChartStability(chart);
+
+            // 100K -> 1K (should match baseline)
+            await chart.update({ ...options, data: data1K });
+            await waitForChartStability(chart);
+            expect(getNodeDataCount()).toBe(baseline1K);
         });
     });
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16832

- Tighten `markStale()` thresholds from 10x to 2x and always update `_dataLength` unconditionally to prevent drift
- Add unit tests for `AggregationManager.markStale()` covering threshold boundaries, initial state, and multi-step drift sequences
- Add integration test for multi-step dataset switching (1K → 10K → 1K → 100K → 1K) in `lineSeries.test.ts`