### PR TITLE
AG-13929: Improve SSR docs, feature matrix, and framework selector

### DIFF
--- a/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
+++ b/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
@@ -126,6 +126,14 @@ Present results as a markdown table:
 
 If any failed, suggest re-running with just the failed assignments by providing the exact `/batch-plunkers` invocation or spec table.
 
+## STEP 4 (Optional): Post Results to JIRA
+
+If the input was a JIRA ticket (Mode A), offer to post the results as a comment on the source ticket.
+
+Use `contentFormat: "adf"` with `mcp__atlassian__addCommentToJiraIssue`. Format as an ADF bullet list where each item has: title — ACs — clickable URL. Wrap each URL in an ADF `link` mark with the full URL as the link text — JIRA's markdown format does not reliably auto-link URLs.
+
+ADF link pattern: `{"type":"text","text":"https://plnkr.co/edit/abc123","marks":[{"type":"link","attrs":{"href":"https://plnkr.co/edit/abc123"}}]}`
+
 ## Notes
 
 - **Sub-agent autonomy**: Each sub-agent handles the full lifecycle — file creation, CSS sourcing, and API upload via `plnkr.sh`. The main thread only orchestrates and collects results.

--- a/external/ag-shared/prompts/skills/jira/SKILL.md
+++ b/external/ag-shared/prompts/skills/jira/SKILL.md
@@ -99,7 +99,9 @@ Each ticket has exactly **one** track value. Never set multiple track values on 
 - **End numbered items with periods.**
 - Bold: `**text**`.
 - Code: backticks.
-- URLs: Paste raw URLs directly (JIRA auto-links them); avoid `[text](url)` markdown links.
+- **contentFormat**: Use `"adf"` for all JIRA API calls (`addCommentToJiraIssue`, `createJiraIssue`, `editJiraIssue`). ADF is JIRA's native format and the only one that reliably renders clickable links. The `"markdown"` format does not auto-link raw URLs in bullet lists or other structured content.
+- URLs: Wrap in ADF `link` marks with the full URL as link text. Never hide the URL behind display text like `[Plunker](url)`.
+  ADF link pattern: `{"type":"text","text":"https://example.com","marks":[{"type":"link","attrs":{"href":"https://example.com"}}]}`
 - Empty sections: Just `N/A`.
 - No comments — all info in description.
 - When creating tickets from analysis/research documents, distil to decisions and recommendations only. Do not reproduce full analysis in the description — link to the analysis document in the "Design Documents" section instead.

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -118,7 +118,22 @@ Bug descriptions should be concise: test cases + notes only. Do not add acceptan
 - [ ] Track field set correctly.
 - [ ] For Bug and Improvement tickets: Affects Version included.
 - [ ] For Bug and Improvement tickets: Bug template used (reproduction steps, actual/expected).
-- [ ] URLs pasted as raw URLs (not markdown links).
+- [ ] URLs are clickable ADF links showing the full URL as link text (not hidden behind display text).
+
+## Issue Link Direction
+
+The "Work item split" link type has: **inward** = "split from", **outward** = "split to".
+
+To express "NEW-TICKET split from PARENT-TICKET":
+- `inwardIssue` = **PARENT-TICKET** (the source — "split from" points here)
+- `outwardIssue` = **NEW-TICKET** (the new ticket — "split to" points here)
+
+Think of it as: the **inward** issue is the one being referenced ("split **from** X"), and the **outward** issue is the one the link is being created on.
+
+## Description Formatting
+
+- **Inline code for option names:** Always wrap API option names, property names, and programmatic values in backticks (e.g., `enableRtl`, `skipNullBars: true`, `bar`). This distinguishes code from prose and improves readability.
+- **Series type references:** When referencing series types, use backtick-wrapped type values (e.g., `bar`) rather than informal names like "bar/column".
 
 ## Critical Rules
 
@@ -128,3 +143,4 @@ Bug descriptions should be concise: test cases + notes only. Do not add acceptan
 4. **No comments** — Put all information in the description.
 5. **No rationale in feature requests** — State **what** and acceptance criteria, not **why**.
 6. **Improvement = internally reported bug** — Always use the bug template for Improvement tickets, not the feature/task template.
