### PR TITLE
AG-3390: sync ag-shared (snyk-viewer security fixes)

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 6291054c31953361956bc031c487e4677603383b
+	commit = 08ff2b3f8deb7ed222f97dbc1e76d4317693e729
 	parent = 47e26ac720d58fe6128139fb360248c71cfb274a
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 29f3a8a32237910aff3bc535e3b9b622466817fe
+	commit = 7a59e51c579a290f5a3e2262a67fa0e8f9398dc2
 	parent = 47e26ac720d58fe6128139fb360248c71cfb274a
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 08ff2b3f8deb7ed222f97dbc1e76d4317693e729
+	commit = 29f3a8a32237910aff3bc535e3b9b622466817fe
 	parent = 47e26ac720d58fe6128139fb360248c71cfb274a
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/prompts/.claude-settings.json
+++ b/external/ag-shared/prompts/.claude-settings.json
@@ -1,77 +1,73 @@
 {
-    "permissions": {
-        "allow": [
-            "Bash(command -v:*)",
-            "Bash(find:*)",
-            "Bash(gh pr checkout:*)",
-            "Bash(gh pr checks:*)",
-            "Bash(gh pr diff:*)",
-            "Bash(gh pr list:*)",
-            "Bash(gh pr review:*)",
-            "Bash(gh pr view:*)",
-            "Bash(git fetch:*)",
-            "Bash(git ls-tree:*)",
-            "Bash(grep:*)",
-            "Bash(jq:*)",
-            "Bash(ls:*)",
-            "Bash(mkdir:*)",
-            "Bash(npx tsc:*)",
-            "Bash(nx benchmark:*)",
-            "Bash(nx build:*)",
-            "Bash(nx dev)",
-            "Bash(nx e2e:*)",
-            "Bash(nx format:*)",
-            "Bash(nx lint:*)",
-            "Bash(nx run:*)",
-            "Bash(nx show projects:*)",
-            "Bash(nx test:*)",
-            "Bash(rg:*)",
-            "Bash(touch:*)",
-            "Bash(yarn nx build:*)",
-            "Bash(yarn nx format:write:*)",
-            "Bash(yarn nx:*)",
-            "Bash(yarn test:*)",
-            "WebFetch(domain:ag-grid.atlassian.net)",
-            "WebFetch(domain:docs.anthropic.com)",
-            "WebFetch(domain:docs.github.com)",
-            "WebFetch(domain:github.com)",
-            "WebFetch(domain:localhost)",
-            "WebFetch(domain:www.npmjs.com)",
-            "mcp__ide__getDiagnostics",
-            "mcp__sequential-thinking__sequentialthinking"
-        ],
-        "deny": []
-    },
-    "attribution": {
-        "commit": "",
-        "pr": ""
-    },
-    "hooks": {
-        "PostToolUse": [
-            {
-                "matcher": "Edit|MultiEdit|Write",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "jq -r '.tool_input.file_path' | ( read file_path; yarn nx format --files \"$file_path\" )"
-                    }
-                ]
-            }
-        ],
-        "SessionStart": [
-            {
-                "matcher": "startup",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "\"$CLAUDE_PROJECT_DIR\"/external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh"
-                    },
-                    {
-                        "type": "command",
-                        "command": "if [ -n \"$CLAUDE_ENV_FILE\" ]; then echo 'export NX_DAEMON=false' >> \"$CLAUDE_ENV_FILE\"; fi"
-                    }
-                ]
-            }
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "permissions": {
+    "allow": [
+      "Bash(command -v:*)",
+      "Bash(find:*)",
+      "Bash(gh pr checkout:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr review:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git fetch:*)",
+      "Bash(git ls-tree:*)",
+      "Bash(grep:*)",
+      "Bash(jq:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(npx tsc:*)",
+      "Bash(nx benchmark:*)",
+      "Bash(nx build:*)",
+      "Bash(nx dev)",
+      "Bash(nx e2e:*)",
+      "Bash(nx format:*)",
+      "Bash(nx lint:*)",
+      "Bash(nx run:*)",
+      "Bash(nx show projects:*)",
+      "Bash(nx test:*)",
+      "Bash(rg:*)",
+      "Bash(touch:*)",
+      "Bash(yarn nx build:*)",
+      "Bash(yarn nx format:write:*)",
+      "Bash(yarn nx:*)",
+      "Bash(yarn test:*)",
+      "WebFetch(domain:ag-grid.atlassian.net)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:docs.github.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:localhost)",
+      "WebFetch(domain:www.npmjs.com)",
+      "mcp__ide__getDiagnostics",
+      "mcp__sequential-thinking__sequentialthinking"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | ( read file_path; yarn nx format --files \"$file_path\" )"
+          }
         ]
-    }
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/external/ag-shared/prompts/.claude-settings.json
+++ b/external/ag-shared/prompts/.claude-settings.json
@@ -1,73 +1,77 @@
 {
-  "attribution": {
-    "commit": "",
-    "pr": ""
-  },
-  "permissions": {
-    "allow": [
-      "Bash(command -v:*)",
-      "Bash(find:*)",
-      "Bash(gh pr checkout:*)",
-      "Bash(gh pr checks:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(gh pr list:*)",
-      "Bash(gh pr review:*)",
-      "Bash(gh pr view:*)",
-      "Bash(git fetch:*)",
-      "Bash(git ls-tree:*)",
-      "Bash(grep:*)",
-      "Bash(jq:*)",
-      "Bash(ls:*)",
-      "Bash(mkdir:*)",
-      "Bash(npx tsc:*)",
-      "Bash(nx benchmark:*)",
-      "Bash(nx build:*)",
-      "Bash(nx dev)",
-      "Bash(nx e2e:*)",
-      "Bash(nx format:*)",
-      "Bash(nx lint:*)",
-      "Bash(nx run:*)",
-      "Bash(nx show projects:*)",
-      "Bash(nx test:*)",
-      "Bash(rg:*)",
-      "Bash(touch:*)",
-      "Bash(yarn nx build:*)",
-      "Bash(yarn nx format:write:*)",
-      "Bash(yarn nx:*)",
-      "Bash(yarn test:*)",
-      "WebFetch(domain:ag-grid.atlassian.net)",
-      "WebFetch(domain:docs.anthropic.com)",
-      "WebFetch(domain:docs.github.com)",
-      "WebFetch(domain:github.com)",
-      "WebFetch(domain:localhost)",
-      "WebFetch(domain:www.npmjs.com)",
-      "mcp__ide__getDiagnostics",
-      "mcp__sequential-thinking__sequentialthinking"
-    ],
-    "deny": []
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|MultiEdit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path' | ( read file_path; yarn nx format --files \"$file_path\" )"
-          }
+    "attribution": {
+        "commit": "",
+        "pr": ""
+    },
+    "permissions": {
+        "allow": [
+            "Bash(command -v:*)",
+            "Bash(find:*)",
+            "Bash(gh pr checkout:*)",
+            "Bash(gh pr checks:*)",
+            "Bash(gh pr diff:*)",
+            "Bash(gh pr list:*)",
+            "Bash(gh pr review:*)",
+            "Bash(gh pr view:*)",
+            "Bash(git fetch:*)",
+            "Bash(git ls-tree:*)",
+            "Bash(grep:*)",
+            "Bash(jq:*)",
+            "Bash(ls:*)",
+            "Bash(mkdir:*)",
+            "Bash(npx tsc:*)",
+            "Bash(nx benchmark:*)",
+            "Bash(nx build:*)",
+            "Bash(nx dev)",
+            "Bash(nx e2e:*)",
+            "Bash(nx format:*)",
+            "Bash(nx lint:*)",
+            "Bash(nx run:*)",
+            "Bash(nx show projects:*)",
+            "Bash(nx test:*)",
+            "Bash(rg:*)",
+            "Bash(touch:*)",
+            "Bash(yarn nx build:*)",
+            "Bash(yarn nx format:write:*)",
+            "Bash(yarn nx:*)",
+            "Bash(yarn test:*)",
+            "WebFetch(domain:ag-grid.atlassian.net)",
+            "WebFetch(domain:docs.anthropic.com)",
+            "WebFetch(domain:docs.github.com)",
+            "WebFetch(domain:github.com)",
+            "WebFetch(domain:localhost)",
+            "WebFetch(domain:www.npmjs.com)",
+            "mcp__ide__getDiagnostics",
+            "mcp__sequential-thinking__sequentialthinking"
+        ],
+        "deny": []
+    },
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|MultiEdit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "jq -r '.tool_input.file_path' | ( read file_path; yarn nx format --files \"$file_path\" )"
+                    }
+                ]
+            }
+        ],
+        "SessionStart": [
+            {
+                "matcher": "startup",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh"
+                    },
+                    {
+                        "type": "command",
+                        "command": "if [ -n \"$CLAUDE_ENV_FILE\" ]; then echo 'export NX_DAEMON=false' >> \"$CLAUDE_ENV_FILE\"; fi"
+                    }
+                ]
+            }
         ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh"
