### PR TITLE
Remove jsonApply and decorators from the axis path

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -13,7 +13,7 @@ import {
     ChartAxisDirection,
     ChartUpdateType,
     CleanupRegistry,
-    ObserveChanges,
+    ReactiveState,
     WeakCache,
     ZIndexMap,
     callWithContext,
@@ -149,10 +149,9 @@ const EMPTY_SKIP: ReadonlySet<string> = new Set();
 
 /**
  * Apply a single top-level options field onto the axis. Primitives and the `context` pass-through
- * are assigned directly (so decorator-backed setters — `@ActionOnSet`, `@ProxyPropertyOnWrite` —
- * still fire). Object-valued fields whose current value is an existing class instance recurse via
- * the instance's own `applyOptions()` or `.set()` entry point so nested structure (e.g.
- * `parentLevel.label`) is preserved rather than replaced with the raw options object.
+ * are assigned directly. Object-valued fields whose current value is an existing class instance
+ * recurse via the instance's own `applyOptions()` or `.set()` entry point so nested structure
+ * (e.g. `parentLevel.label`) is preserved rather than replaced with the raw options object.
  */
 function applyFieldOption(target: any, key: string, value: unknown): void {
     // `context` is a user pass-through reference; assign as-is without recursion.
@@ -305,10 +304,24 @@ export abstract class Axis<
     readonly title = new AxisTitle();
 
     /**
-     * The length of the grid. The grid is only visible in case of a non-zero value.
+     * Per-axis layout-scope reactive state. `gridLength` is pushed here by the chart layout
+     * pipeline and consumers (crossLines + grid-visibility subclasses) subscribe in the
+     * constructor.
      */
-    @ObserveChanges<Axis>((target, value, oldValue) => target.onGridLengthChange(value, oldValue))
-    gridLength: number = 0;
+    private readonly layoutState = new ReactiveState<{ gridLength: number }>();
+
+    /**
+     * The length of the grid. The grid is only visible in case of a non-zero value.
+     * Read-only; use {@link setGridLength} to update.
+     */
+    get gridLength(): number {
+        return this.layoutState.getValue('gridLength') ?? 0;
+    }
+
+    setGridLength(value: number): void {
+        this.layoutState.setValue('gridLength', value);
+        this.layoutState.flushChanges('gridLength');
+    }
 
     /**
      * The distance between the grid ticks and the axis ticks.
@@ -334,6 +347,15 @@ export abstract class Axis<
     };
 
     requiredRange?: number;
+
+    /**
+     * Push a chart-computed required pixel range onto this axis. Base implementation just stores
+     * the value; {@link CategoryAxis} overrides to sync `layoutConstraints` and skip the next
+     * animation batch.
+     */
+    applyRequiredRange(value: number | undefined): void {
+        this.requiredRange = value;
+    }
 
     boundSeries: ISeries<DatumIndexType, unknown, ISeriesProperties>[] = [];
     includeInvisibleDomains: boolean = false;
@@ -426,9 +448,20 @@ export abstract class Axis<
         for (const crossLine of this.crossLines) {
             this.initCrossLine(crossLine);
         }
+        let prevGridLength = 0;
         this.cleanup.register(
             this.moduleCtx.widgets.containerWidget.addListener('mousemove', (e) => this.onMouseMove(e)),
-            this.moduleCtx.widgets.containerWidget.addListener('mouseleave', () => this.endHovering())
+            this.moduleCtx.widgets.containerWidget.addListener('mouseleave', () => this.endHovering()),
+            this.layoutState.observe((get) => {
+                const gridLength = get('gridLength') ?? 0;
+                if ((prevGridLength === 0) !== (gridLength === 0)) {
+                    this.onGridVisibilityChange();
+                }
+                prevGridLength = gridLength;
+                for (const crossLine of this.crossLines) {
+                    this.initCrossLine(crossLine);
+                }
+            })
         );
     }
 
@@ -557,16 +590,6 @@ export abstract class Axis<
         if (value < min) return value - min;
         if (value > max) return value - max;
         return 0;
-    }
-
-    protected onGridLengthChange(value: number, prevValue: number) {
-        // Was visible and now invisible, or was invisible and now visible.
-        if (prevValue ^ value) {
-            this.onGridVisibilityChange();
-        }
-        for (const crossLine of this.crossLines) {
-            this.initCrossLine(crossLine);
-        }
     }
 
     protected onGridVisibilityChange() {}

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -153,6 +153,38 @@ const EMPTY_SKIP: ReadonlySet<string> = new Set();
  * recurse via the instance's own `applyOptions()` or `.set()` entry point so nested structure
  * (e.g. `parentLevel.label`) is preserved rather than replaced with the raw options object.
  */
