### PR TITLE
Sync ag-shared (2026-04-02): drop simplify from canary list

### DIFF
--- a/.rulesync/rules/ag-charts.md
+++ b/.rulesync/rules/ag-charts.md
@@ -49,11 +49,11 @@ After meaningful chart changes, also run:
 
 On the **first response** of a conversation, verify that project skills are available by checking the system-reminder skill list. If **any** of the canary skills are missing, display a one-time warning before doing anything else. Do not repeat the warning on subsequent responses.
 
-**Canary skills:** `example`, `dev-server`, `debug`, `git-conventions`, `jira`, `simplify`
+**Canary skills:** `example`, `dev-server`, `debug`, `git-conventions`, `jira`
 
 **Warning to display (if any canary skill is missing):**
 
-> **Agentic tooling is not initialised.** Expected skills (example, dev-server, debug, git-conventions, jira, simplify) are missing or incomplete. Run `yarn` from the repository root to set up AI tooling configuration, then restart your session. If you are in a worktree, ensure you ran `yarn` in the worktree directory (not just the main checkout).
+> **Agentic tooling is not initialised.** Expected skills (example, dev-server, debug, git-conventions, jira) are missing or incomplete. Run `yarn` from the repository root to set up AI tooling configuration, then restart your session. If you are in a worktree, ensure you ran `yarn` in the worktree directory (not just the main checkout).
 
 Continue assisting the user after displaying the warning.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,11 @@ After meaningful chart changes, also run:
 
 On the **first response** of a conversation, verify that project skills are available by checking the system-reminder skill list. If **any** of the canary skills are missing, display a one-time warning before doing anything else. Do not repeat the warning on subsequent responses.
 
-**Canary skills:** `example`, `dev-server`, `debug`, `git-conventions`, `jira`, `simplify`
+**Canary skills:** `example`, `dev-server`, `debug`, `git-conventions`, `jira`
 
 **Warning to display (if any canary skill is missing):**
 
-> **Agentic tooling is not initialised.** Expected skills (example, dev-server, debug, git-conventions, jira, simplify) are missing or incomplete. Run `yarn` from the repository root to set up AI tooling configuration, then restart your session. If you are in a worktree, ensure you ran `yarn` in the worktree directory (not just the main checkout).
+> **Agentic tooling is not initialised.** Expected skills (example, dev-server, debug, git-conventions, jira) are missing or incomplete. Run `yarn` from the repository root to set up AI tooling configuration, then restart your session. If you are in a worktree, ensure you ran `yarn` in the worktree directory (not just the main checkout).
 
 Continue assisting the user after displaying the warning.
 

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = b22cd4baaa1c0aa6c1ad180492f33ce449348544
-	parent = a4a2ddf46691a53888baf424577d7ba8d63aa18b
+	commit = 1b8f44011b6d6fa91f7872bc1299379ea0f7e192
+	parent = 91f65ca9e359d77884e64af955164df66b07aae3
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 3243c892803bcafcd3367f4654c06023ab16c61e
-	parent = 180fd34728e204aacded62ebf359c0b674f60b7b
+	commit = b22cd4baaa1c0aa6c1ad180492f33ce449348544
+	parent = a4a2ddf46691a53888baf424577d7ba8d63aa18b
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 1b8f44011b6d6fa91f7872bc1299379ea0f7e192
-	parent = 91f65ca9e359d77884e64af955164df66b07aae3
+	commit = 817721d007de082e6bc4d5291bb045e1b0489c00
+	parent = 23dac7dc8bd77c419666ab0622978b6f1e9c6623
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 3aaa87ce8f589716e93a8c71abbe2ec50ae35a0e
-	parent = a019d56eec9b0673921cf885254ae52656b63891
+	commit = 3243c892803bcafcd3367f4654c06023ab16c61e
+	parent = 180fd34728e204aacded62ebf359c0b674f60b7b
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/prompts/guides/code-quality.md
+++ b/external/ag-shared/prompts/guides/code-quality.md
@@ -50,13 +50,13 @@ This guide covers code quality practices, including avoiding code bloat, comment
 ## Import Hygiene
 
 -   **No re-exports for internal APIs**: When moving code between internal packages, update every consumer to import from the new canonical location. Do not leave re-exports at the old path — they add indirection, obscure where code lives, and can hinder tree-shaking.
