### PR TITLE
CRT-1065: Fix initial animation skipped in iframe-embedded examples

### DIFF
--- a/packages/ag-charts-community/src/util/sizeMonitor.test.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { Size } from './sizeMonitor';
+import { SizeMonitor } from './sizeMonitor';
+
+// Capture the ResizeObserver callback registered by SizeMonitor so we can
+// simulate browser-fired resize events in tests.
+let resizeObserverCallback: ResizeObserverCallback | undefined;
+
+function createMockAgDocument({ ready = true } = {}) {
+    return {
+        isReady: () => ready,
+        attachListener: () => () => {},
+        createResizeObserver(callback: ResizeObserverCallback) {
+            resizeObserverCallback = callback;
+            return { observe: () => {}, unobserve: () => {}, disconnect: () => {} };
+        },
+        createIntersectionObserver: () => undefined,
+        devicePixelRatio: 1,
+        matchMedia: () => ({ addEventListener: () => {}, removeEventListener: () => {} }),
+    } as any;
+}
+
+function fireResizeObserver(element: HTMLElement, width: number, height: number) {
+    resizeObserverCallback?.([{ target: element, contentRect: { width, height } } as any], {} as any);
+}
+
+function mockElement(opts: {
+    clientWidth: number;
+    clientHeight: number;
+    paddingLeft?: string;
+    paddingRight?: string;
+    paddingTop?: string;
+    paddingBottom?: string;
+}): HTMLElement {
+    const element = document.createElement('div');
+    Object.defineProperty(element, 'clientWidth', { value: opts.clientWidth });
+    Object.defineProperty(element, 'clientHeight', { value: opts.clientHeight });
+
+    const style = {
+        paddingLeft: opts.paddingLeft ?? '0px',
+        paddingRight: opts.paddingRight ?? '0px',
+        paddingTop: opts.paddingTop ?? '0px',
+        paddingBottom: opts.paddingBottom ?? '0px',
+    };
+    jest.spyOn(element.ownerDocument.defaultView!, 'getComputedStyle').mockReturnValue(style as any);
+
+    return element;
+}
+
+describe('SizeMonitor', () => {
+    beforeEach(() => {
+        resizeObserverCallback = undefined;
+    });
+
+    describe('CRT-1065: synchronous initial read must use content-box dimensions', () => {
+        it('should report content-box size matching ResizeObserver contentRect', () => {
+            const sizeMonitor = new SizeMonitor(createMockAgDocument());
+
+            // Element with 17px padding on all sides (clientWidth includes padding).
+            // clientWidth=1200, padding=17+17=34, so content-box width = 1166.
+            // clientHeight=620, padding=17+17=34, so content-box height = 586.
+            const element = mockElement({
+                clientWidth: 1200,
+                clientHeight: 620,
+                paddingLeft: '17px',
+                paddingRight: '17px',
+                paddingTop: '17px',
+                paddingBottom: '17px',
+            });
+
+            const sizes: Size[] = [];
+            sizeMonitor.observe(element, (size) => sizes.push({ ...size }));
+
+            // Synchronous initial read should report content-box: 1166×586.
+            expect(sizes).toHaveLength(1);
+            expect(sizes[0]).toMatchObject({ width: 1166, height: 586 });
+
+            // ResizeObserver fires with identical content-box dimensions.
+            fireResizeObserver(element, 1166, 586);
+
+            // No second callback — sizes match, no spurious resize.
+            expect(sizes).toHaveLength(1);
+        });
+
+        it('should report exact size when element has no padding', () => {
+            const sizeMonitor = new SizeMonitor(createMockAgDocument());
+
+            const element = mockElement({ clientWidth: 800, clientHeight: 600 });
+
+            const sizes: Size[] = [];
+            sizeMonitor.observe(element, (size) => sizes.push({ ...size }));
+
+            expect(sizes).toHaveLength(1);
+            expect(sizes[0]).toMatchObject({ width: 800, height: 600 });
+
+            // ResizeObserver fires with same dimensions — no second callback.
+            fireResizeObserver(element, 800, 600);
+            expect(sizes).toHaveLength(1);
+        });
+
+        it('should still fire callback when ResizeObserver reports a genuinely different size', () => {
+            const sizeMonitor = new SizeMonitor(createMockAgDocument());
+
+            const element = mockElement({ clientWidth: 800, clientHeight: 600 });
+
+            const sizes: Size[] = [];
+            sizeMonitor.observe(element, (size) => sizes.push({ ...size }));
+            expect(sizes).toHaveLength(1);
+
+            // ResizeObserver fires with a genuinely different size (e.g. container resized).
+            fireResizeObserver(element, 900, 700);
+            expect(sizes).toHaveLength(2);
+            expect(sizes[1]).toMatchObject({ width: 900, height: 700 });
+        });
+    });
+});

