### PR TITLE
Add benchmark-type selector, bump browser timeout to 25m

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,15 @@ on:
                 type: string
                 default: b12.1.1
                 required: true
+            benchmark-type:
+                description: 'Which benchmarks to run'
+                type: choice
+                options:
+                    - all
+                    - jest
+                    - browser
+                default: all
+                required: true
             notify:
                 description: 'Notify Slack channel'
                 type: boolean
@@ -46,7 +55,7 @@ jobs:
 
     benchmark:
         runs-on: macos-benchmark
-        timeout-minutes: 60 # Jest ~13m + browser ~20m + build/setup ~15m; reduce once Jest benchmarks are removed
+        timeout-minutes: 60 # Jest ~25m + browser ~25m + setup ~5m; selective runs via benchmark-type input
         permissions:
             pull-requests: write
         needs: check-permissions
@@ -175,7 +184,9 @@ jobs:
 
             - name: nx benchmark
               id: benchmark-table
-              if: github.event_name == 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
+              if: |
+                  github.event_name == 'issue_comment' &&
+                  (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
               run: |
                   ./tools/benchmark/compare-latest.sh origin/${{ steps.get-branch.outputs.base }}
                   echo "report<<EOF" >> $GITHUB_OUTPUT
@@ -184,14 +195,19 @@ jobs:
 
             - name: nx benchmark
               id: benchmark-json
-              if: github.event_name != 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
+              if: |
+                  github.event_name != 'issue_comment' &&
+                  (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped') &&
+                  (inputs.benchmark-type || 'all') != 'browser'
               run: |
                   ./tools/benchmark/compare-latest.sh -j origin/${{ steps.get-branch.outputs.base }}
 
             - name: Browser Benchmark (table)
               id: browser-benchmark-table
-              if: github.event_name == 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
-              timeout-minutes: 20
+              if: |
+                  github.event_name == 'issue_comment' &&
+                  (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
+              timeout-minutes: 25
               run: |
                   ./tools/benchmark/compare-browser-latest.sh origin/${{ steps.get-branch.outputs.base }}
                   echo "report<<EOF" >> $GITHUB_OUTPUT
@@ -200,8 +216,11 @@ jobs:
 
             - name: Browser Benchmark (json)
               id: browser-benchmark-json
-              if: github.event_name != 'issue_comment' && (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped')
-              timeout-minutes: 20
+              if: |
+                  github.event_name != 'issue_comment' &&
+                  (steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped') &&
+                  (inputs.benchmark-type || 'all') != 'jest'
+              timeout-minutes: 25
               run: |
                   ./tools/benchmark/compare-browser-latest.sh -j origin/${{ steps.get-branch.outputs.base }}
 
@@ -243,7 +262,7 @@ jobs:
                       })
 
             - name: Slack Notification (Jest)
-              if: success() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify == true))
+              if: success() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify == true)) && (inputs.benchmark-type || 'all') != 'browser'
               continue-on-error: true
               env:
                   SLACK_CHANNEL: '#charts-performance'
@@ -255,7 +274,7 @@ jobs:
                   curl -X POST -H 'Content-type: application/json' ${{ secrets.SLACK_WEBHOOK }} --data @./reports/benchmark-slack.json
 
             - name: Slack Notification (Browser)
-              if: success() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify == true))
+              if: success() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify == true)) && (inputs.benchmark-type || 'all') != 'jest'
               continue-on-error: true
               env:
                   SLACK_CHANNEL: '#charts-performance'


### PR DESCRIPTION
## Summary

- **Bump browser benchmark step timeout**: 20m → 25m. The step needs ~22m (8.5m HEAD + 6m worktree setup + 8m BASE) — was timing out with 6 examples remaining (run [23903178633](https://github.com/ag-grid/ag-charts/actions/runs/23903178633/job/69704934660)).
- **Add `benchmark-type` workflow dispatch input**: Choice of `all` / `jest` / `browser` so manual runs can target only browser benchmarks (~25m) without waiting for Jest (~25m). Scheduled and `/benchmarks` PR comment triggers always run both.

Time breakdown from the timed-out run:

| Phase | Duration |
|-------|----------|
| Setup | 2m |
| Jest benchmarks (HEAD + base) | 25m |
| Browser HEAD (27 examples) | 8.5m |
| Browser worktree setup | 6m |
| Browser BASE (21/27 completed) | 5.5m (timed out) |

## Test plan

- [ ] Trigger manual dispatch with `benchmark-type: browser` — verify Jest steps skipped, browser completes within 25m
- [ ] Trigger manual dispatch with `benchmark-type: all` — verify full flow completes under 60m