### PR TITLE
Improve AI skill prompts: plunker, JIRA, batch-plunkers, link verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
-
+/plans
 # compiled output
 libraries/ag-charts-test/dist/
 packages/ag-charts-angular/dist/

--- a/.rulesync/rules/link-verification.md
+++ b/.rulesync/rules/link-verification.md
@@ -15,6 +15,16 @@ Before adding any URL to a document, plan, analysis file, or any other written o
 3. **If the URL is a genuine 404**, do not include it. Search for the correct/current URL instead — pages move, domains change, docs get restructured. If no replacement can be found, either remove the link or mark it visibly as dead (e.g., `~~https://example.com/old-page~~ (dead link)`).
 4. **If the URL redirects** (301/302), update it to the final destination URL so readers don't depend on a redirect that may eventually break.
 
+## Sub-agent Output
+
+Sub-agents (e.g., `technical-research-analyst`, `Explore`) frequently fabricate plausible-looking URLs — especially GitHub issue numbers, forum thread IDs, and Stack Overflow links. Treat every URL from a sub-agent as **unverified** until you fetch it yourself.
+
+Before incorporating sub-agent URLs into a document:
+
+1. Fetch each URL with `WebFetch` or `gh` CLI.
+2. Confirm the page content matches the sub-agent's description (a real URL that describes a different topic is just as bad as a 404).
+3. Remove or replace any URL that fails verification. Do not include it with a caveat — either it's verified or it's not in the document.
+
 ## Scope
 
 This applies to every URL you write into a file — documentation links, reference URLs, Plunker links, GitHub issue links, blog posts, forum threads, and external product pages. It does not apply to URLs you output only in conversation (though verifying those is still good practice).

--- a/.rulesync/skills/codesandbox
+++ b/.rulesync/skills/codesandbox
@@ -1,0 +1,1 @@
+../../external/ag-shared/prompts/skills/codesandbox/

--- a/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
+++ b/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
@@ -96,7 +96,7 @@ Create a Plunker for the following assignment:
 ## Instructions
 
 1. Create a working directory: `PLNKR_DIR=$(mktemp -d /tmp/plnkr-batch-{PLUNKER_NUMBER}-XXXXXX)`
-2. If the assignment involves non-trivial or unfamiliar APIs, verify them against `packages/ag-charts-types/src` before writing files
+2. **Verify API options** against `packages/ag-charts-types/src` before writing files. You may skip verification for basic series properties (`type`, `xKey`, `yKey`, `yName`, `data`) but must verify all other options — especially callbacks, nested objects, styling properties, and anything you are less than fully confident about
 3. Write all files per the product guide below (index.html, main.js, ag-example-styles.css, package.json, and optionally data.js)
 4. Upload: `bash "{ABSOLUTE_PATH_TO_PLNKR_SH}" upload "$PLNKR_DIR" --title "{TITLE}" --tags "ag-charts,qa"`
 5. Report the URL= line from the upload output

--- a/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
+++ b/external/ag-shared/prompts/skills/batch-plunkers/SKILL.md
@@ -51,7 +51,7 @@ Wait for user confirmation. Do NOT launch sub-agents until confirmed.
 
 ### 2a. Read the Product Guide
 
-Read all `*-guide.md` files in the sibling plunker skill directory (`../plunker/`). These contain the product-specific file templates, CDN URLs, styling requirements, and common issues. Also read `.rulesync/skills/example/ag-charts/chart-construction.md` and `.rulesync/skills/example/ag-charts/enterprise-features.md` for chart construction patterns and enterprise/community feature matrix. The guide content will be included in each sub-agent prompt.
+Read all `*-guide.md` files in the sibling plunker skill directory (`../plunker/`). These contain the product-specific file templates, CDN URLs, styling requirements, and common issues. The guide content will be included in each sub-agent prompt.
 
 ### 2b. Determine CDN and Resolve Enterprise/Community Per-Assignment
 
@@ -75,7 +75,7 @@ Launch one `general-purpose` Task sub-agent per assignment, **all in a single me
 Each sub-agent prompt **MUST** include:
 
 1. The assignment text and plunker number
-2. **The full product guide content AND example skill content inline** (from Step 2a) — paste the plunker guide, chart-construction.md, and enterprise-features.md text into the prompt so the sub-agent has it immediately without needing to read files
+2. **The full product guide content inline** (from Step 2a) — paste the entire guide text into the prompt so the sub-agent has it immediately without needing to read files
 3. The **resolved CDN URL** for this specific assignment (enterprise or community, from Step 2b)
 4. Any feature context from the JIRA ticket
 5. The exact upload command with the absolute path to `plnkr.sh`
@@ -96,7 +96,7 @@ Create a Plunker for the following assignment:
 ## Instructions
 
 1. Create a working directory: `PLNKR_DIR=$(mktemp -d /tmp/plnkr-batch-{PLUNKER_NUMBER}-XXXXXX)`
-2. **MANDATORY: Verify ALL API options** against `packages/ag-charts-types/src` before writing files. Grep for every option name, confirm nesting and value shapes. If not found in types, search for a working example in `packages/ag-charts-website/src/content/docs/*/_examples/`. Training data is unreliable — do NOT guess option names or structures
+2. If the assignment involves non-trivial or unfamiliar APIs, verify them against `packages/ag-charts-types/src` before writing files
 3. Write all files per the product guide below (index.html, main.js, ag-example-styles.css, package.json, and optionally data.js)
 4. Upload: `bash "{ABSOLUTE_PATH_TO_PLNKR_SH}" upload "$PLNKR_DIR" --title "{TITLE}" --tags "ag-charts,qa"`
 5. Report the URL= line from the upload output
