### PR TITLE
Migrate /pr-review to composite actions via @ag-grid/dev-prompts (canary)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,26 +18,80 @@ env:
 permissions:
     contents: read
 
+# Security model (public repo, Codex runs with --sandbox danger-full-access):
+#
+# - Fork PRs are **never** reviewed by Codex. The prompt-injection surface (attacker
+#   diff content) combined with full-access Codex would let a hostile PR exfiltrate
+#   CODEX_API_KEY / GITHUB_TOKEN. Fork-safety is enforced at every entry point below,
+#   not relied on implicitly through GitHub's secret scoping.
+# - Same-repo PRs are trusted: only org members with push access can create them.
+# - `/pr-review` comments are gated on author_association AND on the PR being same-repo.
+#   They re-dispatch workflow_dispatch against the PR branch so workflow/action changes
+#   on the PR branch take effect without merging to latest.
+# - workflow_dispatch is implicitly gated on actions:write access (write collaborators).
 jobs:
-    # Check permissions for issue_comment events
-    check-permissions:
+    # /pr-review comment trigger: verify commenter permission, verify PR is same-repo,
+    # then re-dispatch workflow_dispatch against the PR branch. The actual review runs
+    # from the branch's workflow file, so changes to pr-review.yml or the underlying
+    # action can be iterated on from a PR without merging first.
+    comment-trigger:
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
         runs-on: ubuntu-latest
-        outputs:
-            allowed: ${{ steps.check.outputs.allowed }}
+        permissions:
+            contents: read
+            issues: write # for permission-denial comment and fork-refusal comment
+            actions: write # to gh workflow run the branch version
+            pull-requests: read
         steps:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - name: Check user permissions
-              id: check
+            - name: Check commenter permission
+              id: permissions
               uses: ./external/ag-shared/github/actions/check-issue-comment-permissions
               with:
                   command: '/pr-review'
 
-    # Run the Codex PR review
+            - name: Verify PR is same-repo and re-dispatch against its branch
+              if: steps.permissions.outputs.allowed == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.issue.number }}
+              run: |
+                  set -euo pipefail
+                  PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                      --json headRefName,isCrossRepository)
+                  IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
+                  HEAD_REF=$(echo "$PR_JSON" | jq -r '.headRefName')
+
+                  if [ "$IS_FORK" = "true" ]; then
+                      echo "::error::Refusing /pr-review on fork PR #${PR_NUMBER} — Codex runs with network access and would be exposed to prompt-injection from untrusted diff content."
+                      gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
+                          ":no_entry: \`/pr-review\` is disabled on fork PRs. The Codex reviewer runs with network + secret access, so reviewing attacker-controlled diff content would be unsafe. If needed, run \`/pr-review\` locally after checking the branch out yourself."
+                      exit 1
+                  fi
+
+                  echo "Dispatching pr-review.yml@${HEAD_REF} for PR #${PR_NUMBER}"
+                  gh workflow run pr-review.yml --ref "$HEAD_REF" \
+                      --field pr_number="$PR_NUMBER"
+
+    # Run the Codex PR review.
+    #
+    # Entry points:
+    # - pull_request (opened/ready_for_review): same-repo only — forks blocked below.
+    # - workflow_dispatch: direct manual dispatch OR re-dispatch from comment-trigger.
+    #   In both cases the dispatcher has actions:write access.
+    #
+    # The fork check is repeated inside this job (via the resolve-pr-metadata step)
+    # because workflow_dispatch inputs are user-supplied and could reference any PR,
+    # including a fork one.
     pr-review:
+        if: |
+            (github.event_name == 'pull_request' &&
+                github.event.pull_request.draft == false &&
+                github.event.pull_request.head.repo.full_name == github.repository) ||
+            github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
-        needs: check-permissions
         permissions:
             contents: read
             pull-requests: write
@@ -46,29 +100,44 @@ jobs:
             # @ag-grid/dev-prompts package on GitHub Packages. The action
             # authenticates with the default GITHUB_TOKEN via this scope.
             packages: read
