### PR TITLE
Fix ag-dev-prompts marketplace canary ref rendering

### DIFF
--- a/external/ag-shared/.claude-settings.template.json
+++ b/external/ag-shared/.claude-settings.template.json
@@ -150,7 +150,7 @@
     "ag-dev": {
       "source": {
         "source": "github",
-        "repo": "ag-grid/ag-dev-prompts${AG_DEV_PROMPTS_REF_SUFFIX}"
+        "repo": "ag-grid/ag-dev-prompts"${AG_DEV_PROMPTS_REF_FIELD}
       }
     },
     "openai-codex": {

--- a/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
+++ b/external/ag-shared/scripts/setup-prompts/setup-prompts.sh
@@ -279,15 +279,17 @@ copy_extra_configs() {
                 ;;
         esac
 
-        # Derive marketplace ref suffix from AG_DEV_PROMPTS_REF. An unset or
+        # Derive the marketplace `ref` field from AG_DEV_PROMPTS_REF. An unset or
         # 'latest' value leaves the source unqualified (Claude picks the default
-        # branch); any other value pins the marketplace to that branch/tag via
-        # the `repo#ref` syntax. This lets a single consumer opt into the
-        # canary track without changing settings for the other products.
+        # branch); any other value pins the marketplace to that branch/tag via a
+        # sibling `ref` field in the source object (Claude Code plugin schema
+        # does not support `repo#ref` syntax). This lets a single consumer opt
+        # into the canary track without changing settings for the other
+        # products.
         local dev_prompts_ref="${AG_DEV_PROMPTS_REF:-}"
-        local ref_suffix=""
+        local ref_field=""
         if [[ -n "$dev_prompts_ref" && "$dev_prompts_ref" != "latest" ]]; then
-            ref_suffix="#$dev_prompts_ref"
+            ref_field=", \"ref\": \"$dev_prompts_ref\""
         fi
 
         mkdir -p "$REPO_ROOT/.claude"
@@ -295,13 +297,13 @@ copy_extra_configs() {
         local tmp_file="$claude_settings_dest.tmp.$$"
         sed \
             -e "s|\${PRODUCT}|$product|g" \
-            -e "s|\${AG_DEV_PROMPTS_REF_SUFFIX}|$ref_suffix|g" \
+            -e "s|\${AG_DEV_PROMPTS_REF_FIELD}|$ref_field|g" \
             "$REPO_ROOT/$claude_settings_template" > "$tmp_file"
         rm -f "$claude_settings_dest"
         mv "$tmp_file" "$claude_settings_dest"
         if [[ "$verbose" == "true" ]]; then
             local track_note=""
-            [[ -n "$ref_suffix" ]] && track_note=" (marketplace pinned to ${dev_prompts_ref})"
+            [[ -n "$ref_field" ]] && track_note=" (marketplace pinned to ${dev_prompts_ref})"
             echo -e "${GREEN}✓${NC} Rendered Claude Code settings for product: ${product}${track_note}"
         fi
     fi


### PR DESCRIPTION
## Summary

Claude Code's plugin marketplace schema for `github` sources does not support a `repo#ref` suffix — `ref` is a sibling field on the source object ([docs](https://code.claude.com/docs/en/plugin-marketplaces)). The existing template rendered `ag-grid/ag-dev-prompts#canary` as the repo name, producing the malformed clone URL `https://github.com/ag-grid/ag-dev-prompts#canary.git/` and a "repository not found" error on install.

The fix moves the placeholder out of the repo string and emits a sibling `ref` field when `AG_DEV_PROMPTS_REF` is set:

```json
"source": {
  "source": "github",
  "repo": "ag-grid/ag-dev-prompts",
  "ref": "canary"
}
```

When `AG_DEV_PROMPTS_REF` is unset or `latest`, the source is emitted without a `ref` field (Claude picks the default branch), preserving the existing behaviour for ag-grid and ag-studio.

Note: the template file (`.claude-settings.template.json`) is no longer strictly valid JSON because the `${AG_DEV_PROMPTS_REF_FIELD}` placeholder now sits outside a string literal. The file name already conveys it is a template, and the rendered output remains valid JSON in both branches.

## Test plan

- [x] Render with `AG_DEV_PROMPTS_REF=canary`: `extraKnownMarketplaces.ag-dev.source.ref == "canary"`.
- [x] Render with `AG_DEV_PROMPTS_REF` unset: no `ref` field.
- [x] Claude Code successfully clones the canary branch on session start with the new settings.