### PR TITLE
AG-17082(7) Change `SeriesItemHighlightStyle` from a class to a type

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -128,28 +128,7 @@ export function toSelectionString(state: SelectionState): PublicSelectionState {
 type HighlightOptions<TOpts extends object> = Partial<TOpts & StyleMixins>;
 type SelectionOptions<TOpts extends object> = Partial<TOpts & StyleMixins>;
 
-export class SeriesItemHighlightStyle extends BaseProperties {
-    @Property
-    fill?: string;
-
-    @Property
-    fillOpacity?: number;
-
-    @Property
-    stroke?: string;
-
-    @Property
-    strokeWidth?: number;
-
-    @Property
-    strokeOpacity?: number;
-
-    @Property
-    lineDash?: number[];
-
-    @Property
-    lineDashOffset?: number;
-}
+export type SeriesItemHighlightStyle = HighlightOptions<{}>;
 
 export class HighlightProperties<TOpts extends object> extends BaseProperties {
     @Property

--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -128,7 +128,7 @@ export function toSelectionString(state: SelectionState): PublicSelectionState {
 type HighlightOptions<TOpts extends object> = Partial<TOpts & StyleMixins>;
 type SelectionOptions<TOpts extends object> = Partial<TOpts & StyleMixins>;
 
-export type SeriesItemHighlightStyle = HighlightOptions<{}>;
+export type SeriesItemHighlightStyle = HighlightOptions<object>;
 
 export class HighlightProperties<TOpts extends object> extends BaseProperties {
     @Property

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -173,13 +173,13 @@ export type {
     UnknownSeries,
 } from './chart/series/series';
 export { resetLabelFn, seriesLabelFadeInAnimation, seriesLabelFadeOutAnimation } from './chart/series/seriesLabelUtil';
+export type { SeriesItemHighlightStyle } from './chart/series/seriesProperties';
 export {
     FillGradientDefaults,
     FillImageDefaults,
     FillPatternDefaults,
     HighlightProperties,
     HighlightState,
-    SeriesItemHighlightStyle,
     SeriesProperties,
     toHighlightString,
 } from './chart/series/seriesProperties';


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17082

The class-constructor is unused