### PR TITLE
AG-17152 add index page back in and update to pattern match

### DIFF
--- a/packages/ag-charts-website/src/pages/[framework]/index.astro
+++ b/packages/ag-charts-website/src/pages/[framework]/index.astro
@@ -1,0 +1,23 @@
+---
+import { getDocsFrameworkPages } from '@components/docs/utils/pageData';
+import { DOCS_FRAMEWORK_REDIRECT_PAGE } from '@components/docs/constants';
+import Layout from '@layouts/Layout.astro';
+import { FRAMEWORK_DISPLAY_TEXT } from '@constants';
+import FrameworkRedirectPage from '@ag-website-shared/components/framework-redirect-page/FrameworkRedirectPage.astro';
+
+export async function getStaticPaths() {
+    return getDocsFrameworkPages();
+}
+
+const frameworkDisplay = FRAMEWORK_DISPLAY_TEXT[Astro.params?.framework];
+---
+
+<Layout
+    title=`AG Charts ${frameworkDisplay} Documentation`
+    description=`AG Charts ${frameworkDisplay} Documentation - This page will redirect to the landing page for ${frameworkDisplay} docs`
+    hideFooter={true}
+>
+    <FrameworkRedirectPage framework={Astro.params.framework} redirectPageName={DOCS_FRAMEWORK_REDIRECT_PAGE}>
+        <h1>Redirecting to AG Charts {frameworkDisplay} Documentation...</h1>
+    </FrameworkRedirectPage>
+</Layout>

--- a/packages/ag-charts-website/src/utils/htaccess/redirects.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/redirects.ts
@@ -16,8 +16,8 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { from: '/angular/bullet-series', to: '/angular/linear-gauge/#bullet-series' },
     { from: '/react/bullet-series', to: '/react/linear-gauge/#bullet-series' },
     { from: '/vue/bullet-series', to: '/vue/linear-gauge/#bullet-series' },
-    { from: '/javascript', to: '/javascript/quick-start/' },
-    { from: '/react', to: '/react/quick-start/' },
-    { from: '/vue', to: '/vue/quick-start/' },
-    { from: '/angular', to: '/angular/quick-start/' },
+    { fromPattern: '^/javascript/?$', to: '/javascript/quick-start/' },
+    { fromPattern: '^/react/?$', to: '/react/quick-start/' },
+    { fromPattern: '^/vue/?$', to: '/vue/quick-start/' },
+    { fromPattern: '^/angular/?$', to: '/angular/quick-start/' },
 ];


### PR DESCRIPTION
Follow up to https://github.com/ag-grid/ag-charts/pull/6733

Note:

* Adding the `[framework]/index.astro` file back in, so it works in development/staging. The redirect file only works on production