### PR TITLE
Fix AG-16912, AG-16886, AG-16933: pre-release quick wins

### DIFF
--- a/.rulesync/rules/browser-support.md
+++ b/.rulesync/rules/browser-support.md
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/guides/browser-support.md

--- a/external/ag-shared/prompts/guides/browser-support.md
+++ b/external/ag-shared/prompts/guides/browser-support.md
@@ -1,0 +1,30 @@
+---
+targets: ['*']
+description: 'Browser support policy — minimum API/feature baseline for runtime code'
+globs: ['packages/*/src/**/*.ts', 'packages/*/src/**/*.tsx']
+---
+
+# Browser Support Policy
+
+AG products officially support the **two latest major versions** of each browser listed below. All runtime code must work within this baseline.
+
+## Supported Browsers
+
+### Desktop
+
+- Chrome (two latest major versions)
+- Firefox (two latest major versions)
+- Microsoft Edge (two latest major versions)
+- Safari (two latest major versions)
+
+### Mobile
+
+- Safari on iOS / iPad OS (two latest major versions)
+- Chrome on iOS / iPad OS / Android (two latest major versions)
+
+## Implications for Code
+
+-   **ES2023+ built-ins are safe** (e.g. `Array.prototype.toReversed()`, `Array.prototype.toSorted()`, `Array.prototype.findLast()`). All supported browsers have shipped these.
+-   **Do not use APIs that landed only in the very latest browser release.** Check [Can I Use](https://caniuse.com) or MDN compatibility tables when uncertain — the feature must be available in at least the two most recent major versions of every supported browser.
+-   **No polyfills in runtime bundles.** The library ships zero third-party dependencies; if a feature isn't natively available in the support matrix, don't use it.
+-   **CSS features follow the same rule.** Any CSS used in DOM overlays or UI components must be supported across the matrix.

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -589,7 +589,7 @@ export abstract class Axis<
         });
 
         if (this.reverse) {
-            this.dataDomain.domain.reverse();
+            this.dataDomain = { ...this.dataDomain, domain: this.dataDomain.domain.toReversed() };
         }
 
         this.animatable = animatable;

--- a/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -797,7 +797,7 @@ export class GroupedCategoryAxis extends CategoryAxis<GroupedCategoryScale<Group
 
         this.dataDomain = { domain: extent(flatDomains) ?? this.filterDuplicateArrays(flatDomains), clipped: false };
         if (this.isReversed()) {
-            this.dataDomain.domain.reverse();
+            this.dataDomain = { ...this.dataDomain, domain: this.dataDomain.domain.toReversed() };
         }
 
         const domain: GroupedCategoryKey[] = this.dataDomain.domain.map(convertIntegratedCategoryValue);

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -28,7 +28,7 @@ import type {
     ZoomMinMax,
     ZoomState,
 } from 'ag-charts-core';
-import type { AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
+import type { AgRangesButtonValueSource, AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
 import type {
     EventsHub,
@@ -104,7 +104,8 @@ export type UpdateZoomWithFunction = (
     start: Date | number,
     end: Date | number,
     windowStart: Date | number,
-    windowEnd: Date | number
+    windowEnd: Date | number,
+    source: AgRangesButtonValueSource
 ) => [Date | number | undefined, Date | number | undefined];
 
 function refreshCoreState(nextAxes: Array<CartesianAxisLike> | Array<SimpleAxis>, state: CoreZoomStateSafeRetrieval) {
@@ -478,7 +479,13 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const [domainStart, domainEnd] = extents;
         const { start: windowStart, end: windowEnd } = range;
 
-        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number);
+        const result = fn(
+            domainStart,
+            domainEnd,
+            windowStart as Date | number,
+            windowEnd as Date | number,
+            'user-interaction'
+        );
         if (!this.isValidUpdateWithResult(result)) {
             return;
         }
@@ -504,7 +511,13 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const [domainStart, domainEnd] = extents;
         const { start: windowStart, end: windowEnd } = range;
 
-        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number);
+        const result = fn(
+            domainStart,
+            domainEnd,
+            windowStart as Date | number,
+            windowEnd as Date | number,
+            'range-check'
+        );
         if (!this.isValidUpdateWithResult(result)) {
             return false;
         }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -28,7 +28,13 @@ import type {
     ZoomMinMax,
     ZoomState,
 } from 'ag-charts-core';
-import type { AgRangesButtonValueSource, AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
+import type {
+    AgRangesButtonValueSource,
+    AgZoomEvent,
+    AgZoomEventSource,
+    AgZoomRange,
+    AgZoomRatio,
+} from 'ag-charts-types';
 
 import type {
     EventsHub,

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -470,7 +470,8 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
     public updateWith(
         { source, sourceDetail }: UpdateZoomSourcing,
         direction: CartesianAxisDirection,
-        fn: UpdateZoomWithFunction
+        fn: UpdateZoomWithFunction,
+        fnSource: AgRangesButtonValueSource = 'user-interaction'
     ) {
         const axis = this.getPrimaryAxis(direction);
         if (!axis) return;
@@ -485,13 +486,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const [domainStart, domainEnd] = extents;
         const { start: windowStart, end: windowEnd } = range;
 
-        const result = fn(
-            domainStart,
-            domainEnd,
-            windowStart as Date | number,
-            windowEnd as Date | number,
-            'user-interaction'
-        );
+        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number, fnSource);
         if (!this.isValidUpdateWithResult(result)) {
             return;
         }
@@ -503,7 +498,11 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio }, isReset: false });
     }
 
