### PR TITLE
AG-10316 / AG-11689 Consolidate renderer signatures onto shared Renderer<P, R>

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import tseslint from 'typescript-eslint';
 
 import lintChangeDetection from './libraries/ag-charts-eslint-rules/rules/change-detection.mjs';
 import requireExplicitGeneric from './libraries/ag-charts-eslint-rules/rules/require-explicit-generic.mjs';
+import requireSharedRenderer from './libraries/ag-charts-eslint-rules/rules/require-shared-renderer.mjs';
 
 let env = 'unknown';
 if (process.env.CI != null) {
@@ -123,6 +124,7 @@ export default [
             aglint: {
                 rules: {
                     'require-explicit-generic': requireExplicitGeneric,
+                    'require-shared-renderer': requireSharedRenderer,
                     'change-detection': lintChangeDetection,
                 },
             },

--- a/libraries/ag-charts-eslint-rules/rules/require-shared-renderer.mjs
+++ b/libraries/ag-charts-eslint-rules/rules/require-shared-renderer.mjs
@@ -1,0 +1,65 @@
+// -*- Mode: js2; -*-
+/**
+ * @fileoverview Enforce that all `renderer?:` declarations in ag-charts-types use the shared
+ * `Renderer<P, R>` type from `chart/callbackOptions`. This keeps the renderer return-value
+ * contract (TextValue | R | undefined; empty-string suppresses, undefined falls through to the
+ * default) uniform across the public API surface.
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Require that `renderer` properties in ag-charts-types use the shared `Renderer<P, R>` type from callbackOptions.',
+        },
+        messages: {
+            useSharedRenderer:
+                '`renderer` must use the shared `Renderer<P, R>` type from `chart/callbackOptions` (directly, or as part of a union/intersection) so the return-value contract stays uniform across the public API. Replace this bespoke signature with `Renderer<…, R>`. If you have a genuinely exceptional case, you can disable this rule with `// eslint-disable-next-line aglint/require-shared-renderer` and document why.',
+        },
+        schema: [],
+    },
+
+    create(context) {
+        function getTypeName(typeAnnotation) {
+            if (!typeAnnotation || typeAnnotation.type !== 'TSTypeReference') return undefined;
+            const { typeName } = typeAnnotation;
+            if (typeName.type === 'Identifier') return typeName.name;
+            if (typeName.type === 'TSQualifiedName') return typeName.right?.name;
+            return undefined;
+        }
+
+        // Walk the annotation tree so unions/intersections containing `Renderer<…>` still pass.
+        // Examples allowed: `Renderer<…>`, `Renderer<…> | undefined`, `Renderer<…> & Branded`.
+        // Examples flagged: `(params) => string`, bespoke aliases like `MyRenderer<P>`.
+        function containsRendererReference(annotation) {
+            if (!annotation) return false;
+            if (getTypeName(annotation) === 'Renderer') return true;
+            if (annotation.type === 'TSUnionType' || annotation.type === 'TSIntersectionType') {
+                return annotation.types.some(containsRendererReference);
+            }
+            if (annotation.type === 'TSParenthesizedType') {
+                return containsRendererReference(annotation.typeAnnotation);
+            }
+            return false;
+        }
+
+        return {
+            TSPropertySignature(node) {
+                const key = node.key;
+                if (!key || key.type !== 'Identifier' || key.name !== 'renderer') return;
+
+                const annotation = node.typeAnnotation?.typeAnnotation;
+                if (!annotation) return;
+
+                if (containsRendererReference(annotation)) return;
+
+                context.report({
+                    node: annotation,
+                    messageId: 'useSharedRenderer',
+                });
+            },
+        };
+    },
+};

--- a/libraries/ag-charts-eslint-rules/src/__snapshots__/eslint-rules.test.ts.snap
+++ b/libraries/ag-charts-eslint-rules/src/__snapshots__/eslint-rules.test.ts.snap
@@ -222,6 +222,21 @@ exports[`aglint/require-explicit-generic 1`] = `
 }
 `;
 
+exports[`aglint/require-shared-renderer 1`] = `
+{
+  "stderr": "",
+  "stdout": "
+<dirname>/lint-require-shared-renderer.data.ts
+  24:16  error  \`renderer\` must use the shared \`Renderer<P, R>\` type from \`chart/callbackOptions\` (directly, or as part of a union/intersection) so the return-value contract stays uniform across the public API. Replace this bespoke signature with \`Renderer<…, R>\`. If you have a genuinely exceptional case, you can disable this rule with \`// eslint-disable-next-line aglint/require-shared-renderer\` and document why  aglint/require-shared-renderer
+  28:16  error  \`renderer\` must use the shared \`Renderer<P, R>\` type from \`chart/callbackOptions\` (directly, or as part of a union/intersection) so the return-value contract stays uniform across the public API. Replace this bespoke signature with \`Renderer<…, R>\`. If you have a genuinely exceptional case, you can disable this rule with \`// eslint-disable-next-line aglint/require-shared-renderer\` and document why  aglint/require-shared-renderer
+  32:16  error  \`renderer\` must use the shared \`Renderer<P, R>\` type from \`chart/callbackOptions\` (directly, or as part of a union/intersection) so the return-value contract stays uniform across the public API. Replace this bespoke signature with \`Renderer<…, R>\`. If you have a genuinely exceptional case, you can disable this rule with \`// eslint-disable-next-line aglint/require-shared-renderer\` and document why  aglint/require-shared-renderer
+
+✖ 3 problems (3 errors, 0 warnings)
+
+",
+}
+`;
+
 exports[`aglint/validate-module-registration 1`] = `
 {
   "stderr": "",

--- a/libraries/ag-charts-eslint-rules/src/eslint-rules.test.ts
+++ b/libraries/ag-charts-eslint-rules/src/eslint-rules.test.ts
@@ -32,4 +32,5 @@ function testRule(ruleNameSuffix: string) {
 
 testRule('change-detection');
 testRule('require-explicit-generic');
+testRule('require-shared-renderer');
 testRule('validate-module-registration');

--- a/libraries/ag-charts-eslint-rules/src/lint-require-shared-renderer-eslint-config.mjs
+++ b/libraries/ag-charts-eslint-rules/src/lint-require-shared-renderer-eslint-config.mjs
@@ -1,0 +1,32 @@
+// -*- Mode: js -*-
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+import requireSharedRenderer from '../rules/require-shared-renderer.mjs';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+export default [
+    ...tseslint.configs.recommendedTypeChecked,
+    {
+        files: ['**/lint-require-shared-renderer.data.ts'],
+        languageOptions: {
+            globals: globals.browser,
+            parserOptions: {
+                projectService: true,
+                project: './src/lint-require-shared-renderer-tsconfig.json',
+            },
+        },
+        plugins: {
+            aglint: {
+                rules: {
+                    'require-shared-renderer': requireSharedRenderer,
+                },
+            },
+        },
+        rules: {
+            'aglint/require-shared-renderer': 2,
+            '@typescript-eslint/no-unused-vars': 0,
+            '@typescript-eslint/no-empty-object-type': 0,
+        },
+    },
+];

