### PR TITLE
Add validate-prompts skill with path exception rules

### DIFF
--- a/.rulesync/README.md
+++ b/.rulesync/README.md
@@ -74,6 +74,12 @@ Quick-reference for all AI agent commands, skills, sub-agents, and rules availab
 | Agent   | 🟠 `technical-research-analyst`    | Auto                                 | In-depth technical research with citations         |
 | Agent   | 🔵 `nx-expert`                     | Auto                                 | Nx monorepo configuration and build optimisation   |
 
+## Prompt Hygiene
+
+| Type  | Name                  | Invoke                     | What it does                                     |
+| ----- | --------------------- | -------------------------- | ------------------------------------------------ |
+| Skill | 🔵 `validate-prompts` | `/validate-prompts` (user) | Validate prompt file references for path hygiene |
+
 ## Memory
 
 | Type    | Name                   | Invoke              | What it does                                       |
@@ -168,31 +174,32 @@ Rules load automatically when you edit files matching their glob patterns.
 
 Skills load on-demand when invoked. All skills are invoked via `/skill-name`. All skills are shared across AI tools via `.rulesync/skills/`.
 
-| Skill                           | Description                                               |
-| ------------------------------- | --------------------------------------------------------- |
-| 🔵 `batch-lint-cleanup`         | Auto-fix ESLint violations by rule                        |
-| 🔵 `code-fixup`                 | Fix build and lint errors across a package                |
-| 🔵 `dev-server`                 | Start dev server, check build status                      |
-| 🟠 `estimate-jira`              | Estimate complexity, effort, and risks for JIRA tickets   |
-| 🔵 `git-bisect`                 | Find the commit that introduced a regression              |
-| 🔵 `git-conventions`            | Branch, commit, and PR naming conventions                 |
-| 🔵 `git-split`                  | Split large files preserving git history                  |
-| 🔵 `git-worktree-clean`         | Hard-reset worktree to `origin/latest`                    |
-| 🟠 `jira-create`                | Create JIRA tickets with proper formatting and templates  |
-| 🟠 `optimize-series`            | Series performance optimisation and GC pressure reduction |
-| 🔵 `plan-implementation-review` | Review plan execution, identify delivery gaps             |
-| 🔵 `plan-review`                | Review plans for completeness and correctness             |
-| 🟠 `plunker`                    | Create and manage Plunker demos for AG Charts             |
-| 🔵 `pr-create`                  | Commit, push, and open a PR                               |
-| 🔵 `pr-review`                  | Review a PR (Markdown default, JSON with `--json`)        |
-| 🔵 `pr-split`                   | Split a branch into stacked PRs                           |
-| 🔵 `recall`                     | Load branch context, browse project memories              |
-| 🟢 `releases`                   | Release conventions, branch naming, and constraints       |
-| 🔵 `remember`                   | Save branch context or project learnings as memory        |
-| 🟠 `spruce-docs`                | Create or improve documentation following patterns        |
-| 🟠 `spruce-example`             | Improve gallery examples to professional quality          |
-| 🔵 `sync-ag-shared`             | Sync ag-shared subrepo changes across AG repos            |
-| 🟢 `technology-stack`           | Architecture constraints and zero-dependency requirements |
+| Skill                           | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| 🔵 `batch-lint-cleanup`         | Auto-fix ESLint violations by rule                          |
+| 🔵 `code-fixup`                 | Fix build and lint errors across a package                  |
+| 🔵 `dev-server`                 | Start dev server, check build status                        |
+| 🟠 `estimate-jira`              | Estimate complexity, effort, and risks for JIRA tickets     |
+| 🔵 `git-bisect`                 | Find the commit that introduced a regression                |
+| 🔵 `git-conventions`            | Branch, commit, and PR naming conventions                   |
+| 🔵 `git-split`                  | Split large files preserving git history                    |
+| 🔵 `git-worktree-clean`         | Hard-reset worktree to `origin/latest`                      |
+| 🟠 `jira-create`                | Create JIRA tickets with proper formatting and templates    |
+| 🟠 `optimize-series`            | Series performance optimisation and GC pressure reduction   |
+| 🔵 `plan-implementation-review` | Review plan execution, identify delivery gaps               |
+| 🔵 `plan-review`                | Review plans for completeness and correctness               |
+| 🟠 `plunker`                    | Create and manage Plunker demos for AG Charts               |
+| 🔵 `pr-create`                  | Commit, push, and open a PR                                 |
+| 🔵 `pr-review`                  | Review a PR (Markdown default, JSON with `--json`)          |
+| 🔵 `pr-split`                   | Split a branch into stacked PRs                             |
+| 🔵 `recall`                     | Load branch context, browse project memories                |
+| 🟢 `releases`                   | Release conventions, branch naming, and constraints         |
+| 🔵 `remember`                   | Save branch context or project learnings as memory          |
+| 🟠 `spruce-docs`                | Create or improve documentation following patterns          |
+| 🟠 `spruce-example`             | Improve gallery examples to professional quality            |
+| 🔵 `sync-ag-shared`             | Sync ag-shared subrepo changes across AG repos              |
+| 🟢 `technology-stack`           | Architecture constraints and zero-dependency requirements   |
+| 🔵 `validate-prompts`           | Validate prompt file references for consistency and hygiene |
 
 ---
 