-    public isValidUpdateWith(direction: CartesianAxisDirection, fn: UpdateZoomWithFunction) {
+    public isValidUpdateWith(
+        direction: CartesianAxisDirection,
+        fn: UpdateZoomWithFunction,
+        fnSource: AgRangesButtonValueSource = 'range-check'
+    ) {
         const axis = this.getPrimaryAxis(direction);
         if (!axis) return true;
 
@@ -517,13 +516,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const [domainStart, domainEnd] = extents;
         const { start: windowStart, end: windowEnd } = range;
 
-        const result = fn(
-            domainStart,
-            domainEnd,
-            windowStart as Date | number,
-            windowEnd as Date | number,
-            'range-check'
-        );
+        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number, fnSource);
         if (!this.isValidUpdateWithResult(result)) {
             return false;
         }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -28,13 +28,7 @@ import type {
     ZoomMinMax,
     ZoomState,
 } from 'ag-charts-core';
-import type {
-    AgRangesButtonValueSource,
-    AgZoomEvent,
-    AgZoomEventSource,
-    AgZoomRange,
-    AgZoomRatio,
-} from 'ag-charts-types';
+import type { AgZoomEvent, AgZoomEventSource, AgZoomRange, AgZoomRatio } from 'ag-charts-types';
 
 import type {
     EventsHub,
@@ -111,7 +105,7 @@ export type UpdateZoomWithFunction = (
     end: Date | number,
     windowStart: Date | number,
     windowEnd: Date | number,
-    source: AgRangesButtonValueSource
+    source: AgZoomEventSource
 ) => [Date | number | undefined, Date | number | undefined];
 
 function refreshCoreState(nextAxes: Array<CartesianAxisLike> | Array<SimpleAxis>, state: CoreZoomStateSafeRetrieval) {
@@ -485,8 +479,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const [domainStart, domainEnd] = extents;
         const { start: windowStart, end: windowEnd } = range;
 
-        const fnSource = source === 'user-interaction' ? 'user-interaction' : 'range-check';
-        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number, fnSource);
+        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number, source);
         if (!this.isValidUpdateWithResult(result)) {
             return;
         }
@@ -498,11 +491,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         this.updateChanges({ source, sourceDetail, changes: { [direction]: ratio }, isReset: false });
     }
 
