### PR TITLE
AG-16915 Exclude invalid/missing rows from bubble aggregation gate

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -1004,6 +1004,23 @@ describe('BubbleSeries', () => {
             const series = deproxy(chart).series[0] as any;
             expect(series.dataAggregation).toBeDefined();
         });
+
+        it('should not aggregate when renderable (non-missing sizeKey) count is within maxRenderedItems', async () => {
+            const options: AgCartesianChartOptions = {
+                data: [
+                    ...Array.from({ length: 10 }, (_, i) => ({ x: i, y: i, s: 1 + (i % 5) })),
+                    ...Array.from({ length: 10 }, (_, i) => ({ x: 10 + i, y: i })),
+                ],
+                series: [{ type: 'bubble', xKey: 'x', yKey: 'y', sizeKey: 's', maxRenderedItems: 15 }],
+                legend: { enabled: false },
+            };
+            prepareTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const series = deproxy(chart).series[0] as any;
+            expect(series.dataAggregation).toBeUndefined();
+        });
     });
 
     describe('AG-15743 legendItemName', () => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -20,6 +20,7 @@ import { testLegendItemName } from '../../test/legendItemName';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
     PATTERN_SNAPSHOT_DEFAULTS,
+    deproxy,
     expectWarningsCalls,
     extractImageData,
     hoverAction,
@@ -958,6 +959,50 @@ describe('BubbleSeries', () => {
 
             chart = AgCharts.create(options);
             await compare();
+        });
+    });
+
+    describe('AG-16915 maxRenderedItems gate with invalid sizeKey values', () => {
+        const buildData = (validCount: number, invalidCount: number) => [
+            ...Array.from({ length: validCount }, (_, i) => ({ x: i, y: i, s: 1 + (i % 5) })),
+            ...Array.from({ length: invalidCount }, (_, i) => ({ x: validCount + i, y: i, s: Number.NaN })),
+        ];
+
+        it('should not aggregate when renderable (non-NaN sizeKey) count is within maxRenderedItems', async () => {
+            const options: AgCartesianChartOptions = {
+                data: buildData(10, 10),
+                series: [{ type: 'bubble', xKey: 'x', yKey: 'y', sizeKey: 's', maxRenderedItems: 15 }],
+                legend: { enabled: false },
+            };
+            prepareTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - invalid value of type [number] for [BubbleSeries-1 / sizeValue] ignored:",
+    "[NaN]",
+  ],
+]
+`);
+
+            const series = deproxy(chart).series[0] as any;
+            expect(series.dataAggregation).toBeUndefined();
+        });
+
+        it('should still aggregate when renderable count exceeds maxRenderedItems', async () => {
+            const options: AgCartesianChartOptions = {
+                data: buildData(20, 0),
+                series: [{ type: 'bubble', xKey: 'x', yKey: 'y', sizeKey: 's', maxRenderedItems: 15 }],
+                legend: { enabled: false },
+            };
+            prepareTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const series = deproxy(chart).series[0] as any;
+            expect(series.dataAggregation).toBeDefined();
         });
     });
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -403,7 +403,8 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
 
     private aggregateData(dataModel: DataModel<any, any, true>, processedData: ProcessedData<any>) {
         if (processedData.type === 'grouped') return;
-        if (processedData.input.count <= this.properties.maxRenderedItems) return;
+        const renderableCount = processedData.input.count - this.invalidDataCount() - this.missingDataCount();
+        if (renderableCount <= this.properties.maxRenderedItems) return;
 
         const xAxis = this.axes[ChartAxisDirection.X];
         const yAxis = this.axes[ChartAxisDirection.Y];


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16915

Bubble series decided whether to aggregate by comparing `processedData.input.count` (the raw row count, including rows with NaN/undefined sizeKey) against `maxRenderedItems`. When the dataset contained many invalid rows, aggregation would engage unnecessarily and spatially merge valid bubbles even though the renderable count was within budget.

Subtract `invalidDataCount` and `missingDataCount` — both already tracked per-series by DataModel during extraction — so the gate matches the count of bubbles that will actually render. O(1); no extra data-model work.

Fix #AG-16915