### PR TITLE
AG-17012 Org chart keyboard nav: address QA feedback (pt 2)

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/collapsedManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/collapsedManager.ts
@@ -34,7 +34,17 @@ export class CollapsedManager implements MementoOriginator<CollapsedMemento> {
             changed ||= !this.collapsedIds[id];
             after[id] = true;
         }
+        // Also fire `change` if the previous map had ids that aren't in `after` — those got expanded.
+        if (!changed) {
+            for (const prevId of Object.keys(this.collapsedIds)) {
+                if (!after[prevId]) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
         this.collapsedIds = after;
+        if (changed) this.eventsHub.emit('collapsed:change', null);
         return changed;
     }
 
@@ -44,6 +54,7 @@ export class CollapsedManager implements MementoOriginator<CollapsedMemento> {
             changed ||= !this.collapsedIds[id];
             this.collapsedIds[id] = true;
         }
+        if (changed) this.eventsHub.emit('collapsed:change', null);
         return changed;
     }
 
@@ -53,6 +64,7 @@ export class CollapsedManager implements MementoOriginator<CollapsedMemento> {
             changed ||= Boolean(this.collapsedIds[id]);
             delete this.collapsedIds[id];
         }
+        if (changed) this.eventsHub.emit('collapsed:change', null);
         return changed;
     }
 

--- a/packages/ag-charts-community/src/chart/interaction/collapsedManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/collapsedManager.ts
@@ -34,7 +34,7 @@ export class CollapsedManager implements MementoOriginator<CollapsedMemento> {
             changed ||= !this.collapsedIds[id];
             after[id] = true;
         }
