### PR TITLE
Fix flaky sequenced styler and Google Fonts E2E tests

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -25,6 +25,7 @@ import { testLegendItemName } from '../../test/legendItemName';
 import type { CartesianOrPolarTestCase } from '../../test/utils';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
+    MIN_UNHIGHLIGHT_DELAY,
     PATTERN_SNAPSHOT_DEFAULTS,
     cartesianChartAssertions,
     clickAction,
@@ -1303,6 +1304,7 @@ describe('BarSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);
@@ -1314,6 +1316,8 @@ describe('BarSeries', () => {
                     await hover(miss);
                     await hover(legendItem0);
                     await hover(legendItem1);
+                    // Wait for delayed unhighlights to complete
+                    await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
                     expect(styler.mock.mock.calls).toMatchSnapshot();
                 });
             });

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.test.ts
@@ -681,6 +681,7 @@ describe('BoxPlotSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);

--- a/packages/ag-charts-enterprise/src/series/nightingale/__snapshots__/nightingale.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/nightingale/__snapshots__/nightingale.test.ts.snap
@@ -179,25 +179,6 @@ exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 1`] = `
       "cornerRadius": 0,
       "fill": "#fba71b",
       "fillOpacity": 1,
-      "highlightState": "unhighlighted-series",
-      "lineDash": [
-        0,
-      ],
-      "lineDashOffset": 0,
-      "radiusKey": "hw",
-      "seriesId": "NightingaleSeries-2",
-      "stackGroup": undefined,
-      "stroke": "#b07513",
-      "strokeOpacity": 1,
-      "strokeWidth": 1,
-    },
-  ],
-  [
-    {
-      "angleKey": "quarter",
-      "cornerRadius": 0,
-      "fill": "#fba71b",
-      "fillOpacity": 1,
       "highlightState": "none",
       "lineDash": [
         0,

--- a/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
+++ b/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
@@ -758,6 +758,7 @@ describe('NightingaleSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);

--- a/packages/ag-charts-enterprise/src/series/radar-area/radarArea.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-area/radarArea.test.ts
@@ -682,6 +682,7 @@ describe('RadarAreaSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);

--- a/packages/ag-charts-enterprise/src/series/radar-line/radarLine.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-line/radarLine.test.ts
@@ -561,6 +561,7 @@ describe('RadarLineSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
@@ -638,6 +638,7 @@ describe('RadialBarSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
@@ -11,6 +11,7 @@ import {
 } from 'ag-charts-community';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
+    MIN_UNHIGHLIGHT_DELAY,
     type MockRadialColumnStyler,
     expectWarningsCalls,
     extractImageData,
@@ -797,6 +798,7 @@ describe('RadialColumnSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);
@@ -808,6 +810,8 @@ describe('RadialColumnSeries', () => {
                     await hover(miss);
                     await hover(legendItem0);
                     await hover(legendItem1);
+                    // Wait for delayed unhighlights to complete
+                    await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
                     expect(styler.mock.mock.calls).toMatchSnapshot();
                 });
             });

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.test.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.test.ts
@@ -1055,6 +1055,7 @@ describe('RangeBarSeries', () => {
             describe('sequenced', () => {
                 async function hover(p: { readonly x: number; readonly y: number }) {
                     await hoverAction(p.x, p.y)(chart);
+                    await waitForChartStability(chart);
                 }
                 test('1', async () => {
                     await hover(miss);

--- a/packages/ag-charts-website/e2e/fonts.spec.ts
+++ b/packages/ag-charts-website/e2e/fonts.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixture';
-import { gotoExample, locateCanvas, setupIntrinsicAssertions, toExamplePageUrls } from './util';
+import { gotoExample, locateCanvas, setupIntrinsicAssertions, toExamplePageUrls, waitForAllChartUpdates } from './util';
 
 test.describe('fonts', () => {
     setupIntrinsicAssertions(test);
@@ -10,6 +10,8 @@ test.describe('fonts', () => {
         test.describe(`for ${framework}`, () => {
             test('google fonts', async ({ page }) => {
                 await gotoExample(page, url);
+                await page.evaluate(() => document.fonts.ready);
+                await waitForAllChartUpdates(page);
 
                 const { canvas } = await locateCanvas(page);
                 await expect(canvas).toHaveScreenshot('google-fonts.png');


### PR DESCRIPTION
Add `waitForChartStability` to sequenced test hover helpers so each hover event fully completes before the next fires, preventing missed styler calls due to rAF-debounced hover rescheduling. Add `MIN_UNHIGHLIGHT_DELAY` wait in radialColumn and barSeries sequenced tests. Wait for `document.fonts.ready` in fonts E2E before screenshotting.