### PR TITLE
Fix gradient legend sliders producing NaN in framework examples [CRT-1109]

### DIFF
--- a/packages/ag-charts-website/src/content/docs/colour-scale/_examples/gradient-legend/index.html
+++ b/packages/ag-charts-website/src/content/docs/colour-scale/_examples/gradient-legend/index.html
@@ -7,11 +7,11 @@
         <button onclick="setPosition('top')">Top</button>
     </div>
     <div class="controls-row">
-        Thickness: <input type="range" min="5" max="60" value="16" step="1" oninput="setThickness(this.value)" />
+        Thickness: <input type="range" min="5" max="60" value="16" step="1" oninput="setThickness(event)" />
         <span id="thicknessValue">16</span> <span class="gap-left">Length:</span>
-        <input type="range" min="50" max="500" value="100" step="10" oninput="setLength(this.value)" />
+        <input type="range" min="50" max="500" value="100" step="10" oninput="setLength(event)" />
         <span id="lengthValue">100</span> <span class="gap-left">Padding:</span>
-        <input type="range" min="0" max="40" value="10" step="1" oninput="setPadding(this.value)" />
+        <input type="range" min="0" max="40" value="10" step="1" oninput="setPadding(event)" />
         <span id="paddingValue">10</span>
     </div>
 </div>

--- a/packages/ag-charts-website/src/content/docs/colour-scale/_examples/gradient-legend/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colour-scale/_examples/gradient-legend/main.ts
@@ -55,8 +55,8 @@ function setPosition(position: 'bottom' | 'right' | 'left' | 'top') {
     chart.update(options);
 }
 
-function setThickness(value: string) {
-    const thickness = Number(value);
+function setThickness(event: Event) {
+    const thickness = Number((event.target as HTMLInputElement).value);
     options.gradientLegend = {
         ...options.gradientLegend,
         gradient: { ...options.gradientLegend?.gradient, thickness },
@@ -65,8 +65,8 @@ function setThickness(value: string) {
     chart.update(options);
 }
 
-function setLength(value: string) {
-    const preferredLength = Number(value);
+function setLength(event: Event) {
+    const preferredLength = Number((event.target as HTMLInputElement).value);
     options.gradientLegend = {
         ...options.gradientLegend,
         gradient: { ...options.gradientLegend?.gradient, preferredLength },
@@ -75,8 +75,8 @@ function setLength(value: string) {
     chart.update(options);
 }
 
-function setPadding(value: string) {
-    const padding = Number(value);
+function setPadding(event: Event) {
+    const padding = Number((event.target as HTMLInputElement).value);
     options.gradientLegend = {
         ...options.gradientLegend,
         scale: { ...options.gradientLegend?.scale, padding },


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1109

## Summary
- Gradient legend example sliders (`setThickness`, `setLength`, `setPadding`) used `oninput="handler(this.value)"` in HTML
- In vanilla JS, `this` is the input element — works fine
- In React, the generator produces `onInput={() => handler(this.value)}` where `this` in an arrow function is `undefined` → `Number(undefined)` = `NaN`
- In Angular, the generator produces `(input)="handler(this.value)"` where `this` is the component instance → `this.value` is `undefined` → `NaN`
- Fix: switch to `oninput="handler(event)"` and extract `(event.target as HTMLInputElement).value` in the function — the standard pattern used by all other range input examples

## Test plan
- [ ] Verify gradient legend sliders work in Angular (thickness/length/padding update without NaN)
- [ ] Verify gradient legend sliders work in React (same)
- [ ] Verify vanilla JS version still works
- [ ] `yarn nx validate-examples` passes (confirmed locally)