### PR TITLE
Add Org Chart, Colour Scale, and Selection to pricing matrix

### DIFF
--- a/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
@@ -298,6 +298,15 @@
                 "community": false,
                 "enterprise": true,
                 "chartsGrid": true
+            },
+            {
+                "label": {
+                    "name": "Org Chart",
+                    "link": "https://www.ag-grid.com/charts/r/org-chart/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
             }
         ]
     },
@@ -480,6 +489,15 @@
             },
             {
                 "label": {
+                    "name": "Colour Scale",
+                    "link": "https://www.ag-grid.com/charts/r/colour-scale/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
+            },
+            {
+                "label": {
                     "name": "Error Bars",
                     "link": "https://www.ag-grid.com/charts/r/error-bars/"
                 },
@@ -561,6 +579,15 @@
                 "label": {
                     "name": "Crosshairs & Band Highlight",
                     "link": "https://www.ag-grid.com/charts/r/axes-crosshairs/"
+                },
+                "community": false,
+                "enterprise": true,
+                "chartsGrid": true
+            },
+            {
+                "label": {
+                    "name": "Data Selection",
+                    "link": "https://www.ag-grid.com/charts/r/selection/"
                 },
                 "community": false,
                 "enterprise": true,


### PR DESCRIPTION
## Summary
- Adds **Org Chart** to the Series group (enterprise)
- Adds **Colour Scale** to the Data Elements group (enterprise)
- Adds **Data Selection** to the Interactivity group (enterprise)

These features were missing from the Charts pricing page comparison table.

## Test plan
- [ ] Verify pricing page renders correctly with the new rows
- [ ] Verify links resolve to the correct docs pages