### PR TITLE
AG-16886: Use AgRangesButtonValueSource in function signature

### DIFF
--- a/packages/ag-charts-types/src/chart/rangesOptions.ts
+++ b/packages/ag-charts-types/src/chart/rangesOptions.ts
@@ -93,5 +93,5 @@ export type AgRangesButtonValueFunction = (
     end: Date | number,
     windowStart: Date | number,
     windowEnd: Date | number,
-    source: AgZoomEventSource
+    source: AgRangesButtonValueSource
 ) => [Date | number | undefined, Date | number | undefined];


### PR DESCRIPTION
## Summary
- QA feedback: the `source` parameter in `AgRangesButtonValueFunction` referenced `AgZoomEventSource` directly instead of the dedicated `AgRangesButtonValueSource` type alias
- Changed the type annotation on line 96 of `rangesOptions.ts` from `AgZoomEventSource` to `AgRangesButtonValueSource`
- Pure type-level change, no runtime impact

## Test plan
- [x] `yarn nx build:types ag-charts-types` — passes
- [x] `yarn nx build:types ag-charts-community` — passes
- [x] `yarn nx build:types ag-charts-enterprise` — passes
- [x] `yarn nx test ag-charts-enterprise --testPathPattern ranges` — passes
- [x] `yarn nx lint ag-charts-types` — passes