### PR TITLE
AG-3390 - Resolve Snyk security policy issues

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,6 +2,12 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-SVGO-15423912:
+        - cssnano@7.0.4 > cssnano-preset-default@7.0.4 > postcss-svgo@7.0.1 > svgo@3.3.2:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:36.787Z
     SNYK-JS-ROLLUP-15340920:
         - vitest@2.1.9 > vite@6.3.5 > rollup@4.42.0:
               reason: >-

--- a/packages/ag-charts-angular/.snyk
+++ b/packages/ag-charts-angular/.snyk
@@ -2,6 +2,38 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-TAR-15416075:
+        - '@angular/cli@18.2.21 > pacote@18.0.6 > @npmcli/run-script@8.1.0 > node-gyp@10.2.0 > tar@6.2.1':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:52.961Z
+        - '@angular/cli@18.2.21 > pacote@18.0.6 > @npmcli/run-script@8.1.0 > node-gyp@10.2.0 > make-fetch-happen@13.0.1 > cacache@18.0.3 > tar@6.2.0':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:52.959Z
+        - '@angular/cli@18.2.21 > pacote@18.0.6 > tar@6.2.0':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:52.952Z
+        - ng-packagr@18.2.1 > cacache@18.0.3 > tar@6.2.0:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:47.923Z
+    SNYK-JS-IMMUTABLE-15423650:
+        - '@angular-devkit/build-angular@18.2.21 > @angular/build@18.2.21 > sass@1.77.6 > immutable@4.3.4':
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:22.822Z
+        - ng-packagr@18.2.1 > sass@1.80.4 > immutable@4.3.4:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:19.164Z
     SNYK-JS-TAR-15307072:
         - '@angular/cli@18.2.21 > pacote@18.0.6 > @npmcli/run-script@8.1.0 > node-gyp@10.2.0 > tar@6.2.1':
               reason: >-

--- a/packages/ag-charts-website/.snyk
+++ b/packages/ag-charts-website/.snyk
@@ -2,6 +2,18 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+    SNYK-JS-SVGO-15423912:
+        - astro@5.16.7 > svgo@4.0.0:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:41.188Z
+    SNYK-JS-IMMUTABLE-15423650:
+        - sass@1.93.2 > immutable@5.0.3:
+              reason: >-
+                  Used in build & dev - not included in final production build
+              expires: 2026-06-08T00:00:00.000Z
+              created: 2026-03-05T14:42:30.424Z
     SNYK-JS-ASTRO-15338138:
         - astro@5.16.7:
               reason: >-


### PR DESCRIPTION
## Summary

- Adds Snyk policy ignore entries for known vulnerabilities in build/dev dependencies that are not included in the final production build
- Fixes for: ajv, angular core, basic-ftp, koa, minimatch, qs, rollup, serialize-javascript, tar, astro, svgo, immutable
- Adds `.snyk` to `.npmignore` files to prevent policy files from being published with packages

## Test plan

- [ ] Snyk scans pass on this branch