-        // Also fire `change` if the previous map had ids that aren't in `after` — those got expanded.
+        // Detect implicit expansions: previous map ids missing from `after` are now expanded.
         if (!changed) {
             for (const prevId of Object.keys(this.collapsedIds)) {
                 if (!after[prevId]) {

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1426,6 +1426,14 @@ export abstract class Series<
         return undefined;
     }
 
+    // Maps a focus bbox (canvas-space, y-down) into a panToBBox target. Series whose internal
+    // zoom semantics differ from canvas y-down (e.g. network/org charts that render y-up via a
+    // viewport transform) override this to mirror y so `calcPanToBBoxRatios` pans in the correct
+    // direction. Default is identity.
+    public mapFocusBBoxToPanTarget(_seriesRect: BoxBounds, focusBBox: Readonly<BBox>): BoxBounds {
+        return focusBBox;
+    }
+
     public resetDatumCallbackCache() {
         this.datumCallbackCache.clear();
     }

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1426,10 +1426,8 @@ export abstract class Series<
         return undefined;
     }
 
-    // Maps a focus bbox (canvas-space, y-down) into a panToBBox target. Series whose internal
-    // zoom semantics differ from canvas y-down (e.g. network/org charts that render y-up via a
-    // viewport transform) override this to mirror y so `calcPanToBBoxRatios` pans in the correct
-    // direction. Default is identity.
+    // Override in y-up series (network/org) to mirror y so `calcPanToBBoxRatios` (y-down) pans
+    // the right direction. Default identity.
     public mapFocusBBoxToPanTarget(_seriesRect: BoxBounds, focusBBox: Readonly<BBox>): BoxBounds {
         return focusBBox;
     }

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -269,8 +269,12 @@ export class SeriesAreaManager extends BaseManager {
             chart.ctx.eventsHub.on('zoom:change-complete', (event) => this.onZoomChangeComplete(event)),
             chart.ctx.eventsHub.on('collapsed:change', () => {
                 // Force the next updateComplete announcement so SR users get feedback when a
-                // focused tree node toggles between expanded and collapsed.
-                this.announceMode = 'always';
+                // focused tree node toggles between expanded and collapsed. Gated on focus
+                // visibility so background collapse changes (memento restore, programmatic
+                // updates on un-focused series) don't trigger a spurious re-announce.
+                if (this.focusIndicator?.isFocusVisible()) {
+                    this.announceMode = 'always';
+                }
             }),
             chart.ctx.eventsHub.on('zoom:pan-start', () => this.clearAll()),
             chart.ctx.eventsHub.on('legend:item-hover', (event) => this.onLegendHover(event))

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -268,10 +268,8 @@ export class SeriesAreaManager extends BaseManager {
             chart.ctx.eventsHub.on('update:complete', () => this.updateComplete()),
             chart.ctx.eventsHub.on('zoom:change-complete', (event) => this.onZoomChangeComplete(event)),
             chart.ctx.eventsHub.on('collapsed:change', () => {
-                // Force the next updateComplete announcement so SR users get feedback when a
-                // focused tree node toggles between expanded and collapsed. Gated on focus
-                // visibility so background collapse changes (memento restore, programmatic
-                // updates on un-focused series) don't trigger a spurious re-announce.
+                // Re-announce the focused node after a toggle. Gated so background changes
+                // (memento restore, off-screen series) don't trigger spurious announcements.
                 if (this.focusIndicator?.isFocusVisible()) {
                     this.announceMode = 'always';
                 }

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -267,6 +267,11 @@ export class SeriesAreaManager extends BaseManager {
             chart.ctx.eventsHub.on('update:pre-scene-render', () => this.preSceneRender()),
             chart.ctx.eventsHub.on('update:complete', () => this.updateComplete()),
             chart.ctx.eventsHub.on('zoom:change-complete', (event) => this.onZoomChangeComplete(event)),
+            chart.ctx.eventsHub.on('collapsed:change', () => {
+                // Force the next updateComplete announcement so SR users get feedback when a
+                // focused tree node toggles between expanded and collapsed.
+                this.announceMode = 'always';
+            }),
             chart.ctx.eventsHub.on('zoom:pan-start', () => this.clearAll()),
             chart.ctx.eventsHub.on('legend:item-hover', (event) => this.onLegendHover(event))
         );
@@ -983,7 +988,8 @@ export class SeriesAreaManager extends BaseManager {
             const { x, y } = focusBBox.computeCenter();
 
             if (!hoverRect.containsPoint(x, y)) {
-                const panSuccess = this.chart.ctx.zoomManager?.panToBBox(hoverRect, focusBBox);
+                const panTarget = focus.series.mapFocusBBoxToPanTarget(hoverRect, focusBBox);
+                const panSuccess = this.chart.ctx.zoomManager?.panToBBox(hoverRect, panTarget);
                 if (panSuccess) {
                     // Wait for an update to ensure that we show the tooltip/highlight correctly.
                     return PickedFocusStatus.PAN_REQUIRED;

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -129,6 +129,7 @@ export interface EventsHubMap {
     'legend:item-double-click': LegendItemDoubleClickEvent;
     'locale:change': null;
     'collapsed:restore': { collapsed?: string[] };
+    'collapsed:change': null;
     'rtl:change': null;
     'scrollbar:wheel': ScrollbarWheelEvent;
     'series:focus-change': null;

--- a/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
@@ -289,9 +289,8 @@ export abstract class AbstractNetworkSeries<
         }
     }
 
-    // FIXME(AG-17179 follow-up): mirror y around the viewport midline because
-    // `calcPanToBBoxRatios` is y-down internally and we render y-up. Remove once the helper
-    // is direction-aware.
+    // FIXME(AG-17179 follow-up): mirror y because `calcPanToBBoxRatios` is y-down and we
+    // render y-up. Remove once the helper is direction-aware.
     public override mapFocusBBoxToPanTarget(
         seriesRect: BoxBounds,
         focusBBox: Readonly<_ModuleSupport.BBox>

--- a/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
@@ -1,5 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import {
+    type BoxBounds,
     type ChartAnimationPhase,
     type ChartAxisDirection,
     ChartUpdateType,
@@ -282,20 +283,25 @@ export abstract class AbstractNetworkSeries<
         const { zoomManager } = this.ctx;
         if (!zoomManager) return;
 
-        // FIXME(AG-17179 follow-up): mirror y around the viewport midline because
-        // `calcPanToBBoxRatios` is y-down internally and we render y-up. Remove once the
-        // helper is direction-aware.
-        const flippedTarget = {
-            x: canvasBBox.x,
-            y: 2 * seriesRect.y + seriesRect.height - canvasBBox.y - canvasBBox.height,
-            width: canvasBBox.width,
-            height: canvasBBox.height,
-        };
-
-        const panSuccess = zoomManager.panToBBox(seriesRect, flippedTarget);
+        const panSuccess = zoomManager.panToBBox(seriesRect, this.mapFocusBBoxToPanTarget(seriesRect, canvasBBox));
         if (!panSuccess) {
             Logger.warnOnce(`${this.id}: panToBBox failed — chart may be too small.`);
         }
+    }
+
+    // FIXME(AG-17179 follow-up): mirror y around the viewport midline because
+    // `calcPanToBBoxRatios` is y-down internally and we render y-up. Remove once the helper
+    // is direction-aware.
+    public override mapFocusBBoxToPanTarget(
+        seriesRect: BoxBounds,
+        focusBBox: Readonly<_ModuleSupport.BBox>
+    ): BoxBounds {
+        return {
+            x: focusBBox.x,
+            y: 2 * seriesRect.y + seriesRect.height - focusBBox.y - focusBBox.height,
+            width: focusBBox.width,
+            height: focusBBox.height,
+        };
     }
 
     processPendingCollapse() {

--- a/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
@@ -211,6 +211,17 @@ export class OrganizationNode extends _ModuleSupport.TranslatableGroup<Organizat
         return new _ModuleSupport.BBox(0, 0, this.shapeNode.width, this.shapeNode.height);
     }
 
+    // Focus bbox in node-local coords; covers the card plus the expander pill that hangs
+    // below it, so the keyboard focus indicator surrounds both affordances.
+    getFocusBBox(): _ModuleSupport.BBox | undefined {
+        const cardBBox = this.getCardBBox();
+        if (!cardBBox) return;
+        if (!this.expanderNode) return cardBBox;
+        // expanderNode is a TranslatableGroup — its getBBox() returns coords already in
+        // OrganizationNode-local space, so a direct merge is correct.
+        return _ModuleSupport.BBox.merge([cardBBox, this.expanderNode.getBBox()]);
+    }
+
     private updateShapeNode(styles: RequiredOrganizationNodeStyle) {
         this.shapeNode ??= this.appendChild(new _ModuleSupport.Rect());
         this.shapeNode.cornerRadius = styles.cornerRadius;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
@@ -211,14 +211,12 @@ export class OrganizationNode extends _ModuleSupport.TranslatableGroup<Organizat
         return new _ModuleSupport.BBox(0, 0, this.shapeNode.width, this.shapeNode.height);
     }
 
-    // Focus bbox in node-local coords; covers the card plus the expander pill that hangs
-    // below it, so the keyboard focus indicator surrounds both affordances.
+    // Card + expander pill in node-local coords; used by the keyboard focus ring.
     getFocusBBox(): _ModuleSupport.BBox | undefined {
         const cardBBox = this.getCardBBox();
         if (!cardBBox) return;
         if (!this.expanderNode) return cardBBox;
-        // expanderNode is a TranslatableGroup — its getBBox() returns coords already in
-        // OrganizationNode-local space, so a direct merge is correct.
+        // expanderNode.getBBox() is already in OrganizationNode-local coords (TranslatableGroup).
         return _ModuleSupport.BBox.merge([cardBBox, this.expanderNode.getBBox()]);
     }
 

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
@@ -1575,6 +1575,18 @@ describe('OrganizationSeries', () => {
             expect(announcement).not.toContain(', ,');
         });
 
+        it('uses the singular template when a parent has exactly one child', async () => {
+            await setupChart();
+            // ceo → cto → ArrowRight → cfo (Carol Wu, parent of acc — exactly one child).
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            pressArrowOnSeriesArea('ArrowRight');
+            await waitForChartStability(chart);
+            expect(readLiveAnnouncement()).toBe(
+                'Carol Wu, Chief Financial Officer, London, level 2, 2 of 2, expanded, 1 child, press Enter or Space to toggle'
+            );
+        });
+
         it('reports collapsed parents in the live announcement', async () => {
             const options: AgChartOptions = { ...SIMPLE_ORG_CHART, initialState: { collapsed: ['cto'] } };
             prepareEnterpriseTestOptions(options);

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
@@ -1555,7 +1555,9 @@ describe('OrganizationSeries', () => {
             pressArrowOnSeriesArea('ArrowDown');
             await waitForChartStability(chart);
             // Identity-first ordering matches WAI-ARIA tree conventions: name before metadata.
-            expect(readLiveAnnouncement()).toBe('Bob Smith, level 2, 1 of 2, expanded');
+            expect(readLiveAnnouncement()).toBe(
+                'Bob Smith, Chief Technology Officer, London, level 2, 1 of 2, expanded, 2 children, press Enter or Space to toggle'
+            );
         });
 
         it('omits collapsed-state from a leaf announcement', async () => {
@@ -1566,7 +1568,7 @@ describe('OrganizationSeries', () => {
             pressArrowOnSeriesArea('ArrowDown');
             await waitForChartStability(chart);
             const announcement = readLiveAnnouncement();
-            expect(announcement).toBe('Dave Jones, level 3, 1 of 2');
+            expect(announcement).toBe('Dave Jones, Developer, New York, level 3, 1 of 2');
             // Guard against the empty-collapsedState stutter VoiceOver caught before the
             // leaf/parent locale-key split.
             expect(announcement).not.toContain(',,');
@@ -1580,7 +1582,9 @@ describe('OrganizationSeries', () => {
             await waitForChartStability(chart);
             pressArrowOnSeriesArea('ArrowDown');
             await waitForChartStability(chart);
-            expect(readLiveAnnouncement()).toBe('Bob Smith, level 2, 1 of 2, collapsed');
+            expect(readLiveAnnouncement()).toBe(
+                'Bob Smith, Chief Technology Officer, London, level 2, 1 of 2, collapsed, 2 children, press Enter or Space to toggle'
+            );
         });
     });
 

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -501,7 +501,10 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const collapsedState = this.ctx.localeManager.t(
             this.ctx.collapsedManager.isCollapsed(itemId) ? 'ariaOrgChartCollapsed' : 'ariaOrgChartExpanded'
         );
-        return this.ctx.localeManager.t('ariaAnnounceOrgChartParent', {
+        // Singular vs. plural template — locale tooling has no `[plural]` annotation, so we split
+        // the key by child count (the same pattern already used to split leaf vs. parent).
+        const key = childCount === 1 ? 'ariaAnnounceOrgChartParentSingular' : 'ariaAnnounceOrgChartParent';
+        return this.ctx.localeManager.t(key, {
             description,
             level: depth,
             posInSet,

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -452,8 +452,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const node = this.datumSelection.at(nextDatumIdx);
         if (!node) return;
 
-        // Card + expander pill — the focus ring surrounds both affordances so the user
-        // can see what `Enter` will toggle. Excludes any descendant nodes that hang below.
+        // Card + expander pill so the focus ring shows what `Enter` will toggle.
         const focusBBox = node.getFocusBBox();
         if (!focusBBox) return;
         const bounds = _ModuleSupport.Transformable.toCanvas(node, focusBBox);
@@ -483,8 +482,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
 
         const childCount = this.getChildren(vertex).length;
 
-        // Description from the tooltip carries only the heading (title); compose the SR description
-        // from all visible card fields so subtitle and labels are also read out.
+        // Tooltip-derived description carries only the heading; build a fuller one for SR.
         const description = this.composeDatumDescription(vertex);
 
         // Leaf vs. parent — a single key with empty `${collapsedState}` would stutter (",,").
@@ -501,8 +499,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const collapsedState = this.ctx.localeManager.t(
             this.ctx.collapsedManager.isCollapsed(itemId) ? 'ariaOrgChartCollapsed' : 'ariaOrgChartExpanded'
         );
-        // Singular vs. plural template — locale tooling has no `[plural]` annotation, so we split
-        // the key by child count (the same pattern already used to split leaf vs. parent).
+        // Locale tooling has no `[plural]` annotation, so split the key by child count.
         const key = childCount === 1 ? 'ariaAnnounceOrgChartParentSingular' : 'ariaAnnounceOrgChartParent';
         return this.ctx.localeManager.t(key, {
             description,

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -23,6 +23,7 @@ import {
     clamp,
     mergeDefaults,
     strictObjectKeys,
+    toPlainText,
 } from 'ag-charts-core';
 
 import { NetworkLinkNode } from '../network/networkLinkNode';
@@ -451,10 +452,11 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const node = this.datumSelection.at(nextDatumIdx);
         if (!node) return;
 
-        // Card rect, not the node group's bbox — the group includes the expander pill below.
-        const cardBBox = node.getCardBBox();
-        if (!cardBBox) return;
-        const bounds = _ModuleSupport.Transformable.toCanvas(node, cardBBox);
+        // Card + expander pill — the focus ring surrounds both affordances so the user
+        // can see what `Enter` will toggle. Excludes any descendant nodes that hang below.
+        const focusBBox = node.getFocusBBox();
+        if (!focusBBox) return;
+        const bounds = _ModuleSupport.Transformable.toCanvas(node, focusBBox);
         if (!bounds?.isFinite()) return;
 
         const depth = this.graph.findNeighbourValue(next, 'depth') as number | undefined;
@@ -471,7 +473,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         };
     }
 
-    getDatumAriaText(datum: OrganizationDatum, description: string): string | undefined {
+    getDatumAriaText(datum: OrganizationDatum, _description: string): string | undefined {
         const { vertex } = datum;
         const depth = (this.graph.findNeighbourValue(vertex, 'depth') as number | undefined) ?? 1;
 
@@ -480,6 +482,10 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const setSize = siblings.length;
 
         const childCount = this.getChildren(vertex).length;
+
+        // Description from the tooltip carries only the heading (title); compose the SR description
+        // from all visible card fields so subtitle and labels are also read out.
+        const description = this.composeDatumDescription(vertex);
 
         // Leaf vs. parent — a single key with empty `${collapsedState}` would stutter (",,").
         if (childCount === 0) {
@@ -500,8 +506,23 @@ export class OrganizationSeries extends AbstractNetworkSeries<
             level: depth,
             posInSet,
             setSize,
+            childCount,
             collapsedState,
         });
+    }
+
+    private composeDatumDescription(vertex: Vertex<OrganizationVertex, OrganizationEdge>): string {
+        const fields = this.resolveVertexFields(vertex);
+        const parts: string[] = [];
+        const title = toPlainText(fields.title).trim();
+        const subtitle = toPlainText(fields.subtitle).trim();
+        if (title) parts.push(title);
+        if (subtitle) parts.push(subtitle);
+        for (const label of fields.labels ?? []) {
+            const labelText = toPlainText(label).trim();
+            if (labelText) parts.push(labelText);
+        }
+        return parts.join(', ');
     }
 
     // Returns the next focus vertex per the spatial model, or `undefined` for a no-op (ArrowUp

--- a/packages/ag-charts-locale/src/ar-EG.ts
+++ b/packages/ag-charts-locale/src/ar-EG.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_AR_EG: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, المستوى ${level}[number], ${posInSet}[number] من ${setSize}[number], ${collapsedState}, ${childCount}[number] أطفال, اضغط على المسافة أو الإدخال للتبديل',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, المستوى ${level}[number], ${posInSet}[number] من ${setSize}[number], ${collapsedState}, طفل واحد, اضغط على المسافة أو الإدخال للتبديل',
     ariaOrgChartCollapsed: 'مطوي',
     ariaOrgChartExpanded: 'موسع',
     ariaAnnounceGaugeChart: 'مخطط المقياس، ${caption}',

--- a/packages/ag-charts-locale/src/ar-EG.ts
+++ b/packages/ag-charts-locale/src/ar-EG.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_AR_EG: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, المستوى ${level}[number], ${posInSet}[number] من ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, المستوى ${level}[number], ${posInSet}[number] من ${setSize}[number], ${collapsedState}',
+        '${description}, المستوى ${level}[number], ${posInSet}[number] من ${setSize}[number], ${collapsedState}, ${childCount}[number] أطفال, اضغط على المسافة أو الإدخال للتبديل',
     ariaOrgChartCollapsed: 'مطوي',
     ariaOrgChartExpanded: 'موسع',
     ariaAnnounceGaugeChart: 'مخطط المقياس، ${caption}',

--- a/packages/ag-charts-locale/src/bg-BG.ts
+++ b/packages/ag-charts-locale/src/bg-BG.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_BG_BG: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, ниво ${level}[number], ${posInSet}[number] от ${setSize}[number], ${collapsedState}, ${childCount}[number] деца, натиснете Enter или Space за превключване',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, ниво ${level}[number], ${posInSet}[number] от ${setSize}[number], ${collapsedState}, 1 дете, натиснете Enter или Space за превключване',
     ariaOrgChartCollapsed: 'свито',
     ariaOrgChartExpanded: 'разгънато',
     ariaAnnounceGaugeChart: 'графика тип манометър, ${caption}',

--- a/packages/ag-charts-locale/src/bg-BG.ts
+++ b/packages/ag-charts-locale/src/bg-BG.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_BG_BG: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, ниво ${level}[number], ${posInSet}[number] от ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, ниво ${level}[number], ${posInSet}[number] от ${setSize}[number], ${collapsedState}',
+        '${description}, ниво ${level}[number], ${posInSet}[number] от ${setSize}[number], ${collapsedState}, ${childCount}[number] деца, натиснете Enter или Space за превключване',
     ariaOrgChartCollapsed: 'свито',
     ariaOrgChartExpanded: 'разгънато',
     ariaAnnounceGaugeChart: 'графика тип манометър, ${caption}',

--- a/packages/ag-charts-locale/src/cs-CZ.ts
+++ b/packages/ag-charts-locale/src/cs-CZ.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_CS_CZ: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, ${childCount}[number] dětí, stiskněte mezerník nebo Enter pro přepnutí',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, 1 dítě, stiskněte mezerník nebo Enter pro přepnutí',
     ariaOrgChartCollapsed: 'sbalený',
     ariaOrgChartExpanded: 'rozbalený',
     ariaAnnounceGaugeChart: 'graf měřidla, ${caption}',

--- a/packages/ag-charts-locale/src/cs-CZ.ts
+++ b/packages/ag-charts-locale/src/cs-CZ.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_CS_CZ: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}',
+        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, ${childCount}[number] dětí, stiskněte mezerník nebo Enter pro přepnutí',
     ariaOrgChartCollapsed: 'sbalený',
     ariaOrgChartExpanded: 'rozbalený',
     ariaAnnounceGaugeChart: 'graf měřidla, ${caption}',

--- a/packages/ag-charts-locale/src/da-DK.ts
+++ b/packages/ag-charts-locale/src/da-DK.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_DA_DK: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, niveau ${level}[number], ${posInSet}[number] af ${setSize}[number], ${collapsedState}, ${childCount}[number] underordnede, tryk på Enter eller mellemrumstasten for at skifte',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, niveau ${level}[number], ${posInSet}[number] af ${setSize}[number], ${collapsedState}, 1 underordnet, tryk på Enter eller mellemrumstasten for at skifte',
     ariaOrgChartCollapsed: 'skjult',
     ariaOrgChartExpanded: 'udvidet',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',

--- a/packages/ag-charts-locale/src/da-DK.ts
+++ b/packages/ag-charts-locale/src/da-DK.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_DA_DK: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, niveau ${level}[number], ${posInSet}[number] af ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, niveau ${level}[number], ${posInSet}[number] af ${setSize}[number], ${collapsedState}',
+        '${description}, niveau ${level}[number], ${posInSet}[number] af ${setSize}[number], ${collapsedState}, ${childCount}[number] underordnede, tryk på Enter eller mellemrumstasten for at skifte',
     ariaOrgChartCollapsed: 'skjult',
     ariaOrgChartExpanded: 'udvidet',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',

--- a/packages/ag-charts-locale/src/de-DE.ts
+++ b/packages/ag-charts-locale/src/de-DE.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_DE_DE: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, Ebene ${level}[number], ${posInSet}[number] von ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, Ebene ${level}[number], ${posInSet}[number] von ${setSize}[number], ${collapsedState}',
+        '${description}, Ebene ${level}[number], ${posInSet}[number] von ${setSize}[number], ${collapsedState}, ${childCount}[number] untergeordnete Elemente, drücken Sie die Eingabetaste oder die Leertaste zum Umschalten',
     ariaOrgChartCollapsed: 'eingeklappt',
     ariaOrgChartExpanded: 'ausgeklappt',
     ariaAnnounceGaugeChart: 'Tachometerdiagramm, ${caption}',

--- a/packages/ag-charts-locale/src/de-DE.ts
+++ b/packages/ag-charts-locale/src/de-DE.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_DE_DE: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, Ebene ${level}[number], ${posInSet}[number] von ${setSize}[number], ${collapsedState}, ${childCount}[number] untergeordnete Elemente, drücken Sie die Eingabetaste oder die Leertaste zum Umschalten',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, Ebene ${level}[number], ${posInSet}[number] von ${setSize}[number], ${collapsedState}, 1 untergeordnetes Element, drücken Sie die Eingabetaste oder die Leertaste zum Umschalten',
     ariaOrgChartCollapsed: 'eingeklappt',
     ariaOrgChartExpanded: 'ausgeklappt',
     ariaAnnounceGaugeChart: 'Tachometerdiagramm, ${caption}',

--- a/packages/ag-charts-locale/src/el-GR.ts
+++ b/packages/ag-charts-locale/src/el-GR.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_EL_GR: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, επίπεδο ${level}[number], ${posInSet}[number] από ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, επίπεδο ${level}[number], ${posInSet}[number] από ${setSize}[number], ${collapsedState}',
+        '${description}, επίπεδο ${level}[number], ${posInSet}[number] από ${setSize}[number], ${collapsedState}, ${childCount}[number] παιδιά, πατήστε Enter ή Space για εναλλαγή',
     ariaOrgChartCollapsed: 'συμπτυγμένο',
     ariaOrgChartExpanded: 'αναπτυγμένο',
     ariaAnnounceGaugeChart: 'διάγραμμα δείκτη, ${caption}',

--- a/packages/ag-charts-locale/src/el-GR.ts
+++ b/packages/ag-charts-locale/src/el-GR.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_EL_GR: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, επίπεδο ${level}[number], ${posInSet}[number] από ${setSize}[number], ${collapsedState}, ${childCount}[number] παιδιά, πατήστε Enter ή Space για εναλλαγή',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, επίπεδο ${level}[number], ${posInSet}[number] από ${setSize}[number], ${collapsedState}, 1 παιδί, πατήστε Enter ή Space για εναλλαγή',
     ariaOrgChartCollapsed: 'συμπτυγμένο',
     ariaOrgChartExpanded: 'αναπτυγμένο',
     ariaAnnounceGaugeChart: 'διάγραμμα δείκτη, ${caption}',

--- a/packages/ag-charts-locale/src/en-US.ts
+++ b/packages/ag-charts-locale/src/en-US.ts
@@ -19,9 +19,12 @@ export const AG_CHARTS_LOCALE_EN_US: Record<string, string> = {
     ariaAnnounceFlowProportionNode: 'node ${index} of ${count}, ${description}',
     // Screen reader announcement when focusing a leaf node in an Organization chart
     ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
-    // Screen reader announcement when focusing a parent node in an Organization chart
+    // Screen reader announcement when focusing a parent node in an Organization chart with multiple children
     ariaAnnounceOrgChartParent:
         '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}, ${childCount}[number] children, press Enter or Space to toggle',
+    // Screen reader announcement when focusing a parent node in an Organization chart with exactly one child
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}, 1 child, press Enter or Space to toggle',
     ariaOrgChartCollapsed: 'collapsed',
     ariaOrgChartExpanded: 'expanded',
     // Screen reader description for legend items

--- a/packages/ag-charts-locale/src/en-US.ts
+++ b/packages/ag-charts-locale/src/en-US.ts
@@ -21,7 +21,7 @@ export const AG_CHARTS_LOCALE_EN_US: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}',
+        '${description}, level ${level}[number], ${posInSet}[number] of ${setSize}[number], ${collapsedState}, ${childCount}[number] children, press Enter or Space to toggle',
     ariaOrgChartCollapsed: 'collapsed',
     ariaOrgChartExpanded: 'expanded',
     // Screen reader description for legend items

--- a/packages/ag-charts-locale/src/es-ES.ts
+++ b/packages/ag-charts-locale/src/es-ES.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_ES_ES: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, nivel ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, nivel ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+        '${description}, nivel ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] hijos, presiona Enter o Espacio para alternar',
     ariaOrgChartCollapsed: 'contraído',
     ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de velocímetro, ${caption}',

--- a/packages/ag-charts-locale/src/es-ES.ts
+++ b/packages/ag-charts-locale/src/es-ES.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_ES_ES: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, nivel ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] hijos, presiona Enter o Espacio para alternar',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, nivel ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, 1 hijo, presiona Enter o Espacio para alternar',
     ariaOrgChartCollapsed: 'contraído',
     ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de velocímetro, ${caption}',

--- a/packages/ag-charts-locale/src/fa-IR.ts
+++ b/packages/ag-charts-locale/src/fa-IR.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_FA_IR: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, سطح ${level}[number], ${posInSet}[number] از ${setSize}[number], ${collapsedState}, ${childCount}[number] فرزند, برای تغییر وضعیت، اسپیس یا اینتر را فشار دهید',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, سطح ${level}[number], ${posInSet}[number] از ${setSize}[number], ${collapsedState}, 1 فرزند, برای تغییر وضعیت، اسپیس یا اینتر را فشار دهید',
     ariaOrgChartCollapsed: 'جمع‌شده',
     ariaOrgChartExpanded: 'بازشده',
     ariaAnnounceGaugeChart: 'چارت سنجشی، ${caption}',

--- a/packages/ag-charts-locale/src/fa-IR.ts
+++ b/packages/ag-charts-locale/src/fa-IR.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_FA_IR: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, سطح ${level}[number], ${posInSet}[number] از ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, سطح ${level}[number], ${posInSet}[number] از ${setSize}[number], ${collapsedState}',
+        '${description}, سطح ${level}[number], ${posInSet}[number] از ${setSize}[number], ${collapsedState}, ${childCount}[number] فرزند, برای تغییر وضعیت، اسپیس یا اینتر را فشار دهید',
     ariaOrgChartCollapsed: 'جمع‌شده',
     ariaOrgChartExpanded: 'بازشده',
     ariaAnnounceGaugeChart: 'چارت سنجشی، ${caption}',

--- a/packages/ag-charts-locale/src/fi-FI.ts
+++ b/packages/ag-charts-locale/src/fi-FI.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_FI_FI: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, taso ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, ${childCount}[number] alikohdetta, paina Enteriä tai välilyöntiä vaihtaaksesi',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, taso ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, 1 alikohde, paina Enteriä tai välilyöntiä vaihtaaksesi',
     ariaOrgChartCollapsed: 'suljettu',
     ariaOrgChartExpanded: 'avattu',
     ariaAnnounceGaugeChart: 'mittarikaavio, ${caption}',

--- a/packages/ag-charts-locale/src/fi-FI.ts
+++ b/packages/ag-charts-locale/src/fi-FI.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_FI_FI: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, taso ${level}[number], ${posInSet}[number] / ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, taso ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}',
+        '${description}, taso ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, ${childCount}[number] alikohdetta, paina Enteriä tai välilyöntiä vaihtaaksesi',
     ariaOrgChartCollapsed: 'suljettu',
     ariaOrgChartExpanded: 'avattu',
     ariaAnnounceGaugeChart: 'mittarikaavio, ${caption}',

--- a/packages/ag-charts-locale/src/fr-FR.ts
+++ b/packages/ag-charts-locale/src/fr-FR.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_FR_FR: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, niveau ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] enfants, appuyez sur Entrée ou Espace pour basculer',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, niveau ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, 1 enfant, appuyez sur Entrée ou Espace pour basculer',
     ariaOrgChartCollapsed: 'réduit',
     ariaOrgChartExpanded: 'développé',
     ariaAnnounceGaugeChart: 'graphique en jauge, ${caption}',

--- a/packages/ag-charts-locale/src/fr-FR.ts
+++ b/packages/ag-charts-locale/src/fr-FR.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_FR_FR: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, niveau ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, niveau ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+        '${description}, niveau ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] enfants, appuyez sur Entrée ou Espace pour basculer',
     ariaOrgChartCollapsed: 'réduit',
     ariaOrgChartExpanded: 'développé',
     ariaAnnounceGaugeChart: 'graphique en jauge, ${caption}',

--- a/packages/ag-charts-locale/src/he-IL.ts
+++ b/packages/ag-charts-locale/src/he-IL.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_HE_IL: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, רמה ${level}[number], ${posInSet}[number] מתוך ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, רמה ${level}[number], ${posInSet}[number] מתוך ${setSize}[number], ${collapsedState}',
+        '${description}, רמה ${level}[number], ${posInSet}[number] מתוך ${setSize}[number], ${collapsedState}, ${childCount}[number] ילדים, לחץ על מקש הרווח או אנטר כדי להחליף',
     ariaOrgChartCollapsed: 'מכווץ',
     ariaOrgChartExpanded: 'מורחב',
     ariaAnnounceGaugeChart: 'תרשים מד, ${caption}',

--- a/packages/ag-charts-locale/src/he-IL.ts
+++ b/packages/ag-charts-locale/src/he-IL.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_HE_IL: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, רמה ${level}[number], ${posInSet}[number] מתוך ${setSize}[number], ${collapsedState}, ${childCount}[number] ילדים, לחץ על מקש הרווח או אנטר כדי להחליף',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, רמה ${level}[number], ${posInSet}[number] מתוך ${setSize}[number], ${collapsedState}, ילד 1, לחץ על מקש הרווח או אנטר כדי להחליף',
     ariaOrgChartCollapsed: 'מכווץ',
     ariaOrgChartExpanded: 'מורחב',
     ariaAnnounceGaugeChart: 'תרשים מד, ${caption}',

--- a/packages/ag-charts-locale/src/hr-HR.ts
+++ b/packages/ag-charts-locale/src/hr-HR.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_HR_HR: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, razina ${level}[number], ${posInSet}[number] od ${setSize}[number], ${collapsedState}, ${childCount}[number] djece, pritisnite razmaknicu ili Enter za uključivanje/isključivanje',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, razina ${level}[number], ${posInSet}[number] od ${setSize}[number], ${collapsedState}, 1 dijete, pritisnite razmaknicu ili Enter za uključivanje/isključivanje',
     ariaOrgChartCollapsed: 'sažeto',
     ariaOrgChartExpanded: 'prošireno',
     ariaAnnounceGaugeChart: 'mjerna ljestvica, ${caption}',

--- a/packages/ag-charts-locale/src/hr-HR.ts
+++ b/packages/ag-charts-locale/src/hr-HR.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_HR_HR: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, razina ${level}[number], ${posInSet}[number] od ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, razina ${level}[number], ${posInSet}[number] od ${setSize}[number], ${collapsedState}',
+        '${description}, razina ${level}[number], ${posInSet}[number] od ${setSize}[number], ${collapsedState}, ${childCount}[number] djece, pritisnite razmaknicu ili Enter za uključivanje/isključivanje',
     ariaOrgChartCollapsed: 'sažeto',
     ariaOrgChartExpanded: 'prošireno',
     ariaAnnounceGaugeChart: 'mjerna ljestvica, ${caption}',

--- a/packages/ag-charts-locale/src/hu-HU.ts
+++ b/packages/ag-charts-locale/src/hu-HU.ts
@@ -17,7 +17,7 @@ export const AG_CHARTS_LOCALE_HU_HU: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, szint ${level}[number], ${posInSet}[number] / ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, szint ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}',
+        '${description}, szint ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, ${childCount}[number] gyermek, nyomja meg a Szóközt vagy az Entert a váltáshoz',
     ariaOrgChartCollapsed: 'összezárt',
     ariaOrgChartExpanded: 'kinyitott',
     ariaAnnounceGaugeChart: 'mérőműszer diagram, ${caption}',

--- a/packages/ag-charts-locale/src/hu-HU.ts
+++ b/packages/ag-charts-locale/src/hu-HU.ts
@@ -18,6 +18,8 @@ export const AG_CHARTS_LOCALE_HU_HU: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, szint ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, ${childCount}[number] gyermek, nyomja meg a Szóközt vagy az Entert a váltáshoz',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, szint ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, 1 gyermek, nyomja meg a Szóközt vagy az Entert a váltáshoz',
     ariaOrgChartCollapsed: 'összezárt',
     ariaOrgChartExpanded: 'kinyitott',
     ariaAnnounceGaugeChart: 'mérőműszer diagram, ${caption}',

--- a/packages/ag-charts-locale/src/it-IT.ts
+++ b/packages/ag-charts-locale/src/it-IT.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_IT_IT: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, livello ${level}[number], ${posInSet}[number] di ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, livello ${level}[number], ${posInSet}[number] di ${setSize}[number], ${collapsedState}',
+        '${description}, livello ${level}[number], ${posInSet}[number] di ${setSize}[number], ${collapsedState}, ${childCount}[number] figli, premi Invio o Spazio per attivare/disattivare',
     ariaOrgChartCollapsed: 'compresso',
     ariaOrgChartExpanded: 'espanso',
     ariaAnnounceGaugeChart: 'grafico a tachimetro, ${caption}',

--- a/packages/ag-charts-locale/src/it-IT.ts
+++ b/packages/ag-charts-locale/src/it-IT.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_IT_IT: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, livello ${level}[number], ${posInSet}[number] di ${setSize}[number], ${collapsedState}, ${childCount}[number] figli, premi Invio o Spazio per attivare/disattivare',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, livello ${level}[number], ${posInSet}[number] di ${setSize}[number], ${collapsedState}, 1 figlio, premi Invio o Spazio per attivare/disattivare',
     ariaOrgChartCollapsed: 'compresso',
     ariaOrgChartExpanded: 'espanso',
     ariaAnnounceGaugeChart: 'grafico a tachimetro, ${caption}',

--- a/packages/ag-charts-locale/src/ja-JP.ts
+++ b/packages/ag-charts-locale/src/ja-JP.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_JA_JP: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}、レベル ${level}[number]、${posInSet}[number]/${setSize}[number]、${collapsedState}、${childCount}[number] 人の子、Enter キーまたは Space キーを押して切り替えます',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}、レベル ${level}[number]、${posInSet}[number]/${setSize}[number]、${collapsedState}、1 人の子、Enter キーまたは Space キーを押して切り替えます',
     ariaOrgChartCollapsed: '折りたたみ',
     ariaOrgChartExpanded: '展開',
     ariaAnnounceGaugeChart: 'ゲージチャート、${caption}',

--- a/packages/ag-charts-locale/src/ja-JP.ts
+++ b/packages/ag-charts-locale/src/ja-JP.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_JA_JP: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}、レベル ${level}[number]、${posInSet}[number]/${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}、レベル ${level}[number]、${posInSet}[number]/${setSize}[number]、${collapsedState}',
+        '${description}、レベル ${level}[number]、${posInSet}[number]/${setSize}[number]、${collapsedState}、${childCount}[number] 人の子、Enter キーまたは Space キーを押して切り替えます',
     ariaOrgChartCollapsed: '折りたたみ',
     ariaOrgChartExpanded: '展開',
     ariaAnnounceGaugeChart: 'ゲージチャート、${caption}',

--- a/packages/ag-charts-locale/src/ko-KR.ts
+++ b/packages/ag-charts-locale/src/ko-KR.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_KO_KR: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, 레벨 ${level}[number], ${posInSet}[number]/${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, 레벨 ${level}[number], ${posInSet}[number]/${setSize}[number], ${collapsedState}',
+        '${description}, 레벨 ${level}[number], ${posInSet}[number]/${setSize}[number], ${collapsedState}, 자식 ${childCount}[number]개, 엔터 또는 스페이스바를 눌러 전환하세요',
     ariaOrgChartCollapsed: '축소됨',
     ariaOrgChartExpanded: '확장됨',
     ariaAnnounceGaugeChart: '게이지 차트, ${caption}',

--- a/packages/ag-charts-locale/src/ko-KR.ts
+++ b/packages/ag-charts-locale/src/ko-KR.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_KO_KR: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, 레벨 ${level}[number], ${posInSet}[number]/${setSize}[number], ${collapsedState}, 자식 ${childCount}[number]개, 엔터 또는 스페이스바를 눌러 전환하세요',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, 레벨 ${level}[number], ${posInSet}[number]/${setSize}[number], ${collapsedState}, 자식 1개, 엔터 또는 스페이스바를 눌러 전환하세요',
     ariaOrgChartCollapsed: '축소됨',
     ariaOrgChartExpanded: '확장됨',
     ariaAnnounceGaugeChart: '게이지 차트, ${caption}',

--- a/packages/ag-charts-locale/src/nb-NO.ts
+++ b/packages/ag-charts-locale/src/nb-NO.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_NB_NO: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}, ${childCount}[number] underordnede, trykk Enter eller mellomromstasten for å bytte',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}, 1 underordnet, trykk Enter eller mellomromstasten for å bytte',
     ariaOrgChartCollapsed: 'skjult',
     ariaOrgChartExpanded: 'utvidet',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',

--- a/packages/ag-charts-locale/src/nb-NO.ts
+++ b/packages/ag-charts-locale/src/nb-NO.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_NB_NO: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}',
+        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}, ${childCount}[number] underordnede, trykk Enter eller mellomromstasten for å bytte',
     ariaOrgChartCollapsed: 'skjult',
     ariaOrgChartExpanded: 'utvidet',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',

--- a/packages/ag-charts-locale/src/nl-NL.ts
+++ b/packages/ag-charts-locale/src/nl-NL.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_NL_NL: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, niveau ${level}[number], ${posInSet}[number] van ${setSize}[number], ${collapsedState}, ${childCount}[number] onderliggende items, druk op Enter of Spatie om te wisselen',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, niveau ${level}[number], ${posInSet}[number] van ${setSize}[number], ${collapsedState}, 1 onderliggend item, druk op Enter of Spatie om te wisselen',
     ariaOrgChartCollapsed: 'ingeklapt',
     ariaOrgChartExpanded: 'uitgeklapt',
     ariaAnnounceGaugeChart: 'meterdiagram, ${caption}',

--- a/packages/ag-charts-locale/src/nl-NL.ts
+++ b/packages/ag-charts-locale/src/nl-NL.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_NL_NL: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, niveau ${level}[number], ${posInSet}[number] van ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, niveau ${level}[number], ${posInSet}[number] van ${setSize}[number], ${collapsedState}',
+        '${description}, niveau ${level}[number], ${posInSet}[number] van ${setSize}[number], ${collapsedState}, ${childCount}[number] onderliggende items, druk op Enter of Spatie om te wisselen',
     ariaOrgChartCollapsed: 'ingeklapt',
     ariaOrgChartExpanded: 'uitgeklapt',
     ariaAnnounceGaugeChart: 'meterdiagram, ${caption}',

--- a/packages/ag-charts-locale/src/pl-PL.ts
+++ b/packages/ag-charts-locale/src/pl-PL.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_PL_PL: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, poziom ${level}[number], ${posInSet}[number] z ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, poziom ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}',
+        '${description}, poziom ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, ${childCount}[number] dzieci, naciśnij Spację lub Enter, aby przełączyć',
     ariaOrgChartCollapsed: 'zwinięty',
     ariaOrgChartExpanded: 'rozwinięty',
     ariaAnnounceGaugeChart: 'wykres wskaźnikowy, ${caption}',

--- a/packages/ag-charts-locale/src/pl-PL.ts
+++ b/packages/ag-charts-locale/src/pl-PL.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_PL_PL: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, poziom ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, ${childCount}[number] dzieci, naciśnij Spację lub Enter, aby przełączyć',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, poziom ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, 1 dziecko, naciśnij Spację lub Enter, aby przełączyć',
     ariaOrgChartCollapsed: 'zwinięty',
     ariaOrgChartExpanded: 'rozwinięty',
     ariaAnnounceGaugeChart: 'wykres wskaźnikowy, ${caption}',

--- a/packages/ag-charts-locale/src/pt-BR.ts
+++ b/packages/ag-charts-locale/src/pt-BR.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_PT_BR: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] filhos, pressione Enter ou Espaço para alternar',
     ariaOrgChartCollapsed: 'recolhido',
     ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',

--- a/packages/ag-charts-locale/src/pt-BR.ts
+++ b/packages/ag-charts-locale/src/pt-BR.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_PT_BR: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] filhos, pressione Enter ou Espaço para alternar',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, 1 filho, pressione Enter ou Espaço para alternar',
     ariaOrgChartCollapsed: 'recolhido',
     ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',

--- a/packages/ag-charts-locale/src/pt-PT.ts
+++ b/packages/ag-charts-locale/src/pt-PT.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_PT_PT: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}',
+        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] filhos, pressione Enter ou Espaço para alternar',
     ariaOrgChartCollapsed: 'recolhido',
     ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',

--- a/packages/ag-charts-locale/src/pt-PT.ts
+++ b/packages/ag-charts-locale/src/pt-PT.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_PT_PT: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, ${childCount}[number] filhos, pressione Enter ou Espaço para alternar',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, nível ${level}[number], ${posInSet}[number] de ${setSize}[number], ${collapsedState}, 1 filho, pressione Enter ou Espaço para alternar',
     ariaOrgChartCollapsed: 'recolhido',
     ariaOrgChartExpanded: 'expandido',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',

--- a/packages/ag-charts-locale/src/ro-RO.ts
+++ b/packages/ag-charts-locale/src/ro-RO.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_RO_RO: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, nivel ${level}[number], ${posInSet}[number] din ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, nivel ${level}[number], ${posInSet}[number] din ${setSize}[number], ${collapsedState}',
+        '${description}, nivel ${level}[number], ${posInSet}[number] din ${setSize}[number], ${collapsedState}, ${childCount}[number] copii, apăsați Spațiu sau Enter pentru a comuta',
     ariaOrgChartCollapsed: 'restrâns',
     ariaOrgChartExpanded: 'extins',
     ariaAnnounceGaugeChart: 'grafic indicator, ${caption}',

--- a/packages/ag-charts-locale/src/ro-RO.ts
+++ b/packages/ag-charts-locale/src/ro-RO.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_RO_RO: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, nivel ${level}[number], ${posInSet}[number] din ${setSize}[number], ${collapsedState}, ${childCount}[number] copii, apăsați Spațiu sau Enter pentru a comuta',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, nivel ${level}[number], ${posInSet}[number] din ${setSize}[number], ${collapsedState}, 1 copil, apăsați Spațiu sau Enter pentru a comuta',
     ariaOrgChartCollapsed: 'restrâns',
     ariaOrgChartExpanded: 'extins',
     ariaAnnounceGaugeChart: 'grafic indicator, ${caption}',

--- a/packages/ag-charts-locale/src/sk-SK.ts
+++ b/packages/ag-charts-locale/src/sk-SK.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_SK_SK: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}',
+        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, ${childCount}[number] detí, stlačením medzerníka alebo klávesy Enter prepnete',
     ariaOrgChartCollapsed: 'zbalený',
     ariaOrgChartExpanded: 'rozbalený',
     ariaAnnounceGaugeChart: 'stupnicový graf, ${caption}',