--   **Direct imports only**: Internal packages (`ag-charts-core`, `ag-charts-community`, `ag-charts-enterprise`) should import from the source package directly. Only `ag-charts-types` defines the user-facing API contract.
+-   **Direct imports only**: Internal packages should import from the source package directly. Only the public types package defines the user-facing API contract.
 -   **Type-only imports**: Use `import type` for types that are only needed at compile time — these are erased and have zero runtime cost.
 
 ## Refactoring Safety
 
 -   **Grep all consumers before removing/relocating exports**: Before removing or moving an export, search the entire codebase for all import sites. Pre-existing consumers outside the files you're modifying are easy to miss.
--   **Run `build:types` before committing**: After any export relocation, run type checks across affected packages (`ag-charts-core`, `ag-charts-community`, `ag-charts-enterprise`) to catch broken imports before they reach CI.
+-   **Run `build:types` before committing**: After any export relocation, run type checks across affected packages to catch broken imports before they reach CI.
 
 ## Self-Review Before Committing
 

--- a/external/ag-shared/prompts/skills/debug/SKILL.md
+++ b/external/ag-shared/prompts/skills/debug/SKILL.md
@@ -137,7 +137,7 @@ beyond this debugging session.
 ### Option B: E2E test
 
 ```bash
-yarn nx test:e2e ag-charts-website --testPathPattern='<test-file>'
+yarn nx test:e2e <e2e-package> --testPathPattern='<test-file>'
 ```
 
 Console output appears in the Playwright terminal output. For browser-side

--- a/external/ag-shared/prompts/skills/example/SKILL.md
+++ b/external/ag-shared/prompts/skills/example/SKILL.md
@@ -2,12 +2,9 @@
 name: example
 description: >-
   MUST load before creating or modifying any AG Charts, AG Grid, or AG Studio
-  code example — bar, line, pie, donut, treemap, or any chart type — whether
-  for gallery, docs, or Plunker. Contains required conventions that differ from
-  training data: v13 object-based axis syntax, ModuleRegistry registration,
-  enterprise module imports, specific chart option types, custom tooltip
-  renderers with heading rules. Also load when troubleshooting example issues
-  (empty tooltips, TypeScript errors, wrong axis format) or asking about
+  code example — whether for gallery, docs, or Plunker. Contains required
+  conventions that differ from training data. Also load when troubleshooting
+  example issues (TypeScript errors, rendering problems) or asking about
   example file structure and patterns.
 context: fork
 ---
@@ -18,7 +15,7 @@ This skill provides the foundational patterns for building examples across all A
 ## When to Use
 
 - Creating or modifying any example (gallery, docs, or Plunker)
-- Understanding chart construction patterns, module registration, or controls
+- Understanding construction patterns, module registration, or controls
 - Troubleshooting example issues (TypeScript errors, rendering problems)
 - Checking enterprise vs community feature requirements
 
@@ -32,45 +29,12 @@ Determine which product guide to load:
 
 ## Product Guides
 
-| Product | Guide Directory | Status |
-|---------|----------------|--------|
-| AG Charts | `.rulesync/skills/example/ag-charts/` | Complete |
-| AG Grid | `.rulesync/skills/example/ag-grid/` | Placeholder |
-| AG Studio | `.rulesync/skills/example/ag-studio/` | Placeholder |
+Each product has an `index.md` in its guide directory that describes which documents to load and when, plus product-specific critical rules.
 
-## AG Charts Sub-Documents
+| Product | Guide Directory | Index | Status |
+|---------|----------------|-------|--------|
+| AG Charts | `.rulesync/skills/example/ag-charts/` | `index.md` | Complete |
+| AG Grid | `.rulesync/skills/example/ag-grid/` | — | Placeholder |
+| AG Studio | `.rulesync/skills/example/ag-studio/` | — | Placeholder |
 
