### PR TITLE
AG-16936 Fix CSP error with SVG data URI icons

### DIFF
--- a/packages/ag-charts-community/src/dom/domManager.ts
+++ b/packages/ag-charts-community/src/dom/domManager.ts
@@ -8,6 +8,7 @@ import {
     isDirectionRtl,
     isDocumentFragment,
     kebabCase,
+    processCssDataUris,
     setAttribute,
     stopPageScrolling,
 } from 'ag-charts-core';
@@ -679,7 +680,7 @@ export class DOMManager extends BaseManager {
         if (styleElement == null || checkId(styleElement)) return;
 
         styleElement.setAttribute(dataAttribute, id);
-        styleElement.innerHTML = styles;
+        styleElement.innerHTML = processCssDataUris(styles);
     }
 
     removeStyles(id: string) {

--- a/packages/ag-charts-core/src/main.ts
+++ b/packages/ag-charts-core/src/main.ts
@@ -81,6 +81,7 @@ export * from './state/proxy';
 export * from './utils/data/strings';
 export * from './state/stateMachine';
 export * from './rendering/textMeasurer';
+export * from './utils/dom/blobUrl';
 export * from './utils/dom/domElements';
 export * from './utils/dom/domEvents';
 export * from './utils/dom/globalsProxy';

--- a/packages/ag-charts-core/src/utils/dom/blobUrl.test.ts
+++ b/packages/ag-charts-core/src/utils/dom/blobUrl.test.ts
@@ -1,0 +1,100 @@
+import { dataUriToObjectURL, processCssDataUris } from './blobUrl';
+
+const SIMPLE_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><path d="M0 0h20v20H0z"/></svg>';
+const SIMPLE_SVG_BASE64 = btoa(SIMPLE_SVG);
+
+let blobCounter = 0;
+
+beforeAll(() => {
+    // jsdom doesn't provide URL.createObjectURL — polyfill for tests
+    if (typeof URL.createObjectURL !== 'function') {
+        URL.createObjectURL = (_blob: Blob) => `blob:test-${++blobCounter}`;
+        URL.revokeObjectURL = () => {};
+    }
+});
+
+describe('blobUrl', () => {
+    describe('dataUriToObjectURL', () => {
+        it('should convert a base64 SVG data URI to a blob URL', () => {
+            const dataUri = `data:image/svg+xml;base64,${SIMPLE_SVG_BASE64}`;
+            const result = dataUriToObjectURL(dataUri);
+            expect(result).toMatch(/^blob:/);
+        });
+
+        it('should convert a utf8-encoded SVG data URI to a blob URL', () => {
+            const svgEncoded = encodeURIComponent(SIMPLE_SVG);
+            const dataUri = `data:image/svg+xml;utf8,${svgEncoded}`;
+            const result = dataUriToObjectURL(dataUri);
+            expect(result).toMatch(/^blob:/);
+        });
+
+        it('should return the same blob URL for the same data URI (caching)', () => {
+            const dataUri = `data:image/svg+xml;base64,${SIMPLE_SVG_BASE64}`;
+            const first = dataUriToObjectURL(dataUri);
+            const second = dataUriToObjectURL(dataUri);
+            expect(first).toBe(second);
+        });
+
+        it('should return different blob URLs for different data URIs', () => {
+            const dataUri1 = `data:image/svg+xml;base64,${btoa('<svg><rect/></svg>')}`;
+            const dataUri2 = `data:image/svg+xml;base64,${btoa('<svg><circle/></svg>')}`;
+            const result1 = dataUriToObjectURL(dataUri1);
+            const result2 = dataUriToObjectURL(dataUri2);
+            expect(result1).not.toBe(result2);
+        });
+
+        it('should return the original string if no comma is found', () => {
+            const malformed = 'data:image/svg+xml;base64';
+            const result = dataUriToObjectURL(malformed);
+            expect(result).toBe(malformed);
+        });
+    });
+
+    describe('processCssDataUris', () => {
+        it('should replace base64 SVG data URIs in CSS with blob URLs', () => {
+            const css = `.icon { --icon: url(data:image/svg+xml;base64,${SIMPLE_SVG_BASE64}); }`;
+            const result = processCssDataUris(css);
+            expect(result).not.toContain('data:image/svg+xml');
+            expect(result).toContain('url(blob:');
+        });
+
+        it('should replace utf8 SVG data URIs in CSS with blob URLs', () => {
+            const svg = encodeURIComponent(SIMPLE_SVG);
+            const css = `.icon { --checker: url('data:image/svg+xml;utf8,${svg}'); }`;
+            const result = processCssDataUris(css);
+            expect(result).not.toContain('data:image/svg+xml');
+            expect(result).toContain('url(blob:');
+        });
+
+        it('should replace multiple data URIs in the same CSS string', () => {
+            const svg1 = btoa('<svg><path d="M1"/></svg>');
+            const svg2 = btoa('<svg><path d="M2"/></svg>');
+            const css = `.a { --x: url(data:image/svg+xml;base64,${svg1}); } .b { --y: url(data:image/svg+xml;base64,${svg2}); }`;
+            const result = processCssDataUris(css);
+            const blobCount = (result.match(/blob:/g) ?? []).length;
+            expect(blobCount).toBe(2);
+            expect(result).not.toContain('data:image/svg+xml');
+        });
+
+        it('should pass through CSS with no data URIs unchanged', () => {
+            const css = '.icon { color: red; background: url(https://example.com/img.png); }';
+            const result = processCssDataUris(css);
+            expect(result).toBe(css);
+        });
+
+        it('should not replace non-SVG data URIs', () => {
+            const css = '.icon { background: url(data:image/png;base64,iVBOR); }';
+            const result = processCssDataUris(css);
+            expect(result).toBe(css);
+        });
+
+        it('should preserve surrounding CSS structure', () => {
+            const uniqueSvg = btoa('<svg><ellipse/></svg>');
+            const css = `.before { color: red; }\n.icon { --icon: url(data:image/svg+xml;base64,${uniqueSvg}); }\n.after { color: blue; }`;
+            const result = processCssDataUris(css);
+            expect(result).toContain('.before { color: red; }');
+            expect(result).toContain('.after { color: blue; }');
+            expect(result).toContain('url(blob:');
+        });
+    });
+});

--- a/packages/ag-charts-core/src/utils/dom/blobUrl.ts
+++ b/packages/ag-charts-core/src/utils/dom/blobUrl.ts
@@ -1,0 +1,44 @@
+const cache = new Map<string, string>();
+
+function canCreateObjectURLs(): boolean {
+    return typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function' && typeof Blob !== 'undefined';
+}
+
+export function dataUriToObjectURL(dataUri: string): string {
+    const existing = cache.get(dataUri);
+    if (existing) return existing;
+
+    if (!canCreateObjectURLs()) return dataUri;
+
+    const commaIndex = dataUri.indexOf(',');
+    if (commaIndex === -1) return dataUri;
+
+    const header = dataUri.substring(0, commaIndex);
+    const data = dataUri.substring(commaIndex + 1);
+
+    const mimeMatch = header.match(/data:([^;]+)/);
+    const mime = mimeMatch?.[1] ?? 'image/svg+xml';
+    const isBase64 = header.includes('base64');
+
+    let blob: Blob;
+    if (isBase64) {
+        const binary = atob(data);
+        const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+        blob = new Blob([bytes], { type: mime });
+    } else {
+        blob = new Blob([decodeURIComponent(data)], { type: mime });
+    }
+    const url = URL.createObjectURL(blob);
+    cache.set(dataUri, url);
+    return url;
+}
+
+export function processCssDataUris(css: string): string {
+    if (!canCreateObjectURLs()) return css;
+
+    const regex = /url\(\s*['"]?(data:image\/svg\+xml[^)'"]*?)['"]?\s*\)/g;
+    return css.replace(regex, (_match, dataUri: string) => {
+        const blobUrl = dataUriToObjectURL(dataUri);
+        return `url(${blobUrl})`;
+    });
+}

--- a/packages/ag-charts-enterprise/src/license/licenseManager.ts
+++ b/packages/ag-charts-enterprise/src/license/licenseManager.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import { dataUriToObjectURL } from 'ag-charts-core';
+
 import { MD5 } from './md5';
 
 // move to general utils
@@ -210,7 +212,7 @@ export class LicenseManager {
         return {
             text,
             image: {
-                url: WATERMARK_SVG_DATA_URL,
+                url: dataUriToObjectURL(WATERMARK_SVG_DATA_URL),
                 width: 170,
                 height: 25,
                 right: 25,

--- a/packages/ag-charts-website/src/content/docs/security-test/_examples/strict-csp-icons/head.html
+++ b/packages/ag-charts-website/src/content/docs/security-test/_examples/strict-csp-icons/head.html
@@ -1,0 +1,4 @@
+<meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'self' https://cdn.jsdelivr.net 'nonce-123123'; style-src 'self' 'nonce-a1b2c3d4' 'nonce-123123'"
+/>

--- a/packages/ag-charts-website/src/content/docs/security-test/_examples/strict-csp-icons/index.html
+++ b/packages/ag-charts-website/src/content/docs/security-test/_examples/strict-csp-icons/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/security-test/_examples/strict-csp-icons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/security-test/_examples/strict-csp-icons/main.ts
@@ -1,0 +1,51 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    ContextMenuModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    CategoryAxisModule,
+    ContextMenuModule,
+    LegendModule,
+    NumberAxisModule,
+    ZoomModule,
+]);
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    styleNonce: 'a1b2c3d4',
+    data: [
+        { month: 'Jan', sales: 162000, profit: 42000 },
+        { month: 'Feb', sales: 230000, profit: 58000 },
+        { month: 'Mar', sales: 302000, profit: 75000 },
+        { month: 'Apr', sales: 450000, profit: 112000 },
+        { month: 'May', sales: 800000, profit: 200000 },
+        { month: 'Jun', sales: 920000, profit: 230000 },
+        { month: 'Jul', sales: 1254000, profit: 313000 },
+        { month: 'Aug', sales: 1100000, profit: 275000 },
+        { month: 'Sep', sales: 950000, profit: 237000 },
+        { month: 'Oct', sales: 680000, profit: 170000 },
+        { month: 'Nov', sales: 400000, profit: 100000 },
+        { month: 'Dec', sales: 200000, profit: 50000 },
+    ],
+    series: [
+        { type: 'bar', xKey: 'month', yKey: 'sales', yName: 'Sales' },
+        { type: 'bar', xKey: 'month', yKey: 'profit', yName: 'Profit' },
+    ],
+    zoom: {
+        enabled: true,
+        buttons: {
+            visible: 'always',
+        },
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/security-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/security-test/index.mdoc
@@ -9,3 +9,5 @@ Open examples full-screen to exercise properly.
 {% chartExampleRunner title="Basic CSP" name="basic-csp" type="generated" /%}
 
 {% chartExampleRunner title="Complex CSP" name="complex-csp" type="generated" /%}
+
+{% chartExampleRunner title="Strict CSP with Icons" name="strict-csp-icons" type="generated" /%}


### PR DESCRIPTION
## Summary

Fixes CSP violations caused by `data:image/svg+xml` URIs being blocked when `default-src` doesn't include `data:`. Zoom buttons (and other toolbar icons) appeared blank with CSP errors in the console.

**Approach:** Convert SVG data URIs to blob URLs (`URL.createObjectURL()`) at runtime. Blob URLs are same-origin and pass all CSP policies without needing `data:` in any directive.

### Changes

- **New:** `ag-charts-core` `blobUrl.ts` utility — `processCssDataUris()` replaces `url(data:image/svg+xml...)` patterns in CSS strings with blob URLs; `dataUriToObjectURL()` converts individual data URIs. Results are cached; falls back to original data URIs in SSR environments.
- **`domManager.ts`** — applies `processCssDataUris()` to CSS before injecting into `<style>` elements, automatically handling all icon, watermark, and colour picker data URIs.
- **`licenseManager.ts`** — converts the watermark `<img>` src data URI to a blob URL.
- **Tests:** 11 unit tests covering base64/utf8 conversion, caching, passthrough, and CSS structure preservation.

## Test Plan

- [x] `yarn nx build:types ag-charts-core` — passes
- [x] `yarn nx build:types ag-charts-enterprise` — passes
- [x] `yarn nx lint ag-charts-enterprise` — passes (no new warnings)
- [x] `yarn nx test ag-charts-community` — 3122 tests passed
- [x] `yarn nx test ag-charts-enterprise` — 1765 tests passed
- [ ] Manual: verify zoom icons render under strict CSP (reproduction: https://plnkr.co/edit/0kDhBfZZ1RJqWfh5)

Fix AG-16936