### PR TITLE
Optimise /jira skill + add Devil's Advocate to /pr-review and /plan-review

### DIFF
--- a/.rulesync/README.md
+++ b/.rulesync/README.md
@@ -68,9 +68,7 @@ Quick-reference for all AI agent commands, skills, sub-agents, and rules availab
 | Skill   | 🔵 `plan-review`                   | `/plan-review` (user)                | Review plans for completeness and correctness      |
 | Skill   | 🔵 `plan-implementation-review`    | `/plan-implementation-review` (user) | Review plan execution, identify delivery gaps      |
 | Command | 🟠 `/product-requirement-analysis` | `/product-requirement-analysis`      | Analyse requirements with competitor research      |
-| Command | 🟠 `/analyze-jira-issue`           | `/analyze-jira-issue <key>`          | Analyse a JIRA issue and propose solutions         |
-| Skill   | 🟠 `estimate-jira`                 | `/estimate-jira`                     | Estimate complexity, effort, and risks for tickets |
-| Skill   | 🟠 `jira-create`                   | `/jira-create`                       | Create JIRA tickets with proper formatting         |
+| Skill   | 🔵 `jira`                          | `/jira`                              | Create, estimate, or analyse JIRA tickets          |
 | Agent   | 🟠 `technical-research-analyst`    | Auto                                 | In-depth technical research with citations         |
 | Agent   | 🔵 `nx-expert`                     | Auto                                 | Nx monorepo configuration and build optimisation   |
 
@@ -165,7 +163,6 @@ Rules load automatically when you edit files matching their glob patterns.
 
 | Rule               | Activates on                                  | Description                         |
 | ------------------ | --------------------------------------------- | ----------------------------------- |
-| 🟠 `jira`          | Always (no glob)                              | JIRA ticket creation and management |
 | 🔵 `setup-prompts` | `**/setup-prompts/**`, `**/patches/rulesync*` | Rulesync patching guide             |
 
 ---
@@ -179,12 +176,11 @@ Skills load on-demand when invoked. All skills are invoked via `/skill-name`. Al
 | 🔵 `batch-lint-cleanup`         | Auto-fix ESLint violations by rule                          |
 | 🔵 `code-fixup`                 | Fix build and lint errors across a package                  |
 | 🔵 `dev-server`                 | Start dev server, check build status                        |
-| 🟠 `estimate-jira`              | Estimate complexity, effort, and risks for JIRA tickets     |
 | 🔵 `git-bisect`                 | Find the commit that introduced a regression                |
 | 🔵 `git-conventions`            | Branch, commit, and PR naming conventions                   |
 | 🔵 `git-split`                  | Split large files preserving git history                    |
 | 🔵 `git-worktree-clean`         | Hard-reset worktree to `origin/latest`                      |
-| 🟠 `jira-create`                | Create JIRA tickets with proper formatting and templates    |
+| 🔵 `jira`                       | Create, estimate, or analyse JIRA tickets (all AG products) |
 | 🟠 `optimize-series`            | Series performance optimisation and GC pressure reduction   |
 | 🔵 `plan-implementation-review` | Review plan execution, identify delivery gaps               |
 | 🔵 `plan-review`                | Review plans for completeness and correctness               |

--- a/.rulesync/rules/jira.md
+++ b/.rulesync/rules/jira.md
@@ -1,1 +1,0 @@
-../../external/prompts/rules/jira.md

--- a/.rulesync/skills/estimate-jira
+++ b/.rulesync/skills/estimate-jira
@@ -1,1 +1,0 @@
-../../external/prompts/skills/estimate-jira/

--- a/.rulesync/skills/jira
+++ b/.rulesync/skills/jira
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/skills/jira

--- a/.rulesync/skills/jira-create
+++ b/.rulesync/skills/jira-create
@@ -1,1 +1,0 @@
-../../external/prompts/skills/jira-create/

--- a/external/ag-shared/prompts/skills/jira/SKILL.md
+++ b/external/ag-shared/prompts/skills/jira/SKILL.md
@@ -1,7 +1,7 @@
 ---
 targets: ['*']
 name: jira
-description: 'Work with JIRA tickets for AG products. Covers creating tickets (bugs, features, tech-debt), estimating complexity and effort, and analysing issues for product/UX solutions. Use when the user asks to "create a JIRA", "file a bug", "estimate a ticket", "size this feature", "analyse a JIRA issue", or any JIRA-related task.'
+description: 'Create, estimate, and analyse JIRA tickets using Atlassian MCP tools. Creates bug/feature/tech-debt/improvement/docs tickets with structured templates. Estimates ticket complexity, effort (in days), risks, and unknowns. Analyses issues for product/UX solutions with multi-ticket synthesis. Use when the user mentions "create a JIRA", "file a bug", "log a ticket", "estimate this", "size this feature", "how much effort", "break this down", "analyse this issue", or any JIRA workflow task. Does NOT handle simple ticket reads or status checks.'
 ---
 
 # JIRA Skill
@@ -81,20 +81,10 @@ Follow the exact structure from the template. Do not use free-form markdown head
 
 ### Troubleshooting
 
-**Discovering required fields:**
-
-```javascript
-mcp__atlassian__getJiraIssueTypeMetaWithFields({
-    cloudId: '1565837d-d6d1-4228-bcb2-4cb74df700f2',
-    projectIdOrKey: 'AG',
-    issueTypeId: '10105', // Task
-});
-```
+**Discovering required fields:** Use `mcp__atlassian__getJiraIssueTypeMetaWithFields` with `cloudId`, `projectIdOrKey: 'AG'`, `issueTypeId: '10105'` (Task).
 
 **Common errors:**
 
-- **"Track is required"**: Add `customfield_10501`.
-- **"Components is required"**: Add `components` array.
-- **Unknown field IDs**: Use metadata API above.
-- **Ticket created in Backlog instead of To Do**: New AG project tickets default to "Backlog" status. Transition to "To Do" using transition ID `141` after creation.
-- **Do not set the `in_kanban` label**: Never add `in_kanban` to the `labels` field when creating tickets — it is managed automatically.
+- **"Track/Components is required"**: Add `customfield_10501` and/or `components` array.
+- **Ticket in Backlog instead of To Do**: Transition to "To Do" using transition ID `141` after creation.
+- **Do not set `in_kanban` label**: Managed automatically — never add to `labels` field.

--- a/external/ag-shared/prompts/skills/jira/SKILL.md
+++ b/external/ag-shared/prompts/skills/jira/SKILL.md
@@ -1,0 +1,100 @@
+---
+targets: ['*']
+name: jira
+description: 'Work with JIRA tickets for AG products. Covers creating tickets (bugs, features, tech-debt), estimating complexity and effort, and analysing issues for product/UX solutions. Use when the user asks to "create a JIRA", "file a bug", "estimate a ticket", "size this feature", "analyse a JIRA issue", or any JIRA-related task.'
+---
+
+# JIRA Skill
+
+Unified skill for creating, estimating, and analysing JIRA tickets across AG products.
+
+## Product Detection
+
+Detect the product from the repository context:
+
+- **AG Charts**: repos containing `ag-charts-community` — read `products/charts.md`
+- **AG Grid**: repos containing `ag-grid-community` — read `products/grid.md`
+- **AG Studio**: repos containing `ag-studio-core` or with project key `ST` — read `products/studio.md`
+
+Read the appropriate product file **before** proceeding with any workflow.
+
+## Workflow Routing
+
+Based on user intent, read the corresponding workflow file (in the `workflows/` subdirectory of this skill):
+
+| Intent | Keywords | Workflow |
+|--------|----------|----------|
+| **Create** | "create a JIRA", "file a bug", "write up a ticket", "log this issue" | `workflows/create.md` |
+| **Estimate** | "estimate", "size", "analyse complexity", "how long", "effort" | `workflows/estimate.md` |
+| **Analyse** | "analyse this issue", "product analysis", "UX analysis", "propose solutions" | `workflows/analyze.md` |
+
+Read the workflow file, then follow its instructions.
+
+## Shared Reference
+
+### Atlassian Cloud ID
+
+All API calls use: `1565837d-d6d1-4228-bcb2-4cb74df700f2`
+
+### Required Fields
+
+| Field | API Name | Format |
+|-------|----------|--------|
+| Project | `projectKey` | `"AG"` (or `"ST"` for Studio) |
+| Type | `issueTypeName` | `"Bug"` or `"Task"` |
+| Summary | `summary` | `"[Product] Title"` (prefix from product file) |
+| Description | `description` | See templates |
+| Component | `components` | From product file |
+| Track | `customfield_10501` | See track values below |
+
+### Track Values (`customfield_10501`)
+
+| Value | ID | Use For |
+|-------|-----|---------|
+| Bug | 10401 | Bug fixes |
+| Feature Request | 10400 | New features |
+| Improvement | 10403 | Enhancements |
+| Housekeeping | 10404 | Tech-debt, refactoring |
+| Doc change | 10402 | Documentation updates |
+
+Format: `[{"value": "Bug"}]` or `[{"id": "10401"}]`
+
+### Description Formatting
+
+- Use plain numbered lists: `1. Item` (not `#` wiki markup).
+- Indent sub-items with 4 spaces: `    1. Sub-item`.
+- **End numbered items with periods.**
+- Bold: `**text**`.
+- Code: backticks.
+- URLs: Paste raw URLs directly (JIRA auto-links them); avoid `[text](url)` markdown links.
+- Empty sections: Just `N/A`.
+- No comments — all info in description.
+- When creating tickets from analysis/research documents, distil to decisions and recommendations only. Do not reproduce full analysis in the description — link to the analysis document in the "Design Documents" section instead.
+- Related tickets: Use formal JIRA issue links (not ticket keys in description text). When a fix resolves downstream bugs, use "Blocks" link type. Note: the MCP API does not support creating issue links, so ask the user to add them manually after ticket creation.
+
+### Templates
+
+- **Feature/Task**: `templates/feature-task.md` (12-section numbered format)
+- **Bug**: `templates/bug.md` (TC-based format)
+
+Follow the exact structure from the template. Do not use free-form markdown headers (`##`), tables, or code blocks for top-level structure.
+
+### Troubleshooting
+
+**Discovering required fields:**
+
+```javascript
+mcp__atlassian__getJiraIssueTypeMetaWithFields({
+    cloudId: '1565837d-d6d1-4228-bcb2-4cb74df700f2',
+    projectIdOrKey: 'AG',
+    issueTypeId: '10105', // Task
+});
+```
+
+**Common errors:**
+
+- **"Track is required"**: Add `customfield_10501`.
+- **"Components is required"**: Add `components` array.
+- **Unknown field IDs**: Use metadata API above.
+- **Ticket created in Backlog instead of To Do**: New AG project tickets default to "Backlog" status. Transition to "To Do" using transition ID `141` after creation.
+- **Do not set the `in_kanban` label**: Never add `in_kanban` to the `labels` field when creating tickets — it is managed automatically.

--- a/external/ag-shared/prompts/skills/jira/SKILL.md
+++ b/external/ag-shared/prompts/skills/jira/SKILL.md
@@ -1,7 +1,19 @@
 ---
 targets: ['*']
 name: jira