-### Core Documents (load as needed)
-
-| Document | Purpose | When to Load |
-|----------|---------|-------------|
-| `chart-construction.md` | Axes, modules, container, controls, updates | Always for new examples |
-| `quality-rules.md` | Styling rules, formatters, deprecated APIs | Always when editing examples |
-| `enterprise-features.md` | Enterprise vs community matrix | When deciding imports/CDN |
-| `validation.md` | Build and validate commands | Before committing |
-| `examples-guide.md` | Repo paths, guidelines, validation, Plnkr integration | When working with example infrastructure |
-| `framework-patterns.md` | Framework transformation technical reference | When debugging framework generation issues |
-
-### Progressive Feature Modules (AG Charts)
-
-Feature modules live in `.rulesync/skills/example/ag-charts/features/` and provide deep guidance on specific chart features. Load based on need.
-
-| Tier | Files | When to Load |
-|------|-------|-------------|
-| **Tier 1 — Essentials** | `tooltips.md`, `theme-overrides.md` | Always for quality work |
-| **Tier 2 — Enhancement** | `axes.md`, `legends.md`, `data-labels.md` | When improving visual hierarchy, readability, or layout |
-| **Tier 3 — Advanced** | `enterprise.md`, `segmentation.md`, `reference-lines.md`, `recent-features.md` | When PREVis identifies specific advanced needs |
-
-## Quick Reference — Critical Rules
-
-These five rules apply to **every** AG Charts example. Internalise them before reading sub-documents.
-
-1. **No hardcoded colours or fonts.** Never set `fill`, `stroke`, `color`, `fontSize`, `fontWeight`, or `fontFamily`. The theme handles all visual styling.
-
-2. **Object-based axes syntax (v13+).** Use `axes: { x: { type: 'category' }, y: { type: 'number' } }` — not the legacy array syntax. Always specify `type` on every axis.
-
-3. **Root-level formatters.** Prefer `formatter: { y: ..., x: ... }` at the options root so axes, labels, and tooltips share one definition. Only nest formatters when they genuinely differ.
-
-4. **Tooltip `heading` required.** When using a custom tooltip `renderer`, always include `heading` in the return object to prevent empty lines. `heading` is the primary label at the top (category name for pie/donut, x-axis value for cartesian); `title` is the series name.
-
-5. **Specific chart option types.** Use `AgCartesianChartOptions` for cartesian charts and `AgPolarChartOptions` for polar charts. Hierarchy charts (treemap, sunburst) use generic `AgChartOptions`. Financial charts use `AgFinancialChartOptions`.
+After detecting the product, read its `index.md` first, then load sub-documents as directed.

--- a/external/ag-shared/prompts/skills/example/ag-charts/index.md
+++ b/external/ag-shared/prompts/skills/example/ag-charts/index.md
@@ -1,0 +1,38 @@
+# AG Charts Example Guide
+
+This index describes which AG Charts example documents to load and when.
+
+## Core Documents
+
+| Document | Purpose | When to Load |
+|----------|---------|-------------|
+| `chart-construction.md` | Axes, modules, container, controls, updates | Always for new examples |
+| `quality-rules.md` | Styling rules, formatters, deprecated APIs | Always when editing examples |
+| `enterprise-features.md` | Enterprise vs community matrix | When deciding imports/CDN |
+| `validation.md` | Build and validate commands | Before committing |
+| `examples-guide.md` | Repo paths, guidelines, validation, Plnkr integration | When working with example infrastructure |
+| `framework-patterns.md` | Framework transformation technical reference | When debugging framework generation issues |
+
+## Progressive Feature Modules
+
+Feature modules live in `features/` and provide deep guidance on specific chart features. Load based on need.
+
+| Tier | Files | When to Load |
+|------|-------|-------------|
+| **Tier 1 — Essentials** | `tooltips.md`, `theme-overrides.md` | Always for quality work |
+| **Tier 2 — Enhancement** | `axes.md`, `legends.md`, `data-labels.md` | When improving visual hierarchy, readability, or layout |
+| **Tier 3 — Advanced** | `enterprise.md`, `segmentation.md`, `reference-lines.md`, `recent-features.md` | When PREVis identifies specific advanced needs |
+
+## Critical Rules
+
+These five rules apply to **every** AG Charts example. Internalise them before reading sub-documents.
+
+1. **No hardcoded colours or fonts.** Never set `fill`, `stroke`, `color`, `fontSize`, `fontWeight`, or `fontFamily`. The theme handles all visual styling.
+
+2. **Object-based axes syntax (v13+).** Use `axes: { x: { type: 'category' }, y: { type: 'number' } }` — not the legacy array syntax. Always specify `type` on every axis.
+
+3. **Root-level formatters.** Prefer `formatter: { y: ..., x: ... }` at the options root so axes, labels, and tooltips share one definition. Only nest formatters when they genuinely differ.
+
+4. **Tooltip `heading` required.** When using a custom tooltip `renderer`, always include `heading` in the return object to prevent empty lines. `heading` is the primary label at the top (category name for pie/donut, x-axis value for cartesian); `title` is the series name.
+
+5. **Specific chart option types.** Use `AgCartesianChartOptions` for cartesian charts and `AgPolarChartOptions` for polar charts. Hierarchy charts (treemap, sunburst) use generic `AgChartOptions`. Financial charts use `AgFinancialChartOptions`.

