### PR TITLE
AG-17205, AG-17239 Pass touch pans and capped wheel zooms through to the page

### DIFF
--- a/packages/ag-charts-core/src/utils/dom/attributeUtil.ts
+++ b/packages/ag-charts-core/src/utils/dom/attributeUtil.ts
@@ -100,7 +100,7 @@ export type BaseStyleTypeMap = {
     display: 'none';
     position: 'absolute';
     'pointer-events': 'auto' | 'none';
-    'touch-action': 'auto' | 'none';
+    'touch-action': 'auto' | 'none' | 'pan-y';
     width: '100%';
     height: '100%';
 };

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
@@ -357,10 +357,15 @@ describe('Zoom', () => {
             await compare();
         });
 
-        it('AG-17205 should set touch-action: none on the series-area while panning is enabled so touch-drag pans the chart instead of scrolling the page', async () => {
+        it('AG-17205 should toggle series-area touch-action so touch pans the chart only when zoomed in, otherwise pass to the page', async () => {
             await prepareChart();
             const seriesEl = document.querySelector<HTMLElement>('.ag-charts-series-area')!;
             expect(seriesEl).not.toBeNull();
+            // Fully zoomed out — single-finger pan passes to the page; pinch still reaches the chart.
+            expect(seriesEl.style.touchAction).toBe('pan-y');
+
+            await scrollAction(cx, cy, -1)(chart);
+            await waitForChartStability(chart);
             expect(seriesEl.style.touchAction).toBe('none');
 
             await chart.update({ ...EXAMPLE_OPTIONS, zoom: { enabled: false } });

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
@@ -361,7 +361,6 @@ describe('Zoom', () => {
             await prepareChart();
             const seriesEl = document.querySelector<HTMLElement>('.ag-charts-series-area')!;
             expect(seriesEl).not.toBeNull();
-            // Fully zoomed out — single-finger pan passes to the page; pinch still reaches the chart.
             expect(seriesEl.style.touchAction).toBe('pan-y');
 
             await scrollAction(cx, cy, -1)(chart);

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -228,17 +228,13 @@ export class Zoom extends AbstractModuleInstance {
 
                 this.refreshTouchAction();
             }),
-            // Re-evaluate when the zoom range changes — at fully-zoomed-out [0,1] we
-            // pass single-finger pans through to the parent page (matches wheel scroll).
             ctx.eventsHub.on('zoom:change-complete', () => this.refreshTouchAction()),
             () => ctx.widgets.seriesWidget.setTouchAction(undefined)
         );
     }
 
-    // preventDefault on touchmove alone is not sufficient on iOS Safari, so we hint the
-    // browser via touch-action. At [0,1] (fully zoomed out) the chart has nothing to pan,
-    // so we let single-finger pans bubble to the page (same as the wheel scroller does).
-    // Pinch is not in `pan-y`, so two-finger touch events still reach the chart.
+    // iOS Safari ignores late preventDefault on touchmove, so suppress browser scroll via
+    // touch-action. `pan-y` at [0,1] lets single-finger pans bubble; pinch still reaches us.
     private prevTouchAction: 'auto' | 'none' | 'pan-y' | undefined;
     private refreshTouchAction() {
         const { enabled, enablePanning, enableTwoFingerZoom } = this.opts;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -208,7 +208,6 @@ export class Zoom extends AbstractModuleInstance {
         // Observe option changes. The callback runs immediately during registration
         // (chartState is populated before module creation), handling initial setup too.
         let prevEnabled: boolean | undefined;
-        let prevTouchPan: boolean | undefined;
         this.cleanup.register(
             ctx.chartState.observe((get) => {
                 const opts = get('options', 'zoom');
@@ -227,15 +226,29 @@ export class Zoom extends AbstractModuleInstance {
                     this.onEnabledChange(opts.enabled);
                 }
 
-                // preventDefault on touchmove alone is not sufficient on iOS Safari.
-                const touchPan = Boolean(opts.enabled) && Boolean(opts.enablePanning || opts.enableTwoFingerZoom);
-                if (prevTouchPan !== touchPan) {
-                    prevTouchPan = touchPan;
-                    ctx.widgets.seriesWidget.setTouchAction(touchPan ? 'none' : undefined);
-                }
-            })
+                this.refreshTouchAction();
+            }),
+            // Re-evaluate when the zoom range changes — at fully-zoomed-out [0,1] we
+            // pass single-finger pans through to the parent page (matches wheel scroll).
+            ctx.eventsHub.on('zoom:change-complete', () => this.refreshTouchAction()),
+            () => ctx.widgets.seriesWidget.setTouchAction(undefined)
         );
-        this.cleanup.register(() => ctx.widgets.seriesWidget.setTouchAction(undefined));
+    }
+
+    // preventDefault on touchmove alone is not sufficient on iOS Safari, so we hint the
+    // browser via touch-action. At [0,1] (fully zoomed out) the chart has nothing to pan,
+    // so we let single-finger pans bubble to the page (same as the wheel scroller does).
+    // Pinch is not in `pan-y`, so two-finger touch events still reach the chart.
+    private prevTouchAction: 'auto' | 'none' | 'pan-y' | undefined;
+    private refreshTouchAction() {
+        const { enabled, enablePanning, enableTwoFingerZoom } = this.opts;
+        let next: 'none' | 'pan-y' | undefined;
+        if (enabled && (enablePanning || enableTwoFingerZoom)) {
+            next = isMaxZoom(this.getZoom()) ? 'pan-y' : 'none';
+        }
+        if (this.prevTouchAction === next) return;
+        this.prevTouchAction = next;
+        this.ctx.widgets.seriesWidget.setTouchAction(next);
     }
 
     private teardown() {

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
@@ -1592,15 +1592,13 @@ describe('OrganizationSeries', () => {
             chart = AgCharts.create(options);
             await waitForChartStability(chart);
 
-            // Land at the 1:1 floor — both axes saturate at fitX/fitY (input ranges below fit).
+            // Land at the 1:1 floor (both axes saturate at fitX/fitY).
             setZoom(chart, 0.45, 0.55, 0.45, 0.55);
             await waitForChartStability(chart);
             const flooredState = (deproxy(chart) as any).ctx.chartState.getValue('zoom');
             expect(flooredState).toBeDefined();
 
-            // Now request a further-zoomed-in window with a different mid. Without the floor's
-            // no-op short-circuit, the input mid would leak through `clampMid` and translate
-            // the visible window — i.e. the user would see a pan instead of "nothing happens".
+            // Further zoom-in with an off-centre mid must not translate the window.
             setZoom(chart, 0.3, 0.4, 0.3, 0.4);
             await waitForChartStability(chart);
             const afterState = (deproxy(chart) as any).ctx.chartState.getValue('zoom');

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
@@ -1584,6 +1584,30 @@ describe('OrganizationSeries', () => {
         });
     });
 
+    describe('AG-17239 native pixel floor', () => {
+        it('should not pan when a zoom request asks to zoom in past the 1:1 floor', async () => {
+            const options: AgChartOptions = { ...SQUARE_OVERFLOW_ORG_CHART };
+            prepareEnterpriseTestOptions(options);
+
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            // Land at the 1:1 floor — both axes saturate at fitX/fitY (input ranges below fit).
+            setZoom(chart, 0.45, 0.55, 0.45, 0.55);
+            await waitForChartStability(chart);
+            const flooredState = (deproxy(chart) as any).ctx.chartState.getValue('zoom');
+            expect(flooredState).toBeDefined();
+
+            // Now request a further-zoomed-in window with a different mid. Without the floor's
+            // no-op short-circuit, the input mid would leak through `clampMid` and translate
+            // the visible window — i.e. the user would see a pan instead of "nothing happens".
+            setZoom(chart, 0.3, 0.4, 0.3, 0.4);
+            await waitForChartStability(chart);
+            const afterState = (deproxy(chart) as any).ctx.chartState.getValue('zoom');
+            expect(afterState).toEqual(flooredState);
+        });
+    });
+
     describe('aspect-ratio guard', () => {
         it('should project off-isotropic zoom state onto the isotropic line', async () => {
             const options: AgChartOptions = { ...OVERFLOWING_ORG_CHART };

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
@@ -1604,6 +1604,25 @@ describe('OrganizationSeries', () => {
             const afterState = (deproxy(chart) as any).ctx.chartState.getValue('zoom');
             expect(afterState).toEqual(flooredState);
         });
+
+        it('should not pan when only one axis requests further zoom-in past the floor', async () => {
+            const options: AgChartOptions = { ...SQUARE_OVERFLOW_ORG_CHART };
+            prepareEnterpriseTestOptions(options);
+
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            setZoom(chart, 0.45, 0.55, 0.45, 0.55);
+            await waitForChartStability(chart);
+            const flooredState = (deproxy(chart) as any).ctx.chartState.getValue('zoom');
+
+            // Shrink x only, leave y at the floored range. Off-isotropic input would otherwise
+            // land at floor (t = 1) with the new x mid, leaking through `clampMid`.
+            setZoom(chart, 0.3, 0.35, flooredState.y.min, flooredState.y.max);
+            await waitForChartStability(chart);
+            const afterState = (deproxy(chart) as any).ctx.chartState.getValue('zoom');
+            expect(afterState).toEqual(flooredState);
+        });
     });
 
     describe('aspect-ratio guard', () => {

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -182,6 +182,23 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const yRange = yEntry.max - yEntry.min;
         if (xRange <= 0 || yRange <= 0) return;
 
+        // AG-17239: when the chart is already at the 1:1 floor and the request would zoom in
+        // further, treat it as a no-op. Without this, the anchor-translated input mid leaks
+        // through `clampMid` after the range is restored to floor — the user sees a pan.
+        const oldX = event.oldState[xId];
+        const oldY = event.oldState[yId];
+        const wantsFurtherZoomIn = xRange / fitX < 1 - ISOTROPY_EPSILON && yRange / fitY < 1 - ISOTROPY_EPSILON;
+        if (wantsFurtherZoomIn && oldX && oldY) {
+            const oldT = Math.max((oldX.max - oldX.min) / fitX, (oldY.max - oldY.min) / fitY);
+            if (oldT <= 1 + ISOTROPY_EPSILON) {
+                const restored: _ModuleSupport.CoreZoomState = {};
+                restored[xId] = { min: oldX.min, max: oldX.max, direction: ChartAxisDirection.X };
+                restored[yId] = { min: oldY.min, max: oldY.max, direction: ChartAxisDirection.Y };
+                event.constrainChanges(restored);
+                return;
+            }
+        }
+
         // Project to the isotropic line, then floor at sMax (t ≥ 1/sMax).
         const targetT = Math.max(xRange / fitX, yRange / fitY, 1 / sMax);
         const targetXRange = Math.min(1, targetT * fitX);

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -182,9 +182,8 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const yRange = yEntry.max - yEntry.min;
         if (xRange <= 0 || yRange <= 0) return;
 
-        // AG-17239: when the chart is already at the 1:1 floor and the request would zoom in
-        // further, treat it as a no-op. Without this, the anchor-translated input mid leaks
-        // through `clampMid` after the range is restored to floor — the user sees a pan.
+        // AG-17239: at the 1:1 floor, further zoom-in is a no-op — otherwise the
+        // cursor-anchored input mid leaks through `clampMid` and reads as a pan.
         const oldX = event.oldState[xId];
         const oldY = event.oldState[yId];
         const wantsFurtherZoomIn = xRange / fitX < 1 - ISOTROPY_EPSILON && yRange / fitY < 1 - ISOTROPY_EPSILON;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -186,10 +186,13 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         // cursor-anchored input mid leaks through `clampMid` and reads as a pan.
         const oldX = event.oldState[xId];
         const oldY = event.oldState[yId];
-        const wantsFurtherZoomIn = xRange / fitX < 1 - ISOTROPY_EPSILON && yRange / fitY < 1 - ISOTROPY_EPSILON;
-        if (wantsFurtherZoomIn && oldX && oldY) {
-            const oldT = Math.max((oldX.max - oldX.min) / fitX, (oldY.max - oldY.min) / fitY);
-            if (oldT <= 1 + ISOTROPY_EPSILON) {
+        if (oldX && oldY) {
+            const oldXRange = oldX.max - oldX.min;
+            const oldYRange = oldY.max - oldY.min;
+            const inputT = Math.max(xRange / fitX, yRange / fitY);
+            const oldT = Math.max(oldXRange / fitX, oldYRange / fitY);
+            const wantsShrink = xRange < oldXRange - ISOTROPY_EPSILON || yRange < oldYRange - ISOTROPY_EPSILON;
+            if (wantsShrink && inputT <= 1 + ISOTROPY_EPSILON && oldT <= 1 + ISOTROPY_EPSILON) {
                 const restored: _ModuleSupport.CoreZoomState = {};
                 restored[xId] = { min: oldX.min, max: oldX.max, direction: ChartAxisDirection.X };
                 restored[yId] = { min: oldY.min, max: oldY.max, direction: ChartAxisDirection.Y };


### PR DESCRIPTION
## Summary

Follow-ups from David's QA on the org chart touch + zoom MVPs ([AG-17205 comment](https://ag-grid.atlassian.net/browse/AG-17205?focusedCommentId=113582), [AG-17239 comment](https://ag-grid.atlassian.net/browse/AG-17239?focusedCommentId=113371)). Both cases are the same shape: the chart was intercepting a gesture it had nothing meaningful to do with, instead of letting it bubble to the page.

- **AG-17205** — at the `[0,1]` fully-zoomed-out state the chart can't pan, so single-finger touch drags should reach the page. Make the series-area `touch-action` reactive: `pan-y` at `[0,1]`, `none` while zoomed in, cleared when the module is disabled. Pinch is not in `pan-y`, so two-finger zoom still reaches the chart.

- **AG-17239 #1** — at the org chart's 1:1 native-pixel floor, scroll-wheel zoom-in was anchor-translating the visible window: `scroller.update` shrank the range, `applyNativePixelFloor` re-expanded it back to fit while preserving the cursor-anchored mid, and the user perceived a pan. When the old state is already at the floor and the request would zoom in further, short-circuit to a no-op. Downstream `updateChanges` then reports `changeAccepted = false`, the wheel sequencer flags the event capped, and the page-scroll passthrough kicks in (mirroring how the cartesian zoom-out cap already behaves).

AG-17239 #2 (preserve zoom across data updates) is a separate design problem and will be tackled on its own ticket.

## Test plan

- [x] `yarn nx test ag-charts-enterprise --testPathPattern="features/zoom/zoom\.test"` — 65 tests, 67 snapshots
- [x] `yarn nx test ag-charts-enterprise --testPathPattern=organization` — 94 tests, 52 snapshots
- [x] `yarn nx test ag-charts-community` clean
- [x] `yarn nx build:types ag-charts-enterprise` clean
- [x] `yarn nx lint ag-charts-enterprise` 0 errors
- [ ] On-device verification: iOS Safari + Android Chrome — single-finger pan at `[0,1]` scrolls the page; pinch still zooms the chart
- [ ] On-device verification: desktop wheel-scroll past 1:1 floor lets the page scroll, doesn't translate the chart

Fix #AG-17205, Fix #AG-17239