### PR TITLE
AG-17015(2) Add `selectionState` to radialUtils.ts itemStyler

### DIFF
--- a/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
@@ -4,6 +4,7 @@ import type {
     AgRadialSeriesStyle,
     AgRadialSeriesStylerParams,
     HighlightState as HighlightStateString,
+    SelectionState as SelectionStateString,
     Styler,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
@@ -55,6 +56,7 @@ interface RadialSectorSeries<D extends BaseNodeDatum> {
         datumIndex?: number
     ): HighlightStateString;
     getSelectionStyle(datumIndex?: number): AgRadialSeriesStyle | undefined;
+    getSelectionStateString(datumIndex: number | undefined): SelectionStateString | undefined;
 }
 
 export function makeStylerParams(
@@ -137,17 +139,20 @@ export function makeItemStylerParams<D extends BaseNodeDatum, S extends RadialSe
 
     const activeHighlight = series.ctx.highlightManager?.getActiveHighlight();
     const highlightStateString = series.getHighlightStateString(activeHighlight, isHighlight, nodeDatum.datumIndex);
+    const selectionStateString = series.getSelectionStateString(nodeDatum.datumIndex);
     const fill = series.filterItemStylerFillParams(style.fill) ?? style.fill;
 
+    type ItemStylerParamRules = CallbackParamRules<AgRadialSeriesItemStylerParams<unknown, never>>;
     return {
         seriesId,
         datum: nodeDatum.datum,
         highlightState: highlightStateString,
+        selectionState: selectionStateString,
         angleKey,
         radiusKey,
         ...style,
         fill,
-    };
+    } satisfies ItemStylerParamRules;
 }
 
 export function getItemStyle<D extends BaseNodeDatum, S extends RadialSectorSeries<D>>(


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17015

Fixes missing `selectionState` in `itemStyler` param to these series:
-   Radial-Bar
-   Radial-Column
-   Nightingale