### PR TITLE
CRT-1063 Fix UnitTimeScale tick generation performance regression

### DIFF
--- a/packages/ag-charts-community/src/scale/unitTimeScale.test.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.test.ts
@@ -1,4 +1,31 @@
+import type { ScaleTickParams } from 'ag-charts-core';
+import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
+
 import { UnitTimeScale } from './unitTimeScale';
+
+type TickInterval = AgTimeInterval | AgTimeIntervalUnit | number;
+
+function createScale(domain: [Date, Date], interval: AgTimeIntervalUnit | AgTimeInterval) {
+    const scale = new UnitTimeScale();
+    scale.range = [0, 100];
+    scale.domain = domain;
+    scale.interval = interval;
+    return scale;
+}
+
+function tickParams(interval: TickInterval): ScaleTickParams<TickInterval> {
+    return { interval, nice: [false], tickCount: undefined, minTickCount: 0, maxTickCount: Infinity };
+}
+
+function tickTimestamps(
+    scale: UnitTimeScale,
+    interval: TickInterval,
+    domain?: Date[],
+    visibleRange?: [number, number]
+) {
+    const result = scale.ticks(tickParams(interval), domain, visibleRange);
+    return result?.ticks.map((d) => d.valueOf()) ?? [];
+}
 
 describe('UnitTimeScale', () => {
     it('converts a monthly value in the final band', () => {
@@ -11,5 +38,146 @@ describe('UnitTimeScale', () => {
         const convertedValue = scale.convert(lastBandValue);
 
         expect(convertedValue).toBeCloseTo(92, 0);
+    });
+
+    describe('ticksFromNumericBands equivalence', () => {
+        it('produces ticks for daily interval with year tick step', () => {
+            const domain: [Date, Date] = [new Date(2020, 0, 1), new Date(2024, 0, 1)];
+            const scale = createScale(domain, 'day');
+
+            const result = tickTimestamps(scale, { unit: 'year', step: 1 });
+            expect(result.length).toBeGreaterThan(0);
+
+            const d0 = domain[0].valueOf();
+            const d1 = domain[1].valueOf();
+            for (const t of result) {
+                expect(t).toBeGreaterThanOrEqual(d0);
+                expect(t).toBeLessThanOrEqual(d1);
+            }
+        });
+
+        it('produces ticks for monthly interval with year tick step', () => {
+            const domain: [Date, Date] = [new Date(2020, 0, 1), new Date(2025, 0, 1)];
+            const scale = createScale(domain, 'month');
+
+            const result = tickTimestamps(scale, { unit: 'year', step: 1 });
+            expect(result.length).toBeGreaterThan(0);
+
+            for (const t of result) {
+                const d = new Date(t);
+                expect(d.getMonth()).toBe(0);
+                expect(d.getDate()).toBe(1);
+            }
+        });
+
+        it('produces ticks for hourly interval with day tick step', () => {
+            const domain: [Date, Date] = [new Date(2024, 0, 1), new Date(2024, 0, 3)];
+            const scale = createScale(domain, 'hour');
+
+            const result = tickTimestamps(scale, { unit: 'day', step: 1 });
+            expect(result.length).toBeGreaterThan(0);
+        });
+
+        it('produces ticks for numeric interval', () => {
+            const domain: [Date, Date] = [new Date(2024, 0, 1), new Date(2024, 0, 10)];
+            const scale = createScale(domain, 'day');
+
+            const result = tickTimestamps(scale, 9);
+            expect(result.length).toBeGreaterThan(0);
+        });
+
+        it('fast path ticks contain all fallback path ticks for a sub-domain', () => {
+            const domain: [Date, Date] = [new Date(2024, 0, 1), new Date(2024, 6, 1)];
+            const scale = createScale(domain, 'day');
+
+            // Own domain → fast path (ticksFromNumericBands)
+            const fastResult = tickTimestamps(scale, { unit: 'month', step: 1 });
+
+            // Sub-domain → fallback path (ticksFromBands)
+            const subDomain = [new Date(2024, 1, 1), new Date(2024, 5, 1)];
+            const fallbackResult = tickTimestamps(scale, { unit: 'month', step: 1 }, subDomain);
+
+            for (const t of fallbackResult) {
+                expect(fastResult).toContain(t);
+            }
+        });
+    });
+
+    describe('domain setter value equality', () => {
+        it('preserves bands cache when domain values are unchanged', () => {
+            const scale = createScale([new Date(2024, 0, 1), new Date(2024, 3, 1)], 'day');
+
+            const bands1 = scale.bands;
+            expect(bands1.length).toBeGreaterThan(0);
+
+            // New array with identical date values
+            scale.domain = [new Date(2024, 0, 1), new Date(2024, 3, 1)];
+
+            const bands2 = scale.bands;
+            expect(bands2).toBe(bands1);
+        });
+
+        it('invalidates caches when domain values change', () => {
+            const scale = createScale([new Date(2024, 0, 1), new Date(2024, 3, 1)], 'day');
+
+            const bands1 = scale.bands;
+            expect(bands1.length).toBeGreaterThan(0);
+
+            scale.domain = [new Date(2024, 0, 1), new Date(2024, 6, 1)];
+
+            const bands2 = scale.bands;
+            expect(bands2).not.toBe(bands1);
+            expect(bands2.length).toBeGreaterThan(bands1.length);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('returns undefined for empty domain', () => {
+            const scale = new UnitTimeScale();
+            scale.range = [0, 100];
+            scale.domain = [];
+            scale.interval = 'day';
+
+            const result = scale.ticks(tickParams({ unit: 'day', step: 1 }));
+            expect(result).toBeUndefined();
+        });
+
+        it('handles single-day domain', () => {
+            const d = new Date(2024, 5, 15);
+            const scale = createScale([d, d], 'day');
+
+            const result = scale.ticks(tickParams({ unit: 'day', step: 1 }));
+            expect(result?.ticks.length ?? 0).toBeLessThanOrEqual(1);
+        });
+
+        it('handles reversed domain', () => {
+            const scale = createScale([new Date(2024, 6, 1), new Date(2024, 0, 1)], 'month');
+
+            const result = tickTimestamps(scale, { unit: 'month', step: 1 });
+            expect(result.length).toBeGreaterThanOrEqual(0);
+        });
+
+        it('handles partial visible range', () => {
+            const scale = createScale([new Date(2024, 0, 1), new Date(2024, 11, 31)], 'day');
+
+            const fullRange = tickTimestamps(scale, { unit: 'month', step: 1 });
+            const partialRange = tickTimestamps(scale, { unit: 'month', step: 1 }, undefined, [0.25, 0.75]);
+
+            expect(partialRange.length).toBeLessThanOrEqual(fullRange.length);
+        });
+
+        it('repeated ticks() calls are fast due to caching', () => {
+            const start = new Date(2000, 0, 1);
+            const end = new Date(2027, 4, 19);
+            const scale = createScale([start, end], 'day');
+
+            const t0 = performance.now();
+            for (let i = 0; i < 10; i++) {
+                scale.ticks(tickParams({ unit: 'year', step: 1 }));
+            }
+            const elapsed = performance.now() - t0;
+
+            expect(elapsed).toBeLessThan(100);
+        });
     });
 });

--- a/packages/ag-charts-community/src/scale/unitTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.ts
@@ -58,6 +58,16 @@ export class UnitTimeScale extends DiscreteTimeScale {
     override set domain(domain: Date[]) {
         if (domain === this._domain) return;
 
+        if (
+            domain.length === this._domain.length &&
+            domain.length >= 2 &&
+            domain[0].valueOf() === this._domain[0].valueOf() &&
+            domain[1].valueOf() === this._domain[1].valueOf()
+        ) {
+            this._domain = domain;
+            return;
+        }
+
         this._domain = domain;
         this._bands = undefined;
         this._numericBands = undefined;
@@ -335,13 +345,9 @@ export class UnitTimeScale extends DiscreteTimeScale {
         visibleRange: [number, number],
         extend: boolean = false
     ): { bands: Date[]; firstBandIndex: number | undefined } {
-        if (
-            domain === this.domain &&
-            visibleRange[0] === 0 &&
-            visibleRange[1] === 1 &&
-            !extend &&
-            this._bands != null
-        ) {
+        const isDefaultParams = domain === this.domain && visibleRange[0] === 0 && visibleRange[1] === 1 && !extend;
+
+        if (isDefaultParams && this._bands != null) {
             return { bands: this._bands, firstBandIndex: 0 };
         }
 
@@ -365,6 +371,11 @@ export class UnitTimeScale extends DiscreteTimeScale {
 
         const bands = intervalRange(interval, start, stop, rangeParams);
         const firstBandIndex = intervalRangeStartIndex(interval, start, stop, rangeParams);
+
+        if (isDefaultParams) {
+            this._bands = bands;
+        }
+
         return { bands, firstBandIndex };
     }
 
@@ -376,12 +387,18 @@ export class UnitTimeScale extends DiscreteTimeScale {
     ): ScaleTickResult<Date> | undefined {
         if (domain.length < 2) return;
 
+        const isOwnDomain = domain === this.domain && !extend;
+
+        // Fast path: use numeric bands (cached timestamps) to avoid materialising Date objects
+        if (isOwnDomain && interval != null) {
+            return this.ticksFromNumericBands(interval, domain, visibleRange, extend);
+        }
+
         let bands: Date[];
         let firstBandIndex: number | undefined;
         let bandsSliceIndices: [number, number] | undefined;
 
-        if (domain === this.domain && !extend) {
-            // Use cached values
+        if (isOwnDomain) {
             ({ bands } = this.calculateBands(domain, [0, 1], false));
             bandsSliceIndices = visibleTickSliceIndices(bands, false, visibleRange);
             firstBandIndex = bandsSliceIndices[0];
@@ -393,6 +410,94 @@ export class UnitTimeScale extends DiscreteTimeScale {
             return { ticks: bands, count: undefined, firstTickIndex: firstBandIndex };
         }
 
+        return this.ticksFromBands(interval, bands, domain, visibleRange, extend, bandsSliceIndices, firstBandIndex);
+    }
+
+    /** Optimised tick generation using cached numeric bands — avoids creating Date objects for all bands. */
+    private ticksFromNumericBands(
+        interval: AgTimeInterval | AgTimeIntervalUnit | number,
+        domain: Date[],
+        visibleRange: [number, number],
+        extend: boolean
+    ): ScaleTickResult<Date> | undefined {
+        const numBands = this.numericBands; // Cached number[], computed once
+        const n = numBands.length;
+        if (n === 0) return { ticks: [], count: 0, firstTickIndex: undefined };
+
+        const bandsSliceIndices = visibleTickSliceIndices(numBands, false, visibleRange);
+        const firstBandIndex = bandsSliceIndices[0];
+
+        const milliseconds = this.interval ? intervalMilliseconds(this.interval) : Infinity;
+        const d0 = Math.min(domain[0].valueOf(), domain[1].valueOf());
+        const d1 = Math.max(domain[0].valueOf(), domain[1].valueOf());
+
+        let intervalTickValues: number[];
+        let intervalStartIndex: number;
+        let intervalEndIndex: number;
+
+        if (isPlainObject(interval) || typeof interval === 'string') {
+            const intervalDates = intervalRange(interval, domain[0], domain[1], { extend: true, visibleRange });
+            intervalTickValues = intervalDates.map((d) => d.valueOf());
+            intervalStartIndex = 0;
+            intervalEndIndex = intervalTickValues.length - 1;
+        } else {
+            const i0 = bandsSliceIndices[0];
+            const i1 = bandsSliceIndices[1] - 1;
+            intervalTickValues = numBands;
+            intervalStartIndex = findMaxIndex(i0, i1, (index) => numBands[index] <= d0) ?? i0;
+            intervalEndIndex = findMaxIndex(i0, i1, (index) => numBands[index] <= d1) ?? i1;
+        }
+
+        const ticks: Date[] = [];
+        const tickTimestamps: number[] = [];
+        let lastIndex: number | undefined;
+        for (let i = intervalStartIndex; i <= intervalEndIndex; i++) {
+            const intervalTickValue = intervalTickValues[i];
+            const bandIndex = findMaxIndex(0, n - 1, (index) => numBands[index] <= intervalTickValue);
+            if (bandIndex != null && bandIndex !== lastIndex) {
+                if (intervalTickValue - numBands[bandIndex] <= milliseconds) {
+                    ticks.push(new Date(numBands[bandIndex]));
+                    tickTimestamps.push(numBands[bandIndex]);
+                }
+            }
+            lastIndex = bandIndex;
+        }
+
+        let bandStart: number;
+        let bandEnd: number;
+        if (this.interval) {
+            const bandRange = calculateBandRange([new Date(d0), new Date(d1)], this.interval);
+            bandStart = bandRange[0].valueOf();
+            bandEnd = bandRange[1].valueOf();
+        } else {
+            bandStart = d0;
+            bandEnd = d1;
+        }
+        let firstTickIndex = findMinIndex(0, ticks.length - 1, (i) => tickTimestamps[i] >= bandStart) ?? 0;
+        let lastTickIndex = findMaxIndex(0, ticks.length - 1, (i) => tickTimestamps[i] <= bandEnd) ?? ticks.length - 1;
+
+        if (extend) {
+            firstTickIndex = Math.max(firstTickIndex - 1, 0);
+            lastTickIndex = Math.min(lastTickIndex + 1, ticks.length - 1);
+        }
+
+        return {
+            ticks: ticks.slice(firstTickIndex, lastTickIndex + 1),
+            count: ticks.length,
+            firstTickIndex: firstBandIndex,
+        };
+    }
+
+    /** Fallback tick generation using Date[] bands (for non-default domain / sub-domain calls). */
+    private ticksFromBands(
+        interval: AgTimeInterval | AgTimeIntervalUnit | number,
+        bands: Date[],
+        domain: Date[],
+        visibleRange: [number, number],
+        extend: boolean,
+        bandsSliceIndices: [number, number] | undefined,
+        firstBandIndex: number | undefined
+    ): ScaleTickResult<Date> | undefined {
         const milliseconds = this.interval ? intervalMilliseconds(this.interval) : Infinity;
 
         const d0 = Math.min(domain[0].valueOf(), domain[1].valueOf());
@@ -408,7 +513,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
         } else {
             const i0 = bandsSliceIndices ? bandsSliceIndices[0] : 0;
             const i1 = bandsSliceIndices ? bandsSliceIndices[1] : bands.length - 1;
-            intervalTicks = bands; // Could be large array - avoid copying
+            intervalTicks = bands;
             intervalStartIndex = findMaxIndex(i0, i1, (index) => bands[index].valueOf() <= d0) ?? i0;
             intervalEndIndex = findMaxIndex(i0, i1, (index) => bands[index].valueOf() <= d1) ?? i1;
         }

--- a/packages/ag-charts-community/src/scale/unitTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.ts
@@ -58,6 +58,8 @@ export class UnitTimeScale extends DiscreteTimeScale {
     override set domain(domain: Date[]) {
         if (domain === this._domain) return;
 
+        // Value equality check — preserves caches across withTemporaryDomain calls
+        // when the domain endpoints are unchanged. Domains are always [min, max] (length 2).
         if (
             domain.length === this._domain.length &&
             domain.length >= 2 &&
@@ -69,14 +71,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
         }
 
         this._domain = domain;
-        this._bands = undefined;
-        this._numericBands = undefined;
-        this._uniformityCache = undefined;
-        this._domainBoundaries = undefined;
-        this._bandRangeCache = undefined;
-        this._encodedBands = undefined;
-        this._encodingParams = undefined;
-        this._linearParams = undefined;
+        this.invalidateCaches();
     }
     override get domain(): Date[] {
         return this._domain;
@@ -91,6 +86,10 @@ export class UnitTimeScale extends DiscreteTimeScale {
         if (this._interval === interval) return;
 
         this._interval = interval;
+        this.invalidateCaches();
+    }
+
+    private invalidateCaches() {
         this._bands = undefined;
         this._numericBands = undefined;
         this._uniformityCache = undefined;
@@ -391,7 +390,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
 
         // Fast path: use numeric bands (cached timestamps) to avoid materialising Date objects
         if (isOwnDomain && interval != null) {
-            return this.ticksFromNumericBands(interval, domain, visibleRange, extend);
+            return this.ticksFromNumericBands(interval, domain, visibleRange);
         }
 
         let bands: Date[];
@@ -417,10 +416,9 @@ export class UnitTimeScale extends DiscreteTimeScale {
     private ticksFromNumericBands(
         interval: AgTimeInterval | AgTimeIntervalUnit | number,
         domain: Date[],
-        visibleRange: [number, number],
-        extend: boolean
+        visibleRange: [number, number]
     ): ScaleTickResult<Date> | undefined {
-        const numBands = this.numericBands; // Cached number[], computed once
+        const numBands = this.numericBands;
         const n = numBands.length;
         if (n === 0) return { ticks: [], count: 0, firstTickIndex: undefined };
 
@@ -448,7 +446,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
             intervalEndIndex = findMaxIndex(i0, i1, (index) => numBands[index] <= d1) ?? i1;
         }
 
-        const ticks: Date[] = [];
+        // Collect tick timestamps (numbers only), defer Date creation until after slicing
         const tickTimestamps: number[] = [];
         let lastIndex: number | undefined;
         for (let i = intervalStartIndex; i <= intervalEndIndex; i++) {
@@ -456,34 +454,16 @@ export class UnitTimeScale extends DiscreteTimeScale {
             const bandIndex = findMaxIndex(0, n - 1, (index) => numBands[index] <= intervalTickValue);
             if (bandIndex != null && bandIndex !== lastIndex) {
                 if (intervalTickValue - numBands[bandIndex] <= milliseconds) {
-                    ticks.push(new Date(numBands[bandIndex]));
                     tickTimestamps.push(numBands[bandIndex]);
                 }
             }
             lastIndex = bandIndex;
         }
 
-        let bandStart: number;
-        let bandEnd: number;
-        if (this.interval) {
-            const bandRange = calculateBandRange([new Date(d0), new Date(d1)], this.interval);
-            bandStart = bandRange[0].valueOf();
-            bandEnd = bandRange[1].valueOf();
-        } else {
-            bandStart = d0;
-            bandEnd = d1;
-        }
-        let firstTickIndex = findMinIndex(0, ticks.length - 1, (i) => tickTimestamps[i] >= bandStart) ?? 0;
-        let lastTickIndex = findMaxIndex(0, ticks.length - 1, (i) => tickTimestamps[i] <= bandEnd) ?? ticks.length - 1;
-
-        if (extend) {
-            firstTickIndex = Math.max(firstTickIndex - 1, 0);
-            lastTickIndex = Math.min(lastTickIndex + 1, ticks.length - 1);
-        }
-
+        const [first, last] = this.sliceTickWindow(tickTimestamps, d0, d1, false);
         return {
-            ticks: ticks.slice(firstTickIndex, lastTickIndex + 1),
-            count: ticks.length,
+            ticks: tickTimestamps.slice(first, last + 1).map((t) => new Date(t)),
+            count: tickTimestamps.length,
             firstTickIndex: firstBandIndex,
         };
     }
@@ -512,7 +492,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
             intervalEndIndex = intervalTicks.length - 1;
         } else {
             const i0 = bandsSliceIndices ? bandsSliceIndices[0] : 0;
-            const i1 = bandsSliceIndices ? bandsSliceIndices[1] : bands.length - 1;
+            const i1 = bandsSliceIndices ? bandsSliceIndices[1] - 1 : bands.length - 1;
             intervalTicks = bands;
             intervalStartIndex = findMaxIndex(i0, i1, (index) => bands[index].valueOf() <= d0) ?? i0;
             intervalEndIndex = findMaxIndex(i0, i1, (index) => bands[index].valueOf() <= d1) ?? i1;
@@ -529,6 +509,17 @@ export class UnitTimeScale extends DiscreteTimeScale {
             if (tick != null && intervalTickValue - tick.getTime() <= milliseconds) ticks.push(tick);
         }
 
+        const tickTimestamps = ticks.map((t) => t.valueOf());
+        const [first, last] = this.sliceTickWindow(tickTimestamps, d0, d1, extend);
+        return {
+            ticks: ticks.slice(first, last + 1),
+            count: ticks.length,
+            firstTickIndex: firstBandIndex,
+        };
+    }
+
+    /** Returns [firstIndex, lastIndex] of ticks within the band-range window. */
+    private sliceTickWindow(tickTimestamps: number[], d0: number, d1: number, extend: boolean): [number, number] {
         let bandStart: number;
         let bandEnd: number;
         if (this.interval) {
@@ -539,19 +530,18 @@ export class UnitTimeScale extends DiscreteTimeScale {
             bandStart = d0;
             bandEnd = d1;
         }
-        let firstTickIndex = findMinIndex(0, ticks.length - 1, (i) => ticks[i].valueOf() >= bandStart) ?? 0;
-        let lastTickIndex = findMaxIndex(0, ticks.length - 1, (i) => ticks[i].valueOf() <= bandEnd) ?? ticks.length - 1;
+
+        let firstTickIndex = findMinIndex(0, tickTimestamps.length - 1, (i) => tickTimestamps[i] >= bandStart) ?? 0;
+        let lastTickIndex =
+            findMaxIndex(0, tickTimestamps.length - 1, (i) => tickTimestamps[i] <= bandEnd) ??
+            tickTimestamps.length - 1;
 
         if (extend) {
             firstTickIndex = Math.max(firstTickIndex - 1, 0);
-            lastTickIndex = Math.min(lastTickIndex + 1, ticks.length - 1);
+            lastTickIndex = Math.min(lastTickIndex + 1, tickTimestamps.length - 1);
         }
 
-        return {
-            ticks: ticks.slice(firstTickIndex, lastTickIndex + 1),
-            count: ticks.length,
-            firstTickIndex: firstBandIndex,
-        };
+        return [firstTickIndex, lastTickIndex];
     }
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1063

## Summary
- Fix performance regression in `UnitTimeScale.ticks()` introduced by `defaultTickCount = Infinity` change
- Use cached numeric timestamps (`numericBands`) for band comparisons instead of materialising all bands as Date objects
- Cache `calculateBands` results for the default domain case
- Add domain value equality check to preserve caches across `withTemporaryDomain` calls

## Benchmark result
High-perf area benchmark (1M data points): **366ms** avg initial load, down from **1463ms** (regressed) and faster than the **~500ms** baseline in 13.1.0.