+function applyNestedFieldOption(currentValue: any, value: unknown): boolean {
+    // Undefined on an existing class-instance sub-object: delegate to its reset entry point
+    // rather than replacing the instance reference. Mirrors the old jsonApply path which
+    // called `currentValue.clear()` when the diff produced `undefined` for a Properties field.
+    if (value === undefined) {
+        if (typeof currentValue.applyOptions === 'function') {
+            currentValue.applyOptions(undefined);
+            return true;
+        }
+        if (typeof currentValue.clear === 'function') {
+            currentValue.clear();
+            return true;
+        }
+        return false;
+    }
+    // Prefer dedicated option-application entry points so nested structure (class instances,
+    // PropertiesArray item reconciliation, etc.) is preserved rather than replaced.
+    if (typeof currentValue.applyOptions === 'function') {
+        currentValue.applyOptions(value);
+        return true;
+    }
+    if (typeof currentValue.set === 'function') {
+        currentValue.set(value);
+        return true;
+    }
+    if (!Array.isArray(value) && !Array.isArray(currentValue)) {
+        Object.assign(currentValue, value);
+        return true;
+    }
+    return false;
+}
+
 function applyFieldOption(target: any, key: string, value: unknown): void {
     // `context` is a user pass-through reference; assign as-is without recursion.
     if (key === 'context') {
@@ -160,24 +192,11 @@ function applyFieldOption(target: any, key: string, value: unknown): void {
         return;
     }
     const currentValue = target[key];
-    const valueIsObject = value != null && typeof value === 'object';
     const currentIsObject = currentValue != null && typeof currentValue === 'object';
+    const valueIsObject = value != null && typeof value === 'object';
 
-    if (valueIsObject && currentIsObject) {
-        // Prefer dedicated option-application entry points so nested structure (class instances,
-        // PropertiesArray item reconciliation, etc.) is preserved rather than replaced.
-        if (typeof currentValue.applyOptions === 'function') {
-            currentValue.applyOptions(value);
-            return;
-        }
-        if (typeof currentValue.set === 'function') {
-            currentValue.set(value);
-            return;
-        }
-        if (!Array.isArray(value) && !Array.isArray(currentValue)) {
-            Object.assign(currentValue, value);
-            return;
-        }
+    if (currentIsObject && (valueIsObject || value === undefined) && applyNestedFieldOption(currentValue, value)) {
+        return;
     }
     target[key] = value;
 }
@@ -221,6 +240,7 @@ export abstract class Axis<
     id: AxisID = 'unknown' as AxisID;
 
     private _crossLines: CrossLine[] = [];
+    private _lastCrossLinesOptions: object[] | undefined;
     get crossLines() {
         return this._crossLines;
     }
@@ -229,8 +249,14 @@ export abstract class Axis<
      * Reconcile the cross-line set from raw options. Replaces the old `set crossLines` setter —
      * constructs fresh CrossLine instances for each options entry, detaches any previous set,
      * and re-attaches. Behaviour mirrors the pre-refactor setter exactly.
+     *
+     * Short-circuits on reference-equal repeat calls: theme-merged options are reference-stable
+     * when the underlying user config hasn't changed, so the full rebuild runs only when the
+     * options object actually differs.
      */
     protected applyCrossLines(options: object[] | undefined): void {
+        if (options === this._lastCrossLinesOptions) return;
+        this._lastCrossLinesOptions = options;
         const { CrossLineConstructor } = this.constructor as typeof Axis;
         for (const crossLine of this._crossLines) {
             this.detachCrossLine(crossLine);
@@ -448,16 +474,16 @@ export abstract class Axis<
         for (const crossLine of this.crossLines) {
             this.initCrossLine(crossLine);
         }
-        let prevGridLength = 0;
         this.cleanup.register(
             this.moduleCtx.widgets.containerWidget.addListener('mousemove', (e) => this.onMouseMove(e)),
             this.moduleCtx.widgets.containerWidget.addListener('mouseleave', () => this.endHovering()),
+            // The observer fires synchronously on registration with gridLength === 0 and no
+            // cross-lines present, so the first run is an intentional no-op. ReactiveState
+            // only notifies on actual value change (oldValue !== newValue), matching the old
+            // @ObserveChanges(gridLength) decorator.
             this.layoutState.observe((get) => {
-                const gridLength = get('gridLength') ?? 0;
-                if ((prevGridLength === 0) !== (gridLength === 0)) {
-                    this.onGridVisibilityChange();
-                }
-                prevGridLength = gridLength;
+                get('gridLength'); // track the dependency so the observer fires on gridLength changes.
+                this.onGridVisibilityChange();
                 for (const crossLine of this.crossLines) {
                     this.initCrossLine(crossLine);
                 }

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -14,7 +14,6 @@ import {
     ChartUpdateType,
     CleanupRegistry,
     ObserveChanges,
-    Property,
     WeakCache,
     ZIndexMap,
     callWithContext,
@@ -146,6 +145,44 @@ function tickLayoutCacheValid<D, TickLayoutMeta>(
     );
 }
 
+const EMPTY_SKIP: ReadonlySet<string> = new Set();
+
+/**
+ * Apply a single top-level options field onto the axis. Primitives and the `context` pass-through
+ * are assigned directly (so decorator-backed setters — `@ActionOnSet`, `@ProxyPropertyOnWrite` —
+ * still fire). Object-valued fields whose current value is an existing class instance recurse via
+ * the instance's own `applyOptions()` or `.set()` entry point so nested structure (e.g.
+ * `parentLevel.label`) is preserved rather than replaced with the raw options object.
+ */
+function applyFieldOption(target: any, key: string, value: unknown): void {
+    // `context` is a user pass-through reference; assign as-is without recursion.
+    if (key === 'context') {
+        target[key] = value;
+        return;
+    }
+    const currentValue = target[key];
+    const valueIsObject = value != null && typeof value === 'object';
+    const currentIsObject = currentValue != null && typeof currentValue === 'object';
+
+    if (valueIsObject && currentIsObject) {
+        // Prefer dedicated option-application entry points so nested structure (class instances,
+        // PropertiesArray item reconciliation, etc.) is preserved rather than replaced.
+        if (typeof currentValue.applyOptions === 'function') {
+            currentValue.applyOptions(value);
+            return;
+        }
+        if (typeof currentValue.set === 'function') {
+            currentValue.set(value);
+            return;
+        }
+        if (!Array.isArray(value) && !Array.isArray(currentValue)) {
+            Object.assign(currentValue, value);
+            return;
+        }
+    }
+    target[key] = value;
+}
+
 function computeBand<D, I>(
     scale: BandScale<D, I>,
     range: readonly [number, number],
@@ -185,14 +222,23 @@ export abstract class Axis<
     id: AxisID = 'unknown' as AxisID;
 
     private _crossLines: CrossLine[] = [];
-    set crossLines(value: CrossLine[]) {
+    get crossLines() {
+        return this._crossLines;
+    }
+
+    /**
+     * Reconcile the cross-line set from raw options. Replaces the old `set crossLines` setter —
+     * constructs fresh CrossLine instances for each options entry, detaches any previous set,
+     * and re-attaches. Behaviour mirrors the pre-refactor setter exactly.
+     */
+    protected applyCrossLines(options: object[] | undefined): void {
         const { CrossLineConstructor } = this.constructor as typeof Axis;
         for (const crossLine of this._crossLines) {
             this.detachCrossLine(crossLine);
         }
-        this._crossLines = value.map((crossLine) => {
+        this._crossLines = (options ?? []).map((crossLine) => {
             const instance = new CrossLineConstructor();
-            instance.set(crossLine);
+            instance.set(crossLine as any);
             return instance;
         });
         for (const crossLine of this._crossLines) {
@@ -200,27 +246,62 @@ export abstract class Axis<
             this.initCrossLine(crossLine);
         }
     }
-    get crossLines() {
-        return this._crossLines;
+
+    /**
+     * Apply options from the user-provided axis options object. Called by Chart on axis creation
+     * and on option updates (replacing the old jsonApply path). Sub-objects receive their slice
+     * via their own `applyOptions`/`.set()` methods; cross-lines are reconciled via
+     * {@link applyCrossLines}; other keys are assigned directly so subclass field decorators
+     * (`@ActionOnSet`, `@ProxyPropertyOnWrite`) still fire.
+     */
+    applyOptions(options: object | undefined, skip: ReadonlySet<string> = EMPTY_SKIP): void {
+        if (options == null) return;
+        const opts = options as Record<string, any>;
+        for (const key of Object.keys(opts)) {
+            if (key === 'type' || skip.has(key)) continue;
+            const value = opts[key];
+            switch (key) {
+                case 'line':
+                    this.line.applyOptions(value);
+                    break;
+                case 'tick':
+                    this.tick.applyOptions(value);
+                    break;
+                case 'gridLine':
+                    this.gridLine.applyOptions(value);
+                    break;
+                case 'label':
+                    this.label.applyOptions(value);
+                    break;
+                case 'title':
+                    this.title.applyOptions(value);
+                    break;
+                case 'interval':
+                    this.interval.applyOptions(value);
+                    break;
+                case 'crossLines':
+                    this.applyCrossLines(value);
+                    break;
+                default:
+                    applyFieldOption(this, key, value);
+                    break;
+            }
+        }
     }
 
     // user pass-through option: no validation required.
     context?: unknown;
 
-    @Property
     nice: boolean = true;
 
     /** Reverse the axis scale domain. */
-    @Property
     reverse: boolean = false;
 
-    @Property
     readonly interval = new AxisInterval();
 
     dataDomain: { domain: D[]; clipped: boolean } = { domain: [], clipped: false };
     private allowNull = false;
 
-    @Property
     readonly title = new AxisTitle();
 
     /**

--- a/packages/ag-charts-community/src/chart/axis/axisGridLine.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisGridLine.ts
@@ -1,14 +1,8 @@
-import { Property } from 'ag-charts-core';
-import type { AgAxisGridStyle } from 'ag-charts-types';
+import type { AgAxisGridLineOptions, AgAxisGridStyle } from 'ag-charts-types';
 
 export class AxisGridLine {
-    @Property
     enabled = true;
-
-    @Property
     width: number = 1;
-
-    @Property
     style: AgAxisGridStyle[] = [
         {
             fill: undefined,
@@ -18,4 +12,8 @@ export class AxisGridLine {
             lineDash: [],
         },
     ];
+
+    applyOptions(options: AgAxisGridLineOptions | undefined): void {
+        if (options != null) Object.assign(this, options);
+    }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisGridLine.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisGridLine.ts
@@ -1,19 +1,30 @@
 import type { AgAxisGridLineOptions, AgAxisGridStyle } from 'ag-charts-types';
 
+const DEFAULT_STYLE: AgAxisGridStyle[] = [
+    {
+        fill: undefined,
+        fillOpacity: 1,
+        stroke: undefined,
+        strokeWidth: undefined,
+        lineDash: [],
+    },
+];
+
+const DEFAULTS = {
+    enabled: true,
+    width: 1,
+    style: DEFAULT_STYLE,
+};
+
 export class AxisGridLine {
-    enabled = true;
-    width: number = 1;
-    style: AgAxisGridStyle[] = [
-        {
-            fill: undefined,
-            fillOpacity: 1,
-            stroke: undefined,
-            strokeWidth: undefined,
-            lineDash: [],
-        },
-    ];
+    enabled = DEFAULTS.enabled;
+    width: number = DEFAULTS.width;
+    style: AgAxisGridStyle[] = DEFAULTS.style;
 
     applyOptions(options: AgAxisGridLineOptions | undefined): void {
-        if (options != null) Object.assign(this, options);
+        for (const key of Object.keys(DEFAULTS) as (keyof typeof DEFAULTS)[]) {
+            const override = options != null && key in options ? (options as any)[key] : DEFAULTS[key];
+            (this as any)[key] = override;
+        }
     }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisInterval.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisInterval.ts
@@ -1,7 +1,10 @@
 import { BaseProperties, Property } from 'ag-charts-core';
+import type { AgAxisBaseIntervalOptions } from 'ag-charts-types';
 
 import type { TickInterval } from './axisTick';
 
+// NOTE: This class remains on BaseProperties/@Property because enterprise axis code
+// (AngleAxisInterval) extends it. Full migration waits for those subclasses.
 export class AxisInterval<S> extends BaseProperties {
     @Property
     placement?: 'on' | 'between';
@@ -17,4 +20,8 @@ export class AxisInterval<S> extends BaseProperties {
 
     @Property
     maxSpacing?: number;
+
+    applyOptions(options: AgAxisBaseIntervalOptions | undefined): void {
+        this.set(options as Parameters<this['set']>[0]);
+    }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisLabel.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisLabel.ts
@@ -2,6 +2,7 @@ import { BaseProperties, Property, isArray, objectsEqual } from 'ag-charts-core'
 import type {
     AgAxisLabelFormatterParams,
     AgAxisLabelStylerParams,
+    AgBaseAxisLabelOptions,
     AgBaseAxisLabelStyleOptions,
     AgTimeIntervalUnit,
     DateFormatterStyle,
@@ -28,6 +29,10 @@ interface FormatterCache {
     formatter: ((value: any, fractionDigits?: number) => string) | undefined;
 }
 
+// NOTE: This class remains on BaseProperties/@Property because enterprise series (cone-funnel,
+// funnel, radial-gauge, linear-gauge) extend it and still rely on BaseProperties.set(). The axis
+// subtree itself no longer uses jsonApply; the bridge `applyOptions()` method delegates to the
+// legacy .set() so consumers calling applyOptions get identical behaviour to the old path.
 export class AxisLabel extends BaseProperties implements ChartAxisLabel {
     @Property
     enabled = true;
@@ -147,6 +152,15 @@ export class AxisLabel extends BaseProperties implements ChartAxisLabel {
 
     @Property
     format?: string | Record<string, string>;
+
+    /**
+     * Public option-application entry point. Axis consumers should call this rather than
+     * .set() / jsonApply. Internally delegates to BaseProperties.set() until enterprise series
+     * stop inheriting from this class.
+     */
+    applyOptions(options: AgBaseAxisLabelOptions | undefined): void {
+        this.set(options as Parameters<this['set']>[0]);
+    }
 
     private _formatters: Record<FormatterCacheKey, FormatterCache | undefined> = {
         'component:year': undefined,

--- a/packages/ag-charts-community/src/chart/axis/axisLine.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisLine.ts
@@ -1,11 +1,22 @@
 import type { AgAxisLineOptions } from 'ag-charts-types';
 
+const DEFAULTS = {
+    enabled: true,
+    width: 1,
+    stroke: undefined as string | undefined,
+};
+
 export class AxisLine {
-    enabled = true;
-    width: number = 1;
-    stroke?: string = undefined;
+    enabled = DEFAULTS.enabled;
+    width: number = DEFAULTS.width;
+    stroke?: string = DEFAULTS.stroke;
 
     applyOptions(options: AgAxisLineOptions | undefined): void {
-        if (options != null) Object.assign(this, options);
+        // "options replace state": reset to class defaults first, then overlay user values.
+        // Keys are restricted to the DEFAULTS shape so unknown options don't pollute the instance.
+        for (const key of Object.keys(DEFAULTS) as (keyof typeof DEFAULTS)[]) {
+            const override = options != null && key in options ? (options as any)[key] : DEFAULTS[key];
+            (this as any)[key] = override;
+        }
     }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisLine.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisLine.ts
@@ -1,12 +1,11 @@
-import { Property } from 'ag-charts-core';
+import type { AgAxisLineOptions } from 'ag-charts-types';
 
 export class AxisLine {
-    @Property
     enabled = true;
-
-    @Property
     width: number = 1;
-
-    @Property
     stroke?: string = undefined;
+
+    applyOptions(options: AgAxisLineOptions | undefined): void {
+        if (options != null) Object.assign(this, options);
+    }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisTick.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisTick.ts
@@ -1,5 +1,4 @@
-import { BaseProperties, Property } from 'ag-charts-core';
-import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
+import type { AgAxisBaseTickOptions, AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
 
 import type { OrdinalTimeScale } from '../../scale/ordinalTimeScale';
 import type { TimeScale } from '../../scale/timeScale';
@@ -9,19 +8,19 @@ export type TickInterval<S> = S extends TimeScale | OrdinalTimeScale | UnitTimeS
     ? number | AgTimeInterval | AgTimeIntervalUnit
     : number;
 
-export class AxisTick extends BaseProperties {
-    @Property
+export class AxisTick {
     enabled = true;
 
     /** The line width to be used by axis ticks. */
-    @Property
     width: number = 1;
 
     /** The line length to be used by axis ticks. */
-    @Property
     size: number = 6;
 
     /** The colour of the axis ticks. */
-    @Property
     stroke?: string;
+
+    applyOptions(options: AgAxisBaseTickOptions | undefined): void {
+        if (options != null) Object.assign(this, options);
+    }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisTick.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisTick.ts
@@ -8,19 +8,29 @@ export type TickInterval<S> = S extends TimeScale | OrdinalTimeScale | UnitTimeS
     ? number | AgTimeInterval | AgTimeIntervalUnit
     : number;
 
+const DEFAULTS = {
+    enabled: true,
+    width: 1,
+    size: 6,
+    stroke: undefined as string | undefined,
+};
+
 export class AxisTick {
-    enabled = true;
+    enabled = DEFAULTS.enabled;
 
     /** The line width to be used by axis ticks. */
-    width: number = 1;
+    width: number = DEFAULTS.width;
 
     /** The line length to be used by axis ticks. */
-    size: number = 6;
+    size: number = DEFAULTS.size;
 
     /** The colour of the axis ticks. */
-    stroke?: string;
+    stroke?: string = DEFAULTS.stroke;
 
     applyOptions(options: AgAxisBaseTickOptions | undefined): void {
-        if (options != null) Object.assign(this, options);
+        for (const key of Object.keys(DEFAULTS) as (keyof typeof DEFAULTS)[]) {
+            const override = options != null && key in options ? (options as any)[key] : DEFAULTS[key];
+            (this as any)[key] = override;
+        }
     }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisTitle.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisTitle.ts
@@ -1,4 +1,4 @@
-import { BaseProperties, FONT_SIZE, Property } from 'ag-charts-core';
+import { FONT_SIZE } from 'ag-charts-core';
 import type {
     AgAxisCaptionFormatterParams,
     AgAxisCaptionOptions,
@@ -10,45 +10,36 @@ import type {
 
 import { Caption } from '../caption';
 
-export class AxisTitle extends BaseProperties implements AgAxisCaptionOptions {
+export class AxisTitle implements AgAxisCaptionOptions {
     readonly caption = new Caption();
 
-    @Property
     enabled: boolean = false;
 
-    @Property
     text?: string;
 
-    @Property
     spacing!: number;
 
-    @Property
     fontStyle?: FontStyle;
 
-    @Property
     fontWeight?: FontWeight;
 
-    @Property
     fontSize: number = FONT_SIZE.SMALLER;
 
-    @Property
     fontFamily: string = 'sans-serif';
 
-    @Property
     color?: string;
 
-    @Property
     maxWidth?: number;
 
-    @Property
     maxHeight?: number;
 
-    @Property
     wrapping: TextWrap = 'always';
 
-    @Property
     truncate: boolean = true;
 
-    @Property
     formatter?: RichFormatter<AgAxisCaptionFormatterParams>;
+
+    applyOptions(options: AgAxisCaptionOptions | undefined): void {
+        if (options != null) Object.assign(this, options);
+    }
 }

--- a/packages/ag-charts-community/src/chart/axis/axisTitle.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisTitle.ts
@@ -10,36 +10,55 @@ import type {
 
 import { Caption } from '../caption';
 
+const DEFAULTS = {
+    enabled: false,
+    text: undefined as string | undefined,
+    spacing: undefined as number | undefined,
+    fontStyle: undefined as FontStyle | undefined,
+    fontWeight: undefined as FontWeight | undefined,
+    fontSize: FONT_SIZE.SMALLER,
+    fontFamily: 'sans-serif',
+    color: undefined as string | undefined,
+    maxWidth: undefined as number | undefined,
+    maxHeight: undefined as number | undefined,
+    wrapping: 'always' as TextWrap,
+    truncate: true,
+    formatter: undefined as RichFormatter<AgAxisCaptionFormatterParams> | undefined,
+};
+
 export class AxisTitle implements AgAxisCaptionOptions {
     readonly caption = new Caption();
 
-    enabled: boolean = false;
+    enabled: boolean = DEFAULTS.enabled;
 
-    text?: string;
+    text?: string = DEFAULTS.text;
 
     spacing!: number;
 
-    fontStyle?: FontStyle;
+    fontStyle?: FontStyle = DEFAULTS.fontStyle;
 
-    fontWeight?: FontWeight;
+    fontWeight?: FontWeight = DEFAULTS.fontWeight;
 
-    fontSize: number = FONT_SIZE.SMALLER;
+    fontSize: number = DEFAULTS.fontSize;
 
-    fontFamily: string = 'sans-serif';
+    fontFamily: string = DEFAULTS.fontFamily;
 
-    color?: string;
+    color?: string = DEFAULTS.color;
 
-    maxWidth?: number;
+    maxWidth?: number = DEFAULTS.maxWidth;
 
-    maxHeight?: number;
+    maxHeight?: number = DEFAULTS.maxHeight;
 
-    wrapping: TextWrap = 'always';
+    wrapping: TextWrap = DEFAULTS.wrapping;
 
-    truncate: boolean = true;
+    truncate: boolean = DEFAULTS.truncate;
 
-    formatter?: RichFormatter<AgAxisCaptionFormatterParams>;
+    formatter?: RichFormatter<AgAxisCaptionFormatterParams> = DEFAULTS.formatter;
 
     applyOptions(options: AgAxisCaptionOptions | undefined): void {
-        if (options != null) Object.assign(this, options);
+        for (const key of Object.keys(DEFAULTS) as (keyof typeof DEFAULTS)[]) {
+            const override = options != null && key in options ? (options as any)[key] : DEFAULTS[key];
+            (this as any)[key] = override;
+        }
     }
 }

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -1,7 +1,6 @@
 import type { ChartAnimationPhase, DynamicContext, Scale, ZoomMinMax } from 'ag-charts-core';
 import {
     ChartAxisDirection,
-    Property,
     StateMachine,
     arraysEqual,
     calcLineHeight,
@@ -75,16 +74,12 @@ export abstract class CartesianAxis<S extends Scale<D, number, any> = Scale<any,
         return value instanceof CartesianAxis;
     }
 
-    @Property
     thickness?: number;
 
-    @Property
     maxThicknessRatio: number = 0.3;
 
-    @Property
     position!: AgCartesianAxisPosition;
 
-    @Property
     crossAt?: { value: D; sticky?: boolean };
 
     readonly crossAxisTranslation: { x: number; y: number } = { x: 0, y: 0 };

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxisLabel.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxisLabel.ts
@@ -2,6 +2,8 @@ import { Property } from 'ag-charts-core';
 
 import { AxisLabel } from './axisLabel';
 
+// NOTE: AxisLabel still extends BaseProperties (shared with enterprise series labels). Subclass
+// fields therefore require @Property so BaseProperties.set() iterates them during applyOptions.
 export class CartesianAxisLabel extends AxisLabel {
     /**
      * If specified and axis labels may collide, they are rotated to reduce collisions. If the

--- a/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
@@ -1,5 +1,5 @@
 import type { DomainWithMetadata, DynamicContext } from 'ag-charts-core';
-import { ActionOnSet, ChartUpdateType, ProxyPropertyOnWrite, isFiniteNumber } from 'ag-charts-core';
+import { ChartUpdateType, isFiniteNumber } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit, DateFormatterStyle, FormatterParams } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../module/moduleContext';
@@ -27,24 +27,7 @@ export class CategoryAxis<
 
     paddingOuter?: number;
 
-    @ProxyPropertyOnWrite('layoutConstraints', 'align')
-    bandAlignment?: 'justify' | 'start' | 'center' | 'end';
-
     skipNullBars?: boolean;
-
-    @ActionOnSet<CategoryAxis>({
-        newValue(value?: number) {
-            if (value == null || value <= 0) {
-                this.layoutConstraints.width = 100;
-                this.layoutConstraints.unit = 'percent';
-            } else {
-                this.layoutConstraints.width = value;
-                this.layoutConstraints.unit = 'px';
-                this.animationManager.skipCurrentBatch();
-            }
-        },
-    })
-    override requiredRange?: number;
 
     constructor(
         moduleCtx: DynamicContext<ChartRegistry>,
@@ -56,6 +39,31 @@ export class CategoryAxis<
         this.includeInvisibleDomains = includeInvisibleDomains;
         // Has no effect and can speed up tick generation
         this.nice = false;
+    }
+
+    override applyOptions(options: object | undefined, skip?: ReadonlySet<string>): void {
+        if (options != null && 'bandAlignment' in options) {
+            this.layoutConstraints.align =
+                (options as { bandAlignment?: 'justify' | 'start' | 'center' | 'end' }).bandAlignment ?? 'justify';
+        }
+        // `bandAlignment` lives on `layoutConstraints.align`; skip it in the generic apply path so
+        // the default branch doesn't shadow that with a separate field on the axis instance.
+        const combined = skip?.has('bandAlignment') ? skip : new Set([...(skip ?? []), 'bandAlignment']);
+        super.applyOptions(options, combined);
+    }
+
+    override applyRequiredRange(value: number | undefined): void {
+        const oldValue = this.requiredRange;
+        this.requiredRange = value;
+        if (value === oldValue || value === undefined) return;
+        if (value <= 0) {
+            this.layoutConstraints.width = 100;
+            this.layoutConstraints.unit = 'percent';
+        } else {
+            this.layoutConstraints.width = value;
+            this.layoutConstraints.unit = 'px';
+            this.animationManager.skipCurrentBatch();
+        }
     }
 
     override isCategoryLike(): boolean {
@@ -71,7 +79,7 @@ export class CategoryAxis<
     }
 
     override getUpdateTypeOnResize(): ChartUpdateType {
-        if (this.bandAlignment == null || this.bandAlignment === 'justify') {
+        if (this.layoutConstraints.align === 'justify') {
             return super.getUpdateTypeOnResize();
         }
         return ChartUpdateType.PROCESS_DOMAIN;

--- a/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
@@ -1,5 +1,5 @@
 import type { DomainWithMetadata, DynamicContext } from 'ag-charts-core';
-import { ActionOnSet, ChartUpdateType, Property, ProxyPropertyOnWrite, isFiniteNumber } from 'ag-charts-core';
+import { ActionOnSet, ChartUpdateType, ProxyPropertyOnWrite, isFiniteNumber } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit, DateFormatterStyle, FormatterParams } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../module/moduleContext';
@@ -21,19 +21,15 @@ export class CategoryAxis<
     static readonly className: string = 'CategoryAxis';
     static readonly type: 'category' | 'grouped-category' | 'unit-time' | 'ordinal-time' = 'category';
 
-    @Property
     groupPaddingInner: number = 0.1;
 
-    @Property
     paddingInner?: number;
 
-    @Property
     paddingOuter?: number;
 
     @ProxyPropertyOnWrite('layoutConstraints', 'align')
     bandAlignment?: 'justify' | 'start' | 'center' | 'end';
 
-    @Property
     skipNullBars?: boolean;
 
     @ActionOnSet<CategoryAxis>({

--- a/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/categoryAxis.ts
@@ -42,10 +42,12 @@ export class CategoryAxis<
     }
 
     override applyOptions(options: object | undefined, skip?: ReadonlySet<string>): void {
-        if (options != null && 'bandAlignment' in options) {
-            this.layoutConstraints.align =
-                (options as { bandAlignment?: 'justify' | 'start' | 'center' | 'end' }).bandAlignment ?? 'justify';
-        }
+        // Always sync `layoutConstraints.align` from `bandAlignment`: a missing or undefined
+        // value must revert to the documented 'justify' default, otherwise removing the option
+        // from the caller's config leaves the previous alignment sticky.
+        this.layoutConstraints.align =
+            (options as { bandAlignment?: 'justify' | 'start' | 'center' | 'end' } | undefined)?.bandAlignment ??
+            'justify';
         // `bandAlignment` lives on `layoutConstraints.align`; skip it in the generic apply path so
         // the default branch doesn't shadow that with a separate field on the axis instance.
         const combined = skip?.has('bandAlignment') ? skip : new Set([...(skip ?? []), 'bandAlignment']);
@@ -54,9 +56,9 @@ export class CategoryAxis<
 
     override applyRequiredRange(value: number | undefined): void {
         const oldValue = this.requiredRange;
+        if (value === oldValue) return;
         this.requiredRange = value;
-        if (value === oldValue || value === undefined) return;
-        if (value <= 0) {
+        if (value == null || value <= 0) {
             this.layoutConstraints.width = 100;
             this.layoutConstraints.unit = 'percent';
         } else {

--- a/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
@@ -44,7 +44,6 @@ import { UnitTimeScale } from '../../scale/unitTimeScale';
 import type { AxisPrimaryTickCount } from '../../util/secondaryAxisTicks';
 import type { ChartAxisLabel, ChartAxisLabelFlipFlag } from '../chartAxis';
 import { expandLabelPadding } from '../label';
-import type { AxisInterval } from './axisInterval';
 import type { TickInterval } from './axisTick';
 import { NiceMode, type TickDatum } from './axisUtil';
 
@@ -64,7 +63,13 @@ export interface GenerateTicksOptions<TScale extends Scale<TDatum, number, TickI
     labelOffset: number;
     sideFlag: ChartAxisLabelFlipFlag;
     primaryLabel?: ChartAxisLabel;
-    interval: AxisInterval<TScale>;
+    interval: {
+        placement?: 'on' | 'between';
+        step?: TickInterval<TScale>;
+        values?: any[];
+        minSpacing?: number;
+        maxSpacing?: number;
+    };
     minimumTimeGranularity?: AgTimeIntervalUnit;
     sizeLimit?: number;
     isVertical?: boolean;

--- a/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -150,7 +150,6 @@ export class GroupedCategoryAxis extends CategoryAxis<GroupedCategoryScale<Group
     private ftdByDepth: { positions: number[]; ticks: GroupedCategoryKey[] }[] = [];
     private readonly ftdStack: TreeNode[] = [];
 
-    @Property
     depthOptions = new PropertiesArray(DepthProperties);
 
     constructor(moduleCtx: DynamicContext<ChartRegistry>) {

--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -1,5 +1,5 @@
 import type { DomainWithMetadata, DynamicContext } from 'ag-charts-core';
-import { Property, normalisedExtentWithMetadata } from 'ag-charts-core';
+import { normalisedExtentWithMetadata } from 'ag-charts-core';
 import type { FormatterParams } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../module/moduleContext';
@@ -13,16 +13,12 @@ export class NumberAxis extends CartesianAxis<LinearScale | LogScale, number> {
     static readonly className: string = 'NumberAxis';
     static readonly type: string = 'number';
 
-    @Property
     min?: number;
 
-    @Property
     max?: number;
 
-    @Property
     preferredMin?: number;
 
-    @Property
     preferredMax?: number;
 
     constructor(moduleCtx: DynamicContext<ChartRegistry>, scale = new LinearScale() as LinearScale | LogScale) {

--- a/packages/ag-charts-community/src/chart/axis/polarAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/polarAxis.ts
@@ -1,5 +1,5 @@
 import type { Scale } from 'ag-charts-core';
-import { ChartAxisDirection, Property } from 'ag-charts-core';
+import { ChartAxisDirection } from 'ag-charts-core';
 
 import type { BBox } from '../../scene/bbox';
 import type { ChartAxisLabelFlipFlag } from '../chartAxis';
@@ -25,10 +25,8 @@ export abstract class PolarAxis<
     gridAngles: number[] | undefined;
     gridRange: number[] | undefined;
 
-    @Property
     shape: 'polygon' | 'circle' = 'polygon';
 
-    @Property
     innerRadiusRatio: number = 0;
 
     override defaultTickMinSpacing = 20;

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -1,8 +1,6 @@
 import type { ChartAxisDirection, DomainWithMetadata, DynamicContext } from 'ag-charts-core';
 import {
-    BaseProperties,
     Logger,
-    Property,
     ProxyPropertyOnWrite,
     dateTruncationForDomain,
     intervalEpoch,
@@ -26,34 +24,33 @@ import { AxisLabel } from './axisLabel';
 import { AxisTick } from './axisTick';
 import { CartesianAxis } from './cartesianAxis';
 
-export class TimeAxisParentLevel extends BaseProperties {
-    @Property
+export class TimeAxisParentLevel {
     enabled = false;
 
-    @Property
     readonly label = new AxisLabel();
 
-    @Property
     readonly tick = new AxisTick();
+
+    applyOptions(options: { enabled?: boolean; label?: object; tick?: object } | undefined): void {
+        if (options == null) return;
+        if ('enabled' in options) this.enabled = options.enabled!;
+        if (options.label !== undefined) this.label.applyOptions(options.label as any);
+        if (options.tick !== undefined) this.tick.applyOptions(options.tick as any);
+    }
 }
 
 export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
     static readonly className = 'TimeAxis';
     static readonly type = 'time' as const;
 
-    @Property
     readonly parentLevel = new TimeAxisParentLevel();
 
-    @Property
     min?: Date | number = undefined;
 
-    @Property
     max?: Date | number = undefined;
 
-    @Property
     preferredMin?: Date | number = undefined;
 
-    @Property
     preferredMax?: Date | number = undefined;
 
     // eslint-disable-next-line sonarjs/use-type-alias
@@ -64,7 +61,6 @@ export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
         Logger.warnOnce(`To use 'unit', use an axis with type 'unit-time' instead of 'time'.`);
     }
 
-    @Property
     @ProxyPropertyOnWrite('_unit')
     unit: AgTimeInterval | AgTimeIntervalUnit | undefined;
 

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -31,10 +31,10 @@ export class TimeAxisParentLevel {
     readonly tick = new AxisTick();
 
     applyOptions(options: { enabled?: boolean; label?: object; tick?: object } | undefined): void {
-        if (options == null) return;
-        if ('enabled' in options) this.enabled = options.enabled!;
-        if (options.label !== undefined) this.label.applyOptions(options.label as any);
-        if (options.tick !== undefined) this.tick.applyOptions(options.tick as any);
+        // Reset-then-apply: options replace state, so removed keys revert to class defaults.
+        this.enabled = options?.enabled ?? false;
+        this.label.applyOptions(options?.label as any);
+        this.tick.applyOptions(options?.tick as any);
     }
 }
 

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -1,7 +1,6 @@
 import type { ChartAxisDirection, DomainWithMetadata, DynamicContext } from 'ag-charts-core';
 import {
     Logger,
-    ProxyPropertyOnWrite,
     dateTruncationForDomain,
     intervalEpoch,
     intervalFloor,
@@ -53,19 +52,18 @@ export class TimeAxis extends CartesianAxis<TimeScale, number | Date> {
 
     preferredMax?: Date | number = undefined;
 
-    // eslint-disable-next-line sonarjs/use-type-alias
-    get _unit(): AgTimeInterval | AgTimeIntervalUnit | undefined {
-        return undefined;
-    }
-    set _unit(_unit: AgTimeInterval | AgTimeIntervalUnit | undefined) {
-        Logger.warnOnce(`To use 'unit', use an axis with type 'unit-time' instead of 'time'.`);
-    }
-
-    @ProxyPropertyOnWrite('_unit')
-    unit: AgTimeInterval | AgTimeIntervalUnit | undefined;
-
     constructor(moduleCtx: DynamicContext<ChartRegistry>) {
         super(moduleCtx, new TimeScale());
+    }
+
+    override applyOptions(options: object | undefined, skip?: ReadonlySet<string>): void {
+        if (options != null && 'unit' in options) {
+            Logger.warnOnce(`To use 'unit', use an axis with type 'unit-time' instead of 'time'.`);
+        }
+        // `unit` is not a valid option on TimeAxis — dropping it prevents the base-class default
+        // branch from storing a meaningless value on the instance.
+        const combined = skip?.has('unit') ? skip : new Set([...(skip ?? []), 'unit']);
+        super.applyOptions(options, combined);
     }
 
     override hasDefinedDomain(): boolean {

--- a/packages/ag-charts-community/src/chart/axis/unitTimeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/unitTimeAxis.ts
@@ -1,6 +1,5 @@
 import type { DomainWithMetadata, DynamicContext } from 'ag-charts-core';
 import {
-    Property,
     dateTruncationForDomain,
     intervalEpoch,
     intervalFloor,
@@ -28,22 +27,16 @@ export class UnitTimeAxis extends DiscreteTimeAxis<UnitTimeScale> {
 
     override defaultTickMinSpacing = 20;
 
-    @Property
     readonly parentLevel = new TimeAxisParentLevel();
 
-    @Property
     min?: Date | number = undefined;
 
-    @Property
     max?: Date | number = undefined;
 
-    @Property
     preferredMin?: Date | number = undefined;
 
-    @Property
     preferredMax?: Date | number = undefined;
 
-    @Property
     // eslint-disable-next-line sonarjs/use-type-alias
     unit: AgTimeInterval | AgTimeIntervalUnit | undefined = undefined;
 

--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -573,7 +573,7 @@ export class CartesianChart extends Chart {
 
         axis.range = [start, end];
         axis.visibleRange = [min, max];
-        axis.gridLength = isLeftRight ? width : height;
+        axis.setGridLength(isLeftRight ? width : height);
         axis.lineRange = isLeftRight ? [height, 0] : [0, width];
     }
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -1322,7 +1322,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         }
 
         for (const axis of this.axes) {
-            axis.requiredRange = this._requiredRange;
+            axis.applyRequiredRange(this._requiredRange);
         }
     }
 

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -2015,11 +2015,21 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         // Try to optimise updates if axis count and types didn't change.
         if (matchingTypes && isAgCartesianChartOptions(oldOpts)) {
             const pluginSkip = this.combineAxisPluginSkip(skipSet);
+            const prevAxes = oldOpts.axes ?? {};
             for (const axis of chart.axes) {
+                const prevOpts = (prevAxes as any)[axis.id] ?? {};
                 const newOpts = (axes as any)[axis.id] ?? {};
-                debug(`Chart.applyAxes() - applying axis options for ${axis.id}`, newOpts);
-                this.applyAxisModules(axis, newOpts);
-                axis.applyOptions(newOpts, pluginSkip);
+                // Synthesise undefined entries for keys present in the previous options but
+                // absent from the new ones so `applyOptions` resets them back to defaults —
+                // preserves the "removed key clears the field" semantics the old jsonDiff
+                // path provided.
+                const merged: Record<string, any> = { ...newOpts };
+                for (const key of Object.keys(prevOpts)) {
+                    if (!(key in merged)) merged[key] = undefined;
+                }
+                debug(`Chart.applyAxes() - applying axis options for ${axis.id}`, merged);
+                this.applyAxisModules(axis, merged);
+                axis.applyOptions(merged, pluginSkip);
             }
             return true;
         }

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -26,7 +26,6 @@ import {
     isFiniteNumber,
     isInputPending,
     jsonApply,
-    jsonDiff,
     mergeDefaults,
     pause,
     roundTo,
@@ -98,6 +97,8 @@ import { OverlaysProcessor } from './update/overlaysProcessor';
 import type { UpdateProcessor } from './update/processor';
 
 const debug = Debug.create(true, 'opts');
+
+const EMPTY_AXIS_SKIP: ReadonlySet<string> = new Set();
 
 export type TransferableResources = {
     container?: HTMLElement;
@@ -1843,7 +1844,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
 
             horizontalAxis.line.enabled = false;
 
-            horizontalAxis.label.set(
+            horizontalAxis.label.applyOptions(
                 without(labelOptions, [
                     'interval',
                     'autoRotate',
@@ -2005,27 +2006,26 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
             return false;
         }
 
-        skip = ['type', ...skip];
+        const skipSet: ReadonlySet<string> = skip.length > 0 ? new Set(skip) : EMPTY_AXIS_SKIP;
 
         const axes = options.axes;
         const forceRecreate = seriesStatus === 'replaced';
         const matchingTypes = !forceRecreate && chart.axes.matches(axes);
 
-        // Try to optimise series updates if series count and types didn't change.
+        // Try to optimise updates if axis count and types didn't change.
         if (matchingTypes && isAgCartesianChartOptions(oldOpts)) {
+            const pluginSkip = this.combineAxisPluginSkip(skipSet);
             for (const axis of chart.axes) {
-                const previousOpts = oldOpts.axes?.[axis.id] ?? {};
-                const axisDiff = jsonDiff(previousOpts, axes[axis.id]) as any;
-
-                debug(`Chart.applyAxes() - applying axis diff idx ${axis.id}`, axisDiff);
-
-                jsonApply(axis, axisDiff, { skip });
+                const newOpts = (axes as any)[axis.id] ?? {};
+                debug(`Chart.applyAxes() - applying axis options for ${axis.id}`, newOpts);
+                this.applyAxisModules(axis, newOpts);
+                axis.applyOptions(newOpts, pluginSkip);
             }
             return true;
         }
 
         debug(`Chart.applyAxes() - creating new axes instances; seriesStatus: ${seriesStatus}`);
-        chart.axes = this.createAxes(axes, skip);
+        chart.axes = this.createAxes(axes, skipSet);
         return true;
     }
 
@@ -2090,15 +2090,16 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         }
     }
 
-    private createAxes(options: Record<string, AgBaseAxisOptions>, skip: string[]): ChartAxes {
+    private createAxes(options: Record<string, AgBaseAxisOptions>, skip: ReadonlySet<string>): ChartAxes {
         const newAxes = this.createChartAxes();
         const moduleContext = this.getModuleContext();
+        const pluginSkip = this.combineAxisPluginSkip(skip);
 
         for (const [id, axisOptions] of entries(options)) {
             const axis = ModuleRegistry.getAxisModule(axisOptions.type!)!.create(moduleContext) as any;
             axis.id = id as AxisID;
             this.applyAxisModules(axis, axisOptions);
-            jsonApply(axis, axisOptions, { skip });
+            axis.applyOptions(axisOptions, pluginSkip);
 
             newAxes.push(axis);
         }
@@ -2108,6 +2109,16 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         return newAxes;
     }
 
+    // Plugin options are applied by applyAxisModules; Axis.applyOptions must skip those keys so
+    // it doesn't clobber the plugin instance reference with the raw options object.
+    private combineAxisPluginSkip(skip: ReadonlySet<string>): ReadonlySet<string> {
+        const combined = new Set(skip);
+        for (const module of ModuleRegistry.listModulesByType(ModuleType.AxisPlugin)) {
+            combined.add(module.name);
+        }
+        return combined;
+    }
+
     private applyAxisModules(axis: ChartAxis, options: AgBaseAxisOptions) {
         const moduleContext = axis.createModuleContext();
         const moduleMap = axis.getModuleMap();
@@ -2115,14 +2126,28 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         for (const module of ModuleRegistry.listModulesByType(ModuleType.AxisPlugin)) {
             const shouldBeEnabled = (options as any)[module.name] != null;
 
-            if (shouldBeEnabled === moduleMap.isEnabled(module.name)) continue;
+            if (shouldBeEnabled !== moduleMap.isEnabled(module.name)) {
+                if (shouldBeEnabled) {
+                    moduleMap.addModule(module.name, module.create(moduleContext));
+                    (axis as any)[module.name] = moduleMap.getModule(module.name); // TODO remove
+                } else {
+                    moduleMap.removeModule(module.name);
+                    delete (axis as any)[module.name]; // TODO remove
+                }
+            }
 
-            if (shouldBeEnabled) {
-                moduleMap.addModule(module.name, module.create(moduleContext));
-                (axis as any)[module.name] = moduleMap.getModule(module.name); // TODO remove
-            } else {
-                moduleMap.removeModule(module.name);
-                delete (axis as any)[module.name]; // TODO remove
+            // Apply options to the plugin instance if present. Previously handled by jsonApply
+            // recursing into axis[module.name] via the side-channel field.
+            if (moduleMap.isEnabled(module.name)) {
+                const instance: any = moduleMap.getModule(module.name);
+                const pluginOpts = (options as any)[module.name];
+                if (instance != null && pluginOpts != null) {
+                    if (typeof instance.applyOptions === 'function') {
+                        instance.applyOptions(pluginOpts);
+                    } else {
+                        Object.assign(instance, pluginOpts);
+                    }
+                }
             }
         }
     }

--- a/packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/packages/ag-charts-community/src/chart/chartAxis.ts
@@ -131,6 +131,8 @@ export interface ChartAxis {
     processData(): void;
     update(animated?: boolean): void;
     applyOptions(options: object | undefined, skip?: ReadonlySet<string>): void;
+    applyRequiredRange(value: number | undefined): void;
+    setGridLength(value: number): void;
     setDomains(...domains: DomainWithMetadata<unknown>[]): void;
     isCategoryLike(): boolean;
     boundSeries: ISeries<DatumIndexType, unknown, ISeriesProperties>[];

--- a/packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/packages/ag-charts-community/src/chart/chartAxis.ts
@@ -130,6 +130,7 @@ export interface ChartAxis {
     setCrossLinesVisible(visible: boolean): void;
     processData(): void;
     update(animated?: boolean): void;
+    applyOptions(options: object | undefined, skip?: ReadonlySet<string>): void;
     setDomains(...domains: DomainWithMetadata<unknown>[]): void;
     isCategoryLike(): boolean;
     boundSeries: ISeries<DatumIndexType, unknown, ISeriesProperties>[];
@@ -165,7 +166,7 @@ export interface ChartAxis {
 export interface ChartAxisLabel extends TextOptions {
     fontSize: number; // This is required
     getSideFlag(): ChartAxisLabelFlipFlag;
-    set(props: object): void;
+    applyOptions(options: object | undefined): void;
     autoRotate?: boolean;
     autoRotateAngle?: number;
     avoidCollisions: boolean;

--- a/packages/ag-charts-community/src/chart/polarChart.ts
+++ b/packages/ag-charts-community/src/chart/polarChart.ts
@@ -72,7 +72,7 @@ export class PolarChart extends Chart {
 
         angleAxis.innerRadiusRatio = innerRadiusRatio;
         angleAxis.computeRange();
-        angleAxis.gridLength = radius;
+        angleAxis.setGridLength(radius);
 
         radiusAxis.gridAngles = angleScale
             .ticks({

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -109,6 +109,31 @@ export class Crosshair extends AbstractModuleInstance {
         }
     }
 
+    /**
+     * Options-application entry point called by Axis.applyAxisModules. Iterates provided keys and
+     * delegates object-valued fields (`label`) to their existing instance's `.set()` so the
+     * CrosshairLabelProperties instance is mutated in place rather than replaced with the raw
+     * options object.
+     */
+    applyOptions(options: object | undefined): void {
+        if (options == null) return;
+        for (const key of Object.keys(options)) {
+            const value = (options as any)[key];
+            const current = (this as any)[key];
+            if (
+                value != null &&
+                typeof value === 'object' &&
+                !Array.isArray(value) &&
+                current != null &&
+                typeof current.set === 'function'
+            ) {
+                current.set(value);
+            } else {
+                (this as any)[key] = value;
+            }
+        }
+    }
+
     private checkInteractionState(): boolean {
         return this.ctx.interactionManager.isState(InteractionState.Frozen);
     }

--- a/packages/ag-charts-enterprise/src/features/navigator/miniChart.ts
+++ b/packages/ag-charts-enterprise/src/features/navigator/miniChart.ts
@@ -265,13 +265,13 @@ export class MiniChart extends AbstractModuleInstance {
                 case 'top':
                 case 'bottom':
                     axis.range = [0, seriesRect.width];
-                    axis.gridLength = seriesRect.height;
+                    axis.setGridLength(seriesRect.height);
                     break;
                 case 'right':
                 case 'left': {
                     const isCategoryAxis = axis instanceof CategoryAxis;
                     axis.range = isCategoryAxis ? [0, seriesRect.height] : [seriesRect.height, 0];
-                    axis.gridLength = seriesRect.width;
+                    axis.setGridLength(seriesRect.width);
                     break;
                 }
             }


### PR DESCRIPTION
- **Commit 1 (`7b53df1c07`)**: Replace `Chart.createAxes` / `Chart.applyAxes` `jsonApply`+`jsonDiff` calls with an explicit `axis.applyOptions(options, skip)` method. Sub-objects (`AxisLine`, `AxisGridLine`, `AxisTick`, `AxisTitle`, `TimeAxisParentLevel`) migrate to plain classes with their own `applyOptions`; `AxisLabel` / `AxisInterval` / `CartesianAxisLabel` keep `BaseProperties` due to enterprise-series inheritance and expose an `applyOptions` bridge. Axis-plugin modules (Crosshair) configure via `applyOptions` too, eliminating jsonApply's recursion through the side-channel field on the axis.
- **Commit 2 (`50f7fb98f6`)**: Remove `@ObserveChanges`, `@ProxyPropertyOnWrite`, and `@ActionOnSet` from the axis files. `gridLength` now lives in a per-axis `ReactiveState`; callers invoke `axis.setGridLength()` and the constructor-registered observer handles cross-line re-init + grid-visibility change. `TimeAxis` emits its "use unit-time" warning from `applyOptions` instead of a setter proxy. `CategoryAxis` deletes its `bandAlignment` backing field (`layoutConstraints.align` is the single source of truth) and replaces the `requiredRange` `@ActionOnSet` with an `applyRequiredRange` method called explicitly by the chart.

### Out of scope
- Chart-level `jsonApply` (chart.ts:1610) and series-level `properties.set(...)` paths.
- `LabelStyle` / `LabelBorder` / `Caption` remain on `BaseProperties` — they are shared with enterprise series and migrate alongside them in a follow-up.