### PR TITLE
AG-17288 Respect discrete mode in colour scale fallback path

### DIFF
--- a/packages/ag-charts-community/src/scale/colorScaleUtil.test.ts
+++ b/packages/ag-charts-community/src/scale/colorScaleUtil.test.ts
@@ -339,6 +339,36 @@ describe('configureColorScale', () => {
         ]);
     });
 
+    test('fallback path respects discrete mode (AG-17288)', () => {
+        const scale = new ColorScale();
+        configureColorScale(
+            scale,
+            { fills: [], domain: undefined, mode: 'discrete' },
+            [0, 100],
+            ['red', 'yellow', 'green']
+        );
+        expect(scale.mode).toBe('discrete');
+        expect(scale.domain).toEqual([0, expect.closeTo(33.33, 1), expect.closeTo(66.67, 1), 100]);
+        expect(scale.range).toEqual(['red', 'yellow', 'green']);
+        expect(deriveNormalizedStops(scale)).toEqual([
+            { stop: 0, color: 'red' },
+            { stop: expect.closeTo(0.333, 2), color: 'red' },
+            { stop: expect.closeTo(0.333, 2), color: 'yellow' },
+            { stop: expect.closeTo(0.667, 2), color: 'yellow' },
+            { stop: expect.closeTo(0.667, 2), color: 'green' },
+            { stop: 1, color: 'green' },
+        ]);
+    });
+
+    test('fallback discrete path with explicit domain clamps bins', () => {
+        const scale = new ColorScale();
+        configureColorScale(scale, { fills: [], domain: [20, 80], mode: 'discrete' }, [0, 100], ['red', 'green']);
+        expect(scale.mode).toBe('discrete');
+        expect(scale.domain).toEqual([20, 50, 80]);
+        expect(scale.range).toEqual(['red', 'green']);
+        expect(scale.displayDomain).toEqual([20, 80]);
+    });
+
     test('fallback path with 3 colours evenly spaces gradient stops', () => {
         const scale = new ColorScale();
         configureColorScale(

--- a/packages/ag-charts-community/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-community/src/scale/colorScaleUtil.ts
@@ -22,8 +22,10 @@ export function configureColorScale(
     const domainTuple: [number, number] = [dataDomain[0], dataDomain.at(-1)!];
     const displayDomain: [number, number] = colorScaleProps.domain ?? domainTuple;
 
-    if (colorScaleProps.fills.length > 0) {
-        const { domain, range } = computeColorBins(colorScaleProps.fills, displayDomain, colorScaleProps.mode);
+    if (colorScaleProps.fills.length > 0 || colorScaleProps.mode === 'discrete') {
+        const fills =
+            colorScaleProps.fills.length > 0 ? colorScaleProps.fills : fallbackRange.map((color) => ({ color }));
+        const { domain, range } = computeColorBins(fills, displayDomain, colorScaleProps.mode);
         colorScale.mode = colorScaleProps.mode;
         colorScale.domain = domain;
         colorScale.range = range;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17288

## Summary

- Fix `configureColorScale()` ignoring `colorScale.discrete: true` when `colorScale.fills` is not explicitly provided
- Unify the fills and discrete-fallback branches so both route through `computeColorBins` with the correct mode
- Add regression tests for discrete fallback with default palette and explicit domain override

## Test plan

- [x] Unit tests pass (`yarn nx test ag-charts-community` — 3350 tests)
- [x] Enterprise tests pass (`yarn nx test ag-charts-enterprise` — 2000 tests)
- [x] New test: discrete mode with fallback palette colours
- [x] New test: discrete fallback with explicit domain override
- [ ] Manual: verify heatmap/treemap renders discrete bins without explicit fills

Fix #AG-17288