### PR TITLE
AG-17186 Remove dead highlightState from link.itemStyler params

### DIFF
--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -694,7 +694,6 @@ export class OrganizationSeries extends AbstractNetworkSeries<
             fromDatum,
             toDatum,
             seriesId,
-            highlightState: 'none',
             selectionState: 'unselected',
         } satisfies CallbackParamRules<AgOrganizationSeriesLinkItemStylerParams<unknown, unknown>>;
     }

--- a/packages/ag-charts-types/src/series/standalone/organizationOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/organizationOptions.ts
@@ -159,7 +159,7 @@ export interface AgOrganizationNodeTextFormatterParams<TDatum = DatumDefault, TC
 }
 
 export interface AgOrganizationSeriesLinkItemStylerParams<TDatum = DatumDefault, TContext = ContextDefault>
-    extends Omit<DatumCallbackParams<TDatum, HighlightState>, 'datum'>,
+    extends Omit<DatumCallbackParams<TDatum, HighlightState>, 'datum' | 'highlightState'>,
         ContextCallbackParams<TContext>,
         AgOrganizationSeriesLinkStyle {
     /** The data point from which the link starts. */

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-13-3/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-13-3/index.mdoc
@@ -1,0 +1,95 @@
+---
+title: 'Upgrade to AG Charts 13.3'
+description: "See what's new in AG Charts v13.3. View a full list of breaking changes, behaviour changes and deprecations. Read the release post for feature highlights."
+migrationVersion: '13.3.0'
+---
+
+## What's New
+
+<!-- Description with !BLOG_LINK! -->
+
+See the [release post](https://blog.ag-grid.com/whats-new-in-ag-charts-13-3/) for feature highlights of what's new in this version.
+
+Users of integrated charting on AG Grid, should refer to this migration guide when upgrading to AG Grid {% gridVersion() %}.
+
+<!--
+Documentation to the highest patch release of the major/minor
+NOTE: This will not show if the current library version is the same as the migration version.
+DO NOT TOUCH.
+-->
+
+{% documentationArchiveSection version=migrationVersionPatch() /%}
+
+## Breaking Changes
+
+The full list of breaking changes across all features for version {% migrationVersion() %}.
+
+{% expandingSection headerText="Breaking Changes" %}
+This release includes the following breaking changes:
+
+### Organization Series
+
+-   `link.itemStyler` callback params no longer include `highlightState`. The value was always `'none'` and provided no signal. Remove any reference to it from existing `link.itemStyler` implementations.
+
+{% /expandingSection %}
+
+## Behaviour Changes
+
+<!-- If behaviour changes do *not* exist, add the following: -->
+
+There are no behaviour changes in AG Charts version {% migrationVersion() %}.
+
+<!-- Otherwise -->
+<!--
+The full list of behaviour changes across all features for version {% migrationVersion() %}.
+
+{% expandingSection headerText="Behaviour Changes" %}
+
+This release includes the following behaviour changes:
+
+### Behaviour Changes section Name
+
+- item...
+
+{% /expandingSection %}
+-->
+
+## Removal of Deprecated APIs
+
+<!-- If there are *no* deprecated APIs, add the following: -->
+
+There are no deprecated APIs removed in AG Charts version {% migrationVersion() %}.
+
+<!-- Otherwise: -->
+<!--
+The following APIs have been deprecated since version !PREV_x.x! and have now been removed.
+
+{% expandingSection headerText="Removed Deprecated APIs" %}
+
+### Deprecated APIs section Name
+
+- item...
+
+{% /expandingSection %}
+-->
+
+## Deprecations
+
+<!-- If there are *no* deprecations, add the following: -->
+
+There are no deprecations in AG Charts version {% migrationVersion() %}.
+
+<!-- Otherwise: -->
+<!--
+{% expandingSection headerText="Deprecations" %}
+
+### Deprecation section Name
+
+- item...
+
+{% /expandingSection %}
+-->
+
+<!-- Changelog for the `migrationVersion` property DO NOT TOUCH -->
+
+{% changelogSection version=$migrationVersion /%}


### PR DESCRIPTION
## Summary

- Stacked on #6696 (AG-17185).
- `link.itemStyler` callback params surfaced `highlightState`, but the runtime always emitted `'none'` regardless of which node was highlighted, providing no signal. Drop the field from the public type (widen the `Omit` on the inherited `DatumCallbackParams`) and from the runtime params builder.
- Re-introducing the field with `'highlighted-branch'` / `'unhighlighted-branch'` values is **deferred to a post-MVP follow-up sub-task** paired with AG-17187.
- Seeds `upgrade-to-ag-charts-13-3/index.mdoc` with a Breaking Changes entry for the removal; release-prep can amend with the rest of the breaking changes for the version.

JIRA: [AG-17186](https://ag-grid.atlassian.net/browse/AG-17186) — title + description updated to V1-only scope (manual edit pending).

## Test plan

- [x] `yarn nx test ag-charts-enterprise` (full suite green; no link rendering regression).
- [x] `yarn nx build:types` clean — type-level break is intentional and documented.
- [x] `yarn nx lint ag-charts-types`, `yarn nx lint ag-charts-enterprise` — 0 errors.

## Breaking change

`AgOrganizationSeriesLinkItemStylerParams` no longer carries a `highlightState` field. TypeScript consumers reading the field will hit a compile error; runtime semantics for any guard like `params.highlightState === 'none'` are preserved (`undefined === 'none'` is also `false`).