### PR TITLE
Add integrated charts testing CI workflow

### DIFF
--- a/.github/workflows/integrated-charts-test.yml
+++ b/.github/workflows/integrated-charts-test.yml
@@ -1,0 +1,88 @@
+name: Integrated Charts Test
+
+on:
+    workflow_dispatch: {}
+    schedule:
+        - cron: '0 6 * * 1-5' # Weekday mornings UTC
+
+env:
+    NX_NO_CLOUD: true
+    AG_SKIP_NATIVE_DEP_VERSION_CHECK: 1
+
+permissions:
+    contents: read
+
+jobs:
+    test-ag-grid-integration:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 60
+        steps:
+            - name: Checkout ag-charts
+              uses: actions/checkout@v4
+
+            - name: Setup
+              uses: ./.github/actions/setup-nx
+              with:
+                  cache_mode: ro
+                  yarn_postinstall: false
+
+            - name: Build ag-charts packages
+              run: |
+                  yarn nx run-many -t build -p ag-charts-types,ag-charts-locale,ag-charts-core,ag-charts-community,ag-charts-enterprise
+
+            - name: Pack ag-charts tarballs
+              id: pack
+              run: |
+                  TARBALL_DIR=$(mktemp -d)
+                  for pkg in ag-charts-types ag-charts-locale ag-charts-core ag-charts-community ag-charts-enterprise; do
+                      cd packages/$pkg
+                      TARBALL=$(npm pack --pack-destination "$TARBALL_DIR" 2>/dev/null | tail -1)
+                      echo "${pkg}_tarball=${TARBALL_DIR}/${TARBALL}" >> $GITHUB_OUTPUT
+                      cd ../..
+                  done
+                  echo "tarball_dir=${TARBALL_DIR}" >> $GITHUB_OUTPUT
+
+            - name: Clone ag-grid
+              run: |
+                  git clone --depth 1 --branch latest https://github.com/ag-grid/ag-grid.git /tmp/ag-grid
+
+            - name: Replace ag-charts deps with local tarballs
+              run: |
+                  node tools/integration/set-charts-dep-paths.js /tmp/ag-grid "${{ steps.pack.outputs.tarball_dir }}"
+
+            - name: Install ag-grid dependencies
+              working-directory: /tmp/ag-grid
+              run: |
+                  npm run bootstrap
+
+            - name: Build ag-grid-enterprise
+              working-directory: /tmp/ag-grid
+              env:
+                  NODE_ENV: production
+              run: |
+                  yarn nx build ag-grid-enterprise
+
+            - name: Build with Real Implementation
+              working-directory: /tmp/ag-grid
+              env:
+                  NODE_ENV: production
+              run: |
+                  ./scripts/ci/substituteAgChartsTypesScene.sh
+                  yarn nx build ag-grid-enterprise --skip-nx-cache
+
+            - name: Slack Notification (failure)
+              if: failure()
+              uses: rtCamp/action-slack-notify@v2
+              env:
+                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+                  SLACK_COLOR: failure
+                  SLACK_ICON: https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png
+                  SLACK_USERNAME: ag-charts CI
+                  SLACK_FOOTER: ''
+                  SLACK_TITLE: Integrated Charts Pre-Integration Test Failed
+                  SLACK_MESSAGE: >
+                      The ag-grid integration build check failed. AG Charts changes
+                      on the `latest` branch are likely to break the next Charts
+                      Pre-Integration Build in TeamCity.
+                      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  SLACK_CHANNEL: '#charts_teamcity_status'