@@ -106,14 +106,6 @@ Create a Plunker for the following assignment:
 ## Product Guide
 
 {GUIDE_CONTENT}
-
-## Chart Construction Patterns
-
-{CHART_CONSTRUCTION_CONTENT}
-
-## Enterprise Features
-
-{ENTERPRISE_FEATURES_CONTENT}
 ````
 
 Wait for **all** sub-agents to complete before proceeding to Step 3.

--- a/external/ag-shared/prompts/skills/codesandbox/SKILL.md
+++ b/external/ag-shared/prompts/skills/codesandbox/SKILL.md
@@ -1,0 +1,141 @@
+---
+targets: ['*']
+name: codesandbox
+description: 'Create and manage CodeSandbox devboxes for AG Charts and AG Grid. Use this skill whenever the user mentions codesandbox, CodeSandbox, csb, sandbox, or devbox, wants to create or modify a shareable code environment with a real build pipeline, or is asked to convert a CodeSandbox into a Plunker (or vice versa). Also trigger when working with an existing CodeSandbox URL shared by the user. Covers creating sandboxes via the REST API, forking existing devboxes, and modifying devbox contents via terminal commands.'
+context: fork
+---
+
+# CodeSandbox Guide
+
+This guide covers working with CodeSandbox for creating and managing shareable devbox environments with full build pipelines.
+
+## When to Use CodeSandbox vs Plunker
+
+- **Plunker**: Static demos, API feature demos, bug reproductions that work with UMD/CDN bundles. No build step. Faster to create. Use `/plunker` skill.
+- **CodeSandbox**: Anything requiring `npm install` + a real bundler (Vite, esbuild, rollup, webpack) — bundle size analysis, tree-shaking testing, build pipeline issues, full-project reproductions.
+
+## Sandbox Types
+
+CodeSandbox has two environment types:
+
+- **Sandbox** (browser-based): Runs in sandpack, limited capabilities, no custom npm registries. Created via the REST API.
+- **Devbox** (container-based): Full Docker environment with terminal, pnpm, custom `.npmrc` support. Created by forking an existing devbox or converting a sandbox.
+
+## Private Registry and Staging Packages
+
+AG Charts staging/beta packages are published to a private registry at `registry.ag-grid.com`. This is used for pre-release testing before packages go to the public npm registry.
+
+**To use staging packages in a devbox:**
+
+1. Include a `.npmrc` file:
+   ```
+   registry=https://registry.ag-grid.com
+   ```
+2. Use exact staging version strings (not caret ranges) in `package.json`, e.g. `"ag-charts-community": "13.2.1-beta.20260415"`
+3. **Query the latest staging version** before creating or updating a sandbox:
+   ```bash
+   npm view ag-charts-community dist-tags --registry=https://registry.ag-grid.com
+   ```
+   The `latest` tag on this registry points to the current staging build.
+4. **Always confirm with the user** before proceeding: "The latest staging version is X.Y.Z-beta.YYYYMMDD — do you want to use this, or do you need to trigger a CI rebuild first?"
+
+**Important**: Browser sandboxes (created via the REST API) cannot access the private registry. If staging packages are needed, the user must convert the sandbox to a devbox, or fork an existing devbox that already has `.npmrc` configured.
+
+## Workflows
+
+### Create a Sandbox via REST API
+
+Use this for quick creation when you have all file contents ready. Creates a browser sandbox — may need conversion to devbox for private registry access or terminal use.
+
+```bash
+curl -s -X POST "https://codesandbox.io/api/v1/sandboxes/define?json=1" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "files": {
+    "package.json": {
+      "content": "{...json content as string...}",
+      "isBinary": false
+    },
+    "src/main.ts": {
+      "content": "...file content...",
+      "isBinary": false
+    },
+    ".codesandbox/template.json": {
+      "content": "{\"title\": \"My Sandbox\", \"runtime\": \"static\", \"tags\": [\"ag-charts\"], \"published\": false}",
+      "isBinary": false
+    }
+  }
+}'
+```
+
+Response: `{"sandbox_id": "abc123"}` → URL: `https://codesandbox.io/s/abc123`
+
+### Fork an Existing Devbox (Browser)
+
+Forking preserves the devbox environment including `.npmrc`, terminal access, and installed dependencies. This is the preferred method when a similar devbox already exists.
+
+1. Navigate to the devbox URL in Chrome
+2. Wait for the VS Code editor to fully load
+3. Click the **Fork** button in the top-right corner
+4. **Important**: Clicking Fork triggers a browser confirmation alert. Tell the user: "Please approve the alert in the browser." The browser extension will appear disconnected until the user approves — this is expected behaviour.
+5. After approval, the tab navigates to the new forked devbox with a new URL slug
+6. The forked devbox has identical files and environment to the original
+
+### Modify a Devbox via Terminal
+
+Once inside a devbox (forked or existing), use the terminal to modify files. Devboxes use pnpm.
+
+**Opening a new terminal**: Click the "+" button in the terminal toolbar (right side of the terminal tab bar, after the "dev" task label). This creates a fresh zsh session. Do not type commands into the "dev" task terminal — it runs the dev server.
+
+**Writing files via heredoc** (preferred for multi-line content):
+```bash
+cat > filename.ext << 'EOF'
+file content here
+EOF
+```
+
+**Updating package.json and reinstalling**:
+```bash
+cat > package.json << 'EOF'
+{ ...new content... }
+EOF
+pnpm install
+```
+
+### Converting Between CodeSandbox and Plunker
+
+**CodeSandbox → Plunker**: Read the CodeSandbox files, extract the key chart code from `src/main.ts`, and create a Plunker using the `/plunker` skill with UMD/CDN bundles instead of npm packages. The chart options and data transfer directly; only the imports and initialisation wrapper change.
+
+**Plunker → CodeSandbox**: Take the chart code from the Plunker's `main.js`, wrap it in a module-based `src/main.ts` with proper imports, create a `package.json` with the AG Charts npm packages as dependencies, and set up the bundler configuration.
+
+## CodeSandbox REST API Reference
+
+The AG Charts website uses the CodeSandbox define API for creating sandboxes from examples. See `external/ag-website-shared/src/components/codeSandbox/utils/codeSandbox.ts` for the implementation.
+
+**Endpoint**: `POST https://codesandbox.io/api/v1/sandboxes/define`
+
+**Two modes**:
+- **Form POST** (used by website): Encodes files with `codesandbox-import-utils` library's `getParameters()`, submits as form data. Opens in new tab without popup warnings.
+- **JSON API** (used by CLI): POST with `?json=1` query param and JSON body. Returns `{"sandbox_id": "..."}`.
+
+**Authentication**: Not required for creating public sandboxes. Required for forking via API (`POST /api/v1/sandboxes/:id/fork`).
+
+## Browser Automation Notes
+
+- CodeSandbox devboxes are heavy VS Code-in-browser SPAs that can cause browser extension instability
+- The Fork button triggers a JavaScript confirmation alert that blocks the extension until the user approves — always tell the user to approve alerts when clicking Fork
+- After forking, check `tabs_context_mcp` for the new devbox URL slug
+- Use the zsh terminal (not the "dev" task terminal) for running commands
+
+## Existing Devboxes
+
+### Bundle Size Testing (AG-17066)
+
+| Variant | Vite | esbuild | rollup |
+|---------|------|---------|--------|
+| Community | `rtskm9` | `49kns3` | `zj4ffg` |
+| Enterprise | `spxzyd` | `5755h9` | `w8fsws` |
+
+URL pattern: `https://codesandbox.io/p/devbox/ag-chart-bundle-size-forked-{ID}`
+
+Build commands: Vite → `npx vite build`, esbuild → `node build.mjs`, rollup → `npx rollup -c`