-          }
-        ]
-      }
-    ]
-  }
+    }
 }

--- a/external/ag-shared/prompts/skills/sync-ag-shared/SKILL.md
+++ b/external/ag-shared/prompts/skills/sync-ag-shared/SKILL.md
@@ -7,7 +7,7 @@ invocable: user-only
 
 # Sync ag-shared Subrepo Across AG Repos
 
-Orchestrate syncing `external/ag-shared/` changes from the current repo to all other AG repos that consume the subrepo. This handles the full `git subrepo push` / `pull` cycle, companion changes, and cross-linked PRs.
+Orchestrate syncing `external/ag-shared/` changes from the current repo to all other AG repos that consume the subrepo. This handles the full `yarn subrepo push` / `pull` cycle, companion changes, and cross-linked PRs.
 
 ## Help
 
@@ -21,6 +21,8 @@ If the user provides a command option of `help`:
 
 -   Git CLI, GitHub CLI (`gh`), and `yarn` must be available.
 -   `git subrepo` must be installed (`git subrepo --version`).
+-   **Use `yarn subrepo` for push and pull** (never raw `git subrepo push`/`pull`). The wrapper handles edge cases like stale parent references. Other subrepo commands (e.g. `git subrepo status`, `git subrepo clean`) use `git subrepo` directly.
+-   **Never edit `external/ag-shared/.gitrepo` manually.** Only subrepo commands should modify this file.
 -   Must be on a **feature branch** (not `latest`, `main`, or `master`).
 -   Working tree must be **clean** (`git status --porcelain` is empty).
 -   The current repo must have `external/ag-shared/.gitrepo`.