-description: 'Create, estimate, and analyse JIRA tickets using Atlassian MCP tools. Creates bug/feature/tech-debt/improvement/docs tickets with structured templates. Estimates ticket complexity, effort (in days), risks, and unknowns. Analyses issues for product/UX solutions with multi-ticket synthesis. Use when the user mentions "create a JIRA", "file a bug", "log a ticket", "estimate this", "size this feature", "how much effort", "break this down", "analyse this issue", or any JIRA workflow task. Does NOT handle simple ticket reads or status checks.'
+description: >-
+  Whenever the user asks to create a JIRA ticket, file a bug, log an issue,
+  write up a ticket, estimate a ticket, size effort, analyse a JIRA issue, do
+  product analysis, or link tickets — ALWAYS invoke this skill first. It provides
+  the AG project's required JIRA configuration: custom field IDs for Track
+  (customfield_10501), component mappings, description templates with
+  numbered-list format, and issue type conventions. Without this skill, ticket
+  creation will fail due to missing required fields. Covers all ticket types:
+  Bug, Task, Feature Request, Improvement, Housekeeping, Doc change. Does NOT
+  cover: reading tickets, checking status, adding comments, transitioning status,
+  searching issues, or assigning tickets — those use Atlassian MCP tools
+  directly. Does NOT cover: analysing source code, estimating code performance,
+  or reviewing pull requests.
 ---
 
 # JIRA Skill

--- a/external/ag-shared/prompts/skills/jira/products/charts.md
+++ b/external/ag-shared/prompts/skills/jira/products/charts.md
@@ -69,3 +69,9 @@ Use these baseline estimates for common AG Charts work items:
 - **Add 30-50%** if feature has significant unknowns or unclear requirements.
 - **Add 40-60%** for enterprise features requiring licensing checks, advanced theming.
 - **Reduce by 20-30%** only if leveraging substantial existing infrastructure with minimal changes.
+
+### Common Estimation Pitfalls
+
+- Canvas rendering changes always require visual regression test updates — budget at least 30% of implementation time for test maintenance.
+- Changes to AbstractSeries or CartesianSeries affect ALL series types — scope the blast radius before estimating.
+- Theme integration is often underestimated — new properties need defaults in every theme variant.

--- a/external/ag-shared/prompts/skills/jira/products/charts.md
+++ b/external/ag-shared/prompts/skills/jira/products/charts.md
@@ -1,0 +1,71 @@
+# AG Charts — JIRA Product Configuration
+
+## Identity
+
+- **Project**: `AG`
+- **Component**: `Charts` (ID: 11061)
+- **Summary prefix**: `[Charts]`
+- **Search**: Project `AG`, Component `Charts`, Status `Needs Review` for review
+
+## API Field Values
+
+```json
+{
+    "projectKey": "AG",
+    "components": [{ "name": "Charts" }],
+    "summary": "[Charts] ..."
+}
+```
+
+## Version Relationship
+
+Charts major version = Grid major version - 22.
+
+- Charts v9 = Grid v31.
+- Charts v10 = Grid v32.
+
+The `versions` (Affects Version) field uses **Grid** version numbers (e.g., `[{"name": "31.0.0"}]`).
+
+## Bug Version Testing
+
+When creating bug tickets, test affected versions **from the browser** (not by analysing code):
+
+1. Use the reproduction Plunker and change AG Charts version.
+2. Binary search versions to find when the bug was introduced.
+3. Set `versions` field to earliest affected version.
+
+## Estimation Calibration Data
+
+Use these baseline estimates for common AG Charts work items:
+
+### Series Implementation
+
+- **New series type** (extending AbstractBarSeries, CartesianSeries, etc.): **10 days / 2 weeks**.
+    - Includes: Core implementation, type definitions, rendering logic, theme integration.
+    - Includes: Unit tests, visual regression tests, documentation page, framework examples.
+    - Examples: Overlapping bar/column series, timeline series, quadrant chart.
+    - Does NOT include: Highly complex rendering algorithms, advanced interactions beyond standard.
+
+### Annotation Implementation
+
+- **New annotation type**: **15-20 days (3-4 weeks)**.
+    - Includes: Core annotation class, rendering, drag/resize interactions, type definitions.
+    - Includes: Comprehensive testing (unit, E2E, visual regression), documentation, examples.
+    - Examples: Text annotations, shape annotations, measurement tools.
+    - Complexity drivers: Drag/drop interactions, resize handles, connection points, styling system.
+
+### Other Common Work Items
+
+- **Simple bug fix** (isolated, clear root cause): 0.5-1 day.
+- **Complex bug fix** (requires investigation, multiple areas): 2-3 days.
+- **New chart option** (simple property, minimal logic): 1-2 days.
+- **Event/callback addition**: 2-4 days (depending on complexity).
+- **Performance optimisation**: 3-5 days (investigation + implementation).
+- **Breaking API change**: Add 20-30% for migration guide, backward compatibility testing.
+
+### Adjustment Guidelines
+
+- **Add 20-30%** if implementation requires deep integration with multiple systems.
+- **Add 30-50%** if feature has significant unknowns or unclear requirements.
+- **Add 40-60%** for enterprise features requiring licensing checks, advanced theming.
+- **Reduce by 20-30%** only if leveraging substantial existing infrastructure with minimal changes.

--- a/external/ag-shared/prompts/skills/jira/products/grid.md
+++ b/external/ag-shared/prompts/skills/jira/products/grid.md
@@ -1,0 +1,25 @@
+# AG Grid — JIRA Product Configuration
+
+## Identity
+
+- **Project**: `AG`
+- **Component**: `Grid`
+- **Summary prefix**: `[Grid]`
+
+## API Field Values
+
+```json
+{
+    "projectKey": "AG",
+    "components": [{ "name": "Grid" }],
+    "summary": "[Grid] ..."
+}
+```
+
+## Version Relationship
+
+Grid is the reference version. Charts major version = Grid major version - 22.
+
+## Estimation Calibration Data
+
+TBD — to be populated by the Grid team.

--- a/external/ag-shared/prompts/skills/jira/products/studio.md
+++ b/external/ag-shared/prompts/skills/jira/products/studio.md
@@ -1,0 +1,19 @@
+# AG Studio — JIRA Product Configuration
+
+## Identity
+
+- **Project**: `ST`
+- **Summary prefix**: `[Studio]`
+
+## API Field Values
+
+```json
+{
+    "projectKey": "ST",
+    "summary": "[Studio] ..."
+}
+```
+
+## Estimation Calibration Data
+
+TBD — to be populated by the Studio team.

--- a/external/ag-shared/prompts/skills/jira/templates/bug.md
+++ b/external/ag-shared/prompts/skills/jira/templates/bug.md
@@ -1,0 +1,22 @@
+[Charts] Brief bug title
+
+**TC1 - First test case label**
+
+1. Open and preview https://reproduction-url.
+
+2. First reproduction step.
+
+    - **Actual:** What currently happens (the bug behaviour).
+    - **Expected:** What should happen (correct behaviour).
+
+**TC2 - Second test case label** (if multiple scenarios)
+
+1. Reproduction steps for second scenario.
+
+    - **Actual:** What currently happens.
+    - **Expected:** What should happen.
+
+**Notes**
+
+-   Root cause: Technical details about why the bug occurs.
+-   Regression: Version where bug was introduced (if identified).

--- a/external/ag-shared/prompts/skills/jira/templates/feature-task.md
+++ b/external/ag-shared/prompts/skills/jira/templates/feature-task.md
@@ -1,0 +1,82 @@
+[Charts] Feature title
+
+1. **Brief Requirements statement**
+
+    1. What is the desired behavior or capability?
+    2. Avoid implementation detail—focus on what, not how.
+
+2. **Current behavior & Problem statement**
+
+    1. How does this feature currently work?
+    2. What is missing or problematic?
+
+3. **Use cases**
+
+    1. What are users trying to achieve?
+    2. Provide specific examples.
+
+4. **API Design**
+
+    1. **Location:** (e.g., top-level chart options, series options, API method).
+    2. **New Property:** Property name and type.
+    3. **Default Value:** Default value.
+    4. **Valid Values:** Valid values (e.g., boolean, number between 0 and 1).
+
+5. **API Deprecations/Hiding**
+
+    1. N/A
+
+6. **Breaking changes in API or behavior**
+
+    1. N/A
+
+7. **UX Design**
+
+    1. N/A
+
+8. **Dependencies**
+
+    1. N/A
+
+9. **Functional Acceptance Criteria**
+
+    1. **Basic Scenarios:**
+
+        1. New behavior in basic scenarios.
+        2. Expected output/state changes.
+
+    2. **Edge Cases:**
+
+        1. How this interacts with other features.
+        2. Different configurations.
+
+10. **Non-functional Acceptance Criteria**
+
+    1. **State:** Define default or initial state clearly.
+    2. **Documentation:**
+
+        1. API docs updated.
+        2. New section added to docs.
+
+    3. **Accessibility:**
+
+        1. WCAG-compliant: ARIA, focus, keyboard nav.
+        2. Screen reader announcements.
+
+    4. **Localization:**
+
+        1. All user-facing strings are translatable.
+
+    5. **Theming:**
+
+        1. N/A
+
+11. **Out of Scope**
+
+    1. What is explicitly not being handled in this release?
+    2. Future enhancements to consider.
+
+12. **Design Documents**
+
+    1. Link to Google Docs design documents.
+    2. Link to Figma designs.

