### PR TITLE
Add bundle tree-shaking tests for real-world bundler validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
       "tests/angular-package-tests",
       "tests/react-package-tests",
       "tests/server-side-package-tests",
-      "tests/vue-package-tests"
+      "tests/vue-package-tests",
+      "tests/bundle-treeshake-tests"
     ],
     "nohoist": [
       "**/tinypool",

--- a/tests/bundle-treeshake-tests/.gitignore
+++ b/tests/bundle-treeshake-tests/.gitignore
@@ -1,0 +1,2 @@
+# Temporary test projects
+.tmp/

--- a/tests/bundle-treeshake-tests/bundlers/esbuild.mjs
+++ b/tests/bundle-treeshake-tests/bundlers/esbuild.mjs
@@ -1,0 +1,15 @@
+import esbuild from 'esbuild';
+
+export async function bundleWithEsbuild({ entry, outFile }) {
+    await esbuild.build({
+        entryPoints: [entry],
+        bundle: true,
+        minify: true,
+        format: 'esm',
+        outfile: outFile,
+        platform: 'browser',
+        target: 'es2020',
+        treeShaking: true,
+        logLevel: 'error',
+    });
+}

--- a/tests/bundle-treeshake-tests/bundlers/vite.mjs
+++ b/tests/bundle-treeshake-tests/bundlers/vite.mjs
@@ -1,0 +1,24 @@
+import { basename, dirname } from 'node:path';
+import { build } from 'vite';
+
+export async function bundleWithVite({ entry, outFile }) {
+    await build({
+        configFile: false,
+        logLevel: 'error',
+        build: {
+            lib: {
+                entry,
+                formats: ['es'],
+                fileName: () => basename(outFile),
+            },
+            outDir: dirname(outFile),
+            emptyOutDir: false,
+            minify: 'esbuild',
+            rollupOptions: {
+                output: {
+                    entryFileNames: basename(outFile),
+                },
+            },
+        },
+    });
+}

--- a/tests/bundle-treeshake-tests/bundlers/webpack.mjs
+++ b/tests/bundle-treeshake-tests/bundlers/webpack.mjs
@@ -1,0 +1,38 @@
+import { basename, dirname } from 'node:path';
+import webpack from 'webpack';
+
+export async function bundleWithWebpack({ entry, outFile }) {
+    return new Promise((resolve, reject) => {
+        webpack(
+            {
+                mode: 'production',
+                entry,
+                output: {
+                    path: dirname(outFile),
+                    filename: basename(outFile),
+                    library: { type: 'module' },
+                },
+                experiments: {
+                    outputModule: true,
+                },
+                optimization: {
+                    minimize: true,
+                    usedExports: true,
+                    sideEffects: true,
+                },
+                resolve: {
+                    extensions: ['.mjs', '.js', '.json'],
+                    conditionNames: ['import', 'module', 'default'],
+                },
+            },
+            (err, stats) => {
+                if (err) return reject(err);
+                if (stats.hasErrors()) {
+                    const errors = stats.compilation.errors.map((e) => e.message).join('\n');
+                    return reject(new Error(errors));
+                }
+                resolve();
+            }
+        );
+    });
+}

--- a/tests/bundle-treeshake-tests/project.json
+++ b/tests/bundle-treeshake-tests/project.json
@@ -1,0 +1,23 @@
+{
+  "name": "bundle-treeshake-tests",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "tests/bundle-treeshake-tests",
+  "projectType": "application",
+  "targets": {
+    "test:bundle-treeshake": {
+      "dependsOn": ["^pack"],
+      "command": "{projectRoot}/run.sh"
+    },
+    "test:bundle-treeshake:update": {
+      "dependsOn": ["^pack"],
+      "command": "{projectRoot}/run.sh -u"
+    }
+  },
+  "implicitDependencies": [
+    "ag-charts-core",
+    "ag-charts-community",
+    "ag-charts-enterprise",
+    "ag-charts-locale",
+    "ag-charts-types"
+  ]
+}

--- a/tests/bundle-treeshake-tests/run.sh
+++ b/tests/bundle-treeshake-tests/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -eu
+
+update=false
+if [[ "${1:-}" == "-u" ]]; then
+    update=true
+fi
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_dir=$(cd "${script_dir}/../.." && pwd)
+
+# Create temp directory
+mkdir -p "${script_dir}/.tmp"
+if [[ $(uname) == "Darwin" ]]; then
+    tmp_dir=$(mktemp -d "${script_dir}/.tmp/tmp.XXXXXXXX")
+else
+    tmp_dir=$(mktemp -d -p "${script_dir}/.tmp")
+fi
+echo ">>> temp dir: ${tmp_dir}"
+
+# Copy test files
+cp "${script_dir}/test-treeshake.mjs" "${tmp_dir}/"
+cp "${script_dir}/scenarios.mjs" "${tmp_dir}/"
+cp -R "${script_dir}/bundlers" "${tmp_dir}/"
+
+# Copy tarballs
+for pkg in ag-charts-types ag-charts-locale ag-charts-core ag-charts-community ag-charts-enterprise; do
+    cp "${repo_dir}/dist/packages/${pkg}.tgz" "${tmp_dir}/"
+done
+
+# Install packages and bundler dependencies in temp dir
+cd "${tmp_dir}"
+npm init -y >/dev/null 2>&1
+echo ">>> installing tarballs and bundler dependencies..."
+npm install --no-audit --no-fund \
+    ./ag-charts-types.tgz \
+    ./ag-charts-locale.tgz \
+    ./ag-charts-core.tgz \
+    ./ag-charts-community.tgz \
+    ./ag-charts-enterprise.tgz \
+    esbuild vite webpack 2>&1
+
+echo ">>> running bundle tree-shake tests..."
+update_flag=""
+if ${update}; then
+    update_flag="--update --scenarios-path ${script_dir}/scenarios.mjs"
+fi
+node test-treeshake.mjs ${update_flag}

--- a/tests/bundle-treeshake-tests/scenarios.mjs
+++ b/tests/bundle-treeshake-tests/scenarios.mjs
@@ -1,0 +1,93 @@
+// Bundle tree-shake test scenarios.
+// Each scenario defines an import pattern and a gzip size limit (bytes).
+// Limits are established via `run.sh -u` and should not be edited manually.
+
+export const scenarios = [
+    // === ag-charts-community ===
+    {
+        name: 'community/full',
+        package: 'ag-charts-community',
+        import: '*',
+        limit: 425_000,
+    },
+    {
+        name: 'community/CartesianChartModule',
+        package: 'ag-charts-community',
+        import: '{ CartesianChartModule }',
+        limit: 424_000,
+    },
+    {
+        name: 'community/PolarChartModule',
+        package: 'ag-charts-community',
+        import: '{ PolarChartModule }',
+        limit: 424_000,
+    },
+
+    // === ag-charts-enterprise ===
+    {
+        name: 'enterprise/full',
+        package: 'ag-charts-enterprise',
+        import: '*',
+        limit: 713_000,
+    },
+    {
+        name: 'enterprise/AllCartesianModule',
+        package: 'ag-charts-enterprise',
+        import: '{ AllCartesianModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/AllPolarModule',
+        package: 'ag-charts-enterprise',
+        import: '{ AllPolarModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/AllMapSeriesModule',
+        package: 'ag-charts-enterprise',
+        import: '{ AllMapSeriesModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/AllEnterpriseModule',
+        package: 'ag-charts-enterprise',
+        import: '{ AllEnterpriseModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/BoxPlotSeriesModule',
+        package: 'ag-charts-enterprise',
+        import: '{ BoxPlotSeriesModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/MixedA',
+        package: 'ag-charts-enterprise',
+        import: '{ BoxPlotSeriesModule, NavigatorModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/MixedB',
+        package: 'ag-charts-enterprise',
+        import: '{ AngleNumberAxisModule, RadialBarSeriesModule, StatusBarModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/MixedC',
+        package: 'ag-charts-enterprise',
+        import: '{ FunnelSeriesModule, MapLineSeriesModule, CrosshairModule, GradientLegendModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/MixedD',
+        package: 'ag-charts-enterprise',
+        import: '{ HeatmapSeriesModule, LinearGaugeModule, DataSourceModule, ContextMenuModule, AnimationModule }',
+        limit: 712_000,
+    },
+    {
+        name: 'enterprise/MixedE',
+        package: 'ag-charts-enterprise',
+        import: '{ RadarLineSeriesModule, MapMarkerSeriesModule, RangeAreaSeriesModule, BandHighlightModule, SyncModule, ZoomModule }',
+        limit: 712_000,
+    },
+];

--- a/tests/bundle-treeshake-tests/test-treeshake.mjs
+++ b/tests/bundle-treeshake-tests/test-treeshake.mjs
@@ -1,0 +1,143 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { gzipSync } from 'node:zlib';
+
+import { bundleWithEsbuild } from './bundlers/esbuild.mjs';
+import { bundleWithVite } from './bundlers/vite.mjs';
+import { bundleWithWebpack } from './bundlers/webpack.mjs';
+import { scenarios } from './scenarios.mjs';
+
+const bundlers = [
+    { name: 'esbuild', fn: bundleWithEsbuild },
+    { name: 'vite', fn: bundleWithVite },
+    { name: 'webpack', fn: bundleWithWebpack },
+];
+
+const { values: args } = parseArgs({
+    options: {
+        update: { type: 'boolean', default: false },
+        'scenarios-path': { type: 'string' },
+    },
+});
+
+const results = [];
+const workDir = resolve('.entries');
+
+for (const scenario of scenarios) {
+    const scenarioResults = { scenario: scenario.name, limit: scenario.limit, sizes: {} };
+
+    for (const bundler of bundlers) {
+        const entryDir = join(workDir, scenario.name.replace(/\//g, '_'), bundler.name);
+        mkdirSync(entryDir, { recursive: true });
+
+        const entryFile = join(entryDir, 'entry.mjs');
+        const importStatement =
+            scenario.import === '*'
+                ? `export * from '${scenario.package}';`
+                : `export ${scenario.import} from '${scenario.package}';`;
+        writeFileSync(entryFile, importStatement);
+
+        const outFile = join(entryDir, 'output.mjs');
+
+        try {
+            await bundler.fn({ entry: entryFile, outFile });
+            const raw = readFileSync(outFile);
+            const gzipped = gzipSync(raw, { level: 9 });
+            scenarioResults.sizes[bundler.name] = gzipped.length;
+        } catch (err) {
+            console.error(`ERROR: ${scenario.name} / ${bundler.name}: ${err.message}`);
+            scenarioResults.sizes[bundler.name] = -1;
+        }
+    }
+
+    results.push(scenarioResults);
+}
+
+// Print results table
+const pad = (s, n) => String(s).padEnd(n);
+const rpad = (s, n) => String(s).padStart(n);
+const formatKB = (bytes) => (bytes < 0 ? 'ERROR' : `${(bytes / 1000).toFixed(1)} kB`);
+
+console.log();
+console.log('Bundle Tree-Shake Test Results');
+console.log('='.repeat(100));
+console.log(
+    `${pad('Scenario', 42)} ${rpad('esbuild', 10)} ${rpad('vite', 10)} ${rpad('webpack', 10)} ${rpad('limit', 10)}  status`
+);
+console.log('-'.repeat(100));
+
+let hasFailure = false;
+let hasError = false;
+
+for (const r of results) {
+    const maxSize = Math.max(...Object.values(r.sizes));
+    const pass = maxSize >= 0 && maxSize <= r.limit;
+    const error = Object.values(r.sizes).some((s) => s < 0);
+
+    if (!pass) hasFailure = true;
+    if (error) hasError = true;
+
+    const failedBundlers = Object.entries(r.sizes)
+        .filter(([, size]) => size > r.limit)
+        .map(([name]) => name);
+
+    let status;
+    if (error) {
+        status = 'ERROR';
+    } else if (pass) {
+        status = 'PASS';
+    } else {
+        status = `FAIL (${failedBundlers.join(', ')})`;
+    }
+
+    console.log(
+        `${pad(r.scenario, 42)} ${rpad(formatKB(r.sizes.esbuild), 10)} ${rpad(formatKB(r.sizes.vite), 10)} ${rpad(formatKB(r.sizes.webpack), 10)} ${rpad(formatKB(r.limit), 10)}  ${status}`
+    );
+}
+
+console.log('='.repeat(100));
+
+// Update mode: rewrite scenarios.mjs with new limits
+if (args.update && args['scenarios-path']) {
+    const scenariosPath = args['scenarios-path'];
+    let content = readFileSync(scenariosPath, 'utf-8');
+
+    for (const r of results) {
+        const maxSize = Math.max(...Object.values(r.sizes).filter((s) => s >= 0));
+        if (maxSize <= 0) continue;
+
+        // Add 10% margin, round up to nearest 1000
+        const newLimit = Math.ceil((maxSize * 1.1) / 1000) * 1000;
+        const scenario = scenarios.find((s) => s.name === r.scenario);
+        if (scenario) {
+            content = content.replace(
+                new RegExp(`(name: '${escapeRegExp(r.scenario)}'[\\s\\S]*?limit: )\\d[\\d_]*`),
+                `$1${formatLimit(newLimit)}`
+            );
+        }
+    }
+
+    writeFileSync(scenariosPath, content);
+    console.log(`\nUpdated limits in ${scenariosPath}`);
+}
+
+// Summary
+const total = results.length * bundlers.length;
+const passed = results.reduce((acc, r) => acc + Object.values(r.sizes).filter((s) => s >= 0 && s <= r.limit).length, 0);
+const failed = total - passed;
+console.log(`\n${passed}/${total} passed, ${failed} failed`);
+
+if (hasError) process.exit(2);
+if (hasFailure) process.exit(1);
+
+function escapeRegExp(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function formatLimit(n) {
+    if (n >= 1000) {
+        return `${Math.floor(n / 1000)}_${String(n % 1000).padStart(3, '0')}`;
+    }
+    return String(n);
+}


### PR DESCRIPTION
## Summary

- Adds `tests/bundle-treeshake-tests/` project that exercises **Vite, webpack, and esbuild** against published `.tgz` tarballs
- Runs **14 import scenarios** (3 community, 11 enterprise) × 3 bundlers = 42 builds
- Measures gzipped output sizes and compares against defined limits
- Provides `--update` mode to establish/refresh baseline limits

## Motivation

The existing `size-limit` tests only use esbuild and run within the monorepo workspace. These new tests simulate a **real consumer environment** — installing from tarballs into an isolated temp directory and bundling with the three most popular bundlers. This validates that tree-shaking actually works end-to-end for customers.

## Current baseline findings

Tree-shaking is not currently effective for consumers. All community scenarios produce ~335–386 kB regardless of import pattern (full `*` vs single module), and all enterprise scenarios produce ~558–648 kB. The published ESM bundles are monolithic — esbuild's `__export`/`__reExport` patterns prevent downstream bundlers from tree-shaking individual modules. The baselines capture this state and limits will tighten as tree-shaking improvements land.

## Test plan

- [x] `bash tests/bundle-treeshake-tests/run.sh` — all 42 builds pass
- [x] `bash tests/bundle-treeshake-tests/run.sh -u` — limits are updated correctly
- [ ] Verify via Nx: `NX_DAEMON=false yarn nx run bundle-treeshake-tests:test:bundle-treeshake`