--- a/tools/integration/set-charts-dep-paths.js
+++ b/tools/integration/set-charts-dep-paths.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+/**
+ * Replaces ag-charts-* dependency versions in all ag-grid package.json files
+ * with `file:` paths pointing to local tarballs.
+ *
+ * Usage: node set-charts-dep-paths.js <ag-grid-root> <tarball-dir>
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const AG_CHARTS_PACKAGES = [
+    'ag-charts-types',
+    'ag-charts-locale',
+    'ag-charts-core',
+    'ag-charts-community',
+    'ag-charts-enterprise',
+];
+
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+
+function findTarballs(tarballDir) {
+    const files = fs.readdirSync(tarballDir);
+    const tarballs = {};
+    for (const pkg of AG_CHARTS_PACKAGES) {
+        const tarball = files.find((f) => f.startsWith(pkg.replace(/-/g, '-') + '-') && f.endsWith('.tgz'));
+        if (tarball) {
+            tarballs[pkg] = path.resolve(tarballDir, tarball);
+        }
+    }
+    return tarballs;
+}
+
+function findPackageJsonFiles(rootDir) {
+    const results = [];
+
+    // Read workspace packages from root package.json
+    const rootPkg = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+    results.push(path.join(rootDir, 'package.json'));
+
+    const workspaces = rootPkg.workspaces || [];
+    const patterns = Array.isArray(workspaces) ? workspaces : workspaces.packages || [];
+
+    for (const pattern of patterns) {
+        // Simple glob: handle trailing /*
+        const baseDir = pattern.replace(/\/\*$/, '');
+        const fullBase = path.join(rootDir, baseDir);
+        if (!fs.existsSync(fullBase)) continue;
+
+        if (pattern.endsWith('/*')) {
+            // Enumerate subdirectories
+            for (const entry of fs.readdirSync(fullBase, { withFileTypes: true })) {
+                if (entry.isDirectory()) {
+                    const pkgJson = path.join(fullBase, entry.name, 'package.json');
+                    if (fs.existsSync(pkgJson)) results.push(pkgJson);
+                }
+            }
+        } else {
+            const pkgJson = path.join(fullBase, 'package.json');
+            if (fs.existsSync(pkgJson)) results.push(pkgJson);
+        }
+    }
+
+    return results;
+}
+
+function replaceVersions(pkgJsonPath, tarballs) {
+    const content = fs.readFileSync(pkgJsonPath, 'utf8');
+    const pkg = JSON.parse(content);
+    let modified = false;
+
+    for (const field of DEP_FIELDS) {
+        if (!pkg[field]) continue;
+        for (const [name, tarballPath] of Object.entries(tarballs)) {
+            if (pkg[field][name]) {
+                pkg[field][name] = `file:${tarballPath}`;
+                modified = true;
+            }
+        }
+    }
+
+    // Also handle resolutions field (yarn 1.x)
+    if (pkg.resolutions) {
+        for (const [name, tarballPath] of Object.entries(tarballs)) {
+            if (pkg.resolutions[name]) {
+                pkg.resolutions[name] = `file:${tarballPath}`;
+                modified = true;
+            }
+        }
+    }
+
+    if (modified) {
+        fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + '\n');
+        console.log(`Updated: ${pkgJsonPath}`);
+    }
+
+    return modified;
+}
+
+function main() {
+    const [agGridRoot, tarballDir] = process.argv.slice(2);
+
+    if (!agGridRoot || !tarballDir) {
+        console.error('Usage: node set-charts-dep-paths.js <ag-grid-root> <tarball-dir>');
+        process.exit(1);
+    }
+
+    const resolvedRoot = path.resolve(agGridRoot);
+    const resolvedTarballDir = path.resolve(tarballDir);
+
+    if (!fs.existsSync(resolvedRoot)) {
+        console.error(`ag-grid root not found: ${resolvedRoot}`);
+        process.exit(1);
+    }
+
+    if (!fs.existsSync(resolvedTarballDir)) {
+        console.error(`Tarball directory not found: ${resolvedTarballDir}`);
+        process.exit(1);
+    }
+
+    const tarballs = findTarballs(resolvedTarballDir);
+    const found = Object.keys(tarballs);
+    console.log(`Found tarballs for: ${found.join(', ')}`);
+
+    if (found.length === 0) {
+        console.error('No ag-charts tarballs found in tarball directory');
+        process.exit(1);
+    }
+
+    const pkgJsonFiles = findPackageJsonFiles(resolvedRoot);
+    console.log(`Scanning ${pkgJsonFiles.length} package.json files...`);
+
+    let updatedCount = 0;
+    for (const pkgJsonPath of pkgJsonFiles) {
+        if (replaceVersions(pkgJsonPath, tarballs)) {
+            updatedCount++;
+        }
+    }
+
+    console.log(`Updated ${updatedCount} package.json files`);
+}
+
+main();


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds ag-charts packages, packs them as tarballs, clones ag-grid, replaces ag-charts dependency versions with local tarballs, and runs the ag-grid integration build. Runs on weekday mornings and posts to Slack on failure.

Includes a helper script (`tools/integration/set-charts-dep-paths.js`) that scans ag-grid workspace package.json files and replaces ag-charts dependency versions with `file:` paths to locally packed tarballs.