### PR TITLE
AG-10316 Add legend item tooltip customisation

### DIFF
--- a/packages/ag-charts-community/src/chart/legend/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.test.ts
@@ -897,4 +897,184 @@ describe('Legend', () => {
             await compare(chart);
         });
     });
+
+    describe('AG-10316 legend item tooltip', () => {
+        const TOOLTIP_OPTIONS: AgCartesianChartOptions = {
+            data: [
+                { x: 'Q1', y: 10, z: 20 },
+                { x: 'Q2', y: 20, z: 30 },
+            ],
+            series: [
+                { type: 'bar', xKey: 'x', yKey: 'y', yName: 'Series Y' },
+                { type: 'bar', xKey: 'x', yKey: 'z', yName: 'Series Z' },
+            ],
+            legend: { enabled: true },
+        };
+
+        let updateSpy: jest.SpiedFunction<typeof chart.ctx.tooltipManager.updateTooltip>;
+        let removeSpy: jest.SpiedFunction<typeof chart.ctx.tooltipManager.removeTooltip>;
+        let legendX: number;
+        let legendY: number;
+
+        async function setupChart(legendOverrides: AgCartesianChartOptions['legend'] = {}) {
+            const options: AgCartesianChartOptions = prepareTestOptions({
+                ...TOOLTIP_OPTIONS,
+                legend: { ...TOOLTIP_OPTIONS.legend, ...legendOverrides },
+            });
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+            updateSpy = jest.spyOn(chart.ctx.tooltipManager, 'updateTooltip');
+            removeSpy = jest.spyOn(chart.ctx.tooltipManager, 'removeTooltip');
+            const box = computeLegendBBox(chart);
+            legendX = box.x;
+            legendY = box.y;
+        }
+
+        test('no tooltip config — non-truncated items do not show tooltip', async () => {
+            await setupChart();
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).not.toHaveBeenCalled();
+            expect(removeSpy).toHaveBeenCalled();
+        });
+
+        test('visible: always — tooltip shown on every hover', async () => {
+            await setupChart({ item: { tooltip: { visible: 'always' } } });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+            const content = updateSpy.mock.calls[0][2];
+            expect(content).toEqual([{ type: 'structured', title: 'Series Y' }]);
+        });
+
+        test('visible: never — tooltip never shown', async () => {
+            await setupChart({
+                item: {
+                    label: { maxLength: 3 }, // force truncation
+                    tooltip: { visible: 'never' },
+                },
+            });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).not.toHaveBeenCalled();
+        });
+
+        test('text — static text shown on every hover', async () => {
+            await setupChart({ item: { tooltip: { text: 'Click to toggle' } } });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+            const content = updateSpy.mock.calls[0][2];
+            expect(content).toEqual([{ type: 'structured', title: 'Click to toggle' }]);
+        });
+
+        test('renderer — dynamic content on every hover', async () => {
+            await setupChart({
+                item: {
+                    tooltip: {
+                        renderer: (p) => `${p.text} (${p.seriesId})`,
+                    },
+                },
+            });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+            const content = updateSpy.mock.calls[0][2];
+            expect(content).toEqual(
+                expect.arrayContaining([expect.objectContaining({ type: 'raw', rawHtmlString: expect.any(String) })])
+            );
+            const rawContent = (content![0] as { type: 'raw'; rawHtmlString: string }).rawHtmlString;
+            expect(rawContent).toContain('Series Y');
+        });
+
+        test('visible: auto with renderer — tooltip only when truncated', async () => {
+            await setupChart({
+                item: {
+                    tooltip: {
+                        visible: 'auto',
+                        renderer: (p) => `${p.text} — details`,
+                    },
+                },
+            });
+
+            // Non-truncated item: no tooltip
+            await hoverAction(legendX, legendY)(chart);
+            expect(updateSpy).not.toHaveBeenCalled();
+        });
+
+        test('renderer returns empty string — no tooltip', async () => {
+            await setupChart({
+                item: {
+                    tooltip: {
+                        renderer: () => '',
+                    },
+                },
+            });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).not.toHaveBeenCalled();
+        });
+
+        test('both text and renderer — renderer takes precedence', async () => {
+            await setupChart({
+                item: {
+                    tooltip: {
+                        text: 'Static text',
+                        renderer: (p) => `Custom: ${p.text}`,
+                    },
+                },
+            });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+            const content = updateSpy.mock.calls[0][2];
+            const rawContent = (content![0] as { type: 'raw'; rawHtmlString: string }).rawHtmlString;
+            expect(rawContent).toContain('Custom: Series Y');
+        });
+
+        test('text defaults visible to always', async () => {
+            await setupChart({ item: { tooltip: { text: 'Info' } } });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            // Text provided without explicit visible — should default to 'always'
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test('renderer params contain expected fields', async () => {
+            const rendererFn = jest.fn((_p: any) => 'tooltip');
+            await setupChart({
+                item: { tooltip: { renderer: rendererFn } },
+            });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(rendererFn).toHaveBeenCalledTimes(1);
+            const params = rendererFn.mock.calls[0][0];
+            expect(params).toMatchObject({
+                seriesId: expect.any(String),
+                itemId: 'y',
+                text: 'Series Y',
+                enabled: true,
+            });
+        });
+
+        test('toggleSeries: false — tooltip still works', async () => {
+            await setupChart({
+                toggleSeries: false,
+                item: { tooltip: { visible: 'always' } },
+            });
+
+            await hoverAction(legendX, legendY)(chart);
+
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -218,7 +218,7 @@ export class Legend {
             listeners: { legendItemClick, legendItemDoubleClick },
             item: { tooltip },
         } = this.opts;
-        const hasExplicitTooltip = tooltip?.visible === 'always' || tooltip?.text != null || tooltip?.renderer != null;
+        const hasExplicitTooltip = tooltip != null && tooltip.visible !== 'never';
         return toggleSeries || legendItemDoubleClick != null || legendItemClick != null || hasExplicitTooltip;
     }
 
@@ -1037,7 +1037,7 @@ export class Legend {
         if (tooltipOpts?.renderer) {
             const params = {
                 seriesId: datum.seriesId,
-                itemId: datum.itemId,
+                itemId: datum.itemId ?? datum.id,
                 text: toPlainText(datum.label.text),
                 enabled: datum.enabled,
             };

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -218,8 +218,7 @@ export class Legend {
             listeners: { legendItemClick, legendItemDoubleClick },
             item: { tooltip },
         } = this.opts;
-        const hasExplicitTooltip =
-            tooltip?.visible === 'always' || tooltip?.text != null || tooltip?.renderer != null;
+        const hasExplicitTooltip = tooltip?.visible === 'always' || tooltip?.text != null || tooltip?.renderer != null;
         return toggleSeries || legendItemDoubleClick != null || legendItemClick != null || hasExplicitTooltip;
     }
 

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -47,6 +47,7 @@ import { Marker } from '../marker/marker';
 import { Pagination } from '../pagination/pagination';
 import { getShapeStyle } from '../series/shapeUtil';
 import { type TooltipMeta } from '../tooltip/tooltip';
+import type { TooltipContent } from '../tooltip/tooltipContent';
 import { LegendDOMProxy } from './legendDOMProxy';
 import type { CategoryLegendDatum } from './legendDatum';
 import { makeLegendItemEvent } from './legendEvent';
@@ -215,8 +216,11 @@ export class Legend {
         const {
             toggleSeries,
             listeners: { legendItemClick, legendItemDoubleClick },
+            item: { tooltip },
         } = this.opts;
-        return toggleSeries || legendItemDoubleClick != null || legendItemClick != null;
+        const hasExplicitTooltip =
+            tooltip?.visible === 'always' || tooltip?.text != null || tooltip?.renderer != null;
+        return toggleSeries || legendItemDoubleClick != null || legendItemClick != null || hasExplicitTooltip;
     }
 
     private checkInteractionState(): boolean {
@@ -1019,6 +1023,37 @@ export class Legend {
         return { canvasX: point.x, canvasY: point.y, showArrow: false };
     }
 
+    private getTooltipContent(datum: CategoryLegendDatum): TooltipContent[] | undefined {
+        const tooltipOpts = this.opts.item.tooltip;
+        const isTruncated = this.truncatedItems.has(datum.itemId ?? datum.id);
+
+        // Resolve effective visibility: default is 'always' when custom content provided, else 'auto'
+        const hasCustomContent = tooltipOpts?.text != null || tooltipOpts?.renderer != null;
+        const visible = tooltipOpts?.visible ?? (hasCustomContent ? 'always' : 'auto');
+
+        if (visible === 'never') return undefined;
+        if (visible === 'auto' && !isTruncated) return undefined;
+
+        // Content precedence: renderer > text > default label
+        if (tooltipOpts?.renderer) {
+            const params = {
+                seriesId: datum.seriesId,
+                itemId: datum.itemId,
+                text: toPlainText(datum.label.text),
+                enabled: datum.enabled,
+            };
+            const result = this.cachedCallWithContext(tooltipOpts.renderer, params);
+            if (result == null || result === '') return undefined;
+            return [{ type: 'raw', rawHtmlString: result }];
+        }
+
+        if (tooltipOpts?.text != null) {
+            return [{ type: 'structured', title: tooltipOpts.text }];
+        }
+
+        return [{ type: 'structured', title: this.getItemLabel(datum) }];
+    }
+
     onHover(event: FocusEvent | MouseEvent, node: LegendMarkerLabel) {
         if (this.checkInteractionState()) return;
         if (!this.opts.enabled) throw new Error('AG Charts - onHover handler called on disabled legend');
@@ -1027,13 +1062,13 @@ export class Legend {
 
         const datum: CategoryLegendDatum | undefined = node.datum;
         const series = datum ? this.ctx.chartService.series.find((s) => s.id === datum?.id) : undefined;
-        if (datum && this.truncatedItems.has(datum.itemId ?? datum.id)) {
+
+        const content = datum ? this.getTooltipContent(datum) : undefined;
+        if (content) {
             const meta = this.toTooltipMeta(event, node);
-            this.ctx.tooltipManager.updateTooltip(this.id, meta, [
-                { type: 'structured', title: this.getItemLabel(datum) },
-            ]);
+            this.ctx.tooltipManager.updateTooltip(this.id, meta, content);
         } else {
-            this.ctx.tooltipManager.removeTooltip(this.id, undefined, true); // true = delayed
+            this.ctx.tooltipManager.removeTooltip(this.id, undefined, true);
         }
 
         this.updateHighlight(datum?.enabled, datum, series);

--- a/packages/ag-charts-community/src/chart/legend/legendModule.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendModule.ts
@@ -15,6 +15,7 @@ import {
     positiveNumber,
     ratio,
     shapeValidator,
+    string,
     strokeOptionsDef,
     union,
 } from 'ag-charts-core';
@@ -60,6 +61,11 @@ export const LegendModule: PluginModuleDefinition<AgChartLegendOptions> = {
                 maxLength: positiveNumber,
                 formatter: callback,
                 ...fontOptionsDef,
+            },
+            tooltip: {
+                visible: union('auto', 'always', 'never'),
+                text: string,
+                renderer: callback,
             },
             maxWidth: positiveNumber,
             paddingX: positiveNumber,

--- a/packages/ag-charts-core/src/config/chartDefaults.ts
+++ b/packages/ag-charts-core/src/config/chartDefaults.ts
@@ -381,6 +381,11 @@ export const commonChartOptionsDefs: OptionsDefs<Omit<AgBaseThemeableChartOption
                 formatter: callback,
                 ...fontOptionsDef,
             },
+            tooltip: {
+                visible: union('auto', 'always', 'never'),
+                text: string,
+                renderer: callback,
+            },
             maxWidth: positiveNumber,
             paddingX: positiveNumber,
             paddingY: positiveNumber,

--- a/packages/ag-charts-types/src/chart/legendOptions.ts
+++ b/packages/ag-charts-types/src/chart/legendOptions.ts
@@ -13,6 +13,9 @@ import type {
     PixelSize,
 } from './types';
 
+/** Controls when an element tooltip is shown. */
+export type AgElementTooltipVisibility = 'auto' | 'always' | 'never';
+
 export type AgChartLegendPlacement =
     | 'top'
     | 'top-right'
@@ -102,6 +105,37 @@ export interface AgChartLegendLabelOptions<TContext = ContextDefault> {
     formatter?: Formatter<AgChartLegendLabelFormatterParams<TContext>>;
 }
 
+export interface AgChartLegendItemTooltipRendererParams<TContext = ContextDefault> {
+    /** Series id. */
+    seriesId: string;
+    /** Legend item id - usually yKey value for cartesian series. */
+    itemId: string | number;
+    /** The full, untruncated legend item label text. */
+    text: string;
+    /** Whether the legend item is currently enabled (series visible). */
+    enabled: boolean;
+    /** Callback context for this renderer. */
+    context?: TContext;
+}
+
+export interface AgChartLegendItemTooltipOptions<TContext = ContextDefault> {
+    /** Controls when the tooltip is shown.
+     * - `'auto'` shows the tooltip only when the label text is truncated.
+     * - `'always'` shows the tooltip on every hover.
+     * - `'never'` disables the tooltip entirely.
+     *
+     * Default: `'auto'` when no `text` or `renderer` is provided; `'always'` otherwise.
+     */
+    visible?: AgElementTooltipVisibility;
+    /** Static tooltip text shown for all legend items. */
+    text?: string;
+    /** Function to generate tooltip content per legend item. Returns plain text or an HTML string.
+     * Takes precedence over `text`.
+     *
+     * **Note:** Output is rendered as HTML. Ensure content is trusted to avoid XSS. */
+    renderer?: (params: AgChartLegendItemTooltipRendererParams<TContext>) => string;
+}
+
 export interface AgChartLegendItemOptions<TContext = ContextDefault> {
     /** Configuration for the legend markers. */
     marker?: AgChartLegendMarkerOptions;
@@ -109,6 +143,8 @@ export interface AgChartLegendItemOptions<TContext = ContextDefault> {
     line?: AgChartLegendLineOptions;
     /** Configuration for the legend labels. */
     label?: AgChartLegendLabelOptions<TContext>;
+    /** Configuration for the legend item tooltip. */
+    tooltip?: AgChartLegendItemTooltipOptions<TContext>;
     /** Used to constrain the width of legend items. */
     maxWidth?: PixelSize;
     /** The horizontal spacing in pixels to use between legend items. */

--- a/packages/ag-charts-website/e2e/legend-item-tooltip.spec.ts
+++ b/packages/ag-charts-website/e2e/legend-item-tooltip.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from './fixture';
+import { SELECTORS, gotoExample, setupIntrinsicAssertions, toExamplePageUrl, waitForAllChartUpdates } from './util';
+
+test.describe('legend item tooltip', () => {
+    setupIntrinsicAssertions(test);
+
+    const { url } = toExamplePageUrl('legend-test', 'legend-item-tooltip-e2e', 'vanilla');
+
+    test.beforeEach(async ({ page }) => {
+        await gotoExample(page, url);
+    });
+
+    test('auto mode — tooltip shown on truncated item hover', async ({ page }) => {
+        const legendItems = await page.locator(SELECTORS.legendItems).all();
+
+        // "Natural Gas" is truncated to ~5 chars, hover should show tooltip
+        await legendItems[0].hover();
+
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Natural Gas');
+    });
+
+    test('auto mode — tooltip hidden after leaving legend item', async ({ page }) => {
+        const legendItems = await page.locator(SELECTORS.legendItems).all();
+
+        await legendItems[0].hover();
+        await expect(page.locator(SELECTORS.tooltip)).toBeVisible();
+
+        // Move away from legend
+        await page.mouse.move(0, 0);
+        await expect(page.locator(SELECTORS.tooltip)).not.toBeVisible();
+    });
+
+    test('always mode — tooltip shown on every hover', async ({ page }) => {
+        await page.getByText('Always').click();
+        await waitForAllChartUpdates(page);
+
+        const legendItems = await page.locator(SELECTORS.legendItems).all();
+
+        // "Coal" is short and not truncated, but tooltip should still show in 'always' mode
+        await legendItems[1].hover();
+
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Coal');
+    });
+
+    test('never mode — tooltip never shown even on truncated items', async ({ page }) => {
+        await page.getByText('Never').click();
+        await waitForAllChartUpdates(page);
+
+        const legendItems = await page.locator(SELECTORS.legendItems).all();
+
+        // "Natural Gas" is truncated, but tooltip should not show in 'never' mode
+        await legendItems[0].hover();
+
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).not.toBeVisible();
+    });
+
+    test('custom text — static tooltip text shown', async ({ page }) => {
+        await page.getByText('Custom Text').click();
+        await waitForAllChartUpdates(page);
+
+        const legendItems = await page.locator(SELECTORS.legendItems).all();
+        await legendItems[0].hover();
+
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Click to toggle');
+    });
+
+    test('renderer — HTML content rendered in tooltip', async ({ page }) => {
+        await page.getByText('Renderer').click();
+        await waitForAllChartUpdates(page);
+
+        const legendItems = await page.locator(SELECTORS.legendItems).all();
+        await legendItems[0].hover();
+
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Natural Gas');
+        await expect(tooltip).toContainText('Visible');
+
+        // Verify HTML was rendered (bold tag should be present)
+        await expect(tooltip.locator('b')).toContainText('Natural Gas');
+    });
+});

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-item-tooltip-e2e/index.html
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-item-tooltip-e2e/index.html
@@ -1,0 +1,10 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <button onclick="setMode('auto')">Auto</button>
+        <button onclick="setMode('always')">Always</button>
+        <button onclick="setMode('never')">Never</button>
+        <button onclick="setMode('custom-text')">Custom Text</button>
+        <button onclick="setMode('renderer')">Renderer</button>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-item-tooltip-e2e/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-item-tooltip-e2e/main.ts
@@ -1,0 +1,55 @@
+import { AgCartesianChartOptions, AgChartLegendItemTooltipRendererParams, AgCharts } from 'ag-charts-community';
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: [
+        { quarter: 'Q1', coal: -666, naturalGas: -1197, petroleum: -124 },
+        { quarter: 'Q2', coal: 208, naturalGas: 906, petroleum: -318 },
+        { quarter: 'Q3', coal: 426, naturalGas: 276, petroleum: 166 },
+        { quarter: 'Q4', coal: 158, naturalGas: 672, petroleum: -19 },
+    ],
+    series: [
+        { type: 'bar', xKey: 'quarter', yKey: 'naturalGas', yName: 'Natural Gas' },
+        { type: 'bar', xKey: 'quarter', yKey: 'coal', yName: 'Coal' },
+        { type: 'bar', xKey: 'quarter', yKey: 'petroleum', yName: 'Petroleum' },
+    ],
+    legend: {
+        item: {
+            label: { maxLength: 5 },
+            tooltip: { visible: 'auto' },
+        },
+    },
+};
+
+const chart = AgCharts.create(options);
+
+function setMode(mode: string) {
+    switch (mode) {
+        case 'auto':
+            options.legend = { item: { label: { maxLength: 5 }, tooltip: { visible: 'auto' } } };
+            break;
+        case 'always':
+            options.legend = { item: { label: { maxLength: 5 }, tooltip: { visible: 'always' } } };
+            break;
+        case 'never':
+            options.legend = { item: { label: { maxLength: 5 }, tooltip: { visible: 'never' } } };
+            break;
+        case 'custom-text':
+            options.legend = { item: { label: { maxLength: 5 }, tooltip: { text: 'Click to toggle' } } };
+            break;
+        case 'renderer':
+            options.legend = {
+                item: {
+                    label: { maxLength: 5 },
+                    tooltip: {
+                        renderer: ({ text, enabled }: AgChartLegendItemTooltipRendererParams) => {
+                            const status = enabled ? 'Visible' : 'Hidden';
+                            return `<b>${text}</b> — <em>${status}</em>`;
+                        },
+                    },
+                },
+            };
+            break;
+    }
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/legend-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/legend-test/index.mdoc
@@ -54,3 +54,7 @@ Steps to test:
    Expected: Legend goes to page 2.
 
 {% chartExampleRunner title="Legend Interactivity" name="legend-pagination-resize" type="generated" /%}
+
+## Legend Item Tooltip
+
+{% chartExampleRunner title="Legend Item Tooltip" name="legend-item-tooltip-e2e" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/data.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/data.ts
@@ -1,0 +1,37 @@
+// Source: https://www.gov.uk/government/statistics/renewable-sources-of-energy-chapter-6-digest-of-united-kingdom-energy-statistics-dukes
+export function getData() {
+    return [
+        {
+            quarter: 'Q1',
+            coal: -666,
+            manufacturedFuels: -14,
+            primaryOil: -261,
+            petroleum: -124,
+            naturalGas: -1197,
+        },
+        {
+            quarter: 'Q2',
+            coal: 208,
+            manufacturedFuels: 71,
+            primaryOil: 950,
+            petroleum: -318,
+            naturalGas: 906,
+        },
+        {
+            quarter: 'Q3',
+            coal: 426,
+            manufacturedFuels: 19,
+            primaryOil: -845,
+            petroleum: 166,
+            naturalGas: 276,
+        },
+        {
+            quarter: 'Q4',
+            coal: 158,
+            manufacturedFuels: -29,
+            primaryOil: -156,
+            petroleum: -19,
+            naturalGas: 672,
+        },
+    ];
+}

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/index.html
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/index.html
@@ -1,0 +1,13 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <label for="tooltip-mode">Tooltip Mode:</label>
+        <select id="tooltip-mode" onchange="setTooltipMode(event.target.value)">
+            <option value="auto">auto (default)</option>
+            <option value="always">always</option>
+            <option value="never">never</option>
+            <option value="custom-text">custom text</option>
+            <option value="renderer">renderer</option>
+        </select>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/main.ts
@@ -1,0 +1,75 @@
+import { AgCartesianChartOptions, AgChartLegendItemTooltipRendererParams, AgCharts } from 'ag-charts-community';
+import {
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, LegendModule, NumberAxisModule]);
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    series: [
+        { type: 'bar', xKey: 'quarter', yKey: 'naturalGas', yName: 'Natural Gas' },
+        { type: 'bar', xKey: 'quarter', yKey: 'coal', yName: 'Coal' },
+        { type: 'bar', xKey: 'quarter', yKey: 'primaryOil', yName: 'Primary Oil' },
+        { type: 'bar', xKey: 'quarter', yKey: 'petroleum', yName: 'Petroleum' },
+        { type: 'bar', xKey: 'quarter', yKey: 'manufacturedFuels', yName: 'Manufactured Fuels' },
+    ],
+    legend: {
+        item: {
+            label: {
+                maxLength: 10,
+            },
+            tooltip: {
+                visible: 'auto',
+            },
+        },
+    },
+};
+
+const chart = AgCharts.create(options);
+
+function setTooltipMode(value: string) {
+    switch (value) {
+        case 'auto':
+            options.legend = {
+                item: { label: { maxLength: 10 }, tooltip: { visible: 'auto' } },
+            };
+            break;
+        case 'always':
+            options.legend = {
+                item: { label: { maxLength: 10 }, tooltip: { visible: 'always' } },
+            };
+            break;
+        case 'never':
+            options.legend = {
+                item: { label: { maxLength: 10 }, tooltip: { visible: 'never' } },
+            };
+            break;
+        case 'custom-text':
+            options.legend = {
+                item: { label: { maxLength: 10 }, tooltip: { text: 'Click to toggle series visibility' } },
+            };
+            break;
+        case 'renderer':
+            options.legend = {
+                item: {
+                    label: { maxLength: 10 },
+                    tooltip: {
+                        renderer: ({ text, enabled }: AgChartLegendItemTooltipRendererParams) => {
+                            const status = enabled ? 'Visible' : 'Hidden';
+                            return `<b>${text}</b><br/><em>${status}</em>`;
+                        },
+                    },
+                },
+            };
+            break;
+    }
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/legend/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/legend/index.mdoc
@@ -198,6 +198,64 @@ It is possible to override this behaviour and set the `strokeWidth` and `length`
 }
 ```
 
+## Item Tooltip
+
+Legend items display a tooltip when hovering over items with truncated labels. Use `legend.item.tooltip` to customise this behaviour.
+
+{% chartExampleRunner title="Legend Item Tooltip" name="legend-item-tooltip" type="generated" /%}
+
+The `visible` property controls when the tooltip is shown:
+
+-   `'auto'` (default) — shows the tooltip only when the label text is truncated.
+-   `'always'` — shows the tooltip on every hover.
+-   `'never'` — disables the tooltip entirely.
+
+```js format="snippet"
+{
+    legend: {
+        item: {
+            tooltip: {
+                visible: 'always',
+            },
+        },
+    },
+}
+```
+
+Use the `text` property to set static tooltip text for all items. When `text` is provided without an explicit `visible` value, the tooltip defaults to `'always'`.
+
+```js format="snippet"
+{
+    legend: {
+        item: {
+            tooltip: {
+                text: 'Click to toggle series visibility',
+            },
+        },
+    },
+}
+```
+
+For dynamic per-item content, use the `renderer` callback. This receives parameters including the item's `text`, `seriesId`, `itemId`, and `enabled` state.
+The renderer can return plain text or an HTML string.
+
+```js format="snippet"
+{
+    legend: {
+        item: {
+            tooltip: {
+                renderer: ({ text, enabled }) => {
+                    const status = enabled ? 'Visible' : 'Hidden';
+                    return `<b>${text}</b><br/><em>${status}</em>`;
+                },
+            },
+        },
+    },
+}
+```
+
+When both `text` and `renderer` are provided, the `renderer` takes precedence.
+
 ## Series Visibility Toggling
 
 {% chartExampleRunner title="Series Visibility Toggling" name="legend-click-series-toggle" type="generated" /%}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10316

## Summary

- Adds `legend.item.tooltip` sub-object to control when legend item tooltips appear and what they display
- Three new properties: `visible` ('auto'/'always'/'never'), `text` (static string), `renderer` (per-item callback)
- Smart default: `visible` defaults to `'always'` when `text` or `renderer` is provided without explicit `visible`
- Content precedence: `renderer` > `text` > default label text
- `isInteractive()` updated to enable hover events when explicit tooltip config is present (e.g. `visible: 'always'`, `text`, `renderer`), preserving existing behaviour for default configs with `toggleSeries: false`

## Test plan

- [x] 11 unit tests covering all JIRA acceptance criteria (visibility modes, content precedence, renderer params, empty string, toggleSeries independence)
- [x] 6 E2E Playwright tests verifying tooltip appearance in real browser (auto/always/never/text/renderer modes + hide on leave)
- [x] `build:types` passes for ag-charts-types, ag-charts-community
- [x] `lint` passes
- [x] Full `test ag-charts-community` suite passes (3291 tests)
- [x] `generate-examples` + `validate-examples` pass (820 examples)
- [x] E2E tests pass

Fixes AG-10316