-        # Only run if permissions check passed and PR is not a draft
-        # For issue_comment, also verify it's on a PR (not a regular issue)
-        if: |
-            needs.check-permissions.result == 'success' && (
-                (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-                github.event_name == 'workflow_dispatch' ||
-                (github.event_name == 'issue_comment' && needs.check-permissions.outputs.allowed == 'true' && github.event.issue.pull_request)
-            )
         steps:
             - name: Checkout
               uses: actions/checkout@v4
               with:
                   fetch-depth: 1
 
+            # For workflow_dispatch we only have pr_number; resolve the rest.
+            # Also re-checks fork status — blocks dispatch against a fork PR.
+            - name: Resolve PR metadata
+              id: pr-meta
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+              run: |
+                  set -euo pipefail
+                  PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                      --json title,author,headRefName,baseRefName,isCrossRepository)
+                  IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
+                  if [ "$IS_FORK" = "true" ]; then
+                      echo "::error::Refusing to review fork PR #${PR_NUMBER} — Codex runs with unrestricted network/secret access."
+                      exit 1
+                  fi
+                  {
+                      echo "pr_number=${PR_NUMBER}"
+                      echo "base_ref=$(echo "$PR_JSON" | jq -r '.baseRefName')"
+                      echo "head_ref=$(echo "$PR_JSON" | jq -r '.headRefName')"
+                      echo "pr_title=$(echo "$PR_JSON" | jq -r '.title')"
+                      echo "pr_author=$(echo "$PR_JSON" | jq -r '.author.login')"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Run Codex PR Review
               uses: ./external/ag-shared/github/actions/codex-pr-review
               with:
                   codex-api-key: ${{ secrets.CODEX_API_KEY }}
-                  pr-number: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
-                  base-ref: ${{ github.event.pull_request.base.ref || 'latest' }}
-                  head-ref: ${{ github.event.pull_request.head.ref || '' }}
-                  pr-title: ${{ github.event.pull_request.title || '' }}
-                  pr-author: ${{ github.event.pull_request.user.login || '' }}
+                  pr-number: ${{ steps.pr-meta.outputs.pr_number }}
+                  base-ref: ${{ steps.pr-meta.outputs.base_ref }}
+                  head-ref: ${{ steps.pr-meta.outputs.head_ref }}
+                  pr-title: ${{ steps.pr-meta.outputs.pr_title }}
+                  pr-author: ${{ steps.pr-meta.outputs.pr_author }}
                   github-token: ${{ github.token }}
-                  comment-id: ${{ github.event.comment.id }}
                   inline-comments: 'true'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,13 +1,18 @@
 name: PR Review
 
-# Trampoline: delegates to the reusable workflow hosted in ag-dev-prompts.
-# Consumer-specific concerns (triggers, permissions, secret wiring) stay here;
-# all the PR-review logic — fork-PR guards, comment re-dispatch, resolve
-# metadata, Run Codex — lives in the reusable workflow.
+# Installs @ag-grid/dev-prompts from GitHub Packages and delegates to the
+# composite actions shipped inside the package. This is the consumer
+# counterpart to ag-grid/ag-dev-prompts's own dogfood workflow.
 #
-# ag-charts tracks the `canary` ref on ag-dev-prompts (the same track the
-# @ag-grid/dev-prompts package follows, per AG-17085 Phase 4). ag-grid and
-# ag-studio will track `latest` when they roll onto this pattern.
+# Why npm instead of a reusable workflow: ag-dev-prompts is a private repo,
+# and GitHub Actions does not permit public-repo callers to consume
+# reusable workflows from private-repo hosts. The npm package route works
+# because GitHub Packages honours `GITHUB_TOKEN` + `packages: read` from any
+# repo in the same org, regardless of visibility.
+#
+# Channel: ag-charts tracks the `canary` dist-tag (aligned with
+# AG-17085 Phase 4). ag-grid and ag-studio will pin to `latest` when they
+# migrate.
 
 on:
     pull_request:
@@ -21,17 +26,75 @@ on:
                 type: string
                 required: true
 
+permissions:
+    contents: read
+
+env:
+    DEV_PROMPTS_CHANNEL: canary
+
 jobs:
     review:
-        # Permissions at least as permissive as both jobs the reusable
-        # workflow declares (comment-trigger + pr-review). Reusable workflows
-        # cannot escalate beyond what the caller grants.
+        runs-on: ubuntu-latest
+        if: |
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.draft == false
         permissions:
             contents: read
             pull-requests: write
             issues: write
             actions: write
             packages: read
-        uses: ag-grid/ag-dev-prompts/.github/workflows/pr-review.yml@canary
-        secrets:
-            CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+
+            - name: Setup Node (GitHub Packages for @ag-grid scope)
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: package.json
+                  registry-url: https://npm.pkg.github.com
+                  scope: '@ag-grid'
+
+            - name: Install @ag-grid/dev-prompts
+              env:
+                  NODE_AUTH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  mkdir -p "$GITHUB_WORKSPACE/.ag-dev-prompts"
+                  cd "$GITHUB_WORKSPACE/.ag-dev-prompts"
+                  echo '{"name":"ag-dev-prompts-install","private":true}' > package.json
+                  npm install --no-save --silent "@ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL}"
+
+            # --- Comment trigger path (/pr-review) -----------------------------
+            - name: Handle /pr-review comment
+              if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+              uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/pr-review-comment-trigger
+              with:
+                  github-token: ${{ github.token }}
+
+            # --- Review path (pull_request + workflow_dispatch) ---------------
+            - name: Resolve PR metadata
+              id: pr-meta
+              if: |
+                  (github.event_name == 'pull_request' &&
+                      github.event.pull_request.head.repo.full_name == github.repository) ||
+                  github.event_name == 'workflow_dispatch'
+              uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/pr-resolve-metadata
+              with:
+                  github-token: ${{ github.token }}
+                  pr-number: ${{ github.event.pull_request.number || inputs.pr_number }}
+
+            - name: Run Codex PR Review
+              if: steps.pr-meta.outputs.pr-number != ''
+              uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/codex-pr-review
+              with:
+                  codex-api-key: ${{ secrets.CODEX_API_KEY }}
+                  pr-number: ${{ steps.pr-meta.outputs.pr-number }}
+                  base-ref: ${{ steps.pr-meta.outputs.base-ref }}
+                  head-ref: ${{ steps.pr-meta.outputs.head-ref }}
+                  pr-title: ${{ steps.pr-meta.outputs.pr-title }}
+                  pr-author: ${{ steps.pr-meta.outputs.pr-author }}
+                  github-token: ${{ github.token }}
+                  inline-comments: 'true'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -35,9 +35,20 @@ env:
 jobs:
     review:
         runs-on: ubuntu-latest
+        # Top-level gating — keeps the runner from spinning up at all for
+        # events that would only short-circuit at a step-level `if:`:
+        # - pull_request: same-repo, non-draft (forks also blocked inside
+        #   pr-resolve-metadata as a second line of defence).
+        # - issue_comment: must be on a PR AND start with /pr-review.
+        # - workflow_dispatch: always eligible (caller has actions:write).
         if: |
-            github.event_name != 'pull_request' ||
-            github.event.pull_request.draft == false
+            (github.event_name == 'pull_request' &&
+                github.event.pull_request.draft == false &&
+                github.event.pull_request.head.repo.full_name == github.repository) ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'issue_comment' &&
+                github.event.issue.pull_request != null &&
+                startsWith(github.event.comment.body, '/pr-review'))
         permissions:
             contents: read
             pull-requests: write

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,5 +1,14 @@
 name: PR Review
 
