### PR TITLE
AG-16889 Add Range Controls documentation page

### DIFF
--- a/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
@@ -586,6 +586,15 @@
             },
             {
                 "label": {
+                    "name": "Range Buttons",
+                    "link": "https://www.ag-grid.com/charts/r/range-controls/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
+            },
+            {
+                "label": {
                     "name": "Scrollbar",
                     "link": "https://www.ag-grid.com/charts/r/scrollbar/"
                 },

--- a/packages/ag-charts-website/src/content/docs-nav/nav.json
+++ b/packages/ag-charts-website/src/content/docs-nav/nav.json
@@ -285,6 +285,12 @@
                         },
                         {
                             "type": "item",
+                            "title": "Range Controls",
+                            "path": "range-controls",
+                            "isEnterprise": true
+                        },
+                        {
+                            "type": "item",
                             "title": "Scrollbar",
                             "path": "scrollbar",
                             "isEnterprise": true

--- a/packages/ag-charts-website/src/content/docs/range-buttons/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/range-buttons/index.mdoc
@@ -5,6 +5,10 @@ enterprise: true
 
 Range Buttons allow the user to easily navigate to specific time periods and ranges along the chart timeline.
 
+{% note %}
+Range controls can also be used with any chart type. See [Range Controls](./range-controls/) for more details.
+{% /note %}
+
 ## Range Buttons
 
 {% chartExampleRunner title="Range Buttons" name="range-buttons" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/calendar-intervals/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/calendar-intervals/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2022, 0, 1);
+    const end = new Date(2025, 2, 31);
+    let value = 100;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 1234567;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/calendar-intervals/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/calendar-intervals/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/calendar-intervals/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/calendar-intervals/main.ts
@@ -1,0 +1,46 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    title: { text: 'Daily Readings' },
+    series: [{ type: 'line', xKey: 'date', yKey: 'value', yName: 'Value' }],
+    axes: {
+        x: { type: 'unit-time' },
+        y: { type: 'number' },
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+    ranges: {
+        buttons: [
+            { label: '1 Month', value: 'month' },
+            { label: '3 Months', value: { unit: 'month', step: 3 } },
+            { label: '6 Months', value: { unit: 'month', step: 6 } },
+            { label: '1 Year', value: 'year' },
+            { label: 'All Data', value: undefined },
+        ],
+    },
+};
+
+const chart = AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/custom-buttons/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/custom-buttons/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2022, 0, 1);
+    const end = new Date(2024, 11, 31);
+    let value = 100;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 1234567;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/custom-buttons/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/custom-buttons/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/custom-buttons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/custom-buttons/main.ts
@@ -1,0 +1,45 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    title: { text: 'Daily Readings' },
+    series: [{ type: 'line', xKey: 'date', yKey: 'value', yName: 'Value' }],
+    axes: {
+        x: { type: 'unit-time' },
+        y: { type: 'number' },
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+    ranges: {
+        buttons: [
+            { label: '6 Months', value: 6 * 30 * 24 * 60 * 60 * 1000 },
+            { label: '1 Year', value: 365 * 24 * 60 * 60 * 1000 },
+            { label: 'H1 2023', value: [new Date(2023, 0, 1), new Date(2023, 6, 1)] },
+            { label: 'All Data', value: undefined },
+        ],
+    },
+};
+
+const chart = AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2022, 0, 1);
+    const end = new Date(2024, 11, 31);
+    let value = 100;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 1234567;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/index.html
@@ -1,0 +1,13 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <label>Dropdown:</label>
+        <select onchange="changeDropdown(event.target.value)">
+            <option value="auto" selected>Auto</option>
+            <option value="always">Always</option>
+            <option value="never">Never</option>
+        </select>
+    </div>
+</div>
+<div class="resizable-container">
+    <div id="myChart" class="resizable"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/main.ts
@@ -1,5 +1,5 @@
 import {
-    AgChartOptions,
+    AgCartesianChartOptions,
     AgCharts,
     LineSeriesModule,
     ModuleRegistry,
@@ -21,7 +21,7 @@ ModuleRegistry.registerModules([
     NavigatorModule,
 ]);
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     series: [

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/main.ts
@@ -1,0 +1,68 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        {
+            type: 'line',
+            xKey: 'date',
+            yKey: 'value',
+        },
+    ],
+    axes: {
+        x: {
+            type: 'unit-time',
+            label: {
+                autoRotate: false,
+            },
+        },
+        y: {
+            type: 'number',
+        },
+    },
+    ranges: {
+        enabled: true,
+        dropdown: { visible: 'auto' },
+        buttons: [
+            { label: '1 Month', value: 'month' },
+            { label: '3 Months', value: { unit: 'month', step: 3 } },
+            { label: '6 Months', value: { unit: 'month', step: 6 } },
+            { label: '1 Year', value: 'year' },
+            { label: 'All Data', value: undefined },
+        ],
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+};
+
+const chart = AgCharts.create(options);
+
+function changeDropdown(visible: 'auto' | 'always' | 'never') {
+    options.ranges = {
+        ...options.ranges,
+        dropdown: { visible },
+    };
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/styles.css
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/dropdown/styles.css
@@ -1,0 +1,17 @@
+.resizable-container {
+    height: 100%;
+    padding: 4px;
+    border-radius: 8px;
+    background-color: color-mix(in srgb, var(--chart-bg), var(--chart-border) 10%);
+    border: 1px solid var(--chart-border);
+    overflow: hidden;
+    transform: translate3d(0, 0, 0);
+}
+
+.resizable {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden;
+    resize: both;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2024, 9, 1);
+    const end = new Date(2024, 11, 31);
+    let value = 50;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 9876543;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/index.html
@@ -1,0 +1,8 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <label>Enable Out of Range:</label>
+        <button onclick="toggleOutOfRange(true)">True</button>
+        <button onclick="toggleOutOfRange(false)">False (default)</button>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/main.ts
@@ -1,5 +1,5 @@
 import {
-    AgChartOptions,
+    AgCartesianChartOptions,
     AgCharts,
     LineSeriesModule,
     ModuleRegistry,
@@ -21,7 +21,7 @@ ModuleRegistry.registerModules([
     NavigatorModule,
 ]);
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     series: [

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/out-of-range/main.ts
@@ -1,0 +1,60 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        {
+            type: 'line',
+            xKey: 'date',
+            yKey: 'value',
+        },
+    ],
+    axes: {
+        x: {
+            type: 'unit-time',
+            label: {
+                autoRotate: false,
+            },
+        },
+        y: {
+            type: 'number',
+        },
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+    ranges: {
+        enabled: true,
+    },
+};
+
+const chart = AgCharts.create(options);
+
+function toggleOutOfRange(enabled: boolean) {
+    options.ranges = {
+        ...options.ranges,
+        enableOutOfRange: enabled,
+    };
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2022, 0, 1);
+    const end = new Date(2024, 11, 31);
+    let value = 100;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 1234567;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/index.html
@@ -1,0 +1,14 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <label>Position:</label>
+        <select onchange="changePosition(event.target.value)">
+            <option value="top-left">Top Left</option>
+            <option value="top">Top</option>
+            <option value="top-right" selected>Top Right</option>
+            <option value="bottom-left">Bottom Left</option>
+            <option value="bottom">Bottom</option>
+            <option value="bottom-right">Bottom Right</option>
+        </select>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/main.ts
@@ -1,0 +1,50 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    AgRangesPosition,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    title: { text: 'Daily Readings' },
+    series: [{ type: 'line', xKey: 'date', yKey: 'value', yName: 'Value' }],
+    axes: {
+        x: { type: 'unit-time' },
+        y: { type: 'number' },
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+    ranges: {
+        enabled: true,
+        position: 'top-right',
+    },
+};
+
+const chart = AgCharts.create(options);
+
+function changePosition(position: AgRangesPosition) {
+    options.ranges = {
+        ...options.ranges,
+        position,
+    };
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/position/main.ts
@@ -1,5 +1,5 @@
 import {
-    AgChartOptions,
+    AgCartesianChartOptions,
     AgCharts,
     AgRangesPosition,
     LineSeriesModule,
@@ -22,7 +22,7 @@ ModuleRegistry.registerModules([
     NavigatorModule,
 ]);
 
-const options: AgChartOptions = {
+const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     data: getData(),
     title: { text: 'Daily Readings' },

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/range-controls/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/range-controls/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2022, 0, 1);
+    const end = new Date(2024, 11, 31);
+    let value = 100;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 1234567;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/range-controls/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/range-controls/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/range-controls/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/range-controls/main.ts
@@ -1,0 +1,38 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    title: { text: 'Daily Readings' },
+    series: [{ type: 'line', xKey: 'date', yKey: 'value', yName: 'Value' }],
+    axes: {
+        x: { type: 'unit-time' },
+        y: { type: 'number' },
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+    ranges: { enabled: true },
+};
+
+const chart = AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/styling/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/styling/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2024, 6, 1);
+    const end = new Date(2024, 11, 31);
+    let value = 100;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 1234567;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/styling/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/styling/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/styling/main.ts
@@ -1,0 +1,76 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        {
+            type: 'line',
+            xKey: 'date',
+            yKey: 'value',
+        },
+    ],
+    axes: {
+        x: {
+            type: 'unit-time',
+            label: {
+                autoRotate: false,
+            },
+        },
+        y: {
+            type: 'number',
+        },
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+    ranges: {
+        enabled: true,
+        fill: '#6366f1',
+        cornerRadius: 8,
+        textColor: '#ffffff',
+        stroke: '#4f46e5',
+        strokeWidth: 2,
+        active: {
+            fill: '#16a34a',
+            textColor: '#ffffff',
+            stroke: '#15803d',
+        },
+        hover: {
+            fill: '#ea580c',
+            textColor: '#ffffff',
+            stroke: '#c2410c',
+        },
+        disabled: {
+            fill: '#e5e7eb',
+            textColor: '#9ca3af',
+            stroke: '#d1d5db',
+        },
+        button: {
+            padding: { top: 6, right: 12, bottom: 6, left: 12 },
+        },
+        gap: 4,
+    },
+};
+
+const chart = AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/window-relative/data.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/window-relative/data.ts
@@ -1,0 +1,18 @@
+export function getData() {
+    const data: { date: Date; value: number }[] = [];
+    const start = new Date(2023, 0, 1);
+    const end = new Date(2024, 11, 31);
+    let value = 100;
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        value += random() * 6 - 3;
+        value = Math.max(10, value);
+        data.push({ date: new Date(d), value: Math.round(value * 100) / 100 });
+    }
+    return data;
+}
+
+let seed = 1234567;
+function random() {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+}

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/window-relative/index.html
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/window-relative/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/range-controls/_examples/window-relative/main.ts
+++ b/packages/ag-charts-website/src/content/docs/range-controls/_examples/window-relative/main.ts
@@ -1,0 +1,98 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    RangesModule,
+    UnitTimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    NumberAxisModule,
+    UnitTimeAxisModule,
+    RangesModule,
+    ZoomModule,
+    NavigatorModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        {
+            type: 'line',
+            xKey: 'date',
+            yKey: 'value',
+        },
+    ],
+    axes: {
+        x: {
+            type: 'unit-time',
+            label: {
+                autoRotate: false,
+            },
+        },
+        y: {
+            type: 'number',
+        },
+    },
+    ranges: {
+        buttons: [
+            {
+                label: 'Last 1M',
+                value: (_start, _end, _windowStart, windowEnd) => {
+                    const month = 30 * 24 * 60 * 60 * 1000;
+                    return [Number(windowEnd) - month, windowEnd];
+                },
+            },
+            {
+                label: 'Last 3M',
+                value: (_start, _end, _windowStart, windowEnd) => {
+                    const months = 3 * 30 * 24 * 60 * 60 * 1000;
+                    return [Number(windowEnd) - months, windowEnd];
+                },
+            },
+            {
+                label: '1M Centre',
+                value: (_start, _end, windowStart, windowEnd) => {
+                    const mid = (Number(windowStart) + Number(windowEnd)) / 2;
+                    const halfMonth = (30 * 24 * 60 * 60 * 1000) / 2;
+                    return [mid - halfMonth, mid + halfMonth];
+                },
+            },
+            {
+                label: '3M Centre',
+                value: (_start, _end, windowStart, windowEnd) => {
+                    const mid = (Number(windowStart) + Number(windowEnd)) / 2;
+                    const halfRange = (3 * 30 * 24 * 60 * 60 * 1000) / 2;
+                    return [mid - halfRange, mid + halfRange];
+                },
+            },
+            {
+                label: '< 1M',
+                value: (_start, _end, windowStart, windowEnd) => {
+                    const month = 30 * 24 * 60 * 60 * 1000;
+                    return [Number(windowStart) - month, Number(windowEnd) - month];
+                },
+            },
+            {
+                label: '1M >',
+                value: (_start, _end, windowStart, windowEnd) => {
+                    const month = 30 * 24 * 60 * 60 * 1000;
+                    return [Number(windowStart) + month, Number(windowEnd) + month];
+                },
+            },
+            { label: 'All', value: undefined },
+        ],
+    },
+    zoom: { enabled: true },
+    navigator: { enabled: true },
+};
+
+const chart = AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
@@ -21,7 +21,7 @@ Set `ranges.enabled` to `true` to display range control buttons.
 In this example:
 
 -   Clicking a range button updates the visible range to the corresponding time period.