--- a/external/ag-shared/prompts/skills/jira/SKILL.md
+++ b/external/ag-shared/prompts/skills/jira/SKILL.md
@@ -110,7 +110,7 @@ Each ticket has exactly **one** track value. Never set multiple track values on 
 - **End numbered items with periods.**
 - Bold: `**text**`.
 - Code: backticks.
-- **contentFormat**: Use `"markdown"` for all JIRA API calls. This accepts standard markdown syntax and converts it to JIRA's native ADF format.
+- **contentFormat**: Use `"markdown"` for ticket descriptions and fields. This accepts standard markdown syntax and converts it to JIRA's native ADF format.
 - **URLs must use explicit markdown link syntax** — bare URLs will NOT become clickable links in JIRA. Always write `[https://example.com](https://example.com)` instead of just `https://example.com`. The URL should be visible as both the link text and the href (never hide it behind display text like `[Plunker](url)`).
 - Empty sections: Just `N/A`.
 - No comments — all info in description.
@@ -123,6 +123,48 @@ Each ticket has exactly **one** track value. Never set multiple track values on 
 - **Bug**: `templates/bug.md` (TC-based format)
 
 Follow the exact structure from the template. Do not use free-form markdown headers (`##`), tables, or code blocks for top-level structure.
+
+### Writing JIRA Comments
+
+When adding comments to existing tickets (e.g., posting QA plunker links, test results):
+
+- **Use `contentFormat: "adf"`** with explicit link marks. JIRA's markdown renderer does not reliably produce clickable links in comments.
+- **Use bullet lists, not tables.** Tables render inconsistently in JIRA comments.
+- **URLs must use ADF link marks** — without them, URLs appear as plain text and are not clickable.
+- **The Atlassian MCP has no delete-comment tool.** Do not attempt workarounds via curl/REST API. Get the format right on the first attempt — re-posting creates duplicates that must be cleaned up manually.
+
+**ADF bullet list structure for comments with links:**
+
+```json
+{
+  "version": 1,
+  "type": "doc",
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 3},
+      "content": [{"type": "text", "text": "Section Title"}]
+    },
+    {
+      "type": "bulletList",
+      "content": [
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {"type": "text", "text": "Description text — "},
+                {"type": "text", "text": "https://example.com/link", "marks": [{"type": "link", "attrs": {"href": "https://example.com/link"}}]}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
 ### Reading JIRA Comments
 

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -47,7 +47,7 @@ Based on ticket type, read the relevant template (in the `templates/` subdirecto
 
 When the user provides requirements that differ from existing PRDs or design documents, the user's stated requirements take precedence. Confirm requirements with the user before drafting — do not assume PRD content is final.
 
-**Brevity:** When the user requests a concise or minimal ticket, keep the numbered template structure but shorten section content and omit sections that would only contain "N/A" (e.g., sections 5–8 and 10–12 when they add no information). Never replace template section headings with custom ones — always use the numbered sections from the template. Interview the user for missing information rather than padding sections.
+**Brevity:** When the user requests a concise or minimal ticket, keep the numbered template section headings but shorten section content. Sections with no meaningful content should contain just "N/A" — do not remove the heading itself, as downstream tooling may expect fixed section presence. Never replace template section headings with custom ones. Interview the user for missing information rather than padding sections.
 
 **For Tech-debt tickets, collect:**
 

--- a/external/ag-shared/prompts/skills/jira/workflows/create.md
+++ b/external/ag-shared/prompts/skills/jira/workflows/create.md
@@ -33,7 +33,7 @@ Based on ticket type, read the relevant template (in the `templates/` subdirecto
 
 - [ ] Reproduction URL (Plunker, CodeSandbox, etc.).
 - [ ] Steps to reproduce (numbered list).
-- [ ] Actual vs Expected behaviour.
+- [ ] Actual vs Expected behaviour — **you must reproduce the bug yourself** before writing Actual/Expected. If you cannot reproduce it, report this to the user rather than writing unverified claims.
 - [ ] Affected versions (test from end-user perspective in browser — see product file; required for Bug, optional for Improvement).
 - [ ] Root cause analysis (if known).
 
@@ -46,6 +46,8 @@ Based on ticket type, read the relevant template (in the `templates/` subdirecto
 - [ ] Acceptance criteria.
 
 When the user provides requirements that differ from existing PRDs or design documents, the user's stated requirements take precedence. Confirm requirements with the user before drafting — do not assume PRD content is final.
+
+**Brevity:** When the user requests a concise or minimal ticket, keep the numbered template structure but shorten section content and omit sections that would only contain "N/A" (e.g., sections 5–8 and 10–12 when they add no information). Never replace template section headings with custom ones — always use the numbered sections from the template. Interview the user for missing information rather than padding sections.
 
 **For Tech-debt tickets, collect:**
 
@@ -195,14 +197,19 @@ Think of it as: the **inward** issue is the one being referenced ("split **from*
 - **Inline code for option names:** Always wrap API option names, property names, and programmatic values in backticks (e.g., `enableRtl`, `skipNullBars: true`, `bar`). This distinguishes code from prose and improves readability.
 - **Series type references:** When referencing series types, use backtick-wrapped type values (e.g., `bar`) rather than informal names like "bar/column".
 
+## Editing Existing Tickets
+
+When editing an existing ticket (not creating a new one), only modify the fields the user explicitly requested. Do not change issue type, track, summary, or other fields unless specifically asked. If you believe other fields should change, ask first.
+
 ## Critical Rules
 
 1. **Always use templates** — Don't improvise description formats.
 2. **Test bugs in browser** — Not by analysing code.
-3. **End numbered items with periods** — JIRA formatting requirement.
-4. **No comments** — Put all information in the description.
-5. **No rationale in feature requests** — State **what** and acceptance criteria, not **why**.
-6. **Improvement = internally reported bug** — Always use the bug template for Improvement tickets, not the feature/task template.
-7. **Inline code for options** — Always wrap API option/property names in backticks in descriptions.
-8. **URLs must be explicit markdown links** — Bare URLs are NOT clickable in JIRA. Always write `[https://url](https://url)`, never just `https://url`.
-9. **JIRA ticket references must be Smart Links** — Use ADF `inlineCard` nodes, not markdown links or bare keys. Only `inlineCard` renders as an expanded Smart Link with the ticket title.
+3. **Reproduce before documenting** — Never write Actual/Expected claims without verifying the behaviour yourself. If the bug cannot be reproduced, report this to the user.
+4. **End numbered items with periods** — JIRA formatting requirement.
+5. **No comments** — Put all information in the description.
+6. **No rationale in feature requests** — State **what** and acceptance criteria, not **why**.
+7. **Improvement = internally reported bug** — Always use the bug template for Improvement tickets, not the feature/task template.
+8. **Inline code for options** — Always wrap API option/property names in backticks in descriptions.
+9. **URLs must be explicit markdown links** — Bare URLs are NOT clickable in JIRA. Always write `[https://url](https://url)`, never just `https://url`.
+10. **JIRA ticket references must be Smart Links** — Use ADF `inlineCard` nodes, not markdown links or bare keys. Only `inlineCard` renders as an expanded Smart Link with the ticket title.

--- a/external/ag-shared/prompts/skills/plunker/SKILL.md
+++ b/external/ag-shared/prompts/skills/plunker/SKILL.md
@@ -46,7 +46,7 @@ This ensures the implementation step uses the correct CDN URLs, CSS, and API pat
 ### Create a New Plunker
 
 1. Create a working directory: `PLNKR_DIR=$(mktemp -d /tmp/plnkr-new-XXXXXX)`
-2. **Verify API options** — before writing any code, verify every API option against the product's public types package and find a working example that uses the same feature. Training data is unreliable for AG product APIs. Do not guess.
+2. **Verify API options** — before writing any code, verify every API option against the product's public types package AND find at least one working example in `packages/ag-charts-website/src/content/docs/*/_examples/` (or equivalent for the product) that uses the same feature, event, or API pattern. Read the example to confirm option names, nesting, and event signatures. Do NOT proceed to step 3 until verification is complete. Training data is unreliable for AG product APIs. Do not guess.
 3. Copy the CSS asset: `cp "<skill-base-directory>/assets/ag-example-styles.css" "$PLNKR_DIR/ag-example-styles.css"`
 4. Write remaining files per the product-specific guide (index.html, main.js, package.json, etc.)
 5. Upload:
@@ -54,6 +54,7 @@ This ensures the implementation step uses the correct CDN URLs, CSS, and API pat
    bash "<skill-base-directory>/plnkr.sh" upload "$PLNKR_DIR" --title "Example Title"
    ```
 6. Parse output for `URL=` — the shareable link.
+7. **Browser verify** — open the plunker preview URL in the browser (Chrome extension) and verify the chart renders correctly and any interactive features work as expected. Take a screenshot to confirm.
 
 ### Fork/Modify an Existing Plunker
 
@@ -67,6 +68,7 @@ This ensures the implementation step uses the correct CDN URLs, CSS, and API pat
    ```bash
    bash "<skill-base-directory>/plnkr.sh" upload "$DIR" --title "Modified: Original Title"
    ```
+5. **Browser verify** — open the plunker preview URL in the browser (Chrome extension) and verify the chart renders correctly and any interactive features work as expected. Take a screenshot to confirm.
 
 ### Read-Only Inspection
 
@@ -96,6 +98,18 @@ Use these when sharing links or loading existing content:
 | Load a GitHub Gist (embed) | `https://embed.plnkr.co/gist/<gist-id>` |
 
 The gist must contain an `index.html` file. Plnkr reads the gist files directly — no upload needed.
+
+### Browser Verification
+
+When verifying plunkers via browser automation, use the **editor + preview** URL (`https://plnkr.co/edit/<plunk-id>?preview`) rather than the `run.plnkr.co` URL. The `run.plnkr.co` domain shows a phishing warning interstitial that blocks automation.
+
+## Forked Context Limitation
+
+This skill runs in a forked context. If you have already modified plunker files in the parent context (before invoking the skill), the fork may not see those changes. In that case, use the bash script directly instead of invoking the skill for upload-only:
+
+```bash
+bash "<skill-base-directory>/plnkr.sh" upload "$DIR"
+```
 
 ## API Notes
 

--- a/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
+++ b/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
@@ -392,9 +392,11 @@ createApp(App).mount('#app');
 -   `<div id="app">` replaces `<div id="myChart">` in the HTML body
 -   Use `chart.updateDelta({...})` in `watch()` callbacks for reactive updates
 
-### Staging CDN — SystemJS/CJS Paths
+### Framework CDN — SystemJS/CJS Paths
 
-Framework wrappers (Angular, React, Vue) are not published as UMD bundles on jsdelivr, so framework plunkers must use the staging CDN. The same staging-vs-versioned rules apply: use staging by default, versioned when the user specifies a version. CJS package paths differ from the UMD paths:
+Framework plunkers use SystemJS with CJS/ESM paths instead of UMD. The same staging-vs-versioned rules apply as for vanilla plunkers: use staging by default, versioned when the user specifies a version.
+
+**Staging:**
 
 | Package | Staging CJS path |
 |---------|-----------------|
@@ -404,6 +406,17 @@ Framework wrappers (Angular, React, Vue) are not published as UMD bundles on jsd
 | `ag-charts-types` | `https://charts-staging.ag-grid.com/dev/ag-charts-types/dist/package/main.cjs.js` |
 | `ag-charts-locale` | `https://charts-staging.ag-grid.com/dev/ag-charts-locale/dist/package/main.cjs.js` |
 | `ag-charts-angular` (ESM) | `https://charts-staging.ag-grid.com/dev/ag-charts-angular/` (+ `fesm2022/ag-charts-angular.mjs`) |
+
+**Versioned:**
+
+| Package | Versioned CJS path |
+|---------|--------------------|
+| `ag-charts-community` | `https://cdn.jsdelivr.net/npm/ag-charts-community@13.2.1/dist/package/main.cjs.js` |
+| `ag-charts-core` | `https://cdn.jsdelivr.net/npm/ag-charts-core@13.2.1/dist/package/main.cjs.js` |
+| `ag-charts-enterprise` | `https://cdn.jsdelivr.net/npm/ag-charts-enterprise@13.2.1/dist/package/main.cjs.js` |
+| `ag-charts-types` | `https://cdn.jsdelivr.net/npm/ag-charts-types@13.2.1/dist/package/main.cjs.js` |
+| `ag-charts-locale` | `https://cdn.jsdelivr.net/npm/ag-charts-locale@13.2.1/dist/package/main.cjs.js` |
+| `ag-charts-angular` (ESM) | `https://cdn.jsdelivr.net/npm/ag-charts-angular@13.2.1/` (+ `fesm2022/ag-charts-angular.mjs`) |
 
 ### Common Issues
 

--- a/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
+++ b/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
@@ -394,7 +394,7 @@ createApp(App).mount('#app');
 
 ### Staging CDN — SystemJS/CJS Paths
 
-For framework plunkers using SystemJS, the CJS package paths differ from the UMD paths:
+Framework wrappers (Angular, React, Vue) are not published as UMD bundles on jsdelivr, so framework plunkers must use the staging CDN. The same staging-vs-versioned rules apply: use staging by default, versioned when the user specifies a version. CJS package paths differ from the UMD paths:
 
 | Package | Staging CJS path |
 |---------|-----------------|

--- a/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
+++ b/external/ag-shared/prompts/skills/plunker/ag-charts-guide.md
@@ -38,7 +38,7 @@ This section covers the Plunker-specific file structure for AG Charts demos. For
     </head>
     <body>
         <div id="myChart"></div>
-        <script src="https://cdn.jsdelivr.net/npm/ag-charts-community@13.0.0/dist/umd/ag-charts-community.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ag-charts-community@13.2.1/dist/umd/ag-charts-community.js"></script>
         <script src="main.js"></script>
     </body>
 </html>
@@ -73,7 +73,7 @@ This section covers the Plunker-specific file structure for AG Charts demos. For
             </div>
         </div>
         <div id="myChart"></div>
-        <script src="https://cdn.jsdelivr.net/npm/ag-charts-community@13.0.0/dist/umd/ag-charts-community.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ag-charts-community@13.2.1/dist/umd/ag-charts-community.js"></script>
         <script src="main.js"></script>
     </body>
 </html>
@@ -83,14 +83,14 @@ This section covers the Plunker-specific file structure for AG Charts demos. For
 
 -   Include `<meta name="robots" content="noindex" />` to prevent indexing
 -   Include the inline `<style>` block - required for proper sizing
--   Use a **specific version** (e.g., `@13.0.0`) with optional cache-busting timestamp (`?t=1768428202375`)
+-   Use a **specific version** (e.g., `@13.2.1`) with optional cache-busting timestamp (`?t=1768428202375`)
 -   Generate timestamp with: `date +%s%3N`
 -   Do NOT add `<h1>`, `<p>`, or any other elements — use the chart's `title`/`subtitle` options instead
 
 For Enterprise features, use the enterprise CDN URL:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/ag-charts-enterprise@13.0.0/dist/umd/ag-charts-enterprise.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ag-charts-enterprise@13.2.1/dist/umd/ag-charts-enterprise.js"></script>
 ```
 
 ### Enterprise vs Community
@@ -161,8 +161,8 @@ Generate timestamp with: `date +%s%3N`
 
 **Versioned (for reproduction/sharing):**
 
--   Community: `https://cdn.jsdelivr.net/npm/ag-charts-community@13.0.0/dist/umd/ag-charts-community.js`
--   Enterprise: `https://cdn.jsdelivr.net/npm/ag-charts-enterprise@13.0.0/dist/umd/ag-charts-enterprise.js`
+-   Community: `https://cdn.jsdelivr.net/npm/ag-charts-community@13.2.1/dist/umd/ag-charts-community.js`
+-   Enterprise: `https://cdn.jsdelivr.net/npm/ag-charts-enterprise@13.2.1/dist/umd/ag-charts-enterprise.js`
 
 ### data.js (Optional Separate Data File)
 
@@ -180,10 +180,236 @@ function getData() {
 
 In `index.html`, add `<script src="data.js"></script>` **before** `<script src="main.js"></script>`. In `main.js`, call `getData()`. For small datasets, inline the data directly.
 
+### Version Migration (Forking Old Plunkers)
+
+When forking a plunker built on an older AG Charts version, audit **every** option against the current types. Common breaking changes across major versions:
+
+| Change | Old (≤v9) | New (v13+) |
+|--------|-----------|------------|
+| Series type | `type: 'column'` | `type: 'bar'` |
+| Axes format | `axes: [{ type: 'category', position: 'bottom' }]` (array) | `axes: { x: { type: 'category' } }` (object) |
+| Create API | `agCharts.AgChart.create(options)` | `const { AgCharts } = agCharts; AgCharts.create(options)` |
+| Bar labels | Enabled by default for stacked bars | Disabled by default — add `label: {}` explicitly |
+| Legend order | Reversed by default (top of stack first) | Series order by default — add `reverseOrder: true` to restore |
+| Scatter marker | `marker: { size: 0 }` | `size: 0` directly on series (via `AgSeriesMarkerStyle`) |
+
+**Checklist when porting:**
+
+1. Update the CDN URL to the target version
+2. Change `agCharts.AgChart.create()` → `const { AgCharts } = agCharts; AgCharts.create()`
+3. Replace `type: 'column'` with `type: 'bar'`
+4. Convert `axes` array to object format (`x`/`y` keys)
+5. Check every series option against `ag-charts-types` — defaults may have changed
+6. Visually compare both plunkers in the browser before delivering
+
+### Framework Plunkers
+
+The website generates Angular, React, and Vue plunker variants using SystemJS for in-browser module loading. When the user requests a framework plunker, follow the patterns below.
+
+**Boilerplate source:** `packages/ag-charts-website/public/example-runner/charts-angular-boilerplate/`
+
+#### Angular
+
+Angular plunkers use SystemJS with in-browser TypeScript compilation (no build step). Required files:
+
+| File | Source |
+|------|--------|
+| `index.html` | Write per template below |
+| `main.ts` | Copy from `charts-angular-boilerplate/main.ts` |
+| `app.component.ts` | Write — standalone component with `[options]` binding |
+| `systemjs.config.js` | Copy from `charts-angular-boilerplate/systemjs.config.js` |
+| `css.js` | Copy from `charts-angular-boilerplate/css.js` |
+| `ag-example-styles.css` | Copy from skill assets |
+| `package.json` | Write with Angular + ag-charts deps |
+
+**index.html template:**
+
+```html
+<html lang="en">
+    <head>
+        <title>AG Charts - Angular Example</title>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex" />
+        <link rel="stylesheet" href="ag-example-styles.css" />
+        <style>
+            body { padding: 1rem; }
+            div:has(> .ag-charts-wrapper), ag-charts, ag-financial-charts {
+                padding: 0 !important; border: none !important;
+            }
+        </style>
+    </head>
+    <body>
+        <my-app>Loading...</my-app>
+        <script>document.write('<base href="' + document.location + '" />');</script>
+        <script src="https://cdn.jsdelivr.net/npm/core-js-bundle@3.6.5/minified.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/zone.js@0.11.2/dist/zone.min.js"></script>
+        <script>
+            var appLocation = './';
+            var boilerplatePath = './';
+            var systemJsMap = {
+                'ag-charts-angular': 'https://charts-staging.ag-grid.com/dev/ag-charts-angular/'
+            };
+            var systemJsPaths = {
+                'ag-charts-community': 'https://charts-staging.ag-grid.com/dev/ag-charts-community/dist/package/main.cjs.js',
+                'ag-charts-core': 'https://charts-staging.ag-grid.com/dev/ag-charts-core/dist/package/main.cjs.js',
+                'ag-charts-types': 'https://charts-staging.ag-grid.com/dev/ag-charts-types/dist/package/main.cjs.js',
+                'ag-charts-locale': 'https://charts-staging.ag-grid.com/dev/ag-charts-locale/dist/package/main.cjs.js'
+            };
+        </script>
+        <script src="https://cdn.jsdelivr.net/npm/systemjs@0.21.6/dist/system.js"></script>
+        <script src="systemjs.config.js"></script>
+        <script>
+            System.import('ag-charts-community')
+                .then(function() { return System.import('./main.ts'); })
+                .catch(function(err) { console.error(err.originalErr || err); });
+        </script>
+    </body>
+</html>
+```
+
+**For enterprise features**, add to `systemJsPaths`:
+```javascript
+'ag-charts-enterprise': 'https://charts-staging.ag-grid.com/dev/ag-charts-enterprise/dist/package/main.cjs.js'
+```
+
+**Key differences from vanilla:**
+
+-   `systemJsMap` maps package names to base directories (for packages with internal structure like `fesm2022/`)
+-   `systemJsPaths` maps package names directly to CJS entry files (resolved via SystemJS `paths`)
+-   Use `systemjs.config.js` (non-dev) — it supports both `systemJsMap` and `systemJsPaths`
+-   Polyfills (`core-js-bundle`, `zone.js`) and `<base href>` are required
+-   Angular compiles in-browser — first load is slow (~10-20s)
+
+**app.component.ts pattern:**
+
+```typescript
+import { Component } from '@angular/core';
+import { AgCharts } from 'ag-charts-angular';
+import { AgChartOptions, AllCommunityModule, ModuleRegistry } from 'ag-charts-community';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+    selector: 'my-app',
+    standalone: true,
+    imports: [AgCharts],
+    template: `<ag-charts [options]="options"></ag-charts>`,
+})
+export class AppComponent {
+    public options: AgChartOptions;
+
+    constructor() {
+        this.options = {
+            // chart options here
+        };
+    }
+}
+```
+
+#### React
+
+React plunkers use UMD CDN bundles — no build step needed. The `ag-charts-react` wrapper does NOT have a UMD build, so use `agCharts.AgCharts` directly with React's lifecycle.
+
+```html
+<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+<script src="https://charts-staging.ag-grid.com/dev/ag-charts-community/dist/umd/ag-charts-community.js?t={timestamp}"></script>
+<script src="main.js"></script>
+```
+
+In `main.js`, use `React.createElement` (not JSX) with `useRef`/`useEffect`/`useLayoutEffect` to create and update charts:
+
+```javascript
+const { AgCharts: AgChartsAPI } = agCharts;
+const { useState, useRef, useEffect, useLayoutEffect } = React;
+
+function AgCharts({ options }) {
+    const containerRef = useRef(null);
+    const chartRef = useRef(null);
+
+    useLayoutEffect(() => {
+        const chart = AgChartsAPI.create({ ...options, container: containerRef.current });
+        chartRef.current = chart;
+        return () => chart.destroy();
+    }, []);
+
+    useEffect(() => {
+        if (chartRef.current) {
+            chartRef.current.update({ ...options, container: containerRef.current });
+        }
+    }, [options]);
+
+    return React.createElement('div', { ref: containerRef, style: { width: '100%', height: '100%' } });
+}
+```
+
+**Key points:**
+-   Controls are rendered by the React component — do NOT add HTML controls to `index.html`
+-   `<div id="root">` replaces `<div id="myChart">` in the HTML body
+-   Use `ReactDOM.createRoot(document.getElementById('root')).render(...)` to mount
+
+#### Vue
+
+Vue plunkers use Vue 3 global CDN + ag-charts-community UMD. The `ag-charts-vue3` wrapper does NOT have a UMD build, so use `agCharts.AgCharts` directly with Vue's composition API.
+
+```html
+<script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+<script src="https://charts-staging.ag-grid.com/dev/ag-charts-community/dist/umd/ag-charts-community.js?t={timestamp}"></script>
+<script src="main.js"></script>
+```
+
+In `main.js`, use `createApp` with the composition API:
+
+```javascript
+const { AgCharts } = agCharts;
+const { createApp, ref, watch, onMounted, onBeforeUnmount } = Vue;
+
+const App = {
+    template: `<div ref="chartContainer"></div>`,
+    setup() {
+        const chartContainer = ref(null);
+        let chart = null;
+
+        onMounted(() => {
+            chart = AgCharts.create({
+                container: chartContainer.value,
+                // chart options here
+            });
+        });
+
+        onBeforeUnmount(() => { if (chart) chart.destroy(); });
+
+        return { chartContainer };
+    },
+};
+
+createApp(App).mount('#app');
+```
+
+**Key points:**
+-   Controls are rendered by the Vue template — do NOT add HTML controls to `index.html`
+-   `<div id="app">` replaces `<div id="myChart">` in the HTML body
+-   Use `chart.updateDelta({...})` in `watch()` callbacks for reactive updates
+
+### Staging CDN — SystemJS/CJS Paths
+
+For framework plunkers using SystemJS, the CJS package paths differ from the UMD paths:
+
+| Package | Staging CJS path |
+|---------|-----------------|
+| `ag-charts-community` | `https://charts-staging.ag-grid.com/dev/ag-charts-community/dist/package/main.cjs.js` |
+| `ag-charts-core` | `https://charts-staging.ag-grid.com/dev/ag-charts-core/dist/package/main.cjs.js` |
+| `ag-charts-enterprise` | `https://charts-staging.ag-grid.com/dev/ag-charts-enterprise/dist/package/main.cjs.js` |
+| `ag-charts-types` | `https://charts-staging.ag-grid.com/dev/ag-charts-types/dist/package/main.cjs.js` |
+| `ag-charts-locale` | `https://charts-staging.ag-grid.com/dev/ag-charts-locale/dist/package/main.cjs.js` |
+| `ag-charts-angular` (ESM) | `https://charts-staging.ag-grid.com/dev/ag-charts-angular/` (+ `fesm2022/ag-charts-angular.mjs`) |
+
 ### Common Issues
 
 | Issue | Cause | Fix |
 |-------|-------|-----|
+| `axes` silently ignored | Using legacy array format `axes: [...]` | Use object format: `axes: { x: {...}, y: {...} }` |
 | Chart appears small | Missing vanilla framework styles | Copy `ag-example-styles.css` from assets |
 | Chart doesn't render | Wrong CDN URL or missing global | Check script src and use `agCharts.AgCharts` |
 | Styling issues | Missing inline styles in index.html | Add the `<style>` block in `<head>` |
@@ -193,3 +419,22 @@ In `index.html`, add `<script src="data.js"></script>` **before** `<script src="
 | Partial update wipes options | Using `chart.update({ data: newData })` without full options | Use `chart.updateDelta({ data: newData })` for partial/delta updates |
 | Container not found | Using string selector `'#myChart'` | Use `document.getElementById('myChart')` |
 | Controls break chart layout | Chart div nested inside controls div | `<div id="myChart">` must be a **sibling** outside `<div class="example-controls">` |
+
+## QA Plunker Observability
+
+When creating plunkers for JIRA QA testing, always add `console.log` for callback parameters and other relevant runtime values. This enables QA to inspect what the chart is passing at runtime without needing to modify the plunker.
+
+**Example — `dataSource.getData`:**
+
+```js
+dataSource: {
+    getData: async (params) => {
+        console.log('getData params:', params);
+        // ... fetch data
+    },
+},
+```
+
+Apply this to every callback in a QA plunker: `getData`, event handlers, `itemStyler`, `formatter`, etc. Log the params as the first line of the callback body.
+
+**Do NOT** create custom log panels, DOM overlays, or visual logging elements. Use `console.log` exclusively — QA will use browser DevTools to inspect output.


### PR DESCRIPTION
## Summary
- Strengthen plunker skill: mandatory API verification with working example lookup, browser verification step, framework plunker patterns (Angular/React/Vue), staging CDN paths, version migration checklist, QA observability guidance
- Bump plunker CDN version from 13.0.0 to 13.2.1
- Add JIRA comment ADF formatting guidance with link marks, reproduce-before-documenting rule, brevity guidance, and editing-existing-tickets section
- Simplify batch-plunkers by removing redundant chart-construction/enterprise-features context injection
- Add sub-agent URL verification rules to link-verification

## Companion PRs
- ag-charts-prompts: https://github.com/ag-grid/ag-charts-prompts/pull/28

## Test plan
- [ ] Verify skill prompts load correctly in a fresh session
- [ ] Test plunker creation with updated CDN version
- [ ] Test JIRA comment creation with ADF formatting