### PR TITLE
AG-17207 TC3 Do not select the "nearest" datum

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -88,6 +88,7 @@ type HandleFocusInputs = FocusIndices | FocusDeltas;
 type UpdatePickedFocusInputs = FocusIndices & FocusDeltas & FocusOldIndices;
 
 type FindPickedNodesResult = PickedNodes | 'series-hidden' | undefined;
+type SeriesNodeClickResult = { clickedNode: PickedNode; distance: number };
 
 export interface SeriesAreaChartDependencies {
     hasViewportSupport(): boolean;
@@ -611,9 +612,9 @@ export class SeriesAreaManager extends BaseManager {
         }
 
         if (isSeriesWidget) {
-            const clickedNode: PickedNode | undefined = this.checkSeriesNodeClick(event);
-            if (clickedNode) {
-                this.emitSeriesAreaClickEvent(event, true, clickedNode);
+            const clickResult: SeriesNodeClickResult | undefined = this.checkSeriesNodeClick(event);
+            if (clickResult) {
+                this.emitSeriesAreaClickEvent(event, true, clickResult);
                 this.update(ChartUpdateType.SERIES_UPDATE);
                 event.sourceEvent.preventDefault();
                 return;
@@ -637,10 +638,11 @@ export class SeriesAreaManager extends BaseManager {
     private emitSeriesAreaClickEvent(
         event: ClickLikeEvent | KeyboardSyntheticMouseWidgetEvent,
         consumed: boolean,
-        clickedNode?: PickedNode
+        clickResult?: SeriesNodeClickResult
     ): void {
         const { type, sourceEvent } = event;
-        const payload: SeriesAreaClickEvent = { type, consumed, sourceEvent, clickedNode };
+        const { clickedNode, distance = 0 } = clickResult ?? {};
+        const payload: SeriesAreaClickEvent = { type, consumed, sourceEvent, clickedNode, distance };
         this.chart.ctx.eventsHub.emit('series-area:click', payload);
     }
 
@@ -770,7 +772,7 @@ export class SeriesAreaManager extends BaseManager {
                     device: 'keyboard',
                     sourceEvent,
                 };
-                this.emitSeriesAreaClickEvent(syntheticEvent, true, datum);
+                this.emitSeriesAreaClickEvent(syntheticEvent, true, { clickedNode: datum, distance: 0 });
                 this.update(ChartUpdateType.SERIES_UPDATE);
             }
         } else {
@@ -781,7 +783,9 @@ export class SeriesAreaManager extends BaseManager {
         }
     }
 
-    private checkSeriesNodeClick(event: ClickLikeEvent & { preventZoomDblClick?: boolean }): PickedNode | undefined {
+    private checkSeriesNodeClick(
+        event: ClickLikeEvent & { preventZoomDblClick?: boolean }
+    ): SeriesNodeClickResult | undefined {
         const pickedNodes = this.pickNodes({ x: event.currentX, y: event.currentY }, 'event');
         const updated = this.pickManager.onPickedNodesTooltip(pickedNodes);
         if (pickedNodes === undefined || updated.active === undefined) return undefined;
@@ -804,7 +808,7 @@ export class SeriesAreaManager extends BaseManager {
                     });
                 }
             }
-            return updated.active;
+            return { clickedNode: updated.active, distance };
         }
 
         if (event.type === 'dblclick') {
@@ -819,7 +823,7 @@ export class SeriesAreaManager extends BaseManager {
             event.preventZoomDblClick = distance === 0;
 
             updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, updated.active);
-            return updated.active;
+            return { clickedNode: updated.active, distance };
         }
 
         return undefined;

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -77,6 +77,7 @@ export interface SeriesAreaClickEvent {
     readonly consumed: boolean;
     readonly sourceEvent: MouseEvent | TouchEvent | KeyboardEvent;
     readonly clickedNode: SeriesNodeDatum<DatumIndexType> | undefined;
+    readonly distance: number;
 }
 
 export interface DataModelSeriesDiff {

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -158,12 +158,14 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const { enabled, enableClick, enableClickAwayToClear, clickMode } = this.opts;
         if (!enabled || !enableClick) return;
 
-        const { type, clickedNode } = event;
+        const { type, clickedNode, distance } = event;
         if (type !== 'click') return;
 
         const modifierPressed = hasAddToSelectionModifier(event);
         const clickMiss =
-            clickedNode === undefined || !(clickedNode.series.properties.selection.enabled satisfies boolean);
+            clickedNode === undefined ||
+            distance !== 0 ||
+            !(clickedNode.series.properties.selection.enabled satisfies boolean);
 
         if (clickMiss && (modifierPressed || !enableClickAwayToClear)) {
             // Ctrl+Click only toggles selection; it shouldn't clear the selection.


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17207

`SeriesAreaClickEvent` now includes `distance` in the payload so that `dataSelection.ts` can distinguish between nearest & exact clicks.