--- a/packages/ag-charts-locale/src/sk-SK.ts
+++ b/packages/ag-charts-locale/src/sk-SK.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_SK_SK: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, ${childCount}[number] detí, stlačením medzerníka alebo klávesy Enter prepnete',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, úroveň ${level}[number], ${posInSet}[number] z ${setSize}[number], ${collapsedState}, 1 dieťa, stlačením medzerníka alebo klávesy Enter prepnete',
     ariaOrgChartCollapsed: 'zbalený',
     ariaOrgChartExpanded: 'rozbalený',
     ariaAnnounceGaugeChart: 'stupnicový graf, ${caption}',

--- a/packages/ag-charts-locale/src/sv-SE.ts
+++ b/packages/ag-charts-locale/src/sv-SE.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_SV_SE: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}',
+        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}, ${childCount}[number] underordnade, tryck på Enter eller Space för att växla',
     ariaOrgChartCollapsed: 'komprimerad',
     ariaOrgChartExpanded: 'expanderad',
     ariaAnnounceGaugeChart: 'mätargraf, ${caption}',

--- a/packages/ag-charts-locale/src/sv-SE.ts
+++ b/packages/ag-charts-locale/src/sv-SE.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_SV_SE: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}, ${childCount}[number] underordnade, tryck på Enter eller Space för att växla',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, nivå ${level}[number], ${posInSet}[number] av ${setSize}[number], ${collapsedState}, 1 underordnad, tryck på Enter eller Space för att växla',
     ariaOrgChartCollapsed: 'komprimerad',
     ariaOrgChartExpanded: 'expanderad',
     ariaAnnounceGaugeChart: 'mätargraf, ${caption}',