@@ -192,7 +194,7 @@ yarn subrepo pull ag-shared
 git diff HEAD~1 --stat
 
 # Verify the pull succeeded
-git subrepo status ag-shared
+git subrepo status external/ag-shared
 ```
 
 If `subrepo pull` fails in any repo, report the error and **STOP** — ask the user how to proceed.
@@ -231,7 +233,7 @@ For each repo (source + all destinations):
 
 ```bash
 # Check subrepo status
-git subrepo status ag-shared
+git subrepo status external/ag-shared
 
 # Verify clean working tree
 git status --porcelain
@@ -340,7 +342,8 @@ All repos verified. Working trees clean.
 -   **Merge conflicts during subrepo pull:** Stop and ask the user to resolve manually. Provide the conflicting files and repo path.
 -   **Auth failures:** Check `gh auth status` and `git remote -v`. Ask the user to authenticate.
 -   **Dirty working tree:** Always stop and report. Never force-clean a destination repo.
--   **Subrepo push/pull failures:** Report the full error output. Common causes: diverged history (pull first, then push), missing remote access.
+-   **Subrepo push/pull failures:** Report the full error output. Common causes: diverged history (pull first, then push), missing remote access. Always use `yarn subrepo` for push/pull — the wrapper handles stale parent references and other edge cases.
+-   **Never edit `.gitrepo` manually:** Only `yarn subrepo` commands should modify `external/ag-shared/.gitrepo`. If the subrepo state is broken, ask the user to resolve it rather than editing the file directly.
 -   **Stale git lock files:** A failed subrepo operation may leave `index.lock` in the git dir. Remove it and restore `.gitrepo` before retrying (see Step 4).
 -   **Worktree branch conflicts:** Never try to `git checkout` the source branch in the main repo — it's already checked out in the worktree. Always `cd` to the worktree working directory for source repo commands.
 

--- a/external/ag-shared/scripts/snyk-viewer/index.mjs
+++ b/external/ag-shared/scripts/snyk-viewer/index.mjs
@@ -572,11 +572,11 @@ const server = createServer((req, res) => {
                 pkg.resolutions = pkg.resolutions || {};
                 pkg.resolutions[key] = version;
                 writeFileSync(absPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
-                res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ ok: true, key, version }));
+                res.writeHead(200, { 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff' });
+                res.end(JSON.stringify({ ok: true }));
             } catch (err) {
-                res.writeHead(400, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ ok: false, error: err.message }));
+                res.writeHead(400, { 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff' });
+                res.end(JSON.stringify({ ok: false, error: String(err.message) }));
             }
         });
         return;
@@ -633,28 +633,37 @@ const server = createServer((req, res) => {
             let foundField = null;
             let foundVersion = null;
             for (const f of fields) {
-                if (pkgJson[f] && pkg in pkgJson[f]) {
-                    foundField = f;
-                    foundVersion = pkgJson[f][pkg];
-                    break;
+                const section = pkgJson[f];
+                if (section && typeof section === 'object') {
+                    // Iterate own keys to avoid using unsanitised input as a direct property accessor
+                    const match = Object.entries(section).find(([k]) => k === pkg);
+                    if (match) {
+                        foundField = f;
+                        foundVersion = match[1];
+                        break;
+                    }
                 }
             }
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ ok: true, field: foundField, version: foundVersion }));
+            res.writeHead(200, { 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff' });
+            res.end(JSON.stringify({ ok: true, field: foundField ?? '', version: String(foundVersion ?? '') }));
         } catch (err) {
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ ok: false, error: err.message }));
+            res.writeHead(200, { 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff' });
+            res.end(JSON.stringify({ ok: false, error: String(err.message) }));
         }
         return;
     }
 
     // Serve static UI files (.css/.js) from the same directory as ui.html