+# Trampoline: delegates to the reusable workflow hosted in ag-dev-prompts.
+# Consumer-specific concerns (triggers, permissions, secret wiring) stay here;
+# all the PR-review logic — fork-PR guards, comment re-dispatch, resolve
+# metadata, Run Codex — lives in the reusable workflow.
+#
+# ag-charts tracks the `canary` ref on ag-dev-prompts (the same track the
+# @ag-grid/dev-prompts package follows, per AG-17085 Phase 4). ag-grid and
+# ag-studio will track `latest` when they roll onto this pattern.
+
 on:
     pull_request:
         types: [opened, ready_for_review]
@@ -12,132 +21,17 @@ on:
                 type: string
                 required: true
 
-env:
-    NX_NO_CLOUD: true
-
-permissions:
-    contents: read
-
-# Security model (public repo, Codex runs with --sandbox danger-full-access):
-#
-# - Fork PRs are **never** reviewed by Codex. The prompt-injection surface (attacker
-#   diff content) combined with full-access Codex would let a hostile PR exfiltrate
-#   CODEX_API_KEY / GITHUB_TOKEN. Fork-safety is enforced at every entry point below,
-#   not relied on implicitly through GitHub's secret scoping.
-# - Same-repo PRs are trusted: only org members with push access can create them.
-# - `/pr-review` comments are gated on author_association AND on the PR being same-repo.
-#   They re-dispatch workflow_dispatch against the PR branch so workflow/action changes
-#   on the PR branch take effect without merging to latest.
-# - workflow_dispatch is implicitly gated on actions:write access (write collaborators).
 jobs:
-    # /pr-review comment trigger: verify commenter permission, verify PR is same-repo,
-    # then re-dispatch workflow_dispatch against the PR branch. The actual review runs
-    # from the branch's workflow file, so changes to pr-review.yml or the underlying
-    # action can be iterated on from a PR without merging first.
-    comment-trigger:
-        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            issues: write # for permission-denial comment and fork-refusal comment
-            actions: write # to gh workflow run the branch version
-            pull-requests: read
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Check commenter permission
-              id: permissions
-              uses: ./external/ag-shared/github/actions/check-issue-comment-permissions
-              with:
-                  command: '/pr-review'
-
-            - name: Verify PR is same-repo and re-dispatch against its branch
-              if: steps.permissions.outputs.allowed == 'true'
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  PR_NUMBER: ${{ github.event.issue.number }}
-              run: |
-                  set -euo pipefail
-                  PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                      --json headRefName,isCrossRepository)
-                  IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
-                  HEAD_REF=$(echo "$PR_JSON" | jq -r '.headRefName')
-
-                  if [ "$IS_FORK" = "true" ]; then
-                      echo "::error::Refusing /pr-review on fork PR #${PR_NUMBER} — Codex runs with network access and would be exposed to prompt-injection from untrusted diff content."
-                      gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-                          ":no_entry: \`/pr-review\` is disabled on fork PRs. The Codex reviewer runs with network + secret access, so reviewing attacker-controlled diff content would be unsafe. If needed, run \`/pr-review\` locally after checking the branch out yourself."
-                      exit 1
-                  fi
-
-                  echo "Dispatching pr-review.yml@${HEAD_REF} for PR #${PR_NUMBER}"
-                  gh workflow run pr-review.yml --ref "$HEAD_REF" \
-                      --field pr_number="$PR_NUMBER"
-
-    # Run the Codex PR review.
-    #
-    # Entry points:
-    # - pull_request (opened/ready_for_review): same-repo only — forks blocked below.
-    # - workflow_dispatch: direct manual dispatch OR re-dispatch from comment-trigger.
-    #   In both cases the dispatcher has actions:write access.
-    #
-    # The fork check is repeated inside this job (via the resolve-pr-metadata step)
-    # because workflow_dispatch inputs are user-supplied and could reference any PR,
-    # including a fork one.
-    pr-review:
-        if: |
-            (github.event_name == 'pull_request' &&
-                github.event.pull_request.draft == false &&
-                github.event.pull_request.head.repo.full_name == github.repository) ||
-            github.event_name == 'workflow_dispatch'
-        runs-on: ubuntu-latest
+    review:
+        # Permissions at least as permissive as both jobs the reusable
+        # workflow declares (comment-trigger + pr-review). Reusable workflows
+        # cannot escalate beyond what the caller grants.
         permissions:
             contents: read
             pull-requests: write
             issues: write
