### PR TITLE
AG-17015(7) Keep count of the number items selected

### DIFF
--- a/packages/ag-charts-community/src/chart/chartState.ts
+++ b/packages/ag-charts-community/src/chart/chartState.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgActiveItemState, AgChartOptions } from 'ag-charts-types';
 
 import type { HighlightNodeDatum } from '../core/eventsHub';
+import type { DataSelectionState } from './data/dataSelectionState';
 import type { CategoryLegendDatum } from './legend/legendDatum';
 
 export type ResolvedChartOptions = Omit<AgChartOptions, 'legend' | 'selection' | 'zoom'> & {
@@ -23,4 +24,5 @@ export interface ChartState {
     legendVisible: boolean;
     zoom: ZoomState | undefined;
     initialZoom: ZoomState | undefined;
+    selectionState: DataSelectionState | undefined;
 }

--- a/packages/ag-charts-community/src/chart/data/dataSelectionState.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSelectionState.ts
@@ -1,0 +1,3 @@
+export type DataSelectionState = {
+    selectedCount: number;
+};

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -261,6 +261,11 @@ export abstract class DataModelSeries<
     protected override getDataSelectionState(datumIndex: number | undefined): SelectionState | undefined {
         if (datumIndex === undefined || !this.properties.selection.enabled) return undefined;
 
+        const selectionState = this.ctx.chartState.getValue('selectionState');
+        if (selectionState === undefined) return undefined;
+
+        if (selectionState.selectedCount === 0) return SelectionState.None;
+
         const isSelected: boolean = this.data?.selections.get(this.id)?.isSelected(datumIndex) ?? false;
         return isSelected ? SelectionState.Selected : SelectionState.Unselected;
     }

--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -36,6 +36,7 @@ export enum HighlightState {
 }
 
 export enum SelectionState {
+    None,
     Selected,
     Unselected,
 }

--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -78,6 +78,8 @@ export function getSelectionStyleOptionKeys(selectionState: SelectionState): Sel
             return ['selectedItem'];
         case SelectionState.Unselected:
             return ['unselectedItem'];
+        case SelectionState.None:
+            return [];
         default: {
             const unreachable = (a: never): never => a;
             return unreachable(selectionState);
@@ -121,6 +123,8 @@ export function toSelectionString(state: SelectionState): PublicSelectionState {
             return 'selected';
         case SelectionState.Unselected:
             return 'unselected';
+        case SelectionState.None:
+            return 'none';
         default:
             return unreachable(state);
     }

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -126,6 +126,7 @@ export type {
     UngroupedData,
 } from './chart/data/dataModel';
 export { DataSet, DataSetSelection, type TransactionCollectionState } from './chart/data/dataSet';
+export type { DataSelectionState } from './chart/data/dataSelectionState';
 export {
     accumulativeValueProperty,
     animationValidation,

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -34,6 +34,7 @@ type Series = NonNullable<NonNullable<_ModuleSupport.SeriesAreaClickEvent['click
 export class DataSelection extends AbstractModuleInstance implements _ModuleSupport.SelectionModuleFns {
     private dragStartEvent?: _Widget.DragWidgetEvent<'drag-start'>;
     private readonly dragRect: _ModuleSupport.Rect;
+    private readonly state: _ModuleSupport.DataSelectionState;
 
     private get opts(): NormalisedSelectionOptions {
         return this.ctx.chartState.getValue('options', 'selection');
@@ -48,6 +49,9 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
     constructor(private readonly ctx: DynamicContext<_ModuleSupport.ChartRegistry>) {
         super();
+
+        this.state = { selectedCount: 0 };
+        ctx.chartState.setValue('selectionState', this.state);
 
         this.dragRect = new _ModuleSupport.Rect();
         this.dragRect.fill = SELECTION_FILL_VALID;
@@ -64,7 +68,8 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
             ctx.widgets.seriesDragInterpreter?.events.on('drag-start', (ev) => this.onSeriesAreaDragStart(ev)),
             ctx.widgets.seriesDragInterpreter?.events.on('drag-move', (ev) => this.onSeriesAreaDragMove(ev)),
             ctx.widgets.seriesDragInterpreter?.events.on('drag-end', (ev) => this.onSeriesAreaDragEnd(ev)),
-            ctx.widgets.seriesWidget.addListener('keydown', (ev) => this.onKeyDown(ev))
+            ctx.widgets.seriesWidget.addListener('keydown', (ev) => this.onKeyDown(ev)),
+            () => ctx.chartState.setValue('selectionState', undefined)
         );
     }
 
@@ -92,7 +97,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const { chartService } = this.ctx;
 
         const changes = this.allocSelectionChanges();
-        clearAllSelections(changes, chartService.series);
+        clearAllSelections(changes, this.state, chartService.series);
 
         if (!isUnknownIterable(items)) {
             Logger.warn('Selection items is not iterable');
@@ -126,7 +131,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
             setSelected(changes, series, data, datumIndex);
         }
 
-        this.dispatchInternalSelectionChange(chartService.series);
+        this.dispatchInternalSelectionChange(chartService.series, changes);
         this.dispatchExternalSelectionChange('api-call', changes);
         this.redraw(ChartUpdateType.FULL);
     }
@@ -137,9 +142,9 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const { chartService } = this.ctx;
 
         const changes = this.allocSelectionChanges();
-        clearAllSelections(changes, chartService.series);
+        clearAllSelections(changes, this.state, chartService.series);
 
-        this.dispatchInternalSelectionChange(chartService.series);
+        this.dispatchInternalSelectionChange(chartService.series, changes);
         this.dispatchExternalSelectionChange('api-call', changes);
         this.redraw(ChartUpdateType.FULL);
     }
@@ -165,8 +170,8 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
         const changes = this.allocSelectionChanges();
         if (clickMiss) {
-            clearAllSelections(changes, this.ctx.chartService.series);
-            this.dispatchInternalSelectionChange(this.ctx.chartService.series);
+            clearAllSelections(changes, this.state, this.ctx.chartService.series);
+            this.dispatchInternalSelectionChange(this.ctx.chartService.series, changes);
         } else {
             const { data } = clickedNode.series;
             if (data === undefined) return;
@@ -181,10 +186,10 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
                 toggleSelection(changes, series, data, datumIndex);
             } else {
                 clickMode satisfies 'single';
-                clearAllSelections(changes, this.ctx.chartService.series);
+                clearAllSelections(changes, this.state, this.ctx.chartService.series);
                 setSelected(changes, series, data, datumIndex);
             }
-            this.dispatchInternalSelectionChange([series]);
+            this.dispatchInternalSelectionChange([series], changes);
         }
         this.dispatchExternalSelectionChange('user-interaction', changes);
         this.redraw(ChartUpdateType.FULL);
@@ -239,7 +244,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const changes = this.allocSelectionChanges();
         const shouldClearSelections: boolean = !hasAddToSelectionModifier(dragEndEvent);
         if (shouldClearSelections) {
-            clearAllSelections(changes, this.ctx.chartService.series);
+            clearAllSelections(changes, this.state, this.ctx.chartService.series);
         }
 
         const bbox = toBBox(dragStartEvent, dragEndEvent);
@@ -267,7 +272,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
             }
         }
 
