### PR TITLE
AG-NONE Split "styler highlights sequenced" into multiple snapshot comparisons

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/__snapshots__/barSeries.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/series/cartesian/__snapshots__/barSeries.test.ts.snap
@@ -40,6 +40,11 @@ exports[`BarSeries AG-11673 styler highlights sequenced 1 1`] = `
       "yKey": "expenses",
     },
   ],
+]
+`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 2`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -97,6 +102,13 @@ exports[`BarSeries AG-11673 styler highlights sequenced 1 1`] = `
       "yKey": "expenses",
     },
   ],
+]
+`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 4`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -173,6 +185,13 @@ exports[`BarSeries AG-11673 styler highlights sequenced 1 1`] = `
       "yKey": "sales",
     },
   ],
+]
+`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 6`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -287,6 +306,13 @@ exports[`BarSeries AG-11673 styler highlights sequenced 1 1`] = `
       "yKey": "expenses",
     },
   ],
+]
+`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -363,6 +389,11 @@ exports[`BarSeries AG-11673 styler highlights sequenced 1 1`] = `
       "yKey": "sales",
     },
   ],
+]
+`;
+
+exports[`BarSeries AG-11673 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "cornerRadius": 0,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -1306,19 +1306,40 @@ describe('BarSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });

--- a/packages/ag-charts-enterprise/src/series/box-plot/__snapshots__/boxPlotSeries.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/box-plot/__snapshots__/boxPlotSeries.test.ts.snap
@@ -84,6 +84,11 @@ exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yName": "Company 2",
     },
   ],
+]
+`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 2`] = `
+[
   [
     {
       "cap": {
@@ -289,6 +294,13 @@ exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yName": "Company 2",
     },
   ],
+]
+`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 4`] = `
+[
   [
     {
       "cap": {
@@ -494,6 +506,13 @@ exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yName": "Company 2",
     },
   ],
+]
+`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 6`] = `
+[
   [
     {
       "cap": {
@@ -740,6 +759,13 @@ exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yName": "Company 2",
     },
   ],
+]
+`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "cap": {
@@ -986,6 +1012,11 @@ exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yName": "Company 2",
     },
   ],
+]
+`;
+
+exports[`BoxPlotSeries AG-15782 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "cap": {

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.test.ts
@@ -683,19 +683,40 @@ describe('BoxPlotSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });

--- a/packages/ag-charts-enterprise/src/series/nightingale/__snapshots__/nightingale.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/nightingale/__snapshots__/nightingale.test.ts.snap
@@ -40,6 +40,11 @@ exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 1,
     },
   ],
+]
+`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 2`] = `
+[
   [
     {
       "angleKey": "quarter",
@@ -97,6 +102,13 @@ exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 1,
     },
   ],
+]
+`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 4`] = `
+[
   [
     {
       "angleKey": "quarter",
@@ -173,6 +185,13 @@ exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 1,
     },
   ],
+]
+`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 6`] = `
+[
   [
     {
       "angleKey": "quarter",
@@ -268,6 +287,13 @@ exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 1,
     },
   ],
+]
+`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "angleKey": "quarter",
@@ -306,6 +332,11 @@ exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 1,
     },
   ],
+]
+`;
+
+exports[`NightingaleSeries AG-15782 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "angleKey": "quarter",

--- a/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
+++ b/packages/ag-charts-enterprise/src/series/nightingale/nightingale.test.ts
@@ -760,19 +760,40 @@ describe('NightingaleSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });

--- a/packages/ag-charts-enterprise/src/series/radar-area/__snapshots__/radarArea.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/radar-area/__snapshots__/radarArea.test.ts.snap
@@ -92,6 +92,11 @@ exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 2`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -392,6 +397,13 @@ exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 4`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -512,6 +524,13 @@ exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 6`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -782,6 +801,13 @@ exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 3,
     },
   ],
+]
+`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -902,6 +928,11 @@ exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarAreaSeries AG-15782 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "angleKey": "trait",

--- a/packages/ag-charts-enterprise/src/series/radar-area/radarArea.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-area/radarArea.test.ts
@@ -684,19 +684,40 @@ describe('RadarAreaSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });

--- a/packages/ag-charts-enterprise/src/series/radar-line/__snapshots__/radarLine.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/radar-line/__snapshots__/radarLine.test.ts.snap
@@ -86,6 +86,11 @@ exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 2`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -366,6 +371,13 @@ exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 4`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -478,6 +490,13 @@ exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 6`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -730,6 +749,13 @@ exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 3,
     },
   ],
+]
+`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "angleKey": "trait",
@@ -842,6 +868,11 @@ exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 2,
     },
   ],