-            # AG-17085 Phase 3: the pr-review skill is delivered via the
-            # @ag-grid/dev-prompts package on GitHub Packages. The action
-            # authenticates with the default GITHUB_TOKEN via this scope.
+            actions: write
             packages: read
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-              with:
-                  fetch-depth: 1
-
-            # For workflow_dispatch we only have pr_number; resolve the rest.
-            # Also re-checks fork status — blocks dispatch against a fork PR.
-            - name: Resolve PR metadata
-              id: pr-meta
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-              run: |
-                  set -euo pipefail
-                  PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                      --json title,author,headRefName,baseRefName,isCrossRepository)
-                  IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
-                  if [ "$IS_FORK" = "true" ]; then
-                      echo "::error::Refusing to review fork PR #${PR_NUMBER} — Codex runs with unrestricted network/secret access."
-                      exit 1
-                  fi
-                  {
-                      echo "pr_number=${PR_NUMBER}"
-                      echo "base_ref=$(echo "$PR_JSON" | jq -r '.baseRefName')"
-                      echo "head_ref=$(echo "$PR_JSON" | jq -r '.headRefName')"
-                      echo "pr_title=$(echo "$PR_JSON" | jq -r '.title')"
-                      echo "pr_author=$(echo "$PR_JSON" | jq -r '.author.login')"
-                  } >> "$GITHUB_OUTPUT"
-
-            - name: Run Codex PR Review
-              uses: ./external/ag-shared/github/actions/codex-pr-review
-              with:
-                  codex-api-key: ${{ secrets.CODEX_API_KEY }}
-                  pr-number: ${{ steps.pr-meta.outputs.pr_number }}
-                  base-ref: ${{ steps.pr-meta.outputs.base_ref }}
-                  head-ref: ${{ steps.pr-meta.outputs.head_ref }}
-                  pr-title: ${{ steps.pr-meta.outputs.pr_title }}
-                  pr-author: ${{ steps.pr-meta.outputs.pr_author }}
-                  github-token: ${{ github.token }}
-                  inline-comments: 'true'
+        uses: ag-grid/ag-dev-prompts/.github/workflows/pr-review.yml@canary
+        secrets:
+            CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -316,15 +316,18 @@ runs:
               # Run Codex with ALL output suppressed.
               # - stdin: just the skill prompt; Codex runs git/gh directly for diff + metadata
               #   using the ARGUMENTS/BASE_REF/HEAD_REF/etc. env vars and the pre-fetched PR refs.
-              # - sandbox workspace-write: shares host network namespace (avoids the bwrap
-              #   loopback failure that --sandbox read-only hits on GHA) and lets Codex exec
-              #   git/gh within the already-checked-out, ephemeral runner workspace.
+              # - sandbox danger-full-access: both read-only and workspace-write modes use bwrap,
+              #   which fails on GHA runners with `loopback: Failed RTM_NEWADDR: Operation not permitted`
+              #   (unprivileged user namespaces are restricted). Skipping the sandbox is safe here:
+              #   the runner is ephemeral, all relevant secrets (GITHUB_TOKEN, CODEX_API_KEY) are
+              #   already exposed via the process env regardless of sandbox mode, and the primary
+              #   untrusted input (the PR diff) is read-only attacker content we're feeding to an LLM.
               # - stdout (>/dev/null): suppresses reasoning/streaming output
               # - stderr (2>file): captured to file for debugging, not logged
               set +e
               cat "${{ steps.prompt.outputs.prompt_file }}" | codex exec \
                 --output-last-message "${output_file}" \
-                --sandbox workspace-write \
+                --sandbox danger-full-access \
                 2>"${error_file}" \
                 >/dev/null
               exit_code=$?

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -291,128 +291,6 @@ runs:
               echo "prompt_file=${prompt_file}" >> $GITHUB_OUTPUT
               echo "output_ext=${output_ext}" >> $GITHUB_OUTPUT
 
