### PR TITLE
AG-17015(6) Rewrite the `selectionChange` event logic

### DIFF
--- a/packages/ag-charts-community/src/chart/data/dataSetSelection.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSetSelection.ts
@@ -54,14 +54,6 @@ export class DataSetSelection {
         this.selection = desc.applyToTypedArray(this.selection);
     }
 
-    copyBuffer(): Uint8Array {
-        return new Uint8Array(this.selection);
-    }
-
-    restoreBuffer(buffer: Uint8Array): void {
-        this.selection = buffer;
-    }
-
     // --- Query ---
 
     getLength(): number {

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -17,15 +17,13 @@ import {
     SELECTION_STROKEWIDTH,
 } from './dataSelectionConstants';
 import {
-    type BufferMap,
+    type SelectionChanges,
     clearAllSelections,
-    copySelectionBuffers,
-    diffSelectionBuffers,
     getAllDataSets,
     hasAddToSelectionModifier,
     isAgSelectionItem,
     isUnknownIterable,
-    restoreSelectionBuffers,
+    rollbackChanges,
     setSelected,
     toBBox,
     toggleSelection,
@@ -93,8 +91,8 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
         const { chartService } = this.ctx;
 
-        const bufferMap: BufferMap | undefined = copySelectionBuffers(chartService);
-        clearAllSelections(chartService.series);
+        const changes = this.allocSelectionChanges();
+        clearAllSelections(changes, chartService.series);
 
         if (!isUnknownIterable(items)) {
             Logger.warn('Selection items is not iterable');
@@ -125,12 +123,11 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
                 continue;
             }
 
-            const selection = data.enableSelection(item.seriesId);
-            selection.select(datumIndex);
+            setSelected(changes, series, data, datumIndex);
         }
 
         this.dispatchInternalSelectionChange(chartService.series);
-        this.dispatchExternalSelectionChange('api-call', bufferMap);
+        this.dispatchExternalSelectionChange('api-call', changes);
         this.redraw(ChartUpdateType.FULL);
     }
 
@@ -139,11 +136,11 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
         const { chartService } = this.ctx;
 
-        const bufferMap: BufferMap | undefined = copySelectionBuffers(this.ctx.chartService);
-        clearAllSelections(chartService.series);
+        const changes = this.allocSelectionChanges();
+        clearAllSelections(changes, chartService.series);
 
         this.dispatchInternalSelectionChange(chartService.series);
-        this.dispatchExternalSelectionChange('api-call', bufferMap);
+        this.dispatchExternalSelectionChange('api-call', changes);
         this.redraw(ChartUpdateType.FULL);
     }
 
@@ -166,9 +163,9 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
             return;
         }
 
-        const bufferMap: BufferMap | undefined = copySelectionBuffers(this.ctx.chartService);
+        const changes = this.allocSelectionChanges();
         if (clickMiss) {
-            clearAllSelections(this.ctx.chartService.series);
+            clearAllSelections(changes, this.ctx.chartService.series);
             this.dispatchInternalSelectionChange(this.ctx.chartService.series);
         } else {
             const { data } = clickedNode.series;
@@ -181,15 +178,15 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
             }
 
             if (clickMode === 'multiple' || modifierPressed) {
-                toggleSelection(series, data, datumIndex);
+                toggleSelection(changes, series, data, datumIndex);
             } else {
                 clickMode satisfies 'single';
-                clearAllSelections(this.ctx.chartService.series);
-                setSelected(series, data, datumIndex);
+                clearAllSelections(changes, this.ctx.chartService.series);
+                setSelected(changes, series, data, datumIndex);
             }
             this.dispatchInternalSelectionChange([series]);
         }
-        this.dispatchExternalSelectionChange('user-interaction', bufferMap);
+        this.dispatchExternalSelectionChange('user-interaction', changes);
         this.redraw(ChartUpdateType.FULL);
     }
 
@@ -239,13 +236,13 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
             return;
         }
 
+        const changes = this.allocSelectionChanges();
         const shouldClearSelections: boolean = !hasAddToSelectionModifier(dragEndEvent);
         if (shouldClearSelections) {
-            clearAllSelections(this.ctx.chartService.series);
+            clearAllSelections(changes, this.ctx.chartService.series);
         }
 
         const bbox = toBBox(dragStartEvent, dragEndEvent);
