### PR TITLE
Fix ag-grid integration test for unpublished beta versions

### DIFF
--- a/tools/integration/set-charts-dep-paths.js
+++ b/tools/integration/set-charts-dep-paths.js
@@ -106,17 +106,18 @@ function addResolutions(rootPkgJsonPath, tarballs) {
         pkg.resolutions = {};
     }
 
-    let added = 0;
+    let changed = false;
     for (const [name, tarballPath] of Object.entries(tarballs)) {
-        if (!pkg.resolutions[name]) {
-            added++;
+        const value = `file:${tarballPath}`;
+        if (pkg.resolutions[name] !== value) {
+            pkg.resolutions[name] = value;
+            changed = true;
         }
-        pkg.resolutions[name] = `file:${tarballPath}`;
     }
 
-    if (added > 0) {
+    if (changed) {
         fs.writeFileSync(rootPkgJsonPath, JSON.stringify(pkg, null, 2) + '\n');
-        console.log(`Added ${added} resolution(s) to: ${rootPkgJsonPath}`);
+        console.log(`Updated resolutions in: ${rootPkgJsonPath}`);
     }
 }
 

--- a/tools/integration/set-charts-dep-paths.js
+++ b/tools/integration/set-charts-dep-paths.js
@@ -98,6 +98,28 @@ function replaceVersions(pkgJsonPath, tarballs) {
     return modified;
 }
 
+function addResolutions(rootPkgJsonPath, tarballs) {
+    const content = fs.readFileSync(rootPkgJsonPath, 'utf8');
+    const pkg = JSON.parse(content);
+
+    if (!pkg.resolutions) {
+        pkg.resolutions = {};
+    }
+
+    let added = 0;
+    for (const [name, tarballPath] of Object.entries(tarballs)) {
+        if (!pkg.resolutions[name]) {
+            added++;
+        }
+        pkg.resolutions[name] = `file:${tarballPath}`;
+    }
+
+    if (added > 0) {
+        fs.writeFileSync(rootPkgJsonPath, JSON.stringify(pkg, null, 2) + '\n');
+        console.log(`Added ${added} resolution(s) to: ${rootPkgJsonPath}`);
+    }
+}
+
 function main() {
     const [agGridRoot, tarballDir] = process.argv.slice(2);
 
@@ -137,6 +159,13 @@ function main() {
             updatedCount++;
         }
     }
+
+    // Ensure root package.json has resolutions for all ag-charts packages.
+    // This forces yarn to resolve transitive dependencies (e.g. ag-charts-community
+    // depending on ag-charts-core) to the local tarballs rather than looking them
+    // up on the registry, where pre-release versions may not exist.
+    const rootPkgJsonPath = path.join(resolvedRoot, 'package.json');
+    addResolutions(rootPkgJsonPath, tarballs);
 
     console.log(`Updated ${updatedCount} package.json files`);
 }


### PR DESCRIPTION
## Summary

- Add yarn `resolutions` to ag-grid's root `package.json` for all ag-charts packages during integration test setup
- Fixes the "Integrated Charts Pre-Integration Test" which has been failing since March 30

## Problem

After the 13.2.0 release prep, the `latest` branch packages were bumped to `13.2.0-beta.20260329`. The packed tarballs contain inter-package dependencies at that version (e.g. `ag-charts-community` depends on `ag-charts-core@13.2.0-beta.20260329`). When yarn installs these tarballs into ag-grid, it resolves the tarball's internal deps from the registry — where the beta version doesn't exist.

Previously this worked because the version was `13.2.0` (a released version available on the registry).

## Fix

The `set-charts-dep-paths.js` script now adds yarn `resolutions` to ag-grid's root `package.json`, forcing **all** references to ag-charts packages — including transitive dependencies from inside the tarballs — to resolve to the local `file:` paths.

## Test plan

- [x] Tested locally with mock ag-grid workspace structures
- [ ] Verify by re-running the integration test workflow after merge