-        - name: Generate PR Diff Context
-          if: steps.check-auth.outputs.skipped != 'true'
-          id: diff-context
-          shell: bash
-          env:
-              PR_NUMBER: ${{ inputs.pr-number }}
-              BASE_REF: ${{ inputs.base-ref }}
-              HEAD_REF: ${{ inputs.head-ref }}
-              PR_TITLE: ${{ inputs.pr-title }}
-              PR_AUTHOR: ${{ inputs.pr-author }}
-              ARGUMENTS: ${{ inputs.inline-comments == 'true' && format('--json {0}', inputs.pr-number) || inputs.pr-number }}
-              GH_TOKEN: ${{ inputs.github-token }}
-          run: |
-              # Pre-generate the diff and metadata so Codex doesn't need to exec git commands.
-              # This avoids sandbox (bwrap) issues on GitHub Actions runners.
-              context_file=".codex-diff-context-${PR_NUMBER}.md"
-              diff_file=".codex-diff-${PR_NUMBER}.patch"
-              echo "context_file=${context_file}" >> $GITHUB_OUTPUT
-              echo "diff_file=${diff_file}" >> $GITHUB_OUTPUT
-
-              PR_REF="origin/pr/${PR_NUMBER}"
-              DIFF_BASE="origin/${BASE_REF}...${PR_REF}"
-              HEAD_SHA=$(git rev-parse "${PR_REF}")
-              PR_URL="https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
-
-              # Fill in missing metadata (e.g. workflow_dispatch doesn't have PR event context)
-              if [ -z "${PR_TITLE}" ] || [ -z "${PR_AUTHOR}" ] || [ -z "${HEAD_REF}" ]; then
-                PR_META=$(gh pr view "${PR_NUMBER}" --json title,author,headRefName 2>/dev/null || echo '{}')
-                [ -z "${PR_TITLE}" ] && PR_TITLE=$(echo "${PR_META}" | jq -r '.title // empty')
-                [ -z "${PR_AUTHOR}" ] && PR_AUTHOR=$(echo "${PR_META}" | jq -r '.author.login // empty')
-                [ -z "${HEAD_REF}" ] && HEAD_REF=$(echo "${PR_META}" | jq -r '.headRefName // empty')
-              fi
-
-              # Collect diff stats
-              FILES_CHANGED=$(git diff --name-only "${DIFF_BASE}" | wc -l | tr -d ' ')
-              DIFF_STAT=$(git diff --stat "${DIFF_BASE}")
-              LINES_ADDED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $1 } END { print s+0 }')
-              LINES_REMOVED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $2 } END { print s+0 }')
-
-              # Write the raw diff to a standalone file (avoids Markdown escaping issues).
-              # Apply per-file-type size caps so a single churn-heavy file (typically generated
-              # snapshots or lockfiles) cannot blow Codex's 1 MiB turn input limit.
-              DEFAULT_FILE_CAP_BYTES=204800   # 200 KiB for regular source files
-              SNAPSHOT_FILE_CAP_BYTES=10240   # 10 KiB for *.snap (generated snapshots)
-              : > "${diff_file}"
-              TRUNCATED_COUNT=0
-              TRUNCATED_BYTES_SAVED=0
-              per_file_tmp=$(mktemp)
-              while IFS= read -r path; do
-                  [ -z "$path" ] && continue
-                  case "$path" in
-                      *.snap) cap="$SNAPSHOT_FILE_CAP_BYTES" ;;
-                      *)      cap="$DEFAULT_FILE_CAP_BYTES" ;;
-                  esac
-                  git diff "${DIFF_BASE}" -- "$path" > "$per_file_tmp"
-                  file_size=$(wc -c < "$per_file_tmp" | tr -d ' ')
-                  if [ "$file_size" -gt "$cap" ]; then
-                      numstat=$(git diff --numstat "${DIFF_BASE}" -- "$path")
-                      added=$(echo "$numstat" | awk '{print $1}')
-                      removed=$(echo "$numstat" | awk '{print $2}')
-                      {
-                          echo ""
-                          echo "diff --git a/${path} b/${path}"
-                          printf '[truncated by codex-pr-review: diff is %s bytes, exceeds %s-byte cap for this file type; +%s / -%s lines]\n' \
-                              "$file_size" "$cap" "$added" "$removed"
-                      } >> "${diff_file}"
-                      TRUNCATED_COUNT=$((TRUNCATED_COUNT + 1))
-                      TRUNCATED_BYTES_SAVED=$((TRUNCATED_BYTES_SAVED + file_size - cap))
-                  else
-                      cat "$per_file_tmp" >> "${diff_file}"
-                  fi
-              done < <(git diff --name-only "${DIFF_BASE}")
-              rm -f "$per_file_tmp"
-              if [ "$TRUNCATED_COUNT" -gt 0 ]; then
-                  echo "Truncated ${TRUNCATED_COUNT} file(s) in diff (~${TRUNCATED_BYTES_SAVED} bytes elided) to stay under Codex input limits."
-              fi
-
-              # Build the context file (metadata only, no embedded diff).
-              # Uses printf instead of a heredoc to keep content indented within the
-              # YAML block scalar — unindented heredoc lines break GitHub Actions' YAML parser.
-              COMMIT_MSGS=$(git log --format="%s" "origin/${BASE_REF}..${PR_REF}")
-              printf '%s\n' \
-                "" \
-                "## Pre-generated PR Context" \
-                "" \
-                "The PR diff and metadata have been pre-generated and are provided below." \
-                "**Do NOT run any git, gh, or shell commands.** Analyse the diff below directly." \
-                "" \
-                "### Arguments" \
-                "" \
-                "ARGUMENTS: ${ARGUMENTS}" \
-                "" \
-                "### PR Metadata" \
-                "- **PR Number:** ${PR_NUMBER}" \
-                "- **PR Title:** ${PR_TITLE}" \
-                "- **PR URL:** ${PR_URL}" \
-                "- **Author:** ${PR_AUTHOR}" \
-                "- **Base Branch:** ${BASE_REF}" \
-                "- **Head Branch:** ${HEAD_REF}" \
-                "- **Head SHA:** ${HEAD_SHA}" \
-                "- **Files Changed:** ${FILES_CHANGED}" \
-                "- **Lines Added:** ${LINES_ADDED}" \
-                "- **Lines Removed:** ${LINES_REMOVED}" \
-                "" \
-                "### Diff Stats" \
-                '```' \
-                "${DIFF_STAT}" \
-                '```' \
-                "" \
-                "### Commit Messages" \
-                '```' \
-                "${COMMIT_MSGS}" \
-                '```' \
-                "" \
-                "### Full Diff" \
-                "" \
-                "Everything below this line is the raw unified diff for this PR." \
-                "---" \
-                > "${context_file}"
-
-              echo "Generated context ($(wc -c < "${context_file}") bytes) + diff ($(wc -c < "${diff_file}") bytes)"
-
         - name: Run Codex Review
           if: steps.check-auth.outputs.skipped != 'true'
           id: codex
@@ -421,6 +299,7 @@ runs:
               OPENAI_API_KEY: ${{ inputs.codex-api-key }}
               CODEX_API_KEY: ${{ inputs.codex-api-key }}
               ARGUMENTS: ${{ inputs.inline-comments == 'true' && format('--json {0}', inputs.pr-number) || inputs.pr-number }}
+              PR_NUMBER: ${{ inputs.pr-number }}
               BASE_REF: ${{ inputs.base-ref }}
               HEAD_REF: ${{ inputs.head-ref }}
               PR_TITLE: ${{ inputs.pr-title }}
@@ -431,19 +310,21 @@ runs:
               # Output file paths (unique per PR to avoid conflicts)
               output_file=".codex-review-${{ inputs.pr-number }}.${{ steps.prompt.outputs.output_ext }}"
               error_file=".codex-error-${{ inputs.pr-number }}.log"
-              context_file="${{ steps.diff-context.outputs.context_file }}"
-              diff_file="${{ steps.diff-context.outputs.diff_file }}"
 
               echo "output_file=${output_file}" >> $GITHUB_OUTPUT
 
