### PR TITLE
AG-16729 Hide gradient legend arrow when highlight is disabled

### DIFF
--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { type AgChartLegendPosition, type AgChartOptions, AgCharts } from 'ag-charts-community';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
+    deproxy,
     extractImageData,
+    hoverAction,
     setupMockCanvas,
     setupMockConsole,
     waitForChartStability,
@@ -125,5 +127,61 @@ describe('GradientLegend', () => {
         prepareEnterpriseTestOptions(options);
         chart = AgCharts.create(options);
         await compare();
+    });
+
+    it('AG-16729 should not show arrow when highlight.enabled is false', async () => {
+        const options: AgChartOptions = {
+            ...EXAMPLE_OPTIONS,
+            series: [
+                {
+                    type: 'heatmap',
+                    xKey: 'year',
+                    yKey: 'person',
+                    colorKey: 'spending',
+                    colorRange: ['white', 'yellow', 'red', 'blue', 'black'],
+                    highlight: { enabled: false },
+                },
+            ],
+        };
+        prepareEnterpriseTestOptions(options);
+        chart = AgCharts.create(options);
+        await waitForChartStability(chart);
+
+        const chartInstance = deproxy(chart);
+        const gradientLegend: any = chartInstance.modulesManager.getModule('gradientLegend');
+        const arrow = gradientLegend?.arrow;
+
+        // Before hover - arrow should be hidden
+        expect(arrow?.visible).toBe(false);
+
+        // Hover over a heatmap cell (center of chart)
+        await hoverAction(300, 200)(chart);
+        await waitForChartStability(chart);
+
+        // After hover - arrow should still be hidden because highlight.enabled is false
+        expect(arrow?.visible).toBe(false);
+    });
+
+    it('AG-16729 should show arrow when highlight.enabled is true (default)', async () => {
+        const options: AgChartOptions = {
+            ...EXAMPLE_OPTIONS,
+        };
+        prepareEnterpriseTestOptions(options);
+        chart = AgCharts.create(options);
+        await waitForChartStability(chart);
+
+        const chartInstance = deproxy(chart);
+        const gradientLegend: any = chartInstance.modulesManager.getModule('gradientLegend');
+        const arrow = gradientLegend?.arrow;
+
+        // Before hover - arrow should be hidden
+        expect(arrow?.visible).toBe(false);
+
+        // Hover over a heatmap cell (center of chart)
+        await hoverAction(300, 200)(chart);
+        await waitForChartStability(chart);
+
+        // After hover - arrow should be visible because highlight is enabled
+        expect(arrow?.visible).toBe(true);
     });
 });

--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.ts
@@ -252,7 +252,7 @@ export class GradientLegend extends BaseProperties<AgGradientLegendOptions> {
         const highlighted = this.highlightManager.getActiveHighlight();
         const { arrow } = this;
 
-        if (highlighted?.colorValue == null) {
+        if (highlighted?.colorValue == null || highlighted.series?.isHighlightEnabled() === false) {
             arrow.visible = false;
             return;
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16729

When a series has `highlight: { enabled: false }`, the gradient legend arrow should not appear on hover. Previously `updateArrow()` only checked for a null `colorValue` — it now also checks `isHighlightEnabled()` on the highlighted series.