### PR TITLE
AG-11689 Fall back when caption tooltip renderer returns undefined

### DIFF
--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -51,7 +51,7 @@ class CaptionTooltipProperties extends BaseProperties {
     text?: string;
 
     @Property
-    renderer?: (params: AgCaptionTooltipRendererParams) => string;
+    renderer?: (params: AgCaptionTooltipRendererParams) => string | undefined;
 }
 
 export class Caption extends BaseProperties implements CaptionLike {
@@ -209,7 +209,7 @@ export class Caption extends BaseProperties implements CaptionLike {
             const params: AgCaptionTooltipRendererParams = { text: captionText };
             const result = callWithContext(moduleCtx.chartService, renderer, params);
             if (result === '') return undefined;
-            return { type: 'raw', rawHtmlString: result };
+            if (result != null) return { type: 'raw', rawHtmlString: result };
         }
 
         const displayText = text ?? captionText;

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -102,8 +102,12 @@ export interface AgCaptionTooltipOptions<TContext = ContextDefault> {
     visible?: 'auto' | 'always' | 'never';
     /** Static text to display in the tooltip. Overrides the default caption text. */
     text?: string;
-    /** Function to produce tooltip content. Return a plain string or an HTML string. Takes precedence over `text`. */
-    renderer?: (params: AgCaptionTooltipRendererParams<TContext>) => string;
+    /**
+     * Function to produce tooltip content. Return a plain string or an HTML string. Takes precedence over `text`.
+     *
+     * Returning `undefined` falls back to `text` (or the caption's own text). Returning an empty string suppresses the tooltip.
+     */
+    renderer?: (params: AgCaptionTooltipRendererParams<TContext>) => string | undefined;
 }
 
 export interface AgChartCaptionOptions<TContext = ContextDefault> {

--- a/packages/ag-charts-website/e2e/caption-tooltip.spec.ts
+++ b/packages/ag-charts-website/e2e/caption-tooltip.spec.ts
@@ -89,6 +89,22 @@ test.describe('caption tooltip', () => {
         await expect(tooltip).not.toBeVisible();
     });
 
+    test('renderer returning undefined falls back to caption text', async ({ page }) => {
+        await page.locator('#undefined-renderer').click();
+        await hoverTitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Quarterly Revenue');
+    });
+
+    test('renderer returning undefined falls back to tooltip text when set', async ({ page }) => {
+        await page.locator('#undefined-renderer').click();
+        await hoverSubtitle(page);
+        const tooltip = page.locator(SELECTORS.tooltip);
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toContainText('Subtitle fallback text');
+    });
+
     test('auto mode shows tooltip when truncated', async ({ page }) => {
         await page.locator('#truncate').click();
         await hoverTitle(page);

--- a/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/index.html
+++ b/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/index.html
@@ -5,6 +5,7 @@
     <button id="custom-text">Custom Text</button>
     <button id="renderer">Renderer</button>
     <button id="empty-renderer">Empty Renderer</button>
+    <button id="undefined-renderer">Undefined Renderer</button>
     <button id="truncate">Truncate</button>
     <button id="reset">Reset</button>
 </div>

--- a/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/main.ts
+++ b/packages/ag-charts-website/src/content/docs/layout-test/_examples/e2e-caption-tooltip/main.ts
@@ -63,6 +63,19 @@ document.getElementById('empty-renderer')!.addEventListener('click', () => {
     chart.update(options);
 });
 
+document.getElementById('undefined-renderer')!.addEventListener('click', () => {
+    options.title!.tooltip = {
+        visible: 'always',
+        renderer: () => undefined,
+    };
+    options.subtitle!.tooltip = {
+        visible: 'always',
+        text: 'Subtitle fallback text',
+        renderer: () => undefined,
+    };
+    chart.update(options);
+});
+
 document.getElementById('truncate')!.addEventListener('click', () => {
     options.title!.maxWidth = 200;
     options.title!.tooltip = undefined;

--- a/packages/ag-charts-website/src/content/docs/titles/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/titles/index.mdoc
@@ -47,6 +47,8 @@ When `tooltip.text` or `tooltip.renderer` is provided without an explicit `visib
 
 Use `tooltip.text` to display a static tooltip message, or `tooltip.renderer` for dynamic content. The renderer receives the caption's plain text and can return a string or an HTML string.
 
+Return `undefined` from the renderer to fall back to `tooltip.text` (or the caption's own text). Return an empty string to suppress the tooltip.
+
 ```js format="snippet"
 {
     title: {


### PR DESCRIPTION
## Summary

Addresses David's [AC feedback](https://ag-grid.atlassian.net/browse/AG-11689?focusedCommentId=112198) on AG-11689.

Previously a `tooltip.renderer` that returned `undefined` (or did not return) produced an empty raw HTML tooltip, hiding it entirely. The expected behaviour is to fall back to `tooltip.text` (or the caption's own text). Empty string still suppresses the tooltip per AC 9.2.6.

- `caption.ts` — only consume the renderer result when it is a non-empty string; otherwise fall through to `text ?? captionText`.
- `chartOptions.ts` — widen the renderer return type to `string | undefined` and document the fallback / suppress contract.
- E2E example + tests — adds an Undefined Renderer button and two regression tests covering the title (falls back to caption text) and subtitle (falls back to `tooltip.text`) paths.
- Titles docs page — note the fallback / suppress contract for the renderer.

## Test plan

- [x] `yarn nx build:types ag-charts-community`
- [x] `yarn nx lint ag-charts-community`
- [x] `yarn nx lint ag-charts-types`
- [x] `yarn nx test ag-charts-community --testPathPattern=caption`
- [ ] CI Playwright run for `caption-tooltip.spec.ts`

Fix #AG-11689