-    const staticMatch = url.pathname.match(/^\/([a-zA-Z0-9-]+)\.(css|js)$/);
-    if (staticMatch) {
-        const mimeTypes = { css: 'text/css', js: 'application/javascript' };
+    const STATIC_FILES = {
+        '/ui-styles.css': { file: 'ui-styles.css', type: 'text/css' },
+        '/ui-browse.js':  { file: 'ui-browse.js',  type: 'application/javascript' },
+        '/ui-review.js':  { file: 'ui-review.js',  type: 'application/javascript' },
+    };
+    const staticEntry = STATIC_FILES[url.pathname];
+    if (staticEntry) {
         try {
-            const content = readFileSync(resolve(__dirname, staticMatch[1] + '.' + staticMatch[2]));
-            res.writeHead(200, { 'Content-Type': mimeTypes[staticMatch[2]] });
+            const content = readFileSync(resolve(__dirname, staticEntry.file));
+            res.writeHead(200, { 'Content-Type': staticEntry.type });
             res.end(content);
         } catch {
             res.writeHead(404);

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -602,6 +602,7 @@
                 </details>`;
             }).join('');
 
+            const unresolvedCount = vulnCards.filter(c => !c.skipped && ![...c.byDep.values()].every(dps => dps.every(p => p.alreadyIgnored))).length;
             const allVulnIds = [...ignoreVulns.keys()].filter(id => !skipState.vulns.has(id)).join(',');
             const globalActionsHtml = `<div class="rq-actions s3-global-actions">
                 <button class="btn btn-primary" data-action="resolve"
@@ -621,7 +622,7 @@
                         <button class="seg-btn${s3ViewMode === 'by-file' ? ' active' : ''}" data-action="set-s3-view" data-mode="by-file">By File</button>
                         <button class="seg-btn${s3ViewMode === 'all' ? ' active' : ''}" data-action="set-s3-view" data-mode="all">All</button>
                     </div>
-                    <span class="tool-section-badge">${ignoreVulns.size}</span>
+                    <span class="tool-section-badge" id="s3-heading-badge">${unresolvedCount} / ${ignoreVulns.size}</span>
                 </summary>
                 <div class="tool-section-body">
                     ${expiryHtml}
@@ -756,8 +757,15 @@
 
         // recomputeProgress: recompute from current data model and apply — call after any state change
         function recomputeProgress() {
-            const { reviewed } = buildSections();
+            const { ignoreData, reviewed } = buildSections();
             applyProgress(reviewed);
+            // Update Section 3 heading badge
+            const badge = document.getElementById('s3-heading-badge');
+            if (badge) {
+                const { ignoreVulns, autoResolvedIds } = ignoreData;
+                const unresolvedCount = ignoreVulns.size - autoResolvedIds.size;
+                badge.textContent = `${unresolvedCount} / ${ignoreVulns.size}`;
+            }
         }
 
         // ── Render the full tab ──

--- a/external/ag-shared/scripts/snyk-viewer/ui-review.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-review.js
@@ -763,7 +763,9 @@
             const badge = document.getElementById('s3-heading-badge');
             if (badge) {
                 const { ignoreVulns, autoResolvedIds } = ignoreData;
-                const unresolvedCount = ignoreVulns.size - autoResolvedIds.size;
+                const unresolvedCount = [...ignoreVulns.keys()].filter(
+                    id => !skipState.vulns.has(id) && !autoResolvedIds.has(id)
+                ).length;
                 badge.textContent = `${unresolvedCount} / ${ignoreVulns.size}`;
             }
         }


### PR DESCRIPTION
## Summary

Syncs `external/ag-shared` from ag-grid branch `AG-3390-snyk-view-security-fixes`.

Changes pulled from ag-shared:
- Fix path traversal and XSS issues in snyk-viewer server
- Update Section 3 heading badge on snyk ignore changes
- Show unresolved count in Section 3 heading badge
- Add watch configuration to snyk:view target
- Update sync-ag-shared skill to mandate yarn subrepo for push/pull

## Cross-links

- ag-grid source PR: https://github.com/ag-grid/ag-grid/pull/13244
- ag-studio sync PR: https://github.com/ag-grid/ag-studio/pull/861

## Test plan

- [x] Verify `external/ag-shared/scripts/snyk-viewer/` contains security fixes
- [x] Run `bash external/ag-shared/scripts/setup-prompts/verify-rulesync.sh`