--   Time periods are calculated from the end of the axis domain. For example, '1 Month' shows the last month of data.
+-   Time periods are calculated from the end of the axis domain. For example, '1 M' shows the last month of data.
 -   Range controls are commonly used alongside [Zoom](./zoom/) and [Navigator](./navigator/) for a complete navigation experience.
 -   Financial Charts also include range controls - see [Financial Charts - Range Buttons](./range-buttons/).
 
@@ -67,7 +67,7 @@ The `value` property accepts:
 
 -   [Calendar Interval](#calendar-intervals) - An `AgTimeInterval` or `AgTimeIntervalUnit` for calendar-aware ranges on time axes.
 -   Number - A duration in milliseconds for time axes, or a numeric offset for number axes.
--   Pair - A Number, Date or String array `[start, end]` defining an absolute range.
+-   Pair - A Number, Date or `undefined` array `[start, end]` defining an absolute range.
 -   [Function](#window-relative-functions) - A function that receives the data domain and current visible window, and returns a new range.
 -   `undefined` - Resets the zoom to show all data or the initial zoom range.
 

--- a/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
@@ -1,0 +1,239 @@
+---
+title: 'Range Controls'
+description: 'Use range controls in $framework Charts to provide quick navigation buttons for cartesian charts.'
+enterprise: true
+---
+
+Range Controls allow the user to easily navigate to specific time periods and ranges along the chart timeline.
+
+## Enabling Range Controls
+
+Set `ranges.enabled` to `true` to display range control buttons.
+
+{% chartExampleRunner title="Range Controls" name="range-controls" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: { enabled: true },
+}
+```
+
+In this example:
+
+-   Clicking a range button updates the visible range to the corresponding time period.
+-   Time periods are calculated from the end of the axis domain. For example, '1 Month' shows the last month of data.
+-   Range controls are commonly used alongside [Zoom](./zoom/) and [Navigator](./navigator/) for a complete navigation experience.
+-   Financial Charts also include range controls - see [Financial Charts - Range Buttons](./range-buttons/).
+
+## Position
+
+Use the `position` property to change where the range buttons are displayed. The default is `'top-right'`.
+
+{% chartExampleRunner title="Position" name="position" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: {
+        position: 'bottom-left',
+    },
+}
+```
+
+In this example:
+
+-   Use the dropdown to select different positions for the range buttons.
+-   Available positions are: `'top-left'`, `'top'`, `'top-right'`, `'bottom-left'`, `'bottom'`, `'bottom-right'`.
+
+## Custom Ranges
+
+Override the default buttons by providing a `buttons` array. Each button has a `label`, and a `value` that determines the range.
+
+{% chartExampleRunner title="Custom Buttons" name="custom-buttons" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: {
+        buttons: [
+            { label: '6 Months', value: 6 * 30 * 24 * 60 * 60 * 1000 },
+            { label: '1 Year', value: 365 * 24 * 60 * 60 * 1000 },
+            { label: 'H1 2023', value: [new Date(2023, 0, 1), new Date(2023, 6, 1)] },
+            { label: 'All Data', value: undefined },
+        ],
+    },
+}
+```
+
+The `value` property accepts:
+
+-   [Calendar Interval](#calendar-intervals) - An `AgTimeInterval` or `AgTimeIntervalUnit` for calendar-aware ranges on time axes.
+-   Number - A duration in milliseconds for time axes, or a numeric offset for number axes.
+-   Pair - A Number, Date or String array `[start, end]` defining an absolute range.
+-   [Function](#window-relative-functions) - A function that receives the data domain and current visible window, and returns a new range.
+-   `undefined` - Resets the zoom to show all data or the initial zoom range.
+
+### Calendar Intervals
+
+Use `AgTimeInterval` or `AgTimeIntervalUnit` values for calendar-aware ranges that handle variable-length months and years correctly.
+
+{% chartExampleRunner title="Calendar Intervals" name="calendar-intervals" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: {
+        buttons: [
+            { label: '1 Month', value: 'month' },
+            { label: '3 Months', value: { unit: 'month', step: 3 } },
+            { label: '1 Year', value: 'year' },
+            { label: 'All Data', value: undefined },
+        ],
+    },
+}
+```
+
+-   Calendar intervals account for varying month lengths rather than using a fixed number of milliseconds. For example, '1 Month' from 31 March navigates back to 28 February.
+-   See [Time Intervals](./axes-time/#time-intervals) for more details.
+
+### Window-Relative Functions
+
+For full control, provide a function that receives the data domain and current visible window, and returns a new range.
+
+{% chartExampleRunner title="Window-Relative Functions" name="window-relative" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: {
+        buttons: [
+            {
+                label: 'Last 1M',
+                value: (_start, _end, _windowStart, windowEnd) => {
+                    const month = 30 * 24 * 60 * 60 * 1000;
+                    return [Number(windowEnd) - month, windowEnd];
+                },
+            },
+            {
+                label: '1M Centre',
+                value: (_start, _end, windowStart, windowEnd) => {
+                    const mid = (Number(windowStart) + Number(windowEnd)) / 2;
+                    const halfMonth = (30 * 24 * 60 * 60 * 1000) / 2;
+                    return [mid - halfMonth, mid + halfMonth];
+                },
+            },
+            {
+                label: '< 1M',
+                value: (_start, _end, windowStart, windowEnd) => {
+                    const month = 30 * 24 * 60 * 60 * 1000;
+                    return [Number(windowStart) - month, Number(windowEnd) - month];
+                },
+            },
+            { label: 'All', value: undefined },
+        ],
+    },
+}
+```
+
+Use the Navigator to zoom into the middle of the data, then try the buttons:
+
+-   'Last 1M' and 'Last 3M' - Shows the last 1 or 3 months from the right edge of the current window.
+-   '1M Centre' and '3M Centre' - Zooms to 1 or 3 months centred on the midpoint of the current window.
+-   '< 1M' and '1M >' - Pan the entire window one month backward or forward.
+
+The function receives:
+
+-   `start` and `end` - The full data domain bounds.
+-   `windowStart` and `windowEnd` - The currently visible range.
+-   `source` - Indicates what triggered the function call. As the function is also called to determine [whether the button should be disabled](#out-of-range-buttons), this allows differentiation.
+
+## Appearance
+
+### Out-of-Range Buttons
+
+When buttons specify ranges that exceed the data bounds, they are disabled by default. Set `enableOutOfRange` to `true` to keep them enabled.
+
+{% chartExampleRunner title="Out-of-Range Buttons" name="out-of-range" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: {
+        enableOutOfRange: true,
+    },
+}
+```
+
+In this example:
+
+-   The data only spans 3 months, so the '6 Months', 'YTD', and '1 Year' buttons are disabled by default.
+-   The 'All' button is always enabled.
+-   Individual buttons can use the `enabled` property within their definition to force enable or disable states.
+
+### Responsive Dropdown
+
+When the chart is too narrow for all buttons, they automatically collapse into a dropdown.
+
+{% chartExampleRunner title="Responsive Dropdown" name="dropdown" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: {
+        dropdown: { visible: 'auto' },
+    },
+}
+```
+
+Control this behaviour with the `dropdown.visible` property.
+
+In this example:
+
+-   Select the different options and use the resize handle to see how the buttons respond when the chart width is reduced.
+    -   `'auto'` (default) - Switches to dropdown when buttons exceed available space.
+    -   `'always'` - Always shows a dropdown.
+    -   `'never'` - Never collapses to dropdown; buttons may overflow.
+
+### Styling
+
+Customise the appearance of range buttons using styling properties on the `ranges` options object.
+
+{% chartExampleRunner title="Styling" name="styling" type="generated" /%}
+
+```js format="snippet"
+{
+    ranges: {
+        fill: '#6366f1',
+        cornerRadius: 8,
+        textColor: '#ffffff',
+        stroke: '#4f46e5',
+        active: {
+            fill: '#16a34a',
+            textColor: '#ffffff',
+            stroke: '#15803d',
+        },
+        hover: {
+            fill: '#ea580c',
+            textColor: '#ffffff',
+            stroke: '#c2410c',
+        },
+        disabled: {
+            fill: '#e5e7eb',
+            textColor: '#9ca3af',
+            stroke: '#d1d5db',
+        },
+    },
+}
+```
+
+In this example:
+
+-   Default - Purple fill. The idle state for buttons that are not active, hovered, or disabled.
+-   Active - Green fill. Click a button to see this state.
+-   Hover - Orange fill. Hover over a button to see this state.
+-   Disabled - Light grey fill with muted text. The '1 Year' button shows this state as the data only spans 6 months.
+-   Button and dropdown styling inherit from the top level options, but can be overridden with the `button` and `dropdown` objects.
+
+## API Reference
+
+{% tabs %}
+
+{% tabItem id="AgRangesOptions" label="Range Options" %}
+{% apiReference id="AgRangesOptions" /%}
+{% /tabItem %}
+
+{% /tabs %}

--- a/packages/ag-charts-website/src/content/module-mappings/modules.json
+++ b/packages/ag-charts-website/src/content/module-mappings/modules.json
@@ -363,6 +363,12 @@
                     "isEnterprise": true
                 },
                 {
+                    "moduleName": "RangesModule",
+                    "name": "Range Controls",
+                    "path": "range-controls",
+                    "isEnterprise": true
+                },
+                {
                     "moduleName": "ScrollbarModule",
                     "name": "Scrollbar",
                     "path": "scrollbar",

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -9,7 +9,7 @@
             },
             {
                 "text": "Range Buttons",
-                "path": "./range-buttons/"
+                "path": "./range-controls/"
             },
             {
                 "text": "Flash On Update",


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1060

## Summary

- Add new **Range Controls** documentation page with 8 interactive examples: calendar intervals, custom buttons, dropdown, out-of-range handling, position, styling, window-relative configuration, and a main overview example
- Update docs nav to include the new page
- Update feature matrix, modules mapping, and ag-charts versions
- Add cross-reference from Range Buttons page

## Test plan

- [ ] Verify docs dev server renders the Range Controls page correctly
- [ ] Check all 8 examples load and render within their iframes
- [ ] Confirm nav link appears in the correct location
- [ ] Verify framework variants generate correctly

Fix AG-16889