### PR TITLE
AG-16048 Bubble/scatter colour scale QA fixes (pt4)

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -318,7 +318,10 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             const domain = extent(rawDomain);
 
             if (domain != null) {
-                configureColorScale(this.colorScale, this.properties.colorScale, domain, []);
+                // `colorRange` is the palette-bound fallback used when `colorScale.fills` is
+                // empty — see BubbleSeriesProperties.colorRange for why this can't live inside
+                // the `colorScale` sub-tree.
+                configureColorScale(this.colorScale, this.properties.colorScale, domain, this.properties.colorRange);
                 this.colorScaleValid = true;
             }
         }

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesModule.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesModule.ts
@@ -32,8 +32,17 @@ import { predictCartesianAxis } from './util';
 // palette when ag-charts-enterprise is registered, and undefined otherwise. Community resolved
 // options therefore never contain a colorScale from the theme, which lets the enterprise()
 // validator on `colorScale` fire on any user-supplied value without false positives from theme
-// defaults. User-supplied colorScale options replace the entire default object rather than
-// merging element-wise.
+// defaults.
+//
+// Caveat — and why BUBBLE_SCATTER_COLOR_RANGE_THEME exists alongside this: the options graph
+// treats a user-supplied partial like `colorScale: {}` as having set every descendant path
+// (via CHILDREN_SOURCE_EDGE propagation in OptionsGraph.hasUserOption). That wipes the `fills`
+// default below wholesale rather than merging element-wise, so a user who writes
+// `colorScale: {}` ends up with an empty `fills` array. We can't gate the leaf with
+// `$isUserOption` because the same propagation makes it report "user-supplied" for every
+// descendant path, and moving the default down to the `fills` leaf triggers element-wise array
+// merging against user-supplied `fills` (producing hybrid arrays neither side asked for). Hence
+// the secondary palette source on `colorRange` — see BUBBLE_SCATTER_COLOR_RANGE_THEME.
 export const BUBBLE_SCATTER_COLOR_SCALE_THEME: Operation | WithThemeParams<AgColorScale> = {
     $if: [
         { $isPackageType: 'enterprise' },
@@ -42,6 +51,17 @@ export const BUBBLE_SCATTER_COLOR_SCALE_THEME: Operation | WithThemeParams<AgCol
         },
         undefined,
     ],
+};
+
+// Palette source for the fallback range that BubbleSeries.processData passes to
+// configureColorScale when the resolved `colorScale.fills` is empty. Lives on a separate option
+// (`colorRange`, undocumented) rather than the `colorScale` sub-tree so a user-supplied partial
+// `colorScale: {}` can't wipe it — the user's object only touches the `colorScale` branch of
+// the options graph, leaving `colorRange` to provide the default palette. Gated on enterprise
+// so the enterprise() validator on `colorRange` doesn't fire on a theme-injected value in
+// community bundles. Mirrors heatmap's `colorRange` mechanism — same problem, same shape.
+export const BUBBLE_SCATTER_COLOR_RANGE_THEME: Operation | WithThemeParams<string[]> = {
+    $if: [{ $isPackageType: 'enterprise' }, { $palette: 'divergingColors' }, undefined],
 };
 
 // Gradient legend enables automatically for any series that supplies `colorKey` together with
@@ -104,6 +124,12 @@ const themeTemplate: ExtensibleTheme<'bubble'> = {
     },
     gradientLegend: BUBBLE_SCATTER_GRADIENT_LEGEND_THEME,
 };
