### PR TITLE
Standardise x-axis/y-axis hyphenation

### DIFF
--- a/packages/ag-charts-types/src/series/cartesian/cartesianSeriesTooltipOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/cartesianSeriesTooltipOptions.ts
@@ -17,29 +17,29 @@ export interface AgCartesianSeriesTooltipRendererParams<
 }
 
 export interface AgErrorBoundSeriesTooltipRendererParams<TDatum = DatumDefault> {
-    /** The key to use to retrieve lower bound error values from the x axis data. */
+    /** The key to use to retrieve lower bound error values from the x-axis data. */
     xLowerKey?: DatumKey<TDatum>;
     /** The x-axis lower bound error value. */
     xLowerValue?: any;
-    /** Human-readable description of the lower bound error value for the x axis. This is the value to use in tooltips or labels. */
+    /** Human-readable description of the lower bound error value for the x-axis. This is the value to use in tooltips or labels. */
     xLowerName?: string;
-    /** The key to use to retrieve upper bound error values from the x axis data. */
+    /** The key to use to retrieve upper bound error values from the x-axis data. */
     xUpperKey?: DatumKey<TDatum>;
     /** The x-axis upper bound error value. */
     xUpperValue?: any;
-    /** Human-readable description of the upper bound error value for the x axis. This is the value to use in tooltips or labels. */
+    /** Human-readable description of the upper bound error value for the x-axis. This is the value to use in tooltips or labels. */
     xUpperName?: string;
 
-    /** The key to use to retrieve lower bound error values from the y axis data. */
+    /** The key to use to retrieve lower bound error values from the y-axis data. */
     yLowerKey?: DatumKey<TDatum>;
     /** The y-axis lower bound error value. */
     yLowerValue?: any;
-    /** Human-readable description of the lower bound error value for the y axis. This is the value to use in tooltips or labels. */
+    /** Human-readable description of the lower bound error value for the y-axis. This is the value to use in tooltips or labels. */
     yLowerName?: string;
-    /** The key to use to retrieve upper bound error values from the y axis data. */
+    /** The key to use to retrieve upper bound error values from the y-axis data. */
     yUpperKey?: DatumKey<TDatum>;
     /** The y-axis upper bound error value. */
     yUpperValue?: any;
-    /** Human-readable description of the upper bound error value for the y axis. This is the value to use in tooltips or labels. */
+    /** Human-readable description of the upper bound error value for the y-axis. This is the value to use in tooltips or labels. */
     yUpperName?: string;
 }

--- a/packages/ag-charts-website/src/content/docs/axes-secondary/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-secondary/index.mdoc
@@ -94,7 +94,7 @@ In this configuration:
 
 - The `yKey` values of the first series are plotted against the `profit` axis on the left, whilst the `yKey` values of the second series are plotted against the `revenue` axis on the right.
 - Series default to the `x` and `y` axis keys when not specified, so `series[].xKeyAxis` is not required.
-- `axes.x` is not required because no customisation is needed for the default x axis.
+- `axes.x` is not required because no customisation is needed for the default x-axis.
 - There is no `axes.y` in this chart as all series have specified a different `yKeyAxis`.
 
 Specifying `type` is not required but is recommended for type-checking and validation.

--- a/packages/ag-charts-website/src/content/docs/axes-types/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-types/index.mdoc
@@ -7,7 +7,7 @@ The horizontal (X) and vertical (Y) lines in cartesian charts are referred to as
 the relationships between data points on the graph. This section discusses the different axis types.
 
 In most cases, specifying an axis type is unnecessary as an appropriate axis will be inferred from the data and series type used in the chart.