-              # Run Codex with ALL output suppressed
-              # - stdin: Review instructions + metadata context + raw diff (three files concatenated)
-              # - stdout (>/dev/null): Suppresses reasoning/streaming output
-              # - stderr (2>file): Captured to file for debugging, not logged
+              # Run Codex with ALL output suppressed.
+              # - stdin: just the skill prompt; Codex runs git/gh directly for diff + metadata
+              #   using the ARGUMENTS/BASE_REF/HEAD_REF/etc. env vars and the pre-fetched PR refs.
+              # - sandbox workspace-write: shares host network namespace (avoids the bwrap
+              #   loopback failure that --sandbox read-only hits on GHA) and lets Codex exec
+              #   git/gh within the already-checked-out, ephemeral runner workspace.
+              # - stdout (>/dev/null): suppresses reasoning/streaming output
+              # - stderr (2>file): captured to file for debugging, not logged
               set +e
-              cat "${{ steps.prompt.outputs.prompt_file }}" "${context_file}" "${diff_file}" | codex exec \
+              cat "${{ steps.prompt.outputs.prompt_file }}" | codex exec \
                 --output-last-message "${output_file}" \
-                --sandbox read-only \
+                --sandbox workspace-write \
                 2>"${error_file}" \
                 >/dev/null
               exit_code=$?
@@ -799,4 +680,4 @@ runs:
           if: always()
           shell: bash
           run: |
-              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log" ".codex-diff-context-${{ inputs.pr-number }}.md" ".codex-diff-${{ inputs.pr-number }}.patch"
+              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log"

--- a/external/ag-shared/github/actions/codex-pr-review/action.yml
+++ b/external/ag-shared/github/actions/codex-pr-review/action.yml
@@ -291,6 +291,128 @@ runs:
               echo "prompt_file=${prompt_file}" >> $GITHUB_OUTPUT
               echo "output_ext=${output_ext}" >> $GITHUB_OUTPUT
 
+        - name: Generate PR Diff Context
+          if: steps.check-auth.outputs.skipped != 'true'
+          id: diff-context
+          shell: bash
+          env:
+              PR_NUMBER: ${{ inputs.pr-number }}
+              BASE_REF: ${{ inputs.base-ref }}
+              HEAD_REF: ${{ inputs.head-ref }}
+              PR_TITLE: ${{ inputs.pr-title }}
+              PR_AUTHOR: ${{ inputs.pr-author }}
+              ARGUMENTS: ${{ inputs.inline-comments == 'true' && format('--json {0}', inputs.pr-number) || inputs.pr-number }}
+              GH_TOKEN: ${{ inputs.github-token }}
+          run: |
+              # Pre-generate the diff and metadata so Codex doesn't need to exec git commands.
+              # This avoids sandbox (bwrap) issues on GitHub Actions runners.
+              context_file=".codex-diff-context-${PR_NUMBER}.md"
+              diff_file=".codex-diff-${PR_NUMBER}.patch"
+              echo "context_file=${context_file}" >> $GITHUB_OUTPUT
+              echo "diff_file=${diff_file}" >> $GITHUB_OUTPUT
+
+              PR_REF="origin/pr/${PR_NUMBER}"
+              DIFF_BASE="origin/${BASE_REF}...${PR_REF}"
+              HEAD_SHA=$(git rev-parse "${PR_REF}")
+              PR_URL="https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
+
+              # Fill in missing metadata (e.g. workflow_dispatch doesn't have PR event context)
+              if [ -z "${PR_TITLE}" ] || [ -z "${PR_AUTHOR}" ] || [ -z "${HEAD_REF}" ]; then
+                PR_META=$(gh pr view "${PR_NUMBER}" --json title,author,headRefName 2>/dev/null || echo '{}')
+                [ -z "${PR_TITLE}" ] && PR_TITLE=$(echo "${PR_META}" | jq -r '.title // empty')
+                [ -z "${PR_AUTHOR}" ] && PR_AUTHOR=$(echo "${PR_META}" | jq -r '.author.login // empty')
+                [ -z "${HEAD_REF}" ] && HEAD_REF=$(echo "${PR_META}" | jq -r '.headRefName // empty')
+              fi
+
+              # Collect diff stats
+              FILES_CHANGED=$(git diff --name-only "${DIFF_BASE}" | wc -l | tr -d ' ')
+              DIFF_STAT=$(git diff --stat "${DIFF_BASE}")
+              LINES_ADDED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $1 } END { print s+0 }')
+              LINES_REMOVED=$(git diff --numstat "${DIFF_BASE}" | awk '{ s += $2 } END { print s+0 }')
+
+              # Write the raw diff to a standalone file (avoids Markdown escaping issues).
+              # Apply per-file-type size caps so a single churn-heavy file (typically generated
+              # snapshots or lockfiles) cannot blow Codex's 1 MiB turn input limit.
+              DEFAULT_FILE_CAP_BYTES=204800   # 200 KiB for regular source files
+              SNAPSHOT_FILE_CAP_BYTES=10240   # 10 KiB for *.snap (generated snapshots)
+              : > "${diff_file}"
+              TRUNCATED_COUNT=0
+              TRUNCATED_BYTES_SAVED=0
+              per_file_tmp=$(mktemp)
+              while IFS= read -r path; do
+                  [ -z "$path" ] && continue
+                  case "$path" in
+                      *.snap) cap="$SNAPSHOT_FILE_CAP_BYTES" ;;
+                      *)      cap="$DEFAULT_FILE_CAP_BYTES" ;;
+                  esac
+                  git diff "${DIFF_BASE}" -- "$path" > "$per_file_tmp"
+                  file_size=$(wc -c < "$per_file_tmp" | tr -d ' ')
+                  if [ "$file_size" -gt "$cap" ]; then
+                      numstat=$(git diff --numstat "${DIFF_BASE}" -- "$path")
+                      added=$(echo "$numstat" | awk '{print $1}')
+                      removed=$(echo "$numstat" | awk '{print $2}')
+                      {
+                          echo ""
+                          echo "diff --git a/${path} b/${path}"
+                          printf '[truncated by codex-pr-review: diff is %s bytes, exceeds %s-byte cap for this file type; +%s / -%s lines]\n' \
+                              "$file_size" "$cap" "$added" "$removed"
+                      } >> "${diff_file}"
+                      TRUNCATED_COUNT=$((TRUNCATED_COUNT + 1))
+                      TRUNCATED_BYTES_SAVED=$((TRUNCATED_BYTES_SAVED + file_size - cap))
+                  else
+                      cat "$per_file_tmp" >> "${diff_file}"
+                  fi
+              done < <(git diff --name-only "${DIFF_BASE}")
+              rm -f "$per_file_tmp"
+              if [ "$TRUNCATED_COUNT" -gt 0 ]; then
+                  echo "Truncated ${TRUNCATED_COUNT} file(s) in diff (~${TRUNCATED_BYTES_SAVED} bytes elided) to stay under Codex input limits."
+              fi
+
+              # Build the context file (metadata only, no embedded diff).
+              # Uses printf instead of a heredoc to keep content indented within the
+              # YAML block scalar — unindented heredoc lines break GitHub Actions' YAML parser.
+              COMMIT_MSGS=$(git log --format="%s" "origin/${BASE_REF}..${PR_REF}")
+              printf '%s\n' \
+                "" \
+                "## Pre-generated PR Context" \
+                "" \
+                "The PR diff and metadata have been pre-generated and are provided below." \
+                "**Do NOT run any git, gh, or shell commands.** Analyse the diff below directly." \
+                "" \
+                "### Arguments" \
+                "" \
+                "ARGUMENTS: ${ARGUMENTS}" \
+                "" \
+                "### PR Metadata" \
+                "- **PR Number:** ${PR_NUMBER}" \
+                "- **PR Title:** ${PR_TITLE}" \
+                "- **PR URL:** ${PR_URL}" \
+                "- **Author:** ${PR_AUTHOR}" \
+                "- **Base Branch:** ${BASE_REF}" \
+                "- **Head Branch:** ${HEAD_REF}" \
+                "- **Head SHA:** ${HEAD_SHA}" \
+                "- **Files Changed:** ${FILES_CHANGED}" \
+                "- **Lines Added:** ${LINES_ADDED}" \
+                "- **Lines Removed:** ${LINES_REMOVED}" \
+                "" \
+                "### Diff Stats" \
+                '```' \
+                "${DIFF_STAT}" \
+                '```' \
+                "" \
+                "### Commit Messages" \
+                '```' \
+                "${COMMIT_MSGS}" \
+                '```' \
+                "" \
+                "### Full Diff" \
+                "" \
+                "Everything below this line is the raw unified diff for this PR." \
+                "---" \
+                > "${context_file}"
+
+              echo "Generated context ($(wc -c < "${context_file}") bytes) + diff ($(wc -c < "${diff_file}") bytes)"
+
         - name: Run Codex Review
           if: steps.check-auth.outputs.skipped != 'true'
           id: codex
