### PR TITLE
AG-13929 Fix SSR double license output, test spam, and Codespaces version pinning

### DIFF
--- a/packages/ag-charts-enterprise/src/license/licenseManager.ts
+++ b/packages/ag-charts-enterprise/src/license/licenseManager.ts
@@ -20,6 +20,7 @@ export class LicenseManager {
     private static readonly RELEASE_INFORMATION: string = 'MTc3MDgwNzY1NDM4MQ==';
     private static licenseKey?: string;
     private static gridContext: boolean = false;
+    private static licenseOutputLogged = false;
     private watermarkMessage: string | undefined = undefined;
 
     private readonly md5: MD5;
@@ -66,6 +67,8 @@ export class LicenseManager {
         } else if (licenseDetails.isTrial && licenseDetails.trialExpired) {
             this.outputExpiredTrialKey(licenseDetails.expiry, currentLicenseName, suppliedLicenseName);
         }
+
+        LicenseManager.licenseOutputLogged = true;
     }
 
     private static extractExpiry(license: string) {
@@ -348,6 +351,9 @@ export class LicenseManager {
             );
         }
 
+        if (this.licenseKey !== licenseKey) {
+            LicenseManager.licenseOutputLogged = false;
+        }
         LicenseManager.licenseKey = licenseKey;
     }
 
