### PR TITLE
Fix benchmark version checkout leaving orphan files from HEAD

### DIFF
--- a/tools/benchmark/collect-version-benchmark.sh
+++ b/tools/benchmark/collect-version-benchmark.sh
@@ -213,13 +213,15 @@ for version in "${versions[@]}"; do
     # Checkout files in the specified input file set (removing any files that have been added since then)
     # Note: Using git checkout instead of git restore to handle case-sensitive filename changes on macOS
     run_silent git checkout "$version" -- ${included_files[@]}
+    # Remove files that exist on HEAD but not in the target version (e.g., newly added files)
+    run_silent git clean -fd -- ${included_files[@]}
     build ${version}
     # Benchmark
     benchmark ${version}
     # Reset the working tree and staging area to HEAD state
     run_silent git checkout HEAD -- ${included_files[@]}
     run_silent git reset HEAD -- ${included_files[@]}
-    # Remove any files that don't exist in HEAD (e.g., files only in old versions)
+    # Remove any files that don't exist in HEAD (e.g., files only in the target version)
     run_silent git clean -fd -- ${included_files[@]}
 done
 


### PR DESCRIPTION
## Summary

- Fix nightly benchmark CI failures caused by orphan files remaining after `git checkout <old-version>` during version comparison
- When checking out an older release branch's source files, `git checkout <ref> -- <dirs>` replaces existing files but doesn't remove files that only exist on HEAD — added `git clean -fd` after checkout to clean these up
- This has been breaking nightly benchmarks since `b13.2.0` was cut (new files like `colorScaleUtil.ts` on `latest` import types not present in the release branch's `ag-charts-types`)

## Test plan

- [ ] Re-run nightly benchmark workflow to verify it completes successfully against `b13.2.1`