### PR TITLE
AG-16452: Add browser benchmark comparison infrastructure to CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,7 +46,7 @@ jobs:
 
     benchmark:
         runs-on: macos-benchmark
-        timeout-minutes: 60 # ~37 min typical; reduce to 45 once Jest benchmarks are removed
+        timeout-minutes: 60 # Jest ~13m + browser ~20m + build/setup ~15m; reduce once Jest benchmarks are removed
         permissions:
             pull-requests: write
         needs: check-permissions
@@ -191,7 +191,7 @@ jobs:
             - name: Browser Benchmark (table)
               id: browser-benchmark-table
               if: github.event_name == 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
-              timeout-minutes: 90
+              timeout-minutes: 20
               run: |
                   ./tools/benchmark/compare-browser-latest.sh origin/${{ steps.get-branch.outputs.base }}
                   echo "report<<EOF" >> $GITHUB_OUTPUT
@@ -201,7 +201,7 @@ jobs:
             - name: Browser Benchmark (json)
               id: browser-benchmark-json
               if: github.event_name != 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
-              timeout-minutes: 90
+              timeout-minutes: 20
               run: |
                   ./tools/benchmark/compare-browser-latest.sh -j origin/${{ steps.get-branch.outputs.base }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,7 +46,7 @@ jobs:
 
     benchmark:
         runs-on: macos-benchmark
-        timeout-minutes: 120
+        timeout-minutes: 60 # ~37 min typical; reduce to 45 once Jest benchmarks are removed
         permissions:
             pull-requests: write
         needs: check-permissions

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,6 +46,7 @@ jobs:
 
     benchmark:
         runs-on: macos-benchmark
+        timeout-minutes: 120
         permissions:
             pull-requests: write
         needs: check-permissions
@@ -156,6 +157,9 @@ jobs:
                   base_ref: ${{ steps.get-branch.outputs.base }}
                   fetch_base: skip
 
+            - name: Install Playwright Chromium
+              run: npx playwright install chromium
+
             - name: Notify Progress
               uses: actions/github-script@v7
               continue-on-error: true
@@ -184,18 +188,39 @@ jobs:
               run: |
                   ./tools/benchmark/compare-latest.sh -j origin/${{ steps.get-branch.outputs.base }}
 
+            - name: Browser Benchmark (table)
+              id: browser-benchmark-table
+              if: github.event_name == 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
+              timeout-minutes: 90
+              run: |
+                  ./tools/benchmark/compare-browser-latest.sh origin/${{ steps.get-branch.outputs.base }}
+                  echo "report<<EOF" >> $GITHUB_OUTPUT
+                  cat ./reports/browser-benchmark.log >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+
+            - name: Browser Benchmark (json)
+              id: browser-benchmark-json
+              if: github.event_name != 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
+              timeout-minutes: 90
+              run: |
+                  ./tools/benchmark/compare-browser-latest.sh -j origin/${{ steps.get-branch.outputs.base }}
+
             - name: Notify Success
               uses: actions/github-script@v7
               continue-on-error: true
               if: success() && github.event_name == 'issue_comment'
               env:
-                  CONTENT: ${{ steps.benchmark-table.outputs.report }}
+                  JEST_CONTENT: ${{ steps.benchmark-table.outputs.report }}
+                  BROWSER_CONTENT: ${{ steps.browser-benchmark-table.outputs.report }}
               with:
                   script: |
-                      const body = `✅ ${process.env.JOB_URL}
-                      \`\`\`
-                      ${process.env.CONTENT}
-                      \`\`\``;
+                      let body = `✅ ${process.env.JOB_URL}\n\n`;
+                      if (process.env.BROWSER_CONTENT) {
+                        body += `**Browser Benchmarks**\n\`\`\`\n${process.env.BROWSER_CONTENT}\n\`\`\`\n\n`;
+                      }
+                      if (process.env.JEST_CONTENT) {
+                        body += `<details><summary>Jest Benchmarks</summary>\n\n\`\`\`\n${process.env.JEST_CONTENT}\n\`\`\`\n</details>`;
+                      }
                       github.rest.issues.updateComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -217,7 +242,7 @@ jobs:
                         body,
                       })
 
-            - name: Slack Notification
+            - name: Slack Notification (Jest)
               if: success() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify == true))
               continue-on-error: true
               env:
@@ -225,12 +250,27 @@ jobs:
                   SLACK_ICON: 'https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png'
                   SLACK_USERNAME: 'ag-charts CI'
                   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-                  SLACK_COLOR: ${{ steps.benchmark-json.outputs.status != 'failure' && 'success' || 'failure' }}
               run: |
                   node ./tools/benchmark/format-slack-message.js > ./reports/benchmark-slack.json
                   curl -X POST -H 'Content-type: application/json' ${{ secrets.SLACK_WEBHOOK }} --data @./reports/benchmark-slack.json
 
-            - name: Slack Notification
+            - name: Slack Notification (Browser)
+              if: success() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify == true))
+              continue-on-error: true
+              env:
+                  SLACK_CHANNEL: '#charts-performance'
+                  SLACK_ICON: 'https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png'
+                  SLACK_USERNAME: 'ag-charts CI'
+                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+              run: |
+                  if [[ -f ./reports/browser-benchmark.json ]]; then
+                    node ./tools/benchmark/format-browser-slack-message.js > ./reports/browser-benchmark-slack.json
+                    curl -X POST -H 'Content-type: application/json' ${{ secrets.SLACK_WEBHOOK }} --data @./reports/browser-benchmark-slack.json
+                  else
+                    echo "No browser benchmark results to report"
+                  fi
+
+            - name: Slack Notification (failure)
               if: failure() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify == true))
               continue-on-error: true
               env:
@@ -238,7 +278,6 @@ jobs:
                   SLACK_ICON: 'https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png'
                   SLACK_USERNAME: 'ag-charts CI'
                   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-                  SLACK_COLOR: ${{ steps.benchmark-json.outputs.status != 'failure' && 'success' || 'failure' }}
               run: |
                   cat <<EOF > ./reports/benchmark-slack.json
                   {
@@ -265,3 +304,5 @@ jobs:
                   name: benchmark-results
                   path: |
                       packages/ag-charts-website/src/content/docs/benchmarks/_examples/summary/*
+                      reports/browser-benchmarks/*
+                      reports/browser-benchmark.*

--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -102,7 +102,6 @@ export default defineConfig({
             ],
         },
         server: {
-            strictPort: true,
             https: !['0', 'false'].includes(PUBLIC_HTTPS_SERVER),
             cors: {
                 /**

--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
             ],
         },
         server: {
+            strictPort: true,
             https: !['0', 'false'].includes(PUBLIC_HTTPS_SERVER),
             cors: {
                 /**

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -153,7 +153,7 @@ start_dev_server() {
 
     log "Starting dev server on port $port from ${working_dir}..."
     cd "$working_dir"
-    PUBLIC_HTTPS_SERVER=false PORT="$port" npx nx dev ag-charts-website &
+    PUBLIC_SITE_URL="http://localhost:$port" PUBLIC_HTTPS_SERVER=false PORT="$port" npx nx dev ag-charts-website &
     local pid=$!
     cd "$root"
 

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -212,6 +212,10 @@ kill_port $BASE_PORT
 
 logStarBox "Phase 1: HEAD benchmarks (${branch})"
 
+# Ensure examples are generated (dev server needs them for gallery/homepage)
+log "Generating examples..."
+npx nx generate-examples ag-charts-website 2>&1 || log "generate-examples failed (non-fatal, dev server may still work for benchmarks)"
+
 start_dev_server $HEAD_PORT "$root"
 HEAD_SERVER_PID=$_DEV_SERVER_PID
 run_benchmarks "http://localhost:$HEAD_PORT/charts" "$head_results" || {

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -260,7 +260,7 @@ if [[ -d "${worktree_dir}" ]]; then
         # Build the website in the worktree
         log "Building ag-charts-website in worktree (timeout: ${BUILD_TIMEOUT}s)..."
         cd "${worktree_dir}"
-        "${TIMEOUT_CMD[@]}" npx nx build ag-charts-website 2>&1 || {
+        ${TIMEOUT_CMD[@]+"${TIMEOUT_CMD[@]}"} npx nx build ag-charts-website 2>&1 || {
             soft_fail_or_exit "Failed to build website in worktree"
         }
         cd "$root"

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -147,6 +147,9 @@ kill_port() {
 
 # --- Start dev server ---
 
+# Sets global _DEV_SERVER_PID. Do NOT call via command substitution $(...) —
+# the subshell would block forever waiting for the background dev server.
+_DEV_SERVER_PID=""
 start_dev_server() {
     local port=$1
     local working_dir=$2
@@ -154,14 +157,13 @@ start_dev_server() {
     log "Starting dev server on port $port from ${working_dir}..."
     cd "$working_dir"
     PUBLIC_SITE_URL="http://localhost:$port" PUBLIC_HTTPS_SERVER=false PORT="$port" npx nx dev ag-charts-website &
-    local pid=$!
+    _DEV_SERVER_PID=$!
     cd "$root"
 
     log "Waiting for dev server at http://localhost:$port..."
     npx wait-on "http-get://localhost:$port/charts/" --timeout 120000
 
-    log "Dev server ready on port $port (PID $pid)"
-    echo "$pid"
+    log "Dev server ready on port $port (PID $_DEV_SERVER_PID)"
 }
 
 # --- Run browser benchmarks ---
@@ -210,7 +212,8 @@ kill_port $BASE_PORT
 
 logStarBox "Phase 1: HEAD benchmarks (${branch})"
 
-HEAD_SERVER_PID=$(start_dev_server $HEAD_PORT "$root")
+start_dev_server $HEAD_PORT "$root"
+HEAD_SERVER_PID=$_DEV_SERVER_PID
 run_benchmarks "http://localhost:$HEAD_PORT/charts" "$head_results" || {
     if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
         logError "Head benchmarks failed"
@@ -265,7 +268,8 @@ if [[ -d "${worktree_dir}" ]]; then
 
     if [[ -n "$base_results" ]]; then
         kill_port $BASE_PORT
-        BASE_SERVER_PID=$(start_dev_server $BASE_PORT "${worktree_dir}")
+        start_dev_server $BASE_PORT "${worktree_dir}"
+        BASE_SERVER_PID=$_DEV_SERVER_PID
 
         run_benchmarks "http://localhost:$BASE_PORT/charts" "$base_results" || {
             if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+#
+# CI orchestrator for browser benchmark comparison.
+#
+# Benchmarks the current (head) branch and a base branch, then compares results.
+# Uses a git worktree for the base branch build so the head working tree stays clean.
+# browser-benchmark.ts always runs from the head working directory (single Playwright install).
+#
+# Usage:
+#   ./tools/benchmark/compare-browser-latest.sh [options] <base-ref>
+#
+# Options:
+#   -j            Output JSON instead of table format
+#
+# Examples:
+#   ./tools/benchmark/compare-browser-latest.sh origin/b13.2.0
+#   ./tools/benchmark/compare-browser-latest.sh -j origin/latest
+
+set -euo pipefail
+
+export NX_DAEMON=false
+
+# --- Argument parsing ---
+
+format=table
+
+while getopts "j" opt; do
+    case $opt in
+        j)
+            format=json
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+base_ref=${1:?Usage: compare-browser-latest.sh [-j] <base-ref>}
+
+# --- Derived variables ---
+
+root=$(git rev-parse --show-toplevel)
+head=$(git rev-parse --short HEAD)
+branch=$(git rev-parse --abbrev-ref HEAD)
+tools_dir="${root}/tools/benchmark"
+worktree_dir="/tmp/ag-charts-base-bench-$$"
+
+HEAD_PORT=4601
+BASE_PORT=4602
+HEAD_SERVER_PID=""
+BASE_SERVER_PID=""
+WORKTREE_CREATED=false
+BUILD_TIMEOUT=1800  # 30 minutes
+
+# Reports directory
+reports_dir="${root}/reports/browser-benchmarks"
+mkdir -p "${reports_dir}"
+
+head_results="${reports_dir}/head.json"
+base_results="${reports_dir}/base.json"
+
+# --- Logging helpers ---
+
+logStarBox() {
+    local message=$1
+    local max_length=0
+
+    while IFS= read -r line; do
+        (( ${#line} > max_length )) && max_length=${#line}
+    done <<< "$message"
+
+    local border
+    border=$(printf '%*s' "$((max_length + 8))" | tr ' ' '*')
+
+    echo "$border" >&2
+    while IFS= read -r line; do
+        printf "*** %-${max_length}s ***\n" "$line" >&2
+    done <<< "$message"
+    echo "$border" >&2
+}
+
+log() {
+    echo "[compare-browser] $*" >&2
+}
+
+logError() {
+    echo "[compare-browser] ERROR: $*" >&2
+}
+
+# --- Dev server helpers ---
+
+stop_dev_server() {
+    local pid=$1
+    local port=$2
+
+    if [[ -n "$pid" ]]; then
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    fi
+    pkill -f "astro dev --port=${port}" 2>/dev/null || true
+}
+
+# --- Soft-fail helper ---
+
+# If AG_BENCHMARK_SOFT_FAIL is set, log the message and set base_results=""
+# to skip remaining base benchmark steps. Otherwise, exit 1.
+soft_fail_or_exit() {
+    local message=$1
+    logError "$message"
+    if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" == "true" ]]; then
+        log "Continuing in soft-fail mode..."
+        base_results=""
+    else
+        cd "$root" 2>/dev/null || true
+        exit 1
+    fi
+}
+
+# --- Cleanup ---
+
+cleanup() {
+    log "Cleaning up..."
+    stop_dev_server "$HEAD_SERVER_PID" "$HEAD_PORT"
+    stop_dev_server "$BASE_SERVER_PID" "$BASE_PORT"
+
+    if [[ "$WORKTREE_CREATED" == "true" ]]; then
+        log "Removing worktree at ${worktree_dir}..."
+        git worktree remove --force "${worktree_dir}" 2>/dev/null || rm -rf "${worktree_dir}"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# --- Kill stale servers ---
+
+kill_port() {
+    local port=$1
+    local pid
+    pid=$(lsof -ti :"$port" 2>/dev/null || true)
+    if [[ -n "$pid" ]]; then
+        log "Killing stale process on port $port (PID $pid)"
+        kill "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+}
+
+# --- Start dev server ---
+
+start_dev_server() {
+    local port=$1
+    local working_dir=$2
+
+    log "Starting dev server on port $port from ${working_dir}..."
+    cd "$working_dir"
+    PUBLIC_HTTPS_SERVER=false PORT="$port" npx nx dev ag-charts-website &
+    local pid=$!
+    cd "$root"
+
+    log "Waiting for dev server at http://localhost:$port..."
+    npx wait-on "http-get://localhost:$port/charts/" --timeout 120000
+
+    log "Dev server ready on port $port (PID $pid)"
+    echo "$pid"
+}
+
+# --- Run browser benchmarks ---
+
+run_benchmarks() {
+    local base_url=$1
+    local output=$2
+
+    log "Running browser benchmarks against ${base_url}..."
+    cd "$root"
+
+    # Always run from head working directory for consistent Playwright/tooling
+    local exit_code=0
+    npx tsx "${tools_dir}/browser-benchmark.ts" \
+        --base-url "$base_url" \
+        --output "$output" || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" == "true" ]]; then
+            log "Benchmark had failures (exit code $exit_code), continuing in soft-fail mode..."
+        else
+            return $exit_code
+        fi
+    fi
+
+    log "Results written to ${output}"
+}
+
+# ===========================
+# Main
+# ===========================
+
+logStarBox "Browser Benchmark Comparison
+Head: ${branch} (${head})
+Base: ${base_ref}"
+
+# Ensure Playwright chromium is available
+log "Ensuring Playwright Chromium is installed..."
+npx playwright install chromium 2>/dev/null || log "Playwright install skipped (may already be present)"
+
+# Kill any stale servers
+kill_port $HEAD_PORT
+kill_port $BASE_PORT
+
+# --- HEAD BENCHMARKS ---
+
+logStarBox "Phase 1: HEAD benchmarks (${branch})"
+
+HEAD_SERVER_PID=$(start_dev_server $HEAD_PORT "$root")
+run_benchmarks "http://localhost:$HEAD_PORT/charts" "$head_results" || {
+    if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
+        logError "Head benchmarks failed"
+        exit 1
+    fi
+}
+
+log "Stopping head dev server..."
+stop_dev_server "$HEAD_SERVER_PID" "$HEAD_PORT"
+HEAD_SERVER_PID=""
+
+# --- BASE BENCHMARKS (worktree) ---
+
+logStarBox "Phase 2: BASE benchmarks (${base_ref})"
+
+log "Creating worktree at ${worktree_dir} for ${base_ref}..."
+git worktree add "${worktree_dir}" "${base_ref}" 2>&1 || {
+    soft_fail_or_exit "Failed to create worktree for ${base_ref}"
+}
+
+if [[ -d "${worktree_dir}" ]]; then
+    WORKTREE_CREATED=true
+
+    # Share Nx cache between host and worktree
+    export NX_CACHE_DIRECTORY="${root}/.nx/cache"
+
+    # Use timeout for build steps (macOS may need coreutils gtimeout)
+    TIMEOUT_CMD=()
+    if command -v timeout &>/dev/null; then
+        TIMEOUT_CMD=(timeout "$BUILD_TIMEOUT")
+    elif command -v gtimeout &>/dev/null; then
+        TIMEOUT_CMD=(gtimeout "$BUILD_TIMEOUT")
+    fi
+
+    # Install dependencies in worktree
+    log "Installing dependencies in worktree..."
+    cd "${worktree_dir}"
+    log "Trying immutable install..."
+    yarn install --immutable 2>/dev/null || yarn install || {
+        soft_fail_or_exit "Failed to install dependencies in worktree"
+    }
+
+    if [[ -n "$base_results" ]]; then
+        # Build the website in the worktree
+        log "Building ag-charts-website in worktree (timeout: ${BUILD_TIMEOUT}s)..."
+        cd "${worktree_dir}"
+        "${TIMEOUT_CMD[@]}" npx nx build ag-charts-website 2>&1 || {
+            soft_fail_or_exit "Failed to build website in worktree"
+        }
+        cd "$root"
+    fi
+
+    if [[ -n "$base_results" ]]; then
+        kill_port $BASE_PORT
+        BASE_SERVER_PID=$(start_dev_server $BASE_PORT "${worktree_dir}")
+
+        run_benchmarks "http://localhost:$BASE_PORT/charts" "$base_results" || {
+            if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
+                logError "Base benchmarks failed"
+                exit 1
+            fi
+        }
+
+        log "Stopping base dev server..."
+        stop_dev_server "$BASE_SERVER_PID" "$BASE_PORT"
+        BASE_SERVER_PID=""
+    fi
+
+    # Clean up worktree early
+    log "Removing worktree..."
+    cd "$root"
+    git worktree remove --force "${worktree_dir}" 2>/dev/null || rm -rf "${worktree_dir}"
+    WORKTREE_CREATED=false
+fi
+
+# --- COMPARE ---
+
+logStarBox "Phase 3: Comparing results"
+
+# Determine output file
+if [[ "$format" == "json" ]]; then
+    output="${root}/reports/browser-benchmark.json"
+else
+    output="${root}/reports/browser-benchmark.log"
+fi
+
+if [[ -z "$base_results" || ! -f "$base_results" ]]; then
+    log "Base benchmark results unavailable, writing partial report..."
+    echo "Base benchmark results unavailable for ${base_ref}" > "$output"
+    echo "Only head results available at ${head_results}" >> "$output"
+    cat "$output"
+    exit 0
+fi
+
+# Strip 'origin/' prefix for display labels
+base_label="${base_ref#origin/}"
+compare_label="${branch}"
+
+node "${tools_dir}/compare-browser-results.js" \
+    --base "$base_results" \
+    --compare "$head_results" \
+    --base-label "$base_label" \
+    --compare-label "$compare_label" \
+    --format "$format" \
+    --report-only \
+    > "$output"
+
+cat "$output"
+log "Comparison results saved to ${output}"

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -319,7 +319,7 @@ if [[ -d "${worktree_dir}" ]]; then
        rsync -a --quiet "${root}/node_modules/" "${worktree_dir}/node_modules/" 2>/dev/null; then
         # Also clone nested workspace node_modules (Yarn 1 nohoist)
         while IFS= read -r nested; do
-            local rel_path="${nested#${root}/}"
+            rel_path="${nested#${root}/}"
             if [[ ! -d "${worktree_dir}/${rel_path}" ]]; then
                 mkdir -p "$(dirname "${worktree_dir}/${rel_path}")"
                 cp -cR "${nested}/" "${worktree_dir}/${rel_path}/" 2>/dev/null || true

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -299,8 +299,14 @@ fi
 
 if [[ -z "$base_results" || ! -f "$base_results" ]]; then
     log "Base benchmark results unavailable, writing partial report..."
-    echo "Base benchmark results unavailable for ${base_ref}" > "$output"
-    echo "Only head results available at ${head_results}" >> "$output"
+    if [[ "$format" == "json" ]]; then
+        cat > "$output" <<ENDJSON
+{"base":"${base_ref#origin/}","compare":"${branch}","rankedByTime":[],"added":[],"removed":[],"errors":["Base benchmark results unavailable for ${base_ref}"]}
+ENDJSON
+    else
+        echo "Base benchmark results unavailable for ${base_ref}" > "$output"
+        echo "Only head results available at ${head_results}" >> "$output"
+    fi
     cat "$output"
     exit 0
 fi

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -217,7 +217,9 @@ start_dev_server() {
 
     # Verify the server is actually responding
     log "Verifying server at ${_DEV_SERVER_URL}..."
-    npx wait-on "http-get://${_DEV_SERVER_URL#http://}" --timeout 60000
+    local wait_url="${_DEV_SERVER_URL#https://}"
+    wait_url="${wait_url#http://}"
+    npx wait-on "http-get://${wait_url}" --timeout 60000
 
     log "Dev server ready at $_DEV_SERVER_URL (PID $_DEV_SERVER_PID)"
 }

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -310,13 +310,39 @@ if [[ -d "${worktree_dir}" ]]; then
         TIMEOUT_CMD=(gtimeout "$BUILD_TIMEOUT")
     fi
 
-    # Install dependencies in worktree
-    log "Installing dependencies in worktree..."
+    # COW-clone node_modules from HEAD to avoid a full install.
+    # On APFS (macOS) cp -cR is near-instant; falls back to rsync on other FS.
+    # Even if yarn.lock differs, starting from a populated node_modules means
+    # yarn only reconciles the delta rather than resolving/fetching everything.
+    log "COW-cloning node_modules from HEAD..."
+    if cp -cR "${root}/node_modules/" "${worktree_dir}/node_modules/" 2>/dev/null || \
+       rsync -a --quiet "${root}/node_modules/" "${worktree_dir}/node_modules/" 2>/dev/null; then
+        # Also clone nested workspace node_modules (Yarn 1 nohoist)
+        while IFS= read -r nested; do
+            local rel_path="${nested#${root}/}"
+            if [[ ! -d "${worktree_dir}/${rel_path}" ]]; then
+                mkdir -p "$(dirname "${worktree_dir}/${rel_path}")"
+                cp -cR "${nested}/" "${worktree_dir}/${rel_path}/" 2>/dev/null || true
+            fi
+        done < <(find "${root}" -name "node_modules" -type d \
+            -not -path "${root}/node_modules/*" \
+            -not -path "${root}/node_modules" \
+            -maxdepth 3 2>/dev/null)
+        log "COW clone complete"
+    else
+        log "COW clone failed, falling back to full install"
+    fi
+
+    # Install/reconcile dependencies
     cd "${worktree_dir}"
-    log "Trying immutable install..."
-    yarn install --immutable 2>/dev/null || yarn install || {
-        soft_fail_or_exit "Failed to install dependencies in worktree"
-    }
+    if diff -q "${root}/yarn.lock" "${worktree_dir}/yarn.lock" &>/dev/null; then
+        log "yarn.lock matches HEAD, skipping install"
+    else
+        log "yarn.lock differs, reconciling dependencies..."
+        yarn install --prefer-offline || yarn install || {
+            soft_fail_or_exit "Failed to install dependencies in worktree"
+        }
+    fi
 
     if [[ -n "$base_results" ]]; then
         # Build the website in the worktree

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -47,10 +47,12 @@ branch=$(git rev-parse --abbrev-ref HEAD)
 tools_dir="${root}/tools/benchmark"
 worktree_dir="/tmp/ag-charts-base-bench-$$"
 
-HEAD_PORT=4601
-BASE_PORT=4602
+HEAD_PORT=4601  # preferred starting port; actual may differ
+BASE_PORT=4602  # preferred starting port; actual may differ
 HEAD_SERVER_PID=""
+HEAD_ACTUAL_PORT=""
 BASE_SERVER_PID=""
+BASE_ACTUAL_PORT=""
 WORKTREE_CREATED=false
 BUILD_TIMEOUT=1800  # 30 minutes
 
@@ -122,8 +124,8 @@ soft_fail_or_exit() {
 
 cleanup() {
     log "Cleaning up..."
-    stop_dev_server "$HEAD_SERVER_PID" "$HEAD_PORT"
-    stop_dev_server "$BASE_SERVER_PID" "$BASE_PORT"
+    stop_dev_server "$HEAD_SERVER_PID" "${HEAD_ACTUAL_PORT:-$HEAD_PORT}"
+    stop_dev_server "$BASE_SERVER_PID" "${BASE_ACTUAL_PORT:-$BASE_PORT}"
 
     if [[ "$WORKTREE_CREATED" == "true" ]]; then
         log "Removing worktree at ${worktree_dir}..."
@@ -145,25 +147,79 @@ kill_port() {
     fi
 }
 
+# --- Port detection ---
+
+# Find a free port starting from the given number.
+find_free_port() {
+    local start_port=$1
+    node -e "
+        const net = require('net');
+        let port = ${start_port};
+        (function tryPort() {
+            const srv = net.createServer();
+            srv.listen(port, '127.0.0.1', () => {
+                const p = srv.address().port;
+                srv.close(() => { console.log(p); process.exit(0); });
+            });
+            srv.on('error', () => { port++; tryPort(); });
+        })();
+    "
+}
+
 # --- Start dev server ---
 
-# Sets global _DEV_SERVER_PID. Do NOT call via command substitution $(...) —
-# the subshell would block forever waiting for the background dev server.
+# Sets globals: _DEV_SERVER_PID, _DEV_SERVER_URL.
+# Do NOT call via command substitution $(...) — the subshell would block
+# forever waiting for the background dev server.
 _DEV_SERVER_PID=""
+_DEV_SERVER_URL=""
 start_dev_server() {
-    local port=$1
+    local preferred_port=$1
     local working_dir=$2
+
+    # Find an available port starting from the preferred one
+    local port
+    port=$(find_free_port "$preferred_port")
+    if [[ "$port" != "$preferred_port" ]]; then
+        log "Port $preferred_port in use, using $port instead"
+    fi
+
+    local server_log="${reports_dir}/dev-server-${port}.log"
 
     log "Starting dev server on port $port from ${working_dir}..."
     cd "$working_dir"
-    PUBLIC_SITE_URL="http://localhost:$port" PUBLIC_HTTPS_SERVER=false PORT="$port" npx nx dev ag-charts-website &
+    PUBLIC_SITE_URL="http://localhost:$port" PUBLIC_HTTPS_SERVER=false PORT="$port" \
+        npx nx dev ag-charts-website > "$server_log" 2>&1 &
     _DEV_SERVER_PID=$!
     cd "$root"
 
-    log "Waiting for dev server at http://localhost:$port..."
-    npx wait-on "http-get://localhost:$port/charts/" --timeout 120000
+    # Parse Astro's startup output for the actual URL (handles auto-increment edge case)
+    log "Waiting for dev server to start..."
+    local actual_url=""
+    for i in $(seq 1 120); do
+        # Strip ANSI codes, look for "Local    http://..." line from Astro's output
+        actual_url=$(sed 's/\x1b\[[0-9;]*m//g' "$server_log" 2>/dev/null \
+            | grep -oE 'Local[[:space:]]+https?://[^[:space:]]+' \
+            | head -1 \
+            | awk '{print $NF}' || true)
+        if [[ -n "$actual_url" ]]; then
+            break
+        fi
+        sleep 1
+    done
 
-    log "Dev server ready on port $port (PID $_DEV_SERVER_PID)"
+    if [[ -z "$actual_url" ]]; then
+        actual_url="http://localhost:$port/charts"
+        log "Could not detect URL from server output, using default: $actual_url"
+    fi
+
+    _DEV_SERVER_URL="$actual_url"
+
+    # Verify the server is actually responding
+    log "Verifying server at ${_DEV_SERVER_URL}..."
+    npx wait-on "http-get://${_DEV_SERVER_URL#http://}" --timeout 60000
+
+    log "Dev server ready at $_DEV_SERVER_URL (PID $_DEV_SERVER_PID)"
 }
 
 # --- Run browser benchmarks ---
@@ -218,7 +274,9 @@ npx nx generate-examples ag-charts-website 2>&1 || log "generate-examples failed
 
 start_dev_server $HEAD_PORT "$root"
 HEAD_SERVER_PID=$_DEV_SERVER_PID
-run_benchmarks "http://localhost:$HEAD_PORT/charts" "$head_results" || {
+HEAD_URL=$_DEV_SERVER_URL
+HEAD_ACTUAL_PORT=$(echo "$HEAD_URL" | grep -oE ':[0-9]+' | tr -d ':')
+run_benchmarks "$HEAD_URL" "$head_results" || {
     if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
         logError "Head benchmarks failed"
         exit 1
@@ -226,7 +284,7 @@ run_benchmarks "http://localhost:$HEAD_PORT/charts" "$head_results" || {
 }
 
 log "Stopping head dev server..."
-stop_dev_server "$HEAD_SERVER_PID" "$HEAD_PORT"
+stop_dev_server "$HEAD_SERVER_PID" "${HEAD_ACTUAL_PORT:-$HEAD_PORT}"
 HEAD_SERVER_PID=""
 
 # --- BASE BENCHMARKS (worktree) ---
@@ -274,8 +332,10 @@ if [[ -d "${worktree_dir}" ]]; then
         kill_port $BASE_PORT
         start_dev_server $BASE_PORT "${worktree_dir}"
         BASE_SERVER_PID=$_DEV_SERVER_PID
+        BASE_URL=$_DEV_SERVER_URL
+        BASE_ACTUAL_PORT=$(echo "$BASE_URL" | grep -oE ':[0-9]+' | tr -d ':')
 
-        run_benchmarks "http://localhost:$BASE_PORT/charts" "$base_results" || {
+        run_benchmarks "$BASE_URL" "$base_results" || {
             if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
                 logError "Base benchmarks failed"
                 exit 1
@@ -283,7 +343,7 @@ if [[ -d "${worktree_dir}" ]]; then
         }
 
         log "Stopping base dev server..."
-        stop_dev_server "$BASE_SERVER_PID" "$BASE_PORT"
+        stop_dev_server "$BASE_SERVER_PID" "${BASE_ACTUAL_PORT:-$BASE_PORT}"
         BASE_SERVER_PID=""
     fi
 

--- a/tools/benchmark/compare-browser-results.js
+++ b/tools/benchmark/compare-browser-results.js
@@ -12,6 +12,8 @@ const fs = require('fs');
 const yargs = require('yargs');
 const { hideBin } = require('yargs/helpers');
 
+const { formatPercentageChange } = require('./format-utils');
+
 const argv = yargs(hideBin(process.argv))
     .option('base', {
         type: 'string',
@@ -88,13 +90,6 @@ function timeFormat(timeMs) {
         return Math.floor(timeMs * 1000) / 1000;
     }
     return timeMs;
-}
-
-function formatPercentageChange(pctChange) {
-    if (pctChange === null || pctChange === undefined) {
-        return 'N/A';
-    }
-    return `${pctChange > 0 ? '+' : ''}${pctChange}%`;
 }
 
 // --- Extract results from report ---
@@ -186,7 +181,7 @@ for (const err of compare.errors) {
 }
 
 // Rank by time change
-const rankedByTime = matched.toSorted((a, b) => a.pctTimeChange - b.pctTimeChange);
+const rankedByTime = matched.toSorted((a, b) => (a.pctTimeChange ?? -Infinity) - (b.pctTimeChange ?? -Infinity));
 
 // Notable regressions (>10%)
 const notable = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange > 10);

--- a/tools/benchmark/compare-browser-results.js
+++ b/tools/benchmark/compare-browser-results.js
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+
+/**
+ * Compare two browser benchmark JSON reports and produce a comparison table or JSON.
+ *
+ * Usage:
+ *   node compare-browser-results.js --base base.json --compare head.json
+ *   node compare-browser-results.js --base base.json --compare head.json --format json
+ */
+
+const fs = require('fs');
+const yargs = require('yargs');
+const { hideBin } = require('yargs/helpers');
+
+const argv = yargs(hideBin(process.argv))
+    .option('base', {
+        type: 'string',
+        demandOption: true,
+        describe: 'Path to the base (baseline) browser benchmark JSON report',
+    })
+    .option('compare', {
+        type: 'string',
+        demandOption: true,
+        describe: 'Path to the compare (head) browser benchmark JSON report',
+    })
+    .option('base-label', {
+        type: 'string',
+        default: 'base',
+        describe: 'Display name for the base version',
+    })
+    .option('compare-label', {
+        type: 'string',
+        default: 'compare',
+        describe: 'Display name for the compare version',
+    })
+    .option('format', {
+        type: 'string',
+        choices: ['table', 'json'],
+        default: 'table',
+        describe: 'Output format',
+    })
+    .option('report-only', {
+        type: 'boolean',
+        default: false,
+        describe: 'Only report results, do not exit with a failure code on regressions',
+    })
+    .help()
+    .parse();
+
+// --- Helpers ---
+
+function loadReport(filePath) {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+}
+
+/**
+ * Build a unique comparison key for a benchmark result within an example.
+ * Mirrors benchmarkHarness.ts resultKey() but prefixed with the example name
+ * to avoid collisions across examples.
+ */
+function comparisonKey(exampleName, result) {
+    const sortedParams = Object.entries(result.params || {})
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`);
+    return [exampleName, result.testCase, ...sortedParams].join('|');
+}
+
+/**
+ * Build a human-readable display name for a benchmark result.
+ */
+function displayName(exampleName, result) {
+    const parts = [exampleName, result.testCase];
+    const paramStr = Object.entries(result.params || {})
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join(', ');
+    if (paramStr) parts.push(paramStr);
+    return parts.join(' / ');
+}
+
+function timeFormat(timeMs) {
+    if (Math.abs(timeMs) > 10) {
+        return Math.floor(timeMs * 10) / 10;
+    } else if (Math.abs(timeMs) > 1) {
+        return Math.floor(timeMs * 100) / 100;
+    } else if (Math.abs(timeMs) > 0.1) {
+        return Math.floor(timeMs * 1000) / 1000;
+    }
+    return timeMs;
+}
+
+function formatPercentageChange(pctChange) {
+    if (pctChange === null || pctChange === undefined) {
+        return 'N/A';
+    }
+    return `${pctChange > 0 ? '+' : ''}${pctChange}%`;
+}
+
+// --- Extract results from report ---
+
+function extractResults(report) {
+    const results = new Map();
+    const errors = [];
+
+    for (const [exampleName, example] of Object.entries(report.examples || {})) {
+        if (example.status !== 'success' || !example.data?.results) {
+            errors.push({ example: exampleName, status: example.status, error: example.error });
+            continue;
+        }
+
+        for (const result of example.data.results) {
+            const key = comparisonKey(exampleName, result);
+            results.set(key, {
+                exampleName,
+                testCase: result.testCase,
+                params: result.params || {},
+                averageTime: result.averageTime,
+                minTime: result.minTime,
+                maxTime: result.maxTime,
+                sampleCount: result.sampleCount,
+                displayName: displayName(exampleName, result),
+            });
+        }
+    }
+
+    return { results, errors };
+}
+
+// --- Compare ---
+
+const baseReport = loadReport(argv.base);
+const compareReport = loadReport(argv.compare);
+
+const base = extractResults(baseReport);
+const compare = extractResults(compareReport);
+
+const baseKeys = new Set(base.results.keys());
+const compareKeys = new Set(compare.results.keys());
+
+// Matched results
+const matched = [];
+for (const key of baseKeys) {
+    if (compareKeys.has(key)) {
+        const b = base.results.get(key);
+        const c = compare.results.get(key);
+        const pctTimeChange =
+            b.averageTime === 0 ? null : Math.round(((c.averageTime - b.averageTime) / b.averageTime) * 1000) / 10;
+
+        matched.push({
+            test: b.displayName,
+            pctTimeChange,
+            beforeMs: timeFormat(b.averageTime),
+            afterMs: timeFormat(c.averageTime),
+            beforeMinMs: timeFormat(b.minTime),
+            afterMinMs: timeFormat(c.minTime),
+            beforeSamples: b.sampleCount,
+            afterSamples: c.sampleCount,
+        });
+    }
+}
+
+// Added (in compare but not in base)
+const added = [];
+for (const key of compareKeys) {
+    if (!baseKeys.has(key)) {
+        added.push(compare.results.get(key).displayName);
+    }
+}
+
+// Removed (in base but not in compare)
+const removed = [];
+for (const key of baseKeys) {
+    if (!compareKeys.has(key)) {
+        removed.push(base.results.get(key).displayName);
+    }
+}
+
+// Combine errors from both reports
+const errors = [];
+for (const err of base.errors) {
+    errors.push(`${err.example}: ${err.status} (base)${err.error ? ' - ' + err.error.split('\n')[0] : ''}`);
+}
+for (const err of compare.errors) {
+    errors.push(`${err.example}: ${err.status} (compare)${err.error ? ' - ' + err.error.split('\n')[0] : ''}`);
+}
+
+// Rank by time change
+const rankedByTime = matched.toSorted((a, b) => a.pctTimeChange - b.pctTimeChange);
+
+// Notable regressions (>10%)
+const notable = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange > 10);
+
+// --- Output ---
+
+const baseLabel = argv['base-label'];
+const compareLabel = argv['compare-label'];
+
+if (argv.format === 'table') {
+    console.log(`Comparing ${baseLabel} (baseline) vs. ${compareLabel}`);
+
+    if (notable.length > 0) {
+        if (!argv['report-only']) {
+            process.exitCode = 1;
+        }
+        console.log('\nNotable Regressions (>10%)');
+        console.table(
+            notable.map((r) => ({
+                test: r.test,
+                '%': formatPercentageChange(r.pctTimeChange),
+                'Before (ms)': r.beforeMs,
+                'After (ms)': r.afterMs,
+            }))
+        );
+    }
+
+    const rankedOutput =
+        rankedByTime.length > 10 ? [...rankedByTime.slice(0, 5), {}, ...rankedByTime.slice(-5)] : rankedByTime;
+    console.log('Time (top 5/bottom 5)');
+    console.table(
+        rankedOutput.map((r) =>
+            Object.keys(r).length === 0
+                ? {}
+                : {
+                      test: r.test,
+                      '%': formatPercentageChange(r.pctTimeChange),
+                      'Before (ms)': r.beforeMs,
+                      'After (ms)': r.afterMs,
+                  }
+        )
+    );
+
+    if (added.length > 0) {
+        console.log(`\nAdded (${added.length}):`);
+        added.forEach((name) => console.log(`  + ${name}`));
+    }
+    if (removed.length > 0) {
+        console.log(`\nRemoved (${removed.length}):`);
+        removed.forEach((name) => console.log(`  - ${name}`));
+    }
+    if (errors.length > 0) {
+        console.log(`\nErrors (${errors.length}):`);
+        errors.forEach((err) => console.log(`  ! ${err}`));
+    }
+
+    // Summary line
+    const improvements = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange < 0).length;
+    const regressions = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange > 0).length;
+    console.log(`\nSummary: ${improvements} improved, ${regressions} regressed, ${matched.length} total`);
+} else if (argv.format === 'json') {
+    console.log(
+        JSON.stringify(
+            {
+                base: baseLabel,
+                compare: compareLabel,
+                rankedByTime,
+                added,
+                removed,
+                errors,
+            },
+            null,
+            2
+        )
+    );
+}

--- a/tools/benchmark/format-browser-slack-message.js
+++ b/tools/benchmark/format-browser-slack-message.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+/**
+ * Format browser benchmark comparison results as a Slack Block Kit message.
+ *
+ * Reads JSON output from compare-browser-results.js and produces Slack webhook JSON.
+ *
+ * Usage:
+ *   node format-browser-slack-message.js > slack-message.json
+ *   node format-browser-slack-message.js --input ./reports/browser-benchmark.json
+ *
+ * Test with Slack Block Kit Builder:
+ *   SLACK_CHANNEL='a' SLACK_ICON='a' SLACK_USERNAME='a' node format-browser-slack-message.js | pbcopy
+ */
+
+const fs = require('fs');
+const yargs = require('yargs');
+const { hideBin } = require('yargs/helpers');
+
+const { formatTable, requireSlackEnv } = require('./format-utils');
+
+const argv = yargs(hideBin(process.argv))
+    .option('input', {
+        type: 'string',
+        default: './reports/browser-benchmark.json',
+        describe: 'Path to the browser benchmark comparison JSON',
+    })
+    .help()
+    .parse();
+
+const { channel, username, icon_url } = requireSlackEnv();
+
+const {
+    base,
+    compare,
+    rankedByTime,
+    added = [],
+    removed = [],
+    errors = [],
+} = JSON.parse(fs.readFileSync(argv.input, 'utf8'));
+
+// --- Build Slack message ---
+
+const timeImprovements = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange < 0).length;
+const timeRegressions = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange > 0).length;
+const notable = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange > 10);
+
+const blocks = [
+    {
+        type: 'section',
+        text: {
+            type: 'mrkdwn',
+            text: `*Browser benchmark results* for \`${base}\` vs \`${compare}\`.\nTiming: ${timeImprovements} improved, ${timeRegressions} regressed (${rankedByTime.length} total)`,
+        },
+    },
+    { type: 'divider' },
+];
+
+// Notable regressions section
+if (notable.length > 0) {
+    blocks.push(
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: `*Notable Regressions (>10%)*\n\`\`\`\n${formatTable(notable, ['pctTimeChange', 'beforeMs', 'afterMs'], ['%', 'Before (ms)', 'After (ms)'])}\`\`\``,
+            },
+        },
+        { type: 'divider' }
+    );
+}
+
+// Timings section (top 5/bottom 5)
+blocks.push({
+    type: 'section',
+    text: {
+        type: 'mrkdwn',
+        text: `*Timings* (top 5/bottom 5)\n\`\`\`\n${formatTable(rankedByTime, ['pctTimeChange', 'beforeMs', 'afterMs'], ['%', 'Before (ms)', 'After (ms)'])}\`\`\``,
+    },
+});
+
+// Added/removed/errors summary
+const notes = [];
+if (added.length > 0) notes.push(`${added.length} added`);
+if (removed.length > 0) notes.push(`${removed.length} removed`);
+if (errors.length > 0) notes.push(`${errors.length} errors`);
+if (notes.length > 0) {
+    blocks.push({ type: 'divider' });
+    blocks.push({
+        type: 'section',
+        text: {
+            type: 'mrkdwn',
+            text: notes.join(' | '),
+        },
+    });
+}
+
+// Full results in collapsed attachment
+const fullTimingTable = formatTable(
+    rankedByTime,
+    ['pctTimeChange', 'beforeMs', 'afterMs'],
+    ['%', 'Before (ms)', 'After (ms)'],
+    { maxWidth: 77, truncate: false }
+);
+
+const slackMessage = {
+    channel,
+    username,
+    icon_url,
+    blocks,
+    attachments: [
+        {
+            color: '#36a64f',
+            title: `Full Timing Results (${rankedByTime.length} benchmarks)`,
+            text: `\`\`\`\n${fullTimingTable}\`\`\``,
+            fallback: 'Full browser benchmark timing results',
+            mrkdwn_in: ['text'],
+            collapsed: true,
+        },
+    ],
+};
+
+console.log(JSON.stringify(slackMessage, null, 2));