@@ -299,7 +421,6 @@ runs:
               OPENAI_API_KEY: ${{ inputs.codex-api-key }}
               CODEX_API_KEY: ${{ inputs.codex-api-key }}
               ARGUMENTS: ${{ inputs.inline-comments == 'true' && format('--json {0}', inputs.pr-number) || inputs.pr-number }}
-              PR_NUMBER: ${{ inputs.pr-number }}
               BASE_REF: ${{ inputs.base-ref }}
               HEAD_REF: ${{ inputs.head-ref }}
               PR_TITLE: ${{ inputs.pr-title }}
@@ -310,24 +431,19 @@ runs:
               # Output file paths (unique per PR to avoid conflicts)
               output_file=".codex-review-${{ inputs.pr-number }}.${{ steps.prompt.outputs.output_ext }}"
               error_file=".codex-error-${{ inputs.pr-number }}.log"
+              context_file="${{ steps.diff-context.outputs.context_file }}"
+              diff_file="${{ steps.diff-context.outputs.diff_file }}"
 
               echo "output_file=${output_file}" >> $GITHUB_OUTPUT
 
-              # Run Codex with ALL output suppressed.
-              # - stdin: just the skill prompt; Codex runs git/gh directly for diff + metadata
-              #   using the ARGUMENTS/BASE_REF/HEAD_REF/etc. env vars and the pre-fetched PR refs.
-              # - sandbox danger-full-access: both read-only and workspace-write modes use bwrap,
-              #   which fails on GHA runners with `loopback: Failed RTM_NEWADDR: Operation not permitted`
-              #   (unprivileged user namespaces are restricted). Skipping the sandbox is safe here:
-              #   the runner is ephemeral, all relevant secrets (GITHUB_TOKEN, CODEX_API_KEY) are
-              #   already exposed via the process env regardless of sandbox mode, and the primary
-              #   untrusted input (the PR diff) is read-only attacker content we're feeding to an LLM.
-              # - stdout (>/dev/null): suppresses reasoning/streaming output
-              # - stderr (2>file): captured to file for debugging, not logged
+              # Run Codex with ALL output suppressed
+              # - stdin: Review instructions + metadata context + raw diff (three files concatenated)
+              # - stdout (>/dev/null): Suppresses reasoning/streaming output
+              # - stderr (2>file): Captured to file for debugging, not logged
               set +e