--- a/external/ag-shared/prompts/skills/jira/workflows/analyze.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/analyze.md
@@ -1,0 +1,60 @@
+# JIRA Issue Product and UX/DX Analysis Workflow
+
+You are a Technical Analyst and Product Manager. Your goal is to perform a deep, holistic analysis of a given JIRA issue and any referenced tickets to fully understand the impact on user experience (UX) and developer experience (DX), and to propose product-level solutions and API designs.
+
+## 1. Inputs
+
+- **Primary JIRA Ticket ID**: The main JIRA ticket to start the analysis from (e.g., `AG-8445`).
+- **JIRA Instance URL**: The base URL for the JIRA instance.
+
+## 2. Analysis Workflow
+
+### Phase 1: Information Gathering
+
+1. **Fetch Primary Ticket**: Retrieve all details for the primary JIRA ticket, including:
+    - Title and description.
+    - Comments.
+    - Linked issues (blocks, is blocked by, relates to, etc.).
+    - Attachments.
+
+2. **Identify Referenced Tickets**: Parse the description and comments of the primary ticket to find all references to other JIRA tickets.
+
+3. **Fetch Referenced Tickets**: For each referenced ticket found, retrieve its full details as in step 1. Recursively do this for any newly discovered tickets to build a complete graph of related issues.
+
+### Phase 2: Problem Space Synthesis
+
+1. **Synthesise All Information**: Read through all the gathered information from the primary and referenced tickets.
+
+2. **Define the Core User/Developer Problem**: From the user's perspective, what is the core pain point or unmet need? From a developer's perspective, what is the core difficulty or limitation with the API or product? Frame the problem in terms of user stories or job stories.
+
+3. **Identify Key Themes**: Group related pieces of information into logical themes with a product focus. Examples: "Poor User Workflow," "Confusing API Ergonomics," "Inconsistent Visual Design," "Missing Feature Parity," "Accessibility Gaps."
+
+4. **Define Success Criteria and Constraints**: Create a definitive list of what a successful solution looks like from a user and developer standpoint.
+    - **User-Facing Success Criteria**: What must be true for the user to consider this problem solved?
+    - **Developer-Facing Success Criteria**: What must be true for a developer using the API to feel it's intuitive and powerful?
+    - **Product Constraints**: What are the business or product limitations?
+
+### Phase 3: Proposing Solutions
+
+1. **Brainstorm Potential Solutions**: Based on the synthesised problem space, brainstorm at least 2-3 distinct product or API-level solutions.
+
+2. **Detail Each Solution**: For each proposed solution, provide the following:
+    - **High-Level Description**: A clear, concise summary of the solution.
+    - **Pros (UX/DX)**: The advantages of this solution from a user and developer perspective.
+    - **Cons (UX/DX)**: The disadvantages or risks of this solution for users and developers.
+    - **Solution Sketch**: A description of how the user would interact with the new feature, or how a developer would use the new/changed API. Include API signatures, configuration examples, or UI mockups/wireframes if applicable.
+    - **Impact Analysis (UX/DX)**: Will this change be intuitive? Does it introduce complexity? Does it align with existing patterns in the product/API?
+    - **Effort Estimate**: A rough order of magnitude estimate for the implementation effort (e.g., Small, Medium, Large).
+    - **Product Value / ROI**: An estimate of the value this solution provides to the user/business (e.g., High, Medium, Low).
+
+### Phase 4: Recommendation
+
+1. **Compare Solutions**: Create a summary table comparing the proposed solutions against key product criteria (e.g., User Value, Developer Experience, Implementation Effort, Alignment with Product Strategy).
+
+2. **Make a Recommendation**: Based on the comparison, recommend one of the solutions. Justify your recommendation, explaining why it is the best fit for the product's goals and constraints.
+
+3. **Outline Next Steps**: Suggest the immediate next steps to move forward with the recommended solution (e.g., "Validate the proposed UI with the design team," "Write a formal product requirements document (PRD)," "Get feedback on the proposed API from developer advocates or key customers").
+
+## 3. Output Format
+
+The final output should be a well-structured markdown document containing the full analysis, including all the sections from Phase 2, 3, and 4.

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -1,0 +1,104 @@
+# JIRA Ticket Creation Workflow
+
+## Step 0: Determine Ticket Type
+
+Ask the user which type of ticket they need:
+
+| Type | Issue Type | Track Value | Use When |
+|------|-----------|-------------|----------|
+| **Bug** | `"Bug"` | `"Bug"` | Something is broken or behaving incorrectly |
+| **Feature** | `"Task"` | `"Feature Request"` | New capability requested |
+| **Improvement** | `"Task"` | `"Improvement"` | Enhancement to existing feature |
+| **Tech-debt** | `"Task"` | `"Housekeeping"` | Refactoring, cleanup, infrastructure |
+| **Docs** | `"Task"` | `"Doc change"` | Documentation updates only |
+
+### Improvement Tasks
+
+An "improvement task" is a hybrid: it uses the **bug template** (TC-based format) for the description but is filed as a **Task** with **Improvement** track — not as a Bug.
+
+Use this when the user specifically asks for an improvement task or when behaviour is suboptimal but not strictly broken — e.g. a missing interaction, a poor default, or an inconsistency that needs a concrete reproduction to describe.
+
+## Step 1: Load Appropriate Template
+
+Based on ticket type, read the relevant template (in the `templates/` subdirectory of this skill):
+
+- **Bug tickets and Improvement tasks**: Read `templates/bug.md`.
+- **Feature/Tech-debt/Docs**: Read `templates/feature-task.md`.
+
+## Step 2: Gather Information
+
+**For Bug tickets, collect:**
+
+- [ ] Reproduction URL (Plunker, CodeSandbox, etc.).
+- [ ] Steps to reproduce (numbered list).
+- [ ] Actual vs Expected behaviour.
+- [ ] Affected versions (test from end-user perspective in browser — see product file).
+- [ ] Root cause analysis (if known).
+
+**For Feature/Improvement tickets, collect:**
+
+- [ ] Requirements statement (what, not how).
+- [ ] Current behaviour and problem.
+- [ ] Use cases.
+- [ ] API design (if applicable).
+- [ ] Acceptance criteria.
+
+**For Tech-debt tickets, collect:**
+
+- [ ] Context (why this work is needed).
+- [ ] Problem statement.
+- [ ] Proposed solution.
+- [ ] Acceptance criteria.
+
+## Step 3: Create the Ticket
+
+Use the `mcp__atlassian__createJiraIssue` tool. Substitute component, prefix, and project from the product file:
+
+```json
+{
+    "cloudId": "1565837d-d6d1-4228-bcb2-4cb74df700f2",
+    "projectKey": "<from product file>",
+    "issueTypeName": "Bug|Task",
+    "summary": "[<Prefix>] Clear, concise title",
+    "description": "Formatted description from template",
+    "additional_fields": {
+        "components": [{ "name": "<from product file>" }],
+        "priority": { "name": "Medium" },
+        "customfield_10501": [{ "value": "Bug|Feature Request|Improvement|Housekeeping|Doc change" }]
+    }
+}
+```
+
+**For bug tickets, also include:**
+
+```json
+{
+    "additional_fields": {
+        "versions": [{ "name": "<affected version>" }]
+    }
+}
+```
+
+Bug descriptions should be concise: test cases + notes only. Do not add acceptance criteria sections.
+
+**For feature requests:** Do not include rationale or justification in the description. Rationale belongs in the linked PRD/design document, not in the ticket itself. The ticket should state **what** the feature is and its acceptance criteria, not **why** a particular approach was chosen. Link to the design document in the "Design Documents" section.
+
+## Completion Checklist
+
+**Cannot mark complete until ALL checked:**
+
+- [ ] Correct ticket type selected.
+- [ ] Template format followed.
+- [ ] All required fields populated.
+- [ ] Summary starts with correct product prefix.
+- [ ] Track field set correctly.
+- [ ] For bugs: Affects Version included.
+- [ ] URLs pasted as raw URLs (not markdown links).
+
+## Critical Rules
+
+1. **Always use templates** — Don't improvise description formats.
+2. **Test bugs in browser** — Not by analysing code.
+3. **End numbered items with periods** — JIRA formatting requirement.
+4. **No comments** — Put all information in the description.
+5. **No rationale in feature requests** — State **what** and acceptance criteria, not **why**.

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -83,6 +83,28 @@ Bug descriptions should be concise: test cases + notes only. Do not add acceptan
 
 **For feature requests:** Do not include rationale or justification in the description. Rationale belongs in the linked PRD/design document, not in the ticket itself. The ticket should state **what** the feature is and its acceptance criteria, not **why** a particular approach was chosen. Link to the design document in the "Design Documents" section.
 
+### Example: Completed Bug Ticket
+
+**Summary:** `[Charts] Tooltip not shown when hovering near bar edge`
+
+**Description:**
+
+```
+**TC1 - Tooltip missing at bar boundary**
+
+1. Open and preview https://plnkr.co/edit/abc123.
+
+2. Hover the mouse over the rightmost edge of any bar in the bar chart.
+
+    - **Actual:** No tooltip appears when the cursor is within ~2px of the bar edge.
+    - **Expected:** Tooltip should appear consistently across the full bar area.
+
+**Notes**
+
+-   Root cause: Hit-testing uses bar bounds without accounting for stroke width offset.
+-   Regression: Introduced in v9.3.0 (works correctly in v9.2.1).
+```
+
 ## Completion Checklist
 
 **Cannot mark complete until ALL checked:**

