### PR TITLE
AG-11689 Add tooltip to chart title, subtitle, footer

### DIFF
--- a/.rulesync/rules/api-contracts.md
+++ b/.rulesync/rules/api-contracts.md
@@ -63,6 +63,10 @@ This is automatically synced from `processedOptions` via `jsonApply()` in `apply
 2. Add validator to all chart option defs in `chartOptionsDefs.ts`
 3. Add `@Property` field on `Chart` class — `jsonApply` handles the rest
 4. If the option affects the DataSet or other persistent state, ensure state is recreated when the option changes (not just when `data` changes)
+5. If the option includes a callback/renderer, use `TContext = ContextDefault` for the `context` parameter — never `any`. Thread `TContext` from the root chart options through all intermediate interfaces so user-supplied generics propagate to the renderer params.
+6. Nested `BaseProperties` sub-objects on a `BaseProperties` class **must** have the `@Property` decorator. Without it, `BaseProperties.set()` cannot find the property via `listDecoratedProperties()` and will reject it at runtime ("property is unknown").
+
+**Lint constraint**: The `aglint/require-explicit-generic` rule requires explicit type arguments on all generic type references in `ag-charts-types`. When making a previously non-generic interface generic, grep for all references and add explicit type args. Prefer `unknown` over `any` for type aliases that don't propagate a specific context.
 
 ## Propagating Undocumented Options
 

--- a/.rulesync/rules/docs-pages.md
+++ b/.rulesync/rules/docs-pages.md
@@ -20,4 +20,10 @@ When editing `.mdoc` documentation files for AG Charts, follow these conventions
 5. **UK/British English**: For documentation text (US English for API property names)
 6. **Cross-references**: Use `./page-name/` for links between docs pages (e.g., `./tooltips/`, `./axes-types/`). Never use `../page-name/` — all docs pages are siblings under the same base path
 
+## Where to Document a New Feature
+
+-   If the feature is a new top-level chart option (e.g., title, legend, tooltip) or significantly expands an existing one, create a **dedicated page**. Check `nav.json` for existing pages covering the same chart element — if none exists, add one.
+-   Don't add interactive examples or detailed configuration docs to pages that are currently text-only layout descriptions or getting-started tutorials — these have a deliberately minimal scope. Link to the dedicated page instead.
+-   Getting-started tutorials (`create-a-basic-chart`, `quick-start`) should only show basic usage. Advanced configuration belongs on the feature's own page.
+
 For full reference (page types, Markdoc components, content patterns, writing guidelines), load the `/spruce-docs` skill.

--- a/.rulesync/rules/examples.md
+++ b/.rulesync/rules/examples.md
@@ -14,7 +14,15 @@ When creating or editing AG Charts examples, follow these conventions:
 3. **Container pattern**: Use `document.getElementById('myChart')` for container setup
 4. **Top-level functions**: Event handlers and chart update functions must be top-level
 5. **Framework compatible**: All public docs examples MUST work across all frameworks (NO `@ag-skip-fws`)
-6. **Controls in HTML**: Place controls BEFORE chart div, wrapped in `class="example-controls"`
+6. **Controls in HTML**: Place controls BEFORE chart div using this structure:
+    ```html
+    <div class="example-controls">
+        <div class="controls-row">
+            Label Text:
+            <button onclick="handler('value')"><code>'value'</code></button>
+        </div>
+    </div>
+    ```
 
 ## Regenerating Examples After Source Changes
 

--- a/.rulesync/rules/playbook-docs.md
+++ b/.rulesync/rules/playbook-docs.md
@@ -12,9 +12,10 @@ globs: ['packages/ag-charts-website/src/content/docs/**/*']
 3. Modify `.mdoc` under `packages/ag-charts-website/src/content/docs/`
 4. Update `nav.json` if navigation changes
 5. Create/update examples in `_examples/` (all MUST be framework-compatible)
-6. Generate and validate:
+6. Generate, format, and validate:
     - `yarn nx generate-examples ag-charts-website`
     - `yarn nx validate-examples`
+    - `yarn nx format:mdoc ag-charts-website` — format mdoc code blocks (CI checks this separately from Prettier)
 7. Test in dev server across all frameworks
 8. For significant changes: `yarn nx e2e ag-charts-website`
 9. Review the documentation checklist (`.rulesync/skills/spruce-docs/checklist.md`)

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -3,6 +3,7 @@ import {
     FONT_SIZE,
     Property,
     ProxyPropertyOnWrite,
+    callWithContext,
     createId,
     isArray,
     isSegmentTruncated,
@@ -12,7 +13,14 @@ import {
     wrapText,
     wrapTextSegments,
 } from 'ag-charts-core';
-import type { FontStyle, FontWeight, TextAlign, TextOrSegments, TextWrap } from 'ag-charts-types';
+import type {
+    AgCaptionTooltipRendererParams,
+    FontStyle,
+    FontWeight,
+    TextAlign,
+    TextOrSegments,
+    TextWrap,
+} from 'ag-charts-types';
 
 import type { ModuleContext } from '../module/moduleContext';
 import { PointerEvents } from '../scene/node';
@@ -21,6 +29,7 @@ import { Transformable } from '../scene/transformable';
 import type { BoundedTextWidget } from '../widget/boundedTextWidget';
 import type { MouseWidgetEvent } from '../widget/widgetEvents';
 import type { CaptionLike } from './captionLike';
+import type { TooltipContent } from './tooltip/tooltipContent';
 
 type CaptionNodeDatum = {
     visible: boolean;
@@ -32,6 +41,17 @@ type CaptionNodeDatum = {
     rotationCenterY: number;
     rotation: number;
 };
+
+class CaptionTooltipProperties extends BaseProperties {
+    @Property
+    visible?: 'auto' | 'always' | 'never';
+
+    @Property
+    text?: string;
+
+    @Property
+    renderer?: (params: AgCaptionTooltipRendererParams) => string;
+}
 
 export class Caption extends BaseProperties implements CaptionLike {
     static readonly className = 'Caption';
@@ -95,6 +115,9 @@ export class Caption extends BaseProperties implements CaptionLike {
     @Property
     layoutStyle: 'block' | 'overlay' = 'block';
 
+    @Property
+    readonly tooltip = new CaptionTooltipProperties();
+
     private truncated = false;
     private proxyText?: BoundedTextWidget;
     private proxyTextListeners?: Array<() => void>;
@@ -144,7 +167,9 @@ export class Caption extends BaseProperties implements CaptionLike {
             this.proxyText = proxyInteractionService.createProxyElement({ type: 'text', domManagerId, where });
             this.proxyTextListeners = [
                 this.proxyText.addListener('mousemove', (ev) => this.handleMouseMove(moduleCtx, ev)),
-                this.proxyText.addListener('mouseleave', (ev) => this.handleMouseLeave(moduleCtx, ev)),
+                this.proxyText.addListener('mouseleave', () => this.handleTooltipHide(moduleCtx)),
+                this.proxyText.addListener('focus', () => this.handleFocus(moduleCtx)),
+                this.proxyText.addListener('blur', () => this.handleTooltipHide(moduleCtx)),
             ];
         }
 
@@ -169,19 +194,60 @@ export class Caption extends BaseProperties implements CaptionLike {
         }
     }
 
-    private handleMouseMove(moduleCtx: ModuleContext, event?: MouseWidgetEvent<'mousemove'>) {
-        if (event != null && this.enabled && this.truncated) {
-            const { x, y } = Transformable.toCanvas(this.node);
-            const canvasX = event.sourceEvent.offsetX + x;
-            const canvasY = event.sourceEvent.offsetY + y;
-            moduleCtx.tooltipManager.updateTooltip(this.id, { canvasX, canvasY, showArrow: false }, [
-                { type: 'structured', title: toPlainText(this.text) },
-            ]);
-        }
+    private getEffectiveTooltipVisible(): 'auto' | 'always' | 'never' {
+        const { visible, text, renderer } = this.tooltip;
+        if (visible != null) return visible;
+        return text != null || renderer != null ? 'always' : 'auto';
     }
 
-    private handleMouseLeave(moduleCtx: ModuleContext, _event: MouseWidgetEvent<'mouseleave'>) {
-        moduleCtx.tooltipManager.removeTooltip(this.id, undefined, true); // true = delayed
+    private getTooltipContent(moduleCtx: ModuleContext): TooltipContent | undefined {
+        const captionText = toPlainText(this.text);
+        const { renderer, text } = this.tooltip;
+
+        if (renderer != null) {
+            const params: AgCaptionTooltipRendererParams = { text: captionText };
+            const result = callWithContext(moduleCtx.chartService, renderer, params);
+            if (result === '') return undefined;
+            return { type: 'raw', rawHtmlString: result };
+        }
+
+        const displayText = text ?? captionText;
+        return { type: 'structured', title: displayText };
+    }
+
+    private showTooltip(moduleCtx: ModuleContext, canvasX: number, canvasY: number) {
+        if (!this.enabled) return;
+
+        const effectiveVisible = this.getEffectiveTooltipVisible();
+        if (effectiveVisible === 'never') return;
+        if (effectiveVisible === 'auto' && !this.truncated) return;
+
+        const content = this.getTooltipContent(moduleCtx);
+        if (content == null) return;
+
+        moduleCtx.tooltipManager.updateTooltip(this.id, { canvasX, canvasY, showArrow: false }, [content]);
+    }
+
+    private handleMouseMove(moduleCtx: ModuleContext, event?: MouseWidgetEvent<'mousemove'>) {
+        if (event == null) return;
+
+        const { x, y } = Transformable.toCanvas(this.node);
+        const canvasX = event.sourceEvent.offsetX + x;
+        const canvasY = event.sourceEvent.offsetY + y;
+        this.showTooltip(moduleCtx, canvasX, canvasY);
+    }
+
+    private handleFocus(moduleCtx: ModuleContext) {
+        const bbox = Transformable.toCanvas(this.node);
+        if (!bbox) return;
+
+        const canvasX = bbox.x + bbox.width / 2;
+        const canvasY = bbox.y + bbox.height / 2;
+        this.showTooltip(moduleCtx, canvasX, canvasY);
+    }
+
+    private handleTooltipHide(moduleCtx: ModuleContext) {
+        moduleCtx.tooltipManager.removeTooltip(this.id, undefined, true);
     }
 
     destroy() {

--- a/packages/ag-charts-core/src/config/chartDefaults.ts
+++ b/packages/ag-charts-core/src/config/chartDefaults.ts
@@ -171,6 +171,11 @@ const chartCaptionOptionsDefs: OptionsDefs<AgChartCaptionOptions> = {
     maxWidth: positiveNumber,
     maxHeight: positiveNumber,
     ...fontOptionsDef,
+    tooltip: {
+        visible: union('auto', 'always', 'never'),
+        text: string,
+        renderer: callbackOf(string),
+    },
 };
 // @ts-expect-error undocumented option
 chartCaptionOptionsDefs.padding = undocumented(positiveNumber);

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -83,14 +83,14 @@ export interface AgChartOverlaysOptions<TContext = ContextDefault> {
 }
 
 /** Params passed to the caption tooltip renderer callback. */
-export interface AgCaptionTooltipRendererParams {
+export interface AgCaptionTooltipRendererParams<TContext = ContextDefault> {
     /** The caption's own text content as a plain string. */
     text: string;
     /** User-supplied context from the chart options. */
-    context?: any;
+    context?: TContext;
 }
 
-export interface AgCaptionTooltipOptions {
+export interface AgCaptionTooltipOptions<TContext = ContextDefault> {
     /**
      * Controls when the caption tooltip is shown.
      * - `'auto'` — only when text is truncated.
@@ -103,10 +103,10 @@ export interface AgCaptionTooltipOptions {
     /** Static text to display in the tooltip. Overrides the default caption text. */
     text?: string;
     /** Function to produce tooltip content. Return a plain string or an HTML string. Takes precedence over `text`. */
-    renderer?: (params: AgCaptionTooltipRendererParams) => string;
+    renderer?: (params: AgCaptionTooltipRendererParams<TContext>) => string;
 }
 
-export interface AgChartCaptionOptions {
+export interface AgChartCaptionOptions<TContext = ContextDefault> {
     /** Whether the text should be shown. */
     enabled?: boolean;
     /** The text to display. */
@@ -140,10 +140,10 @@ export interface AgChartCaptionOptions {
      */
     wrapping?: TextWrap;
     /** Configuration for the caption tooltip shown on hover. */
-    tooltip?: AgCaptionTooltipOptions;
+    tooltip?: AgCaptionTooltipOptions<TContext>;
 }
-export interface AgChartSubtitleOptions extends AgChartCaptionOptions {}
-export interface AgChartFooterOptions extends AgChartCaptionOptions {}
+export interface AgChartSubtitleOptions<TContext = ContextDefault> extends AgChartCaptionOptions<TContext> {}
+export interface AgChartFooterOptions<TContext = ContextDefault> extends AgChartCaptionOptions<TContext> {}
 
 export interface AgChartBackground {
     /** Whether the background should be visible. */
@@ -256,11 +256,11 @@ export interface AgBaseThemeableChartOptions<TDatum = DatumDefault, TContext = C
     /** Configuration for the background shown behind the chart. */
     background?: AgChartBackground;
     /** Configuration for the title shown at the top of the chart. */
-    title?: AgChartCaptionOptions;
+    title?: AgChartCaptionOptions<TContext>;
     /** Configuration for the subtitle shown beneath the chart title. */
-    subtitle?: AgChartSubtitleOptions;
+    subtitle?: AgChartSubtitleOptions<TContext>;
     /** Configuration for the footnote shown at the bottom of the chart. */
-    footnote?: AgChartFooterOptions;
+    footnote?: AgChartFooterOptions<TContext>;
     /** Configuration for the chart highlighting. */
     highlight?: AgChartHighlightOptions;
     /** HTML overlays. */

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -82,6 +82,30 @@ export interface AgChartOverlaysOptions<TContext = ContextDefault> {
     unsupportedBrowser?: AgChartOverlayOptions<TContext>;
 }
 
+/** Params passed to the caption tooltip renderer callback. */
+export interface AgCaptionTooltipRendererParams {
+    /** The caption's own text content as a plain string. */
+    text: string;
+    /** User-supplied context from the chart options. */
+    context?: any;
+}
+
+export interface AgCaptionTooltipOptions {
+    /**
+     * Controls when the caption tooltip is shown.
+     * - `'auto'` — only when text is truncated.
+     * - `'always'` — on every hover.
+     * - `'never'` — tooltip is disabled.
+     *
+     * Default: `'always'` when `text` or `renderer` is provided, `'auto'` otherwise.
+     */
+    visible?: 'auto' | 'always' | 'never';
+    /** Static text to display in the tooltip. Overrides the default caption text. */
+    text?: string;
+    /** Function to produce tooltip content. Return a plain string or an HTML string. Takes precedence over `text`. */
+    renderer?: (params: AgCaptionTooltipRendererParams) => string;
+}
+
 export interface AgChartCaptionOptions {
     /** Whether the text should be shown. */
     enabled?: boolean;
@@ -115,6 +139,8 @@ export interface AgChartCaptionOptions {
      * Default: `'on-space'`
      */
     wrapping?: TextWrap;
+    /** Configuration for the caption tooltip shown on hover. */
+    tooltip?: AgCaptionTooltipOptions;
 }
 export interface AgChartSubtitleOptions extends AgChartCaptionOptions {}
 export interface AgChartFooterOptions extends AgChartCaptionOptions {}

--- a/packages/ag-charts-types/src/main-scene.ts
+++ b/packages/ag-charts-types/src/main-scene.ts
@@ -20,4 +20,4 @@ export type LinearScale = any;
 
 export type BBox = any;
 
-export type Caption = AgChartCaptionOptions<any>;
+export type Caption = AgChartCaptionOptions<unknown>;

--- a/packages/ag-charts-types/src/main-scene.ts
+++ b/packages/ag-charts-types/src/main-scene.ts
@@ -20,4 +20,4 @@ export type LinearScale = any;
 
 export type BBox = any;
 
-export type Caption = AgChartCaptionOptions;
+export type Caption = AgChartCaptionOptions<any>;

--- a/packages/ag-charts-website/e2e/caption-tooltip.spec.ts
+++ b/packages/ag-charts-website/e2e/caption-tooltip.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from './fixture';
+import { SELECTORS, canvasToPageTransformer, gotoExample, setupIntrinsicAssertions, toExamplePageUrl } from './util';
+
+test.describe('caption tooltip', () => {
+    setupIntrinsicAssertions(test);
+
+    test.beforeEach(async ({ page }) => {
+        await gotoExample(page, toExamplePageUrl('layout-test', 'e2e-caption-tooltip', 'vanilla').url);
+    });
+
+    async function hoverTitle(page: import('@playwright/test').Page) {
+        const toPage = await canvasToPageTransformer(page);
+        // Title is rendered at the top centre of the chart
+        const point = toPage(400, 22);
+        await page.mouse.move(point.x, point.y);
+    }
+
+    async function hoverSubtitle(page: import('@playwright/test').Page) {
+        // The subtitle proxy is a DOM element with the subtitle text content
+        const proxyElements = page.locator('.ag-charts-proxy-elem');
+        const count = await proxyElements.count();
+        for (let i = 0; i < count; i++) {
+            const text = await proxyElements.nth(i).textContent();
+            if (text?.includes('Fiscal Year 2025')) {
+                await proxyElements.nth(i).hover();
+                return;
+            }
+        }
+        throw new Error('Subtitle proxy element not found');
+    }
+
+    async function hoverAway(page: import('@playwright/test').Page) {
+        const toPage = await canvasToPageTransformer(page);
+        // Move to series area, away from captions
+        const point = toPage(400, 300);
+        await page.mouse.move(point.x, point.y);
+    }
+
+    test('no tooltip by default on non-truncated title', async ({ page }) => {
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).not.toBeVisible();
+    });
+
+    test('visible: always shows tooltip on hover', async ({ page }) => {
+        await page.locator('#visible-always').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Quarterly Revenue');
+    });
+
+    test('visible: always shows subtitle tooltip on hover', async ({ page }) => {
+        await page.locator('#visible-always').click();
+        await hoverSubtitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Fiscal Year 2025');
+    });
+
+    test('visible: never hides tooltip even when truncated', async ({ page }) => {
+        await page.locator('#truncate').click();
+        await page.locator('#visible-never').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).not.toBeVisible();
+    });
+
+    test('custom text shows on hover', async ({ page }) => {
+        await page.locator('#custom-text').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Revenue in USD from internal CRM');
+    });
+
+    test('renderer shows HTML content', async ({ page }) => {
+        await page.locator('#renderer').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Source: Internal CRM');
+    });
+
+    test('empty renderer hides tooltip', async ({ page }) => {
+        await page.locator('#empty-renderer').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).not.toBeVisible();
+    });
+
+    test('auto mode shows tooltip when truncated', async ({ page }) => {
+        await page.locator('#truncate').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Quarterly Revenue');
+    });
+
+    test('tooltip hides when mouse leaves caption', async ({ page }) => {
+        await page.locator('#visible-always').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await hoverAway(page);
+        await expect(tooltip).not.toBeVisible();
+    });
+});

--- a/packages/ag-charts-website/src/content/docs-nav/nav.json
+++ b/packages/ag-charts-website/src/content/docs-nav/nav.json
@@ -335,6 +335,11 @@
                         },
                         {
                             "type": "item",
+                            "title": "Titles",
+                            "path": "titles"
+                        },
+                        {
+                            "type": "item",
                             "title": "RTL Text & Layout",
                             "path": "rtl"
                         },

--- a/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
@@ -406,7 +406,7 @@ const options = ref<AgChartOptions>({
 
 {% chartExampleRunner title="Titles Example" name="title-example" type="generated" /%}
 
-_Note: Refer to the [title](/options/#reference-AgChartOptions-title) and [subtitle](/options/#reference-AgChartOptions-subtitle) API docs for a full list of properties that can be configured_
+_Note: Refer to the [Titles](./titles/) docs for the full list of caption properties, including tooltips and text wrapping._
 
 ### Legend
 

--- a/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/index.html
+++ b/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/index.html
@@ -1,0 +1,11 @@
+<div id="controls">
+    <button id="visible-always">Always</button>
+    <button id="visible-never">Never</button>
+    <button id="visible-auto">Auto</button>
+    <button id="custom-text">Custom Text</button>
+    <button id="renderer">Renderer</button>
+    <button id="empty-renderer">Empty Renderer</button>
+    <button id="truncate">Truncate</button>
+    <button id="reset">Reset</button>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/main.ts
+++ b/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/main.ts
@@ -1,0 +1,77 @@
+// @ag-skip-fws
+import { AgCartesianChartOptions, AgCharts } from 'ag-charts-community';
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Quarterly Revenue by Product Line for the Financial Year',
+    },
+    subtitle: {
+        text: 'Fiscal Year 2025',
+    },
+    footnote: {
+        text: 'Excludes returns and refunds',
+    },
+    data: [
+        { quarter: 'Q1', widgets: 420, gadgets: 310 },
+        { quarter: 'Q2', widgets: 490, gadgets: 350 },
+        { quarter: 'Q3', widgets: 530, gadgets: 410 },
+        { quarter: 'Q4', widgets: 610, gadgets: 460 },
+    ],
+    series: [
+        { type: 'bar', xKey: 'quarter', yKey: 'widgets', yName: 'Widgets' },
+        { type: 'bar', xKey: 'quarter', yKey: 'gadgets', yName: 'Gadgets' },
+    ],
+};
+
+const chart = AgCharts.create(options);
+
+document.getElementById('visible-always')!.addEventListener('click', () => {
+    options.title!.tooltip = { visible: 'always' };
+    options.subtitle!.tooltip = { visible: 'always' };
+    chart.update(options);
+});
+
+document.getElementById('visible-never')!.addEventListener('click', () => {
+    options.title!.tooltip = { visible: 'never' };
+    options.subtitle!.tooltip = { visible: 'never' };
+    chart.update(options);
+});
+
+document.getElementById('visible-auto')!.addEventListener('click', () => {
+    options.title!.tooltip = { visible: 'auto' };
+    options.subtitle!.tooltip = { visible: 'auto' };
+    chart.update(options);
+});
+
+document.getElementById('custom-text')!.addEventListener('click', () => {
+    options.title!.tooltip = { text: 'Revenue in USD from internal CRM' };
+    chart.update(options);
+});
+
+document.getElementById('renderer')!.addEventListener('click', () => {
+    options.title!.tooltip = {
+        renderer: ({ text }) => `<b>${text}</b><br/>Source: Internal CRM`,
+    };
+    chart.update(options);
+});
+
+document.getElementById('empty-renderer')!.addEventListener('click', () => {
+    options.title!.tooltip = {
+        renderer: () => '',
+    };
+    chart.update(options);
+});
+
+document.getElementById('truncate')!.addEventListener('click', () => {
+    options.title!.maxWidth = 200;
+    options.title!.tooltip = undefined;
+    chart.update(options);
+});
+
+document.getElementById('reset')!.addEventListener('click', () => {
+    options.title!.tooltip = undefined;
+    options.title!.maxWidth = undefined;
+    options.subtitle!.tooltip = undefined;
+    chart.update(options);
+});

--- a/packages/ag-charts-website/src/content/docs/layout-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/layout-test/index.mdoc
@@ -61,6 +61,10 @@ title: 'Layout Test'
 
 {% chartExampleRunner title="Shadow DOM relocation" name="layout-shadow-dom-relocation" type="generated" /%}
 
+## Caption Tooltips
+
+{% chartExampleRunner title="Caption tooltip E2E" name="e2e-caption-tooltip" type="generated" /%}
+
 ## Sparkline WebComponent / Shadow-DOM OOB
 
 -   Should render at 300px high and full width of example.

--- a/packages/ag-charts-website/src/content/docs/titles/_examples/caption-tooltip/index.html
+++ b/packages/ag-charts-website/src/content/docs/titles/_examples/caption-tooltip/index.html
@@ -1,0 +1,9 @@
+<div class="example-controls">
+    <div class="controls-row">
+        Tooltip Visible:
+        <button onclick="setTooltipVisible('auto')"><code>'auto'</code></button>
+        <button onclick="setTooltipVisible('always')"><code>'always'</code></button>
+        <button onclick="setTooltipVisible('never')"><code>'never'</code></button>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/titles/_examples/caption-tooltip/main.ts
+++ b/packages/ag-charts-website/src/content/docs/titles/_examples/caption-tooltip/main.ts
@@ -1,0 +1,52 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, LegendModule, NumberAxisModule]);
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Quarterly Revenue by Product Line Across All Regions',
+        maxWidth: 250,
+        tooltip: {
+            text: 'Revenue figures in USD, sourced from internal CRM. Updated quarterly.',
+        },
+    },
+    subtitle: {
+        text: 'Fiscal Year 2025',
+        tooltip: {
+            renderer: ({ text }) => `<b>${text}</b><br/>Data refreshed: April 2025`,
+        },
+    },
+    footnote: {
+        text: 'Source: Internal CRM — Excludes returns, refunds and inter-company transfers',
+        maxWidth: 300,
+    },
+    data: [
+        { quarter: 'Q1', widgets: 420, gadgets: 310, gizmos: 220 },
+        { quarter: 'Q2', widgets: 490, gadgets: 350, gizmos: 280 },
+        { quarter: 'Q3', widgets: 530, gadgets: 410, gizmos: 310 },
+        { quarter: 'Q4', widgets: 610, gadgets: 460, gizmos: 370 },
+    ],
+    series: [
+        { type: 'bar', xKey: 'quarter', yKey: 'widgets', yName: 'Widgets' },
+        { type: 'bar', xKey: 'quarter', yKey: 'gadgets', yName: 'Gadgets' },
+        { type: 'bar', xKey: 'quarter', yKey: 'gizmos', yName: 'Gizmos' },
+    ],
+};
+
+const chart = AgCharts.create(options);
+
+function setTooltipVisible(visible: 'auto' | 'always' | 'never') {
+    options.title!.tooltip = { ...options.title!.tooltip, visible };
+    options.subtitle!.tooltip = { ...options.subtitle!.tooltip, visible };
+    options.footnote!.tooltip = { ...options.footnote!.tooltip, visible };
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/titles/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/titles/index.mdoc
@@ -15,7 +15,7 @@ subtitle: {
 },
 footnote: {
     text: 'Source: Internal CRM',
-},
+}
 ```
 
 ## Wrapping & Truncation