--- a/tools/benchmark/format-slack-message.js
+++ b/tools/benchmark/format-slack-message.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
-const path = require('path');
+
+const { formatPercentageChange, formatTable, requireSlackEnv } = require('./format-utils');
 
 const logFile = './reports/benchmark.json';
 const {
@@ -13,145 +14,7 @@ const {
     rankedByMemory,
 } = JSON.parse(fs.readFileSync(logFile, 'utf8').toString());
 
-let channel = process.env.SLACK_CHANNEL;
-let username = process.env.SLACK_USERNAME;
-let icon_url = process.env.SLACK_ICON;
-
-if (!channel) throw new Error('SLACK_CHANNEL is not set');
-if (!username) throw new Error('SLACK_USERNAME is not set');
-if (!icon_url) throw new Error('SLACK_ICON is not set');
-
-function formatSection(data, headers, headerLabels) {
-    const rows = [...data.slice(0, 5)];
-    if (data.length >= 10) {
-        // Include gap then the last 5 rows.
-        rows.push({}, ...data.slice(-5));
-    } else if (data.length > 5) {
-        // Include all remaining rows.
-        rows.push(...data.slice(5));
-    }
-    const dataKeys = ['test', ...headers];
-    const labels = ['Test', ...(headerLabels || dataKeys)];
-
-    // Calculate column widths
-    const maxWidth = 80;
-    const padding = 2; // Space between columns
-    const colWidths = labels.map((h) => h.length);
-    for (const row of rows) {
-        if (Object.keys(row).length > 0) {
-            dataKeys.forEach((key, i) => {
-                const val = String(row[key] ?? '');
-                colWidths[i] = Math.max(colWidths[i], val.length);
-            });
-        }
-    }
-
-    // Adjust first column width to fit within max width
-    const otherColsWidth = colWidths.slice(1).reduce((sum, w) => sum + w, 0);
-    const spacingWidth = (labels.length - 1) * padding;
-    const maxFirstColWidth = maxWidth - otherColsWidth - spacingWidth;
-    colWidths[0] = Math.min(colWidths[0], maxFirstColWidth);
-
-    // Create header row
-    let table =
-        labels
-            .map((h, i) => {
-                const text = i === 0 ? h.slice(0, colWidths[0]) : h;
-                return i === 0 ? text.padEnd(colWidths[i]) : text.padStart(colWidths[i]);
-            })
-            .join('  ') + '\n';
-    table += labels.map((_, i) => '='.repeat(colWidths[i])).join('==') + '\n';
-
-    // Create data rows
-    for (const row of rows) {
-        if (Object.keys(row).length === 0) {
-            table += labels.map((_, i) => '.'.repeat(colWidths[i])).join('..') + '\n';
-        } else {
-            table +=
-                dataKeys
-                    .map((key, i) => {
-                        const val = String(row[key] ?? '');
-                        const text =
-                            i === 0 ? (val.length > colWidths[0] ? val.slice(0, colWidths[0] - 3) + '...' : val) : val;
-                        return i === 0 ? text.padEnd(colWidths[i]) : text.padStart(colWidths[i]);
-                    })
-                    .join('  ') + '\n';
-        }
-    }
-
-    return table;
-}
-
-function formatPercentageChange(pctChange) {
-    if (pctChange === null || pctChange === undefined) {
-        return 'N/A';
-    }
-    return `${pctChange > 0 ? '+' : ''}${pctChange}%`;
-}
-
-function formatFullSection(data, headers, headerLabels) {
-    // Include all rows (no truncation)
-    const rows = data;
-    const dataKeys = ['test', ...headers];
-    const labels = ['Test', ...(headerLabels || dataKeys)];
-
-    // Calculate column widths
-    // Reduced from 80 to 77 to fit within Slack attachment display width
-    const maxWidth = 77;
-    const padding = 2; // Space between columns
-    const colWidths = labels.map((h) => h.length);
-    for (const row of rows) {
-        if (Object.keys(row).length > 0) {
-            dataKeys.forEach((key, i) => {
-                let val;
-                // Format percentage changes properly
-                if (key === 'pctTimeChange' || key === 'pctMemoryChange') {
-                    val = formatPercentageChange(row[key]);
-                } else {
-                    val = String(row[key] ?? '');
-                }
-                colWidths[i] = Math.max(colWidths[i], val.length);
-            });
-        }
-    }
-
-    // Adjust first column width to fit within max width
-    const otherColsWidth = colWidths.slice(1).reduce((sum, w) => sum + w, 0);
-    const spacingWidth = (labels.length - 1) * padding;
-    const maxFirstColWidth = maxWidth - otherColsWidth - spacingWidth;
-    colWidths[0] = Math.min(colWidths[0], maxFirstColWidth);
-
-    // Create header row
-    let table =
-        labels
-            .map((h, i) => {
-                const text = i === 0 ? h.slice(0, colWidths[0]) : h;
-                return i === 0 ? text.padEnd(colWidths[i]) : text.padStart(colWidths[i]);
-            })
-            .join('  ') + '\n';
-    table += labels.map((_, i) => '='.repeat(colWidths[i])).join('==') + '\n';
-
-    // Create data rows
-    for (const row of rows) {
-        table +=
-            dataKeys
-                .map((key, i) => {
-                    let val;
-                    // Format percentage changes properly
-                    if (key === 'pctTimeChange' || key === 'pctMemoryChange') {
-                        val = formatPercentageChange(row[key]);
-                    } else {
-                        val = String(row[key] ?? '');
-                    }
-                    const text =
-                        i === 0 ? (val.length > colWidths[0] ? val.slice(0, colWidths[0] - 3) + '...' : val) : val;
-                    return i === 0 ? text.padEnd(colWidths[i]) : text.padStart(colWidths[i]);
-                })
-                .join('  ') + '\n';
-    }
-
-    return table;
-}
+const { channel, username, icon_url } = requireSlackEnv();
 
 // Count improvements and regressions
 const timeImprovements = rankedByTime.filter((r) => r.pctTimeChange < 0).length;
@@ -188,7 +51,7 @@ if (expectationBreaches.length > 0) {
             type: 'section',
             text: {
                 type: 'mrkdwn',
-                text: `*⚠️  Expectation Breaches*\n\`\`\`\n${formatSection(breachData, ['type', 'expected', 'actual', 'exceeded'], ['Type', 'Expected', 'Actual', 'Exceeded'])}\`\`\``,
+                text: `*⚠️  Expectation Breaches*\n\`\`\`\n${formatTable(breachData, ['type', 'expected', 'actual', 'exceeded'], ['Type', 'Expected', 'Actual', 'Exceeded'])}\`\`\``,
             },
         },
         { type: 'divider' }
@@ -201,7 +64,7 @@ if (critical.length > 0) {
             type: 'section',
             text: {
                 type: 'mrkdwn',
-                text: `*Critical Cases* (regressions)\n\`\`\`\n${formatSection(critical, ['beforeMs', 'afterMs', 'beforeMB', 'afterMB'], ['Before (ms)', 'After (ms)', 'Before (MB)', 'After (MB)'])}\`\`\``,
+                text: `*Critical Cases* (regressions)\n\`\`\`\n${formatTable(critical, ['beforeMs', 'afterMs', 'beforeMB', 'afterMB'], ['Before (ms)', 'After (ms)', 'Before (MB)', 'After (MB)'])}\`\`\``,
             },
         },
         { type: 'divider' }
@@ -213,7 +76,7 @@ blocks.push(
         type: 'section',
         text: {
             type: 'mrkdwn',
-            text: `*Timings* (top 5/bottom 5)\n\`\`\`\n${formatSection(rankedByTime, ['pctTimeChange', 'beforeMs', 'afterMs'], ['%', 'Before (ms)', 'After (ms)'])}\`\`\``,
+            text: `*Timings* (top 5/bottom 5)\n\`\`\`\n${formatTable(rankedByTime, ['pctTimeChange', 'beforeMs', 'afterMs'], ['%', 'Before (ms)', 'After (ms)'])}\`\`\``,
         },
     },
     { type: 'divider' },
@@ -221,7 +84,7 @@ blocks.push(
         type: 'section',
         text: {
             type: 'mrkdwn',
-            text: `*Memory* (top 5/bottom 5)\n\`\`\`\n${formatSection(rankedByMemory, ['pctMemoryChange', 'beforeMB', 'afterMB'], ['%', 'Before (MB)', 'After (MB)'])}\`\`\``,
+            text: `*Memory* (top 5/bottom 5)\n\`\`\`\n${formatTable(rankedByMemory, ['pctMemoryChange', 'beforeMB', 'afterMB'], ['%', 'Before (MB)', 'After (MB)'])}\`\`\``,
         },
     }
 );