--- a/packages/ag-charts-locale/src/tr-TR.ts
+++ b/packages/ag-charts-locale/src/tr-TR.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_TR_TR: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, seviye ${level}[number], ${posInSet}[number] / ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, seviye ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}',
+        '${description}, seviye ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, ${childCount}[number] çocuk, değiştirmek için Boşluk veya Enter tuşuna basın',
     ariaOrgChartCollapsed: 'daraltılmış',
     ariaOrgChartExpanded: 'genişletilmiş',
     ariaAnnounceGaugeChart: 'gösterge grafik, ${caption}',

--- a/packages/ag-charts-locale/src/tr-TR.ts
+++ b/packages/ag-charts-locale/src/tr-TR.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_TR_TR: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, seviye ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, ${childCount}[number] çocuk, değiştirmek için Boşluk veya Enter tuşuna basın',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, seviye ${level}[number], ${posInSet}[number] / ${setSize}[number], ${collapsedState}, 1 çocuk, değiştirmek için Boşluk veya Enter tuşuna basın',
     ariaOrgChartCollapsed: 'daraltılmış',
     ariaOrgChartExpanded: 'genişletilmiş',
     ariaAnnounceGaugeChart: 'gösterge grafik, ${caption}',

--- a/packages/ag-charts-locale/src/uk-UA.ts
+++ b/packages/ag-charts-locale/src/uk-UA.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_UK_UA: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, рівень ${level}[number], ${posInSet}[number] з ${setSize}[number], ${collapsedState}, ${childCount}[number] дочірніх, натисніть Enter або пробіл, щоб перемкнути',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, рівень ${level}[number], ${posInSet}[number] з ${setSize}[number], ${collapsedState}, 1 дочірній, натисніть Enter або пробіл, щоб перемкнути',
     ariaOrgChartCollapsed: 'згорнуто',
     ariaOrgChartExpanded: 'розгорнуто',
     ariaAnnounceGaugeChart: 'діаграма циферблата, ${caption}',

