### PR TITLE
Align ag-charts-server-side-example subrepo with latest branch

### DIFF
--- a/external/ag-charts-server-side-example/.gitrepo
+++ b/external/ag-charts-server-side-example/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = git@github.com:ag-grid/ag-charts-server-side-example.git
-	branch = main
+	branch = latest
 	commit = 1bc583605b1fbb95d7899646dbbf2a7143b1989e
-	method = merge
+	method = rebase
 	cmdver = 0.4.9
 	parent = 5849cf111b5d7dc0390e3af01e2cb73f354ea83a

--- a/external/ag-charts-server-side-example/.gitrepo
+++ b/external/ag-charts-server-side-example/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:ag-grid/ag-charts-server-side-example.git
 	branch = latest
-	commit = 1bc583605b1fbb95d7899646dbbf2a7143b1989e
+	commit = f3b3c1a0d5e104c479b0bdf0fcb4f43a8b8bf2cc
 	method = rebase
 	cmdver = 0.4.9
-	parent = 5849cf111b5d7dc0390e3af01e2cb73f354ea83a
+	parent = 88be3b2cf781f0ff0089bd660c3bbfac876c0187


### PR DESCRIPTION
## Summary
- Renamed remote default branch from `main` to `latest` on `ag-grid/ag-charts-server-side-example`
- Updated `.gitrepo` to track `latest` branch with `rebase` method (aligning with `ag-shared` and `ag-website-shared`)
- Pushed latest package versions (`13.1.0-beta.20260313`) to the renamed branch