--- a/libraries/ag-charts-eslint-rules/src/lint-require-shared-renderer-tsconfig.json
+++ b/libraries/ag-charts-eslint-rules/src/lint-require-shared-renderer-tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "verbatimModuleSyntax": true,
+        "types": ["node"]
+    },
+    "include": ["**/lint-require-shared-renderer.data.ts"]
+}

--- a/libraries/ag-charts-eslint-rules/src/lint-require-shared-renderer.data.ts
+++ b/libraries/ag-charts-eslint-rules/src/lint-require-shared-renderer.data.ts
@@ -1,0 +1,35 @@
+type Renderer<P, R> = (params: P) => string | R | undefined;
+
+interface RendererParams {
+    text: string;
+}
+
+interface RendererResult {
+    html: string;
+}
+
+interface test_CorrectSharedRenderer {
+    renderer?: Renderer<RendererParams, RendererResult>;
+}
+
+interface test_CorrectSharedRendererWithStringR {
+    renderer?: Renderer<RendererParams, string>;
+}
+
+interface test_CorrectSharedRendererInUnion {
+    renderer?: Renderer<RendererParams, RendererResult> | undefined;
+}
+
+interface test_IncorrectBespokeRenderer {
+    renderer?: (params: RendererParams) => string;
+}
+
+interface test_IncorrectBespokeRendererUndefined {
+    renderer?: (params: RendererParams) => string | undefined;
+}
+
+interface test_IncorrectAliasedRenderer {
+    renderer?: SomeOtherType;
+}
+
+type SomeOtherType = (params: RendererParams) => string;

