### PR TITLE
Symlink .rulesync/mcp.json to ag-shared source

### DIFF
--- a/.rulesync/mcp.json
+++ b/.rulesync/mcp.json
@@ -1,9 +1,1 @@
-{
-    "mcpServers": {
-        "sequential-thinking": {
-            "command": "yarn",
-            "args": ["run", "--silent", "mcp-server-sequential-thinking"],
-            "env": {}
-        }
-    }
-}
+../external/ag-shared/prompts/.mcp.json


### PR DESCRIPTION
## Summary
- Replace standalone `.rulesync/mcp.json` with a symlink to `external/ag-shared/prompts/.mcp.json`
- Keeps MCP server configuration (e.g. Atlassian, sequential-thinking) in sync across repos automatically
- Parallel PRs in ag-grid and ag-studio