### PR TITLE
Fix PR review CI sandbox failure on GitHub Actions

### DIFF
--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -316,7 +316,7 @@ runs:
               set +e
               cat "${{ steps.prompt.outputs.prompt_file }}" | codex exec \
                 --output-last-message "${output_file}" \
-                --sandbox read-only \
+                --sandbox workspace-write \
                 2>"${error_file}" \
                 >/dev/null
               exit_code=$?

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -288,6 +288,73 @@ runs:
               echo "prompt_file=${prompt_file}" >> $GITHUB_OUTPUT
               echo "output_ext=${output_ext}" >> $GITHUB_OUTPUT
 
+        - name: Generate PR Diff Context
+          if: steps.check-auth.outputs.skipped != 'true'
+          id: diff-context
+          shell: bash
+          env:
+              PR_NUMBER: ${{ inputs.pr-number }}
+              BASE_REF: ${{ inputs.base-ref }}
+              HEAD_REF: ${{ inputs.head-ref }}
+              PR_TITLE: ${{ inputs.pr-title }}
+              PR_AUTHOR: ${{ inputs.pr-author }}
+          run: |
+              # Pre-generate the diff and metadata so Codex doesn't need to exec git commands.
+              # This avoids sandbox (bwrap) issues on GitHub Actions runners.
+              context_file=".codex-diff-context-${PR_NUMBER}.md"
+              echo "context_file=${context_file}" >> $GITHUB_OUTPUT
+
+              PR_REF="origin/pr/${PR_NUMBER}"
+              DIFF_BASE="origin/${BASE_REF}...${PR_REF}"
+              HEAD_SHA=$(git rev-parse "${PR_REF}")
+              PR_URL="https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
+
+              # Collect diff stats
+              FILES_CHANGED=$(git diff --name-only "${DIFF_BASE}" | wc -l | tr -d ' ')
+              DIFF_STAT=$(git diff --stat "${DIFF_BASE}")
+              LINES_ADDED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $1 } END { print s+0 }')
+              LINES_REMOVED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $2 } END { print s+0 }')
+
+              # Build the context file
+              {
+                cat <<EOF
+
+## Pre-generated PR Context
+
+The PR diff and metadata have been pre-generated and are provided below.
+**Do NOT run any git, gh, or shell commands.** Analyse the diff below directly.
+
+### PR Metadata
+- **PR Number:** ${PR_NUMBER}
+- **PR Title:** ${PR_TITLE}
+- **PR URL:** ${PR_URL}
+- **Author:** ${PR_AUTHOR}
+- **Base Branch:** ${BASE_REF}
+- **Head Branch:** ${HEAD_REF}
+- **Head SHA:** ${HEAD_SHA}
+- **Files Changed:** ${FILES_CHANGED}
+- **Lines Added:** ${LINES_ADDED}
+- **Lines Removed:** ${LINES_REMOVED}
+
+### Diff Stats
+\`\`\`
+${DIFF_STAT}
+\`\`\`
+
+### Commit Messages
+\`\`\`
+$(git log --format="%s" "origin/${BASE_REF}..${PR_REF}")
+\`\`\`
+
+### Full Diff
+\`\`\`diff
+EOF
+                git diff "${DIFF_BASE}"
+                echo '```'
+              } > "${context_file}"
+
+              echo "Generated diff context ($(wc -c < "${context_file}") bytes)"
+
         - name: Run Codex Review
           if: steps.check-auth.outputs.skipped != 'true'
           id: codex
@@ -306,17 +373,18 @@ runs:
               # Output file paths (unique per PR to avoid conflicts)
               output_file=".codex-review-${{ inputs.pr-number }}.${{ steps.prompt.outputs.output_ext }}"
               error_file=".codex-error-${{ inputs.pr-number }}.log"
+              context_file="${{ steps.diff-context.outputs.context_file }}"
 
               echo "output_file=${output_file}" >> $GITHUB_OUTPUT
 
               # Run Codex with ALL output suppressed
-              # - stdin: Prompt file content piped in
+              # - stdin: Review instructions + pre-generated diff context concatenated
               # - stdout (>/dev/null): Suppresses reasoning/streaming output
               # - stderr (2>file): Captured to file for debugging, not logged
               set +e
-              cat "${{ steps.prompt.outputs.prompt_file }}" | codex exec \
+              cat "${{ steps.prompt.outputs.prompt_file }}" "${context_file}" | codex exec \
                 --output-last-message "${output_file}" \
-                --sandbox workspace-write \
+                --sandbox read-only \
                 2>"${error_file}" \
                 >/dev/null
               exit_code=$?
@@ -672,4 +740,4 @@ runs:
           if: always()
           shell: bash
           run: |
