### PR TITLE
CRT-1073 Fix interactive tooltip flickering

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1217,7 +1217,11 @@ export class SeriesAreaManager extends BaseManager {
         if (
             targetElement &&
             this.chart.tooltip.interactive &&
-            this.chart.ctx.domManager.isManagedChildDOMElement(targetElement, 'canvas-overlay', DEFAULT_TOOLTIP_CLASS)
+            this.chart.ctx.domManager.isManagedChildDOMElement(
+                targetElement,
+                'tooltip-container',
+                DEFAULT_TOOLTIP_CLASS
+            )
         ) {
             // Skip tooltip update if tooltip is interactive, and the source event was for a tooltip HTML element.
             return;
@@ -1260,7 +1264,7 @@ export class SeriesAreaManager extends BaseManager {
         return this.chart.tooltip.maybeEnterInteractiveTooltip(event, () => {
             this.pickManager.maybeActivate(undefined, (): void => {
                 this.tooltip.lastHover = undefined;
-                this.chart.ctx.tooltipManager.removeTooltip(this.id);
+                this.chart.ctx.tooltipManager.removeTooltip(this.id, undefined, true); // true = delayed
                 this.chart.ctx.highlightManager.updateHighlight(this.id, undefined, true); // true = delayed
             });
         });

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1217,11 +1217,7 @@ export class SeriesAreaManager extends BaseManager {
         if (
             targetElement &&
             this.chart.tooltip.interactive &&
-            this.chart.ctx.domManager.isManagedChildDOMElement(
-                targetElement,
-                'tooltip-container',
-                DEFAULT_TOOLTIP_CLASS
-            )
+            this.chart.ctx.domManager.isManagedChildDOMElement(targetElement, 'canvas-overlay', DEFAULT_TOOLTIP_CLASS)
         ) {
             // Skip tooltip update if tooltip is interactive, and the source event was for a tooltip HTML element.
             return;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1073

## Summary

- Fix interactive tooltip flickering when moving the pointer around data points
- Root cause: `popInteractiveLeaveCallback` performed **immediate** tooltip removal, causing a synchronous HIDE followed by a deferred SHOW (~28ms gap = 2 frames of visible flicker)
- Secondary fix: `isManagedChildDOMElement` guard checked `canvas-overlay` but the tooltip moved to `tooltip-container` in v12.0.0, so the guard never matched

## Test plan

- [ ] Open [tooltip interaction example](https://ag-grid.com/charts/react/tooltips/#example-tooltip-interaction) and hover over bars — tooltip should follow smoothly without flickering
- [ ] Verify tooltip still dismisses when pointer leaves the chart entirely
- [ ] Verify non-interactive tooltips are unaffected
- [ ] CI passes