-        this.dispatchInternalSelectionChange(changedSeries);
+        this.dispatchInternalSelectionChange(changedSeries, changes);
         this.dispatchExternalSelectionChange('user-interaction', changes);
         this.endDrag();
     }
@@ -288,17 +293,15 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         this.ctx.eventsHub.emit('chart:request-update', { type, opts: { skipAnimations: true } });
     }
 
-    private dispatchInternalSelectionChange(changedSeries: Series[]): void {
+    private dispatchInternalSelectionChange(changedSeries: Series[], changes: SelectionChanges): void {
+        this.state.selectedCount += changes.countDelta;
         for (const series of changedSeries) {
             series.events.emit('data-selection-change', null);
         }
     }
 
-    private dispatchExternalSelectionChange(
-        source: AgSelectionChangeEventSource,
-        changes: SelectionChanges | undefined
-    ): void {
-        if (changes === undefined) return;
+    private dispatchExternalSelectionChange(source: AgSelectionChangeEventSource, changes: SelectionChanges): void {
+        if (changes.added === undefined) return;
 
         const { added, removed } = changes;
 
@@ -322,11 +325,12 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
         if (defaultPrevented) {
             rollbackChanges(changes, this.ctx.chartService.series);
+            this.state.selectedCount -= changes.countDelta;
         }
     }
 
-    private allocSelectionChanges(): SelectionChanges | undefined {
-        if (!this.ctx.chartService.hasListener('selectionChange')) return undefined;
-        return { added: [], removed: [] };
+    private allocSelectionChanges(): SelectionChanges {
+        if (!this.ctx.chartService.hasListener('selectionChange')) return { countDelta: 0 };
+        return { countDelta: 0, added: [], removed: [] };
     }
 }

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
@@ -3,16 +3,19 @@ import { _ModuleSupport } from 'ag-charts-community';
 import { type AreExact, type RequireOptional } from 'ag-charts-core';
 
 type ChangeItem = AgSelectionItem<unknown>;
-type SelectionChanges = { added: ChangeItem[]; removed: ChangeItem[] };
-type OptChanges = SelectionChanges | undefined;
+type SelectionChangesWithItems = { countDelta: number; added: ChangeItem[]; removed: ChangeItem[] };
+type SelectionChangesDeltaOnly = { countDelta: number; added?: never; removed?: never };
+type Changes = SelectionChanges;
 
-type ClickedNode = NonNullable<_ModuleSupport.SeriesAreaClickEvent['clickedNode']>;
 type Series = NonNullable<ClickedNode['series']>;
 type DataSet = _ModuleSupport.DataSet<unknown>;
+type State = _ModuleSupport.DataSelectionState;
+
+type ClickedNode = NonNullable<_ModuleSupport.SeriesAreaClickEvent['clickedNode']>;
 type DataSetSelection = _ModuleSupport.DataSetSelection;
 type DragWidgetEvent = _ModuleSupport.DragWidgetEvent;
 
-export type { SelectionChanges };
+export type SelectionChanges = SelectionChangesWithItems | SelectionChangesDeltaOnly;
 
 function makeChangeItem(seriesId: string, data: DataSet, datumIndex: number): ChangeItem {
     const itemId = data.getItemIdFromIndex(datumIndex);
@@ -39,7 +42,7 @@ export function hasAddToSelectionModifier(event: { sourceEvent: { ctrlKey: boole
     return event.sourceEvent.ctrlKey || event.sourceEvent.metaKey;
 }
 
-export function rollbackChanges(changes: SelectionChanges, allSeries: Series[]): void {
+export function rollbackChanges(changes: SelectionChangesWithItems, allSeries: Series[]): void {
     type K = Series['id'];
     type V = { dataSet: DataSet; selection: DataSetSelection };
     const seriesMap = new Map<K, V>();
@@ -80,30 +83,34 @@ export function getAllDataSets(allSeries: Series[]): Set<DataSet> {
     return result;
 }
 
-export function toggleSelection(changes: OptChanges, series: Series, data: DataSet, datumIndex: number): void {
+export function toggleSelection(changes: Changes, series: Series, data: DataSet, datumIndex: number): void {
     const selections = data.enableSelection(series.id);
-    if (changes !== undefined) {
+    const wasSelected = selections.isSelected(datumIndex);
+    if (changes?.removed !== undefined) {
         const item = makeChangeItem(series.id, data, datumIndex);
-        if (selections.isSelected(datumIndex)) {
+        if (wasSelected) {
             changes.removed.push(item);
         } else {
             changes.added.push(item);
         }
     }
+    changes.countDelta += wasSelected ? -1 : 1;
     selections.toggle(datumIndex);
 }
 
-export function setSelected(changes: OptChanges, series: Series, data: DataSet, datumIndex: number): void {
+export function setSelected(changes: Changes, series: Series, data: DataSet, datumIndex: number): void {
     const selections = data.enableSelection(series.id);
-    if (changes !== undefined && !selections.isSelected(datumIndex)) {
+    const wasSelected = selections.isSelected(datumIndex);
+    if (changes.added !== undefined && !wasSelected) {
         changes.added.push(makeChangeItem(series.id, data, datumIndex));
     }
+    changes.countDelta += Number(!wasSelected);
     selections.select(datumIndex);
 }
 
-export function clearAllSelections(changes: OptChanges, allSeries: Series[]): void {
+export function clearAllSelections(changes: Changes, state: State, allSeries: Series[]): void {
     const dataSets = getAllDataSets(allSeries);
-    if (changes !== undefined) {
+    if (changes.removed !== undefined) {
         for (const data of dataSets) {
             for (const [seriesId, selection] of data.selections) {
                 const n = selection.getLength();
@@ -116,6 +123,7 @@ export function clearAllSelections(changes: OptChanges, allSeries: Series[]): vo
     for (const data of dataSets) {
         data.selections.clear();
     }
+    state.selectedCount = 0;
 }
 
 export function isUnknownIterable(value: unknown): value is Iterable<unknown> {

--- a/packages/ag-charts-types/src/chart/callbackOptions.ts
+++ b/packages/ag-charts-types/src/chart/callbackOptions.ts
@@ -25,7 +25,7 @@ export type HighlightState =
     | 'unhighlighted-series'
     | 'none';
 
-export type SelectionState = 'selected' | 'unselected';
+export type SelectionState = 'none' | 'selected' | 'unselected';
 
 /**
  * Highlight states for hierarchical series (e.g., treemap, sunburst) that support


### PR DESCRIPTION
This allows us to provide a `selectionState: 'none'` property when no items are selected.