-              cat "${{ steps.prompt.outputs.prompt_file }}" | codex exec \
+              cat "${{ steps.prompt.outputs.prompt_file }}" "${context_file}" "${diff_file}" | codex exec \
                 --output-last-message "${output_file}" \
-                --sandbox danger-full-access \
+                --sandbox read-only \
                 2>"${error_file}" \
                 >/dev/null
               exit_code=$?
@@ -683,4 +799,4 @@ runs:
           if: always()
           shell: bash
           run: |
-              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log"
+              rm -f ".codex-review-${{ inputs.pr-number }}.md" ".codex-review-${{ inputs.pr-number }}.json" ".codex-error-${{ inputs.pr-number }}.log" ".codex-diff-context-${{ inputs.pr-number }}.md" ".codex-diff-${{ inputs.pr-number }}.patch"


### PR DESCRIPTION
## Summary

Workflow-only change to `.github/workflows/pr-review.yml`. The net effect is:

- **Fork-PR guards at every entry point** — public-repo safety now explicit in the workflow rather than relying implicitly on GitHub's secret-scoping.
- **`/pr-review` comment re-dispatches against the PR branch** — workflow/action changes on a PR branch take effect when the author types `/pr-review`, without merging to `latest` first.
- **PR-review logic now sourced from `@ag-grid/dev-prompts@canary`** (via GitHub Packages `npm install`) as composite actions, rather than the inline duplicated workflow body. ag-charts no longer carries the full flow locally; it carries only the trigger wiring + install step + three `uses:` references.

No changes to `external/ag-shared/github/actions/codex-pr-review/action.yml` on the merge diff. That copy stays in the subrepo while ag-grid and ag-studio continue consuming it from there; once they migrate too, it can be removed as a follow-up.

## Architecture

The prompt content, composite actions, and review workflow now all ship together through the single canary → latest cadence of `@ag-grid/dev-prompts`:

```
ag-grid/ag-dev-prompts  (private)
├─ plugins/ag-prodeng/skills/pr-review/          ← prompt content
├─ .github/actions/pr-review-comment-trigger/    ← composite action (new, #51)
├─ .github/actions/pr-resolve-metadata/          ← composite action (new, #51)
├─ .github/actions/codex-pr-review/              ← composite action (moved from ag-shared, #48/#49)
└─ .github/workflows/pr-review.yml               ← dogfood workflow using the same actions

ag-grid/ag-charts  (public, this PR)
└─ .github/workflows/pr-review.yml               ← trampoline: triggers + install + composite action uses
```

ag-charts pins to the `canary` dist-tag (matching AG-17085 Phase 4's existing canary opt-in). ag-grid / ag-studio will adopt the same shape against `latest` when they migrate — same file modulo the channel.

### Why not a reusable workflow?

Initially tried ([ag-dev-prompts#48](https://github.com/ag-grid/ag-dev-prompts/pull/48)). GitHub Actions does not permit public-repo callers to consume reusable workflows from private-repo hosts — the cross-visibility `Access` setting only applies to private/internal consumers. Switching to composite actions delivered via the already-working `GITHUB_TOKEN` + `packages:read` GitHub Packages path routes around this cleanly. See the conversation on [ag-dev-prompts#51](https://github.com/ag-grid/ag-dev-prompts/pull/51) for full context.

## Security model (unchanged — explicit, not implicit)

Fork-PR diff content must not reach Codex, because Codex runs with secret access (CODEX_API_KEY, GITHUB_TOKEN in process env) and a prompt injection could exfiltrate them. Three independent guards:

- **`pull_request`**: job-level `if:` checks `head.repo.full_name == github.repository` and `draft == false`.
- **`issue_comment`**: job-level gate requires the PR context and that the comment starts with `/pr-review`; the `pr-review-comment-trigger` action then runs a permission-association check and an explicit `isCrossRepository` refusal with an explanatory comment back to the requester.
- **`workflow_dispatch`**: `pr-resolve-metadata` re-checks `isCrossRepository` and fails fast on cross-repo PRs (prevents a collaborator accidentally dispatching on a fork PR number).

Sandbox mode remains `--sandbox read-only` with pre-generated diff context (reverted the earlier exploration of `danger-full-access`; the marginal simplification wasn't worth reducing defence in depth).

## Dependencies

- **[ag-dev-prompts#51](https://github.com/ag-grid/ag-dev-prompts/pull/51)** — merged. Published to `@ag-grid/dev-prompts@canary`.
- No ag-shared subrepo changes in this PR.

## Test plan

- [x] `workflow_dispatch` against this branch completes end-to-end ([run 24831441256](https://github.com/ag-grid/ag-charts/actions/runs/24831441256), 3m13s). Codex posted summary + inline comments.
- [x] `pull_request` path exercised earlier on the same branch; same result shape.
- [ ] Post-merge: `/pr-review` comment on a subsequent same-repo PR re-dispatches against its branch and returns a review.
- [ ] Post-merge: fork-PR path — a fork-author PR should not trigger a review at all (pull_request: gated by head.repo check; issue_comment: explicit refusal with the explanatory reply).

## Rollout

1. Merge this PR (ag-charts on canary channel).
2. Soak on ag-charts.
3. Promote canary → latest on ag-dev-prompts (normal 24h soak cadence).
4. Apply equivalent trampoline workflows to ag-grid and ag-studio (against `@latest`).
5. Once all three consumers are on the new path, remove the `codex-pr-review` composite action from `ag-grid/ag-shared/github/actions/` as cleanup.