### PR TITLE
AG-13929 Fix SSR example Codespace install by removing from yarn workspaces

### DIFF
--- a/examples/server-side-rendering/package.json
+++ b/examples/server-side-rendering/package.json
@@ -16,15 +16,5 @@
     "@types/express": "^4.17.0",
     "@types/node": "^22.0.0",
     "typescript": "~5.6.0"
-  },
-  "nx": {
-    "implicitDependencies": [
-      "ag-charts-enterprise",
-      "ag-charts-server-side"
-    ],
-    "tags": [
-      "example"
-    ],
-    "includedScripts": []
   }
 }

--- a/examples/server-side-rendering/project.json
+++ b/examples/server-side-rendering/project.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "ag-charts-server-side-example",
+  "implicitDependencies": ["ag-charts-enterprise", "ag-charts-server-side"],
+  "tags": ["example"],
+  "includedScripts": []
+}

--- a/package.json
+++ b/package.json
@@ -156,8 +156,7 @@
       "tests/angular-package-tests",
       "tests/react-package-tests",
       "tests/server-side-package-tests",
-      "tests/vue-package-tests",
-      "examples/server-side-rendering"
+      "tests/vue-package-tests"
     ],
     "nohoist": [
       "**/tinypool",


### PR DESCRIPTION
## Summary

- Remove `examples/server-side-rendering` from root `workspaces.packages` so npm treats it as a standalone project in Codespaces
- Add `project.json` to maintain Nx project discovery (previously discovered via yarn workspaces)
- Move Nx config from `package.json` `nx` field to `project.json`

## Problem

When the SSR example's Codespace runs `npm install`, npm v7+ walks up from the example directory, finds the root `package.json` with its `workspaces` field, and tries to resolve ALL workspace members' dependencies — including `ag-charts-website` with conflicting React peer deps (18 vs 19), causing ERESOLVE failures.

Research confirmed there is no `.npmrc` or `package.json` config to prevent this — npm hard-codes workspace detection to only respect the `--no-workspaces` CLI flag. Removing the example from the workspace array is the only persistent solution.

## Test plan

- [x] `npm prefix` from `examples/server-side-rendering/` returns the example dir (not monorepo root)
- [x] `npm install --dry-run` resolves only SSR example deps (no ERESOLVE errors)
- [x] `nx show project ag-charts-server-side-example` discovers the project via `project.json`
- [x] `nx show project ssr-example-ci` resolves with valid `implicitDependencies`
- [ ] Verify Codespace launches and `npm install` succeeds