### PR TITLE
AG-3390 Add agSourcemapCors plugin from ag-website-shared

### DIFF
--- a/external/ag-website-shared/plugins/agSourcemapCors.ts
+++ b/external/ag-website-shared/plugins/agSourcemapCors.ts
@@ -1,0 +1,48 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Plugin, ViteDevServer } from 'vite';
+
+type ConnectMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+interface StackEntry {
+    route: string;
+    handle: ConnectMiddleware;
+}
+
+/**
+ * Vite plugin that allows cross-origin sourcemap requests through Astro's
+ * secFetchMiddleware.
+ *
+ * Chrome DevTools fetches sourcemaps with `Sec-Fetch-Site: cross-site` but
+ * without an `Origin` header. Astro's secFetchMiddleware (added in Astro 6)
+ * blocks these because it can only validate cross-origin requests that carry
+ * an Origin. This plugin wraps secFetchMiddleware to let `.map` requests
+ * through unconditionally — they are internal browser/DevTools fetches, not
+ * page-initiated subresource loads.
+ */
+export default function agSourcemapCors(): Plugin {
+    return {
+        name: 'ag-sourcemap-cors',
+        configureServer(server: ViteDevServer) {
+            const stack = server.middlewares.stack as StackEntry[];
+            const origUnshift = stack.unshift.bind(stack);
+
+            stack.unshift = function (...items: StackEntry[]) {
+                for (const item of items) {
+                    if (item.handle?.name === 'devSecFetch') {
+                        const original = item.handle;
+                        item.handle = function devSecFetchWithSourcemaps(
+                            req: IncomingMessage,
+                            res: ServerResponse,
+                            next: () => void
+                        ) {
+                            if (req.url?.endsWith('.map')) {
+                                return next();
+                            }
+                            return original(req, res, next);
+                        };
+                    }
+                }
+                return origUnshift(...items);
+            } as typeof stack.unshift;
+        },
+    };
+}

--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -11,6 +11,7 @@ import svgr from 'vite-plugin-svgr';
 import agCacheSitemap from '../../external/ag-website-shared/plugins/agCacheSitemap';
 import agLinkChecker from '../../external/ag-website-shared/plugins/agLinkChecker';
 import agMkcertPreview from '../../external/ag-website-shared/plugins/agMkcertPreview';
+import agSourcemapCors from '../../external/ag-website-shared/plugins/agSourcemapCors';
 import { SITEMAP_CACHE_DIR } from '../../external/ag-website-shared/src/constants';
 import agAutoRedirect from './plugins/agAutoRedirect';
 import agCssAsString from './plugins/agCssAsString';
@@ -72,6 +73,7 @@ console.log(
 );
 
 const plugins = [
+    agSourcemapCors(),
     svgr(),
     agCssAsString(),
     agHotModuleReload(),


### PR DESCRIPTION
## Summary

Wire up the `agSourcemapCors` Vite plugin (already in use by ag-grid-docs, being promoted to `ag-website-shared` in a companion PR) so the charts website dev server lets Chrome DevTools fetch source maps for examples opened on cross-origin hosts (Plunkr / CodeSandbox).

Companion PR in ag-grid that does the actual move into shared: ag-grid/ag-grid#13666
Companion PR in ag-studio: ag-grid/ag-studio#1354

## Why

Astro 6's `secFetchMiddleware` 403s `.map` requests that arrive with `Sec-Fetch-Site: cross-site` but no `Origin` header — exactly what Chrome DevTools sends when an example is running on `run.plnkr.co` or `*.csb.app` and tries to load source maps from `localhost:4610`. The plugin wraps Astro's middleware to let `.map` URLs through unconditionally. Dev-server only — no production impact.

## Note on subrepo state

The plugin file is added to `external/ag-website-shared/plugins/` directly in this repo without a subrepo sync. Same content as the corresponding files landing in ag-grid and ag-studio. Will reconcile via `ag-shared` sync later.

## Test plan

- [ ] `yarn nx dev` and confirm the dev server starts
- [ ] Open an example via "Open in Plunkr" / CodeSandbox; DevTools → Network → filter `.map` → confirm 200s (not 403s)
- [ ] DevTools → Sources should show original `.ts` files for grid/charts bundles served from localhost
- [ ] Lint passes ✅