### PR TITLE
AG-17015(4) Reverse the selection/highlight styling priorities

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -1435,8 +1435,8 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
             const overrides = simpleItemStyler(datum);
             return mergeDefaults(
                 overrides,
-                highlightStyle,
                 selectionStyle,
+                highlightStyle,
                 this.getStyle(false, highlightState)
             ) as Required<AgBarSeriesStyle>;
         }

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -722,7 +722,7 @@ export class DonutSeries extends PolarSeries<
             lineDashOffset,
             cornerRadius,
             opacity,
-        } = mergeDefaults(highlightStyle, selectionStyle, defaultStyle, this.properties);
+        } = mergeDefaults(selectionStyle, highlightStyle, defaultStyle, this.properties);
 
         let overrides: PieDonutSeriesStyle | undefined;
         if (itemStyler) {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1296,8 +1296,8 @@ export abstract class Series<
             ? this.getSelectionStyle(datumIndex, selectionState)
             : undefined;
         const baseStyle = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             defaultOverrideStyle,
             marker.getStyle(),
             inheritedStyle

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -780,8 +780,8 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex, highlightState);
         const selectionStyle = this.getSelectionStyle(datumIndex);
         let style = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             this.getStyle(datumIndex === undefined, highlightState)
         );
 

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeries.ts
@@ -421,8 +421,8 @@ export class ChordSeries extends FlowProportionSeries<
         const highlightStyle = this.getHighlightStyle(isHighlight, nodeDatum.datumIndex);
         const selectionStyle = this.getSelectionStyle(nodeDatum.datumIndex);
         const baseStyle = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             properties.node.getStyle(fills, strokes, fromNodeDatumIndex)
         );
 
@@ -524,8 +524,8 @@ export class ChordSeries extends FlowProportionSeries<
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
         const baseStyle = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             properties.link.getStyle(fills, strokes, fromNodeDatumIndex.index)
         );
 

