### PR TITLE
AG-17005 When `selection.enabled`, hide marker using `size:0`

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -90,9 +90,9 @@ import type {
 } from './cartesianSeriesTypes';
 import { type LinePathSpan, type LineSpanPointDatum, interpolatePoints, plotLinePathStroke } from './lineUtil';
 import {
+    cartesianMarkerDrawMode,
     computeMarkerFocusBounds,
     getMarkerStyles,
-    markerEnabled,
     markerFadeInAnimation,
     markerSwipeScaleInAnimation,
     resetMarkerFn,
@@ -187,6 +187,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
     override connectsToYAxis = true;
 
     private readonly aggregationManager = new AggregationManager<AreaSeriesDataAggregationFilter>();
+    private hideWithSize0 = false;
 
     readonly backgroundGroup = new Group({
         name: `${this.id}-background`,
@@ -1261,16 +1262,22 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
 
         const markerStyle = styler ? this.getStyle().marker : undefined;
 
-        const markersEnabled =
-            contextNodeData?.crossFiltering === true ||
-            markerEnabled(processedData!.input.count, axes[ChartAxisDirection.X]!.scale, marker, markerStyle);
+        const markerDrawMode = cartesianMarkerDrawMode(
+            properties,
+            contextNodeData,
+            processedData!,
+            axes,
+            marker,
+            markerStyle
+        );
+        this.hideWithSize0 = markerDrawMode.hideWithSize0;
 
         if (marker.isDirty()) {
             datumSelection.clear();
             datumSelection.cleanup();
         }
 
-        const data = markersEnabled ? nodeData : [];
+        const data = markerDrawMode.needsNodeData ? nodeData : [];
         if (!processedDataIsAnimatable(this.processedData!)) {
             // Optimised update path, no need to match nodes by id
             return datumSelection.update(data);
@@ -1282,6 +1289,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         datumSelection: Selection<MarkerSelectionDatum, Marker<MarkerSelectionDatum>>;
         isHighlight: boolean;
     }) {
+        const { hideWithSize0 } = this;
         const { datumSelection, isHighlight } = opts;
         const { marker } = this.properties;
 
@@ -1302,7 +1310,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                     marker,
                     datum,
                     params,
-                    { isHighlight, highlightState },
+                    { isHighlight, highlightState, hideWithSize0 },
                     stylerStyle.marker,
                     {
                         stroke,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -71,9 +71,9 @@ import {
     prepareLinePathAnimation,
 } from './lineUtil';
 import {
+    cartesianMarkerDrawMode,
     computeMarkerFocusBounds,
     getMarkerStyles,
-    markerEnabled,
     markerFadeInAnimation,
     markerSwipeScaleInAnimation,
     resetMarkerFn,
@@ -107,6 +107,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
     override properties = new LineSeriesProperties();
 
     private readonly aggregationManager = new AggregationManager<LineSeriesDataAggregationFilter>();
+    private hideWithSize0 = false;
 
     override get pickModeAxis() {
         return this.properties.sparklineMode ? 'main' : 'main-category';
@@ -663,11 +664,9 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         const { contextNodeData, processedData, axes, properties } = this;
         const { marker } = properties;
 
-        const markersEnabled =
-            contextNodeData?.crossFiltering === true ||
-            markerEnabled(processedData!.input.count, axes[ChartAxisDirection.X]!.scale, marker);
-
-        nodeData = markersEnabled ? nodeData : [];
+        const markerDrawMode = cartesianMarkerDrawMode(properties, contextNodeData, processedData!, axes, marker);
+        this.hideWithSize0 = markerDrawMode.hideWithSize0;
+        nodeData = markerDrawMode.needsNodeData ? nodeData : [];
 
         if (marker.isDirty()) {
             datumSelection.clear();
@@ -685,6 +684,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         datumSelection: Selection<LineNodeDatum, Marker<LineNodeDatum>>;
         isHighlight: boolean;
     }) {
+        const { hideWithSize0 } = this;
         const { datumSelection, isHighlight } = opts;
         const { marker } = this.properties;
 
@@ -705,7 +705,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                     marker,
                     datum,
                     params,
-                    { isHighlight, highlightState },
+                    { isHighlight, highlightState, hideWithSize0 },
                     stylerStyle.marker,
                     {
                         stroke,

--- a/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
@@ -1,5 +1,5 @@
 import type { Point, Scale, SizedPoint } from 'ag-charts-core';
-import { clamp, findRangeExtent, inverseEaseOut } from 'ag-charts-core';
+import { ChartAxisDirection, clamp, findRangeExtent, inverseEaseOut } from 'ag-charts-core';
 import type { AgDrawingMode, AgMarkerShape, AgSeriesMarkerStyle } from 'ag-charts-types';
 
 import { QUICK_TRANSITION } from '../../../motion/animation';
@@ -167,11 +167,11 @@ export function computeMarkerFocusBounds<TDatum extends MarkerNodeDatum>(
     return Transformable.toCanvas(series.contentGroup, new BBox(x, y, paddedSize, paddedSize));
 }
 
-export function markerEnabled(
+function markerEnabled(
     dataCount: number,
     scale: Scale<unknown, number, unknown>,
     marker: { enabled: boolean },
-    markerStyle: { enabled?: boolean } = marker
+    markerStyle: { enabled?: boolean }
 ) {
     const enabled = markerStyle.enabled ?? marker.enabled;
     if (!enabled) return false;
@@ -180,6 +180,30 @@ export function markerEnabled(
 
     const step = scale.step ?? findRangeExtent(scale.range) / Math.max(1, dataCount);
     return step > minSpacing;
+}
+
+type CartesianMarkerDrawMode = {
+    needsNodeData: boolean;
+    hideWithSize0: boolean;
+};
+export function cartesianMarkerDrawMode(
+    properties: { selection: { enabled: boolean } },
+    contextNodeData: { crossFiltering?: boolean } | undefined,
+    processedData: { input: { count: number } },
+    axes: { [ChartAxisDirection.X]?: { scale: Scale<unknown, number, unknown> } },
+    marker: { enabled: boolean },
+    markerStyle: { enabled?: boolean } = marker
+): CartesianMarkerDrawMode {
+    const markersEnabled =
+        contextNodeData?.crossFiltering === true ||
+        markerEnabled(processedData!.input.count, axes[ChartAxisDirection.X]!.scale, marker, markerStyle);
+
+    if (properties.selection.enabled) {
+        // selection.enabled needs NodeData for selected-style overrides to function.
+        return { needsNodeData: true, hideWithSize0: !markersEnabled };
+    } else {
+        return { needsNodeData: markersEnabled, hideWithSize0: false };
+    }
 }
 
 type SeriesStyler<TStylerParams, TStylerResult> = (params: TStylerParams) => TStylerResult;

--- a/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
@@ -196,7 +196,7 @@ export function cartesianMarkerDrawMode(
 ): CartesianMarkerDrawMode {
     const markersEnabled =
         contextNodeData?.crossFiltering === true ||
-        markerEnabled(processedData!.input.count, axes[ChartAxisDirection.X]!.scale, marker, markerStyle);
+        markerEnabled(processedData.input.count, axes[ChartAxisDirection.X]!.scale, marker, markerStyle);
 
     if (properties.selection.enabled) {
         // selection.enabled needs NodeData for selected-style overrides to function.

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1,5 +1,4 @@
 import type {
-    AreExact,
     BoxBounds,
     ChartAnimationPhase,
     DomainWithMetadata,
@@ -78,7 +77,7 @@ import type { Marker } from '../marker/marker';
 import type { TooltipContent, TooltipStructuredContent } from '../tooltip/tooltip';
 import { getItemId } from './pickManager';
 import type { SeriesMarker } from './seriesMarker';
-import { HighlightState, SelectionState, toHighlightString, toSelectionString } from './seriesProperties';
+import { HighlightState, SelectionState, isSelected, toHighlightString, toSelectionString } from './seriesProperties';
 import type { SeriesProperties } from './seriesProperties';
 import type { SeriesGrouping } from './seriesStateManager';
 import type { SeriesTooltip } from './seriesTooltip';
@@ -1284,10 +1283,7 @@ export abstract class Series<
         const selectionState: SelectionState | undefined = this.getDataSelectionState(datumIndex);
         const resolvePath = ['series', `${this.declarationOrder}`, ...resolveMarkerSubPath];
 
-        if (hideWithSize0 && (selectionState === SelectionState.None || selectionState === SelectionState.Unselected)) {
-            type ActualComplement = Exclude<SelectionState, typeof selectionState>;
-            type ExpectedComplement = SelectionState.Selected;
-            true satisfies AreExact<ActualComplement, ExpectedComplement>;
+        if (hideWithSize0 && isSelected(selectionState)) {
             return { size: 0 } satisfies AgSeriesMarkerStyle;
         }
 

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1,4 +1,5 @@
 import type {
+    AreExact,
     BoxBounds,
     ChartAnimationPhase,
     DomainWithMetadata,
@@ -1266,6 +1267,7 @@ export abstract class Series<
             checkForHighlight?: boolean;
             resolveMarkerSubPath?: string[];
             resolveStyler?: boolean;
+            hideWithSize0?: boolean;
         },
         defaultOverrideStyle: AgSeriesMarkerStyle & { size: number } = { size: point?.size ?? marker.size ?? 0 },
         inheritedStyle?: AgSeriesMarkerStyle
@@ -1277,9 +1279,17 @@ export abstract class Series<
             checkForHighlight = true,
             resolveMarkerSubPath = ['marker'],
             resolveStyler = false,
+            hideWithSize0 = false,
         } = opts ?? {};
         const selectionState: SelectionState | undefined = this.getDataSelectionState(datumIndex);
         const resolvePath = ['series', `${this.declarationOrder}`, ...resolveMarkerSubPath];
+
+        if (hideWithSize0 && (selectionState === SelectionState.None || selectionState === SelectionState.Unselected)) {
+            type ActualComplement = Exclude<SelectionState, typeof selectionState>;
+            type ExpectedComplement = SelectionState.Selected;
+            true satisfies AreExact<ActualComplement, ExpectedComplement>;
+            return { size: 0 } satisfies AgSeriesMarkerStyle;
+        }
 
         if (resolveStyler) {
             const resolveOpt = { permissivePath: true };

--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -1,4 +1,5 @@
 import type {
+    AreExact,
     ColorSpace,
     InternalAgColorType,
     RequiredInternalAgGradientColor,
@@ -128,6 +129,16 @@ export function toSelectionString(state: SelectionState): PublicSelectionState {
         default:
             return unreachable(state);
     }
+}
+
+export function isSelected(state: SelectionState | undefined): boolean {
+    if (state === SelectionState.None || state === SelectionState.Unselected) {
+        // Compile-time check for SelectionState exhaustiveness:
+        type ActualComplement = Exclude<SelectionState, typeof state>;
+        type ExpectedComplement = SelectionState.Selected;
+        return true satisfies AreExact<ActualComplement, ExpectedComplement>;
+    }
+    return false;
 }
 
 type HighlightOptions<TOpts extends object> = Partial<TOpts & StyleMixins>;

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -257,7 +257,7 @@ export { calculateDataDiff } from './chart/series/cartesian/diffUtil';
 export {
     computeMarkerFocusBounds,
     getMarkerStyles,
-    markerEnabled,
+    cartesianMarkerDrawMode,
     markerFadeInAnimation,
     markerSwipeScaleInAnimation,
     resetMarkerFn,

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -75,7 +75,7 @@ const {
     Marker,
     BBox,
     processedDataIsAnimatable,
-    markerEnabled,
+    cartesianMarkerDrawMode,
     getMarkerStyles,
     calculateSegments,
     toHighlightString,
@@ -197,6 +197,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
     protected override readonly NodeEvent = RangeAreaSeriesNodeEvent;
 
     private readonly aggregationManager = new AggregationManager<RangeAreaSeriesDataAggregationFilter>();
+    private hideWithSize0 = false;
 
     constructor(moduleCtx: DynamicContext<_ModuleSupport.ChartRegistry>) {
         super({
@@ -899,9 +900,10 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         const rules: LowHighRules = properties.styler ? this.getStylerMarkerOptions().item : properties.item;
         const { low, high } = rules;
 
-        const markersEnabled = markerEnabled(processedData!.input.count, axes[ChartAxisDirection.X]!.scale, {
+        const markerDrawMode = cartesianMarkerDrawMode(properties, undefined, processedData!, axes, {
             enabled: low.marker.enabled || high.marker.enabled,
         });
+        this.hideWithSize0 = markerDrawMode.hideWithSize0;
 
         if (properties.item.low.marker.isDirty() || properties.item.high.marker.isDirty()) {
             datumSelection.clear();
@@ -909,8 +911,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         }
 
         let resolvedNodeData: typeof nodeData;
-        if (markersEnabled) {
-            if (low.marker.enabled && high.marker.enabled) {
+        if (markerDrawMode.needsNodeData) {
+            if (markerDrawMode.hideWithSize0 || (low.marker.enabled && high.marker.enabled)) {
                 // All marker enables
                 resolvedNodeData = nodeData;
             } else {
@@ -944,6 +946,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         datumSelection: _ModuleSupport.Selection<RangeAreaMarkerDatum, _ModuleSupport.Marker<RangeAreaMarkerDatum>>;
         isHighlight: boolean;
     }) {
+        const { hideWithSize0 } = this;
         const highlightedDatum = this.ctx.highlightManager.getActiveHighlight();
         datumSelection.each((_, datum) => {
             const highlightState = this.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex);
@@ -957,7 +960,12 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
                 marker,
                 datum,
                 params,
-                { isHighlight, highlightState, resolveMarkerSubPath: ['item', datum.itemType, 'marker'] },
+                {
+                    isHighlight,
+                    highlightState,
+                    resolveMarkerSubPath: ['item', datum.itemType, 'marker'],
+                    hideWithSize0,
+                },
                 stylerStyle.item[datum.itemType].marker,
                 {
                     fill,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17005

When selection is enabled, we need to create marker scene-node objects so that we have something to style when data is selected.