### PR TITLE
Sync ag-shared: new skills, PR review fixes, skill enhancements

### DIFF
--- a/.rulesync/README.md
+++ b/.rulesync/README.md
@@ -65,15 +65,15 @@ Quick-reference for all AI agent commands, skills, sub-agents, and rules availab
 
 ## Planning and Analysis
 
-| Type    | Name                               | Invoke                               | What it does                                               |
-| ------- | ---------------------------------- | ------------------------------------ | ---------------------------------------------------------- |
-| Skill   | 🔵 `plan-review`                   | `/plan-review` (user)                | Review plans for completeness and correctness              |
-| Skill   | 🔵 `plan-implementation-review`    | `/plan-implementation-review` (user) | Review plan execution, identify delivery gaps              |
-| Command | 🟠 `/product-requirement-analysis` | `/product-requirement-analysis`      | Analyse requirements with competitor research              |
-| Skill   | 🔵 `jira`                          | `/jira`                              | Create, estimate, or analyse JIRA tickets                  |
-| Agent   | 🟠 `technical-research-analyst`    | Auto                                 | In-depth technical research with citations                 |
-| Skill   | 🟢 `nx-performance`                | `/nx-performance`                    | Nx caching, build pipeline, and performance best practices |
-| Agent   | 🔵 `nx-expert`                     | Auto                                 | Nx monorepo configuration and build optimisation           |
+| Type    | Name                               | Invoke                               | What it does                                         |
+| ------- | ---------------------------------- | ------------------------------------ | ---------------------------------------------------- |
+| Skill   | 🔵 `plan-review`                   | `/plan-review` (user)                | Review plans for completeness and correctness        |
+| Skill   | 🔵 `plan-implementation-review`    | `/plan-implementation-review` (user) | Review plan execution, identify delivery gaps        |
+| Command | 🟠 `/product-requirement-analysis` | `/product-requirement-analysis`      | Analyse requirements with competitor research        |
+| Skill   | 🔵 `jira`                          | `/jira`                              | Create, estimate, or analyse JIRA tickets            |
+| Agent   | 🟠 `technical-research-analyst`    | Auto                                 | In-depth technical research with citations           |
+| Skill   | 🔵 `nx-performance`                | `/nx-performance`                    | Nx monorepo performance diagnostics and optimization |
+| Agent   | 🔵 `nx-expert`                     | Auto                                 | Nx monorepo configuration and build optimisation     |
 
 ## Prompt Hygiene
 
@@ -195,6 +195,7 @@ Skills load on-demand when invoked. All skills are invoked via `/skill-name`. Al
 | 🔵 `git-split`                  |      | 👤     | Split large files preserving git history                    |
 | 🔵 `git-worktree-clean`         |      | 👤     | Hard-reset worktree to `origin/latest`                      |
 | 🔵 `jira`                       | ✂   | 🤖     | Create, estimate, or analyse JIRA tickets (all AG products) |
+| 🔵 `nx-performance`             | ✂   | 🤖     | Nx monorepo performance diagnostics and optimization        |
 | 🟠 `optimize-series`            | ✂   | 🤖     | Series performance optimisation and GC pressure reduction   |
 | 🔵 `plan-implementation-review` | ✂   | 👤     | Review plan execution, identify delivery gaps               |
 | 🔵 `plan-review`                | ✂   | 👤     | Review plans for completeness and correctness               |

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 8ba8e8e436eed4992181a97843b045a0c5249aef
-	parent = 72249c2bd1e1e36d5cfdd0a63c5ea9b89fbb8e45
+	commit = 2459687b24688dc840629ad808471e7ad7945a8f
+	parent = b87dcedd2dc400915105ae8bf6de1807d5c4619c
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/prompts/skills/sync-ag-shared/SKILL.md
+++ b/external/ag-shared/prompts/skills/sync-ag-shared/SKILL.md
@@ -24,7 +24,7 @@ If the user provides a command option of `help`:
 -   `git subrepo` must be installed (`git subrepo --version`).
 -   **Use `yarn subrepo` for push and pull** (never raw `git subrepo push`/`pull`). The wrapper handles edge cases like stale parent references. Other subrepo commands (e.g. `git subrepo status`, `git subrepo clean`) use `git subrepo` directly.
 -   **Never edit `external/ag-shared/.gitrepo` manually.** Only subrepo commands should modify this file.
--   Must be on a **feature branch** (not `latest`, `main`, or `master`).
+-   Should be on a **feature branch**. If on `latest`/`main`/`master`, the skill will offer to create one.
 -   Working tree must be **clean** (`git status --porcelain` is empty).
 -   The current repo must have `external/ag-shared/.gitrepo`.
 
@@ -55,11 +55,17 @@ SOURCE_REPO=$(basename "$SOURCE_ROOT")
 
 Validate:
 
--   `SOURCE_BRANCH` is not `latest`, `main`, or `master`.
 -   `git status --porcelain` is empty.
 -   `external/ag-shared/.gitrepo` exists.
 
-If any validation fails, report the issue and **STOP**.
+**If on `latest`, `main`, or `master`:** offer to create and switch to a `sync-ag-shared` feature branch. If the user confirms:
+
+```bash
+git checkout -b sync-ag-shared
+SOURCE_BRANCH="sync-ag-shared"
+```
+
+If the user declines or any other validation fails, report the issue and **STOP**.
 
 ### 1b. Discover Destination Repos
 
@@ -109,6 +115,18 @@ The sub-agent should produce:
     -   Changed rule globs may need `.claude/settings.json` updates.
     -   Script changes may need `package.json` or CI updates.
     -   Setup-prompts changes need `setup-prompts.sh` re-run in each repo.
+
+### No Changes Detected (Force Sync)
+
+If `git diff latest...HEAD` shows no changes (i.e., the branch is at the same commit as `latest` or has no ag-shared changes):
+
+1.  Inform the user that no local changes were found relative to `latest`.
+2.  Use `AskUserQuestion` to ask whether they want to proceed with a **force sync** — this will `yarn subrepo push ag-shared` to push the current `external/ag-shared/` state to the ag-shared remote, then pull it into all destination repos. This is useful when:
+    -   The ag-shared remote is out of sync with the consuming repos.
+    -   A previous sync was incomplete or failed partway through.
+    -   Changes were committed directly to `latest` and need propagating.
+3.  If the user confirms, continue to Step 3 with an empty change summary. The plan should note this is a **force sync** with no new changes on the branch.
+4.  If the user declines, **STOP**.
 
 ## STEP 3: Present Plan and Confirm
 


### PR DESCRIPTION
## Summary
Sync ag-shared subrepo — 16 commits since last push, including:

- **New skills:** `reflect` (self-reflection), `nx-performance` (migrated from ag-charts-local)
- **Skill enhancements:** `sync-ag-shared` (branch creation + force sync), `jira` (MCP check), `rulesync` (description), `website-astro` (style module convention)
- **PR review infra:** Codex sandbox fixes (diff handling, stdin piping, metadata, JSON mode)
- **Docs:** SYNC-LOG entry for nx-performance migration

## Cross-repo PRs
- ag-grid: https://github.com/ag-grid/ag-grid/pull/13321
- ag-studio: https://github.com/ag-grid/ag-studio/pull/982

## Test plan
- [x] `yarn subrepo push ag-shared` succeeded
- [x] `yarn subrepo pull ag-shared` in ag-grid and ag-studio
- [x] `verify-rulesync.sh` passes in all repos
- [x] Clean working trees in all repos