--- a/packages/ag-charts-enterprise/src/series/funnel/funnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/funnelSeries.ts
@@ -109,7 +109,7 @@ export class FunnelSeries extends BaseFunnelSeries<FunnelSeriesTypes> {
 
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
-        const baseStyle = mergeDefaults(highlightStyle, selectionStyle, properties.getStyle(datumIndex));
+        const baseStyle = mergeDefaults(selectionStyle, highlightStyle, properties.getStyle(datumIndex));
         let style = baseStyle;
 
         if (itemStyler != null) {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -621,7 +621,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         } else {
             fill = 'transparent';
         }
-        const style = mergeDefaults(highlightStyle, selectionStyle, {
+        const style = mergeDefaults(selectionStyle, highlightStyle, {
             fill,
             fillOpacity: 1,
             stroke,

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -1001,7 +1001,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
 
-        return mergeDefaults(highlightStyle, selectionStyle, {
+        return mergeDefaults(selectionStyle, highlightStyle, {
             ...style,
             opacity: 1,
         });

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -489,7 +489,7 @@ export class MapLineSeries
 
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
-        const style = mergeDefaults(highlightStyle, selectionStyle, baseStyle);
+        const style = mergeDefaults(selectionStyle, highlightStyle, baseStyle);
 
         if (sizeValue != null) {
             style.strokeWidth = sizeScale.convert(sizeValue, { clamp: true });

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -776,7 +776,7 @@ export class MapMarkerSeries
 
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
-        const baseStyle = mergeDefaults(highlightStyle, selectionStyle, properties.getStyle());
+        const baseStyle = mergeDefaults(selectionStyle, highlightStyle, properties.getStyle());
 
         if (!isHighlight && colorValue != null) {
             baseStyle.fill = this.isColorScaleValid()

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -557,7 +557,7 @@ export class MapShapeSeries
 
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
-        let style = mergeDefaults(highlightStyle, selectionStyle, baseStyle);
+        let style = mergeDefaults(selectionStyle, highlightStyle, baseStyle);
 
         if (itemStyler != null && datumIndex != null) {
             const overrides = this.cachedDatumCallback(

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -825,7 +825,7 @@ export abstract class OhlcSeriesBase<
             this.getHighlightStyle(isHighlight, datumIndex, highlightState);
         const selectionStyle: (FillOptions & StrokeOptions & LineDashOptions & { opacity?: number }) | undefined =
             this.getSelectionStyle(datumIndex);
-        const baseStyle = mergeDefaults(highlightStyle, selectionStyle, properties.getStyle(itemType));
+        const baseStyle = mergeDefaults(selectionStyle, highlightStyle, properties.getStyle(itemType));
 
         let style = baseStyle;
 

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -468,7 +468,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex, highlightState);
         const selectionStyle = this.getSelectionStyle(datumIndex);
 
-        let style = mergeDefaults(highlightStyle, selectionStyle, this.getNodeDefaultStyle(), {
+        let style = mergeDefaults(selectionStyle, highlightStyle, this.getNodeDefaultStyle(), {
             title: this.getNodeTextDefaultStyle(this.properties.node.title),
             subtitle: this.getNodeTextDefaultStyle(this.properties.node.subtitle),
             labels: this.properties.node.labels.map((label) => this.getNodeTextDefaultStyle(label)),

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -509,7 +509,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
 
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
-        const baseStyle = mergeDefaults(highlightStyle, selectionStyle, properties.getStyle(datumIndex));
+        const baseStyle = mergeDefaults(selectionStyle, highlightStyle, properties.getStyle(datumIndex));
         let style = baseStyle;
 
         if (itemStyler != null && datumIndex != null) {

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -1057,7 +1057,7 @@ export class RadialGaugeSeries
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
 
-        return mergeDefaults(highlightStyle, selectionStyle, {
+        return mergeDefaults(selectionStyle, highlightStyle, {
             ...style,
             opacity: 1,
         });

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -1049,8 +1049,8 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex, highlightState);
         const selectionStyle = this.getSelectionStyle(datumIndex);
         let style = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             this.getStyle(datumIndex === undefined, highlightState)
         );
 

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
@@ -806,8 +806,8 @@ export class SankeySeries extends FlowProportionSeries<
         const highlightStyle = this.getHighlightStyle(isHighlight, nodeDatum.datumIndex);
         const selectionStyle = this.getSelectionStyle(nodeDatum.datumIndex);
         const baseStyle = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             properties.getStyle(false, fills, strokes, fromNodeDatumIndex)
         );
         const hasNodeFill = properties.node.fill != null;
@@ -937,8 +937,8 @@ export class SankeySeries extends FlowProportionSeries<
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
         const baseStyle = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             properties.getStyle(true, fills, strokes, fromNodeDatumIndex.index)
         );
         const hasLinkFill = properties.link.fill != null;

--- a/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
@@ -183,7 +183,7 @@ export class SunburstSeries extends _ModuleSupport.HierarchySeries<
         const highlightState = this.getHierarchyHighlightState(isHighlight, highlightedNode, nodeDatum);
         const highlightStyles = this.getHierarchyHighlightStyles(highlightState, this.properties.highlight);
         const selectionState = this.getSelectionStyle(nodeDatum.datumIndex);
-        const baseStyle = mergeDefaults(highlightStyles, selectionState, properties.getStyle(rootIndex));
+        const baseStyle = mergeDefaults(selectionState, highlightStyles, properties.getStyle(rootIndex));
 
         if (nodeDatum.colorValue != null && highlightStyles?.fill == null) {
             baseStyle.fill = colorScale.convert(nodeDatum.colorValue);

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -349,8 +349,8 @@ export class TreemapSeries extends _ModuleSupport.HierarchySeries<
             : this.getGroupHighlightStyle(groupHighlightState);
         const selectionStyle = this.getSelectionStyle(nodeDatum.datumIndex);
         const baseStyle = mergeDefaults(
-            highlightStyle,
             selectionStyle,
+            highlightStyle,
             properties.getStyle(isLeaf, fills, strokes, index)
         );
 

--- a/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
@@ -167,8 +167,8 @@ export function getItemStyle<D extends BaseNodeDatum, S extends RadialSectorSeri
     const highlightStyle = series.getHighlightStyle(isHighlight, nodeDatum?.datumIndex, highlightState);
     const selectionStyle = series.getSelectionStyle(nodeDatum?.datumIndex);
     const baseStyle = mergeDefaults(
-        highlightStyle,
         selectionStyle,
+        highlightStyle,
         getStyle(series, nodeDatum === undefined, highlightState)
     );
     let style = baseStyle;

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -786,7 +786,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         const item = properties.item[propertyItemId];
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex, highlightState);
         const selectionStyle = this.getSelectionStyle(datumIndex);
-        const baseStyle = mergeDefaults(highlightStyle, selectionStyle, properties.getStyle(itemType));
+        const baseStyle = mergeDefaults(selectionStyle, highlightStyle, properties.getStyle(itemType));
 
         const { itemStyler } = item;
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17015

On staging, the highlight-styling has priority over selection-styling. This is not what the requirements of AG-17017 say:

> 2. Acceptance Criteria:
>
>    c. When an item is both selected and highlighted, styles merge. Selected
>       properties take precedence over highlight properties where they
>       conflict.