### PR TITLE
AG-16043 Suppress highlight for discrete colour-scale bin legend items

### DIFF
--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -1140,16 +1140,18 @@ export class Legend {
             }
         };
 
-        if (
-            enabled === true &&
-            series !== undefined &&
-            legendDatum !== undefined &&
-            legendDatum.suppressHighlight !== true
-        ) {
+        const hasHighlightTarget = enabled === true && series !== undefined && legendDatum !== undefined;
+        const legendItemSuppressesHighlight = legendDatum?.suppressHighlight === true;
+
+        if (hasHighlightTarget && !legendItemSuppressesHighlight) {
             const itemId = legendDatum.itemId;
             const nodeDatum = toHighlightNodeDatum(series, legendDatum);
             highlightNodeDatum({ itemId, nodeDatum });
         } else {
+            // Either no highlightable target, or the current legend item opts out
+            // (e.g. a discrete colour-scale bin whose itemId is a bin index, not a
+            // datum index). Push an undefined highlight so any prior highlight under
+            // this caller id is cleared on hover transition.
             highlightNodeDatum(undefined);
         }
     }

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -1140,7 +1140,12 @@ export class Legend {
             }
         };
 
-        if (enabled === true && series !== undefined && legendDatum !== undefined) {
+        if (
+            enabled === true &&
+            series !== undefined &&
+            legendDatum !== undefined &&
+            legendDatum.suppressHighlight !== true
+        ) {
             const itemId = legendDatum.itemId;
             const nodeDatum = toHighlightNodeDatum(series, legendDatum);
             highlightNodeDatum({ itemId, nodeDatum });

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.test.ts
@@ -23,6 +23,7 @@ describe('legendDatum', () => {
             expect(result[0].symbol.marker.shape).toBe('square');
             expect(result[0].isFixed).toBe(true);
             expect(result[0].hideToggleOtherSeries).toBe(true);
+            expect(result[0].suppressHighlight).toBe(true);
             expect(result[1].symbol.marker.fill).toBe('green');
         });
 

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -50,6 +50,13 @@ export interface CategoryLegendDatum extends BaseChartLegendDatum {
     skipAnimations?: boolean;
     isFixed?: boolean;
     hideToggleOtherSeries?: true; // used to hide "Toggle Other Series" for Multi-Donut and Pie/Donut combo charts.
+    /**
+     * When true, hovering or clicking this legend item must not drive the series highlight.
+     * Used by discrete colour-scale bin items whose `itemId` is a bin index, not a datum index,
+     * so feeding it through the highlight pipeline would either un-highlight everything
+     * (heatmap/map series) or throw (hierarchy series whose `datumIndex` is a path array).
+     */
+    suppressHighlight?: true;
 }
 
 interface FormatterBoundSeries {
@@ -204,6 +211,7 @@ export function buildColorCategoryLegendData(
             label: { text: name ?? formatColorBinLabel(start, end, i, range.length, formatValue) },
             isFixed: true,
             hideToggleOtherSeries: true,
+            suppressHighlight: true,
         };
     });
 }

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
@@ -556,6 +556,50 @@ describe('HeatmapSeries', () => {
             // (treemap/sunburst whose datumIndex is a path array).
             expect(highlightManager.getActiveHighlight()).toBeUndefined();
         });
