### PR TITLE
Improve rulesync skill description for better triggering

### DIFF
--- a/external/ag-shared/prompts/skills/rulesync/SKILL.md
+++ b/external/ag-shared/prompts/skills/rulesync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 targets: ['*']
 name: rulesync
-description: 'Configure AI/agentic tooling using rulesync. Use when asking about .rulesync/, adding or editing commands, rules, skills, or subagents, configuring AI tools like Claude Code or Cursor, understanding where AI config files live, editing prompt files, or asking how to add a new command/rule/skill/agent. Also use when someone references .claude/, .cursor/, .copilot/ or similar tool-specific config directories.'
+description: 'Use this skill whenever creating, editing, registering, or troubleshooting skills, commands, rules, subagents, or any AI prompt file. Covers SKILL.md authoring, frontmatter syntax (targets, description, globs, alwaysApply), symlink setup between .rulesync/ and external/ tiers, and regeneration/verification via setup-prompts.sh and verify-rulesync.sh. Also use when referencing .rulesync/, .claude/, .cursor/, .copilot/, or any AI tooling config directory — .rulesync/ is the single source of truth and generated directories must never be edited directly. IMPORTANT: Always load this skill alongside the skill-creator plugin — when creating or improving any skill, this skill provides the correct file locations, registration steps, and content tier decisions that the skill-creator workflow depends on.'
 ---
 
 # Rulesync Configuration Guide


### PR DESCRIPTION
Rewrites the rulesync skill description to improve auto-triggering accuracy and ensure it co-loads with the skill-creator plugin.

Key changes:
- Leads with imperative action verbs (creating, editing, registering, troubleshooting)
- Enumerates specific artifacts (SKILL.md, frontmatter fields, setup-prompts.sh, verify-rulesync.sh)
- Explicitly ties to skill-creator as a co-dependency
- Mentions the external/ content tier system
- States the constraint that generated directories must not be edited directly