-        const bufferMap: BufferMap | undefined = copySelectionBuffers(this.ctx.chartService);
         const changedSeries: Series[] = [];
 
         for (const series of this.ctx.chartService.series) {
@@ -259,7 +256,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
                 const datumIndex: unknown = datum.datumIndex;
                 if (typeof datumIndex === 'number') {
                     changed = true;
-                    setSelected(series, data, datumIndex);
+                    setSelected(changes, series, data, datumIndex);
                 } else {
                     Logger.errorOnce(`unsupported datumIndex type: ${typeof datumIndex}`);
                 }
@@ -271,7 +268,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         }
 
         this.dispatchInternalSelectionChange(changedSeries);
-        this.dispatchExternalSelectionChange('user-interaction', bufferMap);
+        this.dispatchExternalSelectionChange('user-interaction', changes);
         this.endDrag();
     }
 
@@ -299,12 +296,11 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
     private dispatchExternalSelectionChange(
         source: AgSelectionChangeEventSource,
-        bufferMap: BufferMap | undefined
+        changes: SelectionChanges | undefined
     ): void {
-        if (bufferMap === undefined) return;
+        if (changes === undefined) return;
 
-        const { chartService } = this.ctx;
-        const { added, removed } = diffSelectionBuffers(chartService, bufferMap);
+        const { added, removed } = changes;
 
         if (added.length === 0 && removed.length === 0) {
             // No selection changes to emit.
@@ -325,7 +321,12 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         });
 
         if (defaultPrevented) {
-            restoreSelectionBuffers(chartService, bufferMap);
+            rollbackChanges(changes, this.ctx.chartService.series);
         }
+    }
+
+    private allocSelectionChanges(): SelectionChanges | undefined {
+        if (!this.ctx.chartService.hasListener('selectionChange')) return undefined;
+        return { added: [], removed: [] };
     }
 }

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
@@ -1,15 +1,26 @@
 import type { AgSelectionChangeEvent, AgSelectionItem, AgSelectionItemIds } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import { type AreExact, Logger } from 'ag-charts-core';
+import { type AreExact, type RequireOptional } from 'ag-charts-core';
+
+type ChangeItem = AgSelectionItem<unknown>;
+type SelectionChanges = { added: ChangeItem[]; removed: ChangeItem[] };
+type OptChanges = SelectionChanges | undefined;
 
 type ClickedNode = NonNullable<_ModuleSupport.SeriesAreaClickEvent['clickedNode']>;
 type Series = NonNullable<ClickedNode['series']>;
 type DataSet = _ModuleSupport.DataSet<unknown>;
-type ChartService = _ModuleSupport.ChartRegistry['chartService'];
+type DataSetSelection = _ModuleSupport.DataSetSelection;
 type DragWidgetEvent = _ModuleSupport.DragWidgetEvent;
 
