### PR TITLE
Fix selection examples breaking in Angular and React [CRT-1105]

### DIFF
--- a/packages/ag-charts-website/src/content/docs/selection/_examples/click-modes/main.ts
+++ b/packages/ag-charts-website/src/content/docs/selection/_examples/click-modes/main.ts
@@ -40,19 +40,18 @@ const options: AgCartesianChartOptions = {
 
 const chart = AgCharts.create(options);
 
-function updateSubtitle() {
+function setClickMode(value: AgSelectionClickMode) {
+    options.selection = { ...options.selection, clickMode: value };
     options.subtitle = {
         text: `clickMode: '${options.selection!.clickMode}', clickAwayToClear: ${options.selection!.enableClickAwayToClear}`,
     };
     chart.update(options);
 }
 
-function setClickMode(value: AgSelectionClickMode) {
-    options.selection = { ...options.selection, clickMode: value };
-    updateSubtitle();
-}
-
 function setClickAway(value: boolean) {
     options.selection = { ...options.selection, enableClickAwayToClear: value };
-    updateSubtitle();
+    options.subtitle = {
+        text: `clickMode: '${options.selection!.clickMode}', clickAwayToClear: ${options.selection!.enableClickAwayToClear}`,
+    };
+    chart.update(options);
 }

--- a/packages/ag-charts-website/src/content/docs/selection/_examples/selection-basic/main.ts
+++ b/packages/ag-charts-website/src/content/docs/selection/_examples/selection-basic/main.ts
@@ -37,16 +37,11 @@ const options: AgCartesianChartOptions = {
     },
     listeners: {
         selectionChange: () => {
-            updateStatus();
+            const count = Array.from(chart.getSelection()).length;
+            document.getElementById('selectionStatus')!.textContent =
+                count === 0 ? 'No items selected' : `${count} item${count === 1 ? '' : 's'} selected`;
         },
     },
 };
 
 const chart = AgCharts.create(options);
-
-/** inScope */
-function updateStatus() {
-    const count = Array.from(chart.getSelection()).length;
-    document.getElementById('selectionStatus')!.textContent =
-        count === 0 ? 'No items selected' : `${count} item${count === 1 ? '' : 's'} selected`;
-}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1105

## Summary
- **selection-basic**: `updateStatus()` called from the `selectionChange` listener was placed as a class method in Angular but referenced as a bare function — `ReferenceError: updateStatus is not defined` on drag/click. Inlined the logic into the listener.
- **click-modes**: `updateSubtitle()` helper was placed at module scope by the generator (not HTML-referenced), but it accessed `options`/`chart` which are component-scoped. Broke both Angular and React when clicking any button. Inlined into each handler.

## Test plan
- [ ] Verify selection-basic example works in Angular (drag to select, status text updates)
- [ ] Verify click-modes example works in Angular (click mode/click-away buttons update subtitle)
- [ ] Verify click-modes example works in React (same)
- [ ] Verify vanilla TypeScript versions still work
- [ ] `yarn nx validate-examples` passes (confirmed locally — 838 examples, no issues)