### PR TITLE
Support $EDITOR env var in test runner editor selection

### DIFF
--- a/tests/shared/run.sh
+++ b/tests/shared/run.sh
@@ -103,10 +103,15 @@ else
 fi
 
 if ${editor} ; then
-    if command -v cursor &>/dev/null ; then
+    if [ -n "${EDITOR:-}" ] ; then
+        ${EDITOR} . &
+    elif command -v cursor &>/dev/null ; then
         cursor . &
-    else
+    elif command -v code &>/dev/null ; then
         code . &
+    else
+        echo ">>> no editor found, install cursor, code, or set EDITOR environment variable"
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Prefer `$EDITOR` environment variable when set for opening the test project in an editor
- Fall back to `cursor`, then `code` if `$EDITOR` is not set
- Exit with a clear error message if no editor is found instead of silently failing