### PR TITLE
Add plan workflow to JIRA skill for plan-mode support

### DIFF
--- a/external/ag-shared/prompts/skills/jira/SKILL.md
+++ b/external/ag-shared/prompts/skills/jira/SKILL.md
@@ -4,13 +4,15 @@ name: jira
 description: >-
   Whenever the user asks to create a JIRA ticket, file a bug, log an issue,
   write up a ticket, estimate a ticket, size effort, analyse a JIRA issue, do
-  product analysis, or link tickets — ALWAYS invoke this skill first. It provides
-  the AG project's required JIRA configuration: custom field IDs for Track
-  (customfield_10501), component mappings, description templates with
-  numbered-list format, and issue type conventions. Without this skill, ticket
-  creation will fail due to missing required fields. Covers all ticket types:
-  Bug, Task, Feature Request, Improvement, Housekeeping, Doc change. Does NOT
-  cover: reading tickets, checking status, adding comments, transitioning status,
+  product analysis, or link tickets — ALWAYS invoke this skill first. Also
+  invoke when **planning** ticket creation — e.g., drafting a plan that includes
+  a "create JIRA ticket" step, or when in plan mode discussing what ticket to
+  file. The skill provides field defaults (Track values, component mappings,
+  description templates) that must be embedded in the plan so the user can
+  review and adjust them before execution. Without this skill, plans and ticket
+  creation will use wrong field values and fail. Covers all ticket types: Bug,
+  Task, Feature Request, Improvement, Housekeeping, Doc change. Does NOT cover:
+  reading tickets, checking status, adding comments, transitioning status,
   searching issues, or assigning tickets — those use Atlassian MCP tools
   directly. Does NOT cover: analysing source code, estimating code performance,
   or reviewing pull requests.
