### PR TITLE
Improve skill quality: link verification, plunker/jira/batch-plunker guardrails

### DIFF
--- a/.rulesync/rules/link-verification.md
+++ b/.rulesync/rules/link-verification.md
@@ -1,0 +1,20 @@
+---
+targets: ['*']
+description: 'Verify all URLs before including them in documents, plans, or analysis files'
+globs: ['plans/**/*.md', 'packages/ag-charts-website/src/content/docs/**/*.mdoc']
+---
+
+# Link Verification
+
+Before adding any URL to a document, plan, analysis file, or any other written output, verify it is reachable. A broken link undermines the credibility of the entire document, and finding dead links after the fact wastes time.
+
+## Verification Process
+
+1. **Fetch every URL** with `WebFetch` before including it. If the page loads (2xx or 3xx), the link is good.
+2. **If the response is 403** (bot protection / WAF), the site is blocking automated requests. Fall back to the Chrome browser extension MCP tools (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__read_page`) to verify the page loads in a real browser.
+3. **If the URL is a genuine 404**, do not include it. Search for the correct/current URL instead — pages move, domains change, docs get restructured. If no replacement can be found, either remove the link or mark it visibly as dead (e.g., `~~https://example.com/old-page~~ (dead link)`).
+4. **If the URL redirects** (301/302), update it to the final destination URL so readers don't depend on a redirect that may eventually break.
+
+## Scope
+
+This applies to every URL you write into a file — documentation links, reference URLs, Plunker links, GitHub issue links, blog posts, forum threads, and external product pages. It does not apply to URLs you output only in conversation (though verifying those is still good practice).

--- a/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
+++ b/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
@@ -62,7 +62,13 @@ Ask the user which CDN to use (staging vs versioned). Then resolve enterprise vs
 
 Record the resolved CDN URL for each assignment so sub-agents don't waste time discovering this themselves.
 
-### 2c. Launch Sub-Agents
+### 2c. Pre-flight Permission Check
+
+Before launching sub-agents, verify Bash and Write tools are available by running a trivial command (e.g., `echo "permission check"`). Sub-agents running in the background cannot prompt the user for tool approval — they silently fail.
+
+**If Bash or Write is denied:** Skip sub-agents entirely. Instead, create all plunkers sequentially in the main thread — create temp dirs, write files, copy CSS, and upload via `plnkr.sh` directly. Still follow Steps 2a–2b for context and CDN resolution, and Steps 3–4 for output and JIRA posting.
+
+### 2d. Launch Sub-Agents
 
 Launch one `general-purpose` Task sub-agent per assignment, **all in a single message** so they run concurrently. Use `run_in_background: true` on each.
 
@@ -90,7 +96,7 @@ Create a Plunker for the following assignment:
 ## Instructions
 
 1. Create a working directory: `PLNKR_DIR=$(mktemp -d /tmp/plnkr-batch-{PLUNKER_NUMBER}-XXXXXX)`
-2. If the assignment involves non-trivial APIs, verify them against `packages/ag-charts-types/src` before writing files
+2. **MANDATORY: Verify ALL API options** against `packages/ag-charts-types/src` before writing files. Grep for every option name, confirm nesting and value shapes. If not found in types, search for a working example in `packages/ag-charts-website/src/content/docs/*/_examples/`. Training data is unreliable — do NOT guess option names or structures
 3. Write all files per the product guide below (index.html, main.js, ag-example-styles.css, package.json, and optionally data.js)
 4. Upload: `bash "{ABSOLUTE_PATH_TO_PLNKR_SH}" upload "$PLNKR_DIR" --title "{TITLE}" --tags "ag-charts,qa"`
 5. Report the URL= line from the upload output
@@ -135,6 +141,10 @@ After collecting all results, mark every background task as completed using `Tas
 ## STEP 4 (Optional): Post Results to JIRA
 
 If the input was a JIRA ticket (Mode A), offer to post the results as a comment on the source ticket.
+
+**⚠️ This step applies whether you used sub-agents or created plunkers manually in the main thread. Always follow the ADF structure below when posting to JIRA — there is no shortcut.**
+
+**⚠️ The Atlassian MCP has no delete-comment tool. Get the format right on the first attempt — re-posting creates duplicates that must be cleaned up manually.**
 
 Use `contentFormat: "adf"` with `mcp__atlassian__addCommentToJiraIssue`. JIRA's markdown renderer does not reliably auto-link URLs, so you must use ADF with explicit link marks to guarantee clickable links. Never use markdown format or tables for this comment — ADF bullet lists are the only format that reliably renders clickable URLs in JIRA.
 

--- a/external/ag-shared/prompts/skills/jira/products/charts.md
+++ b/external/ag-shared/prompts/skills/jira/products/charts.md
@@ -34,6 +34,15 @@ When creating bug tickets, test affected versions **from the browser** (not by a
 2. Binary search versions to find when the bug was introduced.
 3. Set `versions` field to earliest affected version.
 
+## Design Document Links
+
+When linking to PRDs or design decisions in ticket descriptions, use the external URL pattern — not GitHub URLs:
+
+- **Correct:** `[Data Point Selection PRD](https://docs.ag-grid.com/design-decisions/charts/AG-5158-data-point-selection)`
+- **Incorrect:** `https://github.com/ag-grid/ag-grid-documentation/blob/latest/docs/design-decisions/charts/...`
+
+The base URL is `https://docs.ag-grid.com/design-decisions/charts/` followed by the folder name.
+
 ## Estimation Calibration Data
 
 Use these baseline estimates for common AG Charts work items:

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -83,6 +83,8 @@ Use the `mcp__atlassian__createJiraIssue` tool. Substitute component, prefix, an
 }
 ```
 
+**When the description references other JIRA tickets** (dependencies, related work, split-from context), you **must** use `contentFormat: "adf"` instead of `"markdown"` and construct the full ADF document with `inlineCard` nodes for each ticket reference. Markdown format cannot produce Smart Links. See the "Description Formatting" section below for the `inlineCard` syntax.
+
 **For Bug and Improvement tickets, also include:**
 
 ```json

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -65,7 +65,20 @@ When creating a **Sub-task** (issue type `"Sub-task"` with a `parent` field):
 
 ## Step 3: Create the Ticket
 
-Use the `mcp__atlassian__createJiraIssue` tool. Substitute component, prefix, and project from the product file:
+Use the `mcp__atlassian__createJiraIssue` tool. Substitute component, prefix, and project from the product file.
+
+### Choose content format
+
+Pick the format **before** writing the description — it determines how you structure the entire payload:
+
+| Description mentions other JIRA tickets? | Format | Why |
+|------------------------------------------|--------|-----|
+| **Yes** (dependencies, related work, parent context) | `contentFormat: "adf"` | Only ADF supports `inlineCard` Smart Links. Markdown cannot render them. |
+| **No** (standalone bug report, no cross-references) | `contentFormat: "markdown"` | Simpler to write; no ticket references to render. |
+
+Most feature, subtask, and tech-debt tickets reference other tickets, so **ADF is the common case**. See the "Description Formatting" section for the `inlineCard` syntax.
+
+### API call structure
 
 ```json
 {
@@ -73,8 +86,8 @@ Use the `mcp__atlassian__createJiraIssue` tool. Substitute component, prefix, an
     "projectKey": "<from product file>",
     "issueTypeName": "Bug|Task",
     "summary": "[<Prefix>] Clear, concise title",
-    "description": "Formatted description from template",
-    "contentFormat": "markdown",
+    "description": "<formatted description — ADF document or markdown string>",
+    "contentFormat": "<adf or markdown — see table above>",
     "additional_fields": {
         "components": [{ "name": "<from product file>" }],
         "priority": { "name": "Medium" },
@@ -82,8 +95,6 @@ Use the `mcp__atlassian__createJiraIssue` tool. Substitute component, prefix, an
     }
 }
 ```
-
-**When the description references other JIRA tickets** (dependencies, related work, split-from context), you **must** use `contentFormat: "adf"` instead of `"markdown"` and construct the full ADF document with `inlineCard` nodes for each ticket reference. Markdown format cannot produce Smart Links. See the "Description Formatting" section below for the `inlineCard` syntax.
 
 **For Bug and Improvement tickets, also include:**
 

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -45,12 +45,23 @@ Based on ticket type, read the relevant template (in the `templates/` subdirecto
 - [ ] API design (if applicable).
 - [ ] Acceptance criteria.
 
+When the user provides requirements that differ from existing PRDs or design documents, the user's stated requirements take precedence. Confirm requirements with the user before drafting — do not assume PRD content is final.
+
 **For Tech-debt tickets, collect:**
 
 - [ ] Context (why this work is needed).
 - [ ] Problem statement.
 - [ ] Proposed solution.
 - [ ] Acceptance criteria.
+
+## Subtask Rules
+
+When creating a **Sub-task** (issue type `"Sub-task"` with a `parent` field):
+
+1. **Track is always `Housekeeping`** — the parent ticket carries the feature/bug track. Subtasks are internal work items.
+2. **No "split from" issue link** — the parent field already provides this relationship. Do not create a redundant "Work item split" link.
+3. **Description format** — trivial or placeholder subtasks use bold headings + bullets. Subtasks with full requirements detail use the numbered template from `templates/feature-task.md`.
+4. **fixVersion from user input** — when the user provides a version number (e.g., `35.3`) alongside priority/status, this is the **fixVersion** (`fixVersions: [{"name": "35.3.0"}]`), not story points. Append `.0` if the user gives a two-part version.
 
 ## Step 3: Create the Ticket
 
@@ -112,7 +123,13 @@ Bug descriptions should be concise: test cases + notes only. Do not add acceptan
 
 After the ticket is created, perform these steps as applicable:
 
-**1. Transition to "To Do" (only if a fixVersion was provided)**
+**1. Set fixVersion (if provided)**
+
+When the user provides a version number (e.g., `35.3`) alongside other ticket fields, set it as `fixVersions`. Append `.0` if the user gives a two-part version (e.g., `35.3` → `"35.3.0"`). This is never story points — it is always fixVersion.
+
+If `fixVersions` couldn't be set during creation (e.g., field not on create screen), use `mcp__atlassian__editJiraIssue` to set it after creation.
+
+**2. Transition to "To Do" (only if a fixVersion was provided)**
 
 If the user specified a fix version, transition the ticket out of Backlog immediately:
 
@@ -125,11 +142,13 @@ mcp__atlassian__transitionJiraIssue
 
 If no fixVersion was set, leave the ticket in Backlog.
 
-**2. Create issue links (if applicable)**
+**3. Create issue links (if applicable)**
 
 If this ticket was split off from another, or blocks/is blocked by another ticket, create the link using `mcp__atlassian__createIssueLink`. Do not put ticket references only in the description text — use a formal link.
 
-For "split from" links, see the "Issue Link Direction" section below for correct inward/outward usage.
+**Exception:** Do not create "split from" links for subtasks — the parent field already provides this relationship.
+
+For "split from" links on non-subtask tickets, see the "Issue Link Direction" section below for correct inward/outward usage.
 
 ## Completion Checklist
 
@@ -143,6 +162,7 @@ For "split from" links, see the "Issue Link Direction" section below for correct
 - [ ] For Bug and Improvement tickets: Affects Version included.
 - [ ] For Bug and Improvement tickets: Bug template used (reproduction steps, actual/expected).
 - [ ] URLs use explicit markdown link syntax `[url](url)` — bare URLs are not clickable in JIRA.
+- [ ] JIRA ticket references in description use ADF `inlineCard` Smart Links — not markdown links or bare keys.
 - [ ] If fixVersion was provided: ticket transitioned from Backlog to "To Do".
 - [ ] Issue links created (if split-off or related tickets exist).
 
@@ -158,6 +178,7 @@ Think of it as: the **inward** issue is the one being referenced ("split **from*
 
 ## Description Formatting
 
+- **JIRA ticket references must be Smart Links:** When referencing other JIRA tickets in description text, use ADF `inlineCard` nodes — these render as expanded Smart Links showing the ticket title and icon. Neither bare ticket keys (`AG-1234`) nor markdown links (`[AG-1234](url)`) expand into Smart Links. To create Smart Links: submit the description using `contentFormat: "adf"` with `{"type": "inlineCard", "attrs": {"url": "https://ag-grid.atlassian.net/browse/AG-1234"}}` inline in paragraph content. This applies everywhere a ticket is mentioned: dependencies, notes, parenthetical references, etc.
 - **Inline code for option names:** Always wrap API option names, property names, and programmatic values in backticks (e.g., `enableRtl`, `skipNullBars: true`, `bar`). This distinguishes code from prose and improves readability.
 - **Series type references:** When referencing series types, use backtick-wrapped type values (e.g., `bar`) rather than informal names like "bar/column".
 
@@ -171,3 +192,4 @@ Think of it as: the **inward** issue is the one being referenced ("split **from*
 6. **Improvement = internally reported bug** — Always use the bug template for Improvement tickets, not the feature/task template.
 7. **Inline code for options** — Always wrap API option/property names in backticks in descriptions.
 8. **URLs must be explicit markdown links** — Bare URLs are NOT clickable in JIRA. Always write `[https://url](https://url)`, never just `https://url`.
+9. **JIRA ticket references must be Smart Links** — Use ADF `inlineCard` nodes, not markdown links or bare keys. Only `inlineCard` renders as an expanded Smart Link with the ticket title.

--- a/external/ag-shared/prompts/skills/plunker/SKILL.md
+++ b/external/ag-shared/prompts/skills/plunker/SKILL.md
@@ -46,13 +46,14 @@ This ensures the implementation step uses the correct CDN URLs, CSS, and API pat
 ### Create a New Plunker
 
 1. Create a working directory: `PLNKR_DIR=$(mktemp -d /tmp/plnkr-new-XXXXXX)`
-2. Copy the CSS asset: `cp "<skill-base-directory>/assets/ag-example-styles.css" "$PLNKR_DIR/ag-example-styles.css"`
-3. Write remaining files per the product-specific guide (index.html, main.js, package.json, etc.)
-4. Upload:
+2. **Verify API options** — before writing any chart code, grep `packages/ag-charts-types/src` to confirm every option name, nesting structure, and value shape you plan to use. Training data is unreliable for AG Charts APIs. If you cannot find a property in `ag-charts-types`, search for a working example in `packages/ag-charts-website/src/content/docs/*/_examples/` that uses the same feature. Do not guess.
+3. Copy the CSS asset: `cp "<skill-base-directory>/assets/ag-example-styles.css" "$PLNKR_DIR/ag-example-styles.css"`
+4. Write remaining files per the product-specific guide (index.html, main.js, package.json, etc.)
+5. Upload:
    ```bash
    bash "<skill-base-directory>/plnkr.sh" upload "$PLNKR_DIR" --title "Example Title"
    ```
-5. Parse output for `URL=` — the shareable link.
+6. Parse output for `URL=` — the shareable link.
 
 ### Fork/Modify an Existing Plunker
 
@@ -101,6 +102,18 @@ The gist must contain an `index.html` file. Plnkr reads the gist files directly 
 -   No true fork endpoint — "fork" = download + modify + upload as new.
 -   Access tokens are short-lived JWTs; the script manages them internally.
 -   Only the plunk creator can update (using the private token from creation).
+
+## Quick Checklist — Do NOT Rely on Training Data
+
+These are the most commonly violated rules. Training data will lead you astray on every one of them.
+
+1. **Verify every API option** — grep `packages/ag-charts-types/src` to confirm option names, nesting, and value shapes BEFORE writing `main.js`. If unsure, find a working example in `packages/ag-charts-website/src/content/docs/*/_examples/`. Do NOT guess option names from training data — they are frequently wrong (e.g., `rangeButtons` vs `ranges`, `activeStyle` vs `active`, `color` vs `textColor`).
+2. **UMD bundle via `<script>`** — NOT ESM `import`. Use `<script src="https://cdn.jsdelivr.net/npm/ag-charts-community@13.0.0/dist/umd/ag-charts-community.js"></script>`
+3. **UMD global** — `const { AgCharts } = agCharts;` in `main.js`. NOT `import { AgCharts } from '...'`
+4. **Inline onclick handlers** — `<button onclick="myFunction()">` in HTML. NOT `addEventListener` in JS
+5. **Top-level functions** — event handler functions must be top-level in `main.js`, not closures or arrow functions assigned to variables
+6. **No description elements** — no `<h1>`, `<p>`, or explanatory text in the HTML body. Use chart `title`/`subtitle` options instead
+7. **No module registration** — UMD bundles auto-register all modules. Do NOT call `ModuleRegistry.registerModules()` or `AgCharts.setupModules()`
 
 ## Product-Specific Guide
 

--- a/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
+++ b/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
@@ -189,6 +189,7 @@ In `index.html`, add `<script src="data.js"></script>` **before** `<script src="
 | Styling issues | Missing inline styles in index.html | Add the `<style>` block in `<head>` |
 | Layout breaks | Extra HTML elements in body | Remove all elements except controls + `<div id="myChart">` |
 | Wrong UMD global | Using `agChartsEnterprise`/`agChartsCommunity` | Always use `agCharts` — `const { AgCharts } = agCharts;` |
-| Update API error | Using `AgCharts.update(chart, opts)` | Use instance method: `chart.update(options)` (v13+) |
+| Update API error | Using `AgCharts.update(chart, opts)` | Use instance method: `chart.update(options)` for full replacement (v13+) |
+| Partial update wipes options | Using `chart.update({ data: newData })` without full options | Use `chart.updateDelta({ data: newData })` for partial/delta updates |
 | Container not found | Using string selector `'#myChart'` | Use `document.getElementById('myChart')` |
 | Controls break chart layout | Chart div nested inside controls div | `<div id="myChart">` must be a **sibling** outside `<div class="example-controls">` |


### PR DESCRIPTION
## Summary
- **Link verification rule**: Require URL validation (WebFetch or Chrome fallback) before including links in documents/plans
- **Batch-plunkers**: Pre-flight permission check to prevent silent sub-agent failures; mandatory API verification in sub-agent prompts
- **Plunker**: Mandatory API verification step before writing code; quick checklist of commonly violated rules; `updateDelta` guidance for partial updates
- **JIRA**: Subtask conventions (Housekeeping track, no split-from link); fixVersion handling; Smart Link (`inlineCard`) requirements; design document URL pattern

## Companion PRs
- ag-charts-prompts: https://github.com/ag-grid/ag-charts-prompts/pull/26

## Test plan
- [ ] Run `/plunker` and verify API verification step is followed
- [ ] Run `/batch-plunkers` and verify pre-flight permission check occurs
- [ ] Create a JIRA subtask and verify Housekeeping track + no split-from link
- [ ] Verify link verification rule triggers on document/plan file edits