### PR TITLE
AG-17059 Wire up waterfall item-level tooltip.renderer

### DIFF
--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -13,6 +13,7 @@ import {
     deproxy,
     expectWarningsCalls,
     extractImageData,
+    hoverAction,
     setupMockCanvas,
     setupMockConsole,
     spyOnAnimationManager,
@@ -874,6 +875,103 @@ describe('WaterfallSeries', () => {
                     expect(content.data?.[0].missing).not.toBe(true);
                 }
             }
+        });
+    });
+
+    describe('AG-17059: item-level tooltip.renderer', () => {
+        const TOTALS_OPTIONS: AgCartesianChartOptions = {
+            data: [
+                { year: '2020', spending: 10 },
+                { year: '2021', spending: -20 },
+                { year: '2022', spending: 30 },
+                { year: '2023', spending: 40 },
+            ],
+            series: [
+                {
+                    type: 'waterfall',
+                    xKey: 'year',
+                    yKey: 'spending',
+                    totals: [{ totalType: 'subtotal', index: 1, axisLabel: 'Subtotal' }],
+                },
+            ],
+        };
+
+        async function hoverDatum(datumIndex: number): Promise<string> {
+            const series = chart.series[0] as WaterfallSeries;
+            const nodeData = series['contextNodeData']?.nodeData;
+            const datum = nodeData?.[datumIndex];
+            expect(datum).toBeDefined();
+            const cx = datum!.x + datum!.width / 2;
+            const cy = datum!.y + datum!.height / 2;
+            await hoverAction(cx, cy)(chart);
+            await waitForChartStability(chart);
+            const el = chart.ctx.agDocument.body.getElementsByClassName('ag-charts-tooltip')[0] as
+                | HTMLElement
+                | undefined;
+            const html = el?.innerHTML ?? '';
+            expect(html).not.toBe('');
+            return html;
+        }
+
+        it('invokes item.positive.tooltip.renderer for positive datums', async () => {
+            const options: AgCartesianChartOptions = {
+                ...TOTALS_OPTIONS,
+                series: [
+                    {
+                        ...(TOTALS_OPTIONS.series![0] as AgWaterfallSeriesOptions),
+                        item: { positive: { tooltip: { renderer: () => 'POSITIVE-ITEM' } } },
+                    },
+                ],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(await hoverDatum(0)).toContain('POSITIVE-ITEM');
+            expect(await hoverDatum(1)).not.toContain('POSITIVE-ITEM');
+        });
+
+        it('item-level renderer overrides series-level renderer when both are set', async () => {
+            const options: AgCartesianChartOptions = {
+                ...TOTALS_OPTIONS,
+                series: [
+                    {
+                        ...(TOTALS_OPTIONS.series![0] as AgWaterfallSeriesOptions),
+                        tooltip: { renderer: () => 'SERIES-LEVEL' },
+                        item: { positive: { tooltip: { renderer: () => 'ITEM-LEVEL' } } },
+                    },
+                ],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const positiveHtml = await hoverDatum(0);
+            expect(positiveHtml).toContain('ITEM-LEVEL');
+            expect(positiveHtml).not.toContain('SERIES-LEVEL');
+
+            expect(await hoverDatum(1)).toContain('SERIES-LEVEL');
+        });
+
+        it('subtotal datums use item.total.tooltip.renderer', async () => {
+            const options: AgCartesianChartOptions = {
+                ...TOTALS_OPTIONS,
+                series: [
+                    {
+                        ...(TOTALS_OPTIONS.series![0] as AgWaterfallSeriesOptions),
+                        item: { total: { tooltip: { renderer: () => 'TOTAL-ITEM' } } },
+                    },
+                ],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(await hoverDatum(2)).toContain('TOTAL-ITEM');
+            expect(await hoverDatum(0)).not.toContain('TOTAL-ITEM');
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -967,6 +967,9 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         const nodeDatum = this.contextNodeData?.nodeData?.[datumIndex];
         const format = this.getItemStyle(nodeDatum, false, undefined, nodeDatum?.itemType);
 
+        // Override only the renderer; other tooltip fields (enabled, position, range, class,
+        // interaction) are read directly off `series.properties.tooltip` upstream of this method,
+        // so the wrapper's defaults for those fields are never consulted by the tooltip pipeline.
         let effectiveTooltip = tooltip;
         const itemTooltipRenderer = this.getItemConfig(seriesItemType).tooltip?.renderer;
         if (itemTooltipRenderer != null) {

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -4,6 +4,7 @@ import type {
     AgWaterfallSeriesLabelFormatterParams,
     AgWaterfallSeriesOptions,
     AgWaterfallSeriesStyle,
+    AgWaterfallSeriesTooltipRendererParams,
     TextOrSegments,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
@@ -966,8 +967,15 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         const nodeDatum = this.contextNodeData?.nodeData?.[datumIndex];
         const format = this.getItemStyle(nodeDatum, false, undefined, nodeDatum?.itemType);
 
+        let effectiveTooltip = tooltip;
+        const itemTooltipRenderer = this.getItemConfig(seriesItemType).tooltip?.renderer;
+        if (itemTooltipRenderer != null) {
+            effectiveTooltip = _ModuleSupport.makeSeriesTooltip<AgWaterfallSeriesTooltipRendererParams>();
+            effectiveTooltip.renderer = itemTooltipRenderer;
+        }
+
         return this.formatTooltipWithContext(
-            tooltip,
+            effectiveTooltip,
             {
                 heading: this.getAxisValueText(xAxis, 'tooltip', xValue, datum, xKey, legendItemName),
                 symbol: this.legendItemSymbol(seriesItemType),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17059

The waterfall series exposed `item.{positive,negative,total}.tooltip.renderer` on its public API surface but the runtime path only consulted the series-level renderer, so item-level renderers were silently ignored.

`getTooltipContent` now resolves the per-item config and overrides the series-level `SeriesTooltip` with the item-level renderer when set. Item-level wins over series-level; subtotal datums map to `item.total` (matching existing per-item style/label routing).

Tests added drive end-to-end through hover and assert on rendered tooltip HTML.

Fix #AG-17059