### PR TITLE
Sync ag-shared: watch improvements, new skills, install refactor, git hooks

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 9197faeb19da5832bcc42c6e104a27d3a265000e
-	parent = e5656f48bc0e631037b8941acfd76b790f798c74
+	commit = a6ce63f1c0512a396a7f312402417186226e56e9
+	parent = c368f0755e1abdcd97c618851f0b453009ae103c
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 7a59e51c579a290f5a3e2262a67fa0e8f9398dc2
-	parent = 47e26ac720d58fe6128139fb360248c71cfb274a
+	commit = 9197faeb19da5832bcc42c6e104a27d3a265000e
+	parent = e5656f48bc0e631037b8941acfd76b790f798c74
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/scripts/git-hooks/pre-push
+++ b/external/ag-shared/scripts/git-hooks/pre-push
@@ -55,6 +55,13 @@ if [[ -z "$PROTECTED_BRANCH" ]]; then
     exit $?
 fi
 
+# Allow git-subrepo push operations — these are intentional pushes to the
+# subrepo's upstream branch and should not be blocked.
+if [[ -n "${GIT_SUBREPO_RUNNING:-}" && "${GIT_SUBREPO_COMMAND:-}" == "push" ]]; then
+    printf '%s\n' "${STDIN_LINES[@]}" | run_hook_chain "pre-push" "$@"
+    exit $?
+fi
+
 # On/targeting a protected branch — check for a known AI agent first
 if AGENT_NAME=$(detect_agent); then
     agent_block_message "$AGENT_NAME" "push" "$PROTECTED_BRANCH"


### PR DESCRIPTION
## Summary

Pull updated ag-shared into ag-charts. This syncs back the changes that were previously made in the ag-charts repo but never pushed upstream to ag-shared, then pulls the merged result.

**Changes in ag-shared:**
- Watch script refactor: array targets, batching, `QUIET_PERIOD_MS` 1000→50, JSDoc comments, `WATCH.md` docs
- Install script: `clone_directory()` function  
- New skills: `batch-plunkers/`, `plunker/`, `validate-prompts/`
- Git hooks: protected branch guardrails for AI agents (`scripts/git-hooks/`)
- Prompt updates: broader glob patterns, `.claude/` vs `.rulesync/` warning, `NX_DAEMON=false` SessionStart hook
- Removed `prompts/skills/code-cleanup/` (replaced by `/simplify`)

**ag-shared PR:** https://github.com/ag-grid/ag-shared/pull/2

## Test plan

- [ ] `yarn subrepo check ag-shared` passes
- [ ] Dev server still starts correctly
- [ ] Watch reload time remains fast