--- a/external/ag-shared/prompts/skills/jira/workflows/estimate.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/estimate.md
@@ -1,0 +1,426 @@
+# JIRA Ticket Estimation Workflow
+
+Structured complexity and effort estimation for JIRA tickets, features, or projects. Produces consistent reports with complexity levels, time estimates, dependency analysis, risk assessment, and identification of unknowns.
+
+## Prerequisites
+
+- User provides JIRA ticket content (markdown format preferred).
+- Access to repository codebase for dependency analysis.
+- Understanding of project architecture (consult `CLAUDE.md` or technology stack rules if needed).
+- Product-specific calibration data loaded from the product file.
+
+## Workflow
+
+### Step 0: Load Required Documentation
+
+**Read these files FIRST before any analysis:**
+
+1. Technology stack rules (in target repo) — Architecture constraints and patterns.
+2. `CLAUDE.md` — Repository conventions and build requirements.
+
+**After reading, confirm you understand:**
+
+- [ ] Repository structure and key packages.
+- [ ] Build and test commands.
+- [ ] Architectural constraints (e.g., zero runtime dependencies).
+
+### Step 1: Gather and Analyse Ticket Information
+
+**Complete ALL before proceeding:**
+
+- [ ] Receive JIRA ticket content from user (markdown format).
+- [ ] Extract key requirements, acceptance criteria, and constraints.
+- [ ] Identify the primary affected areas (packages/files).
+- [ ] Note what information is present vs. missing in the ticket.
+
+**Initial Analysis Questions:**
+
+- What type of work is this? (bug fix, new feature, refactoring, docs, etc.)
+- Which packages are affected? (community, enterprise, types, website, etc.)
+- Are there related tickets or dependencies mentioned?
+- Is the scope well-defined or vague?
+
+### Step 2: Identify Ambiguities and Implementation Choices
+
+**CRITICAL: Do NOT proceed to estimation without completing this step.**
+
+**Analyse for ambiguities in these areas:**
+
+1. **Technical Approach**
+
+    - Are there multiple valid implementation strategies?
+    - Is the desired architecture/pattern specified?
+    - Are performance requirements defined?
+
+2. **Scope Boundaries**
+
+    - Is the feature scope clearly bounded?
+    - Are edge cases and error handling specified?
+    - Is backward compatibility required?
+
+3. **Integration Points**
+
+    - How should this integrate with existing systems?
+    - Are framework wrappers (React/Angular/Vue) affected?
+    - Are there public API changes?
+
+4. **Testing & Quality**
+
+    - What level of test coverage is expected?
+    - Are visual regression tests needed?
+    - Should benchmarks be added/updated?
+
+5. **Documentation**
+    - Is documentation required?
+    - Are examples needed?
+    - Should migration guides be written?
+
+**For each significant ambiguity identified:**
+
+- [ ] Document the ambiguity clearly.
+- [ ] List the possible implementation choices.
+- [ ] Note how each choice impacts time/complexity/risk.
+- [ ] **USE AskUserQuestion tool** to get clarification before proceeding.
+
+**Use the AskUserQuestion tool to present ambiguities:**
+
+Present 1-4 ambiguities at once using the AskUserQuestion tool with this structure:
+
+- **question**: Clear question about the ambiguity (e.g., "How should the 'xy' mode work visually?").
+- **header**: Short label (max 12 chars) (e.g., "Dual-axis UI").
+- **options**: 2-4 implementation choices with:
+    - **label**: Concise option name (e.g., "Two Navigators").
+    - **description**: Impact explanation (e.g., "Show both X-axis (bottom) and Y-axis (right) navigators - 20% more complexity, clearer UI").
+- **multiSelect**: false (user should pick one approach).
+
+**After receiving answers:**
+
+- Document the chosen approach in a summary.
+- Adjust estimate based on selected options.
+- Include decisions in the "Implementation Decisions" section of the report.
+
+### Step 3: Investigate Codebase Dependencies and Complexity
+
+**Use the Explore agent for thorough codebase analysis:**
+
+- [ ] Identify all affected files and packages.
+- [ ] Analyse existing similar implementations for patterns.
+- [ ] Check for dependencies on other systems/modules.
+- [ ] Look for related tests that need updating.
+- [ ] Search for documentation that needs changes.
+
+**Key Investigation Areas:**
+
+1. **Core Implementation**
+
+    - Where is the main logic located?
+    - How complex is the existing code in that area?
+    - Are there similar features to reference?
+
+2. **Type System**
+
+    - Will `ag-charts-types` need updates?
+    - Are there complex type definitions involved?
+    - Will this affect public API surface?
+
+3. **Testing Surface**
+
+    - How many test files are affected?
+    - Are image snapshots needed?
+    - Will this need E2E tests?
+
+4. **Documentation & Examples**
+
+    - How many doc pages need updates?
+    - Are new examples required?
+    - Will framework variants be generated?
+
+5. **Build Dependencies**
+    - Which packages need rebuilding?
+    - Are there circular dependency risks?
+    - Will this affect build performance?
+
+### Step 4: Generate Structured Estimation Report
+
+**Use this exact template for consistency:**
+
+---
+
+## Estimation Report: [Ticket ID/Feature Name]
+
+**Date:** [Current date]
+**Estimator:** Claude Code
+**Ticket Summary:** [Brief 1-2 sentence summary]
+
+---
+
+## Executive Summary
+
+| Metric | Value |
+|--------|-------|
+| **Total Effort** | [X-Y days] ([X-Y hours]) |
+| **Complexity** | [Low \| Medium \| High \| Very High] |
+| **Risk Level** | [Low \| Medium \| High] |
+| **Confidence** | [Low \| Medium \| High] |
+
+**Key Highlights:**
+
+- [1-2 sentence summary of main implementation work].
+- [Major scope decision or constraint].
+- [Top risk or concern if applicable].
+
+---
+
+### 1. Estimated Complexity Level
+
+**Overall Complexity: [Low | Medium | High | Very High]**
+
+**Rationale:**
+
+- [Explanation of complexity drivers].
+- [Why this level was chosen].
+
+**Complexity Breakdown:**
+
+- Implementation: [Low/Medium/High].
+- Testing: [Low/Medium/High].
+- Documentation: [Low/Medium/High].
+- Integration: [Low/Medium/High].
+
+---
+
+### 2. Estimated Time Effort
+
+**Total Estimate: [X-Y days] for a single developer**
+
+**Confidence Level: [Low | Medium | High]**
+
+**Breakdown:**
+
+- **Investigation & Design:** [X hours/days]
+
+    - Understanding requirements.
+    - Design decisions.
+    - Spike work if needed.
+
+- **Core Implementation:** [X hours/days]
+
+    - Primary code changes.
+    - Type definitions.
+    - Public API updates.
+
+- **Testing:** [X hours/days]
+
+    - Unit tests.
+    - E2E tests (if applicable).
+    - Visual regression tests (if applicable).
+    - Benchmark updates (if applicable).
+
+- **Documentation:** [X hours/days]
+
+    - Doc page updates/creation.
+    - Example creation.
+    - Migration guides (if applicable).
+
+- **Review & Iteration:** [X hours/days]
+    - Code review feedback.
+    - Test failures.
+    - Bug fixes.
+
+**Assumptions:**
+
+- [List key assumptions affecting the estimate].
+- [e.g., "Assuming developer is familiar with canvas rendering"].
+- [e.g., "Assuming no major architectural changes needed"].
+
+---
+
+### 3. Dependencies, Gaps & Missing Information
+
+**External Dependencies:**
+
+- [List dependencies on other teams/tickets].
+- [Any blocked/blocking items].
+
+**Information Gaps:**
+
+- [What's not specified in the ticket].
+- [Questions that remain unanswered].
+- [Areas needing clarification from stakeholders].
+
+**Implicit Scope (not explicitly mentioned):**
+
+- [Tasks likely required but not stated].
+- [e.g., "Framework wrapper updates"].
+- [e.g., "Locale string additions"].
+
+**Out of Scope (confirm with stakeholder):**
+
+- [Items that might be expected but should be separate].
+- [e.g., "Performance optimisation beyond basic implementation"].
+
+---
+
+### 4. Top 3 Highest Risk Aspects
+
+#### Risk #1: [Description]
+
+**Category:** [Known Unknown | Technical Complexity | Integration Risk | etc.]
+
+**Details:**
+
+- [What makes this risky].
+- [Potential impact].
+
+**Mitigation:**
+
+- [How to reduce this risk].
+
+---
+
+#### Risk #2: [Description]
+
+**Category:** [Known Unknown | Technical Complexity | Integration Risk | etc.]
+
+**Details:**
+
+- [What makes this risky].
+- [Potential impact].
+
+**Mitigation:**
+
+- [How to reduce this risk].
+
+---
+
+#### Risk #3: [Description]
+
+**Category:** [Known Unknown | Technical Complexity | Integration Risk | etc.]
+
+**Details:**
+
+- [What makes this risky].
+- [Potential impact].
+
+**Mitigation:**
+
+- [How to reduce this risk].
+
+---
+
+### 5. Overall Risk Level
+
+**Risk Assessment: [Low | Medium | High]**
+
+**Justification:**
+
+- [Overall risk analysis].
+- [Factors contributing to risk level].
+- [Known unknowns summary].
+
+**Risk Factors:**
+
+- **Technical Risk:** [Low/Medium/High] - [Why].
+- **Schedule Risk:** [Low/Medium/High] - [Why].
+- **Integration Risk:** [Low/Medium/High] - [Why].
+- **Requirement Risk:** [Low/Medium/High] - [Why].
+
+**Confidence in Estimate:**
+
+- [High/Medium/Low confidence and why].
+- [What would increase confidence].
+
+---
+
+### Recommended Next Steps
+
+1. [Immediate action item].
+2. [Pre-implementation research needed].
+3. [Stakeholder clarifications required].
+
+---
+
+## Implementation Decisions (Confirmed)
+
+Based on stakeholder clarification on [date]:
+
+1. **[Decision Area 1]**: [Chosen approach] ([Option letter]).
+2. **[Decision Area 2]**: [Chosen approach] ([Option letter]).
+3. **[Decision Area 3]**: [Chosen approach] ([Option letter]).
+
+_Note: Include this section only if significant implementation choices were clarified during estimation._
+
+---
+
+**End of Report**
+
+---
+
+## Completion Checklist
+
+**Cannot mark estimation complete until ALL checked:**
+
+- [ ] User provided JIRA ticket content.
+- [ ] All significant ambiguities identified and clarified with user.
+- [ ] Codebase investigation completed using Explore agent.
+- [ ] All sections of estimation report filled out.
+- [ ] Complexity level justified with rationale.
+- [ ] Time estimate includes breakdown and assumptions.
+- [ ] Top 3 risks identified with mitigation strategies.
+- [ ] Overall risk level assessed.
+- [ ] Report reviewed for completeness and accuracy.
+
+## Critical Rules
+
+1. **NEVER skip ambiguity clarification** — If implementation choices significantly impact estimates, you MUST ask the user before proceeding using the **AskUserQuestion tool**. Better to pause for clarification than provide misleading estimates. Present options with their complexity/time impacts clearly described.
+
+2. **Always use AskUserQuestion tool for ambiguities** — Do not use ad-hoc text conversation for clarifying implementation choices. Use the structured AskUserQuestion tool to present 1-4 ambiguities at once with clear options and impact descriptions.
+
+3. **Always use Explore agent for codebase analysis** — Do not attempt complex codebase navigation manually. The Explore agent is optimised for this task.
+
+4. **Be honest about uncertainty** — If confidence is low, say so clearly. Include what information would increase confidence.
+
+5. **Consider the full scope** — Don't forget testing, documentation, review iterations, and framework wrappers. These often represent 40-50% of total effort.
+
+6. **Account for unknowns** — Known unknowns should increase time estimates and risk levels proportionally.
+
+7. **Use ranges, not point estimates** — Give ranges (e.g., "3-5 days") to reflect uncertainty, especially for complex work.
+
+8. **Document assumptions explicitly** — Every estimate is based on assumptions. State them clearly so they can be validated.
+
+## Failure Handling
+
+### Problem: Insufficient ticket information
+
+**Solution:**
+
+- Request more details from user.
+- List specific information needed.
+- Provide estimate with large uncertainty range if user cannot provide more details.
+
+### Problem: Cannot find relevant code areas
+
+**Solution:**
+
+- Use Explore agent with broader search patterns.
+- Ask user for hints about where code might be located.
+- Document this as a "known unknown" in the report.
+
+### Problem: Multiple valid implementation approaches with vastly different complexity
+
+**Solution:**
+
+- Use the AskUserQuestion tool to present each approach as an option.
+- Include complexity/time impact in each option's description.
+- Provide recommendation in one option's description if applicable.
+- Let user select their preferred approach through the structured interface.
+- Document chosen approach in the "Implementation Decisions" section.
+
+### Problem: Estimate exceeds reasonable time (e.g., >2 weeks for single person)
+
+**Solution:**
+
+- Consider if work should be broken into multiple tickets.
+- Highlight this in the risk assessment.
+- Recommend creating sub-tasks or phases.
+- Discuss with user about scope reduction options.

--- a/external/ag-shared/prompts/skills/jira/workflows/estimate.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/estimate.md
@@ -1,160 +1,91 @@
 # JIRA Ticket Estimation Workflow
 
-Structured complexity and effort estimation for JIRA tickets, features, or projects. Produces consistent reports with complexity levels, time estimates, dependency analysis, risk assessment, and identification of unknowns.
+Structured complexity and effort estimation for JIRA tickets, features, or projects.
 
 ## Prerequisites
 
 - User provides JIRA ticket content (markdown format preferred).
 - Access to repository codebase for dependency analysis.
-- Understanding of project architecture (consult `CLAUDE.md` or technology stack rules if needed).
 - Product-specific calibration data loaded from the product file.
 
 ## Workflow
 
 ### Step 0: Load Required Documentation
 
-**Read these files FIRST before any analysis:**
-
-1. Technology stack rules (in target repo) — Architecture constraints and patterns.
-2. `CLAUDE.md` — Repository conventions and build requirements.
-
-**After reading, confirm you understand:**
-
-- [ ] Repository structure and key packages.
-- [ ] Build and test commands.
-- [ ] Architectural constraints (e.g., zero runtime dependencies).
+Read technology stack rules and `CLAUDE.md` from the target repo first. Confirm you understand repo structure, build/test commands, and architectural constraints before proceeding.
 
 ### Step 1: Gather and Analyse Ticket Information
 
-**Complete ALL before proceeding:**
-
 - [ ] Receive JIRA ticket content from user (markdown format).
 - [ ] Extract key requirements, acceptance criteria, and constraints.
-- [ ] Identify the primary affected areas (packages/files).
-- [ ] Note what information is present vs. missing in the ticket.
+- [ ] Identify the primary affected areas (packages/files) and work type (bug fix, feature, refactoring, docs).
+- [ ] Note what information is present vs. missing.
+- [ ] Determine scope boundaries and related dependencies.
 
-**Initial Analysis Questions:**
+### Step 1.5: Classify Scope
 
-- What type of work is this? (bug fix, new feature, refactoring, docs, etc.)
-- Which packages are affected? (community, enterprise, types, website, etc.)
-- Are there related tickets or dependencies mentioned?
-- Is the scope well-defined or vague?
+Based on initial analysis, classify the scope to determine report depth:
+
+| Scope | Heuristic | Report Depth |
+|-------|-----------|--------------|
+| **Small** | <1 day, single file, clear root cause | Executive Summary + Time Estimate + Top Risk only |
+| **Medium** | 1-5 days, multi-file, moderate unknowns | All 5 sections, concise |
+| **Large** | >5 days, cross-package, new feature | All sections, detailed breakdown |
 
 ### Step 2: Identify Ambiguities and Implementation Choices
 
 **CRITICAL: Do NOT proceed to estimation without completing this step.**
 
-**Analyse for ambiguities in these areas:**
+Only raise ambiguities that would change the estimate by >20% or shift the complexity level. Focus on material decisions:
 
-1. **Technical Approach**
+**DO ask about:**
 
-    - Are there multiple valid implementation strategies?
-    - Is the desired architecture/pattern specified?
-    - Are performance requirements defined?
+- Technical approach when multiple strategies differ significantly in effort.
+- Whether framework wrappers (React/Angular/Vue) are in scope.
+- Whether migration guides or backward compatibility is required.
+- Performance requirements or targets.
+- Documentation and example scope.
 
-2. **Scope Boundaries**
+**Do NOT ask about:**
 
-    - Is the feature scope clearly bounded?
-    - Are edge cases and error handling specified?
-    - Is backward compatibility required?
+- Coding style preferences, exact file placement, variable naming.
+- Standard testing expectations (covered by repo conventions).
+- Obvious architectural patterns already established in the codebase.
 
-3. **Integration Points**
+Present 1-4 ambiguities using the **AskUserQuestion tool** with:
 
-    - How should this integrate with existing systems?
-    - Are framework wrappers (React/Angular/Vue) affected?
-    - Are there public API changes?
+- **question**: Clear question about the ambiguity.
+- **header**: Short label (max 12 chars).
+- **options**: 2-4 implementation choices, each with impact on time/complexity in the description.
+- **multiSelect**: false.
 
-4. **Testing & Quality**
-
-    - What level of test coverage is expected?
-    - Are visual regression tests needed?
-    - Should benchmarks be added/updated?
-
-5. **Documentation**
-    - Is documentation required?
-    - Are examples needed?
-    - Should migration guides be written?
-
-**For each significant ambiguity identified:**
-
-- [ ] Document the ambiguity clearly.
-- [ ] List the possible implementation choices.
-- [ ] Note how each choice impacts time/complexity/risk.
-- [ ] **USE AskUserQuestion tool** to get clarification before proceeding.
-
-**Use the AskUserQuestion tool to present ambiguities:**
-
-Present 1-4 ambiguities at once using the AskUserQuestion tool with this structure:
-
-- **question**: Clear question about the ambiguity (e.g., "How should the 'xy' mode work visually?").
-- **header**: Short label (max 12 chars) (e.g., "Dual-axis UI").
-- **options**: 2-4 implementation choices with:
-    - **label**: Concise option name (e.g., "Two Navigators").
-    - **description**: Impact explanation (e.g., "Show both X-axis (bottom) and Y-axis (right) navigators - 20% more complexity, clearer UI").
-- **multiSelect**: false (user should pick one approach).
-
-**After receiving answers:**
-
-- Document the chosen approach in a summary.
-- Adjust estimate based on selected options.
-- Include decisions in the "Implementation Decisions" section of the report.
+After receiving answers, document chosen approaches and adjust estimates accordingly.
 
 ### Step 3: Investigate Codebase Dependencies and Complexity
 
-**Use the Explore agent for thorough codebase analysis:**
+Use the **Explore agent** to analyse:
 
-- [ ] Identify all affected files and packages.
-- [ ] Analyse existing similar implementations for patterns.
-- [ ] Check for dependencies on other systems/modules.
-- [ ] Look for related tests that need updating.
-- [ ] Search for documentation that needs changes.
-
-**Key Investigation Areas:**
-
-1. **Core Implementation**
-
-    - Where is the main logic located?
-    - How complex is the existing code in that area?
-    - Are there similar features to reference?
-
-2. **Type System**
-
-    - Will `ag-charts-types` need updates?
-    - Are there complex type definitions involved?
-    - Will this affect public API surface?
-
-3. **Testing Surface**
-
-    - How many test files are affected?
-    - Are image snapshots needed?
-    - Will this need E2E tests?
-
-4. **Documentation & Examples**
-
-    - How many doc pages need updates?
-    - Are new examples required?
-    - Will framework variants be generated?
-
-5. **Build Dependencies**
-    - Which packages need rebuilding?
-    - Are there circular dependency risks?
-    - Will this affect build performance?
+- All affected files and packages.
+- Existing similar implementations for patterns.
+- Dependencies on other systems/modules.
+- Related tests that need updating.
+- Documentation that needs changes.
 
 ### Step 4: Generate Structured Estimation Report
 
-**Use this exact template for consistency:**
+Use this structure consistently. All sections required for Medium/Large scope; Small scope uses abbreviated format (see Step 1.5).
 
----
+**Report Header:**
 
+```
 ## Estimation Report: [Ticket ID/Feature Name]
 
 **Date:** [Current date]
 **Estimator:** Claude Code
 **Ticket Summary:** [Brief 1-2 sentence summary]
+```
 
----
-
-## Executive Summary
+**Executive Summary (always required):**
 
 | Metric | Value |
 |--------|-------|
@@ -163,264 +94,51 @@ Present 1-4 ambiguities at once using the AskUserQuestion tool with this structu
 | **Risk Level** | [Low \| Medium \| High] |
 | **Confidence** | [Low \| Medium \| High] |
 
-**Key Highlights:**
+Follow with 2-3 bullet Key Highlights summarising main work, scope decisions, and top concern.
 
-- [1-2 sentence summary of main implementation work].
-- [Major scope decision or constraint].
-- [Top risk or concern if applicable].
+**Section 1 — Estimated Complexity Level:** Overall rating with rationale. Include breakdown across Implementation, Testing, Documentation, Integration (each Low/Medium/High).
 
----
+**Section 2 — Estimated Time Effort:** Total range in days for single developer + confidence level. Break down into: Investigation & Design, Core Implementation, Testing, Documentation, Review & Iteration. Each gets hours/days. End with explicit Assumptions list.
 
-### 1. Estimated Complexity Level
+**Section 3 — Dependencies, Gaps & Missing Information:** Four sub-sections: External Dependencies, Information Gaps, Implicit Scope (not stated but likely required, e.g. framework wrapper updates, locale strings), Out of Scope (confirm with stakeholder).
 
-**Overall Complexity: [Low | Medium | High | Very High]**
+**Section 4 — Top 3 Highest Risk Aspects:** For each risk:
 
-**Rationale:**
+- **Category:** Known Unknown / Technical Complexity / Integration Risk / etc.
+- **Details:** What makes it risky + potential impact.
+- **Mitigation:** How to reduce this risk.
 
-- [Explanation of complexity drivers].
-- [Why this level was chosen].
+Use `###` sub-headings per risk.
 
-**Complexity Breakdown:**
+**Section 5 — Overall Risk Level:** Assessment (Low/Medium/High) with justification. Include factor breakdown: Technical, Schedule, Integration, Requirement risks (each rated). End with Confidence in Estimate and what would increase it.
 
-- Implementation: [Low/Medium/High].
-- Testing: [Low/Medium/High].
-- Documentation: [Low/Medium/High].
-- Integration: [Low/Medium/High].
+**Closing:**
 
----
-
-### 2. Estimated Time Effort
-
-**Total Estimate: [X-Y days] for a single developer**
-
-**Confidence Level: [Low | Medium | High]**
-
-**Breakdown:**
-
-- **Investigation & Design:** [X hours/days]
-
-    - Understanding requirements.
-    - Design decisions.
-    - Spike work if needed.
-
-- **Core Implementation:** [X hours/days]
-
-    - Primary code changes.
-    - Type definitions.
-    - Public API updates.
-
-- **Testing:** [X hours/days]
-
-    - Unit tests.
-    - E2E tests (if applicable).
-    - Visual regression tests (if applicable).
-    - Benchmark updates (if applicable).
-
-- **Documentation:** [X hours/days]
-
-    - Doc page updates/creation.
-    - Example creation.
-    - Migration guides (if applicable).
-
-- **Review & Iteration:** [X hours/days]
-    - Code review feedback.
-    - Test failures.
-    - Bug fixes.
-
-**Assumptions:**
-
-- [List key assumptions affecting the estimate].
-- [e.g., "Assuming developer is familiar with canvas rendering"].
-- [e.g., "Assuming no major architectural changes needed"].
-
----
-
-### 3. Dependencies, Gaps & Missing Information
-
-**External Dependencies:**
-
-- [List dependencies on other teams/tickets].
-- [Any blocked/blocking items].
-
-**Information Gaps:**
-
-- [What's not specified in the ticket].
-- [Questions that remain unanswered].
-- [Areas needing clarification from stakeholders].
-
-**Implicit Scope (not explicitly mentioned):**
-
-- [Tasks likely required but not stated].
-- [e.g., "Framework wrapper updates"].
-- [e.g., "Locale string additions"].
-
-**Out of Scope (confirm with stakeholder):**
-
-- [Items that might be expected but should be separate].
-- [e.g., "Performance optimisation beyond basic implementation"].
-
----
-
-### 4. Top 3 Highest Risk Aspects
-
-#### Risk #1: [Description]
-
-**Category:** [Known Unknown | Technical Complexity | Integration Risk | etc.]
-
-**Details:**
-
-- [What makes this risky].
-- [Potential impact].
-
-**Mitigation:**
-
-- [How to reduce this risk].
-
----
-
-#### Risk #2: [Description]
-
-**Category:** [Known Unknown | Technical Complexity | Integration Risk | etc.]
-
-**Details:**
-
-- [What makes this risky].
-- [Potential impact].
-
-**Mitigation:**
-
-- [How to reduce this risk].
-
----
-
-#### Risk #3: [Description]
-
-**Category:** [Known Unknown | Technical Complexity | Integration Risk | etc.]
-
-**Details:**
-
-- [What makes this risky].
-- [Potential impact].
-
-**Mitigation:**
-
-- [How to reduce this risk].
-
----
-
-### 5. Overall Risk Level
-
-**Risk Assessment: [Low | Medium | High]**
-
-**Justification:**
-
-- [Overall risk analysis].
-- [Factors contributing to risk level].
-- [Known unknowns summary].
-
-**Risk Factors:**
-
-- **Technical Risk:** [Low/Medium/High] - [Why].
-- **Schedule Risk:** [Low/Medium/High] - [Why].
-- **Integration Risk:** [Low/Medium/High] - [Why].
-- **Requirement Risk:** [Low/Medium/High] - [Why].
-
-**Confidence in Estimate:**
-
-- [High/Medium/Low confidence and why].
-- [What would increase confidence].
-
----
-
-### Recommended Next Steps
-
-1. [Immediate action item].
-2. [Pre-implementation research needed].
-3. [Stakeholder clarifications required].
-
----
-
-## Implementation Decisions (Confirmed)
-
-Based on stakeholder clarification on [date]:
-
-1. **[Decision Area 1]**: [Chosen approach] ([Option letter]).
-2. **[Decision Area 2]**: [Chosen approach] ([Option letter]).
-3. **[Decision Area 3]**: [Chosen approach] ([Option letter]).
-
-_Note: Include this section only if significant implementation choices were clarified during estimation._
-
----
-
-**End of Report**
+- Recommended Next Steps (3 numbered items).
+- Implementation Decisions (Confirmed) — include ONLY if significant choices were clarified during estimation. List each decision with the chosen approach.
 
 ---
 
 ## Completion Checklist
 
-**Cannot mark estimation complete until ALL checked:**
-
 - [ ] User provided JIRA ticket content.
-- [ ] All significant ambiguities identified and clarified with user.
+- [ ] Scope classified (Small/Medium/Large).
+- [ ] Material ambiguities identified and clarified with user.
 - [ ] Codebase investigation completed using Explore agent.
-- [ ] All sections of estimation report filled out.
-- [ ] Complexity level justified with rationale.
-- [ ] Time estimate includes breakdown and assumptions.
-- [ ] Top 3 risks identified with mitigation strategies.
-- [ ] Overall risk level assessed.
-- [ ] Report reviewed for completeness and accuracy.
+- [ ] All required report sections filled out.
+- [ ] Time estimate includes breakdown, assumptions, and confidence level.
+- [ ] Top risks identified with mitigations.
+- [ ] Report reviewed for completeness.
 
 ## Critical Rules
 
-1. **NEVER skip ambiguity clarification** — If implementation choices significantly impact estimates, you MUST ask the user before proceeding using the **AskUserQuestion tool**. Better to pause for clarification than provide misleading estimates. Present options with their complexity/time impacts clearly described.
-
-2. **Always use AskUserQuestion tool for ambiguities** — Do not use ad-hoc text conversation for clarifying implementation choices. Use the structured AskUserQuestion tool to present 1-4 ambiguities at once with clear options and impact descriptions.
-
-3. **Always use Explore agent for codebase analysis** — Do not attempt complex codebase navigation manually. The Explore agent is optimised for this task.
-
-4. **Be honest about uncertainty** — If confidence is low, say so clearly. Include what information would increase confidence.
-
-5. **Consider the full scope** — Don't forget testing, documentation, review iterations, and framework wrappers. These often represent 40-50% of total effort.
-
-6. **Account for unknowns** — Known unknowns should increase time estimates and risk levels proportionally.
-
-7. **Use ranges, not point estimates** — Give ranges (e.g., "3-5 days") to reflect uncertainty, especially for complex work.
-
-8. **Document assumptions explicitly** — Every estimate is based on assumptions. State them clearly so they can be validated.
+1. **Never skip ambiguity clarification** — If implementation choices would shift the estimate by >20%, ask the user via AskUserQuestion before proceeding.
+2. **Be honest about uncertainty** — Low confidence should be stated clearly, with what would increase it.
+3. **Use ranges, not point estimates** — Give ranges (e.g. "3-5 days") to reflect uncertainty.
+4. **Consider the full scope** — Testing, documentation, review iterations, and framework wrappers often represent 40-50% of total effort.
 
 ## Failure Handling
 
-### Problem: Insufficient ticket information
+**Insufficient ticket information:** Request specifics from user. List what's needed. If unavailable, provide estimate with large uncertainty range and note the gaps.
 
-**Solution:**
-
-- Request more details from user.
-- List specific information needed.
-- Provide estimate with large uncertainty range if user cannot provide more details.
-
-### Problem: Cannot find relevant code areas
-
-**Solution:**
-
-- Use Explore agent with broader search patterns.
-- Ask user for hints about where code might be located.
-- Document this as a "known unknown" in the report.
-
-### Problem: Multiple valid implementation approaches with vastly different complexity
-
-**Solution:**
-
-- Use the AskUserQuestion tool to present each approach as an option.
-- Include complexity/time impact in each option's description.
-- Provide recommendation in one option's description if applicable.
-- Let user select their preferred approach through the structured interface.
-- Document chosen approach in the "Implementation Decisions" section.
-
-### Problem: Estimate exceeds reasonable time (e.g., >2 weeks for single person)
-
-**Solution:**
-
-- Consider if work should be broken into multiple tickets.
-- Highlight this in the risk assessment.
-- Recommend creating sub-tasks or phases.
-- Discuss with user about scope reduction options.
+**Estimate exceeds 2 weeks:** Recommend breaking into sub-tasks or phases. Highlight in risk assessment and discuss scope reduction with user.

--- a/external/ag-shared/prompts/skills/plan-review/SKILL.md
+++ b/external/ag-shared/prompts/skills/plan-review/SKILL.md
@@ -18,9 +18,10 @@ User provides one of:
 
 Optional flags:
 
--   `--quick` - Fast review with fewer agents (2-3 vs 5-6)
+-   `--quick` - Fast review with fewer agents (3-4 vs 6-8)
 -   `--thorough` - Comprehensive review (default)
 -   `--external` - Include external tools (Codex/Gemini) if available
+-   `--no-devils-advocate` - Skip the Devil's Advocate review pass (runs by default)
 
 ## Sub-Documents
 
@@ -33,6 +34,7 @@ Load sub-documents progressively based on the review mode and phase.
 | `output-format.md` | Report template and output structure | Phase 3 (Synthesis) |
 | `discovered-work.md` | Discovered Work Protocol for sub-agents | Include in all sub-agent prompts |
 | `external-tools.md` | Codex/Gemini integration | Only with --external flag |
+| `agents/devils-advocate.md` | Devil's Advocate adversarial review agent | Default (skip with --no-devils-advocate) |
 
 ## Execution Phases
 
@@ -55,8 +57,8 @@ Load sub-documents progressively based on the review mode and phase.
 
     | Flag                   | Mode     | Agents | Use Case                            |
     | ---------------------- | -------- | ------ | ----------------------------------- |
-    | `--quick`              | Quick    | 2-3    | Fast feedback, simple plans         |
-    | `--thorough` (default) | Thorough | 5-6    | Comprehensive review, complex plans |
+    | `--quick`              | Quick    | 3-4    | Fast feedback, simple plans         |
+    | `--thorough` (default) | Thorough | 6-8    | Comprehensive review, complex plans |
 
 3. **Extract original request/specification:**
 
@@ -115,7 +117,7 @@ Launch specialised review agents based on mode. Load the appropriate agent promp
 
 Include the Discovered Work Protocol from `.rulesync/skills/plan-review/discovered-work.md` in all sub-agent prompts.
 
-#### Quick Mode (3 agents)
+#### Quick Mode (3-4 agents)
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -137,10 +139,16 @@ Include the Discovered Work Protocol from `.rulesync/skills/plan-review/discover
 │    - Concurrency: What can run in parallel?                 │
 │    - Agent topology: Optimal execution pattern              │
 │    - Intent in sub-agent prompts: Is WHY conveyed?          │
+├─────────────────────────────────────────────────────────────┤
+│ 4. Devil's Advocate (default, skip with --no-devils-advocate)│
+│    - Challenge: Is this the right approach?                 │
+│    - Assumptions: What if key assumptions are wrong?        │
+│    - Necessity: Could tasks be removed or deferred?         │
+│    - Adversary: What is the most likely point of failure?   │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-#### Thorough Mode (6-7 agents)
+#### Thorough Mode (6-8 agents)
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -152,7 +160,8 @@ Include the Discovered Work Protocol from `.rulesync/skills/plan-review/discover
 │ 4. Verification Reviewer                                     │
 │ 5. Risk Reviewer                                             │
 │ 6. Parallelisability Analyser                               │
-│ 7. External Reviewer (optional, --external flag)            │
+│ 7. Devil's Advocate (default, skip with --no-devils-advocate)│
+│ 8. External Reviewer (optional, --external flag)            │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -195,6 +204,24 @@ Aggregate findings from all review agents:
 ### Phase 4: Interactive Resolution (Optional)
 
 If issues found, present to user for iterative refinement.
+
+---
+
+## Devil's Advocate Mode (Default)
+
+By default, an additional adversarial review pass runs after the standard review agents complete. This mode challenges assumptions, stress-tests the plan's approach, and questions whether the proposed tasks are the right ones. Pass `--no-devils-advocate` to skip it.
+
+### Workflow
+
+1. **Run the standard review agents first.** Complete Phase 1 (parallel review agents) and collect all findings.
+2. **Spawn a sub-agent with the Devil's Advocate instructions.** Use the Agent tool to spawn a sub-agent with:
+   - The full instructions from `agents/devils-advocate.md`.
+   - The plan content, original requirements, and a summary of the standard review findings (so the DA can challenge those too).
+3. **Merge findings from both passes.**
+   - Combine standard review findings with Devil's Advocate findings (prefixed with `[DA]`).
+   - Deduplicate: if both passes flag the same plan element for the same issue, keep the higher-severity version and note it was flagged by both passes.
+   - Add a `## Devil's Advocate Findings` section in the output report after the standard findings sections.
+4. **Update the assessment.** If the Devil's Advocate pass surfaces CRITICAL or IMPORTANT issues not found in the standard review, adjust the overall assessment and recommendations accordingly.
 
 ---
 

--- a/external/ag-shared/prompts/skills/plan-review/agent-prompts-quick.md
+++ b/external/ag-shared/prompts/skills/plan-review/agent-prompts-quick.md
@@ -125,10 +125,51 @@ created a task, then continue with your focused review.
 
 ---
 
+## Agent 4: Devil's Advocate (Default)
+
+Runs by default unless `--no-devils-advocate` is passed. Read the full agent instructions from `agents/devils-advocate.md`.
+
+```markdown
+You are a Devil's Advocate reviewer for this implementation plan. The standard review agents have
+already covered intent, completeness, verification, and parallelisability. Your job is to challenge,
+question, and stress-test what they missed.
+
+Read and follow the full instructions in the co-located `agents/devils-advocate.md` file for your
+adversarial mandate and focus areas.
+
+**Original Requirements (source of truth):**
+${ORIGINAL_REQUIREMENTS}
+
+**Plan:**
+${PLAN_CONTENT}
+
+**Standard Review Findings (for context — challenge these too):**
+${STANDARD_FINDINGS}
+
+**Your adversarial focus:**
+
+1. **Challenge the approach:** Is this the right plan? Is there a fundamentally simpler way?
+2. **Stress-test assumptions:** What if key assumptions are wrong? What breaks?
+3. **Question task necessity:** For each task — if removed, would the plan still succeed?
+4. **Probe execution gaps:** What goes wrong during execution that the plan ignores?
+5. **Challenge the ordering:** Should risky tasks run first to fail fast?
+6. **Play the adversary:** What is the single most likely point of failure?
+
+**Return findings prefixed with [DA] using severity levels:**
+
+-   CRITICAL: [plan will likely fail or miss the goal]
+-   IMPORTANT: [significant risk the standard review missed]
+-   MINOR: [worthwhile challenge but not blocking]
+
+**Important:** If the plan is solid, say so. Do not manufacture findings.
+```
+
+---
+
 ## Launch Pattern
 
 ```javascript
-// Launch all 3 agents in parallel using Agent tool
+// Launch all 3-4 agents in parallel using Agent tool
 Agent({
     subagent_type: 'general-purpose',
     description: 'Intent & completeness review',
@@ -145,5 +186,12 @@ Agent({
     subagent_type: 'general-purpose',
     description: 'Parallelisability analysis',
     prompt: `[Agent 3 prompt with ${PLAN_CONTENT} substituted]`,
+});
+
+// Only if --no-devils-advocate is NOT set:
+Agent({
+    subagent_type: 'general-purpose',
+    description: "Devil's Advocate review",
+    prompt: `[Agent 4 prompt with ${ORIGINAL_REQUIREMENTS}, ${PLAN_CONTENT}, and ${STANDARD_FINDINGS} substituted]`,
 });
 ```

--- a/external/ag-shared/prompts/skills/plan-review/agent-prompts-thorough.md
+++ b/external/ag-shared/prompts/skills/plan-review/agent-prompts-thorough.md
@@ -232,3 +232,44 @@ If you find significant issues outside your focus area, use TaskCreate to propos
 a follow-up task rather than investigating. Note in your findings that you
 created a task, then continue with your focused review.
 ```
+
+---
+
+## Agent 7: Devil's Advocate (Default)
+
+Runs by default unless `--no-devils-advocate` is passed. Read the full agent instructions from `agents/devils-advocate.md`.
+
+```markdown
+You are a Devil's Advocate reviewer for this implementation plan. The standard review agents have
+already covered intent, completeness, technical correctness, verification, risk, and parallelisability.
+Your job is to challenge, question, and stress-test what they missed.
+
+Read and follow the full instructions in the co-located `agents/devils-advocate.md` file for your
+adversarial mandate and focus areas.
+
+**Original Requirements (source of truth):**
+${ORIGINAL_REQUIREMENTS}
+
+**Plan:**
+${PLAN_CONTENT}
+
+**Standard Review Findings (for context — challenge these too):**
+${STANDARD_FINDINGS}
+
+**Your adversarial focus:**
+
+1. **Challenge the approach:** Is this the right plan? Is there a fundamentally simpler way?
+2. **Stress-test assumptions:** What if key assumptions are wrong? What breaks?
+3. **Question task necessity:** For each task — if removed, would the plan still succeed?
+4. **Probe execution gaps:** What goes wrong during execution that the plan ignores?
+5. **Challenge the ordering:** Should risky tasks run first to fail fast?
+6. **Play the adversary:** What is the single most likely point of failure?
+
+**Return findings prefixed with [DA] using severity levels:**
+
+-   CRITICAL: [plan will likely fail or miss the goal]
+-   IMPORTANT: [significant risk the standard review missed]
+-   MINOR: [worthwhile challenge but not blocking]
+
+**Important:** If the plan is solid, say so. Do not manufacture findings.
+```

--- a/external/ag-shared/prompts/skills/plan-review/agents/devils-advocate.md
+++ b/external/ag-shared/prompts/skills/plan-review/agents/devils-advocate.md
@@ -1,0 +1,98 @@
+# Devil's Advocate Plan Review Agent
+
+You are a Devil's Advocate reviewer for implementation plans. Your job is to **challenge, question, and stress-test** a plan that has already passed a standard multi-agent review. You are not here to rubber-stamp; you are here to find what the standard reviewers missed by thinking adversarially.
+
+## Your Mandate
+
+You operate as a sub-agent spawned after the standard review agents complete. Those agents cover intent clarity, completeness, technical correctness, verification, risk, and parallelisability. Your role is to go deeper by challenging the plan from angles that conventional reviewers tend to skip.
+
+## Focus Areas
+
+### 1. Challenge the Approach
+
+- Is this the right plan, or is there a fundamentally simpler way to achieve the same goal?
+- Is the plan over-engineered? Could it be half as many tasks and still succeed?
+- Is the plan under-engineered? Does it hand-wave over genuinely hard problems?
+- Would an experienced engineer look at this plan and say "why not just..."?
+- Are there well-known patterns or existing solutions being reinvented?
+
+### 2. Stress-Test Assumptions
+
+- What assumptions does the plan make about the codebase, environment, or dependencies that are not explicitly validated?
+- What happens if a key assumption is wrong? Is there a fallback or does the whole plan collapse?
+- Does the plan assume certain APIs, patterns, or behaviours exist without verifying them?
+- Are there timing assumptions (e.g., "this runs fast", "this data is small") that could be violated?
+- Does the plan assume tasks are independent when they actually have hidden coupling?
+
+### 3. Question Task Necessity
+
+- For each task: if you removed it, would the plan still achieve its core intent?
+- Are there tasks that exist only for "completeness" but add no real value?
+- Is there scope creep — tasks that go beyond the original request?
+- Are there "gold-plating" tasks that optimise for unlikely scenarios?
+- Could any tasks be deferred to a follow-up without blocking the core goal?
+
+### 4. Probe Execution Gaps
+
+- What could go wrong during execution that the plan does not account for?
+- If a sub-agent executes task N and gets stuck, what happens? Is there recovery guidance?
+- Are there tasks where the verification criteria are so vague that "done" is ambiguous?
+- Does the plan account for the executing agent's limitations (context window, tool access, codebase knowledge)?
+- Are there tasks that require information not available to the executing agent?
+
+### 5. Challenge the Ordering
+
+- Does the dependency graph actually hold? Are there tasks marked as independent that have hidden dependencies?
+- Would executing tasks in a different order be safer or more efficient?
+- Are there tasks that should be done first to "fail fast" and validate the approach early?
+- Does the plan frontload the easy work and backload the risky work? (This is usually wrong.)
+
+### 6. Play the Adversary
+
+- If you were trying to make this plan fail, what would you exploit?
+- What is the single most likely point of failure?
+- What would a frustrated implementer complain about most?
+- If the plan is executed perfectly, does it actually solve the original problem?
+- What will the user say when they see the result — will they be satisfied, or will they say "that's not what I meant"?
+
+## Output Guidelines
+
+- Use severity levels: CRITICAL, IMPORTANT, MINOR (matching the standard review).
+- Every finding **must** reference a specific plan section, task number, or element.
+- Prefix each finding title with `[DA]` so findings from this agent are clearly identifiable when merged with the standard review.
+- Focus on **genuinely challenging questions and concrete risks**, not hypothetical nitpicks.
+- If the plan is solid and you cannot find substantive issues, say so explicitly rather than manufacturing findings. A clean Devil's Advocate pass is a strong signal.
+- Aim for depth over breadth: a few well-argued findings are more valuable than a long list of shallow ones.
+
+## Output Format
+
+Return your findings as structured text:
+
+```markdown
+## Devil's Advocate Findings
+
+### CRITICAL
+
+{List critical issues, or "None" if empty}
+
+-   **[DA] {Issue title}** (Task N / Section X)
+    {Explanation of why this is a genuine risk to the plan's success}
+
+### IMPORTANT
+
+{List important issues, or "None" if empty}
+
+-   **[DA] {Issue title}** (Task N / Section X)
+    {Explanation and suggested alternative or mitigation}
+
+### MINOR
+
+{List minor issues, or "None" if empty}
+
+-   **[DA] {Issue title}** (Task N / Section X)
+    {Brief explanation}
+
+### Summary
+
+{1-2 sentences on overall adversarial assessment: Is this plan robust, or are there substantive concerns the standard review missed?}
+```

--- a/external/ag-shared/prompts/skills/plan-review/output-format.md
+++ b/external/ag-shared/prompts/skills/plan-review/output-format.md
@@ -157,6 +157,20 @@ Execution Graph:
 
 ---
 
+## Devil's Advocate Findings
+
+### [DA] [Issue Title]
+
+- **Severity:** [Critical/Important/Minor]
+- **Location:** [Task N / Plan section]
+- **Challenge:** [What is being questioned]
+- **Risk:** [Why this matters — what could go wrong]
+- **Recommendation:** [Alternative approach or mitigation]
+
+_{Or "The Devil's Advocate found no substantive issues — this is a strong signal the plan is robust."}_
+
+---
+
 ## Recommendations
 
 ### High Priority (Address Before Implementation)

--- a/external/ag-shared/prompts/skills/pr-review/SKILL.md
+++ b/external/ag-shared/prompts/skills/pr-review/SKILL.md
@@ -16,10 +16,10 @@ You are acting as a reviewer for a proposed code change. Your goal is to identif
 Parse the `ARGUMENTS` environment variable (or skill arguments) for flags and the PR number:
 
 - `--json` — output structured JSON instead of Markdown (used for inline commenting in CI)
-- `--no-devils-advocate` — skip the Devil's Advocate review pass (it runs by default)
+- `--devils-advocate` — run an additional Devil's Advocate review pass after the standard review (see below)
 - Remaining positional argument — the PR number
 
-Examples: `123`, `--json 123`, `123 --json`, `--no-devils-advocate 123`
+Examples: `123`, `--json 123`, `123 --json`, `--devils-advocate 123`, `--json --devils-advocate 123`
 
 ## Output Format
 
@@ -198,9 +198,9 @@ When `--json` is specified, output **ONLY** valid JSON. No markdown code fences,
 }
 ```
 
-## Devil's Advocate Mode (default)
+## Devil's Advocate Mode (`--devils-advocate`)
 
-By default, an additional adversarial review pass runs after the standard review completes. This mode challenges assumptions, stress-tests edge cases, and questions whether the PR's approach is the right one. Pass `--no-devils-advocate` to skip it.
+When the `--devils-advocate` flag is present, run an additional adversarial review pass after the standard review completes. This mode challenges assumptions, stress-tests edge cases, and questions whether the PR's approach is the right one.
 
 ### Workflow
 

--- a/external/ag-shared/prompts/skills/pr-review/SKILL.md
+++ b/external/ag-shared/prompts/skills/pr-review/SKILL.md
@@ -16,9 +16,10 @@ You are acting as a reviewer for a proposed code change. Your goal is to identif
 Parse the `ARGUMENTS` environment variable (or skill arguments) for flags and the PR number:
 
 - `--json` — output structured JSON instead of Markdown (used for inline commenting in CI)
+- `--devils-advocate` — run an additional Devil's Advocate review pass after the standard review (see below)
 - Remaining positional argument — the PR number
 
-Examples: `123`, `--json 123`, `123 --json`
+Examples: `123`, `--json 123`, `123 --json`, `--devils-advocate 123`, `--json --devils-advocate 123`
 
 ## Output Format
 
@@ -196,3 +197,21 @@ When `--json` is specified, output **ONLY** valid JSON. No markdown code fences,
   }
 }
 ```
+
+## Devil's Advocate Mode (`--devils-advocate`)
+
+When the `--devils-advocate` flag is present, run an additional adversarial review pass after the standard review completes. This mode challenges assumptions, stress-tests edge cases, and questions whether the PR's approach is the right one.
+
+### Workflow
+
+1. **Run the standard review first.** Complete the full review as described above and collect all findings.
+2. **Spawn a sub-agent with the Devil's Advocate instructions.** Use the Agent tool to spawn a sub-agent with the following prompt structure:
+   - Include the full contents of `agents/devils-advocate.md` (co-located in this skill's directory) as the sub-agent's instructions.
+   - Pass the PR diff, PR metadata, and the `--json` flag state to the sub-agent so it has full context.
+   - The sub-agent should read and follow `_review-core.md` for shared methodology.
+3. **Merge findings from both passes.**
+   - Combine standard review findings with Devil's Advocate findings (prefixed with `[DA]`).
+   - Deduplicate: if both passes flag the same file and line for the same issue, keep the higher-priority version and note it was flagged by both passes.
+   - In Markdown mode, add a `## Devil's Advocate Findings` section after the standard `## Findings` section.
+   - In JSON mode, merge the Devil's Advocate findings into the `findings` array (the `[DA]` prefix in the title distinguishes them).
+4. **Update the verdict.** If the Devil's Advocate pass surfaces P0 or P1 issues not found in the standard review, adjust the verdict and confidence accordingly.

--- a/external/ag-shared/prompts/skills/pr-review/SKILL.md
+++ b/external/ag-shared/prompts/skills/pr-review/SKILL.md
@@ -16,10 +16,10 @@ You are acting as a reviewer for a proposed code change. Your goal is to identif
 Parse the `ARGUMENTS` environment variable (or skill arguments) for flags and the PR number:
 
 - `--json` — output structured JSON instead of Markdown (used for inline commenting in CI)
-- `--devils-advocate` — run an additional Devil's Advocate review pass after the standard review (see below)
+- `--no-devils-advocate` — skip the Devil's Advocate review pass (it runs by default)
 - Remaining positional argument — the PR number
 
-Examples: `123`, `--json 123`, `123 --json`, `--devils-advocate 123`, `--json --devils-advocate 123`
+Examples: `123`, `--json 123`, `123 --json`, `--no-devils-advocate 123`
 
 ## Output Format
 
@@ -198,9 +198,9 @@ When `--json` is specified, output **ONLY** valid JSON. No markdown code fences,
 }
 ```
 
-## Devil's Advocate Mode (`--devils-advocate`)
+## Devil's Advocate Mode (default)
 
-When the `--devils-advocate` flag is present, run an additional adversarial review pass after the standard review completes. This mode challenges assumptions, stress-tests edge cases, and questions whether the PR's approach is the right one.
+By default, an additional adversarial review pass runs after the standard review completes. This mode challenges assumptions, stress-tests edge cases, and questions whether the PR's approach is the right one. Pass `--no-devils-advocate` to skip it.
 
 ### Workflow
 

--- a/external/ag-shared/prompts/skills/pr-review/_review-core.md
+++ b/external/ag-shared/prompts/skills/pr-review/_review-core.md
@@ -156,6 +156,6 @@ To determine which method to use:
 
 ## 10. Devil's Advocate Mode
 
-By default, the review skill runs a second pass using an adversarial sub-agent defined in `agents/devils-advocate.md`. Pass `--no-devils-advocate` to skip it. This agent challenges assumptions, stress-tests edge cases, questions necessity, and probes for gaps in testing.
+When the `--devils-advocate` flag is passed, the review skill runs a second pass using an adversarial sub-agent defined in `agents/devils-advocate.md`. This agent challenges assumptions, stress-tests edge cases, questions necessity, and probes for gaps in testing.
 
 The Devil's Advocate agent follows the same priority scheme (P0-P3), line number guidelines, and environment detection described in this file. Its findings are prefixed with `[DA]` and merged with the standard review output. See `SKILL.md` for the full workflow and merge logic.

--- a/external/ag-shared/prompts/skills/pr-review/_review-core.md
+++ b/external/ag-shared/prompts/skills/pr-review/_review-core.md
@@ -156,6 +156,6 @@ To determine which method to use:
 
 ## 10. Devil's Advocate Mode
 
-When the `--devils-advocate` flag is passed, the review skill runs a second pass using an adversarial sub-agent defined in `agents/devils-advocate.md`. This agent challenges assumptions, stress-tests edge cases, questions necessity, and probes for gaps in testing.
+By default, the review skill runs a second pass using an adversarial sub-agent defined in `agents/devils-advocate.md`. Pass `--no-devils-advocate` to skip it. This agent challenges assumptions, stress-tests edge cases, questions necessity, and probes for gaps in testing.
 
 The Devil's Advocate agent follows the same priority scheme (P0-P3), line number guidelines, and environment detection described in this file. Its findings are prefixed with `[DA]` and merged with the standard review output. See `SKILL.md` for the full workflow and merge logic.

--- a/external/ag-shared/prompts/skills/pr-review/_review-core.md
+++ b/external/ag-shared/prompts/skills/pr-review/_review-core.md
@@ -153,3 +153,9 @@ To determine which method to use:
 2. **Fallback**: Check for pre-fetched refs with `git rev-parse origin/pr/$ARGUMENTS 2>/dev/null`
    - If successful: Use git diff commands
    - If fails: Use `gh` CLI commands
+
+## 10. Devil's Advocate Mode
+
+When the `--devils-advocate` flag is passed, the review skill runs a second pass using an adversarial sub-agent defined in `agents/devils-advocate.md`. This agent challenges assumptions, stress-tests edge cases, questions necessity, and probes for gaps in testing.
+
+The Devil's Advocate agent follows the same priority scheme (P0-P3), line number guidelines, and environment detection described in this file. Its findings are prefixed with `[DA]` and merged with the standard review output. See `SKILL.md` for the full workflow and merge logic.

--- a/external/ag-shared/prompts/skills/pr-review/agents/devils-advocate.md
+++ b/external/ag-shared/prompts/skills/pr-review/agents/devils-advocate.md
@@ -1,0 +1,109 @@
+# Devil's Advocate Review Agent
+
+You are a Devil's Advocate reviewer. Your job is to **challenge, question, and stress-test** a pull request that has already passed a standard review. You are not here to rubber-stamp; you are here to find what the standard review missed by thinking adversarially.
+
+**Read and follow the shared methodology in the co-located `_review-core.md` file** for priority definitions (P0-P3), line number guidelines, environment detection, and workflow basics. This document defines your additional focus areas and adversarial mindset.
+
+## Your Mandate
+
+You operate as a sub-agent spawned after the standard review pass. The standard review covers correctness, performance, security, and maintainability. Your role is to go deeper by challenging the PR from angles that a conventional review tends to skip.
+
+## Focus Areas
+
+### 1. Challenge Assumptions
+
+- Is this the right approach, or is there a simpler alternative the author did not consider?
+- Is the abstraction level appropriate? Is something over-abstracted or under-abstracted?
+- Would a different architecture or data structure serve the same goal with fewer trade-offs?
+- Are there implicit assumptions about input shape, execution order, or environment that are not enforced?
+
+### 2. Stress-Test Edge Cases
+
+- What happens with empty inputs, null values, or undefined fields?
+- How does this code behave under concurrent access or re-entrant calls?
+- What happens with very large datasets, deeply nested structures, or extreme numeric values?
+- Are there error conditions on the unhappy path that the implementation silently ignores?
+- What happens if an upstream dependency changes its contract (e.g., returns a different shape)?
+
+### 3. Question Necessity
+
+- Is every file change in this PR actually needed to achieve the stated goal?
+- Is there unnecessary complexity, premature generalisation, or over-engineering?
+- Does the PR introduce scope creep beyond what the ticket or description claims?
+- Could any of the new code be replaced by an existing utility or pattern already in the codebase?
+
+### 4. Challenge the Testing
+
+- Do the tests actually verify the behaviour that changed, or do they test incidental details?
+- Could the tests pass while the code is still broken? (e.g., tests that assert on mocks rather than real behaviour)
+- What scenarios are **not** covered by the test suite? Identify the most dangerous gaps.
+- Are there integration or interaction effects between changed modules that unit tests would miss?
+- If there are no new tests, should there be?
+
+### 5. Consider the Consumer
+
+- How does this change affect downstream users, consumers, or dependent packages?
+- Are there breaking changes that are not obvious from the diff alone (e.g., subtle behaviour changes, type narrowing)?
+- Would a consumer need to migrate or update their code? Is that migration path clear?
+- Does this change alter any public API surface (types, events, callbacks, CSS classes)?
+
+### 6. Play the Adversary
+
+- If you were trying to break this code in production, how would you do it?
+- What inputs or sequences of operations would trigger the worst outcome?
+- Are there race conditions, resource leaks, or state corruption vectors?
+- Could a malicious or careless consumer misuse the new API in a way that causes harm?
+
+## Output Guidelines
+
+- Use the same priority scheme as the standard review (P0-P3).
+- Every finding **must** reference a specific file and line number from the diff.
+- Prefix each finding title with `[DA]` so findings from this agent are clearly identifiable when merged with the standard review.
+- Focus on **genuinely challenging questions and concrete risks**, not hypothetical nitpicks.
+- If the PR is solid and you cannot find substantive issues, say so explicitly rather than manufacturing findings. A clean Devil's Advocate pass is a strong signal.
+- Aim for depth over breadth: a few well-argued findings are more valuable than a long list of shallow ones.
+
+## Output Format
+
+Output your findings in the same format as the standard review (Markdown or JSON, depending on the `--json` flag passed to the parent skill). The parent skill will merge your findings with the standard review and deduplicate.
+
+### Markdown
+
+```markdown
+## Devil's Advocate Findings
+
+### P0 - Critical
+
+{List P0 issues, or "None" if empty}
+
+-   **`{filepath}:{line}`** - [DA] {Issue title}
+    {Explanation of why this is a genuine risk}
+
+### P1 - High
+
+...
+
+### P2 - Medium
+
+...
+
+### Summary
+
+{1-2 sentences on overall adversarial assessment: Is this PR robust, or are there substantive concerns the standard review missed?}
+```
+
+### JSON
+
+When `--json` is active, output a JSON array of finding objects using the same schema as the standard review's `findings` array. Prefix each `title` with `[DA]`.
+
+```json
+[
+  {
+    "priority": "P1",
+    "file": "src/example.ts",
+    "line": 42,
+    "title": "[DA] Assumption about input ordering is not enforced",
+    "description": "The code assumes items arrive sorted by timestamp, but nothing validates or enforces this. If the upstream data source changes its ordering, the binary search at line 42 will silently return wrong results."
+  }
+]
+```

--- a/external/ag-shared/prompts/skills/rulesync/SKILL.md
+++ b/external/ag-shared/prompts/skills/rulesync/SKILL.md
@@ -143,7 +143,7 @@ ln -s ../../external/prompts/subagents/visual-qa.md visual-qa.md
 
 # From .rulesync/skills/ (DIRECTORY symlinks)
 ln -s ../../external/ag-shared/prompts/skills/dev-server/ dev-server
-ln -s ../../external/prompts/skills/jira-create/ jira-create
+ln -s ../../external/ag-shared/prompts/skills/jira jira
 ```
 
 ## Adding New Content


