### PR TITLE
AG-16076: Eagerly validate dataIdKey duplicates on initial load

### DIFF
--- a/packages/ag-charts-community/src/chart/data/dataSet.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.test.ts
@@ -1847,7 +1847,7 @@ describe('DataSet', () => {
         });
 
         test('duplicate ID validation: warning logged on initial load', () => {
-            new DataSet<Item>(
+            const dataSet = new DataSet<Item>(
                 [
                     { id: 'a', value: 1 },
                     { id: 'a', value: 2 },
@@ -1855,6 +1855,7 @@ describe('DataSet', () => {
                 ],
                 'id'
             );
+            expect(dataSet.data).toHaveLength(3);
             expectWarningMessages([`AG Charts - dataIdKey 'id' has duplicate value 'a'; first occurrence used.`]);
         });
 

--- a/packages/ag-charts-community/src/chart/data/dataSet.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.test.ts
@@ -1846,7 +1846,7 @@ describe('DataSet', () => {
             });
         });
 
-        test('duplicate ID validation: warning logged on initial load', () => {
+        test('duplicate ID validation: warning logged on first commit cycle', () => {
             const dataSet = new DataSet<Item>(
                 [
                     { id: 'a', value: 1 },
@@ -1855,7 +1855,7 @@ describe('DataSet', () => {
                 ],
                 'id'
             );
-            expect(dataSet.data).toHaveLength(3);
+            dataSet.commitPendingTransactions();
             expectWarningMessages([`AG Charts - dataIdKey 'id' has duplicate value 'a'; first occurrence used.`]);
         });
 

--- a/packages/ag-charts-community/src/chart/data/dataSet.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.test.ts
@@ -1846,6 +1846,18 @@ describe('DataSet', () => {
             });
         });
 
+        test('duplicate ID validation: warning logged on initial load', () => {
+            new DataSet<Item>(
+                [
+                    { id: 'a', value: 1 },
+                    { id: 'a', value: 2 },
+                    { id: 'b', value: 3 },
+                ],
+                'id'
+            );
+            expectWarningMessages([`AG Charts - dataIdKey 'id' has duplicate value 'a'; first occurrence used.`]);
+        });
+
         test('duplicate ID validation: warning logged, first occurrence used', () => {
             const dataSet = new DataSet<Item>(
                 [

--- a/packages/ag-charts-community/src/chart/data/dataSet.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.ts
@@ -78,7 +78,11 @@ export class DataSet<T = unknown> {
     constructor(
         public data: T[],
         public readonly dataIdKey?: string
-    ) {}
+    ) {
+        if (dataIdKey != null && data.length > 0) {
+            this.getIdToIndexMap();
+        }
+    }
 
     /**
      * Creates an empty DataSet.

--- a/packages/ag-charts-community/src/chart/data/dataSet.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.ts
@@ -74,20 +74,12 @@ export class DataSet<T = unknown> {
     private cachedPendingReplacements: Map<string | number, T> | undefined;
     private itemToIndexCache: Map<T, number> | undefined;
     protected idToIndexCache: Map<string | number, number> | undefined;
+    private dataIdKeyValidated = false;
 
     constructor(
         public data: T[],
         public readonly dataIdKey?: string
-    ) {
-        this.validateDataIdKey();
-    }
-
-    /** Eagerly builds the ID index so duplicate/missing-key warnings fire on initial load. */
-    protected validateDataIdKey(): void {
-        if (this.dataIdKey != null && this.data.length > 0) {
-            this.getIdToIndexMap();
-        }
-    }
+    ) {}
 
     /**
      * Creates an empty DataSet.
@@ -176,8 +168,20 @@ export class DataSet<T = unknown> {
         return this.pendingTransactions.length;
     }
 
+    /** Validates dataIdKey on first commit so duplicate/missing-key warnings fire on initial load. */
+    private validateDataIdKey(): void {
+        if (this.dataIdKey != null && this.data.length > 0) {
+            this.getIdToIndexMap();
+        }
+        this.dataIdKeyValidated = true;
+    }
+
     /** Applies all pending transactions to the data array. */
     commitPendingTransactions(): boolean {
+        if (!this.dataIdKeyValidated) {
+            this.validateDataIdKey();
+        }
+
         if (!this.hasPendingTransactions()) {
             return false;
         }

--- a/packages/ag-charts-community/src/chart/data/dataSet.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.ts
@@ -74,7 +74,6 @@ export class DataSet<T = unknown> {
     private cachedPendingReplacements: Map<string | number, T> | undefined;
     private itemToIndexCache: Map<T, number> | undefined;
     protected idToIndexCache: Map<string | number, number> | undefined;
-    private dataIdKeyValidated = false;
 
     constructor(
         public data: T[],
@@ -168,18 +167,12 @@ export class DataSet<T = unknown> {
         return this.pendingTransactions.length;
     }
 
-    /** Validates dataIdKey on first commit so duplicate/missing-key warnings fire on initial load. */
-    private validateDataIdKey(): void {
-        if (this.dataIdKey != null && this.data.length > 0) {
-            this.getIdToIndexMap();
-        }
-        this.dataIdKeyValidated = true;
-    }
-
     /** Applies all pending transactions to the data array. */
     commitPendingTransactions(): boolean {
-        if (!this.dataIdKeyValidated) {
-            this.validateDataIdKey();
+        // Eagerly build the ID index so duplicate/missing-key warnings fire on the first
+        // render cycle, even when there are no pending transactions yet.
+        if (this.dataIdKey != null && this.data.length > 0) {
+            this.getIdToIndexMap();
         }
 
         if (!this.hasPendingTransactions()) {

--- a/packages/ag-charts-community/src/chart/data/dataSet.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.ts
@@ -79,7 +79,12 @@ export class DataSet<T = unknown> {
         public data: T[],
         public readonly dataIdKey?: string
     ) {
-        if (dataIdKey != null && data.length > 0) {
+        this.validateDataIdKey();
+    }
+
+    /** Eagerly builds the ID index so duplicate/missing-key warnings fire on initial load. */
+    protected validateDataIdKey(): void {
+        if (this.dataIdKey != null && this.data.length > 0) {
             this.getIdToIndexMap();
         }
     }

--- a/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.ts
+++ b/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.ts
@@ -16,14 +16,6 @@ export class HierarchyDataSet<T = unknown> extends DataSet<T> {
         private readonly childrenKey: string
     ) {
         super(data, dataIdKey);
-        // Deferred: base constructor calls validateDataIdKey() before childrenKey is set,
-        // so we override it as a no-op and call it here after the subclass is fully initialised.
-        super.validateDataIdKey();
-    }
-
-    /** No-op: deferred to the end of this constructor so childrenKey is available. */
-    protected override validateDataIdKey(): void {
-        // Intentionally empty — called from super() before childrenKey is assigned.
     }
 
     /**

--- a/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.ts
+++ b/packages/ag-charts-enterprise/src/charts/hierarchyDataSet.ts
@@ -16,6 +16,14 @@ export class HierarchyDataSet<T = unknown> extends DataSet<T> {
         private readonly childrenKey: string
     ) {
         super(data, dataIdKey);
+        // Deferred: base constructor calls validateDataIdKey() before childrenKey is set,
+        // so we override it as a no-op and call it here after the subclass is fully initialised.
+        super.validateDataIdKey();
+    }
+
+    /** No-op: deferred to the end of this constructor so childrenKey is available. */
+    protected override validateDataIdKey(): void {
+        // Intentionally empty — called from super() before childrenKey is assigned.
     }
 
     /**


### PR DESCRIPTION
## Summary

- Trigger duplicate-ID and missing-key warnings at `DataSet` construction time rather than deferring until the first transaction
- Adds a dedicated test for the eager validation on initial load

Addresses QA feedback: duplicate `dataIdKey` values now warn immediately when the chart is created, not only when the first transaction happens to need the ID index.

Fix AG-16076