### PR TITLE
AG-17065: Fix large dataset hang on zoom for ordinal-time axes

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { OrdinalTimeScale } from '../../scale/ordinalTimeScale';
+import { estimateScaleTickCount } from './generateTicks';
+
+// AG-17065: for large ordinal-time domains with deep zoom, the binary search in
+// buildTickData needs to cover the full tick count range. If minTickCount is too
+// high relative to tickCount, the overlap loop iterates linearly instead of
+// converging via binary search, causing a hang.
+describe('estimateScaleTickCount', () => {
+    function estimate(domainLength: number, rangeExtent: number, zoomExtent: number) {
+        const scale = new OrdinalTimeScale();
+        const domain = Array.from({ length: domainLength }, (_, i) => new Date(2023, 0, 1, 0, i));
+        scale.domain = domain;
+        scale.range = [0, rangeExtent];
+
+        return estimateScaleTickCount({
+            scale,
+            domain,
+            range: [0, rangeExtent] as [number, number],
+            visibleRange: [0.5 - zoomExtent / 2, 0.5 + zoomExtent / 2] as [number, number],
+            label: { enabled: true, fontSize: 14, avoidCollisions: true } as any,
+            defaultTickMinSpacing: 50,
+            interval: undefined,
+        } as any);
+    }
+
+    it('should allow full binary search range for large domains with deep zoom', () => {
+        const result = estimate(10_000, 300, 0.002);
+
+        // The binary search range is (tickCount - minTickCount). For the search to
+        // converge efficiently, minTickCount must be much smaller than tickCount.
+        const binarySearchRange = result.tickCount - result.minTickCount;
+        expect(binarySearchRange).toBeGreaterThanOrEqual(result.tickCount * 0.9);
+    });
+
+    it('should allow full binary search range for small domains', () => {
+        const result = estimate(100, 300, 0.5);
+
+        const binarySearchRange = result.tickCount - result.minTickCount;
+        expect(binarySearchRange).toBeGreaterThanOrEqual(result.tickCount * 0.9);
+    });
+});

--- a/packages/ag-charts-community/src/chart/axis/generateTicks.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.ts
@@ -141,9 +141,12 @@ function estimateScaleTickCount<TScale extends Scale<TDatum, number, TickInterva
     const rangeExtent = findRangeExtent(range);
     const zoomExtent = findRangeExtent(visibleRange);
 
-    // Ordinal scales with a large number of categories can be slow to generate ticks for.
-    // Therefore, we limit the number of ticks generated for such scales.
-    if (CategoryScale.is(scale) || (OrdinalTimeScale.is(scale) && domain.length < 1000)) {
+    // Ordinal-time tick steps are discrete (time-interval-based), so reducing tickCount
+    // doesn't always produce fewer ticks. minTickCount must be 0 to let the binary search
+    // in buildTickData exit when ticks stop changing — otherwise the overlap loop hangs.
+    const isOrdinalTime = OrdinalTimeScale.is(scale);
+
+    if (CategoryScale.is(scale) || (isOrdinalTime && domain.length < 1000)) {
         const maxTickCount = CategoryScale.is(scale)
             ? domain.length
             : Math.min(domain.length, Math.max(1, Math.floor(rangeExtent / (zoomExtent * defaultTickMinSpacing))));
@@ -155,7 +158,18 @@ function estimateScaleTickCount<TScale extends Scale<TDatum, number, TickInterva
         };
     }
 
-    return estimateTickCount(rangeExtent, zoomExtent, minSpacing, maxSpacing, defaultTickCount, defaultTickMinSpacing);
+    const result = estimateTickCount(
+        rangeExtent,
+        zoomExtent,
+        minSpacing,
+        maxSpacing,
+        defaultTickCount,
+        defaultTickMinSpacing
+    );
+    if (isOrdinalTime) {
+        result.minTickCount = 0;
+    }
+    return result;
 }
 
 function buildTickData<TScale extends Scale<TDatum, number, TickInterval<TScale>>, TDatum>(

--- a/packages/ag-charts-community/src/chart/axis/generateTicks.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.ts
@@ -127,7 +127,7 @@ function getTickGenerationType<TScale extends Scale<TDatum, number, TickInterval
     return TickGenerationType.CREATE;
 }
 
-function estimateScaleTickCount<TScale extends Scale<TDatum, number, TickInterval<TScale>>, TDatum>({
+export function estimateScaleTickCount<TScale extends Scale<TDatum, number, TickInterval<TScale>>, TDatum>({
     scale,
     domain,
     range,

--- a/packages/ag-charts-enterprise/src/axes/ordinal/ordinalTimeAxis.test.ts
+++ b/packages/ag-charts-enterprise/src/axes/ordinal/ordinalTimeAxis.test.ts
@@ -719,4 +719,27 @@ describe('Ordinal Time Axis Examples', () => {
         const imageData = extractImageData(ctx);
         expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     });
+
+    // AG-17065: deeply zoomed large ordinal-time dataset must not hang in tick generation.
+    // Jest's default timeout catches a regression — the fix ensures the overlap loop exits
+    // in O(log n) iterations instead of ~1000 linear iterations.
+    it('should not hang when deeply zoomed with a large dataset', async () => {
+        const largeData = Array.from({ length: 5000 }, (_, i) => ({
+            date: new Date(2023, 0, 1, 0, i),
+            open: 100 + Math.sin(i / 100) * 50,
+        }));
+
+        chart = await createEnterpriseChart({
+            width: 300,
+            height: 200,
+            data: largeData,
+            axes: { x: { type: 'ordinal-time' }, y: { type: 'number' } },
+            series: [{ type: 'line', xKey: 'date', yKey: 'open' }],
+            zoom: {},
+            initialState: { zoom: { ratioX: { start: 0.499, end: 0.501 } } },
+        });
+
+        await waitForChartStability(chart);
+        expect(chart).toBeDefined();
+    });
 });


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17065

## Summary

- Fixes chart hang when deeply zoomed on a small chart with 1M ordinal-time data points
- Root cause: the continuous-scale tick estimator returned `minTickCount ≈ 500` for large ordinal-time domains, but ordinal tick steps are discrete (time-interval-based) and don't change when `tickCount` decreases — so the overlap loop iterated ~1000 times redundantly
- Fix: override `minTickCount` to 0 for ordinal-time scales, letting the binary search in `buildTickData` exit immediately when ticks stop changing

## Test plan

- [x] All 3349 community tests pass (0 snapshot changes)
- [x] All 1993 enterprise tests pass (0 snapshot changes)
- [x] 60 ordinal-time axis tests pass (including parent-level/dual-label scenarios)
- [x] Manually verified: zoom on 1M-point ordinal-time chart at iPhone SE dimensions no longer hangs
- [x] Manually verified: high-frequency data update performance is not regressed