--- a/external/ag-shared/prompts/skills/nx-performance/references/build-and-dev.md
+++ b/external/ag-shared/prompts/skills/nx-performance/references/build-and-dev.md
@@ -28,7 +28,7 @@ build (nx:noop aggregator)
 
 ### Per-package overrides
 
-Individual packages can override `targetDefaults`. For example, a community package (e.g., `ag-charts-community`) may override `build:umd` to build from source rather than `dist/` output, because its UMD bundle is a self-contained browser bundle needing a dedicated entry point (`main-umd.ts`).
+Individual packages can override `targetDefaults`. For example, a community package may override `build:umd` to build from source rather than `dist/` output, because its UMD bundle is a self-contained browser bundle needing a dedicated entry point (`main-umd.ts`).
 
 ```json
 "build:umd": {
@@ -169,7 +169,7 @@ Convenience targets: `blt` (build-lint-test), `blt:ci` (adds e2e and pack), `cle
 
 ## Dynamic project creation
 
-AG product monorepos use custom Nx plugins (e.g., `ag-charts-task-autogen`) that scan example directories (e.g., `packages/*/src/**/_examples/*/main.ts`) and create virtual projects at graph-computation time, each with `generate-example`, `generate-thumbnail`, and `typecheck` targets.
+AG product monorepos use custom Nx plugins that scan example directories (e.g., `packages/*/src/**/_examples/*/main.ts`) and create virtual projects at graph-computation time, each with `generate-example`, `generate-thumbnail`, and `typecheck` targets.
 
 ### What to audit
 

--- a/external/ag-shared/prompts/skills/nx-performance/references/ci-patterns.md
+++ b/external/ag-shared/prompts/skills/nx-performance/references/ci-patterns.md
@@ -110,7 +110,7 @@ Only run on `latest`/release branches or when test files are directly modified.
 
 ### Parallelism
 
-`NX_PARALLEL: 1` for test jobs — tests run sequentially within each shard to avoid resource contention (canvas rendering, GC-sensitive benchmarks).
+`NX_PARALLEL: 1` for test jobs — tests run sequentially within each shard to avoid resource contention.
 
 ---
 

--- a/external/ag-shared/prompts/skills/plan-implementation-review/SKILL.md
+++ b/external/ag-shared/prompts/skills/plan-implementation-review/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 
 # Plan Implementation Review Prompt
 
-You are an implementation reviewer for AG Charts. Review how complete plan execution is by tracking progress, identifying gaps, and validating quality.
+You are an implementation reviewer. Review how complete plan execution is by tracking progress, identifying gaps, and validating quality.
 
 ## Input Requirements
 
@@ -144,15 +144,15 @@ Correlate plan steps with implementation evidence.
 3. **Check Test Results (if available):**
 
     ```bash
-    yarn nx test ag-charts-community --testPathPattern="relevant-test"
-    yarn nx build:types ag-charts-community
+    yarn nx test <package> --testPathPattern="relevant-test"
+    yarn nx build:types <package>
     ```
 
 4. **Check Build Status (if available):**
 
     ```bash
-    yarn nx build:types ag-charts-community ag-charts-enterprise
-    yarn nx lint ag-charts-community ag-charts-enterprise
+    yarn nx build:types <package>
+    yarn nx lint <package>
     ```
 
 ### Phase 3: Report Generation

