### PR TITLE
Fix legend hover clearing active state after setState restore

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1426,7 +1426,6 @@ export class SeriesAreaManager extends BaseManager {
 
     private onLegendHover(_event: null): void {
         if (!this.isState(InteractionState.Hoverable)) return;
-        this.setHoverDevice('pointer');
         this.clearCachedEvents();
         this.chart.ctx.highlightManager.updateHighlight(this.id, undefined);
         this.chart.ctx.tooltipManager.removeTooltip(this.id, undefined);


### PR DESCRIPTION
## Summary

- Remove `setHoverDevice('pointer')` from `seriesAreaManager.onLegendHover()` to fix 4 failing E2E tests (`frozen-legendtoggle` thawed variants)
- The `onLegendHover` handler (added in #6174) was changing `hoverDevice` from `'setState'` to `'pointer'`, which altered downstream active state management during chart updates, causing a spurious `activeChange` event that cleared the active item after a legend visibility toggle

## Test plan

- [x] `yarn nx test ag-charts-community` — 3241 passed
- [x] `yarn nx test ag-charts-enterprise` — 1843 passed
- [ ] CI E2E `frozen-legendtoggle` tests should pass (shard 16/16)