### PR TITLE
fix: respect ancestor CSS transforms in pointer input and tooltip output

### DIFF
--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -196,6 +196,7 @@ export class Tooltip extends BaseProperties {
     }
 
     private localeManager: LocaleManager | undefined = undefined;
+    private domManager: DOMManager | undefined = undefined;
     setup(localeManager: LocaleManager, domManager: DOMManager) {
         this.elementProxy = domManager.addDeferredProxyChild('tooltip-container', DEFAULT_TOOLTIP_CLASS);
         this.elementProxy.toggleClass(DEFAULT_TOOLTIP_CLASS, true);
@@ -207,6 +208,7 @@ export class Tooltip extends BaseProperties {
             this.updateTooltipPosition();
         });
         this.localeManager = localeManager;
+        this.domManager = domManager;
 
         return () => {
             domManager.removeChild('tooltip-container', DEFAULT_TOOLTIP_CLASS);
@@ -228,7 +230,14 @@ export class Tooltip extends BaseProperties {
         if (elementProxy == null || elementSize == null || positionParams == null) return;
 
         const { canvasRect, relativeRect, meta } = positionParams;
-        const { x: canvasX, y: canvasY } = this.springAnimation;
+        // The tooltip is promoted to the top layer via the Popover API, so its containing block
+        // is the viewport and `elementSize` / `canvasRect` / `relativeRect` are all in screen
+        // pixels regardless of ancestor transforms. `springAnimation` holds a chart-logical
+        // coordinate, so convert it to screen pixels before feeding it into placement math that
+        // mixes it with the other screen-space inputs. At scale == 1 this is a no-op.
+        const scale = this.domManager?.getCanvasScale() ?? { x: 1, y: 1 };
+        const canvasX = this.springAnimation.x * scale.x;
+        const canvasY = this.springAnimation.y * scale.y;
 
         const anchorTo = meta.position?.anchorTo ?? 'pointer';
         let placements = meta.position?.placement ?? defaultPlacements[anchorTo];

--- a/packages/ag-charts-community/src/dom/domManager.ts
+++ b/packages/ag-charts-community/src/dom/domManager.ts
@@ -498,6 +498,30 @@ export class DOMManager extends BaseManager {
     }
 
     /**
+     * Ancestor CSS transform scale applied to the canvas, as reflected by the ratio between
+     * `getBoundingClientRect()` (transform-aware) and `clientWidth`/`clientHeight` (preserved
+     * through ancestor transforms). Multiply a chart-logical coordinate by these factors to
+     * convert it to screen pixels; divide a screen-space length to convert back.
+     *
+     * Reads the element fresh rather than using the cached rect: ancestor transform changes
+     * do not fire the resize/scroll listeners that invalidate `_cachedCanvasRect`, so the
+     * cache can be arbitrarily stale with respect to the live transform. Callers of this are
+     * infrequent (tooltip/popover positioning) and the cost of one `getBoundingClientRect()`
+     * plus two property reads is negligible.
+     *
+     * Returns `{ x: 1, y: 1 }` when there is no ancestor transform.
+     */
+    getCanvasScale(): { x: number; y: number } {
+        const el = this.rootElements['canvas'].element;
+        const rect = el.getBoundingClientRect();
+        const { clientWidth, clientHeight } = el;
+        return {
+            x: clientWidth > 0 && rect.width > 0 ? rect.width / clientWidth : 1,
+            y: clientHeight > 0 && rect.height > 0 ? rect.height / clientHeight : 1,
+        };
+    }
+
+    /**
      * Get the client bounding rect for overlay elements that might float outside the bounds of the
      * main chart area.
      */

--- a/packages/ag-charts-community/src/widget/widgetEvents.ts
+++ b/packages/ag-charts-community/src/widget/widgetEvents.ts
@@ -373,6 +373,19 @@ export class WidgetEventUtil {
         event: { clientX: number; clientY: number }
     ): { currentX: number; currentY: number } {
         const currentRect = current.getBoundingClientRect();
-        return { currentX: event.clientX - currentRect.x, currentY: event.clientY - currentRect.y };
+        // `getBoundingClientRect()` is transform-aware (its dimensions reflect
+        // ancestor CSS transforms) while `clientX`/`clientY` are viewport
+        // pixels, so `clientX - rect.x` is a screen-space delta. Callers
+        // interpret `currentXY` in the chart's logical coordinate system, so
+        // if an ancestor applies `transform: scale(...)`, divide by the scale
+        // factor. `clientWidth`/`clientHeight` are preserved through ancestor
+        // transforms, so the ratio is the ancestor scale.
+        const { clientWidth, clientHeight } = current;
+        const scaleX = currentRect.width > 0 && clientWidth > 0 ? clientWidth / currentRect.width : 1;
+        const scaleY = currentRect.height > 0 && clientHeight > 0 ? clientHeight / currentRect.height : 1;
+        return {
+            currentX: (event.clientX - currentRect.x) * scaleX,
+            currentY: (event.clientY - currentRect.y) * scaleY,
+        };
     }
 }


### PR DESCRIPTION
## Problem

When a chart is mounted beneath an ancestor `transform: scale(s)`, two coordinate conversions are needed:

1. **Pointer input** — viewport-space mouse events have to be converted to chart-logical coordinates.
2. **Tooltip output** — chart-logical coordinates have to be converted to screen pixels when positioning the tooltip, which renders in the HTML top layer.

Both conversions were missing, so at any non-`1` ancestor scale the crosshair, drag targets, node picking, and tooltip placement all drifted from the true cursor — invisible at `s = 1`, meaningful at modest zoom levels.

## Reproduction

Wrap any chart in a container with `transform: scale(0.5)` and hover over it:

- Before this PR: crosshair lands at roughly half the intended offset from the element's top-left; tooltip lands at roughly `(1 − s) × canvasXY` off from its anchor.
- `scale(2)` produces the mirrored failures.

## Fix — two commits

### 1. `calcCurrentXY` (input side)

`WidgetEventUtil.calcCurrentXY` returns `clientX - rect.x` as the logical pointer coordinate inside the target element. `rect` comes from `getBoundingClientRect()`, which reflects ancestor CSS transforms, but `clientX` is in viewport pixels — so the delta is in screen (post-transform) pixels. Callers (`allocMouseEvent`, `makeMouseDrag`, `makeTouchDrag`, `Widget.onDispatch`) consume `currentXY` in the chart's logical (pre-transform) coord system.

`element.clientWidth` / `clientHeight` are preserved through ancestor CSS transforms; `rect.width` / `rect.height` track the live visual size. Their ratio is the ancestor scale factor. Divide the screen-space delta by that ratio to recover the logical delta. Zero-size guards preserve the original behavior when either dimension is degenerate.

### 2. `Tooltip.updateTooltipPosition` (output side, same underlying bug)

The tooltip is promoted to the HTML top layer via the Popover API, so its containing block is the viewport and `elementSize`, `canvasRect`, `relativeRect` are all in screen pixels regardless of ancestor transforms. But `springAnimation` holds a chart-logical coordinate fed from `meta.canvasX`/`canvasY`, so `getTooltipBounds` was mixing logical pointer coords with screen-px tooltip dimensions. Under `transform: scale(s)` the tooltip landed `(1 − s) × canvasXY` off from the anchor.

New helper `DOMManager.getCanvasScale()` returns the same `rect / client` ratio, consumed in the inverse direction: multiply the logical `springAnimation.{x,y}` by the scale to convert to screen pixels before feeding them into placement math.

`getCanvasScale()` reads the canvas element fresh rather than via `_cachedCanvasRect`: ancestor-transform changes do not fire the resize/scroll/fullscreenchange listeners that invalidate that cache, so the cache can be arbitrarily stale with respect to the live transform. Cost is one `getBoundingClientRect()` plus two property reads per spring-animation frame while a tooltip is visible, which is negligible.

## No-op at scale 1

Both conversions are provable identities when there is no ancestor transform (`rect.width == clientWidth`), so the common case is unaffected.

## Performance

`calcCurrentXY` is already on the forced-reflow allowlist in `e2e/forcedReflowDetection.ts` — `getBoundingClientRect()` is the reflow trigger. Adding `clientWidth`/`clientHeight` reads does not add new reflow points; layout is already being read. For the tooltip path, `getCanvasScale()` reads fresh but only while a tooltip is visible, which is hover-driven and low-frequency.

## Known limitation (out of scope)

If the user wheel-zooms while a tooltip is already visible **without moving the cursor** (no new pick event), `Tooltip.show()` does not re-run and its snapshot of `canvasRect` / `relativeRect` / `--top` / `--left` stays frozen at pre-zoom values. The scale fix correctly tracks the pointer during active pointer movement under a zooming ancestor, but not during pure wheel-zoom of a stationary tooltip. The underlying cause is the same cache-staleness note above — `_cachedCanvasRect` is only invalidated on resize/scroll/fullscreenchange. Happy to file this as a separate issue; the fix likely wants either a `MutationObserver` on ancestor-transform styles or an explicit invalidation API, which feels like a separate design decision.

Other top-layer UI with the same class of bug that I deliberately did **not** touch in this PR, but would happily fix in follow-ups once this pattern is blessed: `anchoredPopover`, `draggablePopover`, `floatingToolbar` — each mixes a scaled `canvasRect.width/height` with chart-logical anchor coords.

## Tests

I looked for widget-event unit tests but did not find any in `packages/ag-charts-community/src/widget/`. Happy to add test coverage if a reviewer can point me at the preferred harness for this kind of geometry check (JSDOM with a mock `getBoundingClientRect` + `clientWidth`, presumably). Both behaviors are easy to verify interactively with the reproduction recipe above.