### PR TITLE
Simplify UnitTimeScale tick generation and interval type checks

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
@@ -31,6 +31,7 @@ import {
     normalizeAngle360FromDegrees,
     toPlainText,
     toTextString,
+    toTimeInterval,
     wrapTextOrSegments,
 } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit, DateFormatterStyle, TextOrSegments } from 'ag-charts-types';
@@ -125,9 +126,7 @@ function createTimeScaleTicks(
     }
 
     if (typeof interval !== 'number') {
-        const epoch = domain[0];
-        const alignedInterval: AgTimeInterval =
-            typeof interval === 'string' ? { unit: interval, epoch } : { ...interval, epoch };
+        const alignedInterval: AgTimeInterval = { ...toTimeInterval(interval), epoch: domain[0] };
         return intervalRange(alignedInterval, domain[0], domain[1], { visibleRange, extend });
     }
 
@@ -404,13 +403,19 @@ export function getTimeIntervalTicks<S extends Scale<D, number, TickInterval<S>>
             case ParentLevelMode.ContinuousTimeScaleTicks:
                 intervalTicks = createTimeScaleTicks(intervalTickParams.interval, [p0, p1], pVisibleRange, true);
                 break;
-            case ParentLevelMode.UnitTimeScaleTicks:
-            case ParentLevelMode.OrdinalTimeScaleTicks: {
-                const scaleTicks = scale.ticks(intervalTickParams, [p0, p1], pVisibleRange, {
-                    extend: true,
-                    dropInitial: true,
-                });
+            case ParentLevelMode.UnitTimeScaleTicks: {
+                const scaleTicks = scale.ticks(intervalTickParams, [p0, p1], pVisibleRange);
                 intervalTicks = scaleTicks?.ticks ?? [];
+                break;
+            }
+            case ParentLevelMode.OrdinalTimeScaleTicks: {
+                const ordinalTicks = (scale as unknown as OrdinalTimeScale).ticks(
+                    intervalTickParams,
+                    [p0, p1],
+                    pVisibleRange,
+                    { extend: true, dropInitial: true }
+                );
+                intervalTicks = ordinalTicks?.ticks ?? [];
                 break;
             }
             case ParentLevelMode.OrdinalTimeStepTicks:

--- a/packages/ag-charts-community/src/scale/discreteTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/discreteTimeScale.ts
@@ -59,8 +59,7 @@ export abstract class DiscreteTimeScale extends BandScale<Date, AgTimeInterval |
     abstract override ticks(
         params: ScaleTickParams<AgTimeInterval | AgTimeIntervalUnit | number>,
         domain?: Date[],
-        visibleRange?: [number, number],
-        options?: { extend?: boolean; dropInitial?: boolean }
+        visibleRange?: [number, number]
     ): { ticks: Date[]; count: number | undefined; firstTickIndex?: number } | undefined;
 
     override toDomain(value: number): Date {

--- a/packages/ag-charts-community/src/scale/timeScale.ts
+++ b/packages/ag-charts-community/src/scale/timeScale.ts
@@ -8,7 +8,6 @@ import {
     intervalRangeStartIndex,
     intervalStep,
     isDenseInterval,
-    isPlainObject,
 } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
 
@@ -146,7 +145,7 @@ export function getDateTicksForInterval({
         return [];
     }
 
-    if (isPlainObject(interval) || typeof interval === 'string') {
+    if (typeof interval !== 'number') {
         const ticks = intervalRange(interval, new Date(start), new Date(stop), { visibleRange, extend });
         if (isDenseInterval(ticks.length, availableRange)) {
             return;
@@ -195,7 +194,7 @@ function updateNiceDomainIteration(
 
     let i: AgTimeInterval | AgTimeIntervalUnit | undefined;
 
-    if (isPlainObject(interval) || typeof interval === 'string') {
+    if (interval != null && typeof interval !== 'number') {
         i = interval;
     } else {
         let tickCount: number | undefined;

--- a/packages/ag-charts-community/src/scale/unitTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.ts
@@ -18,7 +18,7 @@ import {
     intervalRange,
     intervalRangeCount,
     intervalRangeNumeric,
-    isPlainObject,
+    toTimeInterval,
 } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
 
@@ -74,15 +74,15 @@ export class UnitTimeScale extends DiscreteTimeScale {
         return this._domain;
     }
 
-    /* eslint-disable sonarjs/use-type-alias */
-    private _interval: AgTimeInterval | AgTimeIntervalUnit | undefined;
-    get interval(): AgTimeInterval | AgTimeIntervalUnit | undefined {
+    private _interval: AgTimeInterval | undefined;
+    get interval(): AgTimeInterval | undefined {
         return this._interval;
     }
     set interval(interval: AgTimeInterval | AgTimeIntervalUnit | undefined) {
-        if (this._interval === interval) return;
+        const normalized = interval == null ? undefined : toTimeInterval(interval);
+        if (this._interval?.unit === normalized?.unit && this._interval?.step === normalized?.step) return;
 
-        this._interval = interval;
+        this._interval = normalized;
         this.invalidateCaches();
     }
 
@@ -339,8 +339,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
     override ticks(
         { interval }: ScaleTickParams<AgTimeInterval | AgTimeIntervalUnit | number>,
         domain: Date[] = this.domain,
-        visibleRange: [number, number] = [0, 1],
-        { extend = false } = {}
+        visibleRange: [number, number] = [0, 1]
     ): ScaleTickResult<Date> | undefined {
         const numBands = this.numericBands;
         if (numBands.length === 0 || domain.length < 2) return;
@@ -349,7 +348,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
         const d1 = Math.max(domain[0].valueOf(), domain[1].valueOf());
 
         // Compute the band index range for the requested domain + visibleRange
-        const [iStart, iEnd] = this.visibleBandRange(d0, d1, visibleRange, extend);
+        const [iStart, iEnd] = this.visibleBandRange(d0, d1, visibleRange);
 
         // No interval — return all bands in range
         if (interval == null) {
@@ -372,12 +371,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
     }
 
     /** Compute band slice indices for a domain range + visible range. */
-    private visibleBandRange(
-        d0: number,
-        d1: number,
-        visibleRange: [number, number],
-        extend: boolean
-    ): [number, number] {
+    private visibleBandRange(d0: number, d1: number, visibleRange: [number, number]): [number, number] {
         const numBands = this.numericBands;
         const n = numBands.length;
         if (n === 0) return [0, 0];
@@ -386,13 +380,8 @@ export class UnitTimeScale extends DiscreteTimeScale {
         const windowStart = d0 + visibleRange[0] * span;
         const windowEnd = d0 + visibleRange[1] * span;
 
-        let iStart = findMaxIndex(0, n - 1, (i) => numBands[i] <= windowStart) ?? 0;
-        let iEnd = (findMinIndex(0, n - 1, (i) => numBands[i] >= windowEnd) ?? n - 1) + 1;
-
-        if (extend) {
-            iStart = Math.max(0, iStart - 1);
-            iEnd = Math.min(n, iEnd + 1);
-        }
+        const iStart = findMaxIndex(0, n - 1, (i) => numBands[i] <= windowStart) ?? 0;
+        const iEnd = (findMinIndex(0, n - 1, (i) => numBands[i] >= windowEnd) ?? n - 1) + 1;
 
         return [iStart, iEnd];
     }
@@ -403,7 +392,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
         domain: Date[],
         visibleRange: [number, number]
     ): number[] {
-        if (isPlainObject(interval) || typeof interval === 'string') {
+        if (typeof interval !== 'number') {
             return intervalRange(interval, domain[0], domain[1], { extend: true, visibleRange }).map((d) =>
                 d.valueOf()
             );

--- a/packages/ag-charts-core/src/utils/time/time/index.ts
+++ b/packages/ag-charts-core/src/utils/time/time/index.ts
@@ -49,6 +49,11 @@ export function intervalMilliseconds(interval: AgTimeInterval | AgTimeIntervalUn
     return step * unitEncoding[intervalUnit(interval)].milliseconds;
 }
 
+/** Normalise AgTimeIntervalUnit string to AgTimeInterval object. */
+export function toTimeInterval(interval: AgTimeInterval | AgTimeIntervalUnit): AgTimeInterval {
+    return typeof interval === 'string' ? { unit: interval } : interval;
+}
+
 const intervals = ['millisecond', 'second', 'minute', 'hour', 'day', 'month', 'year'];
 export function isTimeInterval(value: unknown): value is AgTimeInterval {
     if (!isPlainObject(value)) return false;


### PR DESCRIPTION
Normalise calendar interval types early via `toTimeInterval()`, replace `isPlainObject || typeof === 'string'` checks with `typeof !== 'number'`, and remove extend parameter from `UnitTimeScale` by splitting the hierarchical tick case.