-By default, the x-axis uses a [Category](#category), [Time](#time) or [Number](#number) axis based on the data type, whilst the y axis defaults to a [Number](#number) axis.
+By default, the x-axis uses a [Category](#category), [Time](#time) or [Number](#number) axis based on the data type, whilst the y-axis defaults to a [Number](#number) axis.
 
 Axis types can be explicitly configured as explained below.
 

--- a/packages/ag-charts-website/src/content/docs/bubble-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/bubble-series/index.mdoc
@@ -29,8 +29,8 @@ To create a Bubble Series use the `'bubble'` series type, and provide a `sizeKey
 
 In this configuration:
 
-- `xKey` defines the numerical values for the x axis, and is mapped by default to a [Number](./axes-types/#number).
-- `yKey` provides the numerical values for the y axis, and is mapped by default to a [Number Axis](./axes-types/#number).
+- `xKey` defines the numerical values for the x-axis, and is mapped by default to a [Number](./axes-types/#number).
+- `yKey` provides the numerical values for the y-axis, and is mapped by default to a [Number Axis](./axes-types/#number).
 - `sizeKey` provides the numerical values determining the size of each bubble.
 - `xName`, `yName` and `sizeName` are optional and configure display names, reflected in [Tooltips](./tooltips).
 - `title` is optional and is used in the [Tooltip Titles](./tooltips/) and [Legend Items](./legend/).

--- a/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
@@ -45,12 +45,12 @@ Complete our [Quick Start](./quick-start/) (or open the example below in Plunker
 {% if isFramework("javascript") %}
 
 - **Chart Options:** Object which contains the chart configuration options, including the **container**, **data**, and **series** properties:
-    - **Container:** The HTML element in which the chart should be rendered.
-    - **Data:** The data to display within a chart (_typically_ an array of data-points).
-    - **Series:** The type of chart to display, and the data to use. For cartesian charts, a minimum of three properties are required:
-        - **Type:** Defines the type of chart to display (e.g. Line, Bar, etc.).
-        - **xKey:** The data to use for the X axis.
-        - **yKey:** The data to use for the Y axis.
+    - **container:** The HTML element in which the chart should be rendered.
+    - **data:** The data to display within a chart (_typically_ an array of data-points).
+    - **series:** The type of chart to display, and the data to use. For cartesian charts, a minimum of three properties are required:
+        - **type:** Defines the type of chart to display (e.g. Line, Bar, etc.).
+        - **xKey:** The data to use for the x-axis.
+        - **yKey:** The data to use for the y-axis.
 - **Create:** `AgCharts.create(chartOptions)` API for creating new charts, using the Chart Options configurations.
 
 {% /if %}
@@ -58,11 +58,11 @@ Complete our [Quick Start](./quick-start/) (or open the example below in Plunker
 {% if isNotJavascriptFramework() %}
 
 - **Chart Options:** Object which contains the chart configuration options, including **data**, and **series** properties:
-    - **Data:** The data to display within a chart (_typically_ an array of data-points).
-    - **Series:** The type of chart to display, and the data to use. For cartesian charts, a minimum of three properties are required:
-        - **Type:** Defines the type of chart to display (e.g. Line, Bar, etc.).
-        - **xKey:** The data to use for the X axis.
-        - **yKey:** The data to use for the Y axis.
+    - **data:** The data to display within a chart (_typically_ an array of data-points).
+    - **series:** The type of chart to display, and the data to use. For cartesian charts, a minimum of three properties are required:
+        - **type:** Defines the type of chart to display (e.g. Line, Bar, etc.).
+        - **xKey:** The data to use for the x-axis.
+        - **yKey:** The data to use for the y-axis.
 
 {% /if %}
 
@@ -149,14 +149,14 @@ const options = {
             type: 'bar',
             xKey: 'month',
             yKey: 'iceCreamSales',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'priceAxis',
         },
         {
             type: 'line',
             xKey: 'month',
             yKey: 'avgTemp',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'temperatureAxis',
         },
     ],
@@ -175,14 +175,14 @@ const [chartOptions, setChartOptions] = useState({
             type: 'bar',
             xKey: 'month',
             yKey: 'iceCreamSales',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'priceAxis',
         },
         {
             type: 'line',
             xKey: 'month',
             yKey: 'avgTemp',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'temperatureAxis',
         },
     ],
@@ -201,14 +201,14 @@ this.chartOptions = {
             type: 'bar',
             xKey: 'month',
             yKey: 'iceCreamSales',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'priceAxis',
         },
         {
             type: 'line',
             xKey: 'month',
             yKey: 'avgTemp',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'temperatureAxis',
         },
     ],
@@ -227,14 +227,14 @@ const options = ref<AgChartOptions>({
             type: 'bar',
             xKey: 'month',
             yKey: 'iceCreamSales',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'priceAxis',
         },
         {
             type: 'line',
             xKey: 'month',
             yKey: 'avgTemp',
-            // Y Axis Key, to link series to an axis
+            // y-axis Key, to link series to an axis
             yKeyAxis: 'temperatureAxis',
         },
     ],

--- a/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
@@ -60,9 +60,9 @@ These properties include `xKey` and `yKey` for cartesian charts, `colorKey` for 
 In this example:
 
 - The `data` array contains the data for all series in the chart.
-- Series 1 visualises the `women` field on the y axis using `yKey: 'women'`.
-- Series 2 visualises the `men` field on the y axis using `yKey: 'men'`.
-- The `xKey: 'year'` is used by both series, determining the x axis categories.
+- Series 1 visualises the `women` field on the y-axis using `yKey: 'women'`.
+- Series 2 visualises the `men` field on the y-axis using `yKey: 'men'`.
+- The `xKey: 'year'` is used by both series, determining the x-axis categories.
 
 The `_Key` properties vary by series type - see the [Series Options](/options/#reference-AgChartOptions-series) for more details.
 

--- a/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/error-bars/index.mdoc
@@ -67,7 +67,7 @@ In this configuration:
 - `errorBar.yLowerKey` and `errorBar.yUpperKey` denote the y-axis bounds.
 
 A custom [Tooltip](./tooltips/) is also provided to the series `tooltip` option
-to display the x and y axis bounds. The X & Y keys and names are available to the
+to display the x-axis and y-axis bounds. The x and y keys and names are available to the
 renderer when Error Bars are enabled.
 
 {% note %}

--- a/packages/ag-charts-website/src/content/docs/heatmap-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/heatmap-series/index.mdoc
@@ -27,8 +27,8 @@ To create a Heatmap Series, use the `heatmap` series type.
 
 In this configuration:
 
-- `xKey` is set to 'month', which is the category for the X Axis.
-- `yKey` is set to 'year', which is the category for the Y Axis.
+- `xKey` is set to 'month', which is the category for the x-axis.
+- `yKey` is set to 'year', which is the category for the y-axis.
 - `colorKey` is set to 'temperature', which supplies numerical values for the Colour Scale.
 
 ## Colour Scale

--- a/packages/ag-charts-website/src/content/docs/range-area-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/range-area-series/index.mdoc
@@ -24,7 +24,7 @@ The Range Area Series is created using the `range-area` series type.
 }
 ```
 
-The `yLowKey` and `yHighKey` are used to retrieve the range of values for the Y axis.
+The `yLowKey` and `yHighKey` are used to retrieve the range of values for the y-axis.
 
 ## Multiple Range Area Series
 

--- a/packages/ag-charts-website/src/content/docs/range-bar-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/range-bar-series/index.mdoc
@@ -24,7 +24,7 @@ The Range Bar Series is created using the `range-bar` series type.
 }
 ```
 
-The `yLowKey` and `yHighKey` are used to retrieve the range of values for the Y axis.
+The `yLowKey` and `yHighKey` are used to retrieve the range of values for the y-axis.
 
 ## Multiple Range Bar Series
 

--- a/packages/ag-charts-website/src/content/docs/scatter-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/scatter-series/index.mdoc
@@ -27,8 +27,8 @@ To create a Scatter Series use the `'scatter'` series type.
 
 In this configuration:
 
-- `xKey` defines the numerical values for the x axis, and is mapped by default to a [Number](./axes-types/#number).
-- `yKey` provides the numerical values for the y axis, and is mapped by default to a [Number Axis](./axes-types/#number).
+- `xKey` defines the numerical values for the x-axis, and is mapped by default to a [Number](./axes-types/#number).
+- `yKey` provides the numerical values for the y-axis, and is mapped by default to a [Number Axis](./axes-types/#number).
 - `xName` and `yName` are optional and configure display names, reflected in [Tooltips](./tooltips/).
 - `title` is optional and is used in the [Tooltip Titles](./tooltips/) and [Legend Items](./legend/).
 

--- a/packages/ag-charts-website/src/content/docs/sync/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sync/index.mdoc
@@ -9,7 +9,7 @@ Synchronize multiple charts to align data insights and interactive elements, off
 
 {% chartExampleRunner title="Basic Synchronization" name="basic-sync" type="generated" /%}
 
-Enable chart synchronization by configuring the `sync` option on at least two charts. By default this will synchronize the axis domain, zoom, and user node interactions along the x axis.
+Enable chart synchronization by configuring the `sync` option on at least two charts. By default this will synchronize the axis domain, zoom, and user node interactions along the x-axis.
 
 ```js format="snippet"
 {
@@ -21,7 +21,7 @@ Enable chart synchronization by configuring the `sync` option on at least two ch
 
 In the above example:
 
-- Both charts have the same axes domain range for the x axis.
+- Both charts have the same axes domain range for the x-axis.
 - Any changes to the horizontal zoom level or position made in any chart or the Navigator, are reflected in both charts.
 - Hovering a node in one chart, will highlight and show crosshairs and tooltips for the corresponding node in the other chart.
 
@@ -114,7 +114,7 @@ Use `groupId` to synchronize charts within the same group, supporting multiple i
 In the above example:
 
 - The charts on the left are synchronised with each other, as are the charts on the right.
-- The top charts have their x axis and crosshair labels hidden, to give a 'combined chart' effect.
+- The top charts have their x-axis and crosshair labels hidden, to give a 'combined chart' effect.
 
 {% note %}
 Charts without a `groupId` will be allocated to a default group.

--- a/packages/ag-charts-website/src/content/docs/zoom/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/zoom/index.mdoc
@@ -40,9 +40,9 @@ This allows zooming by using the mouse wheel or trackpad, as shown in the above 
 
 By default, the chart will zoom while keeping the right side of the x-axis pinned. You can change this anchor point with the `anchorPointX` and `anchorPointY` properties, setting them each to one of:
 
-- `start`, the left or bottom of the chart when scrolling on the x or y axis respectively,
+- `start`, the left or bottom of the chart when scrolling on the x-axis or y-axis respectively,
 - `middle` (default for y-axis), the middle of the chart,
-- `end` (default for x-axis), the right or top of the chart when scrolling on the x or y axis respectively,
+- `end` (default for x-axis), the right or top of the chart when scrolling on the x-axis or y-axis respectively,
 - `pointer`, keep the mouse pointer above the same position on the chart when zooming.
 
 In the example below, we set the anchor point for both axes to the mouse pointer.


### PR DESCRIPTION
[CRT-1103](https://ag-grid.atlassian.net/browse/CRT-1103)

## Summary

- Standardise all standalone "x axis" / "y axis" spelling variants to hyphenated form (`x-axis` / `y-axis`) across docs and API types JSDoc
- 13 files updated (12 `.mdoc` docs pages + 1 `.ts` API types file)
- Compound terms like "category axis" and "secondary axis" left unchanged

## Test plan

- [ ] Verify docs pages render correctly in dev server
- [ ] Confirm API reference tooltips display updated JSDoc text