### PR TITLE
AG-17004 Bugfix: restore selection-style when re-enabling selection without dataIdKey

### DIFF
--- a/packages/ag-charts-community/src/chart/data/dataSet.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.ts
@@ -196,7 +196,7 @@ export class DataSet<T = unknown> {
         if (predecessor.selections.size === 0) return;
 
         const oldIds = predecessor.getIdArray();
-        if (!oldIds || !this.dataIdKey || this.dataIdKey !== predecessor.dataIdKey) {
+        if (!oldIds) {
             if (predecessor.data.length === this.data.length) {
                 // There's no dataId, but lengths are the same so assume the indices match to the same datums. This
                 // assumption is not guaranteed, but is likely in most use cases. In the use cases where it isn't, it's
@@ -207,6 +207,10 @@ export class DataSet<T = unknown> {
                     this.selections.set(seriesId, oldSelObj);
                 }
             }
+            return;
+        }
+
+        if (!this.dataIdKey || this.dataIdKey !== predecessor.dataIdKey) {
             return;
         }
 

--- a/packages/ag-charts-community/src/chart/data/dataSet.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSet.ts
@@ -196,7 +196,19 @@ export class DataSet<T = unknown> {
         if (predecessor.selections.size === 0) return;
 
         const oldIds = predecessor.getIdArray();
-        if (!oldIds || !this.dataIdKey || this.dataIdKey !== predecessor.dataIdKey) return;
+        if (!oldIds || !this.dataIdKey || this.dataIdKey !== predecessor.dataIdKey) {
+            if (predecessor.data.length === this.data.length) {
+                // There's no dataId, but lengths are the same so assume the indices match to the same datums. This
+                // assumption is not guaranteed, but is likely in most use cases. In the use cases where it isn't, it's
+                // up the user to decide whether to call `chart.clearSelection()` or to integrate `dataIdKey`.
+                //
+                // Just copy the previous selection state:
+                for (const [seriesId, oldSelObj] of predecessor.selections) {
+                    this.selections.set(seriesId, oldSelObj);
+                }
+            }
+            return;
+        }
 
         const newIdMap = this.getIdToIndexMap();
         for (const [seriesId, oldSelObj] of predecessor.selections) {

--- a/packages/ag-charts-community/src/chart/data/dataSetSelection.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSetSelection.test.ts
@@ -212,11 +212,19 @@ describe('DataSet selection transfer', () => {
             expect(getSelectedCount(nextSel!)).toBe(0); // A not in new data
         });
 
-        it('should clear selections without dataIdKey', () => {
+        it('should not clear selections without dataIdKey (same lengths)', () => {
             const old = new DataSet([{ v: 1 }, { v: 2 }]);
             old.enableSelection('s1').select(0);
 
             const next = DataSet.replaceWith(old, [{ v: 3 }, { v: 4 }]);
+            expect(next.selections.size).toBe(1);
+        });
+
+        it('should clear selections without dataIdKey (different lengths)', () => {
+            const old = new DataSet([{ v: 1 }, { v: 2 }]);
+            old.enableSelection('s1').select(0);
+
+            const next = DataSet.replaceWith(old, [{ v: 3 }, { v: 4 }, { v: 5 }]);
             expect(next.selections.size).toBe(0);
         });
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17004

Previously, `transferFrom` assumed that it was only possible to persist the selection state if we use the dataIdKey. But if we're not using dataIdKey and the data-set size isn't changing, and we can assume that the datum indice line up; this assumption is of course not guaranteed, but is likely in most use cases.