### PR TITLE
Add single-track-value rule and UMD module registration note

### DIFF
--- a/external/ag-shared/prompts/skills/jira/SKILL.md
+++ b/external/ag-shared/prompts/skills/jira/SKILL.md
@@ -72,6 +72,8 @@ All API calls use: `1565837d-d6d1-4228-bcb2-4cb74df700f2`
 
 Format: `[{"value": "Bug"}]` or `[{"id": "10401"}]`
 
+Each ticket has exactly **one** track value. Never set multiple track values on a single ticket.
+
 ### Description Formatting
 
 - Use plain numbered lists: `1. Item` (not `#` wiki markup).

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -12,6 +12,8 @@ Ask the user which type of ticket they need:
 | **Tech-debt** | `"Task"` | `"Housekeeping"` | Refactoring, cleanup, infrastructure |
 | **Docs** | `"Task"` | `"Doc change"` | Documentation updates only |
 
+Each ticket has exactly **one** track value. Never set multiple track values on a single ticket.
+
 ### Improvement Tasks
 
 An "improvement task" is a hybrid: it uses the **bug template** (TC-based format) for the description but is filed as a **Task** with **Improvement** track — not as a Bug.

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -6,9 +6,9 @@ Ask the user which type of ticket they need:
 
 | Type | Issue Type | Track Value | Use When |
 |------|-----------|-------------|----------|
-| **Bug** | `"Bug"` | `"Bug"` | Something is broken or behaving incorrectly |
+| **Bug** | `"Bug"` | `"Bug"` | Customer-reported bug |
 | **Feature** | `"Task"` | `"Feature Request"` | New capability requested |
-| **Improvement** | `"Task"` | `"Improvement"` | Enhancement to existing feature |
+| **Improvement** | `"Task"` | `"Improvement"` | Internally reported bug |
 | **Tech-debt** | `"Task"` | `"Housekeeping"` | Refactoring, cleanup, infrastructure |
 | **Docs** | `"Task"` | `"Doc change"` | Documentation updates only |
 
@@ -29,15 +29,15 @@ Based on ticket type, read the relevant template (in the `templates/` subdirecto
 
 ## Step 2: Gather Information
 
-**For Bug tickets, collect:**
+**For Bug and Improvement tickets, collect:**
 
 - [ ] Reproduction URL (Plunker, CodeSandbox, etc.).
 - [ ] Steps to reproduce (numbered list).
 - [ ] Actual vs Expected behaviour.
-- [ ] Affected versions (test from end-user perspective in browser — see product file).
+- [ ] Affected versions (test from end-user perspective in browser — see product file; required for Bug, optional for Improvement).
 - [ ] Root cause analysis (if known).
 
-**For Feature/Improvement tickets, collect:**
+**For Feature tickets, collect:**
 
 - [ ] Requirements statement (what, not how).
 - [ ] Current behaviour and problem.
@@ -71,7 +71,7 @@ Use the `mcp__atlassian__createJiraIssue` tool. Substitute component, prefix, an
 }
 ```
 
-**For bug tickets, also include:**
+**For Bug and Improvement tickets, also include:**
 
 ```json
 {
@@ -116,7 +116,8 @@ Bug descriptions should be concise: test cases + notes only. Do not add acceptan
 - [ ] All required fields populated.
 - [ ] Summary starts with correct product prefix.
 - [ ] Track field set correctly.
-- [ ] For bugs: Affects Version included.
+- [ ] For Bug and Improvement tickets: Affects Version included.
+- [ ] For Bug and Improvement tickets: Bug template used (reproduction steps, actual/expected).
 - [ ] URLs pasted as raw URLs (not markdown links).
 
 ## Critical Rules
@@ -126,3 +127,4 @@ Bug descriptions should be concise: test cases + notes only. Do not add acceptan
 3. **End numbered items with periods** — JIRA formatting requirement.
 4. **No comments** — Put all information in the description.
 5. **No rationale in feature requests** — State **what** and acceptance criteria, not **why**.
+6. **Improvement = internally reported bug** — Always use the bug template for Improvement tickets, not the feature/task template.

--- a/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
+++ b/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
@@ -115,6 +115,8 @@ const options = {
 AgCharts.create(options);
 ```
 
+**No module registration in vanilla JS:** Vanilla JS examples using UMD bundles do NOT call `AgCharts.setupModules()` or `ModuleRegistry.register()`. Module registration is only needed in framework/ESM examples. The UMD bundle automatically registers all included modules.
+
 ### Axes (v13+)
 
 Use the **object-based axes syntax**: `axes: { x: { type: 'time' }, y: { type: 'number' } }`. See `.rulesync/skills/example/ag-charts/chart-construction.md` for full syntax and multiple axes patterns.


### PR DESCRIPTION
## Summary
- **JIRA skill**: Add note that each ticket takes exactly one track value — prevents setting multiple tracks on a single ticket
- **Plunker skill**: Clarify that vanilla JS UMD bundles auto-register all modules, so `setupModules()` / `ModuleRegistry.register()` calls are unnecessary

## Test plan
- [x] Ran skill-creator eval workflow with 3 test cases (multi-track bug, UMD module reg, dual-track feature)
- [x] Eval 3 (dual-track feature) confirmed the old skill set two tracks; new skill correctly flags the constraint
- [x] Eval 2 confirmed both old and new skill handle UMD correctly (new note reinforces existing behaviour)