--- a/packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -119,7 +119,13 @@ export class SizeMonitor {
         if (!opts?.skipInitialRead) {
             // Synchronous initial size read — cross-window ResizeObserver
             // may delay its first callback until the target window gains focus.
-            const { width, height } = element.getBoundingClientRect();
+            // Use content-box dimensions to match ResizeObserver's contentRect,
+            // avoiding a spurious second resize from border-box/content-box mismatch.
+            const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+            const width =
+                element.clientWidth - (parseFloat(style?.paddingLeft ?? '0') + parseFloat(style?.paddingRight ?? '0'));
+            const height =
+                element.clientHeight - (parseFloat(style?.paddingTop ?? '0') + parseFloat(style?.paddingBottom ?? '0'));
             if (width > 0 || height > 0) {
                 this.checkSize(entry, element, width, height);
             }

--- a/packages/ag-charts-community/src/util/sizeMonitor.ts
+++ b/packages/ag-charts-community/src/util/sizeMonitor.ts
@@ -123,9 +123,11 @@ export class SizeMonitor {
             // avoiding a spurious second resize from border-box/content-box mismatch.
             const style = element.ownerDocument.defaultView?.getComputedStyle(element);
             const width =
-                element.clientWidth - (parseFloat(style?.paddingLeft ?? '0') + parseFloat(style?.paddingRight ?? '0'));
+                element.clientWidth -
+                (Number.parseFloat(style?.paddingLeft ?? '0') + Number.parseFloat(style?.paddingRight ?? '0'));
             const height =
-                element.clientHeight - (parseFloat(style?.paddingTop ?? '0') + parseFloat(style?.paddingBottom ?? '0'));
+                element.clientHeight -
+                (Number.parseFloat(style?.paddingTop ?? '0') + Number.parseFloat(style?.paddingBottom ?? '0'));
             if (width > 0 || height > 0) {
                 this.checkSize(entry, element, width, height);
             }

--- a/packages/ag-charts-website/e2e/animation-initial-load.spec.ts
+++ b/packages/ag-charts-website/e2e/animation-initial-load.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from './fixture';
+import { SELECTORS, expectAnimationOccurred, gotoExample, setupIntrinsicAssertions, toExamplePageUrl } from './util';
+
+test.describe('CRT-1065: initial animation with container padding', () => {
+    test.describe.configure({ retries: 3 });
+
+    setupIntrinsicAssertions(test);
+
+    const { url } = toExamplePageUrl('bar-series-test', 'animation-with-padding', 'vanilla');
+
+    test('should animate on initial load when container has padding', async ({ page }) => {
+        await gotoExample(page, url);
+
+        const wrapper = page.locator(SELECTORS.wrapper).first();
+        await expect(wrapper).toBeVisible();
+
+        await expectAnimationOccurred(wrapper);
+    });
+});

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-with-padding/index.html
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-with-padding/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-with-padding/main.ts
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-with-padding/main.ts
@@ -1,0 +1,20 @@
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-enterprise';
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: [
+        { quarter: 'Q1', sales: 100 },
+        { quarter: 'Q2', sales: 200 },
+        { quarter: 'Q3', sales: 150 },
+        { quarter: 'Q4', sales: 300 },
+    ],
+    series: [
+        {
+            type: 'bar',
+            xKey: 'quarter',
+            yKey: 'sales',
+        },
+    ],
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-with-padding/styles.css
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/_examples/animation-with-padding/styles.css
@@ -1,0 +1,8 @@
+/* CRT-1065: padding on the chart container triggers a border-box / content-box
+   mismatch between getBoundingClientRect() and ResizeObserver's contentRect,
+   which previously caused a spurious second resize that skipped the initial
+   animation. */
+#myChart {
+    padding: 17px;
+    height: 100%;
+}

--- a/packages/ag-charts-website/src/content/docs/bar-series-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/bar-series-test/index.mdoc
@@ -10,6 +10,8 @@ title: 'Bar Series Test'
 
 {% chartExampleRunner title="Vertical Animation Example" name="animation-vertical" type="generated" /%}
 
+{% chartExampleRunner title="Animation with Container Padding (CRT-1065)" name="animation-with-padding" type="generated" /%}
+
 # Data-per-series
 
 Verify:


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1065

## Summary

- Fix gallery/docs examples showing no initial animation when embedded in iframes (radar area, nightingale, radial column/bar, sunburst, histogram, range bar)
- Root cause: `SizeMonitor.observe()` synchronous initial read used `getBoundingClientRect()` (border-box: 1200×620) while ResizeObserver reports `contentRect` (content-box: 1166×586). The mismatch triggered a second resize in `Chart.resize()` which called `animationManager.reset()` with `skipAnimations: true`, killing the initial animation
- Fix uses content-box dimensions (`clientWidth/Height` minus padding) for the synchronous read, matching ResizeObserver's measurement and eliminating the spurious double-resize
- Regression introduced by AG-16519 which added the synchronous initial read; not present in b13.1.0

## Test plan

- [x] `yarn nx build:types ag-charts-community` — passes
- [x] `yarn nx lint ag-charts-community` — passes (0 errors)
- [x] `yarn nx test ag-charts-community` — 103 suites, 3134 passed
- [x] `yarn nx test ag-charts-enterprise` — 70 suites, 1768 passed
- [ ] Verify animation plays on gallery pages: simple-radar-area, simple-nightingale, simple-radial-column, simple-radial-bar, simple-sunburst, simple-histogram, simple-range-bar
- [ ] Verify charts still render correctly in popup windows (AG-16519 scenario)