### PR TITLE
AG-17085 Fix setup-prompts.sh aborting yarn install on CI agents

### DIFF
--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -255,24 +255,27 @@ copy_extra_configs() {
     local claude_settings_dest="$REPO_ROOT/.claude/settings.json"
 
     if [[ -f "$REPO_ROOT/$claude_settings_template" ]] && [[ "$targets" == *"claudecode"* || "$targets" == "*" ]]; then
+        # Detect product via AG_PRODUCT env var or by reading package.json .name.
+        # Fall back gracefully when neither source yields a match: skipping the
+        # render leaves any existing .claude/settings.json in place and lets
+        # the rest of postinstall complete. Failing here would otherwise abort
+        # `yarn install` on environments missing jq or on unknown checkouts.
         local product="${AG_PRODUCT:-}"
-        if [[ -z "$product" && -f "$REPO_ROOT/package.json" ]]; then
+        if [[ -z "$product" && -f "$REPO_ROOT/package.json" ]] && command -v jq >/dev/null 2>&1; then
             product=$(jq -r '.name // empty' "$REPO_ROOT/package.json" 2>/dev/null)
         fi
 
         if [[ -z "$product" ]]; then
-            echo -e "${RED}✗${NC} Cannot render .claude/settings.json: no product detected."
-            echo -e "${YELLOW}  Expected workspace root package.json .name to be one of: ag-charts | ag-grid | ag-studio.${NC}"
-            echo -e "${YELLOW}  Override with AG_PRODUCT env var if running from a non-standard checkout.${NC}"
-            return 1
+            echo -e "${YELLOW}!${NC} Skipping .claude/settings.json render: no product detected" >&2
+            echo -e "${YELLOW}  Set AG_PRODUCT (ag-charts | ag-grid | ag-studio) or ensure jq is installed + package.json .name is set.${NC}" >&2
+            return 0
         fi
 
         case "$product" in
             ag-charts|ag-grid|ag-studio) ;;
             *)
-                echo -e "${RED}✗${NC} Unknown product '$product' (expected: ag-charts | ag-grid | ag-studio)"
-                echo -e "${YELLOW}  Detected from package.json .name; override with AG_PRODUCT if needed.${NC}"
-                return 1
+                echo -e "${YELLOW}!${NC} Skipping .claude/settings.json render: unknown product '$product' (expected: ag-charts | ag-grid | ag-studio). Override with AG_PRODUCT if needed." >&2
+                return 0
                 ;;
         esac
 
@@ -455,13 +458,15 @@ generate_config() {
     # items. If it does, rulesync would regenerate them in .claude/skills
     # alongside the same skill delivered by the plugin — duplicate content and
     # ambiguous trigger behaviour. Fail fast if stale symlinks exist.
+    # Cleanup requires python3; skip with a warning when it's unavailable so
+    # postinstall still succeeds on environments without it.
     local cleanup_script="$REPO_ROOT/external/ag-shared/scripts/setup-prompts/cleanup-plugin-delivered.py"
-    if [[ -f "$cleanup_script" ]] && [[ -f "$cache_manifest" ]]; then
+    if [[ -f "$cleanup_script" ]] && [[ -f "$cache_manifest" ]] && command -v python3 >/dev/null 2>&1; then
         if ! python3 "$cleanup_script" --verify >/dev/null 2>&1; then
             echo -e "${YELLOW}Warning: .rulesync/ contains symlinks for plugin-delivered items${NC}"
             python3 "$cleanup_script" --verify || true
             echo -e "${YELLOW}Removing stale symlinks...${NC}"
-            python3 "$cleanup_script"
+            python3 "$cleanup_script" || true
         fi
     fi
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17085

Follow-up fix for the canary opt-in landed in [#6640](https://github.com/ag-grid/ag-charts/pull/6640). TeamCity's macOS agent was exiting `yarn install` with `postinstall:setup-prompts exited with 127` because two external-tool invocations in `setup-prompts.sh` were unguarded:

1. **Product detection at the `.claude/settings.json` render step** called `jq` unconditionally. When `jq` isn't installed, the product came back empty and the hard-fail `return 1` propagated via `set -e` — killing the whole script before rulesync or any other postinstall step could run.
2. **The plugin-delivered cleanup block** invoked `python3 "$cleanup_script"` without `|| true`, so a cleanup failure took down the whole postinstall.

Both paths now degrade to warnings and `return 0`. The existing `.claude/settings.json` stays in place if the render can't be completed, and the rest of postinstall finishes. Symptom was only "✓ Detected: Claude Code" then `ERROR: "postinstall:setup-prompts" exited with 127.` — matches the product-detect path (no `Warning:` lines visible because the error happened before the `Cannot render` echo on `set -e` kill paths vary across bash versions).

## What changes

- `command -v jq` guard before the `jq` invocation — missing jq no longer empties product via silent failure, it just skips the render.
- Both "no product detected" and "unknown product" branches now emit `!` (yellow warning) to stderr and `return 0` instead of `return 1`. The hard-fail was overly strict for a per-repo config render.
- `command -v python3` guard added on the cleanup block, plus `|| true` on the final `python3 "$cleanup_script"` so a cleanup hiccup doesn't abort postinstall.

## Verification

Tested locally with `env -i PATH=/bin:/usr/bin ... ./setup-prompts.sh --postinstall` (no jq, no python3, no node in PATH) — script now exits 0 with appropriate warnings instead of aborting.

## Subrepo note

The change touches `external/ag-shared/scripts/setup-prompts/setup-prompts.sh`, which is a subrepo. **Before merging this PR**, run `git subrepo push external/ag-shared` to publish the fix to the ag-shared mirror so ag-grid and ag-studio pick it up on their next subrepo pull. (I didn't do the push yet — wanted to keep it behind review.)

## Test plan

- [ ] CI green on this branch
- [ ] TeamCity `yarn install` completes on macOS agent
- [ ] Local `yarn` still renders `.claude/settings.json` correctly with canary pin (no regression on the happy path)
- [ ] `git subrepo push external/ag-shared` after merge