### PR TITLE
Add runtime deprecation warning for `colorRange`

### DIFF
--- a/packages/ag-charts-community-examples/src/charts-overview/examples/simple-sunburst/main.ts
+++ b/packages/ag-charts-community-examples/src/charts-overview/examples/simple-sunburst/main.ts
@@ -12,7 +12,9 @@ const options: AgChartOptions = {
             secondaryLabelKey: 'change',
             sizeKey: 'valuation',
             colorKey: 'change',
-            colorRange: ['#cb4b3f', '#6acb64'],
+            colorScale: {
+                fills: [{ color: '#cb4b3f' }, { color: '#6acb64' }],
+            },
             sectorSpacing: 1,
             secondaryLabel: {
                 formatter(params) {

--- a/packages/ag-charts-community/src/chart/cartesianChartModule.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChartModule.ts
@@ -20,7 +20,7 @@ export const CartesianChartModule: ChartModuleDefinition<AgCartesianChartOptions
     create(options: ChartOptions, resources?: TransferableResources) {
         return new CartesianChart(options, resources);
     },
-    validate(options: any, optionsDefs, path) {
+    validate(options: any, optionsDefs, path, opts) {
         const additionalErrors: ValidationError[] = [];
         if (options?.series?.[0]?.type === 'histogram') {
             if (Object.values(options?.axes ?? {}).some(invalidHistogramAxis)) {
@@ -37,7 +37,7 @@ export const CartesianChartModule: ChartModuleDefinition<AgCartesianChartOptions
             }
         }
 
-        const result = validate(options, optionsDefs, path);
+        const result = validate(options, optionsDefs, path, opts);
         result.invalid.push(...additionalErrors);
         return result;
     },

--- a/packages/ag-charts-community/src/chart/polarChartModule.ts
+++ b/packages/ag-charts-community/src/chart/polarChartModule.ts
@@ -17,7 +17,7 @@ export const PolarChartModule: ChartModuleDefinition<AgPolarChartOptions> = {
     create(options: ChartOptions, resources?: TransferableResources) {
         return new PolarChart(options, resources);
     },
-    validate(options: any, optionsDefs, path) {
+    validate(options: any, optionsDefs, path, opts) {
         const additionalErrors: ValidationError[] = [];
         const baseType = options?.series?.[0]?.type;
         if (baseType === 'pie' || baseType === 'donut') {
@@ -27,7 +27,7 @@ export const PolarChartModule: ChartModuleDefinition<AgPolarChartOptions> = {
             }
         }
 
-        const result = validate(options, optionsDefs, path);
+        const result = validate(options, optionsDefs, path, opts);
         result.invalid.push(...additionalErrors);
         return result;
     },

--- a/packages/ag-charts-community/src/chart/series/test/examples.ts
+++ b/packages/ag-charts-community/src/chart/series/test/examples.ts
@@ -938,7 +938,9 @@ export const SUNBURST_SERIES_LABELS: AgHierarchyChartOptions = {
             labelKey: 'orgHierarchy',
             sizeKey: undefined, // make all siblings within a parent the same size
             colorKey: undefined, // if undefined, depth will be used as the value, where root has 0 depth
-            colorRange: ['#d73027', '#fee08b', '#1a9850', 'rgb(0, 116, 52)'],
+            colorScale: {
+                fills: [{ color: '#d73027' }, { color: '#fee08b' }, { color: '#1a9850' }, { color: 'rgb(0, 116, 52)' }],
+            },
             sectorSpacing: 3,
         },
     ],
@@ -958,7 +960,9 @@ export const TREEMAP_SERIES_LABELS: AgHierarchyChartOptions = {
             labelKey: 'orgHierarchy',
             sizeKey: undefined, // make all siblings within a parent the same size
             colorKey: undefined, // if undefined, depth will be used as the value, where root has 0 depth
-            colorRange: ['#d73027', '#fee08b', '#1a9850', 'rgb(0, 116, 52)'],
+            colorScale: {
+                fills: [{ color: '#d73027' }, { color: '#fee08b' }, { color: '#1a9850' }, { color: 'rgb(0, 116, 52)' }],
+            },
             group: {
                 padding: 5,
             },

--- a/packages/ag-charts-community/src/chart/themes/enterpriseThemeableOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/themes/enterpriseThemeableOptionsDef.ts
@@ -11,6 +11,7 @@ import {
     colorUnion,
     commonSeriesThemeableOptionsDefs,
     defined,
+    deprecated,
     fillOptionsDef,
     highlightOptionsDef,
     interpolationOptionsDefs,
@@ -330,7 +331,7 @@ export const mapLineBackgroundSeriesThemeableOptionsDef: OptionsDefs<AgMapLineBa
 };
 
 export const mapMarkerSeriesThemeableOptionsDef: OptionsDefs<AgMapMarkerSeriesThemeableOptions> = {
-    colorRange: arrayOf(color),
+    colorRange: deprecated(arrayOf(color), 'Use `colorScale.fills` instead.'),
     colorScale: colorScaleOptionsDef,
     maxSize: positiveNumber,
     sizeDomain: arrayOf(positiveNumber),
@@ -345,7 +346,7 @@ export const mapMarkerSeriesThemeableOptionsDef: OptionsDefs<AgMapMarkerSeriesTh
 };
 
 export const mapShapeSeriesThemeableOptionsDef: OptionsDefs<AgMapShapeSeriesThemeableOptions> = {
-    colorRange: arrayOf(color),
+    colorRange: deprecated(arrayOf(color), 'Use `colorScale.fills` instead.'),
     colorScale: colorScaleOptionsDef,
     padding: positiveNumber,
     itemStyler: callbackDefs<AgMapShapeSeriesStyle>({
@@ -618,7 +619,7 @@ export const sankeySeriesThemeableOptionsDef: OptionsDefs<AgSankeySeriesThemeabl
 export const sunburstSeriesThemeableOptionsDef: OptionsDefs<AgSunburstSeriesThemeableOptions> = {
     fills: arrayOf(colorUnion),
     strokes: arrayOf(color),
-    colorRange: arrayOf(color),
+    colorRange: deprecated(arrayOf(color), 'Use `colorScale.fills` instead.'),
     colorScale: colorScaleOptionsDef,
     sectorSpacing: positiveNumber,
     cornerRadius: positiveNumber,
@@ -647,7 +648,7 @@ export const sunburstSeriesThemeableOptionsDef: OptionsDefs<AgSunburstSeriesThem
 export const treemapSeriesThemeableOptionsDef: OptionsDefs<AgTreemapSeriesThemeableOptions> = {
     fills: arrayOf(colorUnion),
     strokes: arrayOf(color),
-    colorRange: arrayOf(color),
+    colorRange: deprecated(arrayOf(color), 'Use `colorScale.fills` instead.'),
     colorScale: colorScaleOptionsDef,
     itemStyler: callbackDefs<AgTreemapSeriesStyle>({
         ...fillOptionsDef,

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -8,6 +8,7 @@ import {
     ModuleRegistry,
     ModuleType,
     type PlainObject,
+    type ValidateOptions,
     deepClone,
     deepFreeze,
     distribute,
@@ -389,13 +390,15 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         removeIncompatibleModuleOptions(this.chartDef.name, processedOptions);
         processModuleOptions(this.chartDef.name, processedOptions, missingSeriesModules);
 
-        this.validateSeriesOptions(processedOptions);
+        // Post-theme validation: suppress advisory warnings (e.g. deprecation) so we don't
+        // re-emit them for theme-injected values that the user did not supply themselves.
+        this.validateSeriesOptions(processedOptions, { silentAdvisories: true });
 
         // The second pass validation of the axes, after they have been processed and the keys remapped. Any missing
         // `type` properties are now inferred and those axes can be validated.
-        this.validateAxesOptions(processedOptions, unmappedAxisKeys);
+        this.validateAxesOptions(processedOptions, unmappedAxisKeys, { silentAdvisories: true });
 
-        this.validatePluginOptions(processedOptions);
+        this.validatePluginOptions(processedOptions, { silentAdvisories: true });
         this.processMiniChartSeriesOptions(processedOptions);
 
         if (!processedOptions.loadGoogleFonts) {
@@ -407,7 +410,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         return { activeTheme, processedOptions, themeParameters, annotationThemes, googleFonts, optionsGraph };
     }
 
-    private validatePluginOptions(options: T) {
+    private validatePluginOptions(options: T, opts: ValidateOptions = {}) {
         for (const pluginDef of ModuleRegistry.listModulesByType(ModuleType.Plugin)) {
             const pluginKey = pluginDef.name as keyof T;
             if (
@@ -415,7 +418,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
                 pluginDef.options != null &&
                 (!pluginDef.chartType || pluginDef.chartType === this.chartDef?.name)
             ) {
-                const { cleared, invalid } = validate(options[pluginKey], pluginDef.options, pluginDef.name);
+                const { cleared, invalid } = validate(options[pluginKey], pluginDef.options, pluginDef.name, opts);
                 for (const error of invalid) {
                     Logger.warn(error);
                 }
@@ -424,7 +427,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         }
     }
 
-    private validateSeriesOptions(options: T): ModulePlaceholder[] {
+    private validateSeriesOptions(options: T, opts: ValidateOptions = {}): ModulePlaceholder[] {
         const chartType = this.chartDef?.name;
         const validatedSeriesOptions: any[] = [];
         const seriesCount = options.series?.length ?? 0;
@@ -476,7 +479,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             }
 
             const { validate: validateSeries = validate } = seriesDef;
-            const { cleared, invalid } = validateSeries(seriesOptions, seriesDef.options, keyPath);
+            const { cleared, invalid } = validateSeries(seriesOptions, seriesDef.options, keyPath, opts);
 
             for (const error of invalid) {
                 Logger.warn(error);
@@ -491,7 +494,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         return missingModules;
     }
 
-    private validateAxesOptions(options: T, unmappedAxisKeys?: Map<string, string>) {
+    private validateAxesOptions(options: T, unmappedAxisKeys?: Map<string, string>, opts: ValidateOptions = {}) {
         if (!('axes' in options) || !options.axes) return;
 
         const chartType = this.chartDef?.name;
@@ -541,7 +544,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             }
 
             const { validate: validateAxis = validate } = axisDef;
-            const { cleared, invalid } = validateAxis(axisOptions, axisDef.options, keyPath);
+            const { cleared, invalid } = validateAxis(axisOptions, axisDef.options, keyPath, opts);
 
             for (const error of invalid) {
                 Logger.warn(error);

--- a/packages/ag-charts-core/src/modules/moduleDefinition.ts
+++ b/packages/ag-charts-core/src/modules/moduleDefinition.ts
@@ -1,7 +1,7 @@
 import type { DatumDefault, ExtensibleTheme, SeriesDefaultAxes, SeriesPredictAxis, SeriesType } from 'ag-charts-types';
 
 import type { DynamicContext } from '../module/dynamicContext';
-import type { OptionsDefs, ValidationResult } from '../state/validation';
+import type { OptionsDefs, ValidateOptions, ValidationResult } from '../state/validation';
 import type { AxisID } from '../types/idBranding';
 import type { Normalised } from '../types/normalised-options/normalise';
 import type { ScaleType } from '../types/scales';
@@ -100,7 +100,8 @@ export interface ModuleDefinition<
         this: void,
         options: unknown,
         optionsDefs: OptionsDefs<TOptions>,
-        path: string
+        path: string,
+        opts?: ValidateOptions
     ): ValidationResult<TOptions>;
 }
 

--- a/packages/ag-charts-core/src/state/validation.ts
+++ b/packages/ag-charts-core/src/state/validation.ts
@@ -22,6 +22,7 @@ const requiredSymbol = Symbol('required');
 const markedSymbol = Symbol('marked');
 const undocumentedSymbol = Symbol('undocumented');
 const enterpriseSymbol = Symbol('enterprise');
+const deprecatedSymbol = Symbol('deprecated');
 export const unionSymbol = Symbol('union');
 
 const similarOptionsMap = [
@@ -55,6 +56,7 @@ type PrivateSymbols = {
     [requiredSymbol]?: boolean;
     [undocumentedSymbol]?: boolean;
     [enterpriseSymbol]?: boolean;
+    [deprecatedSymbol]?: string;
     [unionSymbol]?: string;
 };
 
@@ -77,6 +79,17 @@ export interface ValidatorResult extends ValidationResult<any> {
 export interface ValidatorContext {
     path: string;
     options: any;
+    /**
+     * When true, validators that emit advisory warnings (e.g. `deprecated()`) should stay silent.
+     * Used during post-theme passes where the values originate from theme expansion rather than
+     * the user — emitting a deprecation warning for a theme-injected value would be a false
+     * positive.
+     */
+    silentAdvisories?: boolean;
+}
+
+export interface ValidateOptions {
+    silentAdvisories?: boolean;
 }
 
 export enum ErrorType {
@@ -165,7 +178,12 @@ export class UnknownError extends ValidationError {
  * @param path The current path in the options object, for nested properties.
  * @returns An object containing valid options and validation errors.
  */
-export function validate<T>(options: unknown, optionsDefs: OptionsDefs<T>, path = ''): ValidationResult<T> {
+export function validate<T>(
+    options: unknown,
+    optionsDefs: OptionsDefs<T>,
+    path = '',
+    opts: ValidateOptions = {}
+): ValidationResult<T> {
     if (!isObject(options)) {
         return { cleared: null, invalid: [new ValidationError(ErrorType.Required, 'an object', options, path)] };
     }
@@ -183,7 +201,7 @@ export function validate<T>(options: unknown, optionsDefs: OptionsDefs<T>, path 
             (options.type == null && defaultType != null)
         ) {
             const { type = defaultType, ...rest } = options;
-            const nestedResult = validate(rest, (optionsDefs as any)[type], path);
+            const nestedResult = validate(rest, (optionsDefs as any)[type], path, opts);
             Object.assign(cleared, { type }, nestedResult.cleared);
             for (const error of nestedResult.invalid) {
                 error.setUnionType(type, path);
@@ -213,7 +231,7 @@ export function validate<T>(options: unknown, optionsDefs: OptionsDefs<T>, path 
 
         const keyPath = extendPath(path, key);
         if (isFunction(validatorOrDefs)) {
-            const context: ValidatorContext = { options, path: keyPath };
+            const context: ValidatorContext = { options, path: keyPath, silentAdvisories: opts.silentAdvisories };
             const validatorResult = validatorOrDefs(value, context);
             const objectResult = typeof validatorResult === 'object';
 
@@ -239,7 +257,7 @@ export function validate<T>(options: unknown, optionsDefs: OptionsDefs<T>, path 
                 )
             );
         } else {
-            const nestedResult = validate(value, validatorOrDefs, keyPath);
+            const nestedResult = validate(value, validatorOrDefs, keyPath, opts);
             if (nestedResult.cleared != null) {
                 cleared[key as keyof T] = nestedResult.cleared as any;
             }
@@ -368,6 +386,29 @@ export function enterprise<T extends Validator | OptionsDefs<any>>(validatorOrDe
 }
 
 /**
+ * Marks an option as deprecated. Supplied values still pass through to the inner validator (so the
+ * option remains functional during the deprecation window), but a one-shot warning is emitted via
+ * `warnOnce` to nudge consumers toward the replacement API. The provided `message` should describe
+ * the recommended migration (e.g. "Use `colorScale.fills` instead.").
+ */
+export function deprecated(validator: Validator, message: string): Validator;
+export function deprecated<T extends OptionsDefs<any>>(validatorOrDefs: T, message: string): T;
+export function deprecated<T extends Validator | OptionsDefs<any>>(validatorOrDefs: T, message: string) {
+    const inner: Validator = isFunction(validatorOrDefs) ? validatorOrDefs : optionsDefs(validatorOrDefs);
+    const description = (validatorOrDefs as PrivateSymbols)[descriptionSymbol];
+    const gated: Validator = (value, context) => {
+        if (value !== undefined && !context.silentAdvisories) {
+            warnOnce(`Option \`${context.path}\` is deprecated. ${message}`);
+        }
+        return inner(value, context);
+    };
+    return Object.assign(gated, {
+        [deprecatedSymbol]: message,
+        [descriptionSymbol]: description,
+    }) as T;
+}
+
+/**
  * Creates a validator for ensuring an object matches the provided option definitions.
  * @param defs The option definitions against which to validate an object.
  * @param description (Optional) A description for the validator, defaulting to 'an object'.
@@ -375,7 +416,7 @@ export function enterprise<T extends Validator | OptionsDefs<any>>(validatorOrDe
  */
 export const optionsDefs = <T>(defs: OptionsDefs<T>, description = 'an object', failAll = false): Validator =>
     attachDescription((value, context) => {
-        const result = validate(value, defs, context.path);
+        const result = validate(value, defs, context.path, { silentAdvisories: context.silentAdvisories });
         const valid = !hasRequiredInPath(result.invalid, context.path);
         return { valid, cleared: valid || !failAll ? result.cleared : null, invalid: result.invalid };
     }, description);

--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.test.ts
@@ -44,7 +44,15 @@ describe('GradientLegend', () => {
                 xKey: 'year',
                 yKey: 'person',
                 colorKey: 'spending',
-                colorRange: ['white', 'yellow', 'red', 'blue', 'black'],
+                colorScale: {
+                    fills: [
+                        { color: 'white' },
+                        { color: 'yellow' },
+                        { color: 'red' },
+                        { color: 'blue' },
+                        { color: 'black' },
+                    ],
+                },
             },
         ],
         legend: {
@@ -138,7 +146,15 @@ describe('GradientLegend', () => {
                     xKey: 'year',
                     yKey: 'person',
                     colorKey: 'spending',
-                    colorRange: ['white', 'yellow', 'red', 'blue', 'black'],
+                    colorScale: {
+                        fills: [
+                            { color: 'white' },
+                            { color: 'yellow' },
+                            { color: 'red' },
+                            { color: 'blue' },
+                            { color: 'black' },
+                        ],
+                    },
                     highlight: { enabled: false },
                 },
             ],

--- a/packages/ag-charts-enterprise/src/highlight.test.ts
+++ b/packages/ag-charts-enterprise/src/highlight.test.ts
@@ -973,7 +973,7 @@ describe('Enterprise highlight defaults', () => {
                             labelKey: 'name',
                             sizeKey: 'size',
                             colorKey: 'value',
-                            colorRange: ['#2196F3', '#FFC107'],
+                            colorScale: { fills: [{ color: '#2196F3' }, { color: '#FFC107' }] },
                             // No highlight.fill configured - should use colorScale
                         },
                     ],
@@ -994,7 +994,7 @@ describe('Enterprise highlight defaults', () => {
                             labelKey: 'name',
                             sizeKey: 'size',
                             colorKey: 'value',
-                            colorRange: ['#2196F3', '#FFC107'],
+                            colorScale: { fills: [{ color: '#2196F3' }, { color: '#FFC107' }] },
                             tile: {
                                 highlight: {
                                     highlightedItem: {
@@ -1137,7 +1137,7 @@ describe('Enterprise highlight defaults', () => {
                             labelKey: 'name',
                             sizeKey: 'size',
                             colorKey: 'value',
-                            colorRange: ['#E91E63', '#9C27B0'],
+                            colorScale: { fills: [{ color: '#E91E63' }, { color: '#9C27B0' }] },
                             // No highlight.fill configured - should use colorScale
                         },
                     ],
@@ -1158,7 +1158,7 @@ describe('Enterprise highlight defaults', () => {
                             labelKey: 'name',
                             sizeKey: 'size',
                             colorKey: 'value',
-                            colorRange: ['#E91E63', '#9C27B0'],
+                            colorScale: { fills: [{ color: '#E91E63' }, { color: '#9C27B0' }] },
                             highlight: {
                                 highlightedItem: {
                                     fill: 'green', // Should override colorScale

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmap.test.ts
@@ -64,7 +64,9 @@ describe('HeatmapSeries', () => {
                 xKey: 'year',
                 yKey: 'person',
                 colorKey: 'spending',
-                colorRange: ['yellow', 'red', 'blue'],
+                colorScale: {
+                    fills: [{ color: 'yellow' }, { color: 'red' }, { color: 'blue' }],
+                },
             },
         ],
         legend: {
@@ -1013,7 +1015,7 @@ describe('HeatmapSeries', () => {
                         xKey: 'category',
                         yKey: 'quarter',
                         colorKey: 'sales',
-                        colorRange: ['yellow', 'red', 'blue'],
+                        colorScale: { fills: [{ color: 'yellow' }, { color: 'red' }, { color: 'blue' }] },
                         label: { enabled: true },
                     },
                 ],
@@ -1037,7 +1039,7 @@ describe('HeatmapSeries', () => {
                         xKey: 'quarter',
                         yKey: 'category',
                         colorKey: 'sales',
-                        colorRange: ['yellow', 'red', 'blue'],
+                        colorScale: { fills: [{ color: 'yellow' }, { color: 'red' }, { color: 'blue' }] },
                         label: { enabled: true },
                     },
                 ],
@@ -1082,7 +1084,7 @@ describe('HeatmapSeries', () => {
                         xKey: 'period',
                         yKey: 'category',
                         colorKey: 'sales',
-                        colorRange: ['yellow', 'red', 'blue'],
+                        colorScale: { fills: [{ color: 'yellow' }, { color: 'red' }, { color: 'blue' }] },
                     },
                 ],
                 axes: {
@@ -1167,7 +1169,7 @@ describe('HeatmapSeries', () => {
                         xKey: 'category',
                         yKey: 'quarter',
                         colorKey: 'sales',
-                        colorRange: ['yellow', 'red', 'blue'],
+                        colorScale: { fills: [{ color: 'yellow' }, { color: 'red' }, { color: 'blue' }] },
                     },
                 ],
                 axes: {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeriesOptionsDef.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeriesOptionsDef.ts
@@ -6,6 +6,7 @@ import {
     colorScaleOptionsDef,
     commonSeriesOptionsDefs,
     constant,
+    deprecated,
     required,
     string,
     without,
@@ -25,6 +26,6 @@ export const heatmapSeriesOptionsDef: OptionsDefs<AgHeatmapSeriesOptions> = {
     xName: string,
     yName: string,
     colorName: string,
-    colorRange: arrayOf(color),
+    colorRange: deprecated(arrayOf(color), 'Use `colorScale.fills` instead.'),
     colorScale: colorScaleOptionsDef,
 };

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerModule.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerModule.ts
@@ -66,8 +66,8 @@ export const MapMarkerSeriesModule: SeriesModuleDefinition<AgMapMarkerSeriesOpti
     },
 
     create: (ctx) => new MapMarkerSeries(ctx),
-    validate(options, optionsDefs, path) {
-        const result = validate(options, optionsDefs, path);
+    validate(options, optionsDefs, path, opts) {
+        const result = validate(options, optionsDefs, path, opts);
         const { cleared, invalid } = result;
 
         if (cleared?.idKey == null && (cleared?.latitudeKey == null || cleared?.longitudeKey == null)) {

--- a/packages/ag-charts-server-side/src/agChartsServerSide.test.ts
+++ b/packages/ag-charts-server-side/src/agChartsServerSide.test.ts
@@ -492,7 +492,13 @@ describe('AgChartsServerSide enterprise licensing', () => {
                     { x: 'B', y: '2', value: 40 },
                 ],
                 series: [
-                    { type: 'heatmap', xKey: 'x', yKey: 'y', colorKey: 'value', colorRange: ['#c7e9c0', '#00441b'] },
+                    {
+                        type: 'heatmap',
+                        xKey: 'x',
+                        yKey: 'y',
+                        colorKey: 'value',
+                        colorScale: { fills: [{ color: '#c7e9c0' }, { color: '#00441b' }] },
+                    },
                 ],
             },
             width: 400,

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/color-scale/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/color-scale/main.ts
@@ -39,7 +39,9 @@ const options: AgChartOptions = {
             sizeName: 'GDP',
             colorKey: 'gdpChange',
             colorName: 'Change',
-            colorRange: ['#FF9800', '#8BC34A'],
+            colorScale: {
+                fills: [{ color: '#FF9800' }, { color: '#8BC34A' }],
+            },
         },
     ],
     title: {

--- a/packages/ag-charts-website/src/content/docs/treemap-series/_examples/color-scale/main.ts
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/_examples/color-scale/main.ts
@@ -29,7 +29,9 @@ const options: AgChartOptions = {
             sizeName: 'Total',
             colorKey: 'change',
             colorName: 'Change',
-            colorRange: ['#43A047', '#FF5722'],
+            colorScale: {
+                fills: [{ color: '#43A047' }, { color: '#FF5722' }],
+            },
         },
     ],
     title: {

--- a/packages/ag-charts-website/src/content/gallery/_examples/grouped-category-heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/grouped-category-heatmap/main.ts
@@ -35,7 +35,9 @@ const options: AgChartOptions = {
             yName: 'City',
             colorKey: 'temperature',
             colorName: 'Temperature',
-            colorRange: ['lightblue', 'lightyellow', 'orange', 'red'],
+            colorScale: {
+                fills: [{ color: 'lightblue' }, { color: 'lightyellow' }, { color: 'orange' }, { color: 'red' }],
+            },
             tooltip: {
                 renderer: ({ datum, xKey, yKey, colorKey }) => {
                     const [year, quarter] = datum[xKey];

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-heatmap/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-heatmap/main.ts
@@ -35,17 +35,19 @@ const options: AgChartOptions = {
             colorKey: 'temperature',
             colorName: 'Temperature',
             // Enhanced color scale - diverging blue to red
-            colorRange: [
-                'darkblue',
-                'blue',
-                'lightblue',
-                'lightyellow',
-                'yellow',
-                'orange',
-                'darkorange',
-                'red',
-                'darkred',
-            ],
+            colorScale: {
+                fills: [
+                    { color: 'darkblue' },
+                    { color: 'blue' },
+                    { color: 'lightblue' },
+                    { color: 'lightyellow' },
+                    { color: 'yellow' },
+                    { color: 'orange' },
+                    { color: 'darkorange' },
+                    { color: 'red' },
+                    { color: 'darkred' },
+                ],
+            },
             // Enhanced tooltip
             tooltip: {
                 renderer: ({ datum, xKey, yKey, colorKey }) => {

--- a/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-color-range/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/treemap-with-color-range/main.ts
@@ -37,7 +37,17 @@ const options: AgChartOptions<DataType> = {
             sizeKey: 'valuation',
             colorName: 'Daily Change',
             colorKey: 'change',
-            colorRange: ['#d32f2f', '#f44336', '#ffb74d', '#fff9c4', '#c5e1a5', '#66bb6a', '#2e7d32'],
+            colorScale: {
+                fills: [
+                    { color: '#d32f2f' },
+                    { color: '#f44336' },
+                    { color: '#ffb74d' },
+                    { color: '#fff9c4' },
+                    { color: '#c5e1a5' },
+                    { color: '#66bb6a' },
+                    { color: '#2e7d32' },
+                ],
+            },
             group: {
                 label: {
                     formatter({ value }) {

--- a/tests/bundle-render-tests/scenarios.mjs
+++ b/tests/bundle-render-tests/scenarios.mjs
@@ -170,7 +170,15 @@ export const scenarios = [
         ],
         chartOptions: {
             data: heatmapData,
-            series: [{ type: 'heatmap', xKey: 'x', yKey: 'y', colorKey: 'value', colorRange: ['#c7e9c0', '#00441b'] }],
+            series: [
+                {
+                    type: 'heatmap',
+                    xKey: 'x',
+                    yKey: 'y',
+                    colorKey: 'value',
+                    colorScale: { fills: [{ color: '#c7e9c0' }, { color: '#00441b' }] },
+                },
+            ],
         },
     },
     {

--- a/tests/server-side-package-tests/patches/basic/app.ts
+++ b/tests/server-side-package-tests/patches/basic/app.ts
@@ -426,7 +426,15 @@ async function main() {
                     { x: 'B', y: '1', value: 30 },
                     { x: 'B', y: '2', value: 40 },
                 ],
-                series: [{ type: 'heatmap', xKey: 'x', yKey: 'y', colorKey: 'value', colorRange: ['#c7e9c0', '#00441b'] }],
+                series: [
+                    {
+                        type: 'heatmap',
+                        xKey: 'x',
+                        yKey: 'y',
+                        colorKey: 'value',
+                        colorScale: { fills: [{ color: '#c7e9c0' }, { color: '#00441b' }] },
+                    },
+                ],
             },
             width: 400,
             height: 300,


### PR DESCRIPTION
## Summary

`colorRange` has been JSDoc-deprecated since v13.3.0 on `heatmap`, `mapMarker`, `mapShape`, `sunburst`, and `treemap`, but no runtime warning was emitted — users had no signal at runtime that they were on a deprecated path. This PR adds one, scoped strictly to user-supplied values.

- New `deprecated()` validator wrapper alongside `enterprise()` / `undocumented()` in `validation.ts`. It emits `Option \`<path>\` is deprecated. <message>` once per session via `warnOnce`, then falls through to the inner validator so the option keeps working.
- New `silentAdvisories` flag threaded through `validate()` (and through the per-module `validate` overrides on cartesian/polar chart modules and the mapMarker module). The post-theme validation passes in `optionsModule.slowSetup()` set it to `true`, so theme-injected `colorRange` values do not trip the warning — only genuine user input does.
- `colorRange` wrapped in `deprecated()` for the five public option defs: heatmap (series-level def) and the four themeable defs (mapMarker, mapShape, sunburst, treemap).
- Test/example inputs that exercised the deprecated path migrated to `colorScale.fills` so they stop tripping `setupMockConsole`. These are user-style call sites and the migration mirrors what end users will do (`heatmap.test.ts`, `highlight.test.ts`, `gradientLegend.test.ts`, `chart/series/test/examples.ts`, `agChartsServerSide.test.ts`, `simple-sunburst/main.ts`, plus the bundle-render and server-side-package test scenarios).

## Out of scope (deferred)

Internal usages of `colorRange` in theme templates and series fallback logic are intentionally left untouched here — too risky for the current release. A follow-up PR (new JIRA, fixVersion 36.0.0) will migrate:
- Theme templates: heatmap / sunburst / treemap / mapMarker / mapShape modules.
- Series-level fallback paths in `heatmapSeries.ts` and `hierarchySeries.ts` to derive fallback colours from `colorScale.fills` instead of `properties.colorRange`.
- Gallery / docs examples and the `treemap-series` mdoc references.

## Test plan

- [x] `yarn nx format`
- [x] `yarn nx lint ag-charts-core ag-charts-community ag-charts-enterprise`
- [x] `yarn nx test ag-charts-core` — 494 passed
- [x] `yarn nx test ag-charts-community` — 3349 passed
- [x] `yarn nx test ag-charts-enterprise` — 2000 passed (no failures)
- [x] `yarn nx test ag-charts-server-side` — 40 passed
- [ ] Verify on docs site that user-supplied `colorRange` triggers a single deprecation warning per session and the chart still renders identically.