--- a/external/ag-shared/prompts/skills/plunker/SKILL.md
+++ b/external/ag-shared/prompts/skills/plunker/SKILL.md
@@ -46,7 +46,7 @@ This ensures the implementation step uses the correct CDN URLs, CSS, and API pat
 ### Create a New Plunker
 
 1. Create a working directory: `PLNKR_DIR=$(mktemp -d /tmp/plnkr-new-XXXXXX)`
-2. **Verify API options** — before writing any chart code, grep `packages/ag-charts-types/src` to confirm every option name, nesting structure, and value shape you plan to use. Training data is unreliable for AG Charts APIs. If you cannot find a property in `ag-charts-types`, search for a working example in `packages/ag-charts-website/src/content/docs/*/_examples/` that uses the same feature. Do not guess.
+2. **Verify API options** — before writing any code, verify every API option against the product's public types package and find a working example that uses the same feature. Training data is unreliable for AG product APIs. Do not guess.
 3. Copy the CSS asset: `cp "<skill-base-directory>/assets/ag-example-styles.css" "$PLNKR_DIR/ag-example-styles.css"`
 4. Write remaining files per the product-specific guide (index.html, main.js, package.json, etc.)
 5. Upload:
@@ -105,16 +105,13 @@ The gist must contain an `index.html` file. Plnkr reads the gist files directly 
 
 ## Quick Checklist — Do NOT Rely on Training Data
 
-These are the most commonly violated rules. Training data will lead you astray on every one of them.
+These rules apply to all products. Training data will lead you astray.
 
-1. **Verify every API option** — grep `packages/ag-charts-types/src` to confirm option names, nesting, and value shapes BEFORE writing `main.js`. If unsure, find a working example in `packages/ag-charts-website/src/content/docs/*/_examples/`. Do NOT guess option names from training data — they are frequently wrong (e.g., `rangeButtons` vs `ranges`, `activeStyle` vs `active`, `color` vs `textColor`).
-2. **UMD bundle via `<script>`** — NOT ESM `import`. Use `<script src="https://cdn.jsdelivr.net/npm/ag-charts-community@13.0.0/dist/umd/ag-charts-community.js"></script>`
-3. **UMD global** — `const { AgCharts } = agCharts;` in `main.js`. NOT `import { AgCharts } from '...'`
-4. **Inline onclick handlers** — `<button onclick="myFunction()">` in HTML. NOT `addEventListener` in JS
-5. **Top-level functions** — event handler functions must be top-level in `main.js`, not closures or arrow functions assigned to variables
-6. **No description elements** — no `<h1>`, `<p>`, or explanatory text in the HTML body. Use chart `title`/`subtitle` options instead
-7. **No module registration** — UMD bundles auto-register all modules. Do NOT call `ModuleRegistry.registerModules()` or `AgCharts.setupModules()`
+1. **Verify every API option** — check the product's public types package to confirm option names, nesting, and value shapes BEFORE writing code. If unsure, find a working example in the product's docs examples directory. Do NOT guess option names from training data — they are frequently wrong.
+2. **UMD bundle via `<script>`** — NOT ESM `import`. Use the CDN URLs from the product-specific guide.
+3. **No description elements** — no `<h1>`, `<p>`, or explanatory text in the HTML body.
+4. **Follow the product guide** — each guide contains the exact HTML structure, CDN URLs, UMD globals, package.json format, and product-specific patterns. Do not improvise.
 
 ## Product-Specific Guide
 
-Use the **Product Detection** section above to identify which guide to read. Each guide contains the exact HTML structure, CDN URLs, package.json format, and product-specific patterns.
+Use the **Product Detection** section above to identify which guide to read. Product guides contain critical details (UMD globals, module registration rules, inline handler patterns) that differ between products.

--- a/external/ag-shared/prompts/skills/pr-review/SKILL.md
+++ b/external/ag-shared/prompts/skills/pr-review/SKILL.md
@@ -226,8 +226,9 @@ When `--full` is present, run **all** additional review passes in parallel after
 1. Devil's Advocate (as described above)
 2. JIRA Completeness Verification (described below)
 3. Code Simplification Review (described below)
+4. Codex Review (described below) — **only if available** (see detection below)
 
-All three sub-agents can be spawned simultaneously since they are independent of each other.
+All passes can be spawned simultaneously since they are independent of each other.
 
 ### JIRA Completeness Verification
 