-    public isValidUpdateWith(
-        direction: CartesianAxisDirection,
-        fn: UpdateZoomWithFunction,
-        fnSource: AgRangesButtonValueSource
-    ) {
+    public isValidUpdateWith(direction: CartesianAxisDirection, fn: UpdateZoomWithFunction, source: AgZoomEventSource) {
         const axis = this.getPrimaryAxis(direction);
         if (!axis) return true;
 
@@ -516,7 +505,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const [domainStart, domainEnd] = extents;
         const { start: windowStart, end: windowEnd } = range;
 
-        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number, fnSource);
+        const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number, source);
         if (!this.isValidUpdateWithResult(result)) {
             return false;
         }

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -501,7 +501,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
     public isValidUpdateWith(
         direction: CartesianAxisDirection,
         fn: UpdateZoomWithFunction,
-        fnSource: AgRangesButtonValueSource = 'range-check'
+        fnSource: AgRangesButtonValueSource
     ) {
         const axis = this.getPrimaryAxis(direction);
         if (!axis) return true;

--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -470,8 +470,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
     public updateWith(
         { source, sourceDetail }: UpdateZoomSourcing,
         direction: CartesianAxisDirection,
-        fn: UpdateZoomWithFunction,
-        fnSource: AgRangesButtonValueSource = 'user-interaction'
+        fn: UpdateZoomWithFunction
     ) {
         const axis = this.getPrimaryAxis(direction);
         if (!axis) return;
@@ -486,6 +485,7 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         const [domainStart, domainEnd] = extents;
         const { start: windowStart, end: windowEnd } = range;
 
+        const fnSource = source === 'user-interaction' ? 'user-interaction' : 'range-check';
         const result = fn(domainStart, domainEnd, windowStart as Date | number, windowEnd as Date | number, fnSource);
         if (!this.isValidUpdateWithResult(result)) {
             return;

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -2692,4 +2692,34 @@ describe('BarSeries', () => {
             await compare();
         });
     });
+
+    describe('AG-16933 reverse + bandAlignment', () => {
+        it('should maintain reversed domain when processDomains is called multiple times', async () => {
+            const options = prepareTestOptions({
+                data: [
+                    { category: 'A', value: 1 },
+                    { category: 'B', value: 2 },
+                    { category: 'C', value: 3 },
+                ],
+                axes: {
+                    x: { type: 'category', position: 'bottom', reverse: true, bandAlignment: 'start' },
+                    y: { type: 'number', position: 'left' },
+                },
+                series: [{ type: 'bar', xKey: 'category', yKey: 'value' }],
+            } as any);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const chartObj = deproxy(chart);
+            const categoryAxis = chartObj.axes.find((a: any) => a.type === 'category') as any;
+            expect(categoryAxis.scale.domain).toEqual(['C', 'B', 'A']);
+
+            // Simulate what happens when resize triggers PROCESS_DOMAIN:
+            // processDomains() re-calls axis.processData() → axis.setDomains()
+            (chartObj as any).processDomains();
+
+            // Domain must remain reversed after the second processDomains() call
+            expect(categoryAxis.dataDomain.domain).toEqual(['C', 'B', 'A']);
+        });
+    });
 });

--- a/packages/ag-charts-community/src/scale/discreteTimeScale.test.ts
+++ b/packages/ag-charts-community/src/scale/discreteTimeScale.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { checkUniformityBySampling } from './discreteTimeScale';
+
+describe('checkUniformityBySampling', () => {
+    const uniformBands = [
+        new Date('2024-01-01'),
+        new Date('2024-01-02'),
+        new Date('2024-01-03'),
+        new Date('2024-01-04'),
+        new Date('2024-01-05'),
+    ] as const;
+
+    test('returns uniform for evenly spaced dates', () => {
+        const result = checkUniformityBySampling(uniformBands);
+        expect(result.isUniform).toBe(true);
+        expect(result.interval).toBeCloseTo(86400000); // 1 day in ms
+    });
+
+    test('returns non-uniform for unevenly spaced dates', () => {
+        const bands = [
+            new Date('2024-01-01'),
+            new Date('2024-01-02'),
+            new Date('2024-01-05'),
+            new Date('2024-01-06'),
+            new Date('2024-01-07'),
+        ] as const;
+        const result = checkUniformityBySampling(bands);
+        expect(result.isUniform).toBe(false);
+    });
+
+    test('returns non-uniform for fewer than 2 elements', () => {
+        expect(checkUniformityBySampling([new Date('2024-01-01')] as const)).toEqual({ isUniform: false });
+        expect(checkUniformityBySampling([] as unknown as readonly Date[])).toEqual({ isUniform: false });
+    });
+
+    test('AG-16912: returns non-uniform for out-of-bounds startIdx', () => {
+        expect(checkUniformityBySampling(uniformBands, -1, 3)).toEqual({ isUniform: false });
+    });
+
+    test('AG-16912: returns non-uniform for out-of-bounds endIdx', () => {
+        expect(checkUniformityBySampling(uniformBands, 0, 5)).toEqual({ isUniform: false });
+    });
+
+    test('AG-16912: returns non-uniform for both indices out-of-bounds', () => {
+        expect(checkUniformityBySampling(uniformBands, -2, 10)).toEqual({ isUniform: false });
+    });
+
+    test('works with valid sub-range', () => {
+        const result = checkUniformityBySampling(uniformBands, 1, 3);
+        expect(result.isUniform).toBe(true);
+    });
+});

