### PR TITLE
AG-17005 Add `getAggregateRangeReader` to remaining aggregating series

### DIFF
--- a/packages/ag-charts-community/src/chart/series/aggregationRangeReader.ts
+++ b/packages/ag-charts-community/src/chart/series/aggregationRangeReader.ts
@@ -1,0 +1,95 @@
+import {
+    AGGREGATION_INDEX_X_MAX,
+    AGGREGATION_INDEX_X_MIN,
+    aggregationBucketForDatum,
+    aggregationDomain,
+} from 'ag-charts-core';
+
+import type { ChartAxis } from '../chartAxis';
+import type { DataModel } from '../data/dataModel';
+import type { ProcessedData, ScopeProvider } from '../data/dataModelTypes';
+import { type AggregationFilterBase, type AggregationManager } from './aggregationManager';
+import type { DatumRangeReader } from './seriesTypes';
+
+interface ExtremesFilter extends AggregationFilterBase {
+    indexData: Uint32Array;
+}
+
+/** Resolved aggregation bucket lookup state, ready to compute per-datum ranges. */
+export interface AggregateBucketContext<TFilter> {
+    xValues: any[];
+    d0: number;
+    d1: number;
+    filter: TFilter;
+}
+
+interface AggregateBucketContextOpts<TFilter extends AggregationFilterBase> {
+    series: ScopeProvider;
+    xAxis: ChartAxis | undefined;
+    dataModel: DataModel<any, any, any> | undefined;
+    processedData: ProcessedData<any> | undefined;
+    aggregationManager: AggregationManager<TFilter>;
+    domainKey: 'value' | 'key';
+}
+
+/**
+ * Resolve the shared inputs every aggregation-aware series needs to translate
+ * a picked sample datum index into a bucket and back to a raw range:
+ *
+ * - `xValues`: array used by the aggregation builder for this series — keys
+ *   for `'key'`-domain series (bar/area/ohlc/range-*), columns for `'value'`-
+ *   domain series (line). Must match the builder so `aggregationBucketForDatum`
+ *   resolves to the same bucket the index data was written under.
+ * - `d0`/`d1`: the numeric x-domain matching the bucket grid.
+ * - `filter`: the aggregation filter active at the current zoom level.
+ *
+ * Returns `undefined` when the data model isn't ready or no aggregation level
+ * is currently active.
+ */
+export function prepareAggregateBucketContext<TFilter extends AggregationFilterBase>(
+    opts: AggregateBucketContextOpts<TFilter>
+): AggregateBucketContext<TFilter> | undefined {
+    const { series, xAxis, dataModel, processedData, aggregationManager, domainKey } = opts;
+    if (!xAxis || !dataModel || !processedData) return undefined;
+
+    const domainInput = dataModel.getDomain(series, 'xValue', domainKey, processedData);
+    const xValues =
+        domainKey === 'key'
+            ? dataModel.resolveKeysById(series, 'xValue', processedData)
+            : dataModel.resolveColumnById(series, 'xValue', processedData);
+
+    const [r0, r1] = xAxis.scale.range;
+    const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
+
+    const filter = aggregationManager.getFilterForRange(Math.abs(r1 - r0));
+    if (!filter) return undefined;
+
+    return { xValues, d0, d1, filter };
+}
+
+/**
+ * Build a {@link DatumRangeReader} for series whose aggregation filter exposes a
+ * single `indexData` Uint32Array with `AGGREGATION_INDEX_X_MIN/_MAX` slots
+ * (line, area, OHLC, range-bar, range-area).
+ *
+ * Series with split positive/negative arrays (bar) should call
+ * {@link prepareAggregateBucketContext} directly and write their own closure
+ * — the lookup step there needs side-selection logic this helper deliberately
+ * doesn't model.
+ */
+export function makeAggregateRangeReader<TFilter extends ExtremesFilter>(
+    opts: AggregateBucketContextOpts<TFilter>
+): DatumRangeReader | undefined {
+    const ctx = prepareAggregateBucketContext(opts);
+    if (!ctx) return undefined;
+
+    const { xValues, d0, d1, filter } = ctx;
+
+    return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
+        const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
+            xValuesLength: xValues.length,
+        });
+
+        return [filter.indexData[bucket + AGGREGATION_INDEX_X_MIN], filter.indexData[bucket + AGGREGATION_INDEX_X_MAX]];
+    };
+}

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -7,14 +7,10 @@ import type {
     RequireOptional,
 } from 'ag-charts-core';
 import {
-    AGGREGATION_INDEX_X_MAX,
-    AGGREGATION_INDEX_X_MIN,
     ChartAxisDirection,
     DebugMetrics,
     SeriesContentZIndexMap,
     SeriesZIndexMap,
-    aggregationBucketForDatum,
-    aggregationDomain,
     extent,
     isContinuous,
     isDefined,
@@ -64,6 +60,7 @@ import type { LegendSymbolOptions } from '../../legend/legendSymbol';
 import { Marker } from '../../marker/marker';
 import { type TooltipContent, isTooltipValueMissing } from '../../tooltip/tooltip';
 import { AggregationManager } from '../aggregationManager';
+import { makeAggregateRangeReader } from '../aggregationRangeReader';
 import { type PickFocusInputs, SeriesNodePickMode } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { HighlightState, toHighlightString } from '../seriesProperties';
@@ -450,30 +447,14 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
     }
 
     public override getAggregateRangeReader(): DatumRangeReader | undefined {
-        const xAxis = this.axes[ChartAxisDirection.X];
-        const { dataModel, processedData } = this;
-        if (!xAxis || !dataModel || !processedData) return undefined;
-
-        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
-        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-
-        const [r0, r1] = xAxis.scale.range;
-        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
-
-        const range = Math.abs(r1 - r0);
-        const filter = this.aggregationManager.getFilterForRange(range);
-        if (!filter) return undefined;
-
-        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
-            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
-                xValuesLength: xValues.length,
-            });
-
-            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
-            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
-
-            return [xMin, xMax];
-        };
+        return makeAggregateRangeReader({
+            series: this,
+            xAxis: this.axes[ChartAxisDirection.X],
+            dataModel: this.dataModel,
+            processedData: this.processedData,
+            aggregationManager: this.aggregationManager,
+            domainKey: 'key',
+        });
     }
 
     private aggregateData(dataModel: DataModel<any, any>, processedData: ProcessedData<any>): void {

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -7,10 +7,14 @@ import type {
     RequireOptional,
 } from 'ag-charts-core';
 import {
+    AGGREGATION_INDEX_X_MAX,
+    AGGREGATION_INDEX_X_MIN,
     ChartAxisDirection,
     DebugMetrics,
     SeriesContentZIndexMap,
     SeriesZIndexMap,
+    aggregationBucketForDatum,
+    aggregationDomain,
     extent,
     isContinuous,
     isDefined,
@@ -63,6 +67,7 @@ import { AggregationManager } from '../aggregationManager';
 import { type PickFocusInputs, SeriesNodePickMode } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { HighlightState, toHighlightString } from '../seriesProperties';
+import type { DatumRangeReader } from '../seriesTypes';
 import { datumStylerProperties, visibleRangeIndices } from '../util';
 import {
     type AreaSeriesDataAggregationFilter,
@@ -442,6 +447,33 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             yVisibleRange,
             minVisibleItems
         );
+    }
+
+    public override getAggregateRangeReader(): DatumRangeReader | undefined {
+        const xAxis = this.axes[ChartAxisDirection.X];
+        const { dataModel, processedData } = this;
+        if (!xAxis || !dataModel || !processedData) return undefined;
+
+        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
+        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
+
+        const [r0, r1] = xAxis.scale.range;
+        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
+
+        const range = Math.abs(r1 - r0);
+        const filter = this.aggregationManager.getFilterForRange(range);
+        if (!filter) return undefined;
+
+        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
+            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
+                xValuesLength: xValues.length,
+            });
+
+            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
+            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
+
+            return [xMin, xMax];
+        };
     }
 
     private aggregateData(dataModel: DataModel<any, any>, processedData: ProcessedData<any>): void {

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -16,6 +16,9 @@ import {
     AGGREGATION_SPAN,
     ChartAxisDirection,
     DebugMetrics,
+    aggregationBucketForDatum,
+    aggregationDatumMatchesIndex,
+    aggregationDomain,
     areScalingEqual,
     isFiniteNumber,
     mergeDefaults,
@@ -67,7 +70,7 @@ import { AggregationManager } from '../aggregationManager';
 import { type PickFocusInputs, SeriesNodePickMode, type SeriesNodeStyleContext } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { HighlightState, toHighlightString } from '../seriesProperties';
-import type { ErrorBoundSeriesNodeDatum } from '../seriesTypes';
+import type { DatumRangeReader, ErrorBoundSeriesNodeDatum } from '../seriesTypes';
 import { datumStylerProperties, getItemStyles, visibleRangeIndices } from '../util';
 import {
     AbstractBarSeries,
@@ -493,6 +496,47 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
     ): number {
         const yKey = this.yCumulativeKey(this.dataModel!);
         return this.countVisibleItems('xValue', [yKey], xVisibleRange, yVisibleRange, minVisibleItems);
+    }
+
+    public override getAggregateRangeReader(): DatumRangeReader | undefined {
+        const xAxis = this.axes[ChartAxisDirection.X];
+        const { dataModel, processedData } = this;
+        if (!xAxis || !dataModel || !processedData) return undefined;
+
+        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
+        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
+
+        const [r0, r1] = xAxis.scale.range;
+        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
+
+        const range = Math.abs(r1 - r0);
+        const filter = this.aggregationManager.getFilterForRange(range);
+        if (!filter) return undefined;
+
+        const offsets = [
+            AGGREGATION_INDEX_X_MIN,
+            AGGREGATION_INDEX_X_MAX,
+            AGGREGATION_INDEX_Y_MIN,
+            AGGREGATION_INDEX_Y_MAX,
+        ];
+
+        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] | undefined {
+            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
+                xValuesLength: xValues.length,
+            });
+
+            // Bar aggregation splits buckets by sign — positives and negatives
+            // are stacked separately, so the picked datum lives in exactly one side.
+            let data: Uint32Array | undefined;
+            if (aggregationDatumMatchesIndex(filter.positiveIndexData, bucket, sampleDatumIndex, offsets)) {
+                data = filter.positiveIndexData;
+            } else if (aggregationDatumMatchesIndex(filter.negativeIndexData, bucket, sampleDatumIndex, offsets)) {
+                data = filter.negativeIndexData;
+            }
+            if (!data) return undefined;
+
+            return [data[bucket + AGGREGATION_INDEX_X_MIN], data[bucket + AGGREGATION_INDEX_X_MAX]];
+        };
     }
 
     private aggregateData(dataModel: DataModel<any, any, any>, processedData: ProcessedData<any>) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -18,7 +18,6 @@ import {
     DebugMetrics,
     aggregationBucketForDatum,
     aggregationDatumMatchesIndex,
-    aggregationDomain,
     areScalingEqual,
     isFiniteNumber,
     mergeDefaults,
@@ -67,6 +66,7 @@ import type { CategoryLegendDatum, ChartLegendType } from '../../legend/legendDa
 import type { LegendSymbolOptions } from '../../legend/legendSymbol';
 import { type TooltipContent, isTooltipValueMissing } from '../../tooltip/tooltip';
 import { AggregationManager } from '../aggregationManager';
+import { prepareAggregateBucketContext } from '../aggregationRangeReader';
 import { type PickFocusInputs, SeriesNodePickMode, type SeriesNodeStyleContext } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { HighlightState, toHighlightString } from '../seriesProperties';
@@ -499,20 +499,17 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
     }
 
     public override getAggregateRangeReader(): DatumRangeReader | undefined {
-        const xAxis = this.axes[ChartAxisDirection.X];
-        const { dataModel, processedData } = this;
-        if (!xAxis || !dataModel || !processedData) return undefined;
+        const ctx = prepareAggregateBucketContext({
+            series: this,
+            xAxis: this.axes[ChartAxisDirection.X],
+            dataModel: this.dataModel,
+            processedData: this.processedData,
+            aggregationManager: this.aggregationManager,
+            domainKey: 'key',
+        });
+        if (!ctx) return undefined;
 
-        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
-        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-
-        const [r0, r1] = xAxis.scale.range;
-        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
-
-        const range = Math.abs(r1 - r0);
-        const filter = this.aggregationManager.getFilterForRange(range);
-        if (!filter) return undefined;
-
+        const { xValues, d0, d1, filter } = ctx;
         const offsets = [
             AGGREGATION_INDEX_X_MIN,
             AGGREGATION_INDEX_X_MAX,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -1,15 +1,5 @@
 import type { CallbackParamRules, DomainWithMetadata, DynamicContext, RequireOptional } from 'ag-charts-core';
-import {
-    AGGREGATION_INDEX_X_MAX,
-    AGGREGATION_INDEX_X_MIN,
-    ChartAxisDirection,
-    DebugMetrics,
-    aggregationBucketForDatum,
-    aggregationDomain,
-    extent,
-    isDefined,
-    mergeDefaults,
-} from 'ag-charts-core';
+import { ChartAxisDirection, DebugMetrics, extent, isDefined, mergeDefaults } from 'ag-charts-core';
 import {
     type AgDrawingMode,
     type AgErrorBoundSeriesTooltipRendererParams,
@@ -53,6 +43,7 @@ import { type LegendSymbolOptions } from '../../legend/legendSymbol';
 import { Marker } from '../../marker/marker';
 import { type TooltipContent, isTooltipValueMissing } from '../../tooltip/tooltip';
 import { AggregationManager } from '../aggregationManager';
+import { makeAggregateRangeReader } from '../aggregationRangeReader';
 import { type PickFocusInputs, SeriesNodePickMode } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { HighlightState, toHighlightString } from '../seriesProperties';
@@ -376,30 +367,14 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
     }
 
     public override getAggregateRangeReader(): DatumRangeReader | undefined {
-        const xAxis = this.axes[ChartAxisDirection.X];
-        const { dataModel, processedData } = this;
-        if (!xAxis || !dataModel || !processedData) return undefined;
-
-        const domainInput = dataModel.getDomain(this, 'xValue', 'value', processedData);
-        const xValues = dataModel.resolveColumnById(this, 'xValue', processedData);
-
-        const [r0, r1] = xAxis.scale.range;
-        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
-
-        const range = Math.abs(r1 - r0);
-        const filter = this.aggregationManager.getFilterForRange(range);
-        if (!filter) return undefined;
-
-        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
-            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
-                xValuesLength: xValues.length,
-            });
-
-            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
-            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
-
-            return [xMin, xMax];
-        };
+        return makeAggregateRangeReader({
+            series: this,
+            xAxis: this.axes[ChartAxisDirection.X],
+            dataModel: this.dataModel,
+            processedData: this.processedData,
+            aggregationManager: this.aggregationManager,
+            domainKey: 'value',
+        });
     }
 
     private estimateTargetRange(): number {

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -35,7 +35,7 @@ export type SeriesNodeEventTypes =
     | 'seriesNodeClick'
     | 'seriesNodeDoubleClick';
 
-export type DatumRangeReader = (sampledDatumIndex: number) => [number, number];
+export type DatumRangeReader = (sampledDatumIndex: number) => [number, number] | undefined;
 
 export interface INodeEvent<TEvent extends string = SeriesNodeEventTypes> extends TypedEvent {
     readonly type: TEvent;

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -196,6 +196,7 @@ export { SeriesMarker } from './chart/series/seriesMarker';
 export { makeSeriesTooltip, SeriesTooltip } from './chart/series/seriesTooltip';
 export type {
     DatumIndexType,
+    DatumRangeReader,
     ErrorBoundSeriesNodeDatum,
     ISeries,
     ISeriesProperties,

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -301,6 +301,7 @@ export type { GaugeSeries } from './chart/series/gaugeSeries';
 export { getShapeFill, getShapeStyle } from './chart/series/shapeUtil';
 export type { ShapeFillBBox } from './chart/series/shapeUtil';
 export { AggregationManager } from './chart/series/aggregationManager';
+export { makeAggregateRangeReader, prepareAggregateBucketContext } from './chart/series/aggregationRangeReader';
 export { Axis, AxisGroupZIndexMap } from './chart/axis/axis';
 export type { AxisTickFormatParams, LabelNodeDatum } from './chart/axis/axis';
 export { createAxisLabelFormatterCache, formatAxisLabelValue, getAxisLabelSideFlag } from './chart/axis/axisLabelUtil';

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -269,7 +269,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
                 if (asNumericDatumIndex(datum.datumIndex)) {
                     if (getRangeOfAggregateIndex) {
                         const range = getRangeOfAggregateIndex(datum.datumIndex);
-                        if (!intervalSet.has(datum.datumIndex)) {
+                        if (range && !intervalSet.has(datum.datumIndex)) {
                             const [start, end] = range;
                             if (asNumericDatumIndex(start) && asNumericDatumIndex(end)) {
                                 changed = true;

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -22,6 +22,8 @@ import {
     type Mutable,
     type Point,
     type Scale,
+    aggregationBucketForDatum,
+    aggregationDomain,
     mergeDefaults,
 } from 'ag-charts-core';
 
@@ -331,6 +333,36 @@ export abstract class OhlcSeriesBase<
         if (!xAxis) return -1;
         const [r0, r1] = xAxis.scale.range;
         return Math.abs(r1 - r0);
+    }
+
+    public override getAggregateRangeReader(): _ModuleSupport.DatumRangeReader | undefined {
+        const xAxis = this.axes[ChartAxisDirection.X];
+        const { dataModel, processedData } = this;
+        if (!xAxis || !dataModel || !processedData) return undefined;
+
+        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
+        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
+
+        const [r0, r1] = xAxis.scale.range;
+        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
+
+        const range = Math.abs(r1 - r0);
+        const filter = this.aggregationManager.getFilterForRange(range);
+        if (!filter) return undefined;
+
+        // Picked OHLC datums use `midpointIndices[i]`, which is rarely one of the four extrema
+        // stored at OPEN/HIGH/LOW/CLOSE. We re-derive the bucket from the midpoint's xValue
+        // (guaranteed to lie within the bucket's x-range) rather than trusting the index itself.
+        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
+            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
+                xValuesLength: xValues.length,
+            });
+
+            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
+            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
+
+            return [xMin, xMax];
+        };
     }
 
     override getSeriesDomain(direction: ChartAxisDirection) {

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -22,8 +22,6 @@ import {
     type Mutable,
     type Point,
     type Scale,
-    aggregationBucketForDatum,
-    aggregationDomain,
     mergeDefaults,
 } from 'ag-charts-core';
 
@@ -335,34 +333,19 @@ export abstract class OhlcSeriesBase<
         return Math.abs(r1 - r0);
     }
 
+    // Picked OHLC datums use `midpointIndices[i]`, which is rarely one of the four
+    // extrema stored at OPEN/HIGH/LOW/CLOSE. The helper re-derives the bucket from
+    // the midpoint's xValue (guaranteed to lie within the bucket's x-range) rather
+    // than trusting the index itself.
     public override getAggregateRangeReader(): _ModuleSupport.DatumRangeReader | undefined {
-        const xAxis = this.axes[ChartAxisDirection.X];
-        const { dataModel, processedData } = this;
-        if (!xAxis || !dataModel || !processedData) return undefined;
-
-        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
-        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-
-        const [r0, r1] = xAxis.scale.range;
-        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
-
-        const range = Math.abs(r1 - r0);
-        const filter = this.aggregationManager.getFilterForRange(range);
-        if (!filter) return undefined;
-
-        // Picked OHLC datums use `midpointIndices[i]`, which is rarely one of the four extrema
-        // stored at OPEN/HIGH/LOW/CLOSE. We re-derive the bucket from the midpoint's xValue
-        // (guaranteed to lie within the bucket's x-range) rather than trusting the index itself.
-        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
-            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
-                xValuesLength: xValues.length,
-            });
-
-            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
-            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
-
-            return [xMin, xMax];
-        };
+        return _ModuleSupport.makeAggregateRangeReader({
+            series: this,
+            xAxis: this.axes[ChartAxisDirection.X],
+            dataModel: this.dataModel,
+            processedData: this.processedData,
+            aggregationManager: this.aggregationManager,
+            domainKey: 'key',
+        });
     }
 
     override getSeriesDomain(direction: ChartAxisDirection) {

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -11,8 +11,6 @@ import {
 } from 'ag-charts-community';
 import {
     AGGREGATION_INDEX_UNSET,
-    AGGREGATION_INDEX_X_MAX,
-    AGGREGATION_INDEX_X_MIN,
     AGGREGATION_INDEX_Y_MAX,
     AGGREGATION_INDEX_Y_MIN,
     AGGREGATION_SPAN,
@@ -25,8 +23,6 @@ import {
     type DynamicContext,
     type Point,
     type RequireOptional,
-    aggregationBucketForDatum,
-    aggregationDomain,
     extent,
     findMinMax,
     mergeDefaults,
@@ -300,30 +296,14 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
     }
 
     public override getAggregateRangeReader(): _ModuleSupport.DatumRangeReader | undefined {
-        const xAxis = this.axes[ChartAxisDirection.X];
-        const { dataModel, processedData } = this;
-        if (!xAxis || !dataModel || !processedData) return undefined;
-
-        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
-        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-
-        const [r0, r1] = xAxis.scale.range;
-        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
-
-        const range = Math.abs(r1 - r0);
-        const filter = this.aggregationManager.getFilterForRange(range);
-        if (!filter) return undefined;
-
-        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
-            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
-                xValuesLength: xValues.length,
-            });
-
-            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
-            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
-
-            return [xMin, xMax];
-        };
+        return _ModuleSupport.makeAggregateRangeReader({
+            series: this,
+            xAxis: this.axes[ChartAxisDirection.X],
+            dataModel: this.dataModel,
+            processedData: this.processedData,
+            aggregationManager: this.aggregationManager,
+            domainKey: 'key',
+        });
     }
 
     private estimateTargetRange(): number {

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -11,6 +11,8 @@ import {
 } from 'ag-charts-community';
 import {
     AGGREGATION_INDEX_UNSET,
+    AGGREGATION_INDEX_X_MAX,
+    AGGREGATION_INDEX_X_MIN,
     AGGREGATION_INDEX_Y_MAX,
     AGGREGATION_INDEX_Y_MIN,
     AGGREGATION_SPAN,
@@ -23,6 +25,8 @@ import {
     type DynamicContext,
     type Point,
     type RequireOptional,
+    aggregationBucketForDatum,
+    aggregationDomain,
     extent,
     findMinMax,
     mergeDefaults,
@@ -293,6 +297,33 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
                 filters.map((f) => f.maxRange)
             );
         }
+    }
+
+    public override getAggregateRangeReader(): _ModuleSupport.DatumRangeReader | undefined {
+        const xAxis = this.axes[ChartAxisDirection.X];
+        const { dataModel, processedData } = this;
+        if (!xAxis || !dataModel || !processedData) return undefined;
+
+        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
+        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
+
+        const [r0, r1] = xAxis.scale.range;
+        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
+
+        const range = Math.abs(r1 - r0);
+        const filter = this.aggregationManager.getFilterForRange(range);
+        if (!filter) return undefined;
+
+        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
+            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
+                xValuesLength: xValues.length,
+            });
+
+            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
+            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
+
+            return [xMin, xMax];
+        };
     }
 
     private estimateTargetRange(): number {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -21,8 +21,6 @@ import {
     type Mutable,
     type Point,
     type RequireOptional,
-    aggregationBucketForDatum,
-    aggregationDomain,
     areScalingEqual,
     findMinMax,
     mergeDefaults,
@@ -317,33 +315,17 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         }
     }
 