-export type BufferMap = Map<string, Uint8Array>;
-export type BufferDiff = Pick<AgSelectionChangeEvent<unknown, never>, 'added' | 'removed'>;
+export type { SelectionChanges };
+
+function makeChangeItem(seriesId: string, data: DataSet, datumIndex: number): ChangeItem {
+    const itemId = data.getItemIdFromIndex(datumIndex);
+    const datum = data.data[datumIndex];
+    type Rules1 = RequireOptional<AgSelectionChangeEvent<unknown, unknown>['added'][number]>;
+    type Rules2 = RequireOptional<AgSelectionChangeEvent<unknown, unknown>['removed'][number]>;
+    return { seriesId, itemId, datum } satisfies Rules1 satisfies Rules2;
+}
 
 export function toStartAndLength(start: number, end: number): [number, number] {
     if (start > end) {
@@ -28,68 +39,35 @@ export function hasAddToSelectionModifier(event: { sourceEvent: { ctrlKey: boole
     return event.sourceEvent.ctrlKey || event.sourceEvent.metaKey;
 }
 
-export function copySelectionBuffers(chartService: ChartService): BufferMap | undefined {
-    if (!chartService.hasListener('selectionChange')) return undefined;
-
-    const result: BufferMap = new Map();
-    for (const series of chartService.series) {
-        const { data } = series;
-        if (data === undefined) continue;
-
-        const selection = data.enableSelection(series.id);
-        const buffer = selection.copyBuffer();
-        result.set(series.id, buffer);
-    }
-    return result;
-}
-
-export function restoreSelectionBuffers(chartService: ChartService, bufferMap: BufferMap): void {
-    for (const series of chartService.series) {
-        const data = series.data;
-        if (data === undefined) continue;
-
-        const buffer = bufferMap.get(series.id);
-        if (buffer === undefined) continue;
-
-        const selection = data.enableSelection(series.id);
-        selection.restoreBuffer(buffer);
-    }
-}
-
-export function diffSelectionBuffers(chartService: ChartService, bufferMap: BufferMap): BufferDiff {
-    const added: AgSelectionItem<unknown>[] = [];
-    const removed: AgSelectionItem<unknown>[] = [];
-
-    function makeAgSelectionItem(seriesId: string, index: number, data: DataSet): AgSelectionItem<unknown> {
-        const datum = data.data[index];
-        const itemId = data.getIdArray()?.[index] ?? index;
-        return { seriesId, datum, itemId };
-    }
-
-    for (const series of chartService.series) {
-        const data = series.data;
-        if (data === undefined) continue;
-
-        const oldBuffer = bufferMap.get(series.id);
-        if (oldBuffer === undefined) continue;
-
-        const selection = data.enableSelection(series.id);
-        const newBuffer = selection.getSelection();
-
-        if (oldBuffer.length !== newBuffer.length) {
-            Logger.error(`length mismatch (seriesId: ${series.id}): ${oldBuffer.length} !== ${newBuffer.length}`);
-            continue;
-        }
-
-        for (let i = 0; i < oldBuffer.length; i++) {
-            if (oldBuffer[i] && !newBuffer[i]) {
-                removed.push(makeAgSelectionItem(series.id, i, data));
-            } else if (!oldBuffer[i] && newBuffer[i]) {
-                added.push(makeAgSelectionItem(series.id, i, data));
-            }
+export function rollbackChanges(changes: SelectionChanges, allSeries: Series[]): void {
+    type K = Series['id'];
+    type V = { dataSet: DataSet; selection: DataSetSelection };
+    const seriesMap = new Map<K, V>();
+    for (const dataSet of getAllDataSets(allSeries)) {
+        for (const [seriesId, selection] of dataSet.selections) {
+            seriesMap.set(seriesId, { dataSet, selection });
         }
     }
-    return { added, removed };
+
+    for (const change of changes.added) {
+        const entry = seriesMap.get(change.seriesId);
+        if (entry === undefined) return undefined;
+
+        const datumIndex = entry.dataSet.getIndexFromItemId(change.itemId);
+        if (datumIndex === undefined) continue;
+
+        entry.selection.deselect(datumIndex);
+    }
+
+    for (const change of changes.removed) {
+        const entry = seriesMap.get(change.seriesId);
+        if (entry === undefined) continue;
+
+        const datumIndex = entry.dataSet.getIndexFromItemId(change.itemId);
+        if (datumIndex === undefined) continue;
+
+        entry.selection.select(datumIndex);
+    }
 }
 
 export function getAllDataSets(allSeries: Series[]): Set<DataSet> {
@@ -102,18 +80,39 @@ export function getAllDataSets(allSeries: Series[]): Set<DataSet> {
     return result;
 }
 
-export function toggleSelection(series: Series, data: DataSet, datumIndex: number): void {
+export function toggleSelection(changes: OptChanges, series: Series, data: DataSet, datumIndex: number): void {
     const selections = data.enableSelection(series.id);
+    if (changes !== undefined) {
+        const item = makeChangeItem(series.id, data, datumIndex);
+        if (selections.isSelected(datumIndex)) {
+            changes.removed.push(item);
+        } else {
+            changes.added.push(item);
+        }
+    }
     selections.toggle(datumIndex);
 }
 
-export function setSelected(series: Series, data: DataSet, datumIndex: number): void {
+export function setSelected(changes: OptChanges, series: Series, data: DataSet, datumIndex: number): void {
     const selections = data.enableSelection(series.id);
+    if (changes !== undefined && !selections.isSelected(datumIndex)) {
+        changes.added.push(makeChangeItem(series.id, data, datumIndex));
+    }
     selections.select(datumIndex);
 }
 
-export function clearAllSelections(allSeries: Series[]): void {
+export function clearAllSelections(changes: OptChanges, allSeries: Series[]): void {
     const dataSets = getAllDataSets(allSeries);
+    if (changes !== undefined) {
+        for (const data of dataSets) {
+            for (const [seriesId, selection] of data.selections) {
+                const n = selection.getLength();
+                for (let datumIndex = 0; datumIndex < n; datumIndex++) {
+                    changes.removed.push(makeChangeItem(seriesId, data, datumIndex));
+                }
+            }
+        }
+    }
     for (const data of dataSets) {
         data.selections.clear();
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17015

This new behaviour avoids the need for copying the dataSetSelection.ts internal buffer, and it will make it easier to implement `selectionState:'none'` by making it easier to track the selection count.