### PR TITLE
AG-16046 PR review: bubble/scatter tooltip swatch uses missingDataFill

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -1322,6 +1322,8 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
                 if (binLabel != null) {
                     data.at(-1)!.value = binLabel;
                 }
+            } else if (properties.colorScale.missingDataFill != null) {
+                resolvedColorFill = properties.colorScale.missingDataFill;
             }
         }
 

--- a/packages/ag-charts-enterprise/src/test/colorScaleMissingData.test.ts
+++ b/packages/ag-charts-enterprise/src/test/colorScaleMissingData.test.ts
@@ -9,6 +9,7 @@ import {
 import {
     assertTooltipPresentForAll,
     deproxy,
+    hoverAction,
     setupMockCanvas,
     setupMockConsole,
     waitForChartStability,
@@ -85,4 +86,64 @@ describe('colorScale.missingDataFill - bubble/scatter', () => {
             (i) => i
         );
     });
+
+    let capturedFill: unknown;
+
+    const swatchFillCases: Array<
+        | { seriesType: 'bubble'; build: (missingDataFill: string) => AgBubbleSeriesOptions }
+        | { seriesType: 'scatter'; build: (missingDataFill: string) => AgScatterSeriesOptions }
+    > = [
+        {
+            seriesType: 'bubble',
+            build: (missingDataFill) => ({
+                ...seriesBaseByType.bubble,
+                colorScale: { fills, missingDataFill },
+                tooltip: {
+                    renderer: (params) => {
+                        capturedFill = params.fill;
+                        return '';
+                    },
+                },
+            }),
+        },
+        {
+            seriesType: 'scatter',
+            build: (missingDataFill) => ({
+                ...seriesBaseByType.scatter,
+                colorScale: { fills, missingDataFill },
+                tooltip: {
+                    renderer: (params) => {
+                        capturedFill = params.fill;
+                        return '';
+                    },
+                },
+            }),
+        },
+    ];
+
+    it.each(swatchFillCases)(
+        '$seriesType tooltip swatch uses missingDataFill for missing-colour datum',
+        async ({ build }) => {
+            const missingDataFill = 'tomato';
+            const options: AgChartOptions = prepareEnterpriseTestOptions({
+                data,
+                series: [build(missingDataFill)],
+            });
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const markerAt = (predicate: (d: (typeof data)[number]) => boolean) => {
+                const datumIndex = data.findIndex(predicate);
+                const node = chart.series[0].contextNodeData?.nodeData?.[datumIndex];
+                if (node?.midPoint == null) throw new Error(`No rendered marker at index ${datumIndex}`);
+                return node.midPoint as { x: number; y: number };
+            };
+
+            const missingMarker = markerAt((d) => d.intensity == null);
+            await hoverAction(missingMarker.x, missingMarker.y)(chart);
+            await waitForChartStability(chart);
+            expect(capturedFill).toBe(missingDataFill);
+        }
+    );
 });


### PR DESCRIPTION
## Summary

Address David's QA feedback on pt3 (https://ag-grid.atlassian.net/browse/AG-16046?focusedCommentId=113216): hovering a marker rendered with `colorScale.missingDataFill` (e.g. `tomato`) showed a tooltip swatch in the default series fill (blue) instead of the override colour.

`updateDatumStyles` already applies `missingDataFill` on-canvas when `colorKey` is set and `colorValue` is null/undefined. `getTooltipContent` only resolved a swatch fill for non-null colour values, so the renderer params (and the swatch) fell back to the series default.

This PR mirrors the on-canvas rule in the tooltip path: when `colorKey` is set, the colour value is missing, and `missingDataFill` is configured, use it as the resolved tooltip fill so the swatch matches the rendered marker.

## Test plan

- [x] `yarn nx test ag-charts-enterprise --testPathPattern=colorScaleMissingData` (6/6 passing)
- [x] `yarn nx test ag-charts-community --testPathPattern="bubbleSeries\|scatterSeries"` (104/104 passing — no snapshot deltas)
- [x] `yarn nx format`, `yarn nx lint ag-charts-community`, `yarn nx lint ag-charts-enterprise`
- [x] New test drives the chart through the user-facing surface: configures `tooltip.renderer`, hovers the missing-colour marker via `hoverAction`, and asserts the captured `params.fill === missingDataFill`.
- [ ] David to re-verify against the original Plunker (https://plnkr.co/edit/XuLeclVvoaLqFdJK)