### PR TITLE
AG-17130 Skip invisible nodes in leaf pickNode/pickNodes

### DIFF
--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -357,12 +357,18 @@ export abstract class Node<TDatum = unknown> {
     }
 
     pickNode(x: number, y: number): Node | undefined {
+        if (!this.visible || this.pointerEvents === PointerEvents.None) {
+            return;
+        }
         if (this.containsPoint(x, y)) {
             return this;
         }
     }
 
     pickNodes(x: number, y: number, into: Node<any>[] = []): Node<any>[] {
+        if (!this.visible || this.pointerEvents === PointerEvents.None) {
+            return into;
+        }
         if (this.containsPoint(x, y)) {
             into.push(this);
         }

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.test.ts
@@ -792,4 +792,42 @@ describe('TreemapSeries', () => {
             await compare();
         });
     });
+
+    describe('AG-17130 tooltip after options-replacement update', () => {
+        const fullData = [
+            { value: 14.35, displayName: 'Jan.10' },
+            { value: 14.36, displayName: 'Feb.10' },
+            { value: 14.37, displayName: 'Mar.10' },
+            { value: 14.34, displayName: 'Apr.10' },
+            { value: 9_294_717_981.55, displayName: 'Jan.14' },
+            { value: 145_293_355.65, displayName: 'Mar.14' },
+        ];
+        const filteredData = fullData.filter((d) => d.displayName.includes('.10'));
+
+        const buildOptions = (data: typeof fullData): AgChartOptions => ({
+            data,
+            series: [{ type: 'treemap', labelKey: 'displayName', sizeKey: 'value', childrenKey: 'children' }],
+            animation: { enabled: false },
+        });
+
+        it('shows the new top-left tile on hover after replacing options', async () => {
+            const proxy = AgCharts.create(prepareEnterpriseTestOptions(buildOptions(filteredData)));
+            chart = deproxy(proxy);
+            await waitForChartStability(chart);
+
+            await proxy.update(prepareEnterpriseTestOptions(buildOptions(fullData)));
+            await waitForChartStability(chart);
+
+            // Jan.14 dwarfs every other datum, so the new layout places it top-left.
+            // Hovering near the top-left also overlaps where Mar.10's tile was positioned
+            // before the update, which is the scenario covered by the regression.
+            const { x, y } = chart.seriesRect!;
+            await hoverAction(x + 30, y + 30)(chart);
+            await waitForChartStability(chart);
+
+            const tooltip = document.querySelector('.ag-charts-tooltip');
+            expect(tooltip?.textContent).toContain('Jan.14');
+            expect(tooltip?.textContent).not.toContain('Mar.10');
+        });
+    });
 });


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17130

Leaf `Node.pickNode` / `Node.pickNodes` now respect `visible` and
`pointerEvents`, matching the guard already applied by `Group`.

Treemap hides tiles with no valid layout (`bbox == null`) by setting
`rect.visible = false` but leaves `x/y/width/height` untouched so the
rect can be reused on subsequent updates. Without this guard the
picker still hit-tested those invisible rects at their previous
positions. After an options-replacement update that rearranged the
layout, the tooltip could resolve a stale `datumIndex` against the new
root node and show the wrong datum.

Regressed in 12.0.0 with the AG-7126 refactor that moved tooltip
resolution onto `datumIndex`; before then the picked datum object was
used directly, which happened to mask the bug.

Fix #AG-17130