### PR TITLE
Cap per-file diff size in codex-pr-review

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 327f0da9410123e3b792b23d163ef5c917b14f33
-	parent = 4a5f7853ad9ff60d0487d55f478f25b9fe8f32fe
+	commit = acdddd72ce03eef8dab38c0d3895fc7861e04200
+	parent = 874d0a4b7a298946a327082a53a30ec36ee6726e
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -330,8 +330,43 @@ runs:
               LINES_ADDED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $1 } END { print s+0 }')
               LINES_REMOVED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $2 } END { print s+0 }')
 
-              # Write the raw diff to a standalone file (avoids Markdown escaping issues)
-              git diff "${DIFF_BASE}" > "${diff_file}"
+              # Write the raw diff to a standalone file (avoids Markdown escaping issues).
+              # Apply per-file-type size caps so a single churn-heavy file (typically generated
+              # snapshots or lockfiles) cannot blow Codex's 1 MiB turn input limit.
+              DEFAULT_FILE_CAP_BYTES=204800   # 200 KiB for regular source files
+              SNAPSHOT_FILE_CAP_BYTES=10240   # 10 KiB for *.snap (generated snapshots)
+              : > "${diff_file}"
+              TRUNCATED_COUNT=0
+              TRUNCATED_BYTES_SAVED=0
+              per_file_tmp=$(mktemp)
+              while IFS= read -r path; do
+                  [ -z "$path" ] && continue
+                  case "$path" in
+                      *.snap) cap="$SNAPSHOT_FILE_CAP_BYTES" ;;
+                      *)      cap="$DEFAULT_FILE_CAP_BYTES" ;;
+                  esac
+                  git diff "${DIFF_BASE}" -- "$path" > "$per_file_tmp"
+                  file_size=$(wc -c < "$per_file_tmp" | tr -d ' ')
+                  if [ "$file_size" -gt "$cap" ]; then
+                      numstat=$(git diff --numstat "${DIFF_BASE}" -- "$path")
+                      added=$(echo "$numstat" | awk '{print $1}')
+                      removed=$(echo "$numstat" | awk '{print $2}')
+                      {
+                          echo ""
+                          echo "diff --git a/${path} b/${path}"
+                          printf '[truncated by codex-pr-review: diff is %s bytes, exceeds %s-byte cap for this file type; +%s / -%s lines]\n' \
+                              "$file_size" "$cap" "$added" "$removed"
+                      } >> "${diff_file}"
+                      TRUNCATED_COUNT=$((TRUNCATED_COUNT + 1))
+                      TRUNCATED_BYTES_SAVED=$((TRUNCATED_BYTES_SAVED + file_size - cap))
+                  else
+                      cat "$per_file_tmp" >> "${diff_file}"
+                  fi
+              done < <(git diff --name-only "${DIFF_BASE}")
+              rm -f "$per_file_tmp"
+              if [ "$TRUNCATED_COUNT" -gt 0 ]; then
+                  echo "Truncated ${TRUNCATED_COUNT} file(s) in diff (~${TRUNCATED_BYTES_SAVED} bytes elided) to stay under Codex input limits."
+              fi
 
               # Build the context file (metadata only, no embedded diff).
               # Uses printf instead of a heredoc to keep content indented within the


### PR DESCRIPTION
## Summary

Large generated snapshots (or any single churn-heavy file) could push the pre-generated PR diff past Codex's 1 MiB turn input limit, causing the `codex-pr-review` action to fail outright — see e.g. [ag-studio run 24781963958](https://github.com/ag-grid/ag-studio/actions/runs/24781963958/job/72515898369?pr=1319).

Apply per-file caps in the diff generation step:
- **200 KiB** for regular files
- **10 KiB** for `*.snap` files (generated snapshots, low review value)

Over-cap file diffs are replaced with a short placeholder that preserves the `diff --git` header and notes the elided size / line counts, so Codex still sees that the file changed and how much. Also emits a one-line summary of truncated files at the end of the step.

Also includes a routine `git subrepo pull` of `external/ag-shared` (the action lives there; pull was required by subrepo push tooling since upstream had drifted).

## Test plan

- [x] Verified truncation logic against a synthetic case (93 KiB diff with an 83 KiB `.snap` → truncated to 11 KiB, placeholder in place, non-snap files pass through unchanged)
- [x] Verified edge cases: paths with spaces, deleted files, renames
- [ ] CI: codex-pr-review action runs against this PR itself