--- a/packages/ag-charts-locale/src/uk-UA.ts
+++ b/packages/ag-charts-locale/src/uk-UA.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_UK_UA: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, рівень ${level}[number], ${posInSet}[number] з ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, рівень ${level}[number], ${posInSet}[number] з ${setSize}[number], ${collapsedState}',
+        '${description}, рівень ${level}[number], ${posInSet}[number] з ${setSize}[number], ${collapsedState}, ${childCount}[number] дочірніх, натисніть Enter або пробіл, щоб перемкнути',
     ariaOrgChartCollapsed: 'згорнуто',
     ariaOrgChartExpanded: 'розгорнуто',
     ariaAnnounceGaugeChart: 'діаграма циферблата, ${caption}',

--- a/packages/ag-charts-locale/src/ur-PK.ts
+++ b/packages/ag-charts-locale/src/ur-PK.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_UR_PK: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, سطح ${level}[number], ${posInSet}[number] کا ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, سطح ${level}[number], ${posInSet}[number] کا ${setSize}[number], ${collapsedState}',
+        '${description}, سطح ${level}[number], ${posInSet}[number] کا ${setSize}[number], ${collapsedState}, ${childCount}[number] بچے, ٹوگل کرنے کے لیے اسپیس یا انٹر دبائیں',
     ariaOrgChartCollapsed: 'سمٹا ہوا',
     ariaOrgChartExpanded: 'پھیلا ہوا',
     ariaAnnounceGaugeChart: 'گیج چارٹ, ${caption}',