@@ -232,15 +95,17 @@ blocks.push(
 // ```bash
 // SLACK_CHANNEL='a' SLACK_ICON='a' SLACK_USERNAME='a' ./tools/benchmark/format-slack-message.js | pbcopy
 // ```
-const fullTimingTable = formatFullSection(
+const fullTimingTable = formatTable(
     rankedByTime,
     ['pctTimeChange', 'beforeMs', 'afterMs'],
-    ['%', 'Before (ms)', 'After (ms)']
+    ['%', 'Before (ms)', 'After (ms)'],
+    { maxWidth: 77, truncate: false }
 );
-const fullMemoryTable = formatFullSection(
+const fullMemoryTable = formatTable(
     rankedByMemory,
     ['pctMemoryChange', 'beforeMB', 'afterMB'],
-    ['%', 'Before (MB)', 'After (MB)']
+    ['%', 'Before (MB)', 'After (MB)'],
+    { maxWidth: 77, truncate: false }
 );
 
 const slackMessage = {

--- a/tools/benchmark/format-utils.js
+++ b/tools/benchmark/format-utils.js
@@ -1,0 +1,130 @@
+/**
+ * Shared formatting utilities for benchmark comparison scripts.
+ *
+ * Used by both Jest-based (format-slack-message.js) and browser-based
+ * (format-browser-slack-message.js) Slack formatters.
+ */
+
+/**
+ * Format a percentage change value for display.
+ * Returns "N/A" for null/undefined, otherwise "+X%" or "-X%".
+ */
+function formatPercentageChange(pctChange) {
+    if (pctChange === null || pctChange === undefined) {
+        return 'N/A';
+    }
+    return `${pctChange > 0 ? '+' : ''}${pctChange}%`;
+}
+
+/**
+ * Detect whether a data key represents a percentage change field.
+ */
+function isPercentageKey(key) {
+    return key.startsWith('pct') && key.endsWith('Change');
+}
+
+/**
+ * Format a cell value, applying percentage formatting for percentage keys.
+ */
+function formatCellValue(key, value) {
+    if (isPercentageKey(key)) {
+        return formatPercentageChange(value);
+    }
+    return String(value ?? '');
+}
+
+/**
+ * Format benchmark data as a fixed-width text table suitable for Slack code blocks.
+ *
+ * @param {Array<object>} data - Array of result objects (must have a `test` field).
+ * @param {string[]} headers - Data keys to include as columns (after `test`).
+ * @param {string[]} [headerLabels] - Display labels for columns (defaults to header keys).
+ * @param {object} [opts]
+ * @param {number} [opts.maxWidth=80] - Maximum table width in characters.
+ * @param {boolean} [opts.truncate=true] - Show top 5 / bottom 5 with a gap separator.
+ */
+function formatTable(data, headers, headerLabels, { maxWidth = 80, truncate = true } = {}) {
+    // Build row set
+    let rows;
+    if (truncate) {
+        rows = [...data.slice(0, 5)];
+        if (data.length >= 10) {
+            rows.push({}, ...data.slice(-5));
+        } else if (data.length > 5) {
+            rows.push(...data.slice(5));
+        }
+    } else {
+        rows = data;
+    }
+
+    const dataKeys = ['test', ...headers];
+    const labels = ['Test', ...(headerLabels || headers)];
+    const padding = 2;
+
+    // Calculate column widths
+    const colWidths = labels.map((h) => h.length);
+    for (const row of rows) {
+        if (Object.keys(row).length > 0) {
+            dataKeys.forEach((key, i) => {
+                const val = formatCellValue(key, row[key]);
+                colWidths[i] = Math.max(colWidths[i], val.length);
+            });
+        }
+    }
+
+    // Constrain first column to fit within max width
+    const otherColsWidth = colWidths.slice(1).reduce((sum, w) => sum + w, 0);
+    const spacingWidth = (labels.length - 1) * padding;
+    colWidths[0] = Math.min(colWidths[0], maxWidth - otherColsWidth - spacingWidth);
+
+    // Header row
+    let table =
+        labels
+            .map((h, i) => {
+                const text = i === 0 ? h.slice(0, colWidths[0]) : h;
+                return i === 0 ? text.padEnd(colWidths[i]) : text.padStart(colWidths[i]);
+            })
+            .join('  ') + '\n';
+    table += labels.map((_, i) => '='.repeat(colWidths[i])).join('==') + '\n';
+
+    // Data rows
+    for (const row of rows) {
+        if (Object.keys(row).length === 0) {
+            table += labels.map((_, i) => '.'.repeat(colWidths[i])).join('..') + '\n';
+        } else {
+            table +=
+                dataKeys
+                    .map((key, i) => {
+                        const val = formatCellValue(key, row[key]);
+                        const text =
+                            i === 0 ? (val.length > colWidths[0] ? val.slice(0, colWidths[0] - 3) + '...' : val) : val;
+                        return i === 0 ? text.padEnd(colWidths[i]) : text.padStart(colWidths[i]);
+                    })
+                    .join('  ') + '\n';
+        }
+    }
+
+    return table;
+}
+
+/**
+ * Validate that required Slack environment variables are set.
+ * @returns {{ channel: string, username: string, icon_url: string }}
+ */
+function requireSlackEnv() {
+    const channel = process.env.SLACK_CHANNEL;
+    const username = process.env.SLACK_USERNAME;
+    const icon_url = process.env.SLACK_ICON;
+
+    if (!channel) throw new Error('SLACK_CHANNEL is not set');
+    if (!username) throw new Error('SLACK_USERNAME is not set');
+    if (!icon_url) throw new Error('SLACK_ICON is not set');
+
+    return { channel, username, icon_url };
+}
+
+module.exports = {
+    formatPercentageChange,
+    formatTable,
+    requireSlackEnv,
+};

--- a/tools/benchmark/run-browser-benchmarks.sh
+++ b/tools/benchmark/run-browser-benchmarks.sh
@@ -51,7 +51,7 @@ trap cleanup EXIT INT TERM
 
 echo "Starting dev server on port $PORT..."
 cd "$REPO_ROOT"
-PORT="$PORT" npx nx dev ag-charts-website &
+PUBLIC_SITE_URL="http://localhost:$PORT" PUBLIC_HTTPS_SERVER=false PORT="$PORT" npx nx dev ag-charts-website &
 SERVER_PID=$!
 
 echo "Waiting for dev server at http://localhost:$PORT..."


### PR DESCRIPTION
## Summary

Adds browser-based benchmark comparison to the CI pipeline, running alongside existing Jest benchmarks. This addresses the disconnect between Node.js benchmark results and real in-browser performance that led to regressions being missed during release testing.

### New files
- **`tools/benchmark/format-utils.js`** — shared formatting utilities (extracted from `format-slack-message.js`)
- **`tools/benchmark/compare-browser-results.js`** — compares two browser benchmark JSON reports, produces ranked timing tables
- **`tools/benchmark/format-browser-slack-message.js`** — formats comparison results as Slack Block Kit JSON
- **`tools/benchmark/compare-browser-latest.sh`** — CI orchestrator: benchmarks HEAD and base branch (via git worktree), then compares

### Modified files
- **`tools/benchmark/format-slack-message.js`** — refactored to use shared `format-utils.js`
- **`.github/workflows/benchmark.yml`** — Playwright install, browser benchmark steps, split PR comment/Slack reporting, artifacts

### Architecture
- `browser-benchmark.ts` always runs from the HEAD working directory (single Playwright install)
- Base branch built in a git worktree with shared Nx cache
- Strictly sequential dev server lifecycle (start → benchmark → stop per branch)
- PR comments show browser results as primary, Jest in collapsible `<details>`
- Overnight Slack gets separate Jest and browser benchmark messages

## Test plan
- [x] Syntax checks pass for all new/modified files
- [x] Smoke test: comparison script with synthetic data (including division-by-zero edge case)
- [x] Smoke test: Slack formatter produces valid Block Kit JSON
- [ ] Manual `workflow_dispatch` trigger to verify end-to-end CI flow
- [ ] `/benchmarks` PR comment trigger to verify PR reporting
- [ ] Overnight scheduled run to verify Slack `#charts-performance` output

AG-16452