@@ -372,11 +378,13 @@ export class LicenseManager {
     }
 
     private centerPadAndOutput(input: string) {
+        if (LicenseManager.licenseOutputLogged) return;
         const paddingRequired = this.totalMessageLength - input.length;
         console.error(input.padStart(paddingRequired / 2 + input.length, '*').padEnd(this.totalMessageLength, '*'));
     }
 
     private padAndOutput(input: string, padding = '*', terminateWithPadding = '') {
+        if (LicenseManager.licenseOutputLogged) return;
         console.error(
             input.padEnd(this.totalMessageLength - terminateWithPadding.length, padding) + terminateWithPadding
         );

--- a/packages/ag-charts-server-side/src/agChartsServerSide.test.ts
+++ b/packages/ag-charts-server-side/src/agChartsServerSide.test.ts
@@ -326,9 +326,6 @@ describe('AgChartsServerSide enterprise licensing', () => {
     });
 
     beforeEach(async () => {
-        // Reset SSR license cache for each test
-        (AgChartsServerSide as any).licenseValidated = false;
-        (AgChartsServerSide as any).cachedForeground = undefined;
         // Reset license key (also resets LicenseManager.licenseOutputLogged)
         const { LicenseManager } = await import('ag-charts-enterprise');
         LicenseManager.setLicenseKey(undefined);
@@ -387,9 +384,6 @@ describe('AgChartsServerSide community-only watermark', () => {
     setupMockConsole();
 
     beforeEach(async () => {
-        // Reset SSR license cache for each test
-        (AgChartsServerSide as any).licenseValidated = false;
-        (AgChartsServerSide as any).cachedForeground = undefined;
         // Reset license state — no license key set means watermark should appear
         const { LicenseManager } = await import('ag-charts-enterprise');
         LicenseManager.setLicenseKey(undefined);

--- a/packages/ag-charts-server-side/src/agChartsServerSide.test.ts
+++ b/packages/ag-charts-server-side/src/agChartsServerSide.test.ts
@@ -13,6 +13,17 @@ const IMAGE_SNAPSHOT_OPTIONS = {
 };
 
 describe('AgChartsServerSide', () => {
+    afterEach(() => {
+        const errorMock = console.error as jest.Mock;
+        const unexpectedErrors = errorMock.mock.calls
+            .map((args) => String(args[0] ?? ''))
+            .filter((msg) => !msg.startsWith('*'));
+        errorMock.mockClear();
+        expect(unexpectedErrors).toEqual([]);
+    });
+
+    setupMockConsole();
+
     describe('render', () => {
         it('should render a simple line chart to buffer', async () => {
             const renderOptions: AgRenderOptions = {
@@ -315,7 +326,10 @@ describe('AgChartsServerSide enterprise licensing', () => {
     });
 
     beforeEach(async () => {
-        // Reset license state between tests
+        // Reset SSR license cache for each test
+        (AgChartsServerSide as any).licenseValidated = false;
+        (AgChartsServerSide as any).cachedForeground = undefined;
+        // Reset license key (also resets LicenseManager.licenseOutputLogged)
         const { LicenseManager } = await import('ag-charts-enterprise');
         LicenseManager.setLicenseKey(undefined);
     });
@@ -373,6 +387,9 @@ describe('AgChartsServerSide community-only watermark', () => {
     setupMockConsole();
 
     beforeEach(async () => {
+        // Reset SSR license cache for each test
+        (AgChartsServerSide as any).licenseValidated = false;
+        (AgChartsServerSide as any).cachedForeground = undefined;
         // Reset license state — no license key set means watermark should appear
         const { LicenseManager } = await import('ag-charts-enterprise');
         LicenseManager.setLicenseKey(undefined);

--- a/packages/ag-charts-server-side/src/agChartsServerSide.ts
+++ b/packages/ag-charts-server-side/src/agChartsServerSide.ts
@@ -16,9 +16,6 @@ const DEFAULT_TIMEOUT = 30000;
 let renderLock: Promise<void> = Promise.resolve();
 
 export class AgChartsServerSide {
-    private static licenseValidated = false;
-    private static cachedForeground: object | undefined;
-
     /**
      * Acquire exclusive access for rendering.
      * Returns a release function to call when done.
@@ -103,18 +100,15 @@ export class AgChartsServerSide {
             // Show watermark for unlicensed enterprise use.
             // We use getWatermarkForegroundConfig() (not getWatermarkForegroundConfigForBrowser())
             // because SSR should always show the watermark when unlicensed, even for localhost.
-            if (!AgChartsServerSide.licenseValidated) {
-                const licenseManager = enterpriseRegistry.licenseManager?.({ document: env.document } as any);
-                if (licenseManager) {
-                    licenseManager.validateLicense();
-                    AgChartsServerSide.cachedForeground = licenseManager.getWatermarkForegroundConfig();
-                }
-                AgChartsServerSide.licenseValidated = true;
-            }
-
+            // Console output is guarded by LicenseManager.licenseOutputLogged to print at most once.
             let chartOptions: any = options;
-            if (AgChartsServerSide.cachedForeground) {
-                chartOptions = { ...options, foreground: AgChartsServerSide.cachedForeground };
+            const licenseManager = enterpriseRegistry.licenseManager?.({ document: env.document } as any);
+            if (licenseManager) {
+                licenseManager.validateLicense();
+                const foreground = licenseManager.getWatermarkForegroundConfig();
+                if (foreground) {
+                    chartOptions = { ...options, foreground };
+                }
             }
 
             const createdChart = AgCharts[api]({

--- a/packages/ag-charts-server-side/src/agChartsServerSide.ts
+++ b/packages/ag-charts-server-side/src/agChartsServerSide.ts
@@ -16,6 +16,9 @@ const DEFAULT_TIMEOUT = 30000;
 let renderLock: Promise<void> = Promise.resolve();
 
 export class AgChartsServerSide {
+    private static licenseValidated = false;
+    private static cachedForeground: object | undefined;
+
     /**
      * Acquire exclusive access for rendering.
      * Returns a release function to call when done.
@@ -100,16 +103,18 @@ export class AgChartsServerSide {
             // Show watermark for unlicensed enterprise use.
             // We use getWatermarkForegroundConfig() (not getWatermarkForegroundConfigForBrowser())
             // because SSR should always show the watermark when unlicensed, even for localhost.
-            // A fresh LicenseManager is created per render for isolated hostname detection;
-            // the static licenseKey is shared across instances.
-            let chartOptions: any = options;
-            const licenseManager = enterpriseRegistry.licenseManager?.({ document: env.document } as any);
-            if (licenseManager) {
-                licenseManager.validateLicense();
-                const foreground = licenseManager.getWatermarkForegroundConfig();
-                if (foreground) {
-                    chartOptions = { ...options, foreground };
+            if (!AgChartsServerSide.licenseValidated) {
+                const licenseManager = enterpriseRegistry.licenseManager?.({ document: env.document } as any);
+                if (licenseManager) {
+                    licenseManager.validateLicense();
+                    AgChartsServerSide.cachedForeground = licenseManager.getWatermarkForegroundConfig();
                 }
+                AgChartsServerSide.licenseValidated = true;
+            }
+
+            let chartOptions: any = options;
+            if (AgChartsServerSide.cachedForeground) {
+                chartOptions = { ...options, foreground: AgChartsServerSide.cachedForeground };
             }
 
             const createdChart = AgCharts[api]({

--- a/packages/ag-charts-website/markdoc.config.ts
+++ b/packages/ag-charts-website/markdoc.config.ts
@@ -27,6 +27,7 @@ import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
 import {
     chartsVersion,
     chartsVersionPatch,
+    codespaceUrl,
     gridVersion,
     gridVersionPatch,
 } from '@utils/markdoc/functions/libraryVersions';
@@ -50,6 +51,7 @@ export default defineMarkdocConfig({
         gridVersionPatch,
         chartsVersion,
         chartsVersionPatch,
+        codespaceUrl,
     },
     tags: {
         kbd,

--- a/packages/ag-charts-website/src/content/docs/server-side-rendering/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/server-side-rendering/index.mdoc
@@ -7,7 +7,7 @@ enterprise: true
 The `ag-charts-server-side` package renders AG Charts to PNG and JPEG image buffers in Node.js, without a browser or DOM. Use it to generate chart images for email reports, PDF documents, social media cards, thumbnails, or API endpoints.
 
 {% idea %}
-Try server-side rendering with zero setup in {% link href="https://codespaces.new/ag-grid/ag-charts-server-side-example" isExternal=true %}GitHub Codespaces{% /link %}. Note that in Codespaces, the server URL will be a forwarded port URL (e.g. `https://<name>-3000.<domain>`) rather than `localhost:3000`.
+Try server-side rendering with zero setup in {% link href=codespaceUrl() isExternal=true %}GitHub Codespaces{% /link %}. Note that in Codespaces, the server URL will be a forwarded port URL (e.g. `https://<name>-3000.<domain>`) rather than `localhost:3000`.
 {% /idea %}
 
 ## Prerequisites

--- a/packages/ag-charts-website/src/utils/markdoc/functions/libraryVersions.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/functions/libraryVersions.ts
@@ -29,3 +29,14 @@ export const chartsVersionPatch: ConfigFunction = {
         return `${major}.${minor}.${patchNum}`;
     },
 };
+
+export const codespaceUrl: ConfigFunction = {
+    transform() {
+        const { major, minor, patchNum } = parseVersion(agChartsVersion);
+        // Pre-release versions (e.g. "13.1.0-beta.20260312") target 'latest';
+        // release versions (e.g. "13.1.0") target the matching 'bX.Y.Z' branch.
+        const isPreRelease = agChartsVersion.includes('-');
+        const ref = isPreRelease ? 'latest' : `b${major}.${minor}.${patchNum}`;
+        return `https://codespaces.new/ag-grid/ag-charts-server-side-example?ref=${ref}`;
+    },
+};


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-13929

- Guard LicenseManager console output with a static flag so it prints at most once per license key
- Cache SSR watermark foreground config to avoid re-validating every render
- Add setupMockConsole to the first test describe block and reset SSR cache between tests
- Add versioned Codespaces link via codespaceUrl Markdoc function