### PR TITLE
Add publish-prd skill symlink to rulesync

### DIFF
--- a/.rulesync/skills/publish-prd
+++ b/.rulesync/skills/publish-prd
@@ -1,0 +1,1 @@
+../../external/prompts/skills/publish-prd


### PR DESCRIPTION
## Summary
- Register the new `publish-prd` skill by adding its symlink to `.rulesync/skills/`
- Companion to ag-charts-prompts PR: https://github.com/ag-grid/ag-charts-prompts/pull/25

## Test plan
- [ ] Verify symlink resolves correctly after prompts repo PR is merged