### PR TITLE
AG-16043 Fix discrete-bin legend cursor and apply chart formatter

### DIFF
--- a/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
@@ -166,7 +166,7 @@ export class LegendDOMProxy {
         this.itemList.setBounds(groupBBox);
 
         const maxHeight = Math.max(...itemSelection.nodes().map((l) => l.getTextMeasureBBox().height));
-        itemSelection.each((l, _datum) => {
+        itemSelection.each((l, datum) => {
             if (l.proxyButton) {
                 const visible = l.pageIndex === pagination.currentPage;
 
@@ -175,7 +175,9 @@ export class LegendDOMProxy {
                 const bbox: BoxBounds = { x: x - groupBBox.x, y: y - margin - groupBBox.y, height: maxHeight, width };
 
                 const enabled = interactive && visible;
-                l.proxyButton.setCursor('pointer');
+                // Discrete colour-scale bin items don't toggle and don't drive series highlight, so the
+                // pointer cursor is misleading — see `suppressHighlight` on CategoryLegendDatum.
+                l.proxyButton.setCursor(datum.suppressHighlight ? 'default' : 'pointer');
                 l.proxyButton.setEnabled(enabled);
                 l.proxyButton.setPointerEvents(enabled ? undefined : 'none');
                 l.proxyButton.setBounds(bbox);

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, test } from '@jest/globals';
 
 import { ColorScale } from '../../scale/colorScale';
-import { buildColorCategoryLegendData, buildGradientLegendDatum } from './legendDatum';
+import { FormatManager } from '../formatter/formatManager';
+import {
+    type ColorScaleLegendFormatterContext,
+    buildColorCategoryLegendData,
+    buildGradientLegendDatum,
+} from './legendDatum';
 
 describe('legendDatum', () => {
     describe('buildColorCategoryLegendData', () => {
-        const fmt = (v: number, digits?: number) => v.toFixed(digits ?? 2);
+        // Mirrors the legacy `(v, d) => v.toFixed(d ?? 2)` behaviour by routing through
+        // the chart-level formatter. Used by tests that assert on the literal label text.
+        function fixedDigitsFormatterContext(): ColorScaleLegendFormatterContext {
+            const formatManager = new FormatManager();
+            formatManager.setFormatter({
+                color: (p) => {
+                    const fractionDigits = p.type === 'number' ? p.fractionDigits : undefined;
+                    return (p.value as number).toFixed(fractionDigits ?? 2);
+                },
+            });
+            return {
+                formatManager,
+                formatInContext: (fn, params) => fn(params),
+                key: 'value',
+                legendItemName: undefined,
+                boundSeries: [{ seriesId: 'series-1', key: 'value', name: undefined }],
+            };
+        }
 
         test('creates one legend item per bin', () => {
             const scale = new ColorScale();
@@ -15,7 +37,7 @@ describe('legendDatum', () => {
             scale.update();
 
             const fills = [{ color: 'red' }, { color: 'green' }];
-            const result = buildColorCategoryLegendData(scale, fills, 'series-1', true, fmt);
+            const result = buildColorCategoryLegendData(scale, fills, 'series-1', true, fixedDigitsFormatterContext());
 
             expect(result).toHaveLength(2);
             expect(result[0].legendType).toBe('category');
@@ -38,7 +60,7 @@ describe('legendDatum', () => {
                 { color: 'red', name: 'Low' },
                 { color: 'green', name: 'High' },
             ];
-            const result = buildColorCategoryLegendData(scale, fills, 'series-1', true, fmt);
+            const result = buildColorCategoryLegendData(scale, fills, 'series-1', true, fixedDigitsFormatterContext());
 
             expect(result[0].label.text).toBe('Low');
             expect(result[1].label.text).toBe('High');
@@ -52,7 +74,7 @@ describe('legendDatum', () => {
             scale.update();
 
             const fills = [{ color: 'red' }, { color: 'green' }];
-            const result = buildColorCategoryLegendData(scale, fills, 'series-1', true, fmt);
+            const result = buildColorCategoryLegendData(scale, fills, 'series-1', true, fixedDigitsFormatterContext());
 
             expect(result[0].label.text).toBe('0\u201349');
             expect(result[1].label.text).toBe('50.00\u2013100.00');
@@ -62,7 +84,7 @@ describe('legendDatum', () => {
             const scale = new ColorScale();
             scale.mode = 'discrete';
             scale.range = [];
-            const result = buildColorCategoryLegendData(scale, [], 'series-1', true, fmt);
+            const result = buildColorCategoryLegendData(scale, [], 'series-1', true, fixedDigitsFormatterContext());
             expect(result).toEqual([]);
         });
 
@@ -74,13 +96,88 @@ describe('legendDatum', () => {
             scale.update();
 
             const fills = [{ color: 'red' }, { color: 'green' }];
-            const result = buildColorCategoryLegendData(scale, fills, 'my-series', false, fmt);
+            const result = buildColorCategoryLegendData(
+                scale,
+                fills,
+                'my-series',
+                false,
+                fixedDigitsFormatterContext()
+            );
 
             expect(result[0].seriesId).toBe('my-series');
             expect(result[0].enabled).toBe(false);
             expect(result[0].id).toBe('my-series');
             expect(result[0].itemId).toBe(0);
             expect(result[1].itemId).toBe(1);
+        });
+
+        test('routes bin labels through chart-level formatter.color callback', () => {
+            const scale = new ColorScale();
+            scale.mode = 'discrete';
+            scale.domain = [0, 50, 100];
+            scale.range = ['red', 'green'];
+            scale.update();
+
+            const formatManager = new FormatManager();
+            formatManager.setFormatter({ color: (p) => `[${p.value}]` });
+
+            const result = buildColorCategoryLegendData(scale, [{ color: 'red' }, { color: 'green' }], 's', true, {
+                formatManager,
+                formatInContext: (fn, params) => fn(params),
+                key: 'value',
+                legendItemName: undefined,
+                boundSeries: [{ seriesId: 's', key: 'value', name: undefined }],
+            });
+
+            expect(result[0].label.text).toBe('[0]\u2013[49]');
+            expect(result[1].label.text).toBe('[50]\u2013[100]');
+        });
+
+        test('reports source: gradient-legend and property: color to the user formatter', () => {
+            const scale = new ColorScale();
+            scale.mode = 'discrete';
+            scale.domain = [0, 100];
+            scale.range = ['red'];
+            scale.update();
+
+            const formatManager = new FormatManager();
+            const seen: { property?: string; source?: string }[] = [];
+            formatManager.setFormatter({
+                color: (p) => {
+                    seen.push({ property: p.property, source: p.source });
+                    return String(p.value);
+                },
+            });
+
+            buildColorCategoryLegendData(scale, [{ color: 'red' }], 's', true, {
+                formatManager,
+                formatInContext: (fn, params) => fn(params),
+                key: 'value',
+                legendItemName: undefined,
+                boundSeries: [{ seriesId: 's', key: 'value', name: undefined }],
+            });
+
+            expect(seen[0]).toEqual({ property: 'color', source: 'gradient-legend' });
+        });
+
+        test('falls back to default numeric formatting when no formatter is configured', () => {
+            const scale = new ColorScale();
+            scale.mode = 'discrete';
+            scale.domain = [0, 50, 100];
+            scale.range = ['red', 'green'];
+            scale.update();
+
+            const result = buildColorCategoryLegendData(scale, [{ color: 'red' }, { color: 'green' }], 's', true, {
+                formatManager: new FormatManager(),
+                formatInContext: (fn, params) => fn(params),
+                key: 'value',
+                legendItemName: undefined,
+                boundSeries: [{ seriesId: 's', key: 'value', name: undefined }],
+            });
+
+            // Default integer-bin path uses fractionDigits = 0, so no decimal places.
+            expect(result[0].label.text).toBe('0\u201349');
+            expect(result[1].label.text).toBe('50\u2013100');
         });
     });
 

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -200,6 +200,36 @@ export interface ColorScaleLegendFormatterContext {
 }
 
 /**
+ * Minimal shape any colour-scale series exposes that lets us pull together a
+ * `ColorScaleLegendFormatterContext` without the caller hand-packing the same
+ * five fields at every site. Defined structurally so it composes with both
+ * community and enterprise `Series` subclasses without an import cycle.
+ */
+interface ColorScaleSeries {
+    readonly properties: { colorKey?: string; legendItemName?: string };
+    readonly ctx: { formatManager: FormatManager };
+    callWithContext: GlobalContextFormatter;
+    getFormatterContext(property: 'color'): FormatterBoundSeries[];
+}
+
+/**
+ * Pulls together the formatter context for a colour-scale legend from a
+ * series instance. Used by every series that supports
+ * `colorScale.mode === 'discrete'`. Replaces the previous per-call-site
+ * boilerplate that packed the same five fields by hand.
+ */
+export function colorScaleLegendFormatterContext(series: ColorScaleSeries): ColorScaleLegendFormatterContext {
+    return {
+        formatManager: series.ctx.formatManager,
+        formatInContext: series.callWithContext.bind(series),
+        // Read via bracket access so the result is `string | undefined` without an `as` cast.
+        key: 'colorKey' in series.properties ? series.properties.colorKey : undefined,
+        legendItemName: 'legendItemName' in series.properties ? series.properties.legendItemName : undefined,
+        boundSeries: series.getFormatterContext('color'),
+    };
+}
+
+/**
  * Builds a number formatter for discrete-bin colour-scale legend labels.
  *
  * Routes values through the chart-level `formatter.color` callback (or the
@@ -208,12 +238,14 @@ export interface ColorScaleLegendFormatterContext {
  * `'gradient-legend'` rather than `'legend-label'` so that the same user
  * formatter applies in both legend modes — toggling `colorScale.mode` between
  * `'continuous'` and `'discrete'` should not silently switch the user's
- * formatter on or off. Users who want to differentiate the discrete-bin
- * labels can branch on `params.fractionDigits` (set to `0` for the integer
- * bin path) or `params.value`.
+ * formatter on or off. Any future colour-scale legend variant should keep this
+ * source for the same reason. Users who want to differentiate the discrete-bin
+ * labels can branch on `params.fractionDigits` (set to `0` for the integer bin
+ * path) or `params.value`.
  */
 function createBinFormatter(
     colorScale: ColorScaleState,
+    seriesId: string,
     { formatManager, formatInContext, key, legendItemName, boundSeries }: ColorScaleLegendFormatterContext
 ): (value: number, fractionDigits?: number) => string {
     const { domain } = colorScale;
@@ -222,7 +254,7 @@ function createBinFormatter(
             type: 'number',
             value,
             datum: undefined,
-            seriesId: boundSeries[0]?.seriesId,
+            seriesId,
             legendItemName,
             key,
             source: 'gradient-legend',
@@ -253,7 +285,7 @@ export function buildColorCategoryLegendData(
     const { domain, range } = colorScale;
     if (range.length === 0) return [];
 
-    const formatBinValue = createBinFormatter(colorScale, formatterContext);
+    const formatBinValue = createBinFormatter(colorScale, seriesId, formatterContext);
 
     return range.map((color, i): CategoryLegendDatum => {
         const start = domain[i];

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -5,10 +5,17 @@ import {
     deriveNormalizedStops,
     formatColorBinLabel,
 } from 'ag-charts-core';
-import type { AgChartLegendListeners, AgColorScaleColorStop, AgMarkerShape, TextOrSegments } from 'ag-charts-types';
+import type {
+    AgChartLegendListeners,
+    AgColorScaleColorStop,
+    AgMarkerShape,
+    NumberFormatterParams,
+    TextOrSegments,
+} from 'ag-charts-types';
 
 import type { ColorScale } from '../../scale/colorScale';
 import type { Scene } from '../../scene/scene';
+import type { FormatManager, GlobalContextFormatter } from '../formatter/formatManager';
 import type { LegendSymbolOptions } from './legendSymbol';
 
 export interface ChartLegend extends PluginModuleInstance {
@@ -177,19 +184,76 @@ export function buildGradientLegendDatum(
 }
 
 /**
+ * Context required to format discrete-bin colour-scale legend labels through
+ * the chart-level `formatter.color` pipeline. Built once per legend update by
+ * the caller (the series), then handed to `buildColorCategoryLegendData`.
+ */
+export interface ColorScaleLegendFormatterContext {
+    formatManager: FormatManager;
+    formatInContext: GlobalContextFormatter;
+    /** The colour-key of the series, surfaced to user formatters as `params.key`. */
+    key: string | undefined;
+    /** The legendItemName of the series, surfaced to user formatters as `params.legendItemName`. */
+    legendItemName: string | undefined;
+    /** The series formatter-context (`series.getFormatterContext('color')`), surfaced as `params.boundSeries`. */
+    boundSeries: FormatterBoundSeries[];
+}
+
+/**
+ * Builds a number formatter for discrete-bin colour-scale legend labels.
+ *
+ * Routes values through the chart-level `formatter.color` callback (or the
+ * matching specifier-string formatter) before falling back to the manager's
+ * default numeric formatting. The FormatterParams `source` is reported as
+ * `'gradient-legend'` rather than `'legend-label'` so that the same user
+ * formatter applies in both legend modes — toggling `colorScale.mode` between
+ * `'continuous'` and `'discrete'` should not silently switch the user's
+ * formatter on or off. Users who want to differentiate the discrete-bin
+ * labels can branch on `params.fractionDigits` (set to `0` for the integer
+ * bin path) or `params.value`.
+ */
+function createBinFormatter(
+    colorScale: ColorScaleState,
+    { formatManager, formatInContext, key, legendItemName, boundSeries }: ColorScaleLegendFormatterContext
+): (value: number, fractionDigits?: number) => string {
+    const { domain } = colorScale;
+    return (value, fractionDigits) => {
+        const params: NumberFormatterParams<any, any> = {
+            type: 'number',
+            value,
+            datum: undefined,
+            seriesId: boundSeries[0]?.seriesId,
+            legendItemName,
+            key,
+            source: 'gradient-legend',
+            property: 'color',
+            domain,
+            boundSeries,
+            fractionDigits,
+            visibleDomain: undefined,
+        };
+        return formatManager.format(formatInContext, params) ?? formatManager.defaultFormat(params);
+    };
+}
+
+/**
  * Builds category legend data for a discrete colour scale, deriving bin
- * boundaries on the fly from the ColorScale's domain/range state.
+ * boundaries on the fly from the ColorScale's domain/range state. Bin labels
+ * are formatted through the chart-level formatter pipeline supplied by
+ * `formatterContext` (see `ColorScaleLegendFormatterContext`).
  */
 export function buildColorCategoryLegendData(
     colorScale: ColorScaleState,
     fills: AgColorScaleColorStop[],
     seriesId: string,
     enabled: boolean,
-    formatValue: (value: number, maximumFractionDigits?: number) => string,
+    formatterContext: ColorScaleLegendFormatterContext,
     shape: AgMarkerShape = 'square'
 ): CategoryLegendDatum[] {
     const { domain, range } = colorScale;
     if (range.length === 0) return [];
+
+    const formatBinValue = createBinFormatter(colorScale, formatterContext);
 
     return range.map((color, i): CategoryLegendDatum => {
         const start = domain[i];
@@ -212,7 +276,7 @@ export function buildColorCategoryLegendData(
                     strokeOpacity: 1,
                 },
             },
-            label: { text: name ?? formatColorBinLabel(start, end, i, range.length, formatValue) },
+            label: { text: name ?? formatColorBinLabel(start, end, i, range.length, formatBinValue) },
             isFixed: true,
             hideToggleOtherSeries: true,
             suppressHighlight: true,

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -63,6 +63,7 @@ import {
     type GradientLegendDatum,
     buildColorCategoryLegendData,
     buildGradientLegendDatum,
+    colorScaleLegendFormatterContext,
 } from '../../legend/legendDatum';
 import type { LegendSymbolOptions } from '../../legend/legendSymbol';
 import { Marker } from '../../marker/marker';
@@ -1387,13 +1388,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
                     colorScaleProps.fills,
                     this.id,
                     this.visible,
-                    {
-                        formatManager: this.ctx.formatManager,
-                        formatInContext: this.callWithContext.bind(this),
-                        key: this.properties.colorKey,
-                        legendItemName: this.properties.legendItemName,
-                        boundSeries: this.getFormatterContext('color'),
-                    },
+                    colorScaleLegendFormatterContext(this),
                     this.properties.shape
                 );
             }

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -1387,7 +1387,13 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
                     colorScaleProps.fills,
                     this.id,
                     this.visible,
-                    formatValue,
+                    {
+                        formatManager: this.ctx.formatManager,
+                        formatInContext: this.callWithContext.bind(this),
+                        key: this.properties.colorKey,
+                        legendItemName: this.properties.legendItemName,
+                        boundSeries: this.getFormatterContext('color'),
+                    },
                     this.properties.shape
                 );
             }

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -1,5 +1,5 @@
 import type { ChartAnimationPhase, DynamicContext } from 'ag-charts-core';
-import { Logger, type Point, StateMachine, arraysEqual, clamp, formatValue, mergeDefaults } from 'ag-charts-core';
+import { Logger, type Point, StateMachine, arraysEqual, clamp, mergeDefaults } from 'ag-charts-core';
 import type { AgActiveItemState, FillOptions, StrokeOptions } from 'ag-charts-types';
 
 import type { HighlightNodeDatum } from '../../../core/eventsHub';
@@ -350,7 +350,14 @@ export abstract class HierarchySeries<
         const enabled = visible && (legendManager?.getItemEnabled({ seriesId }) ?? true);
 
         if (legendType === 'category' && colorScaleProps.mode === 'discrete' && hasColorScale) {
-            return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, enabled, formatValue);
+            return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, enabled, {
+                formatManager: this.ctx.formatManager,
+                formatInContext: this.callWithContext.bind(this),
+                key: colorKey,
+                legendItemName:
+                    'legendItemName' in this.properties ? (this.properties.legendItemName as string) : undefined,
+                boundSeries: this.getFormatterContext('color'),
+            });
         }
 
         if (legendType === 'gradient') {

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -17,6 +17,7 @@ import {
     type GradientLegendDatum,
     buildColorCategoryLegendData,
     buildGradientLegendDatum,
+    colorScaleLegendFormatterContext,
 } from '../../legend/legendDatum';
 import { type PickFocusInputs, type PickFocusOutputs, Series, SeriesNodePickMode } from '../series';
 import type { ISeries, ItemId, SeriesNodeDatum } from '../seriesTypes';
@@ -350,14 +351,13 @@ export abstract class HierarchySeries<
         const enabled = visible && (legendManager?.getItemEnabled({ seriesId }) ?? true);
 
         if (legendType === 'category' && colorScaleProps.mode === 'discrete' && hasColorScale) {
-            return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, enabled, {
-                formatManager: this.ctx.formatManager,
-                formatInContext: this.callWithContext.bind(this),
-                key: colorKey,
-                legendItemName:
-                    'legendItemName' in this.properties ? (this.properties.legendItemName as string) : undefined,
-                boundSeries: this.getFormatterContext('color'),
-            });
+            return buildColorCategoryLegendData(
+                this.colorScale,
+                colorScaleProps.fills,
+                seriesId,
+                enabled,
+                colorScaleLegendFormatterContext(this)
+            );
         }
 
         if (legendType === 'gradient') {

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -314,6 +314,7 @@ export {
     type CategoryLegendDatum,
     type ChartLegendDatum,
     type ChartLegendType,
+    type ColorScaleLegendFormatterContext,
     type GradientLegendDatum,
     type GradientLegendNamedLabel,
 } from './chart/legend/legendDatum';

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -311,6 +311,7 @@ export { calculateLabelTranslation } from './chart/crossline/crossLineLabelPosit
 export {
     buildColorCategoryLegendData,
     buildGradientLegendDatum,
+    colorScaleLegendFormatterContext,
     type CategoryLegendDatum,
     type ChartLegendDatum,
     type ChartLegendType,

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
@@ -617,6 +617,76 @@ describe('HeatmapSeries', () => {
             // (treemap/sunburst whose datumIndex is a path array).
             expect(highlightManager.getActiveHighlight()).toBeUndefined();
         });
+
+        it('AG-16043: discrete-bin legend items render with the default cursor, not pointer', async () => {
+            const options = prepareEnterpriseTestOptions({
+                data: EXAMPLE_OPTIONS.data,
+                series: [
+                    {
+                        type: 'heatmap',
+                        xKey: 'year',
+                        yKey: 'person',
+                        colorKey: 'spending',
+                        colorScale: {
+                            fills: [{ color: 'blue' }, { color: 'yellow' }, { color: 'red' }],
+                            mode: 'discrete' as const,
+                        },
+                    },
+                ],
+            });
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            // Discrete-bin items don't toggle and don't drive series highlight, so the
+            // pointer cursor would mislead users into expecting an interactive response.
+            const legendButtons = document.querySelectorAll<HTMLElement>('button.ag-charts-proxy-elem[role="switch"]');
+            expect(legendButtons.length).toBeGreaterThan(0);
+            for (const button of Array.from(legendButtons)) {
+                expect(button.style.cursor).toBe('default');
+            }
+        });
+
+        it('AG-16043: discrete-bin legend labels run through chart-level formatter.color', async () => {
+            const options = prepareEnterpriseTestOptions({
+                data: [
+                    { year: '2020', person: 'A', spending: 43384 },
+                    { year: '2020', person: 'B', spending: 250000 },
+                    { year: '2020', person: 'C', spending: 1500000 },
+                ],
+                formatter: {
+                    color: (p) => new Intl.NumberFormat('en', { notation: 'compact' }).format(p.value as number),
+                },
+                series: [
+                    {
+                        type: 'heatmap',
+                        xKey: 'year',
+                        yKey: 'person',
+                        colorKey: 'spending',
+                        colorScale: {
+                            mode: 'discrete' as const,
+                            fills: [
+                                { color: '#fdd49e', stop: 150000 },
+                                { color: '#fdbb84', stop: 500000 },
+                                { color: '#e34a33', stop: 1000000 },
+                                { color: '#b30000' },
+                            ],
+                        },
+                    },
+                ],
+            });
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const series = (chart as Chart).series[0];
+            const legendData = series.getLegendData('category') as { label: { text: string } }[];
+            const labels = legendData.map((d) => d.label.text);
+
+            // Compact-notation formatting should be applied to every bin boundary.
+            // Stops are 150000 / 500000 / 1000000; final bin runs to data max (1.5M).
+            expect(labels).toEqual(['43K–150K', '150K–500K', '500K–1M', '1M–1.5M']);
+        });
     });
 
     describe('null category key', () => {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -36,6 +36,7 @@ const {
     computeBarFocusBounds,
     buildColorCategoryLegendData,
     buildGradientLegendDatum,
+    colorScaleLegendFormatterContext,
     configureColorScale,
     getMissCount,
     valueProperty,
@@ -856,13 +857,13 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         const { colorScale: colorScaleProps } = this.properties;
 
         if (legendType === 'category' && colorScaleProps.mode === 'discrete' && colorScaleProps.fills.length > 0) {
-            return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, this.id, this.visible, {
-                formatManager: this.ctx.formatManager,
-                formatInContext: this.callWithContext.bind(this),
-                key: this.properties.colorKey,
-                legendItemName: this.properties.legendItemName,
-                boundSeries: this.getFormatterContext('color'),
-            });
+            return buildColorCategoryLegendData(
+                this.colorScale,
+                colorScaleProps.fills,
+                this.id,
+                this.visible,
+                colorScaleLegendFormatterContext(this)
+            );
         }
 
         if (legendType === 'gradient') {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -856,13 +856,13 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         const { colorScale: colorScaleProps } = this.properties;
 
         if (legendType === 'category' && colorScaleProps.mode === 'discrete' && colorScaleProps.fills.length > 0) {
-            return buildColorCategoryLegendData(
-                this.colorScale,
-                colorScaleProps.fills,
-                this.id,
-                this.visible,
-                formatValue
-            );
+            return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, this.id, this.visible, {
+                formatManager: this.ctx.formatManager,
+                formatInContext: this.callWithContext.bind(this),
+                key: this.properties.colorKey,
+                legendItemName: this.properties.legendItemName,
+                boundSeries: this.getFormatterContext('color'),
+            });
         }
 
         if (legendType === 'gradient') {

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -38,6 +38,7 @@ const {
     getLabelStyles,
     buildColorCategoryLegendData,
     buildGradientLegendDatum,
+    colorScaleLegendFormatterContext,
     configureColorScale,
     createDatumId,
     SeriesNodePickMode,
@@ -733,13 +734,13 @@ export class MapLineSeries
             ];
         } else if (legendType === 'category') {
             if (colorScaleProps.mode === 'discrete' && hasColorScale) {
-                return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, visible, {
-                    formatManager: this.ctx.formatManager,
-                    formatInContext: this.callWithContext.bind(this),
-                    key: colorKey,
-                    legendItemName,
-                    boundSeries: this.getFormatterContext('color'),
-                });
+                return buildColorCategoryLegendData(
+                    this.colorScale,
+                    colorScaleProps.fills,
+                    seriesId,
+                    visible,
+                    colorScaleLegendFormatterContext(this)
+                );
             }
             const legendDatum: _ModuleSupport.CategoryLegendDatum = {
                 legendType: 'category',

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -733,13 +733,13 @@ export class MapLineSeries
             ];
         } else if (legendType === 'category') {
             if (colorScaleProps.mode === 'discrete' && hasColorScale) {
-                return buildColorCategoryLegendData(
-                    this.colorScale,
-                    colorScaleProps.fills,
-                    seriesId,
-                    visible,
-                    formatValue
-                );
+                return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, visible, {
+                    formatManager: this.ctx.formatManager,
+                    formatInContext: this.callWithContext.bind(this),
+                    key: colorKey,
+                    legendItemName,
+                    boundSeries: this.getFormatterContext('color'),
+                });
             }
             const legendDatum: _ModuleSupport.CategoryLegendDatum = {
                 legendType: 'category',

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -984,13 +984,13 @@ export class MapMarkerSeries
             ];
         } else if (legendType === 'category') {
             if (colorScaleProps.mode === 'discrete' && hasColorScale) {
-                return buildColorCategoryLegendData(
-                    this.colorScale,
-                    colorScaleProps.fills,
-                    seriesId,
-                    visible,
-                    formatValue
-                );
+                return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, visible, {
+                    formatManager: this.ctx.formatManager,
+                    formatInContext: this.callWithContext.bind(this),
+                    key: colorKey,
+                    legendItemName,
+                    boundSeries: this.getFormatterContext('color'),
+                });
             }
             const legendDatum: _ModuleSupport.CategoryLegendDatum = {
                 legendType: 'category',

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -43,6 +43,7 @@ const {
     getMissCount,
     buildColorCategoryLegendData,
     buildGradientLegendDatum,
+    colorScaleLegendFormatterContext,
     configureColorScale,
     createDatumId,
     SeriesNodePickMode,
@@ -984,13 +985,13 @@ export class MapMarkerSeries
             ];
         } else if (legendType === 'category') {
             if (colorScaleProps.mode === 'discrete' && hasColorScale) {
-                return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, visible, {
-                    formatManager: this.ctx.formatManager,
-                    formatInContext: this.callWithContext.bind(this),
-                    key: colorKey,
-                    legendItemName,
-                    boundSeries: this.getFormatterContext('color'),
-                });
+                return buildColorCategoryLegendData(
+                    this.colorScale,
+                    colorScaleProps.fills,
+                    seriesId,
+                    visible,
+                    colorScaleLegendFormatterContext(this)
+                );
             }
             const legendDatum: _ModuleSupport.CategoryLegendDatum = {
                 legendType: 'category',

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -786,13 +786,13 @@ export class MapShapeSeries
             ];
         } else if (legendType === 'category') {
             if (colorScaleProps.mode === 'discrete' && hasColorScale) {
-                return buildColorCategoryLegendData(
-                    this.colorScale,
-                    colorScaleProps.fills,
-                    seriesId,
-                    visible,
-                    formatValue
-                );
+                return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, visible, {
+                    formatManager: this.ctx.formatManager,
+                    formatInContext: this.callWithContext.bind(this),
+                    key: colorKey,
+                    legendItemName,
+                    boundSeries: this.getFormatterContext('color'),
+                });
             }
             const legendDatum: _ModuleSupport.CategoryLegendDatum = {
                 legendType: 'category',

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -48,6 +48,7 @@ const {
     getMissCount,
     buildColorCategoryLegendData,
     buildGradientLegendDatum,
+    colorScaleLegendFormatterContext,
     configureColorScale,
     createDatumId,
     SeriesNodePickMode,
@@ -786,13 +787,13 @@ export class MapShapeSeries
             ];
         } else if (legendType === 'category') {
             if (colorScaleProps.mode === 'discrete' && hasColorScale) {
-                return buildColorCategoryLegendData(this.colorScale, colorScaleProps.fills, seriesId, visible, {
-                    formatManager: this.ctx.formatManager,
-                    formatInContext: this.callWithContext.bind(this),
-                    key: colorKey,
-                    legendItemName,
-                    boundSeries: this.getFormatterContext('color'),
-                });
+                return buildColorCategoryLegendData(
+                    this.colorScale,
+                    colorScaleProps.fills,
+                    seriesId,
+                    visible,
+                    colorScaleLegendFormatterContext(this)
+                );
             }
             const legendDatum: _ModuleSupport.CategoryLegendDatum = {
                 legendType: 'category',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16043

Addresses David's QA feedback in [comment 112227](https://ag-grid.atlassian.net/browse/AG-16043?focusedCommentId=112227) on the discrete colour-scale legend.

## What changed

- **Cursor:** discrete-bin legend items now use the default cursor instead of `pointer`. Those items are intentionally non-toggling (`suppressHighlight: true`) so the pointer cursor was misleading.
- **Formatter:** discrete-bin labels now run through the chart-level `formatter.color` pipeline. `buildColorCategoryLegendData` takes a new `ColorScaleLegendFormatterContext` argument that wires up `formatManager` + `boundSeries`. With a chart-level color formatter configured, the discrete-bin legend now produces identically-formatted values to the gradient legend (e.g. compact `43K–150K` rather than raw `43384–149999`).

## Why source = 'gradient-legend'

The FormatterParams `source` is reported as `'gradient-legend'` for both legend modes so toggling `colorScale.mode` between `'continuous'` and `'discrete'` does not silently switch the user's formatter on or off. Documented in the JSDoc on `createBinFormatter`.

## Tests

- New JSDOM cursor test in `heatmap.test.ts` asserts `style.cursor === 'default'` on every discrete-bin legend button.
- New integration test asserts that a chart-level `formatter.color` (compact-notation `Intl.NumberFormat`) produces `['43K–150K', '150K–500K', '500K–1M', '1M–1.5M']` on a heatmap with discrete bins.
- Existing `legendDatum.test.ts` updated for the new `formatterContext` signature, plus three new cases covering formatter routing, params introspection, and the unconfigured-formatter fallback.

All six callers updated: heatmap, bubble, treemap, sunburst, map-shape, map-marker, map-line.

Fix #AG-16043