### PR TITLE
Fix benchmark CI: git rm for version checkout, soft-fail comparison

### DIFF
--- a/packages/ag-charts-community/benchmarks/sparkline.test.ts
+++ b/packages/ag-charts-community/benchmarks/sparkline.test.ts
@@ -22,7 +22,7 @@ describe('sparkline benchmark', () => {
         async () => {
             await ctx.create({ pool: false });
         },
-        40_000
+        120_000
     );
 
     benchmark(
@@ -32,7 +32,7 @@ describe('sparkline benchmark', () => {
         async () => {
             await ctx.create({ container: document.createElement('div') });
         },
-        40_000
+        120_000
     );
 
     describe('after load', () => {

--- a/tools/benchmark/collect-version-benchmark.sh
+++ b/tools/benchmark/collect-version-benchmark.sh
@@ -210,11 +210,12 @@ trap 'cleanup' ERR EXIT
 
 prebuild
 for version in "${versions[@]}"; do
-    # Checkout files in the specified input file set (removing any files that have been added since then)
-    # Note: Using git checkout instead of git restore to handle case-sensitive filename changes on macOS
+    # Remove all tracked files first, then checkout from target version.
+    # git checkout <version> -- <path> only overlays files that exist in <version>,
+    # leaving HEAD-only files (e.g. colorScaleUtil.ts) that cause TS errors on older branches.
+    # git clean alone is insufficient because those files are still tracked (in the index).
+    run_silent git rm -rf --quiet --ignore-unmatch -- ${included_files[@]}
     run_silent git checkout "$version" -- ${included_files[@]}
-    # Remove files that exist on HEAD but not in the target version (e.g., newly added files)
-    run_silent git clean -fd -- ${included_files[@]}
     build ${version}
     # Benchmark
     benchmark ${version}

--- a/tools/benchmark/compare-latest.sh
+++ b/tools/benchmark/compare-latest.sh
@@ -84,6 +84,7 @@ node ${tools_dir}/compare-versions.js \
     --base ${base#origin/} \
     --compare ${head} \
     --format ${format} \
-    >>${output}
+    >>${output} || \
+    (if [[ $AG_BENCHMARK_SOFT_FAIL == "true" ]] ; then echo "Failed to compare versions, continuing..." ; else exit 1 ; fi)
 cat ${output}
 echo "Benchmark results saved to ${output}"


### PR DESCRIPTION
## Summary

- **Fix stale files during Jest version checkout**: Replace `git clean -fd` with `git rm -rf --ignore-unmatch` before `git checkout` in `collect-version-benchmark.sh`. The prior fix (#6561) used `git clean`, which only removes *untracked* files — HEAD-only files like `colorScaleUtil.ts` remain tracked in the index and cause TS2305 build errors when building older release branches (e.g., `b13.2.1`).
- **Soft-fail `compare-versions.js`**: Wrap the comparison call in `compare-latest.sh` with the same soft-fail pattern so browser benchmarks still run when Jest comparison fails.
- **Increase sparkline timeout**: 40s → 120s for the two `initial load` tests (500 sparkline repeats too slow for CI Mac Mini).
- **Bump browser benchmark step timeout**: 20m → 25m. The step needs ~22m (8.5m HEAD + 6m worktree setup + 8m BASE) — was timing out with 6 examples remaining.
- **Add `benchmark-type` workflow dispatch input**: Choice of `all` / `jest` / `browser` so manual runs can target only browser benchmarks (~25m) without waiting for Jest (~25m). Scheduled and issue_comment triggers always run both.

Fixes nightly benchmark failure: https://github.com/ag-grid/ag-charts/actions/runs/23877192078/job/69622623714
Fixes browser benchmark timeout: https://github.com/ag-grid/ag-charts/actions/runs/23903178633/job/69704934660

## Test plan

- [ ] Trigger manual workflow dispatch with `benchmark-type: browser` to verify selective execution and timeout
- [ ] Trigger manual workflow dispatch with `benchmark-type: all` to verify full flow under 60m
- [ ] Verify `b13.2.0` builds correctly during Jest version comparison (no TS2305)