### PR TITLE
Add Gradient Legend cross-reference to Legend page

### DIFF
--- a/packages/ag-charts-website/src/content/docs/legend/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/legend/index.mdoc
@@ -3,6 +3,10 @@ title: 'Legend'
 description: 'A legend matches visual elements in the $framework chart to the corresponding data categories. Customise the legend layout. Enable pagination. Control series visibility via legend.'
 ---
 
+{% note %}
+This page covers the category Legend. For the Gradient Legend see the [Colour Scale](./colour-scale/#gradient-legend) page.
+{% /note %}
+
 A Legend aids in matching visual elements in the chart to their corresponding series or data categories.
 
 {% chartExampleRunner title="Legend Position" name="legend-position" type="generated" /%}


### PR DESCRIPTION
[CRT-1112](https://ag-grid.atlassian.net/browse/CRT-1112)

## Summary

- Add a note callout at the top of the Legend docs page directing users to the Gradient Legend on the Colour Scale page

## Test plan

- [ ] Verify note renders correctly on the Legend page in dev server
- [ ] Confirm cross-reference link navigates to the correct section