--- a/packages/ag-charts-community/src/scale/discreteTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/discreteTimeScale.ts
@@ -23,6 +23,7 @@ export function checkUniformityBySampling(
 ): UniformityCheck {
     const n = endIdx - startIdx + 1;
     if (n < 2) return { isUniform: false };
+    if (startIdx < 0 || endIdx >= bands.length) return { isUniform: false };
 
     // Sample SAMPLE_POINTS points evenly spaced within the range
     const indices = Array.from(

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.test.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+import type { AgCartesianChartOptions, AgChartInstance } from 'ag-charts-community';
+import { AgCharts } from 'ag-charts-community';
+import { setupMockCanvas, setupMockConsole, waitForChartStability } from 'ag-charts-community-test';
+import type { AgRangesButtonValueSource } from 'ag-charts-types';
+
+import { prepareEnterpriseTestOptions } from '../../test/utils';
+
+describe('Ranges', () => {
+    setupMockConsole();
+    let chart: AgChartInstance;
+    setupMockCanvas();
+
+    afterEach(() => {
+        if (chart) {
+            chart.destroy();
+            (chart as any) = undefined;
+        }
+    });
+
+    describe('AG-16886 button value function source parameter', () => {
+        it('should pass source parameter to AgRangesButtonValueFunction', async () => {
+            const receivedSources: AgRangesButtonValueSource[] = [];
+
+            const options: AgCartesianChartOptions = prepareEnterpriseTestOptions({
+                data: Array.from({ length: 20 }, (_, i) => ({ x: i, y: i * 10 })),
+                series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+                axes: {
+                    x: { type: 'number', position: 'bottom' },
+                    y: { type: 'number', position: 'left' },
+                },
+                ranges: {
+                    enabled: true,
+                    buttons: [
+                        {
+                            label: 'Custom',
+                            value: (
+                                _start: Date | number,
+                                _end: Date | number,
+                                _windowStart: Date | number,
+                                _windowEnd: Date | number,
+                                source: AgRangesButtonValueSource
+                            ): [Date | number | undefined, Date | number | undefined] => {
+                                receivedSources.push(source);
+                                return [5, 15];
+                            },
+                        },
+                    ],
+                },
+            } as any);
+
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            // The range-check source should have been received during initial button enablement validation
+            expect(receivedSources).toContain('range-check');
+        });
+    });
+});

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -425,7 +425,7 @@ export class Ranges extends BaseProperties implements ModuleInstance {
         if (updateWithFn.valid === false || updateWithFn.fn == null) {
             zoomManager.resetZoom(sourcing);
         } else {
-            zoomManager.updateWith(sourcing, ChartAxisDirection.X, updateWithFn.fn, 'user-interaction');
+            zoomManager.updateWith(sourcing, ChartAxisDirection.X, updateWithFn.fn);
         }
 
         this.buttonsToolbar?.toggleActiveButtonByIndex(index);
@@ -477,9 +477,7 @@ export class Ranges extends BaseProperties implements ModuleInstance {
             if (updateWithFn.valid === false) return false;
 
             buttonEnabled =
-                updateWithFn.fn == null
-                    ? true
-                    : zoomManager.isValidUpdateWith(ChartAxisDirection.X, updateWithFn.fn, 'range-check');
+                updateWithFn.fn == null ? true : zoomManager.isValidUpdateWith(ChartAxisDirection.X, updateWithFn.fn);
         }
 
         return buttonEnabled;

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -425,7 +425,7 @@ export class Ranges extends BaseProperties implements ModuleInstance {
         if (updateWithFn.valid === false || updateWithFn.fn == null) {
             zoomManager.resetZoom(sourcing);
         } else {
-            zoomManager.updateWith(sourcing, ChartAxisDirection.X, updateWithFn.fn);
+            zoomManager.updateWith(sourcing, ChartAxisDirection.X, updateWithFn.fn, 'user-interaction');
         }
 
         this.buttonsToolbar?.toggleActiveButtonByIndex(index);
@@ -477,7 +477,9 @@ export class Ranges extends BaseProperties implements ModuleInstance {
             if (updateWithFn.valid === false) return false;
 
             buttonEnabled =
-                updateWithFn.fn == null ? true : zoomManager.isValidUpdateWith(ChartAxisDirection.X, updateWithFn.fn);
+                updateWithFn.fn == null
+                    ? true
+                    : zoomManager.isValidUpdateWith(ChartAxisDirection.X, updateWithFn.fn, 'range-check');
         }
 
         return buttonEnabled;

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -477,7 +477,9 @@ export class Ranges extends BaseProperties implements ModuleInstance {
             if (updateWithFn.valid === false) return false;
 
             buttonEnabled =
-                updateWithFn.fn == null ? true : zoomManager.isValidUpdateWith(ChartAxisDirection.X, updateWithFn.fn);
+                updateWithFn.fn == null
+                    ? true
+                    : zoomManager.isValidUpdateWith(ChartAxisDirection.X, updateWithFn.fn, 'range-check');
         }
 
         return buttonEnabled;

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -84,7 +84,13 @@ export interface AgAnnotationsEvent<TContext = ContextDefault> {
     context?: TContext;
 }
 
-export type AgZoomEventSource = 'chart-update' | 'data-update' | 'state-change' | 'sync' | 'user-interaction';
+export type AgZoomEventSource =
+    | 'chart-update'
+    | 'data-update'
+    | 'range-check'
+    | 'state-change'
+    | 'sync'
+    | 'user-interaction';
 
 export interface AgZoomEvent<TContext = ContextDefault> {
     type: 'zoom';

--- a/packages/ag-charts-types/src/chart/rangesOptions.ts
+++ b/packages/ag-charts-types/src/chart/rangesOptions.ts
@@ -79,9 +79,11 @@ export type AgRangesButtonValue =
     | undefined;
 
 export type AgRangesButtonValuePair = [Date | number, Date | number];
+export type AgRangesButtonValueSource = 'user-interaction' | 'range-check';
 export type AgRangesButtonValueFunction = (
     start: Date | number,
     end: Date | number,
     windowStart: Date | number,
-    windowEnd: Date | number
-) => [Date | number, Date | number];
+    windowEnd: Date | number,
+    source: AgRangesButtonValueSource
+) => [Date | number | undefined, Date | number | undefined];

--- a/packages/ag-charts-types/src/chart/rangesOptions.ts
+++ b/packages/ag-charts-types/src/chart/rangesOptions.ts
@@ -1,6 +1,7 @@
 import type { FillOptions, FontOptions, Padding, StrokeOptions, Toggleable } from '../series/cartesian/commonOptions';
 import type { AgTimeInterval, AgTimeIntervalUnit } from './axisOptions';
 import type { ToolbarButton } from './buttonOptions';
+import type { AgZoomEventSource } from './eventOptions';
 import type { CssColor, PixelSize } from './types';
 
 export interface AgRangesOptions extends Toggleable, AgRangesStyles {
@@ -79,11 +80,11 @@ export type AgRangesButtonValue =
     | undefined;
 
 export type AgRangesButtonValuePair = [Date | number, Date | number];
-export type AgRangesButtonValueSource = 'user-interaction' | 'range-check';
+export type AgRangesButtonValueSource = AgZoomEventSource;
 export type AgRangesButtonValueFunction = (
     start: Date | number,
     end: Date | number,
     windowStart: Date | number,
     windowEnd: Date | number,
-    source: AgRangesButtonValueSource
+    source: AgZoomEventSource
 ) => [Date | number | undefined, Date | number | undefined];


### PR DESCRIPTION
- https://ag-grid.atlassian.net/browse/AG-16912
- https://ag-grid.atlassian.net/browse/AG-16886
- https://ag-grid.atlassian.net/browse/AG-16933

## Summary

- **AG-16912**: Add bounds guard in `checkUniformityBySampling()` to prevent `TypeError` when zooming fully out on ordinal time axis
- **AG-16886**: Add `source` parameter (`'user-interaction' | 'range-check'`) to `AgRangesButtonValueFunction` so consumers can distinguish user clicks from system validation
- **AG-16933**: Fix axis `reverse: true` not applied on initial render when `bandAlignment` is set — the in-place `.reverse()` mutation corrupted the shared domain array from `processedData`, causing a double-reverse on resize-triggered re-render

## Test plan

- [x] New unit tests for `checkUniformityBySampling` bounds guard (`discreteTimeScale.test.ts`)
- [x] New integration test for range button value function source parameter (`ranges.test.ts`)
- [x] New regression test for reverse + bandAlignment double-reverse bug (`barSeries.test.ts`)
- [x] `yarn nx test ag-charts-community` — 102 suites, 3119 tests pass
- [x] `yarn nx test ag-charts-enterprise` — 69 suites, 1763 tests pass
- [x] `yarn nx build:types ag-charts-types` — type-check passes
- [x] `yarn nx lint ag-charts-community` / `ag-charts-types` — no new errors