### PR DESCRIPTION
## Summary

- **Optimise `/jira` skill:** Consolidate JIRA tooling into a single shared skill, reduce context overhead, and improve the skill description for better auto-triggering accuracy.
- **Add Devil's Advocate agent to `/pr-review`:** New adversarial review sub-agent (`--devils-advocate` flag, opt-in) that challenges assumptions, stress-tests edge cases, questions necessity, and probes for testing gaps in code reviews.
- **Add Devil's Advocate agent to `/plan-review`:** New adversarial review sub-agent (default-on, skip with `--no-devils-advocate`) that challenges the plan's approach, stress-tests assumptions, questions task necessity, probes execution gaps, and challenges ordering. Integrated into both Quick mode (agent 4) and Thorough mode (agent 7).

## Related PRs

- **ag-charts-prompts:** ag-grid/ag-charts-prompts#19 — removes old JIRA skills/commands/rules superseded by the consolidated `/jira` skill in ag-shared

## Changes

### `/jira` skill
- Consolidated into single shared skill at `external/ag-shared/prompts/skills/jira/`
- Optimised description for better auto-triggering (action-first format with explicit trigger phrases)
- Reduced context by restructuring templates and workflows

### `/pr-review` skill
- New `agents/devils-advocate.md` with 6 focus areas: Challenge Assumptions, Stress-Test Edge Cases, Question Necessity, Challenge Testing, Consider the Consumer, Play the Adversary
- Opt-in via `--devils-advocate` flag
- Findings prefixed with `[DA]`, merged with standard review output

### `/plan-review` skill
- New `agents/devils-advocate.md` tailored for plan review (not code diffs)
- 6 focus areas: Challenge the Approach, Stress-Test Assumptions, Question Task Necessity, Probe Execution Gaps, Challenge the Ordering, Play the Adversary
- **Default-on** (skip with `--no-devils-advocate`)
- Integrated into agent diagrams, prompt sub-documents, and output format template
- Updated agent counts: Quick 3→3-4, Thorough 6-7→6-8

## Test plan

- [ ] Verify `/jira` skill triggers correctly for ticket creation queries
- [ ] Verify `/pr-review --devils-advocate <PR>` runs DA pass and merges findings
- [ ] Verify `/plan-review` runs DA by default
- [ ] Verify `/plan-review --no-devils-advocate` skips DA agent