--- a/packages/ag-charts-locale/src/ur-PK.ts
+++ b/packages/ag-charts-locale/src/ur-PK.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_UR_PK: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, سطح ${level}[number], ${posInSet}[number] کا ${setSize}[number], ${collapsedState}, ${childCount}[number] بچے, ٹوگل کرنے کے لیے اسپیس یا انٹر دبائیں',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, سطح ${level}[number], ${posInSet}[number] کا ${setSize}[number], ${collapsedState}, 1 بچہ, ٹوگل کرنے کے لیے اسپیس یا انٹر دبائیں',
     ariaOrgChartCollapsed: 'سمٹا ہوا',
     ariaOrgChartExpanded: 'پھیلا ہوا',
     ariaAnnounceGaugeChart: 'گیج چارٹ, ${caption}',

--- a/packages/ag-charts-locale/src/vi-VN.ts
+++ b/packages/ag-charts-locale/src/vi-VN.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_VI_VN: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, cấp độ ${level}[number], ${posInSet}[number] trong ${setSize}[number], ${collapsedState}, ${childCount}[number] con, nhấn Enter hoặc Phím Cách để chuyển đổi',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, cấp độ ${level}[number], ${posInSet}[number] trong ${setSize}[number], ${collapsedState}, 1 con, nhấn Enter hoặc Phím Cách để chuyển đổi',
     ariaOrgChartCollapsed: 'đã thu gọn',
     ariaOrgChartExpanded: 'đã mở rộng',
     ariaAnnounceGaugeChart: 'biểu đồ đồng hồ đo, ${caption}',