+]
+`;
+
+exports[`RadarLineSeries AG-15782 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "angleKey": "trait",

--- a/packages/ag-charts-enterprise/src/series/radar-line/radarLine.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-line/radarLine.test.ts
@@ -563,19 +563,40 @@ describe('RadarLineSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });

--- a/packages/ag-charts-enterprise/src/series/radial-bar/__snapshots__/radialBar.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/__snapshots__/radialBar.test.ts.snap
@@ -40,6 +40,11 @@ exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 0,
     },
   ],
+]
+`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 2`] = `
+[
   [
     {
       "angleKey": "sw",
@@ -97,6 +102,13 @@ exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 0,
     },
   ],
+]
+`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 4`] = `
+[
   [
     {
       "angleKey": "sw",
@@ -173,6 +185,13 @@ exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 0,
     },
   ],
+]
+`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 6`] = `
+[
   [
     {
       "angleKey": "hw",
@@ -268,6 +287,13 @@ exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 0,
     },
   ],
+]
+`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "angleKey": "hw",
@@ -306,6 +332,11 @@ exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 0,
     },
   ],
+]
+`;
+
+exports[`RadialBarSeries AG-15782 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "angleKey": "sw",

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBar.test.ts
@@ -640,19 +640,40 @@ describe('RadialBarSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });

--- a/packages/ag-charts-enterprise/src/series/radial-column/__snapshots__/radialColumn.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/radial-column/__snapshots__/radialColumn.test.ts.snap
@@ -40,6 +40,23 @@ exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 0,
     },
   ],
+]
+`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 2`] = `[]`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 4`] = `[]`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 6`] = `[]`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "angleKey": "quarter",
@@ -78,6 +95,11 @@ exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 1`] = `
       "strokeWidth": 0,
     },
   ],
+]
+`;
+
+exports[`RadialColumnSeries AG-15782 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "angleKey": "quarter",

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumn.test.ts
@@ -800,19 +800,40 @@ describe('RadialColumnSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });

--- a/packages/ag-charts-enterprise/src/series/range-bar/__snapshots__/rangeBar.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/series/range-bar/__snapshots__/rangeBar.test.ts.snap
@@ -40,6 +40,11 @@ exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yLowKey": "loss_low",
     },
   ],
+]
+`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 2`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -97,6 +102,13 @@ exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yLowKey": "loss_low",
     },
   ],
+]
+`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 3`] = `[]`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 4`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -192,6 +204,13 @@ exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yLowKey": "loss_low",
     },
   ],
+]
+`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 5`] = `[]`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 6`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -306,6 +325,13 @@ exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yLowKey": "loss_low",
     },
   ],
+]
+`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 7`] = `[]`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 8`] = `
+[
   [
     {
       "cornerRadius": 0,
@@ -382,6 +408,11 @@ exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 1`] = `
       "yLowKey": "loss_low",
     },
   ],
+]
+`;
+
+exports[`RangeBarSeries AG-15782 styler highlights sequenced 1 9`] = `
+[
   [
     {
       "cornerRadius": 0,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.test.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBar.test.ts
@@ -1118,19 +1118,40 @@ describe('RangeBarSeries', () => {
                     await hoverAction(p.x, p.y)(chart);
                     await waitForChartStability(chart);
                 }
+                function popCalls() {
+                    const result = [...styler.mock.mock.calls];
+                    styler.mock.mockClear();
+                    return result;
+                }
                 test('1', async () => {
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series0datum2);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(series1datum0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(miss);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem0);
+                    expect(popCalls()).toMatchSnapshot();
+
                     await hover(legendItem1);
                     // Wait for delayed unhighlights to complete
                     await waitForChartStability(chart, MIN_UNHIGHLIGHT_DELAY);
-                    expect(styler.mock.mock.calls).toMatchSnapshot();
+                    expect(popCalls()).toMatchSnapshot();
                 });
             });
         });


### PR DESCRIPTION
This makes is much easier to debug failures with these tests, because Jest will report exactly which `hover()` interaction is causing snapshot mismatches.