### PR TITLE
Detect system libvips during preinstall and fail fast

### DIFF
--- a/tools/dependencies/check-versions.sh
+++ b/tools/dependencies/check-versions.sh
@@ -51,6 +51,23 @@ else
     checkVersion fontconfig libfontconfig "2..*" "2..*"
 fi
 
+## sharp (used by ag-charts-generate-chart-thumbnail) probes for a system
+## libvips via pkg-config and, if found, builds from source against it. An
+## incompatible host libvips is a common cause of cryptic `yarn install`
+## failures in `node_modules/sharp`. Force prebuilt binaries unless the
+## developer has explicitly opted in to the global build path.
+if [[ -z ${SHARP_IGNORE_GLOBAL_LIBVIPS:-} && -z ${SHARP_FORCE_GLOBAL_LIBVIPS:-} ]] ; then
+    if (which pkg-config >/dev/null 2>&1) && pkg-config --exists vips 2>/dev/null ; then
+        vipsVersion=$(pkg-config --modversion vips 2>/dev/null || echo "unknown")
+        PASS=false
+        echo -e "${RED}Detected system libvips ${vipsVersion} on PATH.${RESET}"
+        echo -e "sharp will try to build from source against it, which often fails."
+        echo -e "Re-run with prebuilt binaries:"
+        echo -e "    SHARP_IGNORE_GLOBAL_LIBVIPS=true yarn install"
+        echo -e "Or set SHARP_IGNORE_GLOBAL_LIBVIPS=true in your shell profile."
+    fi
+fi
+
 if [[ $PASS == "false" ]] ; then
     exit 1
 fi


### PR DESCRIPTION
## Summary

`yarn install` occasionally fails inside `node_modules/sharp` with a cryptic "Command failed" message ([report](https://ag-grid.slack.com/archives/CNPAX7PA5/p1778235265300979)). Root cause: sharp 0.33.x (and 0.34.x — the logic is unchanged) probes for a system libvips via pkg-config and, when found, builds from source against it. An incompatible host libvips (e.g., a brew-installed copy left over from another project) breaks the build.

Add an early check in `tools/dependencies/check-versions.sh` that detects this condition during `preinstall:verify-native-dep-versions` and aborts with the `SHARP_IGNORE_GLOBAL_LIBVIPS=true yarn install` workaround spelled out. Honors `SHARP_IGNORE_GLOBAL_LIBVIPS` / `SHARP_FORCE_GLOBAL_LIBVIPS` as opt-outs.

Bumping sharp was considered and rejected — diffing `lib/libvips.js` between 0.33.5 and 0.34.5 shows the global-libvips probe is byte-identical, so a version bump would not auto-adapt.

## Test plan

- [x] `bash tools/dependencies/check-versions.sh` with no system libvips passes.
- [x] With a stub `pkg-config` reporting `vips 8.15.2`, the script exits 1 and prints the workaround.
- [x] Setting `SHARP_IGNORE_GLOBAL_LIBVIPS=true` short-circuits the new check.