### PR TITLE
Add missing LegendModule to heatmap color-range example

### DIFF
--- a/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/color-range-with-many-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/_examples/color-range-with-many-values/main.ts
@@ -5,12 +5,13 @@ import {
     CategoryAxisModule,
     GradientLegendModule,
     HeatmapSeriesModule,
+    LegendModule,
     ModuleRegistry,
 } from 'ag-charts-enterprise';
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([CategoryAxisModule, GradientLegendModule, HeatmapSeriesModule]);
+ModuleRegistry.registerModules([CategoryAxisModule, GradientLegendModule, LegendModule, HeatmapSeriesModule]);
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),


### PR DESCRIPTION
[CRT-1101](https://ag-grid.atlassian.net/browse/CRT-1101)

## Summary
- Add missing `LegendModule` import and registration to the `color-range-with-many-values` heatmap example, fixing broken legend functionality.

## Test plan
- [ ] Open the heatmap color-range-with-many-values docs example
- [ ] Verify the gradient legend renders correctly