--- a/packages/ag-charts-locale/src/vi-VN.ts
+++ b/packages/ag-charts-locale/src/vi-VN.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_VI_VN: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, cấp độ ${level}[number], ${posInSet}[number] trong ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, cấp độ ${level}[number], ${posInSet}[number] trong ${setSize}[number], ${collapsedState}',
+        '${description}, cấp độ ${level}[number], ${posInSet}[number] trong ${setSize}[number], ${collapsedState}, ${childCount}[number] con, nhấn Enter hoặc Phím Cách để chuyển đổi',
     ariaOrgChartCollapsed: 'đã thu gọn',
     ariaOrgChartExpanded: 'đã mở rộng',
     ariaAnnounceGaugeChart: 'biểu đồ đồng hồ đo, ${caption}',

--- a/packages/ag-charts-locale/src/zh-CN.ts
+++ b/packages/ag-charts-locale/src/zh-CN.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_ZH_CN: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, 级别 ${level}[number], ${posInSet}[number] 的 ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, 级别 ${level}[number], ${posInSet}[number] 的 ${setSize}[number], ${collapsedState}',
+        '${description}, 级别 ${level}[number], ${posInSet}[number] 的 ${setSize}[number], ${collapsedState}, ${childCount}[number] 个子项, 按回车键或空格键切换',
     ariaOrgChartCollapsed: '已折叠',
     ariaOrgChartExpanded: '已展开',
     ariaAnnounceGaugeChart: '仪表盘图表, ${caption}',