@@ -285,3 +286,33 @@ The sub-agent should focus on the same concerns as the `/simplify` skill: reuse,
 #### 3. Verdict Impact
 
 Simplification findings are advisory and should not change the code correctness verdict or confidence score. They appear as P2 or P3 suggestions in `required_actions` only if they represent genuine quality concerns (e.g., copy-pasted logic that should be extracted).
+
+### Codex Review (Optional)
+
+This pass is **conditional** — it only runs when the Codex review skill is available in the current session.
+
+#### 1. Detect Availability
+
+Check the system-reminder skill list in the current conversation for the skill `codex:review`. If it is **not** listed, skip this entire section silently — do not warn, log, or mention its absence.
+
+#### 2. Invoke the Codex Review
+
+If `codex:review` is available, invoke it using the **Skill tool** with the PR number as the argument:
+
+```
+Skill: codex:review
+Args: {PR_NUMBER}
+```
+
+Invoke this in parallel with the other sub-agent spawns (Devil's Advocate, JIRA, Simplification) in the same message. The Codex review skill is responsible for its own prompting and diff retrieval.
+
+#### 3. Merge Codex Findings
+
+- Prefix all Codex-originated findings with `[CODEX]` in the title.
+- In Markdown mode, add a `## Codex Review` section after `## Simplification Opportunities` (or after whatever the last preceding section is).
+- In JSON mode, merge Codex findings into the `findings` array with the `[CODEX]` title prefix.
+- Deduplicate against findings from all other passes — if both the standard review (or any other pass) and Codex flag the same file and line for the same issue, keep the higher-priority version and note it was flagged by both.
+
+#### 4. Verdict Impact
+
+If the Codex review surfaces P0 or P1 issues not found by any other pass, adjust the verdict and confidence accordingly. P2/P3 Codex findings are advisory and do not change the verdict on their own.

--- a/external/ag-shared/scripts/setup-worktree/preinstall-worktree.sh
+++ b/external/ag-shared/scripts/setup-worktree/preinstall-worktree.sh
@@ -48,9 +48,12 @@ detect_mode() {
 # ---------------------------------------------------------------------------
 
 get_cow_source() {
+    # NOTE: this function returns a path via stdout, so all log_info calls
+    # must redirect to stderr to avoid corrupting the captured value.
+
     # Explicit override (set by claude-worktree-create.sh)
     if [[ -n "${ROOT_WORKTREE_PATH:-}" ]] && [[ -d "${ROOT_WORKTREE_PATH}/node_modules" ]]; then
-        log_info "COW source: ROOT_WORKTREE_PATH=${ROOT_WORKTREE_PATH}"
+        log_info "COW source: ROOT_WORKTREE_PATH=${ROOT_WORKTREE_PATH}" >&2
         echo "$ROOT_WORKTREE_PATH"; return
     fi
 
@@ -59,7 +62,7 @@ get_cow_source() {
     if [[ "$check_path" == *".claude-worktrees"* ]]; then
         local root="${check_path%%/.claude-worktrees/*}"
         if [[ -d "$root/node_modules" ]]; then
-            log_info "COW source: .claude-worktrees root=${root}"
+            log_info "COW source: .claude-worktrees root=${root}" >&2
             echo "$root"; return
         fi
     fi
@@ -79,13 +82,13 @@ get_cow_source() {
         main_repo=$(dirname "$(dirname "$(dirname "$gitdir_path")")")
 
         if [[ -d "$main_repo/node_modules" ]]; then
-            log_info "COW source: main repo=${main_repo}"
+            log_info "COW source: main repo=${main_repo}" >&2
             echo "$main_repo"; return
         fi
-        log_info "Main repo ${main_repo} has no node_modules, skipping COW"
+        log_info "Main repo ${main_repo} has no node_modules, skipping COW" >&2
     fi
 
-    log_info "No COW source found"
+    log_info "No COW source found" >&2
     echo ""
 }
 


### PR DESCRIPTION
## Summary

- Pushed ag-shared subrepo (25 commits)
- Dropped `simplify` from canary skill list — it's Claude Code specific, falsely failing Tooling Health Check for other harnesses

### Cross-links
- ag-grid: ag-grid/ag-grid#13466
- ag-studio: ag-grid/ag-studio#1237