@@ -46,10 +46,12 @@ When `tooltip.text` or `tooltip.renderer` is provided without an explicit `visib
 Use `tooltip.text` to display a static tooltip message, or `tooltip.renderer` for dynamic content. The renderer receives the caption's plain text and can return a string or an HTML string.
 
 ```js format="snippet"
-title: {
-    text: 'Annual Revenue',
-    tooltip: {
-        renderer: ({ text }) => `<b>${text}</b><br/>Source: Internal CRM`,
+{
+    title: {
+        text: 'Annual Revenue',
+        tooltip: {
+            renderer: ({ text }) => `<b>${text}</b><br/>Source: Internal CRM`,
+        },
     },
 }
 ```

--- a/packages/ag-charts-website/src/content/docs/titles/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/titles/index.mdoc
@@ -6,15 +6,17 @@ description: 'Configure $framework chart title, subtitle, and footnote captions,
 Chart captions — `title`, `subtitle` and `footnote` — label and annotate the chart. Each accepts the same set of options for text content, font styling, wrapping and tooltips.
 
 ```js format="snippet"
-title: {
-    text: 'Quarterly Revenue',
-    fontSize: 18,
-},
-subtitle: {
-    text: 'Fiscal Year 2025',
-},
-footnote: {
-    text: 'Source: Internal CRM',
+{
+    title: {
+        text: 'Quarterly Revenue',
+        fontSize: 18,
+    },
+    subtitle: {
+        text: 'Fiscal Year 2025',
+    },
+    footnote: {
+        text: 'Source: Internal CRM',
+    },
 }
 ```
 

--- a/packages/ag-charts-website/src/content/docs/titles/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/titles/index.mdoc
@@ -1,0 +1,61 @@
+---
+title: 'Titles'
+description: 'Configure $framework chart title, subtitle, and footnote captions, including text wrapping, truncation and tooltips.'
+---
+
+Chart captions — `title`, `subtitle` and `footnote` — label and annotate the chart. Each accepts the same set of options for text content, font styling, wrapping and tooltips.
+
+```js format="snippet"
+title: {
+    text: 'Quarterly Revenue',
+    fontSize: 18,
+},
+subtitle: {
+    text: 'Fiscal Year 2025',
+},
+footnote: {
+    text: 'Source: Internal CRM',
+},
+```
+
+## Wrapping & Truncation
+
+Use `maxWidth` and `maxHeight` to constrain caption dimensions. The `wrapping` option controls how text behaves when it exceeds the available space:
+
+-   `'always'` — Wrap text to fit within `maxWidth` (default).
+-   `'hyphenate'` — Similar to `'always'`, but inserts a hyphen if forced to break mid-word.
+-   `'on-space'` — Only wrap on white space; truncate if no break point fits.
+-   `'never'` — No wrapping; text is truncated if it exceeds `maxWidth`.
+
+## Tooltips
+
+Tooltips can be added to any caption to show additional information on hover. This is useful for providing data source notes, methodology details or the full text of a truncated caption.
+
+{% chartExampleRunner title="Caption Tooltips" name="caption-tooltip" type="generated" /%}
+
+In this example, the title and footnote are constrained by `maxWidth` and truncated. Hovering over a truncated caption shows its tooltip automatically. Use the buttons to change the `tooltip.visible` mode:
+
+-   `'auto'` — Show the tooltip only when the caption text is truncated (default).
+-   `'always'` — Always show the tooltip on hover, even when not truncated.
+-   `'never'` — Never show a tooltip, even when the text is truncated.
+
+{% note %}
+When `tooltip.text` or `tooltip.renderer` is provided without an explicit `visible` value, the tooltip defaults to `'always'`.
+{% /note %}
+
+Use `tooltip.text` to display a static tooltip message, or `tooltip.renderer` for dynamic content. The renderer receives the caption's plain text and can return a string or an HTML string.
+
+```js format="snippet"
+title: {
+    text: 'Annual Revenue',
+    tooltip: {
+        renderer: ({ text }) => `<b>${text}</b><br/>Source: Internal CRM`,
+    },
+}
+```
+
+Content precedence: `renderer` > `text` > default caption text.
+
+## API Reference
+
+{% apiReference id="AgChartCaptionOptions" /%}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-11689

Add `tooltip` sub-object to `AgChartCaptionOptions` (shared by title, subtitle, footnote) with `visible`, `text` and `renderer` properties.

- `visible: 'auto' | 'always' | 'never'` — controls when tooltip appears
- `text: string` — static tooltip text override
- `renderer: (params) => string` — dynamic HTML/text content
- Smart defaults: `visible` is `'always'` when `text`/`renderer` provided, `'auto'` otherwise
- Keyboard accessible via focus/blur on existing proxy elements
- New dedicated Titles documentation page under Layout & Styling
- 9 Playwright E2E tests covering all functional ACs

Fix #AG-11689