### PR TITLE
Add Claude settings configuration for cloud environment setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh"
+          },
+          {
+            "type": "command",
+            "command": "if [ -n \"$CLAUDE_ENV_FILE\" ]; then echo 'export NX_DAEMON=false' >> \"$CLAUDE_ENV_FILE\"; fi"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/external/ag-shared/scripts/install-for-cloud/setup-terminal-title.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,7 @@ vitest.config.*.timestamp*
 
 # Ignore local AI.
 /.context/
-/.claude/*
-!/.claude/settings.json
+/.claude/
 /.gemini/
 /.github/prompts/
 /.github/instructions/

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,8 @@ vitest.config.*.timestamp*
 
 # Ignore local AI.
 /.context/
-/.claude/
+/.claude/*
+!/.claude/settings.json
 /.gemini/
 /.github/prompts/
 /.github/instructions/


### PR DESCRIPTION
## Summary
Added a new `.claude/settings.json` configuration file that defines session startup hooks for cloud environment initialization.

## Key Changes
- Created `.claude/settings.json` with SessionStart hooks that execute during startup
- Configured three initialization commands:
  - Runs the cloud installation script from `external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh`
  - Disables the NX daemon by appending `export NX_DAEMON=false` to the Claude environment file
  - Executes the terminal title setup script from `external/ag-shared/scripts/install-for-cloud/setup-terminal-title.sh`

## Implementation Details
The hooks are configured to run on the "startup" matcher, ensuring they execute automatically when a session starts in the cloud environment. The configuration uses environment variables (`$CLAUDE_PROJECT_DIR` and `$CLAUDE_ENV_FILE`) to maintain portability across different project setups.

https://claude.ai/code/session_01T1feTRwub6QreEhh5riuQo