### PR TITLE
AG-16076: Warn when dataIdKey field not found on data items

### DIFF
--- a/packages/ag-charts-community/src/chart/data/dataSet.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.test.ts
@@ -2127,6 +2127,40 @@ describe('DataSet', () => {
             });
         });
 
+        test('warns when dataIdKey field is not found on any data item', () => {
+            const dataSet = new DataSet<Item>([{ ...a }, { ...b }, { ...c }], 'nonExistent');
+            dataSet.addTransaction({ remove: [{ nonExistent: 'x' } as any] });
+            dataSet.commitPendingTransactions();
+            expectWarningMessages([
+                "AG Charts - dataIdKey 'nonExistent' was not found on any data item.",
+                'AG Charts - applyTransaction() remove includes items not present in current data; ignoring missing items.',
+            ]);
+        });
+
+        test('does not warn when dataIdKey field exists on data items', () => {
+            const newA: Item = { id: 'a', value: 10 };
+            const dataSet = new DataSet<Item>([{ ...a }, { ...b }, { ...c }], 'id');
+            dataSet.addTransaction({ update: [newA] });
+            dataSet.commitPendingTransactions();
+            expect(dataSet.data[0]).toBe(newA);
+            expectWarningMessages([]);
+        });
+
+        test('does not warn when data is empty', () => {
+            const dataSet = new DataSet<Item>([], 'id');
+            dataSet.addTransaction({ append: [{ id: 'a', value: 10 }] });
+            dataSet.commitPendingTransactions();
+            expectWarningMessages([]);
+        });
+
+        test('does not warn when dataIdKey is not set', () => {
+            const items = [{ ...a }, { ...b }, { ...c }];
+            const dataSet = new DataSet<Item>(items);
+            dataSet.addTransaction({ update: [items[0]] });
+            dataSet.commitPendingTransactions();
+            expectWarningMessages([]);
+        });
+
         test('prepend duplicate ID: cache maps to prepended (first) occurrence after warm cache', () => {
             const dataSet = new DataSet<Item>([{ ...a }, { ...b }, { ...c }], 'id');
 

--- a/packages/ag-charts-community/src/chart/data/dataSet.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.ts
@@ -803,6 +803,9 @@ export class DataSet<T = unknown> {
                     this.idToIndexCache.set(id, i);
                 }
             }
+            if (this.idToIndexCache.size === 0 && this.data.length > 0) {
+                Logger.warnOnce(`dataIdKey '${this.dataIdKey}' was not found on any data item.`);
+            }
         }
         return this.idToIndexCache;
     }

--- a/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.test.ts
+++ b/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 
+import { expectWarningMessages, setupMockConsole } from 'ag-charts-community-test';
+
 import { HierarchyDataSet } from './hierarchyDataSet';
 
 interface TreeItem {
@@ -37,6 +39,27 @@ function createTestData(): TreeItem[] {
 }
 
 describe('HierarchyDataSet', () => {
+    setupMockConsole();
+
+    describe('dataIdKey validation', () => {
+        test('warns when dataIdKey field is not found on any data item', () => {
+            const data = createTestData();
+            const ds = new HierarchyDataSet<TreeItem>(data, 'nonExistent', 'children');
+            ds.addTransaction({ remove: [{ nonExistent: 'x' } as any] });
+            ds.commitPendingTransactions();
+            expectWarningMessages(["AG Charts - dataIdKey 'nonExistent' was not found on any data item."]);
+        });
+
+        test('does not warn when dataIdKey field exists on data items', () => {
+            const data = createTestData();
+            const ds = new HierarchyDataSet<TreeItem>(data, 'id', 'children');
+            ds.addTransaction({ update: [{ id: 'eng-fe', name: 'Frontend', value: 50 }] });
+            ds.commitPendingTransactions();
+            expect(ds.data[0].children![0].value).toBe(50);
+            expectWarningMessages([]);
+        });
+    });
+
     describe('update by ID', () => {
         test('should update a root-level item', () => {
             const data = createTestData();

--- a/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.ts
+++ b/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.ts
@@ -69,6 +69,9 @@ export class HierarchyDataSet<T = unknown> extends DataSet<T> {
             for (let i = 0; i < this.data.length; i++) {
                 this.indexItemRecursively(this.data[i], i);
             }
+            if (this.idToIndexCache.size === 0 && this.data.length > 0) {
+                Logger.warnOnce(`dataIdKey '${this.dataIdKey}' was not found on any data item.`);
+            }
         }
         return this.idToIndexCache;
     }


### PR DESCRIPTION
## Summary

- Adds a `Logger.warnOnce()` validation to `DataSet.getIdToIndexMap()` and `HierarchyDataSet.getIdToIndexMap()` that warns when `dataIdKey` is configured but no data items contain the specified field
- Zero performance cost — check piggybacks on the existing ID-to-index iteration
- Addresses feedback point 3 on AG-16076

## Test plan

- [x] 4 new unit tests in `dataSet.test.ts` covering warn/no-warn scenarios
- [x] All 127 DataSet tests pass
- [x] Lint and type-check clean for both community and enterprise packages