### PR TITLE
CRT-1083 - Fix stale animation on set legend state

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -656,6 +656,9 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
     protected updateSelections() {
         const animationSkipUpdate = !this.opts.animationAlwaysUpdateSelections && this.ctx.animationManager.isSkipped();
         if (!this.visible && animationSkipUpdate) {
+            // Sync visibility even though we skip createNodeData(). Without this,
+            // _contextNodeData retains stale visible:true from before the series was
+            // hidden, causing a spurious animation on the next non-skipped update.
             if (this._contextNodeData) {
                 this._contextNodeData.visible = false;
             }

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -656,6 +656,9 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
     protected updateSelections() {
         const animationSkipUpdate = !this.opts.animationAlwaysUpdateSelections && this.ctx.animationManager.isSkipped();
         if (!this.visible && animationSkipUpdate) {
+            if (this._contextNodeData) {
+                this._contextNodeData.visible = false;
+            }
             return false;
         }
         const { nodeDataRefresh } = this;


### PR DESCRIPTION
PR for https://ag-grid.atlassian.net/browse/CRT-1083

When the animation batch is skipped (e.g. due to layout changes), updateSelections() early-returns for hidden series without updating _contextNodeData. This leaves stale visible: true data from before the series was hidden. On the next update where the batch isn't skipped, the animation system compares the stale previousContextData (visible: true) against the new contextNodeData (visible: false) and plays a spurious hide animation from the wrong state.

Fix: When the early return skips createNodeData() for a hidden series, update _contextNodeData.visible = false so subsequent updates don't see stale visibility state.