-              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log"
+              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log" ".codex-diff-context-${{ inputs.pr-number }}.md"

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -302,7 +302,9 @@ runs:
               # Pre-generate the diff and metadata so Codex doesn't need to exec git commands.
               # This avoids sandbox (bwrap) issues on GitHub Actions runners.
               context_file=".codex-diff-context-${PR_NUMBER}.md"
+              diff_file=".codex-diff-${PR_NUMBER}.patch"
               echo "context_file=${context_file}" >> $GITHUB_OUTPUT
+              echo "diff_file=${diff_file}" >> $GITHUB_OUTPUT
 
               PR_REF="origin/pr/${PR_NUMBER}"
               DIFF_BASE="origin/${BASE_REF}...${PR_REF}"
@@ -315,9 +317,11 @@ runs:
               LINES_ADDED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $1 } END { print s+0 }')
               LINES_REMOVED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $2 } END { print s+0 }')
 
-              # Build the context file
-              {
-                cat <<EOF
+              # Write the raw diff to a standalone file (avoids Markdown escaping issues)
+              git diff "${DIFF_BASE}" > "${diff_file}"
+
+              # Build the context file (metadata only, no embedded diff)
+              cat > "${context_file}" <<EOF
 
 ## Pre-generated PR Context
 
@@ -347,13 +351,11 @@ $(git log --format="%s" "origin/${BASE_REF}..${PR_REF}")
 \`\`\`
 
 ### Full Diff
-\`\`\`diff
-EOF
-                git diff "${DIFF_BASE}"
-                echo '```'
-              } > "${context_file}"
 
-              echo "Generated diff context ($(wc -c < "${context_file}") bytes)"
+The unified diff follows immediately after this line.
+EOF
+
+              echo "Generated context ($(wc -c < "${context_file}") bytes) + diff ($(wc -c < "${diff_file}") bytes)"
 
         - name: Run Codex Review
           if: steps.check-auth.outputs.skipped != 'true'
@@ -374,15 +376,16 @@ EOF
               output_file=".codex-review-${{ inputs.pr-number }}.${{ steps.prompt.outputs.output_ext }}"
               error_file=".codex-error-${{ inputs.pr-number }}.log"
               context_file="${{ steps.diff-context.outputs.context_file }}"
+              diff_file="${{ steps.diff-context.outputs.diff_file }}"
 
               echo "output_file=${output_file}" >> $GITHUB_OUTPUT
 
               # Run Codex with ALL output suppressed
-              # - stdin: Review instructions + pre-generated diff context concatenated
+              # - stdin: Review instructions + metadata context + raw diff (three files concatenated)
               # - stdout (>/dev/null): Suppresses reasoning/streaming output
               # - stderr (2>file): Captured to file for debugging, not logged
               set +e
-              cat "${{ steps.prompt.outputs.prompt_file }}" "${context_file}" | codex exec \
+              cat "${{ steps.prompt.outputs.prompt_file }}" "${context_file}" "${diff_file}" | codex exec \
                 --output-last-message "${output_file}" \
                 --sandbox read-only \
                 2>"${error_file}" \
@@ -740,4 +743,4 @@ EOF
           if: always()
           shell: bash
           run: |
-              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log" ".codex-diff-context-${{ inputs.pr-number }}.md"
+              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log" ".codex-diff-context-${{ inputs.pr-number }}.md" ".codex-diff-${{ inputs.pr-number }}.patch"

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -352,7 +352,7 @@ $(git log --format="%s" "origin/${BASE_REF}..${PR_REF}")
 
 ### Full Diff
 