+
+// `colorRange` is undocumented, so it isn't part of AgBubbleSeriesThemeableOptions and can't be
+// expressed inside the `ExtensibleTheme<'bubble'>` literal above. Attaching it after the fact
+// with @ts-expect-error matches the same pattern heatmap uses in its themes (heatmapThemes.ts).
+// @ts-expect-error undocumented option
+themeTemplate.series.colorRange = BUBBLE_SCATTER_COLOR_RANGE_THEME;
 
 export const BubbleSeriesModule: SeriesModuleDefinition<AgBubbleSeriesOptions> = {
     type: 'series',

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesOptionsDef.ts
@@ -3,6 +3,7 @@ import {
     arrayOf,
     boolean,
     callbackDefs,
+    color,
     colorScaleOptionsDef,
     commonSeriesOptionsDefs,
     commonSeriesThemeableOptionsDefs,
@@ -70,3 +71,12 @@ export const bubbleSeriesOptionsDef: OptionsDefs<AgBubbleSeriesOptions> = {
 
 // @ts-expect-error undocumented option
 bubbleSeriesOptionsDef.selectedKey = undocumented(string);
+
+// Undocumented `colorRange` — see BubbleSeriesProperties.colorRange for the rationale. Exposed
+// on both the themeable and full options def so theme template injection survives user-level
+// option merging. Wrapped in `enterprise()` because `colorScale` / `colorKey` are themselves
+// enterprise-gated, keeping the community validator surface consistent.
+// @ts-expect-error undocumented option
+bubbleSeriesThemeableOptionsDef.colorRange = enterprise(undocumented(arrayOf(color)));
+// @ts-expect-error undocumented option
+bubbleSeriesOptionsDef.colorRange = enterprise(undocumented(arrayOf(color)));

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesProperties.ts
@@ -82,6 +82,27 @@ export class BubbleSeriesProperties extends CartesianSeriesProperties<AgBubbleSe
     @Property
     readonly colorScale = new ColorScaleProperties();
 
+    /**
+     * Fallback palette used by {@link BubbleSeries.processData} when the resolved
+     * {@link colorScale}.fills array is empty. This exists because the options graph treats any
+     * user-supplied partial object (e.g. `colorScale: {}` or `colorScale: { mode: 'discrete' }`)
+     * as "user-supplied" for every descendant path, which wipes the theme's
+     * `colorScale.fills` default wholesale. Without a separate fallback the scale would collapse
+     * to the raw `ColorScale` constructor defaults (red→blue over [0,1]) and every data point
+     * would render as a single colour.
+     *
+     * Populated by the series theme template from the active palette's `divergingColors` so the
+     * fallback tracks palette switches (light/dark/financial/etc.) rather than hard-coding the
+     * default chart theme's orange→yellow→green. Same mechanism heatmap uses via its own
+     * `colorRange` option.
+     *
+     * Undocumented: users who want an explicit gradient should supply `colorScale.fills`. This
+     * field exists purely so an omitted or empty `colorScale` still produces the heatmap-style
+     * default palette instead of red→blue.
+     */
+    @Property
+    colorRange: string[] = ['black', 'black'];
+
     @Property
     title?: string;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesModule.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesModule.ts
@@ -15,7 +15,11 @@ import type { AgScatterSeriesOptions, ExtensibleTheme } from 'ag-charts-types';
 import type { ModuleContext } from '../../../module/moduleContext';
 import { VERSION } from '../../../version';
 import { CartesianChartModule } from '../../cartesianChartModule';
-import { BUBBLE_SCATTER_COLOR_SCALE_THEME, BUBBLE_SCATTER_GRADIENT_LEGEND_THEME } from './bubbleSeriesModule';
+import {
+    BUBBLE_SCATTER_COLOR_RANGE_THEME,
+    BUBBLE_SCATTER_COLOR_SCALE_THEME,
+    BUBBLE_SCATTER_GRADIENT_LEGEND_THEME,
+} from './bubbleSeriesModule';
 import { ScatterSeries } from './scatterSeries';
 import { scatterSeriesOptionsDef } from './scatterSeriesOptionsDef';
 import { predictCartesianAxis } from './util';
@@ -62,6 +66,11 @@ const themeTemplate: ExtensibleTheme<'scatter'> = {
     },
     gradientLegend: BUBBLE_SCATTER_GRADIENT_LEGEND_THEME,
 };
+
+// See bubbleSeriesModule.ts for why `colorRange` is attached here (undocumented option; can't
+// appear in the ExtensibleTheme literal above).
+// @ts-expect-error undocumented option
+themeTemplate.series.colorRange = BUBBLE_SCATTER_COLOR_RANGE_THEME;
 
 export const ScatterSeriesModule: SeriesModuleDefinition<AgScatterSeriesOptions> = {
     type: 'series',

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesOptionsDef.ts
@@ -1,7 +1,9 @@
 import {
     type OptionsDefs,
+    arrayOf,
     boolean,
     callbackDefs,
+    color,
     colorScaleOptionsDef,
     commonSeriesOptionsDefs,
     commonSeriesThemeableOptionsDefs,
@@ -65,3 +67,10 @@ export const scatterSeriesOptionsDef: OptionsDefs<AgScatterSeriesOptions> = {
 
 // @ts-expect-error undocumented option
 scatterSeriesOptionsDef.selectedKey = undocumented(string);
+
+// Undocumented `colorRange` — mirrors BubbleSeries (ScatterSeries extends BubbleSeries and
+// shares its colour-scale code path). See BubbleSeriesProperties.colorRange for the rationale.
+// @ts-expect-error undocumented option
+scatterSeriesThemeableOptionsDef.colorRange = enterprise(undocumented(arrayOf(color)));
+// @ts-expect-error undocumented option
+scatterSeriesOptionsDef.colorRange = enterprise(undocumented(arrayOf(color)));

--- a/packages/ag-charts-community/src/util/properties.test.ts
+++ b/packages/ag-charts-community/src/util/properties.test.ts
@@ -101,6 +101,33 @@ describe('BaseProperties', () => {
         expect(instance.prop2).toBeUndefined();
         expect(instance.nested.nestedValue).toBeUndefined();
     });
+
+    it('AG-16048 should clear a nested PropertiesArray without throwing when set(null) is called', () => {
+        // Regression: BaseProperties.clear() walks every decorated field where isProperties(value)
+        // returns true — which includes PropertiesArray. Prior to AG-16048 pt4 follow-up, clear()
+        // threw `TypeError: currentValue.clear is not a function` when reaching an array-typed
+        // child. This happens whenever a parent property is set to null (e.g. when the enterprise()
+        // validator strips a community-supplied colorScale in ag-charts-community bundles).
+        class Item extends BaseProperties<{ value: string }> {
+            @Property
+            value!: string;
+        }
+        class Container extends BaseProperties<{ items: { value: string }[] }> {
+            @Property
+            items = new PropertiesArray(Item);
+        }
+        class Parent extends BaseProperties<{ container: { items: { value: string }[] } }> {
+            @Property
+            container = new Container();
+        }
+
+        const instance = new Parent();
+        instance.container.set({ items: [{ value: 'a' }, { value: 'b' }] });
+        expect(instance.container.items).toHaveLength(2);
+
+        expect(() => instance.set({ container: null as any })).not.toThrow();
+        expect(instance.container.items).toHaveLength(0);
+    });
 });
 
 describe('PropertiesArray', () => {

--- a/packages/ag-charts-core/src/state/properties.ts
+++ b/packages/ag-charts-core/src/state/properties.ts
@@ -105,6 +105,15 @@ export class PropertiesArray<T extends BaseProperties> extends Array<T> {
         }
     }
 
+    // Matches BaseProperties.clear() — BaseProperties.clear() recurses into any field where
+    // isProperties(value) is true, which includes PropertiesArray. Without this, clearing a
+    // parent (e.g. ColorScaleProperties) throws TypeError when a child array-typed property
+    // is reached.
+    clear(): this {
+        this.length = 0;
+        return this;
+    }
+
     toJson() {
         return this.map((value) => value?.toJson?.() ?? value);
     }

--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
@@ -567,5 +567,39 @@ describe('GradientLegend', () => {
 
             await compare();
         });
+
+        // Regression for AG-16048 QA feedback point 2: an empty user-supplied `colorScale: {}`
+        // must still pick up the theme's diverging palette for `fills`. Prior to moving the
+        // theme default from the `colorScale` object to the `colorScale.fills` leaf, the user's
+        // partial object wiped the theme wholesale and the series fell back to the raw
+        // ColorScale defaults (red→blue), producing all-blue markers in David's plunker.
+        it('AG-16048 should apply the theme fills palette when user supplies an empty colorScale', async () => {
+            const options = prepareEnterpriseTestOptions({
+                data: SCATTER_DATA,
+                series: [
+                    {
+                        type: 'scatter' as const,
+                        xKey: 'x',
+                        yKey: 'y1',
+                        colorKey: 'temp',
+                        colorScale: {},
+                    },
+                ],
+            });
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const chartInstance = deproxy(chart);
+            const series: any = chartInstance.series[0];
+            // `configureColorScale`'s fallback branch sets `domain` to the raw data-domain
+            // tuple (it bypasses `computeColorBins`), so the expectation here is [min, max]
+            // over the `temp` values rather than a 3-stop binned domain.
+            expect(series.colorScale.domain).toEqual([5, 45]);
+            // Range resolves to the active palette's `divergingColors` (3 entries on the
+            // default chart theme). Guard against a regression to the ColorScale constructor
+            // defaults (`range = ['red', 'blue']`).
+            expect(series.colorScale.range).toHaveLength(3);
+            expect(series.colorScale.range).not.toEqual(['red', 'blue']);
+        });
     });
 });


