### PR TITLE
AG-17258 Draw selection-rect above series-data

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -268,6 +268,10 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         name: `${this.id}-annotation-root`,
         zIndex: ZIndexMap.SERIES_ANNOTATION,
     });
+    readonly selectionRoot = new TranslatableGroup({
+        name: `${this.id}-selection-root`,
+        zIndex: ZIndexMap.SERIES_ANNOTATION,
+    });
     // Titles change infrequently, so cache them as an offscreen bitmap to avoid
     // ctx.font assignments on the main canvas (each assignment triggers a browser
     // "recalculate style" for CSS font resolution).
@@ -473,6 +477,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         root.visible = false;
         root.append(this.seriesRoot);
         root.append(this.annotationRoot);
+        root.append(this.selectionRoot);
         root.append(this.titleGroup);
 
         this.titleGroup.append(this.title.node);

--- a/packages/ag-charts-community/src/chart/chartService.ts
+++ b/packages/ag-charts-community/src/chart/chartService.ts
@@ -22,6 +22,7 @@ export interface ChartService {
     readonly title: CaptionLike;
     readonly series: BaseSeries[];
     readonly seriesRoot: Group;
+    readonly selectionRoot: Group;
     readonly publicApi?: AgChartInstance;
     readonly touch: DeepRequired<AgTouchOptions>;
     readonly context?: unknown;

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -69,8 +69,9 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         this.dragRect.lineDash = SELECTION_LINEDASH;
         this.dragRect.visible = false;
 
+        ctx.chartService.selectionRoot.appendChild(this.dragRect);
         this.cleanup.register(
-            ctx.scene.attachNode(this.dragRect),
+            () => ctx.chartService.selectionRoot.removeChild(this.dragRect),
             ctx.eventsHub.on('series-area:click', (ev) => this.onSeriesAreaClick(ev)),
             ctx.widgets.seriesDragInterpreter?.events.on('drag-start', (ev) => this.onSeriesAreaDragStart(ev)),
             ctx.widgets.seriesDragInterpreter?.events.on('drag-move', (ev) => this.onSeriesAreaDragMove(ev)),

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -71,7 +71,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
         ctx.chartService.selectionRoot.appendChild(this.dragRect);
         this.cleanup.register(
-            () => ctx.chartService.selectionRoot.removeChild(this.dragRect),
+            () => this.dragRect.remove(),
             ctx.eventsHub.on('series-area:click', (ev) => this.onSeriesAreaClick(ev)),
             ctx.widgets.seriesDragInterpreter?.events.on('drag-start', (ev) => this.onSeriesAreaDragStart(ev)),
             ctx.widgets.seriesDragInterpreter?.events.on('drag-move', (ev) => this.onSeriesAreaDragMove(ev)),


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17258

I've created a new group (`selectionRoot`) for this, rendered above the `seriesRoot` and the `annotationRoot`.

I initially tried just rendering the selection-rect in the `annotationRoot`, but this group has different (x,y) origins on cartesian and polar charts which needlessly complicated the 'drag-move' logic in `dataSelection.ts`

Depends on:
- https://github.com/ag-grid/ag-charts/pull/6731
