### PR TITLE
Fix sankey label-placement button text

### DIFF
--- a/packages/ag-charts-website/src/content/docs/sankey-series/_examples/label-placement/index.html
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/_examples/label-placement/index.html
@@ -7,7 +7,7 @@
         <span> Edge Placement: </span>
         <button onclick="placeEdgeOutside()"><code>'outside'</code></button>
         <button onclick="placeEdgeInside()"><code>'inside'</code></button>
-        <button onclick="placeEdgeDefault()"><code>'undefined'</code></button>
+        <button onclick="placeEdgeDefault()"><code>undefined</code></button>
     </div>
 </div>
 <div id="myChart"></div>


### PR DESCRIPTION
[CRT-1115](https://ag-grid.atlassian.net/browse/CRT-1115)

## Summary

- Remove erroneous quotes around `undefined` in the sankey label-placement example reset button

## Test plan

- [ ] Verify button displays `undefined` without quotes in dev server