--- a/packages/ag-charts-community/src/api/preset/sparkline.ts
+++ b/packages/ag-charts-community/src/api/preset/sparkline.ts
@@ -298,6 +298,10 @@ const tooltipRendererFn = simpleMemorize((context: any, tooltip?: AgSparklineToo
             return toTextString(userContent);
         }
 
+        // `userContent === undefined` (renderer absent or returning `undefined`) falls through
+        // naturally: optional chaining on `userContent?.content` / `userContent?.title` yields
+        // undefined and the default `yValue.toFixed(2)` content is used. Per the Renderer<P, R>
+        // contract this is the documented "fall through to default" behaviour.
         const content = userContent?.content ?? yValue.toFixed(2);
 
         return userContent?.title

--- a/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
+++ b/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
@@ -275,6 +275,8 @@ export function cartesianAxisCrosshairOptions(
         renderer: callbackOf(
             or(
                 string,
+                number,
+                date,
                 optionsDefs<AgCrosshairLabelRendererResult>(
                     {
                         text: string,

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -52,7 +52,7 @@ class CaptionTooltipProperties extends BaseProperties {
     text?: string;
 
     @Property
-    renderer?: Renderer<AgCaptionTooltipRendererParams, string>;
+    renderer?: Renderer<AgCaptionTooltipRendererParams, never>;
 }
 
 export class Caption extends BaseProperties implements CaptionLike {

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -18,6 +18,7 @@ import type {
     AgCaptionTooltipRendererParams,
     FontStyle,
     FontWeight,
+    Renderer,
     TextAlign,
     TextOrSegments,
     TextWrap,
@@ -51,7 +52,7 @@ class CaptionTooltipProperties extends BaseProperties {
     text?: string;
 
     @Property
-    renderer?: (params: AgCaptionTooltipRendererParams) => string;
+    renderer?: Renderer<AgCaptionTooltipRendererParams, string>;
 }
 
 export class Caption extends BaseProperties implements CaptionLike {
@@ -209,7 +210,7 @@ export class Caption extends BaseProperties implements CaptionLike {
             const params: AgCaptionTooltipRendererParams = { text: captionText };
             const result = callWithContext(moduleCtx.chartService, renderer, params);
             if (result === '') return undefined;
-            return { type: 'raw', rawHtmlString: result };
+            if (result != null) return { type: 'raw', rawHtmlString: toTextString(result) };
         }
 
         const displayText = text ?? captionText;

--- a/packages/ag-charts-community/src/chart/legend/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.test.ts
@@ -1072,8 +1072,40 @@ describe('Legend', () => {
                 seriesId: expect.any(String),
                 itemId: 'y',
                 text: 'Series Y',
-                enabled: true,
+                visible: true,
             });
+        });
+
+        test('renderer returns undefined — falls back to text', async () => {
+            await setupChart({
+                item: {
+                    tooltip: {
+                        text: 'Fallback text',
+                        renderer: () => undefined,
+                    },
+                },
+            });
+
+            await hoverLegendItem();
+
+            expect(isTooltipVisible()).toBe(true);
+            expect(getTooltipText()).toContain('Fallback text');
+        });
+
+        test('renderer returns undefined — falls back to default label when no text', async () => {
+            await setupChart({
+                item: {
+                    tooltip: {
+                        visible: 'always',
+                        renderer: () => undefined,
+                    },
+                },
+            });
+
+            await hoverLegendItem();
+
+            expect(isTooltipVisible()).toBe(true);
+            expect(getTooltipText()).toContain('Series Y');
         });
 
         test('toggleSeries: false — tooltip still works', async () => {

--- a/packages/ag-charts-community/src/chart/legend/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.test.ts
@@ -1108,6 +1108,38 @@ describe('Legend', () => {
             expect(getTooltipText()).toContain('Series Y');
         });
 
+        test('renderer returns a number — coerced to string content', async () => {
+            await setupChart({
+                item: {
+                    tooltip: {
+                        renderer: () => 42,
+                    },
+                },
+            });
+
+            await hoverLegendItem();
+
+            expect(isTooltipVisible()).toBe(true);
+            expect(getTooltipText()).toContain('42');
+        });
+
+        test('renderer returns a Date — coerced to string content', async () => {
+            // Mid-year noon UTC so the Date stringifies to the same calendar day in every timezone.
+            await setupChart({
+                item: {
+                    tooltip: {
+                        renderer: () => new Date('2026-06-15T12:00:00Z'),
+                    },
+                },
+            });
+
+            await hoverLegendItem();
+
+            expect(isTooltipVisible()).toBe(true);
+            expect(getTooltipText()).toContain('2026');
+            expect(getTooltipText()).toContain('Jun');
+        });
+
         test('toggleSeries: false — tooltip still works', async () => {
             await setupChart({
                 toggleSeries: false,

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -24,6 +24,7 @@ import {
     isTextTruncated,
     objectsEqual,
     toPlainText,
+    toTextString,
     truncateLine,
 } from 'ag-charts-core';
 import type { AgChartLegendContextMenuEvent, AgMarkerShapeFn } from 'ag-charts-types';
@@ -1069,7 +1070,7 @@ export class Legend {
             };
             const result = this.cachedCallWithContext(tooltipOpts.renderer, params);
             if (result === '') return undefined;
-            if (result != null) return [{ type: 'raw', rawHtmlString: result }];
+            if (result != null) return [{ type: 'raw', rawHtmlString: toTextString(result) }];
         }
 
         if (tooltipOpts?.text != null) {

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -1058,17 +1058,18 @@ export class Legend {
         if (visible === 'never') return undefined;
         if (visible === 'auto' && !isTruncated) return undefined;
 
-        // Content precedence: renderer > text > default label
+        // Content precedence: renderer > text > default label.
+        // A renderer returning '' suppresses the tooltip; returning undefined falls through to text/label.
         if (tooltipOpts?.renderer) {
             const params = {
                 seriesId: datum.seriesId,
                 itemId: datum.itemId ?? datum.id,
                 text: toPlainText(datum.label.text),
-                enabled: datum.enabled,
+                visible: datum.enabled,
             };
             const result = this.cachedCallWithContext(tooltipOpts.renderer, params);
-            if (result == null || result === '') return undefined;
-            return [{ type: 'raw', rawHtmlString: result }];
+            if (result === '') return undefined;
+            if (result != null) return [{ type: 'raw', rawHtmlString: result }];
         }
 
         if (tooltipOpts?.text != null) {

--- a/packages/ag-charts-community/src/chart/overlay/overlay.test.ts
+++ b/packages/ag-charts-community/src/chart/overlay/overlay.test.ts
@@ -206,6 +206,46 @@ HTMLCollection [
 `);
         });
 
+        test('renderer returning undefined falls through to default no data overlay', async () => {
+            chart = await createChart({
+                data: [],
+                series: [{ type: 'line', xKey: 'x', yKey: 'y1' }],
+                overlays: {
+                    noData: { renderer: () => undefined },
+                },
+            });
+            const overlayEl = chart.ctx.agDocument.body.querySelector('.ag-charts-overlay')?.firstChild as HTMLElement;
+            expect(overlayEl?.innerText).toEqual('No data to display');
+        });
+
+        test('renderer returning a number is coerced to string content', async () => {
+            chart = await createChart({
+                data: [],
+                series: [{ type: 'line', xKey: 'x', yKey: 'y1' }],
+                overlays: {
+                    noData: { renderer: () => 42 },
+                },
+            });
+            // textContent is used here (not innerText) because JSDOM's innerText is unreliable
+            // for raw text nodes — see overlay.ts where a non-element renderer result is wrapped in tempDiv.
+            const overlayEl = chart.ctx.agDocument.body.querySelector('.ag-charts-overlay')?.firstChild as HTMLElement;
+            expect(overlayEl?.textContent).toEqual('42');
+        });
+
+        test('renderer returning a Date is coerced to string content', async () => {
+            chart = await createChart({
+                data: [],
+                series: [{ type: 'line', xKey: 'x', yKey: 'y1' }],
+                overlays: {
+                    // Mid-year noon UTC so the Date stringifies to the same calendar day in every timezone.
+                    noData: { renderer: () => new Date('2026-06-15T12:00:00Z') },
+                },
+            });
+            const overlayEl = chart.ctx.agDocument.body.querySelector('.ag-charts-overlay')?.firstChild as HTMLElement;
+            expect(overlayEl?.textContent).toContain('2026');
+            expect(overlayEl?.textContent).toContain('Jun');
+        });
+
         test('custom no data text with multiple html elements', async () => {
             chart = await createChart({
                 data: [],

--- a/packages/ag-charts-community/src/chart/overlay/overlay.ts
+++ b/packages/ag-charts-community/src/chart/overlay/overlay.ts
@@ -4,11 +4,13 @@ import {
     callWithContext,
     createElement,
     isArray,
+    isDate,
     isHTMLElement,
+    isNumber,
     toPlainText,
     toTextString,
 } from 'ag-charts-core';
-import type { AgChartOverlayRendererParams, DatumDefault, TextOrSegments } from 'ag-charts-types';
+import type { AgChartOverlayRendererParams, DatumDefault, Renderer, TextOrSegments } from 'ag-charts-types';
 
 import type { LocaleManager } from '../../locale/localeManager';
 import type { BBox } from '../../scene/bbox';
@@ -25,7 +27,7 @@ export class Overlay extends BaseProperties {
     text?: TextOrSegments;
 
     @Property
-    renderer?: (params: AgChartOverlayRendererParams<DatumDefault>) => string | HTMLElement;
+    renderer?: Renderer<AgChartOverlayRendererParams<DatumDefault>, HTMLElement>;
 
     private content?: HTMLElement;
     private rendererAsText?: string;
@@ -58,10 +60,15 @@ export class Overlay extends BaseProperties {
         this.rendererAsText = undefined;
         this.focusBox = rect;
 
-        if (this.renderer) {
-            const params: AgChartOverlayRendererParams<DatumDefault> = {};
-            const htmlContent = callWithContext(callers, this.renderer, params);
+        // The renderer is optional, and per the documented Renderer<P, R> contract may
+        // return `undefined` to fall through to the default overlay text. An empty string
+        // still renders (as an empty overlay). Number/Date returns (TextValue) are coerced
+        // via toTextString to keep behaviour consistent with other Renderer<P, R> consumers.
+        const params: AgChartOverlayRendererParams<DatumDefault> = {};
+        const rendered = this.renderer ? callWithContext(callers, this.renderer, params) : undefined;
+        const htmlContent = isNumber(rendered) || isDate(rendered) ? toTextString(rendered) : rendered;
 
+        if (typeof htmlContent === 'string' || isHTMLElement(htmlContent)) {
             if (isHTMLElement(htmlContent)) {
                 this.content = htmlContent;
             } else {

--- a/packages/ag-charts-community/src/chart/overlay/overlay.ts
+++ b/packages/ag-charts-community/src/chart/overlay/overlay.ts
@@ -2,11 +2,10 @@ import {
     BaseProperties,
     Property,
     callWithContext,
+    coerceTextValue,
     createElement,
     isArray,
-    isDate,
     isHTMLElement,
-    isNumber,
     toPlainText,
     toTextString,
 } from 'ag-charts-core';
@@ -62,11 +61,10 @@ export class Overlay extends BaseProperties {
 
         // The renderer is optional, and per the documented Renderer<P, R> contract may
         // return `undefined` to fall through to the default overlay text. An empty string
-        // still renders (as an empty overlay). Number/Date returns (TextValue) are coerced
-        // via toTextString to keep behaviour consistent with other Renderer<P, R> consumers.
+        // still renders (as an empty overlay).
         const params: AgChartOverlayRendererParams<DatumDefault> = {};
         const rendered = this.renderer ? callWithContext(callers, this.renderer, params) : undefined;
-        const htmlContent = isNumber(rendered) || isDate(rendered) ? toTextString(rendered) : rendered;
+        const htmlContent = coerceTextValue(rendered);
 
         if (typeof htmlContent === 'string' || isHTMLElement(htmlContent)) {
             if (isHTMLElement(htmlContent)) {

--- a/packages/ag-charts-community/src/chart/series/seriesTooltip.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTooltip.ts
@@ -15,12 +15,13 @@ import type {
     ContextDefault,
     DatumDefault,
     InteractionRange,
+    Renderer,
 } from 'ag-charts-types';
 
 import type { LegendLine, LegendMarker, LegendSymbolOptions } from '../legend/legendSymbol';
 import { type TooltipContent, TooltipPosition, type TooltipStructuredContent } from '../tooltip/tooltip';
 
-export type TooltipRenderer<P> = (params: P) => string | AgTooltipRendererResult;
+export type TooltipRenderer<P> = Renderer<P, AgTooltipRendererResult>;
 
 function buildLineWithMarkerDefaults(
     line:

--- a/packages/ag-charts-core/src/config/chartDefaults.ts
+++ b/packages/ag-charts-core/src/config/chartDefaults.ts
@@ -176,7 +176,7 @@ const chartCaptionOptionsDefs: OptionsDefs<AgChartCaptionOptions> = {
     tooltip: {
         visible: union('auto', 'always', 'never'),
         text: string,
-        renderer: callbackOf(string),
+        renderer: callbackOf(or(string, number, date)),
     },
 };
 // @ts-expect-error undocumented option
@@ -187,7 +187,7 @@ chartCaptionOptionsDefs.truncate = undocumented(boolean);
 const chartOverlayOptionsDefs: OptionsDefs<AgChartOverlayOptions> = {
     enabled: boolean,
     text: textOrSegments,
-    renderer: callbackOf(or(string, htmlElement)),
+    renderer: callbackOf(or(string, number, date, htmlElement)),
 };
 
 const contextMenuItemLiterals: AgContextMenuItemLiteral[] = [

--- a/packages/ag-charts-core/src/utils/text/textUtils.ts
+++ b/packages/ag-charts-core/src/utils/text/textUtils.ts
@@ -1,7 +1,7 @@
 import type { TextOrSegments, TextSegment, TextValue } from 'ag-charts-types';
 
 import { EllipsisChar, type FontOptions, TrimCharsRegex, TrimEdgeGuard } from '../../types/text';
-import { isArray } from '../types/typeGuards';
+import { isArray, isDate, isNumber } from '../types/typeGuards';
 
 export function toFontString({ fontSize, fontStyle, fontWeight, fontFamily }: FontOptions) {
     let fontString = '';
@@ -22,6 +22,18 @@ export function calcLineHeight(fontSize: number, lineHeightRatio = 1.15) {
 
 export function toTextString(value: TextValue | undefined): string {
     return String(value ?? '');
+}
+
+type CoercedTextValue<R> = string | R | undefined;
+
+// Coerce the TextValue (number/Date) portion of a Renderer<P, R> return to a string,
+// leaving R values, plain strings, and `undefined` unchanged. Centralises the contract
+// shared by overlay/crosshair-style consumers that mix text and DOM/object outputs.
+export function coerceTextValue<R>(value: TextValue | R): string | R;
+export function coerceTextValue<R>(value: TextValue | R | undefined): CoercedTextValue<R>;
+export function coerceTextValue<R>(value: TextValue | R | undefined): CoercedTextValue<R> {
+    if (isNumber(value) || isDate(value)) return toTextString(value);
+    return value;
 }
 
 export function appendEllipsis(text: string) {

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.test.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.test.ts
@@ -541,4 +541,63 @@ describe('Crosshair', () => {
         // Expect the y axis label to contain a numeric default formatted value.
         expect(visibleText(yLabels).some((t) => /\d/.test(t))).toBe(true);
     });
+
+    it('AG-10316 label.renderer returning null falls through (treated as undefined)', async () => {
+        const options: AgCartesianChartOptions = {
+            data: [
+                { x: 'A', y: 100 },
+                { x: 'B', y: 200 },
+                { x: 'C', y: 150 },
+                { x: 'D', y: 300 },
+            ],
+            series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+            axes: {
+                y: {
+                    type: 'number',
+                    position: 'left',
+                    crosshair: {
+                        ...CROSSHAIR_OPTIONS,
+                        snap: true,
+                        // JS callers can return null even though the type forbids it; this should
+                        // fall through to the default formatted value rather than throwing.
+                        label: { renderer: (() => null) as any },
+                    },
+                },
+                x: {
+                    type: 'category',
+                    position: 'bottom',
+                    crosshair: {
+                        ...CROSSHAIR_OPTIONS,
+                        snap: true,
+                        label: { renderer: (() => null) as any },
+                    },
+                },
+            },
+        };
+        prepareEnterpriseTestOptions(options);
+
+        chart = AgCharts.create(options);
+        await waitForChartStability(chart);
+        await hoverAction(300, 300)(chart);
+        await waitForChartStability(chart);
+
+        const yLabels = Array.from(
+            document.querySelectorAll<HTMLElement>(
+                `.ag-charts-crosshair-label[data-axis-id="y"]:not(.ag-charts-crosshair-label--hidden)`
+            )
+        );
+        const xLabels = Array.from(
+            document.querySelectorAll<HTMLElement>(
+                `.ag-charts-crosshair-label[data-axis-id="x"]:not(.ag-charts-crosshair-label--hidden)`
+            )
+        );
+        const visibleText = (els: HTMLElement[]) =>
+            els.map((el) => el.textContent?.trim() ?? '').filter((t) => t.length > 0);
+
+        expect(yLabels.length).toBeGreaterThan(0);
+        expect(xLabels.length).toBeGreaterThan(0);
+        expect(visibleText(xLabels).some((t) => t.includes('null'))).toBe(false);
+        expect(visibleText(yLabels).some((t) => t.includes('null'))).toBe(false);
+        expect(visibleText(yLabels).some((t) => /\d/.test(t))).toBe(true);
+    });
 });

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.test.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.test.ts
@@ -481,4 +481,64 @@ describe('Crosshair', () => {
         expect(visibleLabels('y').length).toBeGreaterThan(0);
         expect(labelTexts('x')).toEqual(expect.arrayContaining([expect.stringContaining('2000')]));
     });
+
+    it('AG-10316 label.renderer returning undefined falls through to default formatted value', async () => {
+        const options: AgCartesianChartOptions = {
+            data: [
+                { x: 'A', y: 100 },
+                { x: 'B', y: 200 },
+                { x: 'C', y: 150 },
+                { x: 'D', y: 300 },
+            ],
+            series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+            axes: {
+                y: {
+                    type: 'number',
+                    position: 'left',
+                    crosshair: {
+                        ...CROSSHAIR_OPTIONS,
+                        snap: true,
+                        label: { renderer: () => undefined },
+                    },
+                },
+                x: {
+                    type: 'category',
+                    position: 'bottom',
+                    crosshair: {
+                        ...CROSSHAIR_OPTIONS,
+                        snap: true,
+                        label: { renderer: () => undefined },
+                    },
+                },
+            },
+        };
+        prepareEnterpriseTestOptions(options);
+
+        chart = AgCharts.create(options);
+        await waitForChartStability(chart);
+        await hoverAction(300, 300)(chart);
+        await waitForChartStability(chart);
+
+        const yLabels = Array.from(
+            document.querySelectorAll<HTMLElement>(
+                `.ag-charts-crosshair-label[data-axis-id="y"]:not(.ag-charts-crosshair-label--hidden)`
+            )
+        );
+        const xLabels = Array.from(
+            document.querySelectorAll<HTMLElement>(
+                `.ag-charts-crosshair-label[data-axis-id="x"]:not(.ag-charts-crosshair-label--hidden)`
+            )
+        );
+        const visibleText = (els: HTMLElement[]) =>
+            els.map((el) => el.textContent?.trim() ?? '').filter((t) => t.length > 0);
+
+        // The renderer returns undefined; the crosshair label must fall through to the
+        // default formatted value rather than rendering literal "undefined".
+        expect(yLabels.length).toBeGreaterThan(0);
+        expect(xLabels.length).toBeGreaterThan(0);
+        expect(visibleText(xLabels).some((t) => t.includes('undefined'))).toBe(false);
+        expect(visibleText(yLabels).some((t) => t.includes('undefined'))).toBe(false);
+        // Expect the y axis label to contain a numeric default formatted value.
+        expect(visibleText(yLabels).some((t) => /\d/.test(t))).toBe(true);
+    });
 });

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -6,7 +6,10 @@ import {
     Property,
     ZIndexMap,
     createId,
+    isDate,
+    isNumber,
     toPlainText,
+    toTextString,
 } from 'ag-charts-core';
 
 import { readDatum } from '../../utils/datum';
@@ -396,10 +399,16 @@ export class Crosshair extends AbstractModuleInstance {
     private getLabelHtml(value: any, label: CrosshairLabel) {
         const fractionDigits = this.axisLayout?.label?.fractionDigits ?? 0;
         const defaults: AgCrosshairLabelRendererResult = { text: this.formatValue(value) };
-        if (this.label.renderer) {
-            return label.toLabelHtml(this.label.renderer({ value, fractionDigits }), defaults);
+        // Returning `undefined` from the renderer falls through to the default formatted value,
+        // matching the documented Renderer<P, R> contract. Empty strings still render an empty label.
+        // Number/Date returns (TextValue) are coerced via toTextString to keep behaviour consistent
+        // with other Renderer<P, R> consumers.
+        const rendered = this.label.renderer?.({ value, fractionDigits });
+        if (rendered === undefined) {
+            return label.toLabelHtml(defaults);
         }
-        return label.toLabelHtml(defaults);
+        const input = isNumber(rendered) || isDate(rendered) ? toTextString(rendered) : rendered;
+        return label.toLabelHtml(input, defaults);
     }
 
     private showLabel(x: number, y: number, value: any, key: string) {

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -5,11 +5,9 @@ import {
     ChartUpdateType,
     Property,
     ZIndexMap,
+    coerceTextValue,
     createId,
-    isDate,
-    isNumber,
     toPlainText,
-    toTextString,
 } from 'ag-charts-core';
 
 import { readDatum } from '../../utils/datum';
@@ -401,14 +399,11 @@ export class Crosshair extends AbstractModuleInstance {
         const defaults: AgCrosshairLabelRendererResult = { text: this.formatValue(value) };
         // Returning `undefined` from the renderer falls through to the default formatted value,
         // matching the documented Renderer<P, R> contract. Empty strings still render an empty label.
-        // Number/Date returns (TextValue) are coerced via toTextString to keep behaviour consistent
-        // with other Renderer<P, R> consumers.
         const rendered = this.label.renderer?.({ value, fractionDigits });
         if (rendered === undefined) {
             return label.toLabelHtml(defaults);
         }
-        const input = isNumber(rendered) || isDate(rendered) ? toTextString(rendered) : rendered;
-        return label.toLabelHtml(input, defaults);
+        return label.toLabelHtml(coerceTextValue(rendered), defaults);
     }
 
     private showLabel(x: number, y: number, value: any, key: string) {

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -397,10 +397,11 @@ export class Crosshair extends AbstractModuleInstance {
     private getLabelHtml(value: any, label: CrosshairLabel) {
         const fractionDigits = this.axisLayout?.label?.fractionDigits ?? 0;
         const defaults: AgCrosshairLabelRendererResult = { text: this.formatValue(value) };
-        // Returning `undefined` from the renderer falls through to the default formatted value,
-        // matching the documented Renderer<P, R> contract. Empty strings still render an empty label.
+        // Returning `undefined` (or `null`, defensively) from the renderer falls through to the
+        // default formatted value, matching the documented Renderer<P, R> contract. Empty strings
+        // still render an empty label.
         const rendered = this.label.renderer?.({ value, fractionDigits });
-        if (rendered === undefined) {
+        if (rendered == null) {
             return label.toLabelHtml(defaults);
         }
         return label.toLabelHtml(coerceTextValue(rendered), defaults);

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshairLabel.ts
@@ -5,6 +5,7 @@ import type {
     ContextDefault,
     Formatter,
     FormatterParams,
+    Renderer,
     TextValue,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
@@ -40,7 +41,7 @@ export class CrosshairLabelProperties
     format?: string = undefined;
 
     @Property
-    renderer?: (params: AgCrosshairLabelRendererParams) => string | AgCrosshairLabelRendererResult = undefined;
+    renderer?: Renderer<AgCrosshairLabelRendererParams, AgCrosshairLabelRendererResult> = undefined;
 
     private _cachedFormatter: FormatterCache | undefined = undefined;
     formatValue(

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -973,5 +973,28 @@ describe('WaterfallSeries', () => {
             expect(await hoverDatum(2)).toContain('TOTAL-ITEM');
             expect(await hoverDatum(0)).not.toContain('TOTAL-ITEM');
         });
+
+        it('AG-10316 item-level renderer returning undefined falls through to default tooltip content', async () => {
+            const options: AgCartesianChartOptions = {
+                ...TOTALS_OPTIONS,
+                series: [
+                    {
+                        ...(TOTALS_OPTIONS.series![0] as AgWaterfallSeriesOptions),
+                        yName: 'Spending',
+                        item: { positive: { tooltip: { renderer: () => undefined } } },
+                    },
+                ],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            // Returning undefined must fall through to the default structured tooltip
+            // rather than rendering literal "undefined".
+            const html = await hoverDatum(0);
+            expect(html).not.toContain('undefined');
+            expect(html).toContain('Spending');
+        });
     });
 });

--- a/packages/ag-charts-types/eslint.config.mjs
+++ b/packages/ag-charts-types/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
         files: ['**/*.ts'],
         rules: {
             'aglint/require-explicit-generic': 2,
+            'aglint/require-shared-renderer': 2,
         },
     },
 ];

--- a/packages/ag-charts-types/src/chart/callbackOptions.ts
+++ b/packages/ag-charts-types/src/chart/callbackOptions.ts
@@ -71,5 +71,5 @@ export interface DatumItemCallbackParams<
 export type Formatter<P> = (params: P) => TextValue | undefined;
 export type RichFormatter<P> = (params: P) => TextOrSegments | undefined;
 export type Styler<P, S> = (params: P) => S | undefined;
-export type Renderer<P, R> = (params: P) => TextValue | R | undefined;
+export type Renderer<P, R = never> = (params: P) => TextValue | R | undefined;
 export type Listener<E> = (event: E) => void;

--- a/packages/ag-charts-types/src/chart/callbackOptions.ts
+++ b/packages/ag-charts-types/src/chart/callbackOptions.ts
@@ -71,17 +71,5 @@ export interface DatumItemCallbackParams<
 export type Formatter<P> = (params: P) => TextValue | undefined;
 export type RichFormatter<P> = (params: P) => TextOrSegments | undefined;
 export type Styler<P, S> = (params: P) => S | undefined;
-/**
- * Standard renderer callback for content-producing options (tooltips, crosshair labels, overlays, etc.).
- *
- * Return semantics (consumers must follow this convention):
- * - Return a `TextValue` (string/number/Date) or `R` to provide content.
- * - Return `undefined` (or omit a return value) to fall through to the default content
- *   (e.g. `tooltip.text`, the formatted axis value, or the built-in overlay text).
- * - Return an empty string to render empty content. Whether that suppresses the tooltip/label
- *   entirely is a per-consumer choice — tooltip-style consumers treat empty string as "suppress".
- *
- * All `renderer?:` declarations in `ag-charts-types` MUST use this type so the contract is uniform.
- */
 export type Renderer<P, R> = (params: P) => TextValue | R | undefined;
 export type Listener<E> = (event: E) => void;

--- a/packages/ag-charts-types/src/chart/callbackOptions.ts
+++ b/packages/ag-charts-types/src/chart/callbackOptions.ts
@@ -71,5 +71,17 @@ export interface DatumItemCallbackParams<
 export type Formatter<P> = (params: P) => TextValue | undefined;
 export type RichFormatter<P> = (params: P) => TextOrSegments | undefined;
 export type Styler<P, S> = (params: P) => S | undefined;
-export type Renderer<P, R> = (params: P) => TextValue | R;
+/**
+ * Standard renderer callback for content-producing options (tooltips, crosshair labels, overlays, etc.).
+ *
+ * Return semantics (consumers must follow this convention):
+ * - Return a `TextValue` (string/number/Date) or `R` to provide content.
+ * - Return `undefined` (or omit a return value) to fall through to the default content
+ *   (e.g. `tooltip.text`, the formatted axis value, or the built-in overlay text).
+ * - Return an empty string to render empty content. Whether that suppresses the tooltip/label
+ *   entirely is a per-consumer choice — tooltip-style consumers treat empty string as "suppress".
+ *
+ * All `renderer?:` declarations in `ag-charts-types` MUST use this type so the contract is uniform.
+ */
+export type Renderer<P, R> = (params: P) => TextValue | R | undefined;
 export type Listener<E> = (event: E) => void;

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -107,7 +107,7 @@ export interface AgCaptionTooltipOptions<TContext = ContextDefault> {
      *
      * Returning `undefined` falls back to `text` (or the caption's own text). Returning an empty string suppresses the tooltip.
      */
-    renderer?: Renderer<AgCaptionTooltipRendererParams<TContext>, string>;
+    renderer?: Renderer<AgCaptionTooltipRendererParams<TContext>, never>;
 }
 
 export interface AgChartCaptionOptions<TContext = ContextDefault> {

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -102,8 +102,12 @@ export interface AgCaptionTooltipOptions<TContext = ContextDefault> {
     visible?: 'auto' | 'always' | 'never';
     /** Static text to display in the tooltip. Overrides the default caption text. */
     text?: string;
-    /** Function to produce tooltip content. Return a plain string or an HTML string. Takes precedence over `text`. */
-    renderer?: (params: AgCaptionTooltipRendererParams<TContext>) => string;
+    /**
+     * Function to produce tooltip content. Return a plain string or an HTML string. Takes precedence over `text`.
+     *
+     * Returning `undefined` falls back to `text` (or the caption's own text). Returning an empty string suppresses the tooltip.
+     */
+    renderer?: Renderer<AgCaptionTooltipRendererParams<TContext>, string>;
 }
 
 export interface AgChartCaptionOptions<TContext = ContextDefault> {

--- a/packages/ag-charts-types/src/chart/legendOptions.ts
+++ b/packages/ag-charts-types/src/chart/legendOptions.ts
@@ -134,7 +134,7 @@ export interface AgChartLegendItemTooltipOptions<TContext = ContextDefault> {
      * `text` or the default legend item label. Return an empty string to suppress the tooltip.
      *
      * **Note:** Output is rendered as HTML. Ensure content is trusted to avoid XSS. */
-    renderer?: Renderer<AgChartLegendItemTooltipRendererParams<TContext>, string>;
+    renderer?: Renderer<AgChartLegendItemTooltipRendererParams<TContext>, never>;
 }
 
 export interface AgChartLegendItemOptions<TContext = ContextDefault> {

--- a/packages/ag-charts-types/src/chart/legendOptions.ts
+++ b/packages/ag-charts-types/src/chart/legendOptions.ts
@@ -112,8 +112,8 @@ export interface AgChartLegendItemTooltipRendererParams<TContext = ContextDefaul
     itemId: string | number;
     /** The full, untruncated legend item label text. */
     text: string;
-    /** Whether the legend item is currently enabled (series visible). */
-    enabled: boolean;
+    /** Whether the series for this legend item is currently visible. */
+    visible: boolean;
     /** Callback context for this renderer. */
     context?: TContext;
 }
@@ -130,10 +130,11 @@ export interface AgChartLegendItemTooltipOptions<TContext = ContextDefault> {
     /** Static tooltip text shown for all legend items. */
     text?: string;
     /** Function to generate tooltip content per legend item. Returns plain text or an HTML string.
-     * Takes precedence over `text`.
+     * Takes precedence over `text`. Return `undefined` (or omit a return value) to fall back to
+     * `text` or the default legend item label. Return an empty string to suppress the tooltip.
      *
      * **Note:** Output is rendered as HTML. Ensure content is trusted to avoid XSS. */
-    renderer?: (params: AgChartLegendItemTooltipRendererParams<TContext>) => string;
+    renderer?: (params: AgChartLegendItemTooltipRendererParams<TContext>) => string | undefined;
 }
 
 export interface AgChartLegendItemOptions<TContext = ContextDefault> {

--- a/packages/ag-charts-types/src/chart/legendOptions.ts
+++ b/packages/ag-charts-types/src/chart/legendOptions.ts
@@ -1,5 +1,5 @@
 import type { AgColorType, BorderOptions, FillOptions, Padding } from '../series/cartesian/commonOptions';
-import type { Formatter } from './callbackOptions';
+import type { Formatter, Renderer } from './callbackOptions';
 import type { AgPreventableEvent } from './eventOptions';
 import type {
     AgMarkerShape,
@@ -134,7 +134,7 @@ export interface AgChartLegendItemTooltipOptions<TContext = ContextDefault> {
      * `text` or the default legend item label. Return an empty string to suppress the tooltip.
      *
      * **Note:** Output is rendered as HTML. Ensure content is trusted to avoid XSS. */
-    renderer?: (params: AgChartLegendItemTooltipRendererParams<TContext>) => string | undefined;
+    renderer?: Renderer<AgChartLegendItemTooltipRendererParams<TContext>, string>;
 }
 
 export interface AgChartLegendItemOptions<TContext = ContextDefault> {

--- a/packages/ag-charts-website/e2e/caption-tooltip.spec.ts
+++ b/packages/ag-charts-website/e2e/caption-tooltip.spec.ts
@@ -89,6 +89,22 @@ test.describe('caption tooltip', () => {
         await expect(tooltip).not.toBeVisible();
     });
 
+    test('renderer returning undefined falls back to caption text', async ({ page }) => {
+        await page.locator('#undefined-renderer').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Quarterly Revenue');
+    });
+
+    test('renderer returning undefined falls back to tooltip text when set', async ({ page }) => {
+        await page.locator('#undefined-renderer').click();
+        await hoverSubtitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Subtitle fallback text');
+    });
+
     test('auto mode shows tooltip when truncated', async ({ page }) => {
         await page.locator('#truncate').click();
         await hoverTitle(page);

--- a/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/index.html
+++ b/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/index.html
@@ -5,6 +5,7 @@
     <button id="custom-text">Custom Text</button>
     <button id="renderer">Renderer</button>
     <button id="empty-renderer">Empty Renderer</button>
+    <button id="undefined-renderer">Undefined Renderer</button>
     <button id="truncate">Truncate</button>
     <button id="reset">Reset</button>
 </div>

--- a/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/main.ts
+++ b/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/main.ts
@@ -63,6 +63,19 @@ document.getElementById('empty-renderer')!.addEventListener('click', () => {
     chart.update(options);
 });
 
+document.getElementById('undefined-renderer')!.addEventListener('click', () => {
+    options.title!.tooltip = {
+        visible: 'always',
+        renderer: () => undefined,
+    };
+    options.subtitle!.tooltip = {
+        visible: 'always',
+        text: 'Subtitle fallback text',
+        renderer: () => undefined,
+    };
+    chart.update(options);
+});
+
 document.getElementById('truncate')!.addEventListener('click', () => {
     options.title!.maxWidth = 200;
     options.title!.tooltip = undefined;

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-item-tooltip-e2e/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-item-tooltip-e2e/main.ts
@@ -42,8 +42,8 @@ function setMode(mode: string) {
                 item: {
                     label: { maxLength: 5 },
                     tooltip: {
-                        renderer: ({ text, enabled }: AgChartLegendItemTooltipRendererParams) => {
-                            const status = enabled ? 'Visible' : 'Hidden';
+                        renderer: ({ text, visible }: AgChartLegendItemTooltipRendererParams) => {
+                            const status = visible ? 'Visible' : 'Hidden';
                             return `<b>${text}</b> — <em>${status}</em>`;
                         },
                     },

--- a/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend/_examples/legend-item-tooltip/main.ts
@@ -62,8 +62,8 @@ function setTooltipMode(value: string) {
                 item: {
                     label: { maxLength: 10 },
                     tooltip: {
-                        renderer: ({ text, enabled }: AgChartLegendItemTooltipRendererParams) => {
-                            const status = enabled ? 'Visible' : 'Hidden';
+                        renderer: ({ text, visible }: AgChartLegendItemTooltipRendererParams) => {
+                            const status = visible ? 'Visible' : 'Hidden';
                             return `<b>${text}</b><br/><em>${status}</em>`;
                         },
                     },

--- a/packages/ag-charts-website/src/content/docs/legend/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/legend/index.mdoc
@@ -236,16 +236,16 @@ Use the `text` property to set static tooltip text for all items. When `text` is
 }
 ```
 
-For dynamic per-item content, use the `renderer` callback. This receives parameters including the item's `text`, `seriesId`, `itemId`, and `enabled` state.
-The renderer can return plain text or an HTML string.
+For dynamic per-item content, use the `renderer` callback. This receives parameters including the item's `text`, `seriesId`, `itemId`, and `visible` state.
+The renderer can return plain text or an HTML string. Return `undefined` (or omit a return value) to fall back to `text` or the default legend item label; return an empty string to suppress the tooltip.
 
 ```js format="snippet"
 {
     legend: {
         item: {
             tooltip: {
-                renderer: ({ text, enabled }) => {
-                    const status = enabled ? 'Visible' : 'Hidden';
+                renderer: ({ text, visible }) => {
+                    const status = visible ? 'Visible' : 'Hidden';
                     return `<b>${text}</b><br/><em>${status}</em>`;
                 },
             },

--- a/packages/ag-charts-website/src/content/docs/titles/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/titles/index.mdoc
@@ -47,6 +47,8 @@ When `tooltip.text` or `tooltip.renderer` is provided without an explicit `visib
 
 Use `tooltip.text` to display a static tooltip message, or `tooltip.renderer` for dynamic content. The renderer receives the caption's plain text and can return a string or an HTML string.
 
+Return `undefined` from the renderer to fall back to `tooltip.text` (or the caption's own text). Return an empty string to suppress the tooltip.
+
 ```js format="snippet"
 {
     title: {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-10316
https://ag-grid.atlassian.net/browse/AG-11689

Bundles the AG-10316 legend item tooltip follow-up with the AG-11689 caption tooltip fall-through (originally proposed in #6678) plus a global consolidation of renderer signatures onto the shared `Renderer<P, R>` type. Addresses [iMoses's review comment](https://github.com/ag-grid/ag-charts/pull/6677#issuecomment-4333946986) — _"Shouldn't we have a consistent behaviour on all renderers?"_ — by making `Renderer<P, R>` the single canonical renderer type across `ag-charts-types`, with a uniform "empty string suppresses, undefined falls through to default" contract.

#6678 is closed in favour of this PR.

## Summary

### Type-level

- Widen `Renderer<P, R>` from `(params: P) => TextValue | R` to `(params: P) => TextValue | R | undefined`.
- Document the return-value contract on the shared type:
  - Return `TextValue` (string/number/Date) or `R` to provide content.
  - Return `undefined` (or omit) to fall through to the default content.
  - Return `''` to render empty content (tooltip-style consumers treat `''` as "suppress").
- Migrate the two bespoke renderer signatures to use the shared type:
  - `AgCaptionTooltipOptions.renderer` → `Renderer<…, string>`
  - `AgChartLegendItemTooltipOptions.renderer` → `Renderer<…, string>`
- Alias the community-internal `TooltipRenderer<P>` to `Renderer<P, AgTooltipRendererResult>`.
- Add `aglint/require-shared-renderer` lint rule preventing future bespoke renderer signatures.

### Runtime

- Widen runtime validators (caption / overlay / crosshair) so number + Date returns are accepted alongside the existing string / R / HTMLElement options.
- Coerce TextValue (number/Date) via `toTextString` at every Renderer<P, R> consumer call site (legend, caption, overlay, crosshair, waterfall, sparkline) so number/Date returns work consistently.
- Fix call sites that didn't previously honour `undefined`:
  - overlay → fall through to default text branch
  - crosshair label → fall through to `defaults`
  - waterfall + sparkline already handled it correctly via existing structured-tooltip logic; regression tests added.
- Caption tooltip: ported from #6678 — empty string suppresses, undefined falls through to `text ?? captionText`.
- Legend item tooltip:
  - Rename renderer param `enabled` → `visible` to match `AgInitialStateLegendOptions.visible` and the rest of the legend API surface.
  - Undefined falls through to `text` or default legend item label; empty string suppresses.

### Tests / docs / examples

- Regression coverage for undefined fall-through: legend, caption, overlay, crosshair, waterfall, sparkline.
- TextValue (number/Date) regression tests: legend tooltip, overlay.
- Aglint rule snapshot test (catches the 3 bespoke-signature patterns in test data; passes on union/intersection forms).
- Caption e2e: ported #6678's "Undefined Renderer" button + 2 specs.
- Legend example/docs: `enabled` → `visible` rename + new fall-through documentation.
- Titles docs page: fall-through / suppress contract documented.

## Test plan

- [x] `yarn nx format`
- [x] `yarn nx run-many -t build:types -p ag-charts-types,ag-charts-community,ag-charts-enterprise`
- [x] `yarn nx run-many -t lint -p ag-charts-types,ag-charts-community,ag-charts-enterprise`
- [x] `yarn nx test ag-charts-community --testPathPattern="legend|caption|overlay"` (3328 passed)
- [x] `yarn nx test ag-charts-enterprise --testPathPattern="crosshair"` / `--testPathPattern="waterfall"`
- [x] `yarn nx test ag-charts-eslint-rules` (new `require-shared-renderer` snapshot)
- [ ] Playwright e2e on CI (caption + legend item tooltip specs)

Fix #AG-10316
Fix #AG-11689