### PR TITLE
AG-16915 Treat NaN as minimum size in aggregation bucketing

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
@@ -238,9 +238,8 @@ export function computeBubbleAggregation(
         const sizeIndices = Array.from({ length: SIZE_QUANTIZATION }, (): number[] => []);
         for (let datumIndex = 0; datumIndex < sizeValues.length; datumIndex += 1) {
             const sizeValue = sizeValues[datumIndex];
-            // NaN check via self-inequality (faster than Number.isFinite in hot loops)
-            if (sizeValue !== sizeValue) continue;
-            const sizeRatio = (sizeValue - sd0) / (sd1 - sd0);
+            // Treat NaN as minimum size (self-inequality is faster than Number.isFinite in hot loops)
+            const sizeRatio = sizeValue !== sizeValue ? 0 : (sizeValue - sd0) / (sd1 - sd0);
             const sizeIndex = Math.trunc(sizeRatio * SIZE_QUANTIZATION);
             if (sizeIndex >= 0 && sizeIndex < SIZE_QUANTIZATION) {
                 sizeIndices[sizeIndex].push(datumIndex);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
@@ -238,8 +238,8 @@ export function computeBubbleAggregation(
         const sizeIndices = Array.from({ length: SIZE_QUANTIZATION }, (): number[] => []);
         for (let datumIndex = 0; datumIndex < sizeValues.length; datumIndex += 1) {
             const sizeValue = sizeValues[datumIndex];
-            // Treat NaN as minimum size (self-inequality is faster than Number.isFinite in hot loops)
-            const sizeRatio = sizeValue !== sizeValue ? 0 : (sizeValue - sd0) / (sd1 - sd0);
+            // Treat NaN as minimum size (self-equality check is faster than Number.isFinite in hot loops)
+            const sizeRatio = sizeValue === sizeValue ? (sizeValue - sd0) / (sd1 - sd0) : 0;
             const sizeIndex = Math.trunc(sizeRatio * SIZE_QUANTIZATION);
             if (sizeIndex >= 0 && sizeIndex < SIZE_QUANTIZATION) {
                 sizeIndices[sizeIndex].push(datumIndex);


### PR DESCRIPTION
## Summary

- Treat NaN-size data points as minimum size in the aggregation bucketing path, consistent with the non-aggregated rendering path (merged in #6450)
- Use the self-inequality idiom (`value !== value`) for the NaN check in this hot loop

Follow-up to #6450 which was merged before this consistency fix was added.

Fix AG-16915

## Test plan

- [x] `yarn nx build:types ag-charts-community` — passes
- [x] `yarn nx test ag-charts-community --testPathPattern bubbleSeries` — 54/54 tests pass
- [x] `yarn nx test ag-charts-community --testPathPattern tooltip` — 38/38 tests pass