--- a/packages/ag-charts-locale/src/zh-CN.ts
+++ b/packages/ag-charts-locale/src/zh-CN.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_ZH_CN: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, 级别 ${level}[number], ${posInSet}[number] 的 ${setSize}[number], ${collapsedState}, ${childCount}[number] 个子项, 按回车键或空格键切换',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, 级别 ${level}[number], ${posInSet}[number] 的 ${setSize}[number], ${collapsedState}, 1 个子项, 按回车键或空格键切换',
     ariaOrgChartCollapsed: '已折叠',
     ariaOrgChartExpanded: '已展开',
     ariaAnnounceGaugeChart: '仪表盘图表, ${caption}',

--- a/packages/ag-charts-locale/src/zh-HK.ts
+++ b/packages/ag-charts-locale/src/zh-HK.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_ZH_HK: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}, ${childCount}[number] 個子項, 按 Enter 或空格鍵切換',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}, 1 個子項, 按 Enter 或空格鍵切換',
     ariaOrgChartCollapsed: '已收合',
     ariaOrgChartExpanded: '已展開',
     ariaAnnounceGaugeChart: '儀表圖, ${caption}',

--- a/packages/ag-charts-locale/src/zh-HK.ts
+++ b/packages/ag-charts-locale/src/zh-HK.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_ZH_HK: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}',
+        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}, ${childCount}[number] 個子項, 按 Enter 或空格鍵切換',
     ariaOrgChartCollapsed: '已收合',
     ariaOrgChartExpanded: '已展開',
     ariaAnnounceGaugeChart: '儀表圖, ${caption}',

--- a/packages/ag-charts-locale/src/zh-TW.ts
+++ b/packages/ag-charts-locale/src/zh-TW.ts
@@ -16,7 +16,7 @@ export const AG_CHARTS_LOCALE_ZH_TW: Record<string, string> = {
     ariaAnnounceOrgChartLeaf: '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number]',
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
-        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}',
+        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}, ${childCount}[number] 個子項目, 按回車鍵或空格鍵切換',
     ariaOrgChartCollapsed: '已收合',
     ariaOrgChartExpanded: '已展開',
     ariaAnnounceGaugeChart: '儀表板圖表, ${caption}',

--- a/packages/ag-charts-locale/src/zh-TW.ts
+++ b/packages/ag-charts-locale/src/zh-TW.ts
@@ -17,6 +17,8 @@ export const AG_CHARTS_LOCALE_ZH_TW: Record<string, string> = {
     // Screen reader announcement when focusing a parent node in an Organization chart
     ariaAnnounceOrgChartParent:
         '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}, ${childCount}[number] 個子項目, 按回車鍵或空格鍵切換',
+    ariaAnnounceOrgChartParentSingular:
+        '${description}, 層級 ${level}[number], ${posInSet}[number] 之 ${setSize}[number], ${collapsedState}, 1 個子項目, 按回車鍵或空格鍵切換',
     ariaOrgChartCollapsed: '已收合',
     ariaOrgChartExpanded: '已展開',
     ariaAnnounceGaugeChart: '儀表板圖表, ${caption}',


### PR DESCRIPTION
## Summary

Addresses David's QA feedback on the Org Chart keyboard navigation MVP ([AG-17012](https://ag-grid.atlassian.net/browse/AG-17012?focusedCommentId=113460)):

- **Focus ring** now wraps both the card and the expander pill (was card-only).
- **Vertical pan-to-focus when zoomed** — added `Series.mapFocusBBoxToPanTarget` hook; network/org overrides it to mirror y around the viewport midline (`calcPanToBBoxRatios` is y-down internally, network/org renders y-up). Replaces the inline workaround in `maybePanToItem` with a shared mapping.
- **Screen-reader announcement** for parent nodes now includes title + subtitle + label tiers (was title-only via the tooltip's heading), child count, and a "press Enter or Space to toggle" hint.
- **Re-announce on expand/collapse** — `CollapsedManager` emits a new `collapsed:change` event; `seriesAreaManager` flips `announceMode` to `'always'` for the next refresh, gated on focus visibility so background changes (memento restore, off-screen series) don't trigger spurious announcements.
- Pluralisation: split parent template into singular (`1 child`) and plural (`N children`) keys to avoid "1 children" — applied across all 31 locales.

## Test plan

- [x] `yarn nx build:types ag-charts-{community,enterprise,locale}`
- [x] `yarn nx lint ag-charts-{community,enterprise,locale}` — no new warnings
- [x] `yarn nx test ag-charts-community` (3,335 pass)
- [x] `yarn nx test ag-charts-enterprise` (1,984 pass — added singular-template regression test)
- [x] `yarn nx test ag-charts-locale`
- [ ] Manual VoiceOver/NVDA pass on the org chart docs page to confirm the announcement updates after Enter/Space toggles a parent node
- [ ] Manual check that focus ring wraps the expander pill at default theme

Fix #AG-17012