@@ -37,6 +39,7 @@ Based on user intent, read the corresponding workflow file (in the `workflows/` 
 
 | Intent | Keywords | Workflow |
 |--------|----------|----------|
+| **Plan** | In plan mode, drafting a plan that includes JIRA ticket creation | `workflows/plan.md` |
 | **Create** | "create a JIRA", "file a bug", "write up a ticket", "log this issue" | `workflows/create.md` |
 | **Estimate** | "estimate", "size", "analyse complexity", "how long", "effort" | `workflows/estimate.md` |
 | **Analyse** | "analyse this issue", "product analysis", "UX analysis", "propose solutions" | `workflows/analyze.md` |
@@ -85,7 +88,7 @@ Each ticket has exactly **one** track value. Never set multiple track values on 
 - Empty sections: Just `N/A`.
 - No comments — all info in description.
 - When creating tickets from analysis/research documents, distil to decisions and recommendations only. Do not reproduce full analysis in the description — link to the analysis document in the "Design Documents" section instead.
-- Related tickets: Use formal JIRA issue links (not ticket keys in description text). When a fix resolves downstream bugs, use "Blocks" link type. Note: the MCP API does not support creating issue links, so ask the user to add them manually after ticket creation.
+- Related tickets: Use formal JIRA issue links (not ticket keys in description text). When a fix resolves downstream bugs, use "Blocks" link type. Use `mcp__atlassian__createIssueLink` to create links after ticket creation.
 
 ### Templates
 

--- a/external/ag-shared/prompts/skills/jira/workflows/plan.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/plan.md
@@ -1,0 +1,62 @@
+# JIRA Ticket Planning Workflow
+
+Use this workflow when the user is **planning** JIRA ticket creation — i.e., drafting a plan that will be reviewed and adjusted before execution. The goal is to embed the correct field values and description template into the plan so the user can see and override the defaults before any API calls are made.
+
+## Step 0: Detect Product and Ticket Type
+
+1. Read the appropriate product file (from the `products/` subdirectory of this skill) based on the repository context.
+2. Determine the ticket type from the user's description using the same mapping as `create.md`:
+
+| Type | Issue Type | Track Value |
+|------|-----------|-------------|
+| **Bug** | `"Bug"` | `"Bug"` |
+| **Feature** | `"Task"` | `"Feature Request"` |
+| **Improvement** | `"Task"` | `"Improvement"` |
+| **Tech-debt** | `"Task"` | `"Housekeeping"` |
+| **Docs** | `"Task"` | `"Doc change"` |
+
+## Step 1: Load the Description Template
+
+Read the appropriate template file (from the `templates/` subdirectory):
+
+- **Bug / Improvement task**: `templates/bug.md`
+- **Feature / Tech-debt / Docs**: `templates/feature-task.md`
+
+## Step 2: Output the Plan
+
+Structure the plan with two sections: **Fields** (the API parameters) and **Description** (the ticket body using the template). Fill in every value you can derive from context; mark unknowns with `[TODO: ...]` so the user knows what to fill in.
+
+### Plan structure
+
+```markdown
+## Action: Create JIRA Ticket
+
+### Fields
+- **Cloud ID:** 1565837d-d6d1-4228-bcb2-4cb74df700f2
+- **Project:** <from product file, e.g. AG>
+- **Type:** <issueTypeName, e.g. Bug>
+- **Summary:** <[Prefix] concise title>
+- **Component:** <from product file, e.g. Charts>
+- **Track:** <track value, e.g. Bug> (customfield_10501)
+- **Priority:** <High | Medium | Low — default Medium>
+- **Affects Version:** <version if known, or [TODO: test in browser]>
+
+### Description
+
+<Paste the filled-in template here, using the exact TC-based or numbered-list format from the template file. Do not use free-form ## headers.>
+
+### Issue Links (if any)
+- **Link type:** <e.g. Problem/Incident, Blocks, Relates>
+- **Direction:** <this ticket "is caused by" / "blocks" / "relates to"> <OTHER-TICKET>
+```
+
+### Important
+
+- **Use the template format exactly.** The description must follow the TC-based (bug) or numbered-list (feature) template structure — not free-form markdown with `##` headers.
+- **Track is not Component.** Track values are: Bug, Feature Request, Improvement, Housekeeping, Doc change. Component values come from the product file (e.g., Charts, Grid).
+- **Include all required fields.** The plan must specify every field needed for `mcp__atlassian__createJiraIssue` so execution doesn't need to discover them at runtime.
+- **Mark gaps explicitly.** If information is missing (e.g., reproduction URL, affected version), use `[TODO: ...]` rather than omitting the field. This lets the user decide whether to fill it in or remove it.
+
+## Why This Matters
+
+Plans are an intermediate artifact that the user reviews and adjusts before execution. If the plan contains wrong defaults (e.g., a non-existent Track value), the user approves bad data. Execution then follows the plan faithfully, leading to API errors or incorrectly filed tickets. By embedding the correct defaults in the plan, the user can make informed adjustments and the execution step becomes straightforward.


### PR DESCRIPTION
## Summary

- Adds a `workflows/plan.md` to the JIRA skill so it triggers during plan mode and embeds correct field defaults (Track values, component mappings, description templates, Cloud ID) into plans
- Updates skill description to trigger on planning-related keywords
- Fixes incorrect claim that the MCP API doesn't support `createIssueLink`

**Problem:** When planning JIRA ticket creation, the skill wasn't triggered. Plans were authored with wrong defaults (e.g. "Charts" as a Track value, free-form `##` headers instead of TC templates) that failed at execution time.

**Eval results:** 100% assertion pass rate with skill vs 23% without across 3 test cases (bug, feature, tech-debt).

## Test plan

- [x] Eval 1: Bug plan uses correct Track=Bug, Component=Charts, TC template, UUID Cloud ID
- [x] Eval 2: Feature plan uses Track=Feature Request, Type=Task, 12-section numbered template
- [x] Eval 3: Tech-debt plan uses Track=Housekeeping, Type=Task, correct Component and Cloud ID