### PR DESCRIPTION
## Summary

Addresses two items from David's QA feedback on [AG-16048 comment 111360](https://ag-grid.atlassian.net/browse/AG-16048?focusedCommentId=111360):

### 1. `TypeError` when enterprise-only `colorScale` supplied in community

> Correctly warns. However chart does not load and there is an exception thrown `TypeError: currentValue.clear is not a function at ColorScaleProperties.clear`

Root cause: `BaseProperties.clear()` recurses into every decorated field where `isProperties(value)` is `true` — which includes `PropertiesArray`, but the array class had no `clear()` method. The community bundle's `enterprise()` validator strips a user-supplied `colorScale` to `null`, which drives `ColorScaleProperties.set(null) → clear()` → crash on the `fills` `PropertiesArray`.

Fix: add `clear()` to `PropertiesArray` matching the existing `set()`/`reset()`/`toJson()` API symmetry. Regression covered in `properties.test.ts`.

### 2. Marker colours fall back to red→blue instead of the heatmap palette

> If no `fills` is provided, use the default palette used by heatmap. Actual: markers are blue. Expected: markers range from orange to green.

Root cause: the options graph treats any user-supplied partial object as "user-supplied" for every descendant path (via `CHILDREN_SOURCE_EDGE` propagation in `OptionsGraph.hasUserOption`), which wipes the theme's `colorScale.fills` default wholesale. `$isUserOption` inherits the same propagation so it can't discriminate an explicitly-set leaf from an inherited one, and moving the default down to the `fills` leaf triggers element-wise array merging against user-supplied `fills` entries.

Fix: add an undocumented `colorRange` option (palette-bound via the theme template's `{ $palette: 'divergingColors' }`) that lives outside the `colorScale` sub-tree so a user-supplied partial can't wipe it. `BubbleSeries.processData` threads it through as the `fallbackRange` arg to `configureColorScale`, so an empty `colorScale.fills` resolves to the palette-appropriate gradient and tracks light/dark/financial palette switches. Mirrors heatmap's existing `colorRange` mechanism.

## Test plan

- [x] `yarn nx test ag-charts-community` — 3318 passed (new `properties.test.ts` regression)
- [x] `yarn nx test ag-charts-enterprise` — 1880 passed (new `gradientLegend.test.ts` regression for point 2)
- [x] `yarn nx format` / `build:types` / `lint` clean for core + community + enterprise
- [ ] Re-verify David's reproducer plunkers (6RcHTXkxqfOngpJa community-colorScale, yNVXgZ43XcrEEd1d empty colorScale heatmap fallback)

Fix #AG-16048