### PR TITLE
AG-16934 Fix Omit type display in SSR API reference docs

### DIFF
--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -406,17 +406,17 @@ export type AgCartesianAxisOptions<TContext = ContextDefault> =
 
 export type AgCartesianAxisType<TContext = ContextDefault> = NonNullable<AgCartesianAxisOptions<TContext>['type']>;
 
-type AgCartesianAxisThemeSpecialOptions = 'position' | 'type' | 'crossLines';
 /** This is the configuration shared by all types of axis. */
 export interface AgCartesianAxisThemeOptions<T> {
     /** An object with axis theme overrides for the `top` positioned axes. Same configs apply here as one level above. For example, to rotate labels by 45 degrees in 'top' positioned axes one can use `top: { label: { rotation: 45 } } }`. */
-    top?: Omit<T, AgCartesianAxisThemeSpecialOptions>;
+    // eslint-disable-next-line sonarjs/use-type-alias
+    top?: Omit<T, 'position' | 'type' | 'crossLines'>;
     /** An object with axis theme overrides for the `right` positioned axes. Same configs apply here as one level above. */
-    right?: Omit<T, AgCartesianAxisThemeSpecialOptions>;
+    right?: Omit<T, 'position' | 'type' | 'crossLines'>;
     /** An object with axis theme overrides for the `bottom` positioned axes. Same configs apply here as one level above. */
-    bottom?: Omit<T, AgCartesianAxisThemeSpecialOptions>;
+    bottom?: Omit<T, 'position' | 'type' | 'crossLines'>;
     /** An object with axis theme overrides for the `left` positioned axes. Same configs apply here as one level above. */
-    left?: Omit<T, AgCartesianAxisThemeSpecialOptions>;
+    left?: Omit<T, 'position' | 'type' | 'crossLines'>;
 }
 
 export interface AgBaseCartesianThemeOptions<TDatum = DatumDefault, TContext = ContextDefault>

--- a/packages/ag-charts-types/src/serverSideRenderingOptions.ts
+++ b/packages/ag-charts-types/src/serverSideRenderingOptions.ts
@@ -3,8 +3,6 @@ import type { AgChartOptions, AgFinancialChartOptions, AgGaugeOptions } from './
 
 export type AgImageFormat = 'png' | 'jpeg';
 
-type AgRenderExcludedKeys = 'width' | 'height' | 'container';
-
 /** Base render options shared by all server-side render methods. */
 export interface AgBaseRenderOptions {
     /** Output image width in pixels. */
@@ -24,25 +22,26 @@ export interface AgBaseRenderOptions {
 /** Render options for server-side chart rendering, parameterised by chart options type. */
 export interface AgChartRenderOptions<T> extends AgBaseRenderOptions {
     /** Chart configuration options (excludes `container`, `width`, and `height`). */
-    options: Omit<T, AgRenderExcludedKeys>;
+    // eslint-disable-next-line sonarjs/use-type-alias
+    options: Omit<T, 'width' | 'height' | 'container'>;
 }
 
 /** Render options for standard charts. */
 export interface AgRenderOptions extends AgBaseRenderOptions {
     /** Chart configuration options (excludes `container`, `width`, and `height`). */
-    options: Omit<AgChartOptions<DatumDefault, ContextDefault>, AgRenderExcludedKeys>;
+    options: Omit<AgChartOptions<DatumDefault, ContextDefault>, 'width' | 'height' | 'container'>;
 }
 
 /** Render options for gauge charts. */
 export interface AgGaugeRenderOptions extends AgBaseRenderOptions {
     /** Chart configuration options (excludes `container`, `width`, and `height`). */
-    options: Omit<AgGaugeOptions<DatumDefault, ContextDefault>, AgRenderExcludedKeys>;
+    options: Omit<AgGaugeOptions<DatumDefault, ContextDefault>, 'width' | 'height' | 'container'>;
 }
 
 /** Render options for financial charts. */
 export interface AgFinancialChartRenderOptions extends AgBaseRenderOptions {
     /** Chart configuration options (excludes `container`, `width`, and `height`). */
-    options: Omit<AgFinancialChartOptions<DatumDefault>, AgRenderExcludedKeys>;
+    options: Omit<AgFinancialChartOptions<DatumDefault>, 'width' | 'height' | 'container'>;
 }
 
 /** Static API for server-side chart rendering. */

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -115,7 +115,8 @@ export function normalizeType(refType: TypeNode, keepGenerics?: boolean): string
     }
 
     if (isTypeReferenceNode(refType)) {
-        return keepGenerics && refType.typeArguments?.length
+        const showArgs = keepGenerics === true || refType.type === 'Omit' || refType.type === 'Pick';
+        return showArgs && refType.typeArguments?.length
             ? `${refType.type}<${refType.typeArguments.map((typeArg) => normalizeType(typeArg)).join(', ')}>`
             : refType.type;
     }
@@ -358,12 +359,14 @@ function buildGenericsMap(interfaceRef: InterfaceNode, typeArguments?: string[])
 
 function applyGenericsToMember(member: MemberNode, genericsMap: Map<string, unknown>) {
     let omit: string | undefined;
-    let memberType: string | TypeNode = normalizeType(member.type);
+    let memberType: string | TypeNode;
 
-    if (memberType === 'Omit') {
+    if (isTypeReferenceNode(member.type) && member.type.type === 'Omit') {
         const omitType = extractOmitType(member.type);
-        memberType = omitType?.type ?? memberType;
+        memberType = omitType?.type ?? normalizeType(member.type);
         omit = omitType?.omit;
+    } else {
+        memberType = normalizeType(member.type);
     }
 
     const genericType = typeof memberType === 'string' ? resolveGenericType(memberType, genericsMap) : null;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16934

The docs generator rendered `Omit<T, K>` utility types as bare `Omit;` (no type arguments) in the API reference for server-side rendering interfaces. Two root causes:

1. Private (non-exported) type aliases used as the second arg to `Omit` were preserved in `.d.ts` output but unresolvable by the docs toolchain
2. `normalizeType()` unconditionally stripped type arguments from all `TypeReferenceNode`s

**Fix:**
- Inline the literal unions in `Omit` second args (removes `AgRenderExcludedKeys` and `AgCartesianAxisThemeSpecialOptions` private aliases)
- Show type arguments for `Omit` and `Pick` in `normalizeType()`
- Update `applyGenericsToMember()` to check the raw AST node for Omit detection instead of the normalised string