+
+        it('AG-16043: hovering a discrete-bin legend item clears any legend-scoped highlight', async () => {
+            const options = prepareEnterpriseTestOptions({
+                data: EXAMPLE_OPTIONS.data,
+                series: [
+                    {
+                        type: 'heatmap',
+                        xKey: 'year',
+                        yKey: 'person',
+                        colorKey: 'spending',
+                        colorScale: {
+                            fills: [{ color: 'blue' }, { color: 'yellow' }, { color: 'red' }],
+                            mode: 'discrete' as const,
+                        },
+                    },
+                ],
+            });
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const { highlightManager } = (chart as Chart).ctx;
+            const legendModule = (chart as Chart).modulesManager.getModule('legend') as unknown as { id: string };
+            const [series0] = (chart as Chart).series;
+
+            // Seed a highlight under the legend's own caller id, as would be the case if the
+            // user had just hovered a non-suppressed legend item in a mixed scenario.
+            highlightManager.updateHighlight(legendModule.id, {
+                series: series0,
+                itemId: undefined,
+                datum: undefined,
+                datumIndex: 0,
+                legendItemName: undefined,
+            } as any);
+            expect(highlightManager.getActiveHighlight()).toBeDefined();
+
+            const legendBBox = computeLegendBBox(chart);
+            await hoverAction(legendBBox.x + 5, legendBBox.y + legendBBox.height / 2)(chart);
+            await waitForChartStability(chart);
+
+            // The suppressed bin hover must still push an undefined highlight for the legend's
+            // caller id so any prior legend-scoped highlight is cleared.
+            expect(highlightManager.getActiveHighlight()).toBeUndefined();
+        });
     });
 
     describe('null category key', () => {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
@@ -2,9 +2,13 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { type AgChartOptions, AgCharts } from 'ag-charts-community';
 import {
+    type Chart,
     IMAGE_SNAPSHOT_DEFAULTS,
+    computeLegendBBox,
+    deproxy,
     expectWarningsCalls,
     extractImageData,
+    hoverAction,
     setupMockCanvas,
     setupMockConsole,
     waitForChartStability,
@@ -518,6 +522,39 @@ describe('HeatmapSeries', () => {
 
             chart = AgCharts.create(options);
             await compare();
+        });
+
+        it('AG-16043: hovering a discrete-bin legend item must not register a highlight', async () => {
+            const options = prepareEnterpriseTestOptions({
+                data: EXAMPLE_OPTIONS.data,
+                series: [
+                    {
+                        type: 'heatmap',
+                        xKey: 'year',
+                        yKey: 'person',
+                        colorKey: 'spending',
+                        colorScale: {
+                            fills: [{ color: 'blue' }, { color: 'yellow' }, { color: 'red' }],
+                            mode: 'discrete' as const,
+                        },
+                    },
+                ],
+            });
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const { highlightManager } = (chart as Chart).ctx;
+            expect(highlightManager.getActiveHighlight()).toBeUndefined();
+
+            const legendBBox = computeLegendBBox(chart);
+            await hoverAction(legendBBox.x + 5, legendBBox.y + legendBBox.height / 2)(chart);
+            await waitForChartStability(chart);
+
+            // The bin's itemId is a bin index, not a datum index; feeding it through the
+            // highlight pipeline would either dim everything (heatmap/maps) or throw
+            // (treemap/sunburst whose datumIndex is a path array).
+            expect(highlightManager.getActiveHighlight()).toBeUndefined();
         });
     });
 

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
@@ -556,50 +556,6 @@ describe('HeatmapSeries', () => {
             // (treemap/sunburst whose datumIndex is a path array).
             expect(highlightManager.getActiveHighlight()).toBeUndefined();
         });
-
-        it('AG-16043: hovering a discrete-bin legend item clears any legend-scoped highlight', async () => {
-            const options = prepareEnterpriseTestOptions({
-                data: EXAMPLE_OPTIONS.data,
-                series: [
-                    {
-                        type: 'heatmap',
-                        xKey: 'year',
-                        yKey: 'person',
-                        colorKey: 'spending',
-                        colorScale: {
-                            fills: [{ color: 'blue' }, { color: 'yellow' }, { color: 'red' }],
-                            mode: 'discrete' as const,
-                        },
-                    },
-                ],
-            });
-
-            chart = deproxy(AgCharts.create(options));
-            await waitForChartStability(chart);
-
-            const { highlightManager } = (chart as Chart).ctx;
-            const legendModule = (chart as Chart).modulesManager.getModule('legend') as unknown as { id: string };
-            const [series0] = (chart as Chart).series;
-
-            // Seed a highlight under the legend's own caller id, as would be the case if the
-            // user had just hovered a non-suppressed legend item in a mixed scenario.
-            highlightManager.updateHighlight(legendModule.id, {
-                series: series0,
-                itemId: undefined,
-                datum: undefined,
-                datumIndex: 0,
-                legendItemName: undefined,
-            } as any);
-            expect(highlightManager.getActiveHighlight()).toBeDefined();
-
-            const legendBBox = computeLegendBBox(chart);
-            await hoverAction(legendBBox.x + 5, legendBBox.y + legendBBox.height / 2)(chart);
-            await waitForChartStability(chart);
-
-            // The suppressed bin hover must still push an undefined highlight for the legend's
-            // caller id so any prior legend-scoped highlight is cleared.
-            expect(highlightManager.getActiveHighlight()).toBeUndefined();
-        });
     });
 
     describe('null category key', () => {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
@@ -524,6 +524,67 @@ describe('HeatmapSeries', () => {
             await compare();
         });
 
+        it('AG-16043: moving from a normal legend item onto a suppressed bin clears the legend-scoped highlight', async () => {
+            const options = prepareEnterpriseTestOptions({
+                data: [
+                    { x: 1, y: 1, size: 10, v: 10 },
+                    { x: 2, y: 2, size: 20, v: 30 },
+                    { x: 3, y: 3, size: 30, v: 50 },
+                    { x: 4, y: 4, size: 40, v: 70 },
+                    { x: 5, y: 5, size: 50, v: 90 },
+                ],
+                series: [
+                    {
+                        type: 'bubble',
+                        xKey: 'x',
+                        yKey: 'y',
+                        sizeKey: 'size',
+                        title: 'Series A',
+                    },
+                    {
+                        type: 'bubble',
+                        xKey: 'x',
+                        yKey: 'y',
+                        sizeKey: 'size',
+                        colorKey: 'v',
+                        colorScale: {
+                            mode: 'discrete' as const,
+                            fills: [{ color: 'red' }, { color: 'green' }, { color: 'blue' }],
+                        },
+                        title: 'Series B',
+                    },
+                ],
+            });
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            // Drive Legend.onHover directly rather than simulating canvas coordinates — the
+            // legend's own markerLabel nodes already carry the datum association, and the
+            // MouseEvent argument is only used for tooltip positioning, not highlight state.
+            const legendModule = (chart as Chart).modulesManager.getModule('legend') as any;
+            const items: any[] = [];
+            legendModule.itemSelection.each((item: any) => items.push(item));
+            // 1 toggleable Series A + 3 bin items from Series B.
+            expect(items).toHaveLength(4);
+            expect(items[0].datum.suppressHighlight).toBeUndefined();
+            expect(items[1].datum.suppressHighlight).toBe(true);
+
+            const { highlightManager } = (chart as Chart).ctx;
+            const mockEvent = new MouseEvent('mousemove');
+            expect(highlightManager.getActiveHighlight()).toBeUndefined();
+
+            // Hover the toggleable Series A item — the legend sets a highlight under its caller id.
+            legendModule.onHover(mockEvent, items[0]);
+            await waitForChartStability(chart);
+            expect(highlightManager.getActiveHighlight()).toBeDefined();
+
+            // Move onto a suppressed bin item — the prior legend-scoped highlight must be cleared.
+            legendModule.onHover(mockEvent, items[1]);
+            await waitForChartStability(chart);
+            expect(highlightManager.getActiveHighlight()).toBeUndefined();
+        });
+
         it('AG-16043: hovering a discrete-bin legend item must not register a highlight', async () => {
             const options = prepareEnterpriseTestOptions({
                 data: EXAMPLE_OPTIONS.data,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16043

Addresses David's feedback on [comment 111730](https://ag-grid.atlassian.net/browse/AG-16043?focusedCommentId=111730): hovering a discrete-bin legend item un-highlighted everything on heatmap / map-shape / map-marker / map-line, and threw in treemap / sunburst.

**Root cause.** `buildColorCategoryLegendData` stamps each bin legend item with `itemId: <bin-index>`. `Legend.updateHighlight` routes a numeric `itemId` into `HighlightNodeDatum.datumIndex`, but a bin index is not a datum index — so map/heatmap series matched nothing (dimming all nodes) and `HierarchySeries` (whose `datumIndex` is a `number[]` path) threw.

**Fix.** Introduce a `suppressHighlight?: true` flag on `CategoryLegendDatum`, set by `buildColorCategoryLegendData` for every bin item. `Legend.updateHighlight` treats flagged items as clear-only so bin-item hover/click no longer drives the highlight manager. Legend tooltip and click event still fire.

Regression test in `heatmap.test.ts` hovers the first bin legend item and asserts `highlightManager.getActiveHighlight()` stays `undefined`. Verified to fail without the fix.

Option B (actually highlight the datums that fall inside the hovered bin) is left for David to decide whether it warrants a follow-up ticket.

Fix #AG-16043