### PR TITLE
Sync ag-charts-server-side-example subrepo

### DIFF
--- a/external/ag-charts-server-side-example/.gitrepo
+++ b/external/ag-charts-server-side-example/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:ag-grid/ag-charts-server-side-example.git
 	branch = main
-	commit = 2bf5a05d0e620e543b2aab936c6a337ab3abba6c
+	commit = 1bc583605b1fbb95d7899646dbbf2a7143b1989e
 	method = merge
 	cmdver = 0.4.9
-	parent = 2cb7a394733c4c5916111d1de9297d7f177512bc
+	parent = 5849cf111b5d7dc0390e3af01e2cb73f354ea83a


### PR DESCRIPTION
Pushes the latest package version bump to the `ag-charts-server-side-example` external subrepo.