### PR TITLE
AG-17207 TC1 Mute console errors

### DIFF
--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1002,7 +1002,10 @@ export abstract class Series<
     public *pickNodesInBBox(selectionBox: BoxBounds): Iterable<TDatum> {
         function* walkNodes(node: Group, callback: (node: Node) => TDatum | undefined): Iterable<TDatum> {
             for (const child of node.children()) {
-                if (child.datum !== undefined) {
+                // Note: Some series-type include `datum` values in the scene-graph that not assignable to `TDatum`.
+                // For example: line-series `SegmentedPath` include segmentation data in `datum`). So add some basic
+                // check for `datumIndex` to filter out datums that definitely not assignable to `TDatum`.
+                if (child.datum != null && typeof child.datum === 'object' && 'datumIndex' in child.datum) {
                     const result = callback(child);
                     if (result !== undefined) {
                         yield result;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17207

We'll filter out non-datum scene-node (e.g. line/polys of line/area/range-area series types).