### PR TITLE
AG-16900 Fix sparkline forced reflow regression

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -374,13 +374,13 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
                 this.update(ChartUpdateType.PERFORM_LAYOUT);
             }),
             ctx.eventsHub.on('rtl:change', () => {
-                ctx.scene.canvas.setDirection(ctx.domManager.isRtl);
+                ctx.scene.setDirection(ctx.domManager.isRtl);
                 this.update(ChartUpdateType.PERFORM_LAYOUT);
             }),
             ctx.eventsHub.on('chart:request-update', (e) => this.update(e.type, e.opts)),
             ctx.scene.on('scene-changed', () => this.update(ChartUpdateType.SCENE_RENDER))
         );
-        ctx.scene.canvas.setDirection(ctx.domManager.isRtl);
+        ctx.scene.setDirection(ctx.domManager.isRtl);
 
         this.overlays = new ChartOverlays();
         this.overlays.loading.renderer ??= () =>

--- a/packages/ag-charts-community/src/dom/domElementProxy.test.ts
+++ b/packages/ag-charts-community/src/dom/domElementProxy.test.ts
@@ -450,7 +450,7 @@ describe('DOMElementProxy', () => {
             const proxy = new DOMElementProxy(el, { sizeMonitor: mockSizeMonitor });
             const unsub = proxy.addResizeListener((_size: Size) => {});
 
-            expect(observeFn).toHaveBeenCalledWith(el, expect.any(Function));
+            expect(observeFn).toHaveBeenCalledWith(el, expect.any(Function), { skipInitialRead: false });
 
             unsub();
             expect(unobserveFn).toHaveBeenCalledWith(el);

--- a/packages/ag-charts-community/src/dom/domElementProxy.ts
+++ b/packages/ag-charts-community/src/dom/domElementProxy.ts
@@ -63,13 +63,15 @@ export class DOMElementProxy {
     private readonly pendingWrites = new Map<CacheKey, () => void>();
     private readonly deferredMode: DeferredMode | undefined;
     private readonly sizeMonitor: SizeMonitor | undefined;
+    private readonly skipInitialRead: boolean;
 
     constructor(
         private readonly element: HTMLElement,
-        opts?: { deferredMode?: DeferredMode; sizeMonitor?: SizeMonitor }
+        opts?: { deferredMode?: DeferredMode; sizeMonitor?: SizeMonitor; skipInitialRead?: boolean }
     ) {
         this.deferredMode = opts?.deferredMode;
         this.sizeMonitor = opts?.sizeMonitor;
+        this.skipInitialRead = opts?.skipInitialRead ?? false;
     }
 
     /** Delegates to `element.isConnected`. */
@@ -272,11 +274,11 @@ export class DOMElementProxy {
 
     /** Observe the element for resize events via the shared SizeMonitor. Returns an unsubscribe function. */
     addResizeListener(cb: (size: Size) => void): () => void {
-        const { sizeMonitor, element } = this;
+        const { sizeMonitor, element, skipInitialRead } = this;
         if (sizeMonitor == null) {
             throw new Error('AG Charts - addResizeListener requires a SizeMonitor');
         }
-        sizeMonitor.observe(element, (size) => cb(size));
+        sizeMonitor.observe(element, (size) => cb(size), { skipInitialRead });
         return () => sizeMonitor.unobserve(element);
     }
 

--- a/packages/ag-charts-community/src/dom/domManager.ts
+++ b/packages/ag-charts-community/src/dom/domManager.ts
@@ -153,7 +153,9 @@ export class DOMManager extends BaseManager {
 
         this.rootElements['canvas'].element.style.setProperty('anchor-name', this.anchorName);
 
-        this.sizeMonitor.observe(this.rootElements['canvas'].element, () => this.invalidateRectCaches());
+        this.sizeMonitor.observe(this.rootElements['canvas'].element, () => this.invalidateRectCaches(), {
+            skipInitialRead: this.mode === 'minimal',
+        });
 
         let hidden = false;
         this.observer = setupObserver(agDocument, this.element, (intersectionRatio) => {
@@ -398,12 +400,16 @@ export class DOMManager extends BaseManager {
         }
 
         pendingContainer.appendChild(this.element);
-        this.sizeMonitor.observe(pendingContainer, (size) => {
-            this.containerSize = size;
-            this.updateContainerSize();
-            this.invalidateRectCaches();
-            this.eventsHub.emit('dom:resize', null);
-        });
+        this.sizeMonitor.observe(
+            pendingContainer,
+            (size) => {
+                this.containerSize = size;
+                this.updateContainerSize();
+                this.invalidateRectCaches();
+                this.eventsHub.emit('dom:resize', null);
+            },
+            { skipInitialRead: this.mode === 'minimal' }
+        );
 
         this.invalidateAllCaches();
         this.updateRtl();
@@ -679,7 +685,11 @@ export class DOMManager extends BaseManager {
     }
 
     private updateRtl() {
-        const isRtl = this.enableRtl ?? isDirectionRtl(this.container ?? this.pendingContainer);
+        // Skip getComputedStyle for minimal mode (sparklines) to avoid forced style recalculation.
+        // If RTL is needed, it should be set explicitly via enableRtl in the chart options.
+        const isRtl =
+            this.enableRtl ??
+            (this.mode === 'minimal' ? false : isDirectionRtl(this.container ?? this.pendingContainer));
         if (isRtl === this._isRtl) return;
         this._isRtl = isRtl;
         this.element.dir = isRtl ? 'rtl' : 'ltr';
@@ -724,17 +734,24 @@ export class DOMManager extends BaseManager {
 
     addProxyChild(domElementClass: DOMElementClass, id: string): DOMElementProxy {
         const element = this.addChild(domElementClass, id);
-        return new DOMElementProxy(element, { sizeMonitor: this.sizeMonitor });
+        const skipInitialRead = this.mode === 'minimal';
+        return new DOMElementProxy(element, { sizeMonitor: this.sizeMonitor, skipInitialRead });
     }
 
     addDeferredProxyChild(domElementClass: DOMElementClass, id: string): DOMElementProxy {
         const element = this.addChild(domElementClass, id);
-        const proxy = new DOMElementProxy(element, { deferredMode: this.deferredMode, sizeMonitor: this.sizeMonitor });
+        const skipInitialRead = this.mode === 'minimal';
+        const proxy = new DOMElementProxy(element, {
+            deferredMode: this.deferredMode,
+            sizeMonitor: this.sizeMonitor,
+            skipInitialRead,
+        });
         this.deferredProxies.set(`${domElementClass}:${id}`, proxy);
         return proxy;
     }
 
     public setDeferring(active: boolean): void {
+        if (this.mode === 'minimal') return; // Sparklines: skip deferring to avoid concentrated flush
         this._deferring = active;
         if (!active) {
             this.flushDeferredProxies();

--- a/packages/ag-charts-community/src/scene/group.test.ts
+++ b/packages/ag-charts-community/src/scene/group.test.ts
@@ -151,6 +151,7 @@ describe('Group', () => {
                 // Create a render context and call preRender to trigger layer creation
                 const renderCtx: RenderContext = {
                     ctx: {} as any,
+                    direction: 'ltr',
                     width: 100,
                     height: 100,
                     devicePixelRatio: 1,
@@ -189,6 +190,7 @@ describe('Group', () => {
 
                 const renderCtx: RenderContext = {
                     ctx: {} as any,
+                    direction: 'ltr',
                     width: 100,
                     height: 100,
                     devicePixelRatio: 1,
@@ -221,6 +223,7 @@ describe('Group', () => {
 
                 const renderCtx: RenderContext = {
                     ctx: {} as any,
+                    direction: 'ltr',
                     width: 100,
                     height: 100,
                     devicePixelRatio: 1,

--- a/packages/ag-charts-community/src/scene/group.ts
+++ b/packages/ag-charts-community/src/scene/group.ts
@@ -331,7 +331,7 @@ export class Group<TDatum = unknown> extends Node<TDatum> {
                 ...transform: [DOMMatrix] | [number, number, number, number, number, number]
             ) => {
                 const offscreenCtx = offscreenCanvas.context;
-                offscreenCtx.direction = ctx.direction;
+                offscreenCtx.direction = childRenderCtx.direction;
                 childRenderCtx.ctx = offscreenCtx;
 
                 offscreenCanvas.clear();

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -21,6 +21,7 @@ export enum PointerEvents {
 
 export type RenderContext = {
     ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    direction: CanvasDirection;
     width: number;
     height: number;
     devicePixelRatio: number;

--- a/packages/ag-charts-community/src/scene/scene.ts
+++ b/packages/ag-charts-community/src/scene/scene.ts
@@ -34,6 +34,7 @@ export class Scene extends EventEmitter<EventMap> {
     private root: Group | null = null;
     private pendingSize: [number, number, number] | null = null;
     private isDirty: boolean = false;
+    private direction: CanvasDirection = 'ltr';
     private _baseFont: string | undefined;
 
     private readonly cleanup = new CleanupRegistry();
@@ -149,6 +150,11 @@ export class Scene extends EventEmitter<EventMap> {
         return false;
     }
 
+    setDirection(isRtl: boolean) {
+        this.direction = isRtl ? 'rtl' : 'ltr';
+        this.canvas.setDirection(isRtl);
+    }
+
     updateBaseFont() {
         const baseFont = this.root?.resolveFont();
         if (baseFont != null && baseFont !== this._baseFont) {
@@ -225,6 +231,7 @@ export class Scene extends EventEmitter<EventMap> {
 
         const renderCtx: RenderContext = {
             ctx,
+            direction: this.direction,
             width,
             height,
             devicePixelRatio,

--- a/packages/ag-charts-community/src/scene/shape/range.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/range.test.ts
@@ -94,6 +94,7 @@ describe('Range', () => {
                     ctx.save();
                     range.render({
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,

--- a/packages/ag-charts-community/src/scene/shape/rect.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.test.ts
@@ -351,6 +351,7 @@ describe('Rect', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,

--- a/packages/ag-charts-community/src/scene/shape/sector.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/sector.test.ts
@@ -250,6 +250,7 @@ describe('Sector', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -400,6 +401,7 @@ describe('Sector', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,

--- a/packages/ag-charts-community/src/scene/shape/shape.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/shape.test.ts
@@ -425,6 +425,7 @@ describe('Shape', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -473,6 +474,7 @@ describe('Shape', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -521,6 +523,7 @@ describe('Shape', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -569,6 +572,7 @@ describe('Shape', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -617,6 +621,7 @@ describe('Shape', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -665,6 +670,7 @@ describe('Shape', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -713,6 +719,7 @@ describe('Shape', () => {
                     // Render.
                     const renderCtx = {
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,

--- a/packages/ag-charts-community/src/scene/shape/text.test.ts
+++ b/packages/ag-charts-community/src/scene/shape/text.test.ts
@@ -241,6 +241,7 @@ describe('Text', () => {
                     ctx.save();
                     textNode.render({
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,
@@ -299,6 +300,7 @@ describe('Text', () => {
                     ctx.save();
                     textNode.render({
                         ctx,
+                        direction: 'ltr' as const,
                         width: canvasCtx.nodeCanvas.width,
                         height: canvasCtx.nodeCanvas.height,
                         devicePixelRatio: 1,

--- a/packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -102,7 +102,7 @@ export class SizeMonitor {
     }
 
     // Only a single callback is supported.
-    observe(element: HTMLElement, cb: OnSizeChange) {
+    observe(element: HTMLElement, cb: OnSizeChange, opts?: { skipInitialRead?: boolean }) {
         if (!this.documentReady) {
             this.queuedObserveRequests.push([element, cb]);
             return;
@@ -116,11 +116,13 @@ export class SizeMonitor {
         const entry: Entry = { cb };
         this.elements.set(element, entry);
 
-        // Synchronous initial size read — cross-window ResizeObserver
-        // may delay its first callback until the target window gains focus.
-        const { width, height } = element.getBoundingClientRect();
-        if (width > 0 || height > 0) {
-            this.checkSize(entry, element, width, height);
+        if (!opts?.skipInitialRead) {
+            // Synchronous initial size read — cross-window ResizeObserver
+            // may delay its first callback until the target window gains focus.
+            const { width, height } = element.getBoundingClientRect();
+            if (width > 0 || height > 0) {
+                this.checkSize(entry, element, width, height);
+            }
         }
     }
 

--- a/packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -20,7 +20,7 @@ export class SizeMonitor {
     private resizeObserver: ResizeObserver | undefined;
     private pixelRatioObserver: PixelRatioObserver | undefined;
     private documentReady = false;
-    private queuedObserveRequests: [HTMLElement, OnSizeChange][] = [];
+    private queuedObserveRequests: [HTMLElement, OnSizeChange, { skipInitialRead?: boolean }?][] = [];
     private removeLoadListener: (() => void) | undefined;
 
     constructor(agDocument: AgDocument) {
@@ -60,8 +60,8 @@ export class SizeMonitor {
 
     onLoad: EventListener = () => {
         this.documentReady = true;
-        for (const [el, cb] of this.queuedObserveRequests) {
-            this.observe(el, cb);
+        for (const [el, cb, opts] of this.queuedObserveRequests) {
+            this.observe(el, cb, opts);
         }
         this.queuedObserveRequests = [];
         this.observeWindow();
@@ -104,7 +104,7 @@ export class SizeMonitor {
     // Only a single callback is supported.
     observe(element: HTMLElement, cb: OnSizeChange, opts?: { skipInitialRead?: boolean }) {
         if (!this.documentReady) {
-            this.queuedObserveRequests.push([element, cb]);
+            this.queuedObserveRequests.push([element, cb, opts]);
             return;
         }
 

--- a/packages/ag-charts-website/e2e/example-options.ts
+++ b/packages/ag-charts-website/e2e/example-options.ts
@@ -72,6 +72,9 @@ export const EXAMPLE_OPTIONS: Record<string, Record<string, ExampleOverrides>> =
     sparklines: {
         '*': { frameworks: ['vanilla'] },
     },
+    'sparklines-test': {
+        '*': { frameworks: ['vanilla'] },
+    },
     'example-logger-test': {
         'console-logs': { frameworks: [] },
     },

--- a/packages/ag-charts-website/e2e/forced-reflow.spec.ts
+++ b/packages/ag-charts-website/e2e/forced-reflow.spec.ts
@@ -54,6 +54,16 @@ test.describe('forced reflow detection', () => {
         expect(finalTooltipBox?.x).not.toBe(initialTooltipBox?.x);
     });
 
+    // Canvas rendering operations inherently trigger UpdateLayoutTree (style recalculation)
+    // when setting canvas dimensions or font properties. These are unavoidable for the initial
+    // render of each sparkline. The key reflow sources we're guarding against are:
+    // - Concentrated deferred DOM flushes between sparkline updates (fixed via setDeferring no-op)
+    // - SizeMonitor's synchronous getBoundingClientRect interleaved with DOM writes (fixed via skipInitialRead)
+    // - getComputedStyle in isDirectionRtl during container setup (fixed via minimal mode skip)
+    // - Tooltip's addResizeListener calling getBoundingClientRect (fixed via skipInitialRead on proxy)
+    const sparklineAllowlist = ['applyPendingResize', 'updateBaseFont', 'renderOffscreen'];
+    const SPARKLINE_COUNT = 30; // must match the count in the test example
+
     test('sparkline creation should not cause forced reflows', async ({ page }) => {
         await gotoExample(page, toExamplePageUrl('sparklines-test', 'e2e-sparkline-reflow', 'vanilla').url);
         await waitForAllChartUpdates(page);
@@ -63,8 +73,14 @@ test.describe('forced reflow detection', () => {
             await page.waitForTimeout(500);
         });
         const analysis = analyseForcedReflows(events);
-        const filtered = filterAgChartsReflows(analysis);
+        const filtered = filterAgChartsReflows(analysis, { additionalAllowlist: sparklineAllowlist });
         expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
+
+        // Canvas resize fires once per new sparkline; font resolution fires once globally.
+        // Assert upper bounds so regressions that add new reflow sources are caught.
+        expect(filtered.allowlisted.applyPendingResize ?? 0).toBeLessThanOrEqual(SPARKLINE_COUNT);
+        expect(filtered.allowlisted.updateBaseFont ?? 0).toBeLessThanOrEqual(1);
+        expect(filtered.allowlisted.renderOffscreen ?? 0).toBe(0);
     });
 
     test('sparkline data update should not cause forced reflows', async ({ page }) => {
@@ -81,8 +97,13 @@ test.describe('forced reflow detection', () => {
             await page.waitForTimeout(500);
         });
         const analysis = analyseForcedReflows(events);
-        const filtered = filterAgChartsReflows(analysis);
+        const filtered = filterAgChartsReflows(analysis, { additionalAllowlist: sparklineAllowlist });
         expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
+
+        // Data updates should not resize canvases; at most one offscreen render recalc.
+        expect(filtered.allowlisted.applyPendingResize ?? 0).toBe(0);
+        expect(filtered.allowlisted.updateBaseFont ?? 0).toBe(0);
+        expect(filtered.allowlisted.renderOffscreen ?? 0).toBeLessThanOrEqual(1);
     });
 
     // Simulates grid scroll: destroy visible sparklines (returning them to pool)
@@ -103,8 +124,46 @@ test.describe('forced reflow detection', () => {
             await page.waitForTimeout(500);
         });
         const analysis = analyseForcedReflows(events);
-        const filtered = filterAgChartsReflows(analysis);
+        const filtered = filterAgChartsReflows(analysis, { additionalAllowlist: sparklineAllowlist });
         expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
+
+        // Pool recycling reuses existing canvases at the same size — no resize expected.
+        // At most one offscreen render recalc.
+        expect(filtered.allowlisted.applyPendingResize ?? 0).toBe(0);
+        expect(filtered.allowlisted.updateBaseFont ?? 0).toBe(0);
+        expect(filtered.allowlisted.renderOffscreen ?? 0).toBeLessThanOrEqual(1);
+    });
+
+    // Realistic virtual-scroll scenario: 1000-row list with a 400px viewport,
+    // sparklines created/destroyed as rows enter/leave the visible area.
+    test('sparkline virtual scroll should not cause forced reflows', async ({ page }) => {
+        await gotoExample(page, toExamplePageUrl('sparklines-test', 'e2e-sparkline-virtual-scroll', 'vanilla').url);
+        await waitForAllChartUpdates(page);
+
+        const viewport = page.locator('#viewport');
+        const statsEl = page.locator('#stats');
+        await expect(statsEl).toContainText('active');
+
+        // Scroll down a large distance to trigger destroy/create cycles.
+        const events = await traceAction(page, async () => {
+            // Scroll incrementally to simulate realistic user scrolling.
+            for (let i = 0; i < 5; i++) {
+                await viewport.evaluate((el) => (el.scrollTop += 800));
+                await page.waitForTimeout(150);
+            }
+            // Let final batch of sparklines render.
+            await page.waitForTimeout(300);
+        });
+        const analysis = analyseForcedReflows(events);
+        const filtered = filterAgChartsReflows(analysis, { additionalAllowlist: sparklineAllowlist });
+        expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
+
+        // After scrolling ~4000px through 36px rows, expect pool-recycled sparklines.
+        // Canvas resize should only fire for genuinely new sparklines (not pooled reuse
+        // at the same dimensions). Upper bound is generous to account for timing variance.
+        const visibleRows = Math.ceil(400 / 36) + 2 * 5; // viewport/rowHeight + 2*overscan
+        expect(filtered.allowlisted.applyPendingResize ?? 0).toBeLessThanOrEqual(visibleRows);
+        expect(filtered.allowlisted.updateBaseFont ?? 0).toBeLessThanOrEqual(1);
     });
 
     test('crosshair label hover should not cause forced reflows', async ({ page }) => {

--- a/packages/ag-charts-website/e2e/forced-reflow.spec.ts
+++ b/packages/ag-charts-website/e2e/forced-reflow.spec.ts
@@ -61,8 +61,36 @@ test.describe('forced reflow detection', () => {
     // - SizeMonitor's synchronous getBoundingClientRect interleaved with DOM writes (fixed via skipInitialRead)
     // - getComputedStyle in isDirectionRtl during container setup (fixed via minimal mode skip)
     // - Tooltip's addResizeListener calling getBoundingClientRect (fixed via skipInitialRead on proxy)
-    const sparklineAllowlist = ['applyPendingResize', 'updateBaseFont', 'renderOffscreen', 'drawImage'];
+    // - ctx.direction reads during offscreen rendering (fixed via RenderContext caching)
+    //
+    // IMPORTANT: Data in the test examples uses 150 points (> RENDER_TO_OFFSCREEN_CANVAS_THRESHOLD
+    // of 100) to ensure the offscreen rendering path in group.ts is exercised. Without this,
+    // regressions in the offscreen path (e.g. expensive ctx.direction reads) would go undetected.
+    const sparklineAllowlist = ['applyPendingResize', 'updateBaseFont', 'drawImage'];
     const SPARKLINE_COUNT = 30; // must match the count in the test example
+
+    // Duration budget per allowlisted reflow event (microseconds). If any single
+    // allowlisted event exceeds this, a fixable performance bug is hiding behind the
+    // allowlist (e.g. the ctx.direction regression that was 1,942ms under renderOffscreen).
+    const MAX_ALLOWLISTED_EVENT_DURATION_US = 5_000; // 5ms — font resolution can take ~1.5ms; ctx.direction regression was 1,942ms
+
+    function assertAllowlistBounds(filtered: ReturnType<typeof filterAgChartsReflows>, bounds: Record<string, number>) {
+        for (const [fn, maxCount] of Object.entries(bounds)) {
+            const entry = filtered.allowlisted[fn];
+            expect(entry?.count ?? 0, `allowlisted ${fn} count`).toBeLessThanOrEqual(maxCount);
+        }
+
+        // Assert no single allowlisted event is suspiciously expensive — catches
+        // regressions like ctx.direction reads hiding behind function-name allowlisting.
+        for (const [fn, entry] of Object.entries(filtered.allowlisted)) {
+            if (entry.count === 0) continue;
+            const avgDuration = entry.totalDuration / entry.count;
+            expect(
+                avgDuration,
+                `allowlisted ${fn}: avg duration ${(avgDuration / 1000).toFixed(2)}ms exceeds budget`
+            ).toBeLessThan(MAX_ALLOWLISTED_EVENT_DURATION_US);
+        }
+    }
 
     test('sparkline creation should not cause forced reflows', async ({ page }) => {
         await gotoExample(page, toExamplePageUrl('sparklines-test', 'e2e-sparkline-reflow', 'vanilla').url);
@@ -76,11 +104,11 @@ test.describe('forced reflow detection', () => {
         const filtered = filterAgChartsReflows(analysis, { additionalAllowlist: sparklineAllowlist });
         expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
 
-        // Canvas resize fires once per new sparkline; font resolution fires once globally.
-        // Assert upper bounds so regressions that add new reflow sources are caught.
-        expect(filtered.allowlisted.applyPendingResize ?? 0).toBeLessThanOrEqual(SPARKLINE_COUNT);
-        expect(filtered.allowlisted.updateBaseFont ?? 0).toBeLessThanOrEqual(1);
-        expect(filtered.allowlisted.renderOffscreen ?? 0).toBe(0);
+        assertAllowlistBounds(filtered, {
+            applyPendingResize: SPARKLINE_COUNT,
+            updateBaseFont: 1,
+            drawImage: 0,
+        });
     });
 
     test('sparkline data update should not cause forced reflows', async ({ page }) => {
@@ -100,10 +128,11 @@ test.describe('forced reflow detection', () => {
         const filtered = filterAgChartsReflows(analysis, { additionalAllowlist: sparklineAllowlist });
         expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
 
-        // Data updates should not resize canvases; at most one offscreen render recalc.
-        expect(filtered.allowlisted.applyPendingResize ?? 0).toBe(0);
-        expect(filtered.allowlisted.updateBaseFont ?? 0).toBe(0);
-        expect(filtered.allowlisted.renderOffscreen ?? 0).toBeLessThanOrEqual(1);
+        assertAllowlistBounds(filtered, {
+            applyPendingResize: 0,
+            updateBaseFont: 0,
+            drawImage: SPARKLINE_COUNT, // offscreen compositing during update
+        });
     });
 
     // Simulates grid scroll: destroy visible sparklines (returning them to pool)
@@ -127,11 +156,11 @@ test.describe('forced reflow detection', () => {
         const filtered = filterAgChartsReflows(analysis, { additionalAllowlist: sparklineAllowlist });
         expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
 
-        // Pool recycling reuses existing canvases at the same size — no resize expected.
-        // At most one offscreen render recalc.
-        expect(filtered.allowlisted.applyPendingResize ?? 0).toBe(0);
-        expect(filtered.allowlisted.updateBaseFont ?? 0).toBe(0);
-        expect(filtered.allowlisted.renderOffscreen ?? 0).toBeLessThanOrEqual(1);
+        assertAllowlistBounds(filtered, {
+            applyPendingResize: 0,
+            updateBaseFont: 0,
+            drawImage: SPARKLINE_COUNT, // offscreen compositing during pool recycling
+        });
     });
 
     // Realistic virtual-scroll scenario: 1000-row list with a 400px viewport,
@@ -159,11 +188,11 @@ test.describe('forced reflow detection', () => {
         expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
 
         // After scrolling ~4000px through 36px rows, expect pool-recycled sparklines.
-        // Canvas resize should only fire for genuinely new sparklines (not pooled reuse
-        // at the same dimensions). Upper bound is generous to account for timing variance.
         const visibleRows = Math.ceil(400 / 36) + 2 * 5; // viewport/rowHeight + 2*overscan
-        expect(filtered.allowlisted.applyPendingResize ?? 0).toBeLessThanOrEqual(visibleRows);
-        expect(filtered.allowlisted.updateBaseFont ?? 0).toBeLessThanOrEqual(1);
+        assertAllowlistBounds(filtered, {
+            applyPendingResize: visibleRows,
+            updateBaseFont: 1,
+        });
     });
 
     test('crosshair label hover should not cause forced reflows', async ({ page }) => {

--- a/packages/ag-charts-website/e2e/forced-reflow.spec.ts
+++ b/packages/ag-charts-website/e2e/forced-reflow.spec.ts
@@ -54,6 +54,59 @@ test.describe('forced reflow detection', () => {
         expect(finalTooltipBox?.x).not.toBe(initialTooltipBox?.x);
     });
 
+    test('sparkline creation should not cause forced reflows', async ({ page }) => {
+        await gotoExample(page, toExamplePageUrl('sparklines-test', 'e2e-sparkline-reflow', 'vanilla').url);
+        await waitForAllChartUpdates(page);
+
+        const events = await traceAction(page, async () => {
+            await page.getByText('Create Sparklines').click();
+            await page.waitForTimeout(500);
+        });
+        const analysis = analyseForcedReflows(events);
+        const filtered = filterAgChartsReflows(analysis);
+        expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
+    });
+
+    test('sparkline data update should not cause forced reflows', async ({ page }) => {
+        await gotoExample(page, toExamplePageUrl('sparklines-test', 'e2e-sparkline-reflow', 'vanilla').url);
+        await waitForAllChartUpdates(page);
+
+        // Create sparklines first, then wait for them to settle.
+        await page.getByText('Create Sparklines').click();
+        await page.waitForTimeout(500);
+        await waitForAllChartUpdates(page);
+
+        const events = await traceAction(page, async () => {
+            await page.getByText('Update Sparklines').click();
+            await page.waitForTimeout(500);
+        });
+        const analysis = analyseForcedReflows(events);
+        const filtered = filterAgChartsReflows(analysis);
+        expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
+    });
+
+    // Simulates grid scroll: destroy visible sparklines (returning them to pool)
+    // then create new ones from pool — the lifecycle that occurs as rows scroll
+    // in and out of the viewport.
+    test('sparkline scroll recycling should not cause forced reflows', async ({ page }) => {
+        await gotoExample(page, toExamplePageUrl('sparklines-test', 'e2e-sparkline-reflow', 'vanilla').url);
+        await waitForAllChartUpdates(page);
+
+        // Create initial sparklines, then wait for them to settle.
+        await page.getByText('Create Sparklines').click();
+        await page.waitForTimeout(500);
+        await waitForAllChartUpdates(page);
+
+        const events = await traceAction(page, async () => {
+            // Destroy and recreate from pool (simulates scroll).
+            await page.getByText('Scroll Sparklines').click();
+            await page.waitForTimeout(500);
+        });
+        const analysis = analyseForcedReflows(events);
+        const filtered = filterAgChartsReflows(analysis);
+        expect(filtered.count, formatReflowDiagnostics(filtered)).toBe(0);
+    });
+
     test('crosshair label hover should not cause forced reflows', async ({ page }) => {
         await gotoExample(page, toExamplePageUrl('axes-crosshairs', 'crosshair-snap', 'vanilla').url);
         await waitForAllChartUpdates(page);

--- a/packages/ag-charts-website/e2e/forced-reflow.spec.ts
+++ b/packages/ag-charts-website/e2e/forced-reflow.spec.ts
@@ -61,7 +61,7 @@ test.describe('forced reflow detection', () => {
     // - SizeMonitor's synchronous getBoundingClientRect interleaved with DOM writes (fixed via skipInitialRead)
     // - getComputedStyle in isDirectionRtl during container setup (fixed via minimal mode skip)
     // - Tooltip's addResizeListener calling getBoundingClientRect (fixed via skipInitialRead on proxy)
-    const sparklineAllowlist = ['applyPendingResize', 'updateBaseFont', 'renderOffscreen'];
+    const sparklineAllowlist = ['applyPendingResize', 'updateBaseFont', 'renderOffscreen', 'drawImage'];
     const SPARKLINE_COUNT = 30; // must match the count in the test example
 
     test('sparkline creation should not cause forced reflows', async ({ page }) => {

--- a/packages/ag-charts-website/e2e/forcedReflowDetection.ts
+++ b/packages/ag-charts-website/e2e/forcedReflowDetection.ts
@@ -162,9 +162,15 @@ interface FilterOptions {
     additionalAllowlist?: string[];
 }
 
+interface AllowlistedEntry {
+    count: number;
+    /** Total duration in microseconds. */
+    totalDuration: number;
+}
+
 interface FilteredReflowAnalysis extends ForcedReflowAnalysis {
-    /** Counts of allowlisted reflows keyed by the matched function name. */
-    allowlisted: Record<string, number>;
+    /** Counts and durations of allowlisted reflows keyed by the matched function name. */
+    allowlisted: Record<string, AllowlistedEntry>;
 }
 
 /**
@@ -185,7 +191,7 @@ interface FilteredReflowAnalysis extends ForcedReflowAnalysis {
  */
 export function filterAgChartsReflows(analysis: ForcedReflowAnalysis, opts?: FilterOptions): FilteredReflowAnalysis {
     const allowlist = new Set([...DEFAULT_ALLOWLIST, ...(opts?.additionalAllowlist ?? [])]);
-    const allowlisted: Record<string, number> = {};
+    const allowlisted: Record<string, AllowlistedEntry> = {};
 
     const filtered = analysis.reflows.filter((r) => {
         // Source filter: at least one frame must come from ag-charts source.
@@ -196,7 +202,9 @@ export function filterAgChartsReflows(analysis: ForcedReflowAnalysis, opts?: Fil
         // named frame because the top frame may be anonymous (e.g. an IIFE).
         const firstNamedFunction = r.stackFrames.find((f) => f.functionName)?.functionName;
         if (firstNamedFunction != null && allowlist.has(firstNamedFunction)) {
-            allowlisted[firstNamedFunction] = (allowlisted[firstNamedFunction] ?? 0) + 1;
+            const entry = (allowlisted[firstNamedFunction] ??= { count: 0, totalDuration: 0 });
+            entry.count++;
+            entry.totalDuration += r.dur;
             return false;
         }
 

--- a/packages/ag-charts-website/e2e/forcedReflowDetection.ts
+++ b/packages/ag-charts-website/e2e/forcedReflowDetection.ts
@@ -162,6 +162,11 @@ interface FilterOptions {
     additionalAllowlist?: string[];
 }
 
+interface FilteredReflowAnalysis extends ForcedReflowAnalysis {
+    /** Counts of allowlisted reflows keyed by the matched function name. */
+    allowlisted: Record<string, number>;
+}
+
 /**
  * Filter a reflow analysis to only include reflows attributable to AG Charts code.
  *
@@ -174,9 +179,13 @@ interface FilterOptions {
  * 2. **Allowlist filter** — exclude reflows whose top stack frame function name
  *    matches a known-unavoidable pattern (e.g. `togglePopover` from the native
  *    Popover API).
+ *
+ * Returns both the unexpected reflows and per-function counts of allowlisted
+ * reflows so callers can assert upper bounds on the allowlisted ones.
  */
-export function filterAgChartsReflows(analysis: ForcedReflowAnalysis, opts?: FilterOptions): ForcedReflowAnalysis {
+export function filterAgChartsReflows(analysis: ForcedReflowAnalysis, opts?: FilterOptions): FilteredReflowAnalysis {
     const allowlist = new Set([...DEFAULT_ALLOWLIST, ...(opts?.additionalAllowlist ?? [])]);
+    const allowlisted: Record<string, number> = {};
 
     const filtered = analysis.reflows.filter((r) => {
         // Source filter: at least one frame must come from ag-charts source.
@@ -186,7 +195,10 @@ export function filterAgChartsReflows(analysis: ForcedReflowAnalysis, opts?: Fil
         // Allowlist filter: skip known-unavoidable functions. Check the first
         // named frame because the top frame may be anonymous (e.g. an IIFE).
         const firstNamedFunction = r.stackFrames.find((f) => f.functionName)?.functionName;
-        if (firstNamedFunction != null && allowlist.has(firstNamedFunction)) return false;
+        if (firstNamedFunction != null && allowlist.has(firstNamedFunction)) {
+            allowlisted[firstNamedFunction] = (allowlisted[firstNamedFunction] ?? 0) + 1;
+            return false;
+        }
 
         return true;
     });
@@ -195,6 +207,7 @@ export function filterAgChartsReflows(analysis: ForcedReflowAnalysis, opts?: Fil
         count: filtered.length,
         totalDuration: filtered.reduce((sum, r) => sum + r.dur, 0),
         reflows: filtered,
+        allowlisted,
     };
 }
 

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/data.ts
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/data.ts
@@ -1,5 +1,7 @@
+// 150 points exceeds RENDER_TO_OFFSCREEN_CANVAS_THRESHOLD (100) so the
+// offscreen rendering path in group.ts is exercised by these tests.
 export function getData(): { x: number; y: number }[] {
-    return Array.from({ length: 20 }, (_, i) => ({
+    return Array.from({ length: 150 }, (_, i) => ({
         x: i,
         y: Math.sin(i * 0.5) * 50 + 50 + Math.random() * 10,
     }));

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/data.ts
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/data.ts
@@ -1,0 +1,6 @@
+export function getData(): { x: number; y: number }[] {
+    return Array.from({ length: 20 }, (_, i) => ({
+        x: i,
+        y: Math.sin(i * 0.5) * 50 + 50 + Math.random() * 10,
+    }));
+}

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/index.html
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/index.html
@@ -1,0 +1,9 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <button onclick="createSparklines()">Create Sparklines</button>
+        <button onclick="updateSparklines()">Update Sparklines</button>
+        <button onclick="scrollSparklines()">Scroll Sparklines</button>
+    </div>
+</div>
+<div id="myChart" style="width: 200px; height: 30px"></div>
+<div id="sparklineContainer"></div>

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-reflow/main.ts
@@ -1,0 +1,100 @@
+// @ag-skip-fws
+// @ag-skip-container-check
+import {
+    AgChartInstance,
+    AgCharts,
+    AgSparklineOptions,
+    CategoryAxisModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([CategoryAxisModule, LineSeriesModule, NumberAxisModule]);
+
+const SPARKLINE_COUNT = 30;
+
+const options: AgSparklineOptions = {
+    container: document.getElementById('myChart'),
+    type: 'line',
+    width: 200,
+    height: 30,
+    background: { visible: false },
+    minHeight: 0,
+    minWidth: 0,
+    xKey: 'x',
+    yKey: 'y',
+    data: getData(),
+};
+
+// Create one initial sparkline so gotoExample detects a canvas on load.
+const initialChart = AgCharts.__createSparkline(options);
+
+const charts: AgChartInstance<AgSparklineOptions>[] = [initialChart];
+
+// Simulates Grid creating sparkline cells as rows scroll into view.
+function createSparklines() {
+    const container = document.getElementById('sparklineContainer');
+    if (!container) return;
+
+    for (let i = 0; i < SPARKLINE_COUNT; i++) {
+        const div = document.createElement('div');
+        div.style.width = '200px';
+        div.style.height = '30px';
+        div.style.display = 'inline-block';
+        container.appendChild(div);
+
+        charts.push(
+            AgCharts.__createSparkline({
+                ...options,
+                container: div,
+                data: getData(),
+            })
+        );
+    }
+}
+
+// Simulates Grid calling instance.update() with new row data — matches
+// SparklineCellRenderer.refresh() which uses full update(), not updateDelta().
+function updateSparklines() {
+    for (const chart of charts) {
+        chart.update({
+            ...options,
+            data: getData(),
+        });
+    }
+}
+
+// Simulates Grid scroll: destroy visible sparklines (returning them to pool),
+// then create new ones from pool with fresh data — matches the destroy/recreate
+// cycle that occurs as rows scroll in and out of the viewport.
+function scrollSparklines() {
+    const container = document.getElementById('sparklineContainer');
+    if (!container) return;
+
+    // Destroy existing sparklines (returns to pool).
+    for (const chart of charts) {
+        chart.destroy();
+    }
+    charts.length = 0;
+    container.innerHTML = '';
+
+    // Recreate from pool with new data.
+    for (let i = 0; i < SPARKLINE_COUNT; i++) {
+        const div = document.createElement('div');
+        div.style.width = '200px';
+        div.style.height = '30px';
+        div.style.display = 'inline-block';
+        container.appendChild(div);
+
+        charts.push(
+            AgCharts.__createSparkline({
+                ...options,
+                container: div,
+                data: getData(),
+            })
+        );
+    }
+}

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/data.ts
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/data.ts
@@ -1,5 +1,7 @@
+// 150 points exceeds RENDER_TO_OFFSCREEN_CANVAS_THRESHOLD (100) so the
+// offscreen rendering path in group.ts is exercised by these tests.
 export function getData(): { x: number; y: number }[] {
-    return Array.from({ length: 20 }, (_, i) => ({
+    return Array.from({ length: 150 }, (_, i) => ({
         x: i,
         y: Math.sin(i * 0.5) * 50 + 50 + Math.random() * 10,
     }));

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/data.ts
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/data.ts
@@ -1,0 +1,6 @@
+export function getData(): { x: number; y: number }[] {
+    return Array.from({ length: 20 }, (_, i) => ({
+        x: i,
+        y: Math.sin(i * 0.5) * 50 + 50 + Math.random() * 10,
+    }));
+}

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/index.html
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/index.html
@@ -1,0 +1,3 @@
+<div id="myChart" style="width: 200px; height: 30px"></div>
+<div id="stats" style="font: 12px monospace; padding: 4px 0"></div>
+<div id="viewport"></div>

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/main.ts
@@ -1,0 +1,135 @@
+// @ag-skip-fws
+// @ag-skip-container-check
+import {
+    AgChartInstance,
+    AgCharts,
+    AgSparklineOptions,
+    CategoryAxisModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([CategoryAxisModule, LineSeriesModule, NumberAxisModule]);
+
+// ---------------------------------------------------------------------------
+// Virtual-scroll sparkline demo
+//
+// Simulates a grid with 1000 rows, each containing a sparkline. Only the rows
+// visible inside the 400px viewport are materialised. As the user scrolls,
+// sparklines leaving the viewport are destroyed (returned to pool) and new ones
+// entering the viewport are created (reused from pool).
+// ---------------------------------------------------------------------------
+
+const TOTAL_ROWS = 1000;
+const ROW_HEIGHT = 36;
+const OVERSCAN = 5; // extra rows rendered above/below viewport
+
+const baseOptions: AgSparklineOptions = {
+    type: 'line',
+    width: 200,
+    height: 30,
+    background: { visible: false },
+    minHeight: 0,
+    minWidth: 0,
+    xKey: 'x',
+    yKey: 'y',
+};
+
+// Pre-generate data for all rows so scrolling back shows the same sparkline.
+const rowData: { x: number; y: number }[][] = Array.from({ length: TOTAL_ROWS }, () => getData());
+
+// Create one initial sparkline so gotoExample detects a canvas on load.
+AgCharts.__createSparkline({ ...baseOptions, container: document.getElementById('myChart')!, data: getData() });
+
+// ---------------------------------------------------------------------------
+// Virtual-scroll state
+// ---------------------------------------------------------------------------
+
+interface RowEntry {
+    element: HTMLElement;
+    sparkline: AgChartInstance<AgSparklineOptions>;
+}
+
+const activeRows = new Map<number, RowEntry>();
+let currentStart = -1;
+let currentEnd = -1;
+
+const viewport = document.getElementById('viewport')!;
+const stats = document.getElementById('stats')!;
+
+// Sentinel element whose height matches the full virtual list, providing the
+// scrollbar range.
+const scrollContent = document.createElement('div');
+scrollContent.id = 'scroll-content';
+scrollContent.style.height = `${TOTAL_ROWS * ROW_HEIGHT}px`;
+viewport.appendChild(scrollContent);
+
+// ---------------------------------------------------------------------------
+// Render visible rows
+// ---------------------------------------------------------------------------
+
+function renderVisibleRows() {
+    const scrollTop = viewport.scrollTop;
+    const viewportHeight = viewport.clientHeight;
+
+    const firstVisible = Math.floor(scrollTop / ROW_HEIGHT);
+    const lastVisible = Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT) - 1;
+
+    const start = Math.max(0, firstVisible - OVERSCAN);
+    const end = Math.min(TOTAL_ROWS - 1, lastVisible + OVERSCAN);
+
+    if (start === currentStart && end === currentEnd) return;
+    currentStart = start;
+    currentEnd = end;
+
+    // Remove rows that scrolled out of range.
+    for (const [index, entry] of activeRows) {
+        if (index < start || index > end) {
+            entry.sparkline.destroy();
+            entry.element.remove();
+            activeRows.delete(index);
+        }
+    }
+
+    // Add rows that scrolled into range.
+    for (let i = start; i <= end; i++) {
+        if (activeRows.has(i)) continue;
+
+        const row = document.createElement('div');
+        row.className = 'row';
+        row.style.position = 'absolute';
+        row.style.top = `${i * ROW_HEIGHT}px`;
+        row.style.width = '100%';
+
+        const label = document.createElement('div');
+        label.className = 'row-label';
+        label.textContent = `Row ${i}`;
+        row.appendChild(label);
+
+        const cell = document.createElement('div');
+        cell.className = 'sparkline-cell';
+        row.appendChild(cell);
+
+        scrollContent.appendChild(row);
+
+        const sparkline = AgCharts.__createSparkline({
+            ...baseOptions,
+            container: cell,
+            data: rowData[i],
+        });
+
+        activeRows.set(i, { element: row, sparkline });
+    }
+
+    stats.textContent = `rows ${start}–${end} (${activeRows.size} active, pool recycling via destroy/create)`;
+}
+
+// ---------------------------------------------------------------------------
+// Wire up scroll listener and initial render
+// ---------------------------------------------------------------------------
+
+viewport.addEventListener('scroll', renderVisibleRows, { passive: true });
+renderVisibleRows();

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/styles.css
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/_examples/e2e-sparkline-virtual-scroll/styles.css
@@ -1,0 +1,31 @@
+#viewport {
+    position: relative;
+    height: 400px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+}
+
+#scroll-content {
+    position: relative;
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    height: 36px;
+    border-bottom: 1px solid #eee;
+    padding: 0 8px;
+    box-sizing: border-box;
+}
+
+.row-label {
+    width: 80px;
+    font: 12px monospace;
+    flex-shrink: 0;
+}
+
+.sparkline-cell {
+    width: 200px;
+    height: 30px;
+    flex-shrink: 0;
+}

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/index.mdoc
@@ -7,3 +7,7 @@ title: 'Sparklines Test'
 ## Sparkline Reflow
 
 {% chartExampleRunner title="Sparkline Reflow E2E" name="e2e-sparkline-reflow" type="generated" /%}
+
+## Virtual Scroll
+
+{% chartExampleRunner title="Sparkline Virtual Scroll" name="e2e-sparkline-virtual-scroll" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/sparklines-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sparklines-test/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: 'Sparklines Test'
+---
+
+# E2E Tests
+
+## Sparkline Reflow
+
+{% chartExampleRunner title="Sparkline Reflow E2E" name="e2e-sparkline-reflow" type="generated" /%}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16900

## Summary
- Skip deferred DOM flush for minimal-mode (sparkline) charts to avoid concentrated write bursts between consecutive updates
- Skip synchronous `getBoundingClientRect` in SizeMonitor for sparklines to eliminate creation-time layout thrashing
- Skip `getComputedStyle` RTL check for sparklines (use explicit `enableRtl` if needed)
- Thread `skipInitialRead` through DOMElementProxy so tooltip resize observation also skips sync reads
- Add virtual-scroll test example (1000 rows, 400px viewport) with pool recycling
- Add bounded assertions on allowlisted canvas reflow counts

## Test plan
- [x] E2E forced reflow tests (6/6 pass including new virtual-scroll test)
- [x] Community unit tests (102 suites, 3107 tests)
- [x] Enterprise unit tests (68 suites, 1742 tests)
- [x] Lint and format clean