### PR TITLE
AG-17092 Colour scale docs and migration updates

### DIFF
--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-13-3/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-13-3/index.mdoc
@@ -92,7 +92,6 @@ The following APIs have been deprecated since version 13.2 and have now been rem
 -   `AgMapMarkerSeriesThemeableOptions.colorRange`
 -   `AgMapShapeSeriesThemeableOptions.colorRange`
 
-
 {% /expandingSection %}
 
 <!-- Changelog for the `migrationVersion` property DO NOT TOUCH -->

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-13-3/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-13-3/index.mdoc
@@ -82,20 +82,18 @@ The following APIs have been deprecated since version 13.2 and have now been rem
 
 ## Deprecations
 
-<!-- If there are *no* deprecations, add the following: -->
-
-There are no deprecations in AG Charts version {% migrationVersion() %}.
-
-<!-- Otherwise: -->
-<!--
 {% expandingSection headerText="Deprecations" %}
 
-### Deprecation section Name
+`colorRange` is deprecated on the following series types. Use `colorScale.fills` instead.
 
-- item...
+-   `AgHeatmapSeriesOptions.colorRange`
+-   `AgSunburstSeriesThemeableOptions.colorRange`
+-   `AgTreemapSeriesThemeableOptions.colorRange`
+-   `AgMapMarkerSeriesThemeableOptions.colorRange`
+-   `AgMapShapeSeriesThemeableOptions.colorRange`
+
 
 {% /expandingSection %}
--->
 
 <!-- Changelog for the `migrationVersion` property DO NOT TOUCH -->
 

--- a/packages/ag-charts-website/src/content/module-mappings/modules.json
+++ b/packages/ag-charts-website/src/content/module-mappings/modules.json
@@ -241,6 +241,12 @@
                     "isEnterprise": true
                 },
                 {
+                    "moduleName": "OrganizationSeriesModule",
+                    "name": "Org Chart",
+                    "path": "org-chart",
+                    "isEnterprise": true
+                },
+                {
                     "name": "Maps",
                     "path": "maps",
                     "isEnterprise": true,
@@ -382,7 +388,7 @@
                 },
                 {
                     "moduleName": "SelectionModule",
-                    "name": "Selection",
+                    "name": "Data Selection",
                     "path": "selection",
                     "isEnterprise": true
                 },


### PR DESCRIPTION
## Summary

- Revise colour scale documentation and consolidate gradient legend examples
- Add `colorRange` deprecation notice to v13.3 migration page (heatmap, sunburst, treemap, map marker, map shape series)
- Rename "Selection" to "Data Selection" in the modules matrix
- Add Org Chart to Specialised Charts in the modules matrix
- Register LegendModule in legend-choice example
- Fix formatting: trailing whitespace and list indentation

## Test plan

- [ ] Verify v13.3 migration page renders the deprecation section correctly
- [ ] Verify modules matrix shows "Data Selection" and "Org Chart" entries
- [ ] Check colour scale docs page renders correctly