+7. **Inline code for options** — Always wrap API option/property names in backticks in descriptions.

--- a/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
@@ -371,6 +371,22 @@
     },
     {
         "group": {
+            "name": "Server-Side Rendering"
+        },
+        "items": [
+            {
+                "label": {
+                    "name": "Server-Side Rendering",
+                    "link": "https://www.ag-grid.com/charts/r/server-side-rendering/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
+            }
+        ]
+    },
+    {
+        "group": {
             "name": "Data"
         },
         "items": [

--- a/packages/ag-charts-website/src/components/framework-selector-inside-doc/FrameworkSelectorInsideDocs.tsx
+++ b/packages/ag-charts-website/src/components/framework-selector-inside-doc/FrameworkSelectorInsideDocs.tsx
@@ -18,28 +18,21 @@ interface Props {
 }
 
 export const FrameworkSelectorInsideDocs = ({ path, currentFramework, menuItems }: Props) => {
-    const pageName = getPageNameFromPath(path);
-    const menuItem = getMenuItemFromPageName({ menuItems: menuItems, pageName });
-
     const frameworkOptions = useMemo(() => {
-        const allowedFrameworks = menuItem?.frameworks ?? FRAMEWORKS;
-        return allowedFrameworks.map((framework) => ({
+        return FRAMEWORKS.map((framework) => ({
             label: getFrameworkDisplayText(framework),
             value: framework,
         }));
-    }, [menuItem?.frameworks]);
+    }, [FRAMEWORKS]);
 
     const frameworkOption = useMemo(
         () => frameworkOptions.find((o: { value: string }) => o.value === currentFramework) ?? frameworkOptions[0],
         [frameworkOptions, currentFramework]
     );
 
-    // Hide selector when only one framework is available
-    if (frameworkOptions.length <= 1) {
-        return null;
-    }
-
     const handleFrameworkChange = (selectedFramework: Framework) => {
+        const pageName = getPageNameFromPath(path);
+        const menuItem = getMenuItemFromPageName({ menuItems: menuItems, pageName });
         let newUrl = getNewFrameworkPath({
             path,
             currentFramework,

--- a/packages/ag-charts-website/src/content/docs/server-side-rendering/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/server-side-rendering/index.mdoc
@@ -4,21 +4,16 @@ description: 'Render AG Charts to PNG and JPEG image buffers in Node.js without 
 enterprise: true
 ---
 
-The `ag-charts-server-side` package renders AG Charts to PNG and JPEG image buffers in Node.js, without a browser or DOM. Use it to generate chart images for email reports, PDF documents, social media cards, thumbnails, or API endpoints.
+The `ag-charts-server-side` package renders AG Charts to PNG and JPEG image buffers in Node.js, without the need for a browser. Use it to generate chart images for email reports, PDF documents, or API endpoints.
 
 {% idea %}
-Try server-side rendering with zero setup in {% link href=codespaceUrl() isExternal=true %}GitHub Codespaces{% /link %}. Note that in Codespaces, the server URL will be a forwarded port URL (e.g. `https://<name>-3000.<domain>`) rather than `localhost:3000`.
+Try server-side rendering with zero setup in {% link href=codespaceUrl() isExternal=true %}GitHub Codespaces{% /link %}.  
+Note that in Codespaces, the server URL will be a forwarded port URL (e.g. `https://<name>-3000.<domain>`) rather than `localhost:3000`.
 {% /idea %}
-
-## Prerequisites
-
-{% note %}
-Server-side rendering requires Node.js 20.0.0 or later, and an [AG Charts Enterprise licence](./license-install/).
-{% /note %}
 
 ## Installation
 
-Install `ag-charts-server-side`:
+Install the `ag-charts-server-side` package:
 
 {% tabs omitFromOverview=true snippetTabs=true %}
 {% tabItem id="ssr-npm" label="NPM" %}
@@ -37,9 +32,11 @@ yarn add ag-charts-server-side
 {% /tabItem %}
 {% /tabs %}
 
-## Module registration
+Node.js 20.0.0 or later is required to run `ag-charts-server-side`.
 
-Register modules before rendering any charts. This is typically done once at application startup:
+### Module Registration
+
+Register chart modules before rendering any charts. This is typically done once at application startup.
 
 ```js format="snippet"
 import { AllEnterpriseModule, LicenseManager, ModuleRegistry } from 'ag-charts-enterprise';
@@ -48,17 +45,29 @@ LicenseManager.setLicenseKey('your-licence-key');
 ModuleRegistry.registerModules([AllEnterpriseModule]);
 ```
 
-## Rendering a chart
+See [Module Registry](./module-registry/) for details on selecting specific modules to reduce bundle size.
 
-{% note %}
+### Licensing
+
+Server-side rendering requires an AG Charts Enterprise licence.
+
+See [Upgrading to Enterprise](./licensing/) for licence options, and [Installing Your Licence Key](./license-install/) for setup instructions.
+
+## Rendering
+
+`AgChartsServerSide` is the static entry point for all server-side rendering.
+
+It exposes `render()`, `renderGauge()`, and `renderFinancialChart()` methods, each returning a `Promise<Uint8Array>` containing the image data.
+
+Because there is no DOM container to derive dimensions from, `width` and `height` are required top-level options on every render call.
+
+The `options` property accepts all [AG Charts options](/options/), excluding `container`, `width`, and `height`.
+
 Multiple render calls can safely be issued concurrently. The package serialises rendering internally to prevent global state conflicts.
-{% /note %}
 
-`AgChartsServerSide` exposes static `render()`, `renderGauge()`, and `renderFinancialChart()` methods. Each returns a `Promise<Uint8Array>` containing the image data.
+### Basic Rendering
 
-{% apiReference id="AgChartsServerSideApi" include=["render"] hideHeader=true hideRequired=true /%}
-
-The `options` property accepts the same chart options as `AgCharts.create()`, excluding `container`, `width`, and `height` which are provided as top-level render options instead.
+Use `render()` to render all standard chart types. This method is the equivalent of the browser-based `AgChart.create()`.
 
 ```js
 import * as fs from 'fs';
@@ -85,11 +94,83 @@ const buffer = await AgChartsServerSide.render({
 fs.writeFileSync('chart.png', buffer);
 ```
 
-## JPEG output
+In this configuration:
 
-Set `format: 'jpeg'` to render JPEG images. Use `quality` to control the compression level.
+-   `options` contains the chart configuration — the same structure used in browser rendering.
+-   `width` and `height` set the output image dimensions in pixels.
+-   The default output format is PNG. See [Image Format](#image-format) for JPEG output.
 
-```js
+### Rendering Gauges
+
+Use `renderGauge()` to render [Radial](./radial-gauge/) and [Linear Gauges](./linear-gauge/).
+
+```js format="snippet"
+const buffer = await AgChartsServerSide.renderGauge({
+    options: {
+        type: 'radial-gauge',
+        value: 75,
+        scale: { min: 0, max: 100 },
+    },
+    width: 300,
+    height: 300,
+});
+```
+
+See [Radial Gauge](./radial-gauge/) and [Linear Gauge](./linear-gauge/) for the full range of Gauge options.
+
+### Rendering Financial Charts
+
+Use `renderFinancialChart()` to render [Financial Charts](./financial-charts/).
+
+```js format="snippet"
+const buffer = await AgChartsServerSide.renderFinancialChart({
+    options: {
+        data: financialData,
+    },
+    width: 800,
+    height: 500,
+});
+```
+
+See [Financial Charts](./financial-charts-configuration/#reference-AgFinancialChartOptions) for the full range of Financial Chart options.
+
+### Timeout
+
+By default, each render call times out after 30 seconds. Use the `timeout` option to adjust this limit.
+
+```js format="snippet"
+const buffer = await AgChartsServerSide.render({
+    // ... chart options ...
+    timeout: 60000, // 60 seconds
+});
+```
+
+Increase the timeout for charts with large datasets or complex animations that need more time to settle. Decrease it in request handlers where fast failure is preferable to a long wait.
+
+## Image Format
+
+### High-DPI Output
+
+Set `pixelRatio` to produce higher-resolution images suitable for Retina displays, print-quality PDFs, or any context where sharp text and crisp lines are important.
+
+```js format="snippet"
+const buffer = await AgChartsServerSide.render({
+    // ... chart options ...
+    width: 200,
+    height: 150,
+    pixelRatio: 2,
+});
+```
+
+The actual pixel dimensions of the output are `width * pixelRatio` by `height * pixelRatio`.
+
+### JPEG Output
+
+The default output format is PNG. Set `format: 'jpeg'` to produce JPEG images instead.
+
+Use the `quality` option (0–100) to control JPEG compression. Lower values produce smaller files with more compression artefacts. This option has no effect on PNG output.
+
+```js format="snippet"
 const buffer = await AgChartsServerSide.render({
     // ... chart options ...
     format: 'jpeg',
@@ -97,25 +178,12 @@ const buffer = await AgChartsServerSide.render({
 });
 ```
 
-## High-DPI output
+## Loading Custom Fonts
 
-Set `pixelRatio` to produce higher-resolution images. The actual pixel dimensions of the output are `width * pixelRatio` by `height * pixelRatio`.
+The `ag-charts-server-side` does not fetch Google Fonts or other remote font resources automatically.
+Use the `loadFonts()` method to load custom fonts from local font files.
 
-```js
-const buffer = await AgChartsServerSide.render({
-    // ... chart options ...
-    width: 200,
-    height: 150,
-    pixelRatio: 2,
-});
-// Output image is 400x300 actual pixels
-```
-
-## Custom fonts
-
-{% apiReference id="AgChartsServerSideApi" include=["loadFonts"] hideHeader=true hideRequired=true /%}
-
-Font variants (weight, style) are detected automatically from the font file metadata. Register each variant under the same family name:
+Font variants are detected automatically from the font file metadata. Register each variant under the same family name:
 
 ```js
 AgChartsServerSide.loadFonts([
@@ -125,11 +193,17 @@ AgChartsServerSide.loadFonts([
 ]);
 ```
 
-## Example use-cases
+Special characters, extended Unicode, and non-Latin scripts may not render correctly unless their fonts are explicitly loaded.
 
-### Express.js endpoint
+## Examples
 
-Serve chart images from an HTTP endpoint:
+There are many use cases for server-side rendering. We recommend you take a look at those in our {% link href=codespaceUrl() isExternal=true %}GitHub Codespaces{% /link %}.
+
+Additionally, here are a few code examples to get you started.
+
+### Express.js Endpoint
+
+Serve chart images dynamically from an HTTP endpoint:
 
 ```js
 import express from 'express';
@@ -161,6 +235,33 @@ app.get('/chart.png', async (req, res) => {
 });
 
 app.listen(3000);
+```
+
+### Saving to File
+
+Generate chart images during build steps or scheduled jobs:
+
+```js
+import * as fs from 'fs';
+
+import { AllEnterpriseModule, ModuleRegistry } from 'ag-charts-enterprise';
+import { AgChartsServerSide } from 'ag-charts-server-side';
+
+ModuleRegistry.registerModules([AllEnterpriseModule]);
+
+const charts = [
+    { name: 'sales', data: salesData, series: [{ type: 'bar', xKey: 'month', yKey: 'revenue' }] },
+    { name: 'users', data: userData, series: [{ type: 'line', xKey: 'month', yKey: 'count' }] },
+];
+
+for (const chart of charts) {
+    const buffer = await AgChartsServerSide.render({
+        options: { data: chart.data, series: chart.series },
+        width: 800,
+        height: 400,
+    });
+    fs.writeFileSync(`output/${chart.name}.png`, buffer);
+}
 ```
 
 ## API Reference


### PR DESCRIPTION
## Summary

- **SSR docs rewrite**: Restructured the server-side rendering page with dedicated sections for gauge rendering, financial chart rendering, timeout configuration, high-DPI output, JPEG output, and a saving-to-file example.
- **Feature matrix**: Added Server-Side Rendering to the charts features matrix (enterprise only).
- **Framework selector**: Always show all frameworks in the doc framework selector instead of filtering per page.
- **Skill updates**: Updated JIRA and batch-plunkers skills to use ADF link formatting, added issue link direction docs and inline code formatting rules.

## Test Plan

- [ ] Verify SSR docs page renders correctly on the dev server
- [ ] Confirm framework selector shows all frameworks on all doc pages
- [ ] Check features matrix displays SSR row correctly