### PR TITLE
AG-17012 Org chart keyboard navigation and screen-reader support

### DIFF
--- a/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
@@ -333,6 +333,11 @@ export abstract class AbstractNetworkSeries<
     }
 
     private updateSelections() {
+        // Without the gate, per-vertex datum objects are re-allocated on every update; that
+        // tricks HighlightManager's `a.datum === b.datum` check into a spurious change → loop.
+        if (!this.nodeDataRefresh) return;
+        this.nodeDataRefresh = false;
+
         this.contextNodeData = this.createNodeData();
         if (!this.contextNodeData) return;
 

--- a/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
@@ -5,6 +5,13 @@ import { layoutScenesColumn, layoutScenesRow } from '../../utils/sceneLayout';
 import type { OrganizationDatum, RequiredOrganizationNodeStyle } from './organizationTypes';
 import { applyFillStyles, applyStrokeStyles, applyTextBoxingStyles, applyTextStyles } from './organizationUtils';
 
+export interface OrganizationNodeFields {
+    image?: string;
+    title?: TextOrSegments;
+    subtitle?: TextOrSegments;
+    labels?: (TextOrSegments | undefined)[];
+}
+
 export class OrganizationNode extends _ModuleSupport.TranslatableGroup<OrganizationDatum> {
     private shapeNode?: _ModuleSupport.Rect;
     private imageNode?: _ModuleSupport.Rect;
@@ -17,17 +24,17 @@ export class OrganizationNode extends _ModuleSupport.TranslatableGroup<Organizat
     private appliedStyles?: RequiredOrganizationNodeStyle;
 
     update(
-        datum: OrganizationDatum['datum'],
+        fields: OrganizationNodeFields,
         descendantsCount: number,
         styles: RequiredOrganizationNodeStyle,
         isCollapsed: boolean
     ) {
         this.appliedStyles = styles;
         this.updateShapeNode(styles);
-        this.updateImageNode(datum.image, styles);
-        this.updateTitleNode(datum.title, styles);
-        this.updateSubtitleNode(datum.subtitle, styles);
-        this.updateLabelNodes(datum.labels, styles);
+        this.updateImageNode(fields.image, styles);
+        this.updateTitleNode(fields.title, styles);
+        this.updateSubtitleNode(fields.subtitle, styles);
+        this.updateLabelNodes(fields.labels, styles);
         this.updateExpanderNode(descendantsCount, isCollapsed, styles);
 
         let rowScenes = [];
@@ -169,6 +176,12 @@ export class OrganizationNode extends _ModuleSupport.TranslatableGroup<Organizat
     expanderContainsPoint(point: Point) {
         if (!this.expanderNode) return false;
         return this.expanderNode.containsPoint(point.x, point.y);
+    }
+
+    // Card-only bbox in node-local coords; excludes the expander pill that hangs below.
+    getCardBBox(): _ModuleSupport.BBox | undefined {
+        if (!this.shapeNode) return;
+        return new _ModuleSupport.BBox(0, 0, this.shapeNode.width, this.shapeNode.height);
     }
 
     private updateShapeNode(styles: RequiredOrganizationNodeStyle) {

--- a/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
@@ -2,15 +2,8 @@ import { type TextAlign, type TextOrSegments, _ModuleSupport } from 'ag-charts-c
 import type { Point } from 'ag-charts-core';
 
 import { layoutScenesColumn, layoutScenesRow } from '../../utils/sceneLayout';
-import type { OrganizationDatum, RequiredOrganizationNodeStyle } from './organizationTypes';
+import type { OrganizationDatum, OrganizationNodeFields, RequiredOrganizationNodeStyle } from './organizationTypes';
 import { applyFillStyles, applyStrokeStyles, applyTextBoxingStyles, applyTextStyles } from './organizationUtils';
-
-export interface OrganizationNodeFields {
-    image?: string;
-    title?: TextOrSegments;
-    subtitle?: TextOrSegments;
-    labels?: (TextOrSegments | undefined)[];
-}
 
 export class OrganizationNode extends _ModuleSupport.TranslatableGroup<OrganizationDatum> {
     private shapeNode?: _ModuleSupport.Rect;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
@@ -1198,6 +1198,138 @@ describe('OrganizationSeries', () => {
         });
     });
 
+    describe('keyboard navigation', () => {
+        // Same `(otherIndexDelta, datumIndexDelta)` deltas the seriesAreaManager dispatches for
+        // arrow keys.
+        const ARROW_UP = { datumIndexDelta: 0, otherIndexDelta: -1 };
+        const ARROW_DOWN = { datumIndexDelta: 0, otherIndexDelta: 1 };
+        const ARROW_LEFT = { datumIndexDelta: -1, otherIndexDelta: 0 };
+        const ARROW_RIGHT = { datumIndexDelta: 1, otherIndexDelta: 0 };
+
+        async function setupChart() {
+            const options: AgChartOptions = { ...SIMPLE_ORG_CHART };
+            prepareEnterpriseTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+            return deproxy(chart).series[0] as any;
+        }
+
+        function press(series: any, key: typeof ARROW_DOWN, datumIndex: number, otherIndex = 0) {
+            return series.pickFocus({
+                datumIndex: datumIndex + key.datumIndexDelta,
+                datumIndexDelta: key.datumIndexDelta,
+                otherIndex: otherIndex + key.otherIndexDelta,
+                otherIndexDelta: key.otherIndexDelta,
+            });
+        }
+
+        it('ArrowDown moves from the root to its first child', async () => {
+            const series = await setupChart();
+            const pick = press(series, ARROW_DOWN, 0, 0);
+            expect(pick?.datum.itemId).toBe('cto');
+            expect(pick?.otherIndex).toBe(2);
+        });
+
+        it('ArrowDown into a leaf is a no-op', async () => {
+            const series = await setupChart();
+            // dev is at nodeData[2], depth 3, leaf.
+            expect(press(series, ARROW_DOWN, 2, 3)).toBeUndefined();
+        });
+
+        it('ArrowUp moves from a child to its parent', async () => {
+            const series = await setupChart();
+            // cfo (datumIndex 4, depth 2) → ceo (datumIndex 0, depth 1).
+            const pick = press(series, ARROW_UP, 4, 2);
+            expect(pick?.datum.itemId).toBe('ceo');
+            expect(pick?.otherIndex).toBe(1);
+        });
+
+        it('ArrowUp at the top tier is a no-op', async () => {
+            const series = await setupChart();
+            expect(press(series, ARROW_UP, 0, 1)).toBeUndefined();
+        });
+
+        it('ArrowRight moves to the next sibling', async () => {
+            const series = await setupChart();
+            // cto (datumIndex 1) → cfo (datumIndex 4).
+            const pick = press(series, ARROW_RIGHT, 1, 2);
+            expect(pick?.datum.itemId).toBe('cfo');
+        });
+
+        it('ArrowLeft moves to the previous sibling', async () => {
+            const series = await setupChart();
+            // qa (datumIndex 3) → dev (datumIndex 2).
+            const pick = press(series, ARROW_LEFT, 3, 3);
+            expect(pick?.datum.itemId).toBe('dev');
+        });
+
+        it('ArrowRight at the last sibling clamps (no wrap)', async () => {
+            const series = await setupChart();
+            // qa is the last sibling under cto; ArrowRight should stay on qa.
+            const pick = press(series, ARROW_RIGHT, 3, 3);
+            expect(pick?.datum.itemId).toBe('qa');
+        });
+
+        it('ArrowDown into a collapsed node is a no-op', async () => {
+            const options: AgChartOptions = { ...SIMPLE_ORG_CHART, initialState: { collapsed: ['cto'] } };
+            prepareEnterpriseTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+            const series = deproxy(chart).series[0] as any;
+            // With cto collapsed, nodeData is [ceo, cto, cfo, acc]; cto sits at index 1, depth 2.
+            expect(press(series, ARROW_DOWN, 1, 2)).toBeUndefined();
+        });
+
+        // Follows the same DOM chain a screen reader would: the visible swap-chain announcer
+        // (`aria-hidden="false"`) labelled by a hidden `<div>` carrying the message.
+        function readLiveAnnouncement(): string {
+            const announcer = document.querySelector<HTMLElement>('.ag-charts-swapchain[aria-hidden="false"]');
+            const labelId = announcer?.getAttribute('aria-labelledby');
+            const label = labelId ? document.getElementById(labelId) : null;
+            return label?.textContent ?? '';
+        }
+
+        function pressArrowOnSeriesArea(key: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') {
+            const seriesArea = document.querySelector<HTMLElement>('.ag-charts-series-area');
+            if (!seriesArea) throw new Error('series-area element not found');
+            seriesArea.dispatchEvent(new KeyboardEvent('keydown', { key, code: key, bubbles: true }));
+        }
+
+        it('announces a parent node identity-first with level, position, and expanded state', async () => {
+            await setupChart();
+            // Default focus sits on the root (ceo); ArrowDown moves to its first child (cto).
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            // Identity-first ordering matches WAI-ARIA tree conventions: name before metadata.
+            expect(readLiveAnnouncement()).toBe('Bob Smith, level 2, 1 of 2, expanded');
+        });
+
+        it('omits collapsed-state from a leaf announcement', async () => {
+            await setupChart();
+            // ArrowDown twice: ceo → cto → dev (a leaf at depth 3).
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            const announcement = readLiveAnnouncement();
+            expect(announcement).toBe('Dave Jones, level 3, 1 of 2');
+            // Guard against the empty-collapsedState stutter VoiceOver caught before the
+            // leaf/parent locale-key split.
+            expect(announcement).not.toContain(',,');
+            expect(announcement).not.toContain(', ,');
+        });
+
+        it('reports collapsed parents in the live announcement', async () => {
+            const options: AgChartOptions = { ...SIMPLE_ORG_CHART, initialState: { collapsed: ['cto'] } };
+            prepareEnterpriseTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            expect(readLiveAnnouncement()).toBe('Bob Smith, level 2, 1 of 2, collapsed');
+        });
+    });
+
     describe('aspect-ratio guard', () => {
         it('should project off-isotropic zoom state onto the isotropic line', async () => {
             const options: AgChartOptions = { ...OVERFLOWING_ORG_CHART };

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -469,12 +469,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const posInSet = siblings.indexOf(vertex) + 1;
         const setSize = siblings.length;
 
-        const childCount =
-            (
-                this.graph.neighboursWithEdgeValue(vertex, 'child') as
-                    | Vertex<OrganizationVertex, OrganizationEdge>[]
-                    | undefined
-            )?.length ?? 0;
+        const childCount = this.graph.neighboursWithEdgeValue(vertex, 'child')?.length ?? 0;
 
         // Leaf vs. parent — a single key with empty `${collapsedState}` would stutter (",,").
         if (childCount === 0) {
@@ -487,7 +482,9 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         }
 
         const itemId = vertex.value as string;
-        const collapsedState = this.ctx.collapsedManager.isCollapsed(itemId) ? 'collapsed' : 'expanded';
+        const collapsedState = this.ctx.localeManager.t(
+            this.ctx.collapsedManager.isCollapsed(itemId) ? 'ariaOrgChartCollapsed' : 'ariaOrgChartExpanded'
+        );
         return this.ctx.localeManager.t('ariaAnnounceOrgChartParent', {
             description,
             level: depth,

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -469,7 +469,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const posInSet = siblings.indexOf(vertex) + 1;
         const setSize = siblings.length;
 
-        const childCount = this.graph.neighboursWithEdgeValue(vertex, 'child')?.length ?? 0;
+        const childCount = this.getChildren(vertex).length;
 
         // Leaf vs. parent — a single key with empty `${collapsedState}` would stutter (",,").
         if (childCount === 0) {
@@ -504,10 +504,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         if (depthDelta > 0) {
             const itemId = current.value as string;
             if (this.ctx.collapsedManager.isCollapsed(itemId)) return;
-            const children = this.graph.neighboursWithEdgeValue(current, 'child') as
-                | Vertex<OrganizationVertex, OrganizationEdge>[]
-                | undefined;
-            return children?.[0];
+            return this.getChildren(current)[0];
         }
         if (depthDelta < 0) {
             const parent = this.graph.findNeighbour(current, 'parent') as
@@ -540,8 +537,14 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         if (parent === this.rootVertex || parent == null) {
             return this.getRootVertices();
         }
+        return this.getChildren(parent);
+    }
+
+    private getChildren(
+        vertex: Vertex<OrganizationVertex, OrganizationEdge>
+    ): Vertex<OrganizationVertex, OrganizationEdge>[] {
         return (
-            (this.graph.neighboursWithEdgeValue(parent, 'child') as Vertex<OrganizationVertex, OrganizationEdge>[]) ??
+            (this.graph.neighboursWithEdgeValue(vertex, 'child') as Vertex<OrganizationVertex, OrganizationEdge>[]) ??
             []
         );
     }

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -20,6 +20,7 @@ import {
     type DynamicContext,
     type Point,
     Vertex,
+    clamp,
     mergeDefaults,
     strictObjectKeys,
 } from 'ag-charts-core';
@@ -321,23 +322,19 @@ export class OrganizationSeries extends AbstractNetworkSeries<
                 descendantsCount > 0 && datum.itemId != null && this.ctx.collapsedManager.isCollapsed(datum.itemId);
             const styles = this.getNodeStyle(datumIndex, depth, isHighlight, highlightState, isCollapsed);
 
-            const title = this.formatText(
-                datum.datum.title,
-                this.properties.node.title.formatter,
-                datumIndex,
-                isCollapsed
-            );
+            const fields = this.resolveVertexFields(datum.vertex);
+            const title = this.formatText(fields.title, this.properties.node.title.formatter, datumIndex, isCollapsed);
             const subtitle = this.formatText(
-                datum.datum.subtitle,
+                fields.subtitle,
                 this.properties.node.subtitle.formatter,
                 datumIndex,
                 isCollapsed
             );
-            const labels = datum.datum.labels?.map((label, index) =>
+            const labels = fields.labels?.map((label, index) =>
                 this.formatText(label, this.properties.node.labels[index]?.formatter, datumIndex, isCollapsed)
             );
 
-            node.update({ image: datum.datum.image, title, subtitle, labels }, descendantsCount, styles, isCollapsed);
+            node.update({ image: fields.image, title, subtitle, labels }, descendantsCount, styles, isCollapsed);
         });
     }
 
@@ -413,14 +410,143 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         //     return;
         // }
 
-        this.ctx.collapsedManager.expand([id]);
+        if (this.ctx.collapsedManager.expand([id])) {
+            this.markNodeDataDirty();
+        }
     }
 
     collapseItem(itemIdOrIndex: string | number, _point: Point) {
         const id = this.getItemId(itemIdOrIndex);
         if (id == null) return;
 
-        this.ctx.collapsedManager.collapseAppend([id]);
+        if (this.ctx.collapsedManager.collapseAppend([id])) {
+            this.markNodeDataDirty();
+        }
+    }
+
+    public override pickFocus(opts: _ModuleSupport.PickFocusInputs): _ModuleSupport.PickFocusOutputs | undefined {
+        const nodeData = this.contextNodeData?.nodeData;
+        if (!nodeData?.length) return;
+
+        const currentNodeIdx = clamp(0, opts.datumIndex - opts.datumIndexDelta, nodeData.length - 1);
+        const currentVertex = nodeData[currentNodeIdx]?.vertex;
+        if (!currentVertex) return;
+
+        const next = this.resolveFocusVertex(currentVertex, opts.datumIndexDelta, opts.otherIndexDelta);
+        if (!next) return;
+
+        const nextDatumIdx = this.vertexDatumIndex[next.value as string];
+        if (nextDatumIdx == null) return;
+
+        const node = this.datumSelection.at(nextDatumIdx);
+        if (!node) return;
+
+        // Card rect, not the node group's bbox — the group includes the expander pill below.
+        const cardBBox = node.getCardBBox();
+        if (!cardBBox) return;
+        const bounds = _ModuleSupport.Transformable.toCanvas(node, cardBBox);
+        if (!bounds?.isFinite()) return;
+
+        const depth = this.graph.findNeighbourValue(next, 'depth') as number | undefined;
+
+        const datum = node.datum;
+        if (!datum) return;
+
+        return {
+            datum,
+            datumIndex: nextDatumIdx,
+            otherIndex: depth,
+            bounds,
+            clipFocusBox: true,
+        };
+    }
+
+    getDatumAriaText(datum: OrganizationDatum, description: string): string | undefined {
+        const { vertex } = datum;
+        const depth = (this.graph.findNeighbourValue(vertex, 'depth') as number | undefined) ?? 1;
+
+        const siblings = this.getSiblings(vertex);
+        const posInSet = siblings.indexOf(vertex) + 1;
+        const setSize = siblings.length;
+
+        const childCount =
+            (
+                this.graph.neighboursWithEdgeValue(vertex, 'child') as
+                    | Vertex<OrganizationVertex, OrganizationEdge>[]
+                    | undefined
+            )?.length ?? 0;
+
+        // Leaf vs. parent — a single key with empty `${collapsedState}` would stutter (",,").
+        if (childCount === 0) {
+            return this.ctx.localeManager.t('ariaAnnounceOrgChartLeaf', {
+                description,
+                level: depth,
+                posInSet,
+                setSize,
+            });
+        }
+
+        const itemId = vertex.value as string;
+        const collapsedState = this.ctx.collapsedManager.isCollapsed(itemId) ? 'collapsed' : 'expanded';
+        return this.ctx.localeManager.t('ariaAnnounceOrgChartParent', {
+            description,
+            level: depth,
+            posInSet,
+            setSize,
+            collapsedState,
+        });
+    }
+
+    // Returns the next focus vertex per the spatial model, or `undefined` for a no-op (ArrowUp
+    // at the top tier, ArrowDown into a leaf or collapsed node) so focus stays put.
+    private resolveFocusVertex(
+        current: Vertex<OrganizationVertex, OrganizationEdge>,
+        siblingDelta: number,
+        depthDelta: number
+    ): Vertex<OrganizationVertex, OrganizationEdge> | undefined {
+        if (depthDelta > 0) {
+            const itemId = current.value as string;
+            if (this.ctx.collapsedManager.isCollapsed(itemId)) return;
+            const children = this.graph.neighboursWithEdgeValue(current, 'child') as
+                | Vertex<OrganizationVertex, OrganizationEdge>[]
+                | undefined;
+            return children?.[0];
+        }
+        if (depthDelta < 0) {
+            const parent = this.graph.findNeighbour(current, 'parent') as
+                | Vertex<OrganizationVertex, OrganizationEdge>
+                | undefined;
+            if (!parent) return;
+            // The synthetic root carries no datumIndex — clamp at the top tier.
+            const parentDatumIdx = this.graph.findNeighbourValue(parent, 'datumIndex');
+            if (parentDatumIdx == null) return;
+            return parent;
+        }
+        if (siblingDelta !== 0) {
+            const siblings = this.getSiblings(current);
+            const idx = siblings.indexOf(current);
+            if (idx === -1) return;
+            const next = clamp(0, idx + siblingDelta, siblings.length - 1);
+            return siblings[next];
+        }
+        return current;
+    }
+
+    private getSiblings(
+        vertex: Vertex<OrganizationVertex, OrganizationEdge>
+    ): Vertex<OrganizationVertex, OrganizationEdge>[] {
+        const parent = this.graph.findNeighbour(vertex, 'parent') as
+            | Vertex<OrganizationVertex, OrganizationEdge>
+            | undefined;
+        // Top-tier nodes' parent is the synthetic root; falling back to `getRootVertices()` keeps
+        // the sibling set consistent for ArrowLeft/ArrowRight at the top of the tree.
+        if (parent === this.rootVertex || parent == null) {
+            return this.getRootVertices();
+        }
+        return (
+            (this.graph.neighboursWithEdgeValue(parent, 'child') as Vertex<OrganizationVertex, OrganizationEdge>[]) ??
+            []
+        );
     }
 
     findNodeDatum(itemIdOrIndex: AgActiveItemState['itemId']): OrganizationDatum | undefined {
@@ -443,7 +569,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
 
         return this.formatTooltipWithContext(
             this.properties.tooltip,
-            { heading: nodeDatum.datum.title },
+            { heading: this.resolveVertexFields(nodeDatum.vertex).title },
             {
                 seriesId: this.id,
                 datum: datum,
@@ -551,17 +677,23 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         );
     }
 
+    private resolveVertexFields(vertex: Vertex<OrganizationVertex, OrganizationEdge>) {
+        return {
+            image: this.graph.findNeighbourValue(vertex, 'image') as string | undefined,
+            title: this.graph.findNeighbourValue(vertex, 'title') as TextOrSegments | undefined,
+            subtitle: this.graph.findNeighbourValue(vertex, 'subtitle') as TextOrSegments | undefined,
+            labels: this.graph.findNeighbourValue(vertex, 'labels') as (TextOrSegments | undefined)[] | undefined,
+        };
+    }
+
     private createNodeDatumFromVertex(vertex: Vertex<OrganizationVertex, OrganizationEdge>): OrganizationDatum {
+        const datumIndex = this.graph.findNeighbourValue(vertex, 'datumIndex') as number;
+        const userDatum = this.processedData?.dataSources.get(this.id)?.data?.[datumIndex];
         return {
             series: this,
-            datum: {
-                image: this.graph.findNeighbourValue(vertex, 'image') as string | undefined,
-                title: this.graph.findNeighbourValue(vertex, 'title') as string | undefined,
-                subtitle: this.graph.findNeighbourValue(vertex, 'subtitle') as string | undefined,
-                labels: this.graph.findNeighbourValue(vertex, 'labels') as string[] | undefined,
-            },
+            datum: userDatum,
             itemId: vertex.value as string,
-            datumIndex: this.graph.findNeighbourValue(vertex, 'datumIndex') as number,
+            datumIndex,
             vertex,
         };
     }

--- a/packages/ag-charts-enterprise/src/series/organization/organizationTypes.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationTypes.ts
@@ -1,10 +1,5 @@
 import type { DeepRequired } from 'ag-charts-core';
-import type {
-    AgOrganizationSeriesNodeStyle,
-    AgOrganizationSeriesNodeTextStyle,
-    CssColor,
-    TextOrSegments,
-} from 'ag-charts-types';
+import type { AgOrganizationSeriesNodeStyle, AgOrganizationSeriesNodeTextStyle, CssColor } from 'ag-charts-types';
 
 import type { NetworkDatum, NetworkLinkDatum } from '../network/networkSeries';
 
@@ -22,12 +17,9 @@ export type OrganizationEdge =
     | 'labels';
 
 export interface OrganizationDatum extends NetworkDatum<OrganizationVertex, OrganizationEdge> {
-    datum: {
-        image?: string;
-        title?: TextOrSegments;
-        subtitle?: TextOrSegments;
-        labels?: (TextOrSegments | undefined)[];
-    };
+    // The user's source data row — stable across renders so reference-equality
+    // (e.g. HighlightManager) works correctly.
+    datum: unknown;
 }
 
 export type OrganizationLinkDatum = NetworkLinkDatum<OrganizationVertex, OrganizationEdge>;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationTypes.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationTypes.ts
@@ -1,7 +1,19 @@
 import type { DeepRequired } from 'ag-charts-core';
-import type { AgOrganizationSeriesNodeStyle, AgOrganizationSeriesNodeTextStyle, CssColor } from 'ag-charts-types';
+import type {
+    AgOrganizationSeriesNodeStyle,
+    AgOrganizationSeriesNodeTextStyle,
+    CssColor,
+    TextOrSegments,
+} from 'ag-charts-types';
 
 import type { NetworkDatum, NetworkLinkDatum } from '../network/networkSeries';
+
+export interface OrganizationNodeFields {
+    image?: string;
+    title?: TextOrSegments;
+    subtitle?: TextOrSegments;
+    labels?: (TextOrSegments | undefined)[];
+}
 
 export type OrganizationVertex = string | string[] | number | boolean;
 

--- a/packages/ag-charts-locale/src/ar-EG.ts
+++ b/packages/ag-charts-locale/src/ar-EG.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_AR_EG: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'رابط ${index} من ${count}، من ${from} إلى ${to}، ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'العقدة ${index} من ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, المستوى ${level}[number], ${posInSet}[number] من ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, المستوى ${level}[number], ${posInSet}[number] من ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'مطوي',
+    ariaOrgChartExpanded: 'موسع',
     ariaAnnounceGaugeChart: 'مخطط المقياس، ${caption}',
     ariaAnnounceHierarchyChart: 'مخطط هرمي، ${caption}',
     ariaAnnounceHierarchyDatum: 'المستوى ${level}[number]، ${count}[number] أطفال، ${description}',

--- a/packages/ag-charts-locale/src/ar-EG.ts
+++ b/packages/ag-charts-locale/src/ar-EG.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_AR_EG: Record<string, string> = {
     ariaAnnounceChart: 'مخطط، ${seriesCount}[number] سلسلة',
     ariaAnnounceFlowProportionLink: 'رابط ${index} من ${count}، من ${from} إلى ${to}، ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'العقدة ${index} من ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'مخطط المقياس، ${caption}',
     ariaAnnounceHierarchyChart: 'مخطط هرمي، ${caption}',
     ariaAnnounceHierarchyDatum: 'المستوى ${level}[number]، ${count}[number] أطفال، ${description}',

--- a/packages/ag-charts-locale/src/bg-BG.ts
+++ b/packages/ag-charts-locale/src/bg-BG.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_BG_BG: Record<string, string> = {
     ariaAnnounceChart: 'диаграма, ${seriesCount}[number] серии',
     ariaAnnounceFlowProportionLink: 'връзка ${index} от ${count}, от ${from} до ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'възел ${index} от ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'графика тип манометър, ${caption}',
     ariaAnnounceHierarchyChart: 'йерархична диаграма, ${caption}',
     ariaAnnounceHierarchyDatum: 'ниво ${level}[number], ${count}[number] деца, ${description}',

--- a/packages/ag-charts-locale/src/bg-BG.ts
+++ b/packages/ag-charts-locale/src/bg-BG.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_BG_BG: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'връзка ${index} от ${count}, от ${from} до ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'възел ${index} от ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, ниво ${level}[number], ${posInSet}[number] от ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, ниво ${level}[number], ${posInSet}[number] от ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'свито',
+    ariaOrgChartExpanded: 'разгънато',
     ariaAnnounceGaugeChart: 'графика тип манометър, ${caption}',
     ariaAnnounceHierarchyChart: 'йерархична диаграма, ${caption}',
     ariaAnnounceHierarchyDatum: 'ниво ${level}[number], ${count}[number] деца, ${description}',

--- a/packages/ag-charts-locale/src/cs-CZ.ts
+++ b/packages/ag-charts-locale/src/cs-CZ.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_CS_CZ: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'odkaz ${index} z ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'uzel ${index} z ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'sbalený',
+    ariaOrgChartExpanded: 'rozbalený',
     ariaAnnounceGaugeChart: 'graf měřidla, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchický graf, ${caption}',
     ariaAnnounceHierarchyDatum: 'úroveň ${level}[number], ${count}[number] děti, ${description}',

--- a/packages/ag-charts-locale/src/cs-CZ.ts
+++ b/packages/ag-charts-locale/src/cs-CZ.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_CS_CZ: Record<string, string> = {
     ariaAnnounceChart: 'graf, ${seriesCount}[number] sérií',
     ariaAnnounceFlowProportionLink: 'odkaz ${index} z ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'uzel ${index} z ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'graf měřidla, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchický graf, ${caption}',
     ariaAnnounceHierarchyDatum: 'úroveň ${level}[number], ${count}[number] děti, ${description}',

--- a/packages/ag-charts-locale/src/da-DK.ts
+++ b/packages/ag-charts-locale/src/da-DK.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_DA_DK: Record<string, string> = {
     ariaAnnounceChart: 'diagram, ${seriesCount}[number] serier',
     ariaAnnounceFlowProportionLink: 'link ${index} af ${count}, fra ${from} til ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'node ${index} af ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkisk diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] børn, ${description}',

--- a/packages/ag-charts-locale/src/da-DK.ts
+++ b/packages/ag-charts-locale/src/da-DK.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_DA_DK: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'link ${index} af ${count}, fra ${from} til ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'node ${index} af ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, niveau ${level}[number], ${posInSet}[number] af ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, niveau ${level}[number], ${posInSet}[number] af ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'skjult',
+    ariaOrgChartExpanded: 'udvidet',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkisk diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] børn, ${description}',

--- a/packages/ag-charts-locale/src/de-DE.ts
+++ b/packages/ag-charts-locale/src/de-DE.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_DE_DE: Record<string, string> = {
     ariaAnnounceChart: 'Diagramm, ${seriesCount}[number] Reihen',
     ariaAnnounceFlowProportionLink: 'Link ${index} von ${count}, von ${from} bis ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'Knoten ${index} von ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'Tachometerdiagramm, ${caption}',
     ariaAnnounceHierarchyChart: 'Hierarchiediagramm, ${caption}',
     ariaAnnounceHierarchyDatum: 'Ebene ${level}[number], ${count}[number] Kinder, ${description}',

--- a/packages/ag-charts-locale/src/de-DE.ts
+++ b/packages/ag-charts-locale/src/de-DE.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_DE_DE: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'Link ${index} von ${count}, von ${from} bis ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'Knoten ${index} von ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, Ebene ${level}[number], ${posInSet}[number] von ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, Ebene ${level}[number], ${posInSet}[number] von ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'eingeklappt',
+    ariaOrgChartExpanded: 'ausgeklappt',
     ariaAnnounceGaugeChart: 'Tachometerdiagramm, ${caption}',
     ariaAnnounceHierarchyChart: 'Hierarchiediagramm, ${caption}',
     ariaAnnounceHierarchyDatum: 'Ebene ${level}[number], ${count}[number] Kinder, ${description}',

--- a/packages/ag-charts-locale/src/el-GR.ts
+++ b/packages/ag-charts-locale/src/el-GR.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_EL_GR: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'σύνδεσμος ${index} από ${count}, από ${from} προς ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'κόμβος ${index} από ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, επίπεδο ${level}[number], ${posInSet}[number] από ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, επίπεδο ${level}[number], ${posInSet}[number] από ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'συμπτυγμένο',
+    ariaOrgChartExpanded: 'αναπτυγμένο',
     ariaAnnounceGaugeChart: 'διάγραμμα δείκτη, ${caption}',
     ariaAnnounceHierarchyChart: 'διάγραμμα ιεραρχίας, ${caption}',
     ariaAnnounceHierarchyDatum: 'επίπεδο ${level}[number], ${count}[number] παιδιά, ${description}',

--- a/packages/ag-charts-locale/src/el-GR.ts
+++ b/packages/ag-charts-locale/src/el-GR.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_EL_GR: Record<string, string> = {
     ariaAnnounceChart: 'διάγραμμα, ${seriesCount}[number] σειρές',
     ariaAnnounceFlowProportionLink: 'σύνδεσμος ${index} από ${count}, από ${from} προς ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'κόμβος ${index} από ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'διάγραμμα δείκτη, ${caption}',
     ariaAnnounceHierarchyChart: 'διάγραμμα ιεραρχίας, ${caption}',
     ariaAnnounceHierarchyDatum: 'επίπεδο ${level}[number], ${count}[number] παιδιά, ${description}',

--- a/packages/ag-charts-locale/src/en-US.ts
+++ b/packages/ag-charts-locale/src/en-US.ts
@@ -17,6 +17,11 @@ export const AG_CHARTS_LOCALE_EN_US: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'link ${index} of ${count}, from ${from} to ${to}, ${sizeName} ${size}',
     // Screen reader announcement when focusing a node in a Sankey or chord chart
     ariaAnnounceFlowProportionNode: 'node ${index} of ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     // Screen reader description for legend items
     ariaDescriptionLegendItem: 'Press Space or Enter to toggle visibility',
     // Screen reader for the '+' horizontal line button on the Y-axis

--- a/packages/ag-charts-locale/src/en-US.ts
+++ b/packages/ag-charts-locale/src/en-US.ts
@@ -22,6 +22,8 @@ export const AG_CHARTS_LOCALE_EN_US: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'collapsed',
+    ariaOrgChartExpanded: 'expanded',
     // Screen reader description for legend items
     ariaDescriptionLegendItem: 'Press Space or Enter to toggle visibility',
     // Screen reader for the '+' horizontal line button on the Y-axis

--- a/packages/ag-charts-locale/src/es-ES.ts
+++ b/packages/ag-charts-locale/src/es-ES.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_ES_ES: Record<string, string> = {
     ariaAnnounceChart: 'gráfico, ${seriesCount}[number] series',
     ariaAnnounceFlowProportionLink: 'enlace ${index} de ${count}, de ${from} a ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nodo ${index} de ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'gráfico de velocímetro, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico de jerarquía, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivel ${level}[number], ${count}[number] hijos, ${description}',

--- a/packages/ag-charts-locale/src/es-ES.ts
+++ b/packages/ag-charts-locale/src/es-ES.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_ES_ES: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'enlace ${index} de ${count}, de ${from} a ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nodo ${index} de ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, nivel ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, nivel ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'contraído',
+    ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de velocímetro, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico de jerarquía, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivel ${level}[number], ${count}[number] hijos, ${description}',

--- a/packages/ag-charts-locale/src/fa-IR.ts
+++ b/packages/ag-charts-locale/src/fa-IR.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_FA_IR: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'لینک ${index} از ${count}، از ${from} به ${to}، ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'گره ${index} از ${count}، ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, سطح ${level}[number], ${posInSet}[number] از ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, سطح ${level}[number], ${posInSet}[number] از ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'جمع‌شده',
+    ariaOrgChartExpanded: 'بازشده',
     ariaAnnounceGaugeChart: 'چارت سنجشی، ${caption}',
     ariaAnnounceHierarchyChart: 'نمودار سلسله مراتبی، ${caption}',
     ariaAnnounceHierarchyDatum: 'سطح ${level}[number]، ${count}[number] فرزند، ${description}',

--- a/packages/ag-charts-locale/src/fa-IR.ts
+++ b/packages/ag-charts-locale/src/fa-IR.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_FA_IR: Record<string, string> = {
     ariaAnnounceChart: 'چارت، ${seriesCount}[number] مجموعه',
     ariaAnnounceFlowProportionLink: 'لینک ${index} از ${count}، از ${from} به ${to}، ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'گره ${index} از ${count}، ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'چارت سنجشی، ${caption}',
     ariaAnnounceHierarchyChart: 'نمودار سلسله مراتبی، ${caption}',
     ariaAnnounceHierarchyDatum: 'سطح ${level}[number]، ${count}[number] فرزند، ${description}',

--- a/packages/ag-charts-locale/src/fi-FI.ts
+++ b/packages/ag-charts-locale/src/fi-FI.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_FI_FI: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'linkki ${index} / ${count}, lähtien ${from} päättyen ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'solmu ${index} ${count} näkyvissä, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, taso ${level}[number], ${posInSet}[number] / ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, taso ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'suljettu',
+    ariaOrgChartExpanded: 'avattu',
     ariaAnnounceGaugeChart: 'mittarikaavio, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkkinen kaavio, ${caption}',
     ariaAnnounceHierarchyDatum: 'taso ${level}[number], ${count}[number] lasta, ${description}',

--- a/packages/ag-charts-locale/src/fi-FI.ts
+++ b/packages/ag-charts-locale/src/fi-FI.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_FI_FI: Record<string, string> = {
     ariaAnnounceChart: 'kaavio, ${seriesCount}[number] sarjaa',
     ariaAnnounceFlowProportionLink: 'linkki ${index} / ${count}, lähtien ${from} päättyen ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'solmu ${index} ${count} näkyvissä, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'mittarikaavio, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkkinen kaavio, ${caption}',
     ariaAnnounceHierarchyDatum: 'taso ${level}[number], ${count}[number] lasta, ${description}',

--- a/packages/ag-charts-locale/src/fr-FR.ts
+++ b/packages/ag-charts-locale/src/fr-FR.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_FR_FR: Record<string, string> = {
     ariaAnnounceChart: 'graphique, ${seriesCount}[number] séries',
     ariaAnnounceFlowProportionLink: 'lien ${index} de ${count}, de ${from} à ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nœud ${index} de ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'graphique en jauge, ${caption}',
     ariaAnnounceHierarchyChart: 'graphique hiérarchique, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] enfants, ${description}',

--- a/packages/ag-charts-locale/src/fr-FR.ts
+++ b/packages/ag-charts-locale/src/fr-FR.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_FR_FR: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'lien ${index} de ${count}, de ${from} à ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nœud ${index} de ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, niveau ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, niveau ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'réduit',
+    ariaOrgChartExpanded: 'développé',
     ariaAnnounceGaugeChart: 'graphique en jauge, ${caption}',
     ariaAnnounceHierarchyChart: 'graphique hiérarchique, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] enfants, ${description}',

--- a/packages/ag-charts-locale/src/he-IL.ts
+++ b/packages/ag-charts-locale/src/he-IL.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_HE_IL: Record<string, string> = {
     ariaAnnounceChart: 'תרשים, ${seriesCount}[number] סדרות',
     ariaAnnounceFlowProportionLink: 'קישור ${index} מתוך ${count}, מ-${from} ל-${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'צומת ${index} מתוך ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'תרשים מד, ${caption}',
     ariaAnnounceHierarchyChart: 'תרשים היררכי, ${caption}',
     ariaAnnounceHierarchyDatum: 'רמה ${level}[number], ${count}[number] ילדים, ${description}',

--- a/packages/ag-charts-locale/src/he-IL.ts
+++ b/packages/ag-charts-locale/src/he-IL.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_HE_IL: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'קישור ${index} מתוך ${count}, מ-${from} ל-${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'צומת ${index} מתוך ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, רמה ${level}[number], ${posInSet}[number] מתוך ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, רמה ${level}[number], ${posInSet}[number] מתוך ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'מכווץ',
+    ariaOrgChartExpanded: 'מורחב',
     ariaAnnounceGaugeChart: 'תרשים מד, ${caption}',
     ariaAnnounceHierarchyChart: 'תרשים היררכי, ${caption}',
     ariaAnnounceHierarchyDatum: 'רמה ${level}[number], ${count}[number] ילדים, ${description}',

--- a/packages/ag-charts-locale/src/hr-HR.ts
+++ b/packages/ag-charts-locale/src/hr-HR.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_HR_HR: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'veza ${index} od ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'čvor ${index} od ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, razina ${level}[number], ${posInSet}[number] od ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, razina ${level}[number], ${posInSet}[number] od ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'sažeto',
+    ariaOrgChartExpanded: 'prošireno',
     ariaAnnounceGaugeChart: 'mjerna ljestvica, ${caption}',
     ariaAnnounceHierarchyChart: 'hijerarhijski grafikon, ${caption}',
     ariaAnnounceHierarchyDatum: 'razina ${level}[number], ${count}[number] djece, ${description}',

--- a/packages/ag-charts-locale/src/hr-HR.ts
+++ b/packages/ag-charts-locale/src/hr-HR.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_HR_HR: Record<string, string> = {
     ariaAnnounceChart: 'grafikon, ${seriesCount}[number] serija',
     ariaAnnounceFlowProportionLink: 'veza ${index} od ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'čvor ${index} od ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'mjerna ljestvica, ${caption}',
     ariaAnnounceHierarchyChart: 'hijerarhijski grafikon, ${caption}',
     ariaAnnounceHierarchyDatum: 'razina ${level}[number], ${count}[number] djece, ${description}',

--- a/packages/ag-charts-locale/src/hu-HU.ts
+++ b/packages/ag-charts-locale/src/hu-HU.ts
@@ -14,10 +14,12 @@ export const AG_CHARTS_LOCALE_HU_HU: Record<string, string> = {
         'hivatkozás ${index} a(z) ${count} közül, ${from}-tól ${to}-ig, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '${count} közül ${index} csomópont, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, szint ${level}[number], ${posInSet}[number] / ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, szint ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'összezárt',
+    ariaOrgChartExpanded: 'kinyitott',
     ariaAnnounceGaugeChart: 'mérőműszer diagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchia diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'szint ${level}[number], ${count}[number] gyermek, ${description}',

--- a/packages/ag-charts-locale/src/hu-HU.ts
+++ b/packages/ag-charts-locale/src/hu-HU.ts
@@ -13,6 +13,11 @@ export const AG_CHARTS_LOCALE_HU_HU: Record<string, string> = {
     ariaAnnounceFlowProportionLink:
         'hivatkozás ${index} a(z) ${count} közül, ${from}-tól ${to}-ig, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '${count} közül ${index} csomópont, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'mérőműszer diagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchia diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'szint ${level}[number], ${count}[number] gyermek, ${description}',

--- a/packages/ag-charts-locale/src/it-IT.ts
+++ b/packages/ag-charts-locale/src/it-IT.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_IT_IT: Record<string, string> = {
     ariaAnnounceChart: 'grafico, ${seriesCount}[number] serie',
     ariaAnnounceFlowProportionLink: 'collegamento ${index} di ${count}, da ${from} a ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nodo ${index} di ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'grafico a tachimetro, ${caption}',
     ariaAnnounceHierarchyChart: 'grafico gerarchico, ${caption}',
     ariaAnnounceHierarchyDatum: 'livello ${level}[number], ${count}[number] figli, ${description}',

--- a/packages/ag-charts-locale/src/it-IT.ts
+++ b/packages/ag-charts-locale/src/it-IT.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_IT_IT: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'collegamento ${index} di ${count}, da ${from} a ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nodo ${index} di ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, livello ${level}[number], ${posInSet}[number] di ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, livello ${level}[number], ${posInSet}[number] di ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'compresso',
+    ariaOrgChartExpanded: 'espanso',
     ariaAnnounceGaugeChart: 'grafico a tachimetro, ${caption}',
     ariaAnnounceHierarchyChart: 'grafico gerarchico, ${caption}',
     ariaAnnounceHierarchyDatum: 'livello ${level}[number], ${count}[number] figli, ${description}',

--- a/packages/ag-charts-locale/src/ja-JP.ts
+++ b/packages/ag-charts-locale/src/ja-JP.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_JA_JP: Record<string, string> = {
     ariaAnnounceChart: 'チャート, ${seriesCount}[number]シリーズ',
     ariaAnnounceFlowProportionLink: 'リンク ${index} / ${count}、${from} から ${to} へ、${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'ノード ${index} / ${count}、${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'ゲージチャート、${caption}',
     ariaAnnounceHierarchyChart: '階層チャート, ${caption}',
     ariaAnnounceHierarchyDatum: 'レベル ${level}[number]、${count}[number] の子供、${description}',

--- a/packages/ag-charts-locale/src/ja-JP.ts
+++ b/packages/ag-charts-locale/src/ja-JP.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_JA_JP: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'リンク ${index} / ${count}、${from} から ${to} へ、${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'ノード ${index} / ${count}、${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}、レベル ${level}[number]、${posInSet}[number]/${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}、レベル ${level}[number]、${posInSet}[number]/${setSize}[number]、${collapsedState}',
+    ariaOrgChartCollapsed: '折りたたみ',
+    ariaOrgChartExpanded: '展開',
     ariaAnnounceGaugeChart: 'ゲージチャート、${caption}',
     ariaAnnounceHierarchyChart: '階層チャート, ${caption}',
     ariaAnnounceHierarchyDatum: 'レベル ${level}[number]、${count}[number] の子供、${description}',

--- a/packages/ag-charts-locale/src/ko-KR.ts
+++ b/packages/ag-charts-locale/src/ko-KR.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_KO_KR: Record<string, string> = {
     ariaAnnounceFlowProportionLink: '링크 ${index} / ${count}, ${from}에서 ${to}로, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '노드 ${index} / ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, 레벨 ${level}[number], ${posInSet}[number]/${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, 레벨 ${level}[number], ${posInSet}[number]/${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: '축소됨',
+    ariaOrgChartExpanded: '확장됨',
     ariaAnnounceGaugeChart: '게이지 차트, ${caption}',
     ariaAnnounceHierarchyChart: '계층 차트, ${caption}',
     ariaAnnounceHierarchyDatum: '레벨 ${level}[number], ${count}[number] 자식, ${description}',

--- a/packages/ag-charts-locale/src/ko-KR.ts
+++ b/packages/ag-charts-locale/src/ko-KR.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_KO_KR: Record<string, string> = {
     ariaAnnounceChart: '차트, ${seriesCount}[number] 시리즈',
     ariaAnnounceFlowProportionLink: '링크 ${index} / ${count}, ${from}에서 ${to}로, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '노드 ${index} / ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: '게이지 차트, ${caption}',
     ariaAnnounceHierarchyChart: '계층 차트, ${caption}',
     ariaAnnounceHierarchyDatum: '레벨 ${level}[number], ${count}[number] 자식, ${description}',

--- a/packages/ag-charts-locale/src/nb-NO.ts
+++ b/packages/ag-charts-locale/src/nb-NO.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_NB_NO: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'lenke ${index} av ${count}, fra ${from} til ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'node ${index} av ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'skjult',
+    ariaOrgChartExpanded: 'utvidet',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkidiagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivå ${level}[number], ${count}[number] barn, ${description}',

--- a/packages/ag-charts-locale/src/nb-NO.ts
+++ b/packages/ag-charts-locale/src/nb-NO.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_NB_NO: Record<string, string> = {
     ariaAnnounceChart: 'diagram, ${seriesCount}[number] serier',
     ariaAnnounceFlowProportionLink: 'lenke ${index} av ${count}, fra ${from} til ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'node ${index} av ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkidiagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivå ${level}[number], ${count}[number] barn, ${description}',

--- a/packages/ag-charts-locale/src/nl-NL.ts
+++ b/packages/ag-charts-locale/src/nl-NL.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_NL_NL: Record<string, string> = {
     ariaAnnounceChart: 'grafiek, ${seriesCount}[number] reeksen',
     ariaAnnounceFlowProportionLink: 'link ${index} van ${count}, van ${from} naar ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'knooppunt ${index} van ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'meterdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hiërarchie diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] kinderen, ${description}',

--- a/packages/ag-charts-locale/src/nl-NL.ts
+++ b/packages/ag-charts-locale/src/nl-NL.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_NL_NL: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'link ${index} van ${count}, van ${from} naar ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'knooppunt ${index} van ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, niveau ${level}[number], ${posInSet}[number] van ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, niveau ${level}[number], ${posInSet}[number] van ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'ingeklapt',
+    ariaOrgChartExpanded: 'uitgeklapt',
     ariaAnnounceGaugeChart: 'meterdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hiërarchie diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] kinderen, ${description}',

--- a/packages/ag-charts-locale/src/pl-PL.ts
+++ b/packages/ag-charts-locale/src/pl-PL.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_PL_PL: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'link ${index} z ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'węzeł ${index} z ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, poziom ${level}[number], ${posInSet}[number] z ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, poziom ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'zwinięty',
+    ariaOrgChartExpanded: 'rozwinięty',
     ariaAnnounceGaugeChart: 'wykres wskaźnikowy, ${caption}',
     ariaAnnounceHierarchyChart: 'wykres hierarchii, ${caption}',
     ariaAnnounceHierarchyDatum: 'poziom ${level}[number], ${count}[number] dzieci, ${description}',

--- a/packages/ag-charts-locale/src/pl-PL.ts
+++ b/packages/ag-charts-locale/src/pl-PL.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_PL_PL: Record<string, string> = {
     ariaAnnounceChart: 'wykres, ${seriesCount}[number] serii',
     ariaAnnounceFlowProportionLink: 'link ${index} z ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'węzeł ${index} z ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'wykres wskaźnikowy, ${caption}',
     ariaAnnounceHierarchyChart: 'wykres hierarchii, ${caption}',
     ariaAnnounceHierarchyDatum: 'poziom ${level}[number], ${count}[number] dzieci, ${description}',

--- a/packages/ag-charts-locale/src/pt-BR.ts
+++ b/packages/ag-charts-locale/src/pt-BR.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_PT_BR: Record<string, string> = {
     ariaAnnounceChart: 'gráfico, ${seriesCount}[number] séries',
     ariaAnnounceFlowProportionLink: 'link ${index} de ${count}, de ${from} para ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nó ${index} de ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico de hierarquia, ${caption}',
     ariaAnnounceHierarchyDatum: 'nível ${level}[number], ${count}[number] filhos, ${description}',

--- a/packages/ag-charts-locale/src/pt-BR.ts
+++ b/packages/ag-charts-locale/src/pt-BR.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_PT_BR: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'link ${index} de ${count}, de ${from} para ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nó ${index} de ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'recolhido',
+    ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico de hierarquia, ${caption}',
     ariaAnnounceHierarchyDatum: 'nível ${level}[number], ${count}[number] filhos, ${description}',

--- a/packages/ag-charts-locale/src/pt-PT.ts
+++ b/packages/ag-charts-locale/src/pt-PT.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_PT_PT: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'link ${index} de ${count}, de ${from} para ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nó ${index} de ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'recolhido',
+    ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico hierárquico, ${caption}',
     ariaAnnounceHierarchyDatum: 'nível ${level}[number], ${count}[number] filhos, ${description}',

--- a/packages/ag-charts-locale/src/pt-PT.ts
+++ b/packages/ag-charts-locale/src/pt-PT.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_PT_PT: Record<string, string> = {
     ariaAnnounceChart: 'gráfico, ${seriesCount}[number] séries',
     ariaAnnounceFlowProportionLink: 'link ${index} de ${count}, de ${from} para ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nó ${index} de ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico hierárquico, ${caption}',
     ariaAnnounceHierarchyDatum: 'nível ${level}[number], ${count}[number] filhos, ${description}',

--- a/packages/ag-charts-locale/src/ro-RO.ts
+++ b/packages/ag-charts-locale/src/ro-RO.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_RO_RO: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'legătură ${index} din ${count}, de la ${from} la ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nodul ${index} din ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, nivel ${level}[number], ${posInSet}[number] din ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, nivel ${level}[number], ${posInSet}[number] din ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'restrâns',
+    ariaOrgChartExpanded: 'extins',
     ariaAnnounceGaugeChart: 'grafic indicator, ${caption}',
     ariaAnnounceHierarchyChart: 'diagramă ierarhică, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivel ${level}[number], ${count}[number] copii, ${description}',

--- a/packages/ag-charts-locale/src/ro-RO.ts
+++ b/packages/ag-charts-locale/src/ro-RO.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_RO_RO: Record<string, string> = {
     ariaAnnounceChart: 'diagramă, ${seriesCount}[number] serii',
     ariaAnnounceFlowProportionLink: 'legătură ${index} din ${count}, de la ${from} la ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nodul ${index} din ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'grafic indicator, ${caption}',
     ariaAnnounceHierarchyChart: 'diagramă ierarhică, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivel ${level}[number], ${count}[number] copii, ${description}',

--- a/packages/ag-charts-locale/src/sk-SK.ts
+++ b/packages/ag-charts-locale/src/sk-SK.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_SK_SK: Record<string, string> = {
     ariaAnnounceChart: 'graf, ${seriesCount}[number] sérií',
     ariaAnnounceFlowProportionLink: 'odkaz ${index} z ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'uzol ${index} z ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'stupnicový graf, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchický graf, ${caption}',
     ariaAnnounceHierarchyDatum: 'úroveň ${level}[number], ${count}[number] detí, ${description}',

--- a/packages/ag-charts-locale/src/sk-SK.ts
+++ b/packages/ag-charts-locale/src/sk-SK.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_SK_SK: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'odkaz ${index} z ${count}, od ${from} do ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'uzol ${index} z ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'zbalený',
+    ariaOrgChartExpanded: 'rozbalený',
     ariaAnnounceGaugeChart: 'stupnicový graf, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchický graf, ${caption}',
     ariaAnnounceHierarchyDatum: 'úroveň ${level}[number], ${count}[number] detí, ${description}',

--- a/packages/ag-charts-locale/src/sv-SE.ts
+++ b/packages/ag-charts-locale/src/sv-SE.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_SV_SE: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'länk ${index} av ${count}, från ${from} till ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nod ${index} av ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'komprimerad',
+    ariaOrgChartExpanded: 'expanderad',
     ariaAnnounceGaugeChart: 'mätargraf, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkidiagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivå ${level}[number], ${count}[number] barn, ${description}',

--- a/packages/ag-charts-locale/src/sv-SE.ts
+++ b/packages/ag-charts-locale/src/sv-SE.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_SV_SE: Record<string, string> = {
     ariaAnnounceChart: 'diagram, ${seriesCount}[number] serier',
     ariaAnnounceFlowProportionLink: 'länk ${index} av ${count}, från ${from} till ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nod ${index} av ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'mätargraf, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkidiagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivå ${level}[number], ${count}[number] barn, ${description}',

--- a/packages/ag-charts-locale/src/tr-TR.ts
+++ b/packages/ag-charts-locale/src/tr-TR.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_TR_TR: Record<string, string> = {
     ariaAnnounceChart: 'grafik, ${seriesCount}[number] seri',
     ariaAnnounceFlowProportionLink: 'bağlantı ${index} / ${count}, ${from} - ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'düğüm ${index} / ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'gösterge grafik, ${caption}',
     ariaAnnounceHierarchyChart: 'hiyerarşi grafiği, ${caption}',
     ariaAnnounceHierarchyDatum: 'seviye ${level}[number], ${count}[number] çocuk, ${description}',

--- a/packages/ag-charts-locale/src/tr-TR.ts
+++ b/packages/ag-charts-locale/src/tr-TR.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_TR_TR: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'bağlantı ${index} / ${count}, ${from} - ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'düğüm ${index} / ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, seviye ${level}[number], ${posInSet}[number] / ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, seviye ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'daraltılmış',
+    ariaOrgChartExpanded: 'genişletilmiş',
     ariaAnnounceGaugeChart: 'gösterge grafik, ${caption}',
     ariaAnnounceHierarchyChart: 'hiyerarşi grafiği, ${caption}',
     ariaAnnounceHierarchyDatum: 'seviye ${level}[number], ${count}[number] çocuk, ${description}',

--- a/packages/ag-charts-locale/src/uk-UA.ts
+++ b/packages/ag-charts-locale/src/uk-UA.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_UK_UA: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'посилання ${index} з ${count}, від ${from} до ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'вузол ${index} з ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, рівень ${level}[number], ${posInSet}[number] з ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, рівень ${level}[number], ${posInSet}[number] з ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'згорнуто',
+    ariaOrgChartExpanded: 'розгорнуто',
     ariaAnnounceGaugeChart: 'діаграма циферблата, ${caption}',
     ariaAnnounceHierarchyChart: 'ієрархічна діаграма, ${caption}',
     ariaAnnounceHierarchyDatum: 'рівень ${level}[number], ${count}[number] дочірні, ${description}',

--- a/packages/ag-charts-locale/src/uk-UA.ts
+++ b/packages/ag-charts-locale/src/uk-UA.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_UK_UA: Record<string, string> = {
     ariaAnnounceChart: 'діаграма, ${seriesCount}[number] серій',
     ariaAnnounceFlowProportionLink: 'посилання ${index} з ${count}, від ${from} до ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'вузол ${index} з ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'діаграма циферблата, ${caption}',
     ariaAnnounceHierarchyChart: 'ієрархічна діаграма, ${caption}',
     ariaAnnounceHierarchyDatum: 'рівень ${level}[number], ${count}[number] дочірні, ${description}',

--- a/packages/ag-charts-locale/src/ur-PK.ts
+++ b/packages/ag-charts-locale/src/ur-PK.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_UR_PK: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'لنک ${index} کا ${count} میں سے، ${from} سے ${to} تک، ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'نوڈ ${index} کا ${count}، ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, سطح ${level}[number], ${posInSet}[number] کا ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, سطح ${level}[number], ${posInSet}[number] کا ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'سمٹا ہوا',
+    ariaOrgChartExpanded: 'پھیلا ہوا',
     ariaAnnounceGaugeChart: 'گیج چارٹ, ${caption}',
     ariaAnnounceHierarchyChart: 'درجہ بندی چارٹ، ${caption}',
     ariaAnnounceHierarchyDatum: 'سطح ${level}[number], ${count}[number] بچے, ${description}',

--- a/packages/ag-charts-locale/src/ur-PK.ts
+++ b/packages/ag-charts-locale/src/ur-PK.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_UR_PK: Record<string, string> = {
     ariaAnnounceChart: 'چارٹ، ${seriesCount}[number] سیریز',
     ariaAnnounceFlowProportionLink: 'لنک ${index} کا ${count} میں سے، ${from} سے ${to} تک، ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'نوڈ ${index} کا ${count}، ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'گیج چارٹ, ${caption}',
     ariaAnnounceHierarchyChart: 'درجہ بندی چارٹ، ${caption}',
     ariaAnnounceHierarchyDatum: 'سطح ${level}[number], ${count}[number] بچے, ${description}',

--- a/packages/ag-charts-locale/src/vi-VN.ts
+++ b/packages/ag-charts-locale/src/vi-VN.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_VI_VN: Record<string, string> = {
     ariaAnnounceFlowProportionLink: 'liên kết ${index} của ${count}, từ ${from} đến ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nút ${index} của ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, cấp độ ${level}[number], ${posInSet}[number] trong ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, cấp độ ${level}[number], ${posInSet}[number] trong ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: 'đã thu gọn',
+    ariaOrgChartExpanded: 'đã mở rộng',
     ariaAnnounceGaugeChart: 'biểu đồ đồng hồ đo, ${caption}',
     ariaAnnounceHierarchyChart: 'biểu đồ phân cấp, ${caption}',
     ariaAnnounceHierarchyDatum: 'cấp độ ${level}[number], ${count}[number] con, ${description}',

--- a/packages/ag-charts-locale/src/vi-VN.ts
+++ b/packages/ag-charts-locale/src/vi-VN.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_VI_VN: Record<string, string> = {
     ariaAnnounceChart: 'biểu đồ, ${seriesCount}[number] chuỗi',
     ariaAnnounceFlowProportionLink: 'liên kết ${index} của ${count}, từ ${from} đến ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: 'nút ${index} của ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: 'biểu đồ đồng hồ đo, ${caption}',
     ariaAnnounceHierarchyChart: 'biểu đồ phân cấp, ${caption}',
     ariaAnnounceHierarchyDatum: 'cấp độ ${level}[number], ${count}[number] con, ${description}',

--- a/packages/ag-charts-locale/src/zh-CN.ts
+++ b/packages/ag-charts-locale/src/zh-CN.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_ZH_CN: Record<string, string> = {
     ariaAnnounceFlowProportionLink: '链接 ${index} 总共 ${count}，从 ${from} 到 ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '节点 ${index} 之 ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, 级别 ${level}[number], ${posInSet}[number] 的 ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, 级别 ${level}[number], ${posInSet}[number] 的 ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: '已折叠',
+    ariaOrgChartExpanded: '已展开',
     ariaAnnounceGaugeChart: '仪表盘图表, ${caption}',
     ariaAnnounceHierarchyChart: '层次图表, ${caption}',
     ariaAnnounceHierarchyDatum: '级别 ${level}[number], ${count}[number] 子项, ${description}',

--- a/packages/ag-charts-locale/src/zh-CN.ts
+++ b/packages/ag-charts-locale/src/zh-CN.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_ZH_CN: Record<string, string> = {
     ariaAnnounceChart: '图表，共有${seriesCount}[number]个系列',
     ariaAnnounceFlowProportionLink: '链接 ${index} 总共 ${count}，从 ${from} 到 ${to}, ${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '节点 ${index} 之 ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: '仪表盘图表, ${caption}',
     ariaAnnounceHierarchyChart: '层次图表, ${caption}',
     ariaAnnounceHierarchyDatum: '级别 ${level}[number], ${count}[number] 子项, ${description}',

--- a/packages/ag-charts-locale/src/zh-HK.ts
+++ b/packages/ag-charts-locale/src/zh-HK.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_ZH_HK: Record<string, string> = {
     ariaAnnounceFlowProportionLink: '連結 ${index} 的 ${count}，從 ${from} 到 ${to}，${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '節點 ${index} 在 ${count} 中, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: '已收合',
+    ariaOrgChartExpanded: '已展開',
     ariaAnnounceGaugeChart: '儀表圖, ${caption}',
     ariaAnnounceHierarchyChart: '層次圖, ${caption}',
     ariaAnnounceHierarchyDatum: '層級 ${level}[number]，${count}[number] 個子項，${description}',

--- a/packages/ag-charts-locale/src/zh-HK.ts
+++ b/packages/ag-charts-locale/src/zh-HK.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_ZH_HK: Record<string, string> = {
     ariaAnnounceChart: '圖表，${seriesCount}[number] 系列',
     ariaAnnounceFlowProportionLink: '連結 ${index} 的 ${count}，從 ${from} 到 ${to}，${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '節點 ${index} 在 ${count} 中, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: '儀表圖, ${caption}',
     ariaAnnounceHierarchyChart: '層次圖, ${caption}',
     ariaAnnounceHierarchyDatum: '層級 ${level}[number]，${count}[number] 個子項，${description}',

--- a/packages/ag-charts-locale/src/zh-TW.ts
+++ b/packages/ag-charts-locale/src/zh-TW.ts
@@ -12,6 +12,11 @@ export const AG_CHARTS_LOCALE_ZH_TW: Record<string, string> = {
     ariaAnnounceChart: '圖表，${seriesCount}[number] 個系列',
     ariaAnnounceFlowProportionLink: '連結 ${index} / ${count}，從 ${from} 到 ${to}，${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '節點 ${index} 之 ${count}, ${description}',
+    // Screen reader announcement when focusing a leaf node in an Organization chart
+    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    // Screen reader announcement when focusing a parent node in an Organization chart
+    ariaAnnounceOrgChartParent:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
     ariaAnnounceGaugeChart: '儀表板圖表, ${caption}',
     ariaAnnounceHierarchyChart: '階層圖表, ${caption}',
     ariaAnnounceHierarchyDatum: '層級 ${level}[number]，${count}[number] 個子項目，${description}',

--- a/packages/ag-charts-locale/src/zh-TW.ts
+++ b/packages/ag-charts-locale/src/zh-TW.ts
@@ -13,10 +13,12 @@ export const AG_CHARTS_LOCALE_ZH_TW: Record<string, string> = {
     ariaAnnounceFlowProportionLink: '連結 ${index} / ${count}，從 ${from} 到 ${to}，${sizeName} ${size}',
     ariaAnnounceFlowProportionNode: '節點 ${index} 之 ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
-    ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
+    ariaAnnounceOrgChartLeaf: '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}',
+    ariaOrgChartCollapsed: '已收合',
+    ariaOrgChartExpanded: '已展開',
     ariaAnnounceGaugeChart: '儀表板圖表, ${caption}',
     ariaAnnounceHierarchyChart: '階層圖表, ${caption}',
     ariaAnnounceHierarchyDatum: '層級 ${level}[number]，${count}[number] 個子項目，${description}',


### PR DESCRIPTION
## Summary

Implements keyboard navigation and screen-reader announcements for the Org Chart series per AG-17012.

- **`pickFocus`** on `OrganizationSeries` with the spatial arrow-key model (parent / child / sibling walks via the `OrganizationGraph` edges). Focus bounds drawn from the card rect, excluding the descendants-count expander pill that hangs below.
- **`getDatumAriaText`** with two locale keys (leaf vs parent) so empty `${collapsedState}` slots don't stutter (`",,"`) for leaves. Identity-first ordering — name precedes structural metadata, matching WAI-ARIA tree conventions.
- **`AbstractNetworkSeries.updateSelections` now honours `nodeDataRefresh`.** Without the gate, per-vertex datum objects were re-allocated on every chart update; that tricked `HighlightManager.isEqual`'s `a.datum === b.datum` check into a spurious "highlight change" → `SERIES_UPDATE` loop on focus.
- **`OrganizationDatum.datum`** now references the user's source data row (`processedData.dataSources.get(seriesId).data[i]`) instead of a derived `{image, title, subtitle, labels}` projection. Aligns with the `SeriesNodeDatum` convention and gives the highlight equality check a meaningful, stable identity.

### Scope cuts (per design plan §4)

ARIA tree DOM (`role="tree"` / `treeitem` / `aria-setsize` / `aria-posinset`) is **not** added — the chart's `FocusSwapChain` is a single-string aria-live announcer, not a treeitem DOM. The structural information is encoded in the announced string instead. Documented as a deviation against AG-17012 §4.2.

## Stacking

Stacks on `ag-17179/org-chart-zoom-support` to reuse that branch's `Transformable` / `pendingPanToItemId` plumbing.

## Test plan

- [x] `yarn nx build:types ag-charts-enterprise`
- [x] `yarn nx lint ag-charts-enterprise`
- [x] `yarn nx test ag-charts-enterprise` — 1960 passing (incl. 11 new keyboard-nav + aria tests)
- [x] DOM-driven aria tests (real `KeyboardEvent` dispatch + reading from the live `ag-charts-swapchain` announcer) verified against VoiceOver feedback (identity-first, no `, ,` stutter)
- [ ] Manual VoiceOver pass on the gallery org-chart example