+    // Picked datumIndex is the bucket's midpoint (not an extrema); the helper re-derives
+    // the bucket from its xValue, which still falls within the bucket's x-range.
     public override getAggregateRangeReader(): _ModuleSupport.DatumRangeReader | undefined {
-        const xAxis = this.axes[ChartAxisDirection.X];
-        const { dataModel, processedData } = this;
-        if (!xAxis || !dataModel || !processedData) return undefined;
-
-        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
-        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-
-        const [r0, r1] = xAxis.scale.range;
-        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
-
-        const range = Math.abs(r1 - r0);
-        const filter = this.aggregationManager.getFilterForRange(range);
-        if (!filter) return undefined;
-
-        // Picked datumIndex is the bucket's midpoint (not an extrema); aggregationBucketForDatum
-        // re-derives the bucket from its xValue, which still falls within the bucket's x-range.
-        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
-            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
-                xValuesLength: xValues.length,
-            });
-
-            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
-            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
-
-            return [xMin, xMax];
-        };
+        return _ModuleSupport.makeAggregateRangeReader({
+            series: this,
+            xAxis: this.axes[ChartAxisDirection.X],
+            dataModel: this.dataModel,
+            processedData: this.processedData,
+            aggregationManager: this.aggregationManager,
+            domainKey: 'key',
+        });
     }
 
     private estimateTargetRange(): number {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -21,6 +21,8 @@ import {
     type Mutable,
     type Point,
     type RequireOptional,
+    aggregationBucketForDatum,
+    aggregationDomain,
     areScalingEqual,
     findMinMax,
     mergeDefaults,
@@ -313,6 +315,35 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
                 filters.map((f) => f.maxRange)
             );
         }
