### PR TITLE
CRT-1074 Always check isFocusVisible() in updateComplete()

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -346,12 +346,7 @@ export class SeriesAreaManager extends BaseManager {
             } finally {
                 this.focus.pendingViewportFocus = undefined;
             }
-            // NOTE: Do the `isFocusVisible()` check last as its the most expensive part.
-        } else if (
-            this.isState(InteractionState.Focusable) &&
-            this.getHoverDevice() !== 'pointer' &&
-            this.focusIndicator?.isFocusVisible()
-        ) {
+        } else if (this.isState(InteractionState.Focusable) && this.focusIndicator?.isFocusVisible()) {
             // This function is usually called when something in the scene is redrawn such as a resize, or zoompan
             // change. In such a case, we need to update the bounds of the focus indicator, but not aria-label. Hence
             // setting mode='never' to avoid announcing the change.
@@ -647,9 +642,10 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     private onFocus(): void {
-        if (!this.isState(InteractionState.Focusable)) return;
+        if (!this.isState(InteractionState.Focusable) || !this.focusIndicator) return;
         this.initFocus(this.chart.keyboard.initialFocus);
-        this.setHoverDevice(this.focusIndicator?.isFocusVisible(true) ? 'keyboard' : 'pointer');
+        const focusVisibleStyle: boolean = this.focusIndicator.onFocus();
+        this.setHoverDevice(focusVisibleStyle ? 'keyboard' : 'pointer');
         this.refreshFocus();
     }
 
@@ -659,7 +655,7 @@ export class SeriesAreaManager extends BaseManager {
         if (!this.isState(InteractionState.Frozen) && !this.maybeEnterInteractiveTooltip(event)) {
             this.clearAll(true); // true = delayed
         }
-        this.focusIndicator?.overrideFocusVisible(undefined);
+        this.focusIndicator?.onBlur();
     }
 
     private onKeyDown(widgetEvent: KeyboardWidgetEvent<'keydown'>): void {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -69,6 +69,7 @@ enum PickedFocusStatus {
     SERIES_NOT_FOUND,
     DATUM_NOT_FOUND,
     PAN_REQUIRED,
+    PENDING_VIEWPORT_FOCUS,
 }
 
 type FocusIndices = {
@@ -340,12 +341,10 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     private updateComplete() {
-        if (this.focus.pendingViewportFocus && this.focus.series !== undefined) {
-            try {
-                this.pickViewportFocus(this.focus.pendingViewportFocus);
-            } finally {
-                this.focus.pendingViewportFocus = undefined;
-            }
+        const { pendingViewportFocus } = this.focus;
+        if (pendingViewportFocus && this.focus.series !== undefined) {
+            this.focus.pendingViewportFocus = undefined;
+            this.pickViewportFocus(pendingViewportFocus);
         } else if (this.isState(InteractionState.Focusable) && this.focusIndicator?.isFocusVisible()) {
             // This function is usually called when something in the scene is redrawn such as a resize, or zoompan
             // change. In such a case, we need to update the bounds of the focus indicator, but not aria-label. Hence
@@ -646,7 +645,12 @@ export class SeriesAreaManager extends BaseManager {
         this.initFocus(this.chart.keyboard.initialFocus);
         const focusVisibleStyle: boolean = this.focusIndicator.onFocus();
         this.setHoverDevice(focusVisibleStyle ? 'keyboard' : 'pointer');
-        this.refreshFocus();
+
+        const { pendingViewportFocus } = this.focus;
+        if (this.refreshFocus() === PickedFocusStatus.PENDING_VIEWPORT_FOCUS && pendingViewportFocus) {
+            this.focus.pendingViewportFocus = undefined;
+            this.pickViewportFocus(pendingViewportFocus);
+        }
     }
 
     private onBlur(event: FocusEvent) {
@@ -805,23 +809,26 @@ export class SeriesAreaManager extends BaseManager {
         this.chart.ctx.eventsHub.emit('series:focus-change', null);
     }
 
-    private refreshFocus(): void {
-        this.handleFocus({ datumIndexDelta: 0, otherIndexDelta: 0 });
+    private refreshFocus(): PickedFocusStatus {
+        return this.handleFocus({ datumIndexDelta: 0, otherIndexDelta: 0 });
     }
 
-    private handleFocus(inputs: HandleFocusInputs) {
+    private handleFocus(inputs: HandleFocusInputs): PickedFocusStatus {
         const overlayFocus = this.chart.overlays.getFocusInfo(this.chart.ctx.localeManager);
         if (overlayFocus == null) {
-            if (this.handleSeriesFocus(inputs) === PickedFocusStatus.SUCCESS) {
+            const status = this.handleSeriesFocus(inputs);
+            if (status === PickedFocusStatus.SUCCESS) {
                 this.announceMode = 'when-changed';
             } else {
                 // As a safe-guard, always announce the next focus-change if this current focus-change failed.
                 this.announceMode = 'always';
             }
+            return status;
         } else {
             this.focusIndicator?.update(overlayFocus.rect, this.seriesRect, false);
             this.swapChain.update(overlayFocus.text);
             this.announceMode = 'always';
+            return PickedFocusStatus.SUCCESS;
         }
     }
 
@@ -935,6 +942,7 @@ export class SeriesAreaManager extends BaseManager {
         const { datumIndexDelta, oldDatumIndex, otherIndexDelta, oldOtherIndex } = inputs;
         const { focus, hoverRect } = this;
         if (focus.series == null || hoverRect == null) return PickedFocusStatus.SERIES_NOT_FOUND;
+        if (focus.pendingViewportFocus !== undefined) return PickedFocusStatus.PENDING_VIEWPORT_FOCUS;
 
         const { datum } = pick;
         focus.datum = datum;

--- a/packages/ag-charts-community/src/dom/focusIndicator.ts
+++ b/packages/ag-charts-community/src/dom/focusIndicator.ts
@@ -11,7 +11,6 @@ export class FocusIndicator {
     private readonly outerPath: SVGPathElement;
     private readonly innerPath: SVGPathElement;
     private readonly div: HTMLDivElement;
-    private hasBeenActivated = false;
 
     constructor(private readonly swapChain: FocusSwapChain) {
         this.div = createElement('div');
@@ -72,13 +71,16 @@ export class FocusIndicator {
     }
 
     private show(child: Element) {
-        this.hasBeenActivated = true;
         this.element.innerHTML = '';
         this.element.append(child);
     }
 
     // Use with caution! The focus must be visible when using the keyboard.
     private focusVisible?: boolean;
+    // Cached `:focus-visible` CSS state. getComputedStyle() is very expensive. So this should only be check for the
+    // :focus-visible pseudo-class when we receive a 'focus' .
+    private focusVisibleStyle: boolean = false;
+
     overrideFocusVisible(focusVisible: boolean | undefined) {
         this.focusVisible = focusVisible;
         const opacity = { true: '1', false: '0', undefined: '' } as const;
@@ -86,18 +88,21 @@ export class FocusIndicator {
         parent?.style.setProperty('opacity', opacity[`${focusVisible}`]);
     }
 
-    // Get the `:focus-visible` CSS state.
-    public isFocusVisible(force = false): boolean {
-        // Short-circuit from an expensive call to `getComputedStyle()` if focus has
-        // never been activated.
-        if (!force && !this.hasBeenActivated) return false;
+    public isFocusVisible(): boolean {
+        return this.focusVisible ?? this.focusVisibleStyle;
+    }
 
-        // Return the cached value when it has been explicitly set via overrideFocusVisible(),
-        // avoiding a getComputedStyle() call on paths where we already know the state.
-        if (this.focusVisible !== undefined) return this.focusVisible;
-
+    public onFocus(): boolean {
+        this.overrideFocusVisible(undefined);
         const parent = this.element.parentElement;
         const elWin = this.element.ownerDocument.defaultView!;
-        return parent != null && elWin.getComputedStyle(parent).opacity === '1';
+        // !!!SLOW!!! Only call this when you receive a 'focus' event.
+        this.focusVisibleStyle = parent != null && elWin.getComputedStyle(parent).opacity === '1';
+        return this.focusVisibleStyle;
+    }
+
+    public onBlur(): void {
+        this.overrideFocusVisible(undefined);
+        this.focusVisibleStyle = false;
     }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1074

It is incorrect to assume that `getHoverDevice() == 'pointer'` implies `isFocusVisible() === false`.

The hoverDevice (pointer | keyboard | setState) is the device that is currently responsible for updating the highlight/tooltip (i.e., active). The focus indicator is not the same thing as the active state; they cannot be assumed to be the same. We MUST update the focus element SVG/HTML path/bounds regardless of what the current highlight/tooltip is.

However, we only need to compute the CSS style when receiving a 'focus' event, because that's the only time we cannot determine whether the event came from a keyboard user or a mouse user. In all other cases, we can listen to 'click' and 'keydown' events (i.e., overrideFocusVisible) to determine whether the focus indicator is visible.