### PR TITLE
Retry Playwright image pull to reduce E2E shard flakes

### DIFF
--- a/packages/ag-charts-website/playwright.sh
+++ b/packages/ag-charts-website/playwright.sh
@@ -100,19 +100,21 @@ if [ "$1" == "--host" ] ; then
   cd $(git rev-parse --show-toplevel)
 
   playwright_image=mcr.microsoft.com/playwright:v1.57.0-jammy
-  pull_attempts=3
-  for attempt in $(seq 1 ${pull_attempts}) ; do
-    if docker pull ${playwright_image} ; then
-      break
-    fi
-    if [[ ${attempt} -eq ${pull_attempts} ]] ; then
-      echo "Failed to pull ${playwright_image} after ${pull_attempts} attempts."
-      exit 1
-    fi
-    backoff=$((attempt * 10))
-    echo "Pull attempt ${attempt} failed, retrying in ${backoff}s..."
-    sleep ${backoff}
-  done
+  if ! docker image inspect ${playwright_image} >/dev/null 2>&1 ; then
+    pull_attempts=3
+    for attempt in $(seq 1 ${pull_attempts}) ; do
+      if docker pull ${playwright_image} ; then
+        break
+      fi
+      if [[ ${attempt} -eq ${pull_attempts} ]] ; then
+        echo "Failed to pull ${playwright_image} after ${pull_attempts} attempts."
+        exit 1
+      fi
+      backoff=$((attempt * 10))
+      echo "Pull attempt ${attempt} failed, retrying in ${backoff}s..."
+      sleep ${backoff}
+    done
+  fi
 
   docker run -d --rm --ipc=host --init \
     -v $(pwd):/data:ro \

--- a/packages/ag-charts-website/playwright.sh
+++ b/packages/ag-charts-website/playwright.sh
@@ -98,6 +98,22 @@ if [ "$1" == "--host" ] ; then
   trap cleanup SIGINT SIGTERM ERR EXIT
 
   cd $(git rev-parse --show-toplevel)
+
+  playwright_image=mcr.microsoft.com/playwright:v1.57.0-jammy
+  pull_attempts=3
+  for attempt in $(seq 1 ${pull_attempts}) ; do
+    if docker pull ${playwright_image} ; then
+      break
+    fi
+    if [[ ${attempt} -eq ${pull_attempts} ]] ; then
+      echo "Failed to pull ${playwright_image} after ${pull_attempts} attempts."
+      exit 1
+    fi
+    backoff=$((attempt * 10))
+    echo "Pull attempt ${attempt} failed, retrying in ${backoff}s..."
+    sleep ${backoff}
+  done
+
   docker run -d --rm --ipc=host --init \
     -v $(pwd):/data:ro \
     -v $(pwd)/reports:/data/reports \
@@ -111,7 +127,7 @@ if [ "$1" == "--host" ] ; then
     -e AG_SKIP_NATIVE_DEP_VERSION_CHECK \
     ${EXTRA_DOCKER_ARGS} \
     --name ${container_name} \
-    mcr.microsoft.com/playwright:v1.57.0-jammy \
+    ${playwright_image} \
     /bin/bash -l playwright.sh $@
 
   docker logs -f ${container_name} &


### PR DESCRIPTION
Split the `mcr.microsoft.com/playwright` pull out of `docker run` in `packages/ag-charts-website/playwright.sh` and wrap it in a 3-attempt loop with linear backoff (10s, 20s).

MCR occasionally returns a transient block (seen as `The request is blocked` / HTTP error in the docker daemon response) which causes `docker run` to exit 125 before Playwright even starts, sinking the whole shard. With 16 shards per run, every CI invocation rolls the dice 16× against MCR, so flakes have been creeping up.

On the happy path the behaviour is unchanged — `docker run` hits the local image cache after the pull. On a transient MCR hiccup, we now retry twice before failing the shard with a clear "Failed to pull ... after N attempts" message rather than an opaque docker exit-125.

This is a stopgap; the longer-term fix is to mirror the image to GHCR so CI doesn't depend on MCR at all.