--- a/.rulesync/rules/ag-charts.md
+++ b/.rulesync/rules/ag-charts.md
@@ -43,3 +43,4 @@ After meaningful chart changes, also run:
 -   **Dev server:** `yarn nx dev`
 -   **Clean:** `yarn nx clean` – purge dist folders when switching branches
 -   **Benchmark:** `yarn nx benchmark <package>`
+-   **NX daemon:** Always use `NX_DAEMON=false` for nx commands to avoid pipe hangs (set automatically via SessionStart hook)

--- a/.rulesync/skills/validate-prompts
+++ b/.rulesync/skills/validate-prompts
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/skills/validate-prompts

--- a/external/ag-shared/prompts/skills/validate-prompts/SKILL.md
+++ b/external/ag-shared/prompts/skills/validate-prompts/SKILL.md
@@ -1,0 +1,153 @@
+---
+targets: ['*']
+name: validate-prompts
+description: 'Validate prompt file references for consistency, canonical paths, and hygiene'
+invocable: user-only
+---
+
+# Validate Prompts Skill
+
+This skill scans `.rulesync/` source files for common path reference issues and reports them. It does **not** auto-fix anything — it reports only, so the user can review before making changes.
+
+## When to Use This Skill
+
+Activate this skill when the user requests:
+
+-   "Run validate-prompts"
+-   "Check prompt file references"
+-   "Validate rulesync files"
+-   "Are there any stale references in the prompts?"
+
+## Workflow
+
+### Step 1: Bare `skills/` or `rules/` references
+
+Grep `.rulesync/` source files (skills, rules, commands) for unanchored `skills/` or `rules/` paths that are not:
+
+-   Relative paths starting with `../` or `./`
+-   Already prefixed with `.rulesync/`
+-   Co-located file references (bare filename with no directory separator)
+
+These should use `.rulesync/skills/` or `.rulesync/rules/` as the prefix.
+
+```bash
+grep -rn --include="*.md" -E "(^|[^./\w])(skills|rules)/" .rulesync/ | grep -v "\.rulesync/" | grep -v "\.\.\/" | grep -v "^\.\/"
+```
+
+### Step 2: `external/prompts/` or `external/ag-shared/prompts/` references
+
+Any path using `external/` directly should use the `.rulesync/` equivalent instead. Three categories are **excluded** from this check (but still validated for existence in Step 6):
+
+-   `.rulesync/README.md` — structural overview that describes the `external/prompts/` convention by design
+-   `external/prompts/**/_*.md` — underscore-prefixed shared core partials with no `.rulesync/` equivalent
+-   `external/prompts/technical-review*/**` — review exception/plan files that live in `external/prompts/` by design
+
+```bash
+grep -rn --include="*.md" -E "external/(prompts|ag-shared/prompts)/" .rulesync/
+```
+
+After running the grep, filter out hits matching these patterns:
+
+-   The file producing the hit is `.rulesync/README.md`
+-   The matched path matches `external/prompts/_*.md` (underscore-prefixed partial)
+-   The matched path matches the prefix `external/prompts/technical-review*/`
+
+The remaining hits are genuine issues. Note: excluded `external/` paths are still validated for file existence in Step 6.
+
+### Step 3: `.claude/` references in source files
+
+`.rulesync/` source files should not reference `.claude/` paths (which are generated output). Exclude `.gitignore` from this check.
+
+```bash
+grep -rn --include="*.md" "\.claude/" .rulesync/ | grep -v "\.gitignore" | grep -v "README\.md"
+```
+
+### Step 4: Stale symlinks in `.rulesync/`
+
+Check for broken symlinks whose targets no longer exist.
+
+```bash
+find .rulesync/ -type l | while read link; do
+  if [ ! -e "$link" ]; then
+    echo "$link -> (broken: $(readlink "$link"))"
+  fi
+done
+```
+
+### Step 5: Orphaned generated files in `.claude/`
+
+Run rulesync's check mode to see if generated files are out of date.
+
+```bash
+npx rulesync generate --check
+```
+
+Note: If `npx rulesync generate --check` is not supported, skip this step and note it in the report.
+
+### Step 6: Cross-reference validation
+
+For each file path referenced in backticks within `.rulesync/` files, verify the target exists. Skip:
+
+-   `${VARIABLE}` placeholders
+-   Relative co-located references (bare filenames like `jira-bug-template.md` noted as "in this skill directory")
+-   Relative paths (`../../rules/jira.md`, `../jira-create/SKILL.md`)
+-   Non-file references (URLs, command examples, code snippets)
+
+Extract backtick references that look like file paths (contain `/` and don't start with `$`):
+
+```bash
+grep -rn --include="*.md" -oE '\`[^`]*\/[^`]*\`' .rulesync/ | grep -v '\${'
+```
+
+For each match, determine if it's a plausible file path (ends in `.md`, `.ts`, `.json`, etc. or contains a directory structure) and check if it exists from the repo root.
+
+In addition, validate `external/` paths that were excluded from Step 2 (underscore-prefixed partials and technical-review files) — check these for existence unless they contain `${VARIABLE}` placeholders.
+
+## Output Format
+
+Produce a grouped report in this exact format:
+
+```
+## Prompt Validation Report
+
+### Bare path references (need .rulesync/ prefix)
+- .rulesync/skills/foo/SKILL.md:42: `rules/jira.md`
+
+### external/ path references (use .rulesync/ instead)
+- .rulesync/skills/bar/SKILL.md:31: `external/prompts/commands/baz.md`
+
+### .claude/ references in source files (use .rulesync/ instead)
+- .rulesync/skills/qux/SKILL.md:26: `.claude/rules/technology-stack.md`
+
+### Stale symlinks
+- .rulesync/commands/old-command.md -> (broken)
+
+### Generated files out of date
+- (output from rulesync generate --check, or "Check not supported / skipped")
+
+### Broken cross-references
+- .rulesync/skills/foo/SKILL.md:88 references `.rulesync/rules/nonexistent.md` (not found)
+
+✅ No issues found
+```
+
+Or, if issues were found:
+
+```
+❌ Found N issue(s)
+```
+
+with a count of total issues across all sections.
+
+## Anti-patterns / Rules
+
+-   **Do NOT auto-fix** — report only, never modify any files
+-   **Do NOT modify any files** during this skill
+-   Co-located references (e.g. `jira-bug-template.md` with "(in this skill directory)") are OK — skip these
+-   Relative paths (`../../rules/jira.md`, `../jira-create/SKILL.md`) are OK — skip these
+-   `.gitignore` entries referencing `.claude/` are OK — skip these
+-   `${VARIABLE}` placeholders are OK — skip these
+-   Grep output in code examples (e.g. `grep -rn "skills/"`) are OK — only flag prose references
+-   `.rulesync/README.md` is excluded from Steps 2 and 3 — it is a structural overview document that describes the `external/prompts/` and `.claude/` conventions by design
+-   `external/prompts/**/_*.md` references (underscore-prefixed shared partials) are OK in Step 2 — validate existence in Step 6
+-   `external/prompts/technical-review*/**` references are OK in Step 2 — validate existence in Step 6


### PR DESCRIPTION
Adds the `validate-prompts` skill (`/validate-prompts`) for checking `.rulesync/` source files for path reference hygiene.

**Skill capabilities:**
- Detects bare `skills/`/`rules/` references missing the `.rulesync/` prefix
- Flags `external/` paths that should use `.rulesync/` equivalents
- Detects `.claude/` references in source files (generated output paths)
- Checks for stale symlinks and orphaned generated files
- Cross-validates backtick file path references for existence

**Exception rules added** to avoid false positives:
- `.rulesync/README.md` excluded from Steps 2 & 3 (structural overview referencing both conventions by design)
- `external/prompts/**/_*.md` underscore-prefixed partials excluded from Step 2 (no `.rulesync/` equivalent exists)
- `external/prompts/technical-review*/**` files excluded from Step 2 (live in `external/` by design)

All excluded paths are still validated for existence in Step 6.

Also includes:
- README entry for the new skill
- `NX_DAEMON=false` note in `ag-charts.md` rules