### PR TITLE
Route chart update requests through eventsHub

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -351,7 +351,6 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
             withDragInterpretation: options.optionMetadata.withDragInterpretation ?? true,
             syncManager: new SyncManager(this),
             fireEvent: (event) => this.fireEvent(event),
-            updateCallback: (type, opts) => this.update(type, opts),
             updateMutex: this.updateMutex,
         }));
 
@@ -373,7 +372,9 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
             ctx.eventsHub.on('rtl:change', () => {
                 ctx.scene.canvas.setDirection(ctx.domManager.isRtl);
                 this.update(ChartUpdateType.PERFORM_LAYOUT);
-            })
+            }),
+            ctx.eventsHub.on('chart:request-update', (e) => this.update(e.type, e.opts)),
+            ctx.scene.on('scene-changed', () => this.update(ChartUpdateType.SCENE_RENDER))
         );
         ctx.scene.canvas.setDirection(ctx.domManager.isRtl);
 

--- a/packages/ag-charts-community/src/chart/chartContext.ts
+++ b/packages/ag-charts-community/src/chart/chartContext.ts
@@ -1,7 +1,6 @@
 import {
     AgDocument,
     CallbackCache,
-    ChartUpdateType,
     CleanupRegistry,
     EventEmitter,
     ModuleRegistry,
@@ -43,7 +42,7 @@ import { LegendManager } from './legend/legendManager';
 import { OptionsGraphService } from './optionsGraphService';
 import { SeriesStateManager } from './series/seriesStateManager';
 import type { Tooltip } from './tooltip/tooltip';
-import { type UpdateCallback, UpdateService } from './updateService';
+import { UpdateService } from './updateService';
 
 export class ChartContext implements ModuleContext {
     readonly eventsHub = new EventEmitter<EventsHubMap>();
@@ -95,7 +94,6 @@ export class ChartContext implements ModuleContext {
             domMode?: 'normal' | 'minimal';
             withDragInterpretation: boolean;
             fireEvent: <TEvent extends TypedEvent>(event: TEvent) => void;
-            updateCallback: UpdateCallback;
             updateMutex: Mutex;
         }
     ) {
@@ -106,7 +104,6 @@ export class ChartContext implements ModuleContext {
             agDocument,
             container,
             fireEvent,
-            updateCallback,
             updateMutex,
             styleContainer,
             skipCss,
@@ -140,11 +137,6 @@ export class ChartContext implements ModuleContext {
 
         this.scene = scene ?? new Scene({ canvasElement, pixelRatio: localWindow.devicePixelRatio ?? 1 });
         this.scene.setRoot(root);
-        this.cleanup.register(
-            this.scene.on('scene-changed', () => {
-                this.updateService.update(ChartUpdateType.SCENE_RENDER);
-            })
-        );
 
         this.axisManager = new AxisManager(this.eventsHub, root);
         this.legendManager = new LegendManager(this.eventsHub);
@@ -153,7 +145,7 @@ export class ChartContext implements ModuleContext {
         this.interactionManager = new InteractionManager();
         this.contextMenuRegistry = new ContextMenuRegistry(this.eventsHub);
         this.optionsGraphService = new OptionsGraphService();
-        this.updateService = new UpdateService(updateCallback);
+        this.updateService = new UpdateService();
         this.activeManager = new ActiveManager(
             this.chartService,
             this.eventsHub,

--- a/packages/ag-charts-community/src/chart/chartProxy.ts
+++ b/packages/ag-charts-community/src/chart/chartProxy.ts
@@ -378,7 +378,10 @@ export class AgChartInstanceProxy implements AgChartProxy {
 
     private async setStateOriginators(state: AgChartState, originators: MementoOriginator[]) {
         this.factoryApi.caretaker.restore(state, ...originators);
-        this.chart?.ctx.updateService.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true });
+        this.chart?.ctx.eventsHub.emit('chart:request-update', {
+            type: ChartUpdateType.PROCESS_DATA,
+            opts: { forceNodeDataRefresh: true },
+        });
         await this.chart?.waitForUpdate();
     }
 }

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -357,7 +357,7 @@ export class Legend extends BaseProperties {
         super();
 
         this.pagination = new Pagination(
-            (type: ChartUpdateType) => ctx.updateService.update(type),
+            () => ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER }),
             (page) => this.updatePageNumber(page)
         );
         this.pagination.attachPagination(this.group);
@@ -916,7 +916,7 @@ export class Legend extends BaseProperties {
         this.updatePositions(pageNumber);
         this.domProxy.onPageChange({ itemSelection, group, pagination, interactive: this.isInteractive() });
 
-        this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
     }
 
     update() {
@@ -1130,9 +1130,9 @@ export class Legend extends BaseProperties {
         this.updateHighlight(newEnabled, datum, series);
 
         this.ctx.legendManager.update();
-        this.ctx.updateService.update(ChartUpdateType.PROCESS_DATA, {
-            forceNodeDataRefresh: true,
-            skipAnimations: datum.skipAnimations ?? false,
+        this.ctx.eventsHub.emit('chart:request-update', {
+            type: ChartUpdateType.PROCESS_DATA,
+            opts: { forceNodeDataRefresh: true, skipAnimations: datum.skipAnimations ?? false },
         });
 
         return true;
@@ -1202,7 +1202,10 @@ export class Legend extends BaseProperties {
         }
 
         this.ctx.legendManager.update();
-        this.ctx.updateService.update(ChartUpdateType.PROCESS_DATA, { forceNodeDataRefresh: true });
+        this.ctx.eventsHub.emit('chart:request-update', {
+            type: ChartUpdateType.PROCESS_DATA,
+            opts: { forceNodeDataRefresh: true },
+        });
 
         return true;
     }

--- a/packages/ag-charts-community/src/chart/pagination/pagination.ts
+++ b/packages/ag-charts-community/src/chart/pagination/pagination.ts
@@ -1,13 +1,4 @@
-import {
-    ActionOnSet,
-    BaseProperties,
-    ChartUpdateType,
-    FONT_SIZE,
-    ObserveChanges,
-    Property,
-    clamp,
-    createId,
-} from 'ag-charts-core';
+import { ActionOnSet, BaseProperties, FONT_SIZE, ObserveChanges, Property, clamp, createId } from 'ag-charts-core';
 import type { AgChartLegendOrientation, AgMarkerShape, FontStyle, FontWeight } from 'ag-charts-types';
 
 import { Group, TranslatableGroup } from '../../scene/group';
@@ -101,7 +92,7 @@ export class Pagination extends BaseProperties {
     private highlightActive?: 'previous' | 'next';
 
     constructor(
-        private readonly chartUpdateCallback: (type: ChartUpdateType) => void,
+        private readonly chartUpdateCallback: () => void,
         private readonly pageUpdateCallback: (newPage: number) => void
     ) {
         super();
@@ -304,7 +295,7 @@ export class Pagination extends BaseProperties {
     public onMouseHover(node: 'previous' | 'next' | undefined) {
         this.highlightActive = node;
         this.updateMarkers();
-        this.chartUpdateCallback(ChartUpdateType.SCENE_RENDER);
+        this.chartUpdateCallback();
     }
 
     private onPaginationChanged() {
@@ -322,7 +313,7 @@ export class Pagination extends BaseProperties {
     onMarkerShapeChange() {
         this.updatePositions();
         this.updateMarkers();
-        this.chartUpdateCallback(ChartUpdateType.SCENE_RENDER);
+        this.chartUpdateCallback();
     }
 
     attachPagination(node: Group) {

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -1823,13 +1823,13 @@ export class DonutSeries extends PolarSeries<PieDonutNodeDatum, AgDonutSeriesOpt
     setLegendState(enabledItems: boolean[]) {
         const {
             id: seriesId,
-            ctx: { legendManager, updateService },
+            ctx: { legendManager, eventsHub },
         } = this;
         for (const [itemId, enabled] of enabledItems.entries()) {
             legendManager.toggleItem(enabled, seriesId, itemId);
         }
         legendManager.update();
-        updateService.update(ChartUpdateType.SERIES_UPDATE);
+        eventsHub.emit('chart:request-update', { type: ChartUpdateType.SERIES_UPDATE });
     }
 
     override animateEmptyUpdateReady(_data?: PolarAnimationData) {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -261,7 +261,7 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     private update(type?: ChartUpdateType, opts?: UpdateOpts) {
-        this.chart.ctx.updateService.update(type, opts);
+        this.chart.ctx.eventsHub.emit('chart:request-update', { type, opts });
     }
 
     public seriesChanged(series: UnknownSeries[]) {

--- a/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
+++ b/packages/ag-charts-community/src/chart/update/dataWindowProcessor.ts
@@ -38,11 +38,11 @@ export class DataWindowProcessor<D extends object> implements UpdateProcessor {
 
     private onDataLoad() {
         this.animationManager.skip();
-        this.updateService.update(ChartUpdateType.UPDATE_DATA);
+        this.eventsHub.emit('chart:request-update', { type: ChartUpdateType.UPDATE_DATA });
     }
 
     private onDataError() {
-        this.updateService.update(ChartUpdateType.PERFORM_LAYOUT);
+        this.eventsHub.emit('chart:request-update', { type: ChartUpdateType.PERFORM_LAYOUT });
     }
 
     private onDataSourceChange() {

--- a/packages/ag-charts-community/src/chart/updateService.ts
+++ b/packages/ag-charts-community/src/chart/updateService.ts
@@ -1,8 +1,6 @@
-import { ChartAxisDirection, ChartUpdateType, EventEmitter, type EventListener } from 'ag-charts-core';
+import { ChartAxisDirection, EventEmitter, type EventListener } from 'ag-charts-core';
 
 import type { ISeries } from './series/seriesTypes';
-
-export type UpdateCallback = (type: ChartUpdateType, opts?: UpdateOpts) => void;
 
 export interface UpdateCompleteEvent {
     readonly type: 'update-complete';
@@ -51,18 +49,12 @@ interface EventMap {
 export class UpdateService {
     private readonly events = new EventEmitter<EventMap>();
 
-    constructor(private readonly updateCallback: UpdateCallback) {}
-
     public addListener<K extends keyof EventMap>(eventName: K, listener: EventListener<EventMap[K]>) {
         return this.events.on(eventName, listener);
     }
 
     public destroy() {
         this.events.clear();
-    }
-
-    public update(type = ChartUpdateType.FULL, options?: UpdateOpts) {
-        this.updateCallback(type, options);
     }
 
     public dispatchUpdateComplete(apiUpdate: boolean, wasShortcut: boolean) {

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -1,6 +1,7 @@
 import type {
     AxisID,
     ChartAxisDirection,
+    ChartUpdateType,
     DeepReadonly,
     DefinedZoomState,
     Scale,
@@ -27,6 +28,7 @@ import { DataSet } from '../chart/data/dataSet';
 import type { ContextShowOnMap } from '../chart/interaction/contextMenuTypes';
 import type { CategoryLegendDatum, ChartLegendType } from '../chart/legend/legendDatum';
 import type { DatumIndexType, SeriesNodeDatum } from '../chart/series/seriesTypes';
+import type { UpdateOpts } from '../chart/updateService';
 import type { BBox } from '../scene/bbox';
 import type { KeyboardWidgetEvent, MouseWidgetEvent } from '../widget/widgetEvents';
 
@@ -106,6 +108,7 @@ export interface EventsHubMap {
      */
     'zoom:change-complete': ZoomChangeCompleteEvent;
     'zoom:pan-start': ZoomPanStartEvent;
+    'chart:request-update': UpdateRequestEvent;
 }
 
 export interface ActiveLoadMementoEvent {
@@ -263,6 +266,11 @@ export interface ZoomChangeCompleteEvent {
 
 export interface ZoomPanStartEvent {
     readonly callerId: string;
+}
+
+export interface UpdateRequestEvent {
+    readonly type?: ChartUpdateType;
+    readonly opts?: UpdateOpts;
 }
 
 export interface HighlightNodeDatum<I extends DatumIndexType = DatumIndexType> extends SeriesNodeDatum<I> {

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -1223,7 +1223,7 @@ export class Annotations extends AbstractModuleInstance {
         );
     }
 
-    private update(status = ChartUpdateType.PRE_SCENE_RENDER) {
-        this.ctx.updateService.update(status);
+    private update(type = ChartUpdateType.PRE_SCENE_RENDER) {
+        this.ctx.eventsHub.emit('chart:request-update', { type });
     }
 }

--- a/packages/ag-charts-enterprise/src/features/background/background.ts
+++ b/packages/ag-charts-enterprise/src/features/background/background.ts
@@ -26,6 +26,6 @@ export class Background extends _ModuleSupport.Background<Image> {
     }
 
     protected onImageLoad() {
-        this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
     }
 }

--- a/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
+++ b/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
@@ -78,7 +78,7 @@ export class BandHighlight extends AbstractModuleInstance {
             const isSeriesAreaChild = target instanceof HTMLElement && ctx.domManager.contains(target, 'series-area');
             if (this.bandHighlightGroup.visible && !isSeriesAreaChild) {
                 this.hideBand();
-                this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+                this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
             }
         });
 
@@ -216,7 +216,7 @@ export class BandHighlight extends AbstractModuleInstance {
             this.hideBand();
         }
 
-        this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
     }
 
     private updateBandPosition() {

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -79,7 +79,7 @@ export class Crosshair extends AbstractModuleInstance {
             const isSeriesAreaChild = target instanceof HTMLElement && ctx.domManager.contains(target, 'series-area');
             if (this.crosshairGroup.visible && !isSeriesAreaChild) {
                 this.hideCrosshairs();
-                this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+                this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
             }
         });
 
@@ -216,13 +216,13 @@ export class Crosshair extends AbstractModuleInstance {
         this.updatePositions(this.getData(event));
         this.crosshairGroup.visible = true;
 
-        this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
     }
 
     private onMouseOut() {
         if (!this.ctx.interactionManager.isState(InteractionState.Clickable)) return;
         this.hideCrosshairs();
-        this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
     }
 
     private onKeyPress() {

--- a/packages/ag-charts-enterprise/src/features/foreground/foreground.ts
+++ b/packages/ag-charts-enterprise/src/features/foreground/foreground.ts
@@ -48,7 +48,7 @@ export class Foreground extends _ModuleSupport.Background<Image> {
     }
 
     protected onImageLoad() {
-        this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
     }
 
     private updateTextNode(placement: Placement) {

--- a/packages/ag-charts-enterprise/src/features/scrollbar/scrollbar.ts
+++ b/packages/ag-charts-enterprise/src/features/scrollbar/scrollbar.ts
@@ -378,7 +378,7 @@ export class Scrollbar extends AbstractModuleInstance {
 
         state.hovered = nextHovered;
         this.updateStyles(state);
-        this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER);
+        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
     }
 
     override destroy() {

--- a/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
+++ b/packages/ag-charts-enterprise/src/features/sync/chartSync.ts
@@ -105,9 +105,12 @@ export class ChartSync extends BaseProperties implements ModuleInstance, AgChart
     private updateChart(chart: _ModuleSupport.SyncChartLike, updateType = ChartUpdateType.PROCESS_DOMAIN) {
         debug('ChartSync.updateChart()', chart.id, ChartUpdateType[updateType], chart);
         if (updateType === ChartUpdateType.PROCESS_DOMAIN) {
-            chart.ctx.updateService.update(updateType, { forceNodeDataRefresh: true });
+            chart.ctx.eventsHub.emit('chart:request-update', {
+                type: updateType,
+                opts: { forceNodeDataRefresh: true },
+            });
         } else {
-            chart.ctx.updateService.update(updateType);
+            chart.ctx.eventsHub.emit('chart:request-update', { type: updateType });
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -459,7 +459,10 @@ export class Zoom extends AbstractModuleInstance {
         }
 
         tooltipManager.updateTooltip(TOOLTIP_ID);
-        updateService.update(ChartUpdateType.PERFORM_LAYOUT, { skipAnimations: true });
+        eventsHub.emit('chart:request-update', {
+            type: ChartUpdateType.PERFORM_LAYOUT,
+            opts: { skipAnimations: true },
+        });
     }
 
     private onSeriesAreaDragEnd() {
@@ -501,7 +504,7 @@ export class Zoom extends AbstractModuleInstance {
                         this.updateZoom(userInteraction('zoom-seriesarea-selector'), newZoom);
                     } else {
                         // Change rejected (invalid zoom) - redraw canvas to remove the zoom-selection.
-                        this.ctx.updateService.update();
+                        this.ctx.eventsHub.emit('chart:request-update', { type: ChartUpdateType.SCENE_RENDER });
                     }
                 }
                 break;
@@ -591,7 +594,10 @@ export class Zoom extends AbstractModuleInstance {
         }
 
         tooltipManager.updateTooltip(TOOLTIP_ID);
-        updateService.update(ChartUpdateType.PERFORM_LAYOUT, { skipAnimations: true });
+        eventsHub.emit('chart:request-update', {
+            type: ChartUpdateType.PERFORM_LAYOUT,
+            opts: { skipAnimations: true },
+        });
     }
 
     private onAxisDragEnd() {

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -428,7 +428,7 @@ export class Zoom extends AbstractModuleInstance {
             paddedRect,
             panner,
             selector,
-            ctx: { interactionManager, tooltipManager, updateService },
+            ctx: { interactionManager, tooltipManager, eventsHub },
         } = this;
 
         if (this.activeAxis) {
@@ -564,7 +564,7 @@ export class Zoom extends AbstractModuleInstance {
             enableAxisDragging,
             seriesRect,
             shouldFlipXY,
-            ctx: { interactionManager, tooltipManager, updateService, zoomManager },
+            ctx: { interactionManager, tooltipManager, eventsHub, zoomManager },
         } = this;
 
         if (!enabled || !enableAxisDragging || !seriesRect) return;
@@ -975,7 +975,10 @@ export class Zoom extends AbstractModuleInstance {
 
         if (!this.isZoomValid(zoom, validOptions)) {
             // Ensure any lingering zoom interaction elements (e.g. selection rect) are cleared
-            this.ctx.updateService.update(ChartUpdateType.SCENE_RENDER, { skipAnimations: true });
+            this.ctx.eventsHub.emit('chart:request-update', {
+                type: ChartUpdateType.SCENE_RENDER,
+                opts: { skipAnimations: true },
+            });
             return false;
         }
 


### PR DESCRIPTION
Removes `UpdateService.update()` and routes all chart update requests through `eventsHub.emit('chart:request-update', ...)` instead. A single centralised listener in `chart.ts` handles the event. `UpdateService` is retained for its lifecycle dispatch methods (`pre-series-update`, `update-complete`, etc.).