-The unified diff follows immediately after this line.
+Read the unified diff from: \`${diff_file}\`
 EOF
 
               echo "Generated context ($(wc -c < "${context_file}") bytes) + diff ($(wc -c < "${diff_file}") bytes)"
@@ -376,16 +376,15 @@ EOF
               output_file=".codex-review-${{ inputs.pr-number }}.${{ steps.prompt.outputs.output_ext }}"
               error_file=".codex-error-${{ inputs.pr-number }}.log"
               context_file="${{ steps.diff-context.outputs.context_file }}"
-              diff_file="${{ steps.diff-context.outputs.diff_file }}"
 
               echo "output_file=${output_file}" >> $GITHUB_OUTPUT
 
               # Run Codex with ALL output suppressed
-              # - stdin: Review instructions + metadata context + raw diff (three files concatenated)
+              # - stdin: Review instructions + metadata context (diff is referenced by filepath)
               # - stdout (>/dev/null): Suppresses reasoning/streaming output
               # - stderr (2>file): Captured to file for debugging, not logged
               set +e
-              cat "${{ steps.prompt.outputs.prompt_file }}" "${context_file}" "${diff_file}" | codex exec \
+              cat "${{ steps.prompt.outputs.prompt_file }}" "${context_file}" | codex exec \
                 --output-last-message "${output_file}" \
                 --sandbox read-only \
                 2>"${error_file}" \

--- a/external/ag-shared/prompts/skills/pr-review/_review-core.md
+++ b/external/ag-shared/prompts/skills/pr-review/_review-core.md
@@ -53,14 +53,21 @@ Apply any repo-specific rules found (e.g., "Don't log PII", "Verify auth middlew
 ## 4. Workflow
 
 1. Determine the PR number from `$ARGUMENTS` (required in CI, optional locally).
-2. Determine if running in CI (PR refs pre-fetched) or locally (use `gh` CLI).
-3. Fetch the PR diff and metadata using the appropriate method (see sections below).
+2. Check if a **"Pre-generated PR Context"** section is appended to this prompt. If it is, use the diff, metadata, and commit messages provided there directly — **do NOT run any git, gh, or shell commands**.
+3. Otherwise, determine if running in CI (PR refs pre-fetched) or locally (use `gh` CLI), and fetch the PR diff and metadata using the appropriate method (see sections below).
 4. Analyse the changes and identify issues.
 5. Output the review in the format specified by the calling prompt.
 
+### Pre-supplied Diff (CI Default)
+
+In CI, the workflow pre-generates the diff and metadata and appends them to this prompt under a **"Pre-generated PR Context"** heading. When this section is present:
+- Use the provided diff, metadata, commit messages, and stats directly.
+- **Do NOT execute any commands** — the sandbox does not support it.
+- All required information (PR number, title, author, base/head branches, head SHA, diff stats, full diff) is included.
+
 ### CI Environment (Sandboxed - No Network Access)
 
-In CI, PR refs are pre-fetched by the workflow. Use git commands with these environment variables:
+Fallback when diff is not pre-supplied. In CI, PR refs are pre-fetched by the workflow. Use git commands with these environment variables:
 - `$ARGUMENTS` - PR number
 - `$BASE_REF` - Target branch (e.g., `latest`, `main`)
 - `$HEAD_REF` - Source branch name (may be empty)

--- a/external/ag-shared/prompts/skills/pr-review/_review-core.md
+++ b/external/ag-shared/prompts/skills/pr-review/_review-core.md
@@ -53,7 +53,7 @@ Apply any repo-specific rules found (e.g., "Don't log PII", "Verify auth middlew
 ## 4. Workflow
 
 1. Determine the PR number from `$ARGUMENTS` (required in CI, optional locally).
-2. Check if a **"Pre-generated PR Context"** section is appended to this prompt. If it is, use the diff, metadata, and commit messages provided there directly — **do NOT run any git, gh, or shell commands**.
+2. Check if a **"Pre-generated PR Context"** section is appended to this prompt. If it is, use the metadata and commit messages provided there directly, and **read the diff from the file path specified** in the "Full Diff" subsection.
 3. Otherwise, determine if running in CI (PR refs pre-fetched) or locally (use `gh` CLI), and fetch the PR diff and metadata using the appropriate method (see sections below).
 4. Analyse the changes and identify issues.
 5. Output the review in the format specified by the calling prompt.
@@ -61,9 +61,9 @@ Apply any repo-specific rules found (e.g., "Don't log PII", "Verify auth middlew
 ### Pre-supplied Diff (CI Default)
 
 In CI, the workflow pre-generates the diff and metadata and appends them to this prompt under a **"Pre-generated PR Context"** heading. When this section is present:
-- Use the provided diff, metadata, commit messages, and stats directly.
-- **Do NOT execute any commands** — the sandbox does not support it.
-- All required information (PR number, title, author, base/head branches, head SHA, diff stats, full diff) is included.
+- Use the provided metadata, commit messages, and stats directly.
+- **Read the full diff** from the file path given in the "Full Diff" subsection (e.g., `.codex-diff-123.patch`).
+- **Do NOT execute git, gh, or other shell commands** — the sandbox does not support it. Reading the diff file is the only file-system access needed.
 
 ### CI Environment (Sandboxed - No Network Access)
 


### PR DESCRIPTION
## Summary

- Pre-generate the git diff and PR metadata in the workflow, then supply them as part of the Codex prompt
- Update `_review-core.md` to prioritise pre-supplied diff context over executing git commands

The Codex CLI's `--sandbox read-only` mode uses bubblewrap (`bwrap`) which fails on GitHub Actions runners with `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`. Rather than widening sandbox permissions, this pre-generates all required context (diff, metadata, commit messages, stats) outside the sandbox and appends it to the prompt. Codex then analyses the provided text directly without needing to execute any commands.

## Test plan

- [ ] Verify the PR Review workflow succeeds on this PR
- [ ] Confirm the PR comment shows a structured review, not the "I'm blocked" error