+    }
+
+    public override getAggregateRangeReader(): _ModuleSupport.DatumRangeReader | undefined {
+        const xAxis = this.axes[ChartAxisDirection.X];
+        const { dataModel, processedData } = this;
+        if (!xAxis || !dataModel || !processedData) return undefined;
+
+        const domainInput = dataModel.getDomain(this, 'xValue', 'key', processedData);
+        const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
+
+        const [r0, r1] = xAxis.scale.range;
+        const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
+
+        const range = Math.abs(r1 - r0);
+        const filter = this.aggregationManager.getFilterForRange(range);
+        if (!filter) return undefined;
+
+        // Picked datumIndex is the bucket's midpoint (not an extrema); aggregationBucketForDatum
+        // re-derives the bucket from its xValue, which still falls within the bucket's x-range.
+        return function getRangeOfAggregateIndex(sampleDatumIndex: number): [number, number] {
+            const bucket = aggregationBucketForDatum(xValues, d0, d1, filter.maxRange, sampleDatumIndex, {
+                xValuesLength: xValues.length,
+            });
+
+            const xMin = filter.indexData[bucket + AGGREGATION_INDEX_X_MIN];
+            const xMax = filter.indexData[bucket + AGGREGATION_INDEX_X_MAX];
+
+            return [xMin, xMax];
+        };
     }
 
     private estimateTargetRange(): number {

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/data.ts
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/data.ts
@@ -26,11 +26,9 @@ function seedRandom(seed = 1337): () => number {
     return sfc32(0x9e3779b9, 0x243f6a88, 0xb7e15162, realSeed);
 }
 
-const referenceDate = new Date(2024, 0, 1, 0).getTime();
 export function getData(hours: number) {
     let currentPrice = startPrice;
     const random = seedRandom();
-    const period = 60 * 60 * 1000;
     const startDate = new Date(2024, 0, 1, -hours);
     return Array.from({ length: hours }, () => {
         // Note time is reversed

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/data.ts
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/data.ts
@@ -1,0 +1,55 @@
+const startPrice = 100;
+const maxDailyPriceChange = 5;
+const maxRangeDelta = 1;
+
+function sfc32(a: number, b: number, c: number, d: number) {
+    return function () {
+        a >>>= 0;
+        b >>>= 0;
+        c >>>= 0;
+        d >>>= 0;
+        let t = (a + b) | 0;
+        a = b ^ (b >>> 9);
+        b = (c + (c << 3)) | 0;
+        c = (c << 21) | (c >>> 11);
+        d = (d + 1) | 0;
+        t = (t + d) | 0;
+        c = (c + t) | 0;
+        return (t >>> 0) / 4294967296;
+    };
+}
+
+function seedRandom(seed = 1337): () => number {
+    const realSeed = seed ^ 0xdeadbeef; // 32-bit seed with optional XOR value
+    // Pad seed with Phi, Pi and E.
+    // https://en.wikipedia.org/wiki/Nothing-up-my-sleeve_number
+    return sfc32(0x9e3779b9, 0x243f6a88, 0xb7e15162, realSeed);
+}
+
+const referenceDate = new Date(2024, 0, 1, 0).getTime();
+export function getData(hours: number) {
+    let currentPrice = startPrice;
+    const random = seedRandom();
+    const period = 60 * 60 * 1000;
+    const startDate = new Date(2024, 0, 1, -hours);
+    return Array.from({ length: hours }, () => {
+        // Note time is reversed
+        const close = currentPrice;
+        const open = close + (random() * 2 - 1) * maxDailyPriceChange;
+        currentPrice = open;
+
+        const high = Math.max(open, close) + random() * maxRangeDelta;
+        const low = Math.min(open, close) - random() * maxRangeDelta;
+
+        startDate.setHours(startDate.getHours() + 1);
+        const timestamp = startDate.getTime();
+
+        let x = random();
+        let y = random();
+        x *= random();
+        y *= random();
+        const size = random();
+
+        return { timestamp, open, close, high, low, x, y, size };
+    });
+}

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/index.html
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/index.html
@@ -1,0 +1,35 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <span>Selected:</span>
+        <span id="selected-count">0</span>
+    </div>
+    <div class="controls-row">
+        <span>Series Type:</span>
+        <select onchange="setSeries(event.target.value, event.target.selectedOptions[0].text)">
+            <option value="line" selected>Line</option>
+            <option value="area">Area</option>
+            <option value="bar">Bar</option>
+            <hr />
+            <option value="stacked-bar">Stacked Bar</option>
+            <option value="stacked-area">Stacked Area</option>
+            <hr />
+            <option value="range-area">Range Area</option>
+            <option value="range-bar">Range Bar</option>
+            <hr />
+            <option value="candlestick">Candlestick</option>
+            <option value="ohlc">OHLC</option>
+            <hr />
+            <option value="scatter">Scatter</option>
+            <option value="bubble">Bubble</option>
+            <hr />
+            <option value="histogram">Histogram</option>
+        </select>
+        <span class="gap-left">Data Size:</span>
+        <button onclick="setData(1e3, '1K')">1K</button>
+        <button onclick="setData(1e4, '10K')">10K</button>
+        <button onclick="setData(1e5, '100K')">100K</button>
+        <button onclick="setData(5e5, '500K')">500K</button>
+        <button onclick="setData(1e6, '1M')">1M</button>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/main.ts
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/main.ts
@@ -1,7 +1,6 @@
 import {
     AgCartesianAxisOptions,
     AgCartesianChartOptions,
-    AgCartesianSeriesOptions,
     AgCharts,
     AnimationModule,
     AreaSeriesModule,
@@ -115,7 +114,6 @@ const chart = AgCharts.create(options);
 
 function setSeries(type: string, label: string) {
     seriesType = label;
-    let series: AgCartesianSeriesOptions[] = [];
     switch (type) {
         case 'bar':
         case 'area':

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/main.ts
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/_examples/aggregated-selection/main.ts
@@ -1,0 +1,259 @@
+import {
+    AgCartesianAxisOptions,
+    AgCartesianChartOptions,
+    AgCartesianSeriesOptions,
+    AgCharts,
+    AnimationModule,
+    AreaSeriesModule,
+    BarSeriesModule,
+    BubbleSeriesModule,
+    CandlestickSeriesModule,
+    CategoryAxisModule,
+    ContextMenuModule,
+    CrosshairModule,
+    HistogramSeriesModule,
+    LegendModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    OhlcSeriesModule,
+    OrdinalTimeAxisModule,
+    RangeAreaSeriesModule,
+    RangeBarSeriesModule,
+    ScatterSeriesModule,
+    SelectionModule,
+    TimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([
+    AnimationModule,
+    AreaSeriesModule,
+    BarSeriesModule,
+    BubbleSeriesModule,
+    CandlestickSeriesModule,
+    CrosshairModule,
+    HistogramSeriesModule,
+    LegendModule,
+    LineSeriesModule,
+    NavigatorModule,
+    NumberAxisModule,
+    OhlcSeriesModule,
+    OrdinalTimeAxisModule,
+    RangeAreaSeriesModule,
+    RangeBarSeriesModule,
+    ScatterSeriesModule,
+    SelectionModule,
+    TimeAxisModule,
+    ZoomModule,
+    CategoryAxisModule,
+    ContextMenuModule,
+]);
+
+let dataLabel = '1K';
+let seriesType = 'Line';
+let datapoints = 1e3;
+let selectedCount = 0;
+
+const timeAxes: Record<string, AgCartesianAxisOptions> = {
+    x: { type: 'ordinal-time', parentLevel: { enabled: true } },
+};
+
+const numberAxes: Record<string, AgCartesianAxisOptions> = {
+    x: { type: 'number' },
+};
+
+const baseData = getData(1e6);
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: baseData.slice(-datapoints),
+    title: { text: `${seriesType} with ${dataLabel} datapoints` },
+    animation: { enabled: false },
+    selection: {
+        enabled: true,
+        enableDrag: true,
+    },
+    zoom: {
+        enabled: true,
+        axes: 'x',
+        anchorPointX: 'pointer',
+        anchorPointY: 'pointer',
+        autoScaling: {
+            enabled: true,
+        },
+    },
+    navigator: {
+        enabled: true,
+        miniChart: {
+            enabled: true,
+        },
+    },
+    listeners: {
+        selectionChange: (ev) => {
+            selectedCount += ev.added.length - ev.removed.length;
+            const el = document.getElementById('selected-count');
+            if (el) {
+                el.textContent = String(selectedCount);
+            }
+        },
+    },
+    series: [
+        {
+            type: 'line',
+            xKey: 'timestamp',
+            yKey: 'close',
+            selection: { enabled: true },
+        },
+    ],
+    axes: timeAxes,
+};
+
+const chart = AgCharts.create(options);
+
+function setSeries(type: string, label: string) {
+    seriesType = label;
+    let series: AgCartesianSeriesOptions[] = [];
+    switch (type) {
+        case 'bar':
+        case 'area':
+        case 'line':
+            options.series = [
+                {
+                    type,
+                    xKey: 'timestamp',
+                    yKey: 'high',
+                    selection: { enabled: true },
+                },
+            ];
+            break;
+        case 'stacked-bar':
+        case 'stacked-area':
+            const stackedType = type === 'stacked-bar' ? 'bar' : 'area';
+            options.series = [
+                {
+                    type: stackedType,
+                    xKey: 'timestamp',
+                    yKey: 'open',
+                    stacked: true,
+                    selection: { enabled: true },
+                },
+                {
+                    type: stackedType,
+                    xKey: 'timestamp',
+                    yKey: 'close',
+                    stacked: true,
+                    selection: { enabled: true },
+                },
+            ];
+            break;
+
+        case 'range-area':
+        case 'range-bar':
+            options.series = [
+                {
+                    type,
+                    xKey: 'timestamp',
+                    yLowKey: 'low',
+                    yHighKey: 'high',
+                    selection: { enabled: true },
+                },
+            ];
+            break;
+        case 'candlestick':
+        case 'ohlc':
+            options.series = [
+                {
+                    type,
+                    xKey: 'timestamp',
+                    lowKey: 'low',
+                    highKey: 'high',
+                    openKey: 'open',
+                    closeKey: 'close',
+                    selection: {
+                        enabled: true,
+                        selectedItem: { fill: '#ff3b30', stroke: '#990000', strokeWidth: 2 },
+                    },
+                },
+            ];
+            break;
+        case 'scatter':
+            options.series = [
+                {
+                    type,
+                    xKey: 'x',
+                    yKey: 'y',
+                    fillOpacity: 0.2,
+                    strokeOpacity: 0.2,
+                    selection: {
+                        enabled: true,
+                        selectedItem: { fill: '#ff3b30', stroke: '#990000', strokeWidth: 2 },
+                    },
+                    itemStyler: (params: { selectionState?: string }) =>
+                        params.selectionState === 'selected' ? { size: 12 } : {},
+                },
+            ];
+            break;
+        case 'bubble':
+            options.series = [
+                {
+                    type,
+                    xKey: 'x',
+                    yKey: 'y',
+                    sizeKey: 'size',
+                    fillOpacity: 0.2,
+                    strokeOpacity: 0.2,
+                    selection: {
+                        enabled: true,
+                        selectedItem: { fill: '#ff3b30', stroke: '#990000', strokeWidth: 2 },
+                    },
+                    itemStyler: (params: { size: number; selectionState?: string }) =>
+                        params.selectionState === 'selected' ? { size: params.size * 1.6 } : {},
+                },
+            ];
+            break;
+        case 'histogram':
+            options.series = [
+                {
+                    type,
+                    xKey: 'close',
+                },
+            ];
+            break;
+        default:
+            return;
+    }
+
+    const newDatapoints = (options.series?.[0] as any)?.stacked ? datapoints / 2 : datapoints;
+    if (options.data?.length !== newDatapoints) {
+        options.data = baseData.slice(-newDatapoints);
+    }
+    if (type == 'bubble' || type == 'scatter' || type == 'histogram') {
+        options.zoom!.axes = 'xy';
+        options.zoom!.autoScaling!.enabled = false;
+        options.navigator!.enabled = false;
+        options.axes = numberAxes;
+    } else {
+        options.zoom!.axes = 'xy';
+        options.zoom!.autoScaling!.enabled = true;
+        options.navigator!.enabled = true;
+        options.axes = timeAxes;
+    }
+
+    options.title!.text = `${seriesType} with ${dataLabel} datapoints`;
+    chart.update(options);
+}
+
+function setData(points: number, label: string) {
+    const newDatapoints = (options.series?.[0] as any)?.stacked ? points / 2 : points;
+    if (options.data?.length !== newDatapoints) {
+        options.data = baseData.slice(-newDatapoints);
+    }
+    dataLabel = label;
+    datapoints = points;
+    options.title!.text = `${seriesType} with ${dataLabel} datapoints`;
+    chart.update(options);
+}
+/* @ag-skip-clone */

--- a/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/large-dataset-interactivity-test/index.mdoc
@@ -1,0 +1,7 @@
+---
+title: 'Large Dataset Interactivity (Test)'
+---
+
+Internal test page for AG-17005. Exercises data-point selection at high data volumes across the series types now wired up to `getAggregateRangeReader()`, so drag-select reconciles with aggregated buckets.
+
+{% chartExampleRunner title="Aggregated Selection" name="aggregated-selection" type="generated" /%}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17005

Mirrors LineSeries's `getAggregateRangeReader` override on the remaining
series that use `AggregationManager`, so drag-selection reconciles with
aggregated buckets at high data volumes for `bar`, `area`, `ohlc`,
`candlestick`, `range-bar`, and `range-area`.

- Area, OHLC, range-bar, range-area share the single-`indexData` shape and
  read `[X_MIN, X_MAX]` directly.
- Bar reads from the matching positive/negative side via
  `aggregationDatumMatchesIndex`. `DatumRangeReader` is widened to allow
  `undefined` so the consumer can skip ambiguous picks rather than commit
  to a wrong range.
- Each override uses `resolveKeysById` + `getDomain(_, _, 'key', _)` to
  match the corresponding aggregation builder. LineSeries's
  `resolveColumnById` is correct only because `lineAggregation.ts` is the
  lone builder that uses Column.

Click-to-select-on-aggregate and bucketed event-payload semantics are
separate work in flight, not in this PR.

Adds an internal `large-dataset-interactivity-test` page (not in nav) for
verifying drag-select across all 11 selection-supporting series types at
1K–1M points.