### PR TITLE
CRT-1090 Call `styler` fns with series selection state

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -1329,7 +1329,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         selectionState: SelectionState | undefined,
         datum: MarkerSelectionDatum
     ): AgSeriesMarkerStyle {
-        const stylerStyle = series.getStyle(highlightState, selectionState);
+        const stylerStyle = series.getStyle(highlightState);
         return series.getMarkerStyle(
             ctx.marker,
             datum,
@@ -1349,10 +1349,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         series: AreaSeries,
         _ctx: AreaStylerPassCtx,
         highlightState: HighlightState,
-        selectionState: SelectionState | undefined,
+        _selectionState: SelectionState | undefined,
         _datum: MarkerSelectionDatum
     ): ReturnType<AreaSeries['getStyle']> {
-        return series.getStyle(highlightState, selectionState);
+        return series.getStyle(highlightState);
     }
 
     private static applyStylerDatum(
@@ -1786,14 +1786,14 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
     }
 
     public getStyle(
-        highlightState: HighlightState | undefined,
-        selectionState: SelectionState | undefined
+        highlightState: HighlightState | undefined
     ): Required<AgAreaSeriesStylerResult> & { marker: Required<AgSeriesMarkerStyle> & { enabled: boolean } } {
         const { styler, marker, fill, fillOpacity, lineDash, lineDashOffset, stroke, strokeOpacity, strokeWidth } =
             this.properties;
         const { size, shape, fill: markerFill = 'transparent', fillOpacity: markerFillOpacity } = marker;
         let stylerResult: AgAreaSeriesStylerResult & { marker?: { enabled?: boolean } } = {};
         if (styler) {
+            const selectionState: SelectionState | undefined = this.getDataSelectionState(undefined);
             const stylerParams = this.makeStylerParams(highlightState, selectionState);
             const cbResult = this.cachedCallWithContext(styler, stylerParams) ?? {};
             const resolved = this.ctx.optionsGraphService.resolvePartial(

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -1212,7 +1212,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
 
         const highlightStyle = this.getHighlightStyle();
         const selectionStyle = this.getSelectionStyle();
-        const seriesStyle = this.getStyle(undefined, undefined);
+        const seriesStyle = this.getStyle(undefined);
         const merged = mergeDefaults(selectionStyle, highlightStyle, seriesStyle);
         const { strokeWidth, stroke, strokeOpacity, lineDash, lineDashOffset, fill, fillOpacity, opacity } = merged;
 
@@ -1293,7 +1293,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         const { contextNodeData, processedData, axes, properties } = this;
         const { marker, styler } = properties;
 
-        const markerStyle = styler ? this.getStyle(undefined, undefined).marker : undefined;
+        const markerStyle = styler ? this.getStyle(undefined).marker : undefined;
 
         const markerDrawMode = cartesianMarkerDrawMode(
             properties,
@@ -1572,7 +1572,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         if (xValue === undefined && !allowNullKeys) return; // eslint-disable-line sonarjs/different-types-comparison
 
-        const stylerStyle = this.getStyle(undefined, undefined);
+        const stylerStyle = this.getStyle(undefined);
         const params = this.makeItemStylerParams(dataModel, processedData, datumIndex, stylerStyle.marker);
 
         const format = this.getMarkerStyle<AgAreaSeriesMarkerItemStylerParams<unknown, unknown>>(
@@ -1612,10 +1612,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
     }
 
     legendItemSymbol(): LegendSymbolOptions {
-        const { fill, stroke, fillOpacity, strokeOpacity, strokeWidth, lineDash, marker } = this.getStyle(
-            undefined,
-            undefined
-        );
+        const { fill, stroke, fillOpacity, strokeOpacity, strokeWidth, lineDash, marker } = this.getStyle(undefined);
         const useAreaFill = !marker.enabled || marker.fill == null;
         const legendMarkerFill = useAreaFill ? fill : marker.fill;
 
@@ -1828,7 +1825,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
     }
 
     public getFormattedMarkerStyle(datum: MarkerSelectionDatum) {
-        const stylerStyle = this.getStyle(undefined, undefined);
+        const stylerStyle = this.getStyle(undefined);
         const params = this.makeItemStylerParams(
             this.dataModel!,
             this.processedData!,

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -1019,10 +1019,10 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         series: BubbleSeries,
         _ctx: BubbleStylerPassCtx,
         highlightState: HighlightState,
-        selectionState: SelectionState | undefined,
+        _selectionState: SelectionState | undefined,
         _datum: BubbleScatterNodeDatum
     ): ReturnType<BubbleSeries['getStyle']> {
-        return series.getStyle(highlightState, selectionState);
+        return series.getStyle(highlightState);
     }
 
     private static applyPerDatumStyle(
@@ -1483,7 +1483,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
     }
 
     private legendItemSymbol(styleOverride?: Partial<AgSeriesMarkerStyle>): LegendSymbolOptions {
-        const style = this.getStyle(undefined, undefined);
+        const style = this.getStyle(undefined);
         const marker = this.getMarkerStyle<AgBubbleSeriesOptionsKeys>(
             this.properties.marker,
             {},
@@ -1609,7 +1609,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
     }
 
     public getSizeRange(): [number, number] {
-        const { size, maxSize } = this.getStyle(undefined, undefined);
+        const { size, maxSize } = this.getStyle(undefined);
         return [size, maxSize];
     }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -991,7 +991,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         selectionState: SelectionState | undefined,
         datum: BubbleScatterNodeDatum
     ): AgSeriesMarkerStyle {
-        const stylerStyle = series.getStyle(highlightState, selectionState);
+        const stylerStyle = series.getStyle(highlightState);
         return series.getMarkerStyle(
             ctx.marker,
             datum,
@@ -1578,14 +1578,12 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         return new Marker<BubbleScatterNodeDatum>();
     }
 
-    public getStyle(
-        highlightState: HighlightState | undefined,
-        selectionState: SelectionState | undefined
-    ): Required<AgBubbleSeriesStylerResult> {
+    public getStyle(highlightState: HighlightState | undefined): Required<AgBubbleSeriesStylerResult> {
         const { properties } = this;
 
         let stylerResult: AgBubbleSeriesStylerResult = {};
         if (properties.styler) {
+            const selectionState: SelectionState | undefined = this.getDataSelectionState(undefined);
             const stylerParams = this.makeStylerParams(highlightState, selectionState);
             const cbResult = this.cachedCallWithContext(properties.styler, stylerParams) ?? {};
             const resolved = this.ctx.optionsGraphService.resolvePartial(

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -666,7 +666,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
 
         const highlightStyle = this.getHighlightStyle();
         const selectionStyle = this.getSelectionStyle();
-        const seriesStyle = this.getStyle(undefined, undefined);
+        const seriesStyle = this.getStyle(undefined);
         const merged = mergeDefaults(selectionStyle, highlightStyle, seriesStyle);
         const { strokeWidth, stroke, strokeOpacity, lineDash, lineDashOffset, opacity } = merged;
 
@@ -997,7 +997,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
 
         if (xValue === undefined && !allowNullKeys) return;
 
-        const stylerStyle = this.getStyle(undefined, undefined);
+        const stylerStyle = this.getStyle(undefined);
         const params = this.makeItemStylerParams(dataModel, processedData, datumIndex, stylerStyle.marker);
 
         const format = this.getMarkerStyle(
@@ -1037,7 +1037,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
     }
 
     private legendItemSymbol(): LegendSymbolOptions {
-        const { stroke, strokeOpacity, strokeWidth, lineDash, marker } = this.getStyle(undefined, undefined);
+        const { stroke, strokeOpacity, strokeWidth, lineDash, marker } = this.getStyle(undefined);
 
         const markerStyle = this.getMarkerStyle(
             this.properties.marker,
@@ -1292,7 +1292,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
     }
 
     public getFormattedMarkerStyle(datum: LineNodeDatum) {
-        const stylerStyle = this.getStyle(undefined, undefined);
+        const stylerStyle = this.getStyle(undefined);
         const params = this.makeItemStylerParams(
             this.dataModel!,
             this.processedData!,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -737,7 +737,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         selectionState: SelectionState | undefined,
         datum: LineNodeDatum
     ): AgSeriesMarkerStyle {
-        const stylerStyle = series.getStyle(highlightState, selectionState);
+        const stylerStyle = series.getStyle(highlightState);
         return series.getMarkerStyle(
             ctx.marker,
             datum,
@@ -757,10 +757,10 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         series: LineSeries,
         _ctx: LineStylerPassCtx,
         highlightState: HighlightState,
-        selectionState: SelectionState | undefined,
+        _selectionState: SelectionState | undefined,
         _datum: LineNodeDatum
     ): ReturnType<LineSeries['getStyle']> {
-        return series.getStyle(highlightState, selectionState);
+        return series.getStyle(highlightState);
     }
 
     private static applyStylerDatum(
@@ -1254,13 +1254,13 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
     }
 
     public getStyle(
-        highlightState: HighlightState | undefined,
-        selectionState: SelectionState | undefined
+        highlightState: HighlightState | undefined
     ): Required<AgLineSeriesStylerResult> & { marker: Required<AgSeriesMarkerStyle> } {
         const { styler, marker, lineDash, lineDashOffset, stroke, strokeOpacity, strokeWidth } = this.properties;
         const { size, shape, fill = 'transparent', fillOpacity } = marker;
         let stylerResult: AgLineSeriesStylerResult = {};
         if (styler) {
+            const selectionState: SelectionState | undefined = this.getDataSelectionState(undefined);
             const stylerParams = this.makeStylerParams(highlightState, selectionState);
             const cbResult = this.cachedCallWithContext(styler, stylerParams) ?? {};
             const resolved = this.ctx.optionsGraphService.resolvePartial(

--- a/packages/ag-charts-enterprise/src/series/radar-area/radarAreaSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-area/radarAreaSeries.ts
@@ -44,7 +44,7 @@ export class RadarAreaSeries extends RadarSeries<S, O, P> {
 
     protected override getMarkerFill(highlightedStyle?: _ModuleSupport.SeriesItemHighlightStyle) {
         if (highlightedStyle?.fill != null) return highlightedStyle.fill;
-        const stylerStyle = this.getStyle(undefined, undefined);
+        const stylerStyle = this.getStyle(undefined);
         return stylerStyle.marker.fill ?? stylerStyle.fill;
     }
 
@@ -117,7 +117,7 @@ export class RadarAreaSeries extends RadarSeries<S, O, P> {
         if (areaNode) {
             const { path: areaPath } = areaNode;
             const areaPoints = this.getAreaPoints();
-            const stylerStyle = superStyle ?? this.getStyle(undefined, undefined);
+            const stylerStyle = superStyle ?? this.getStyle(undefined);
             const fillBBox = this.getShapeFillBBox();
 
             areaNode.setStyleProperties(
@@ -189,12 +189,12 @@ export class RadarAreaSeries extends RadarSeries<S, O, P> {
     }
 
     override getStyle(
-        highlightState: _ModuleSupport.HighlightState | undefined,
-        selectionState: _ModuleSupport.SelectionState | undefined
+        highlightState: _ModuleSupport.HighlightState | undefined
     ): ResolvedRadarStyle<AgRadarAreaSeriesStyle> {
         const { marker, fill, fillOpacity, lineDash, lineDashOffset, stroke, strokeOpacity, strokeWidth } =
             this.properties;
         const { size, shape, fill: markerFill = 'transparent', fillOpacity: markerFillOpacity } = marker;
+        const selectionState: _ModuleSupport.SelectionState | undefined = this.getDataSelectionState(undefined);
         const stylerResult = this.getStylerResult({}, highlightState, selectionState);
         stylerResult.marker ??= {};
 

--- a/packages/ag-charts-enterprise/src/series/radar-line/radarLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-line/radarLineSeries.ts
@@ -83,11 +83,11 @@ export class RadarLineSeries extends RadarSeries<S, O, P> {
     }
 
     override getStyle(
-        highlightState: _ModuleSupport.HighlightState | undefined,
-        selectionState: _ModuleSupport.SelectionState | undefined
+        highlightState: _ModuleSupport.HighlightState | undefined
     ): ResolvedRadarStyle<AgRadarLineSeriesStyle> {
         const { marker, lineDash, lineDashOffset, stroke, strokeOpacity, strokeWidth } = this.properties;
         const { size, shape, fill = 'transparent', fillOpacity } = marker;
+        const selectionState: _ModuleSupport.SelectionState | undefined = this.getDataSelectionState(undefined);
         const stylerResult = this.getStylerResult({}, highlightState, selectionState);
         stylerResult.marker ??= {};
 

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -411,7 +411,7 @@ export abstract class RadarSeries<
         selectionState: _ModuleSupport.SelectionState | undefined,
         datum: RadarNodeDatum
     ): AgSeriesMarkerStyle {
-        const stylerStyle = series.getStyle(highlightState, selectionState);
+        const stylerStyle = series.getStyle(highlightState);
         const { stroke, strokeWidth, strokeOpacity } = stylerStyle;
         // No hideWithSize0 — polar series don't use the cartesian markerDrawMode mechanism.
         return series.getMarkerStyle(
@@ -429,10 +429,10 @@ export abstract class RadarSeries<
         series: RadarSeries<any, any, any>,
         _ctx: { marker: RadarSeriesProperties<any, any>['marker']; isHighlight: boolean },
         highlightState: _ModuleSupport.HighlightState,
-        selectionState: _ModuleSupport.SelectionState | undefined,
+        _selectionState: _ModuleSupport.SelectionState | undefined,
         _datum: RadarNodeDatum
     ): ResolvedRadarStyle<any> {
-        return series.getStyle(highlightState, selectionState);
+        return series.getStyle(highlightState);
     }
 
     private static applyStylerDatum(
@@ -908,10 +908,7 @@ export abstract class RadarSeries<
         return stylerResult;
     }
 
-    abstract getStyle(
-        highlightState: _ModuleSupport.HighlightState | undefined,
-        selectionState: _ModuleSupport.SelectionState | undefined
-    ): ResolvedRadarStyle<TStyle>;
+    abstract getStyle(highlightState: _ModuleSupport.HighlightState | undefined): ResolvedRadarStyle<TStyle>;
 
     public getFormattedMarkerStyle(datum: RadarNodeDatum) {
         const { angleKey, radiusKey } = this.properties;

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -362,7 +362,7 @@ export abstract class RadarSeries<
             this.itemSelection = Selection.select(this.itemGroup, () => this.nodeFactory(), false);
         }
 
-        const markersEnabled = styler == null ? marker.enabled : this.getStyle(undefined, undefined).marker.enabled;
+        const markersEnabled = styler == null ? marker.enabled : this.getStyle(undefined).marker.enabled;
         const data = this.visible && marker.shape && markersEnabled ? this.nodeData : [];
         this.itemSelection.update(data);
     }
@@ -375,7 +375,7 @@ export abstract class RadarSeries<
             this.highlightSelection = Selection.select(this.highlightGroup, () => this.nodeFactory(), false);
         }
 
-        const markersEnabled = styler == null ? marker.enabled : this.getStyle(undefined, undefined).marker.enabled;
+        const markersEnabled = styler == null ? marker.enabled : this.getStyle(undefined).marker.enabled;
         const highlighted = this.ctx.highlightManager?.getActiveHighlight();
         const data =
             this.visible && marker.shape && markersEnabled && highlighted?.datum
@@ -385,7 +385,7 @@ export abstract class RadarSeries<
     }
 
     protected getMarkerFill(highlightedStyle?: _ModuleSupport.SeriesItemHighlightStyle) {
-        return highlightedStyle?.fill ?? this.getStyle(undefined, undefined).marker.fill;
+        return highlightedStyle?.fill ?? this.getStyle(undefined).marker.fill;
     }
 
     protected getDatumStylerProperties(datum: any) {
@@ -595,7 +595,7 @@ export abstract class RadarSeries<
     }
 
     private legendItemSymbol(): _ModuleSupport.LegendSymbolOptions {
-        const { stroke, strokeWidth, strokeOpacity, lineDash, marker } = this.getStyle(undefined, undefined);
+        const { stroke, strokeWidth, strokeOpacity, lineDash, marker } = this.getStyle(undefined);
 
         const markerStyle = {
             shape: marker.shape,
@@ -722,7 +722,7 @@ export abstract class RadarSeries<
         const highlightStyle = this.getHighlightStyle(undefined, undefined, highlightState);
         const selectionState = this.getDataSelectionState(undefined);
         const selectionStyle = this.getSelectionStyle(undefined, selectionState);
-        const stylerStyle = this.getStyle(highlightState, selectionState);
+        const stylerStyle = this.getStyle(highlightState);
         return mergeDefaults(selectionStyle, highlightStyle, stylerStyle);
     }
 
@@ -853,7 +853,7 @@ export abstract class RadarSeries<
         if (lineNode) {
             const { path: linePath } = lineNode;
             const linePoints = this.getLinePoints();
-            const stylerStyle = this.getStyle(undefined, undefined);
+            const stylerStyle = this.getStyle(undefined);
 
             lineNode.fill = undefined;
             lineNode.stroke = stylerStyle.stroke;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -1061,10 +1061,10 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         series: RangeAreaSeries,
         _ctx: RangeAreaStylerPassCtx,
         highlightState: _ModuleSupport.HighlightState,
-        selectionState: _ModuleSupport.SelectionState | undefined,
+        _selectionState: _ModuleSupport.SelectionState | undefined,
         _datum: RangeAreaMarkerDatum
     ): StylerResult {
-        return series.getStyle(highlightState, selectionState);
+        return series.getStyle(highlightState);
     }
 
     private static applyStylerDatum(
@@ -1215,23 +1215,20 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         return highlightItems.length > 0 ? highlightItems : undefined;
     }
 
-    private getStyle(
-        highlightState: _ModuleSupport.HighlightState | undefined,
-        selectionState: _ModuleSupport.SelectionState | undefined
-    ): StylerResult {
-        return this.getStylerCouple(highlightState, selectionState)[0];
+    private getStyle(highlightState: _ModuleSupport.HighlightState | undefined): StylerResult {
+        return this.getStylerCouple(highlightState)[0];
     }
 
     private getStylerMarkerOptions(): StylerMarkerOptionsResult {
-        return this.getStylerCouple(undefined, undefined)[1];
+        return this.getStylerCouple(undefined)[1];
     }
 
     private getStylerCouple(
-        highlightState: _ModuleSupport.HighlightState | undefined,
-        selectionState: _ModuleSupport.SelectionState | undefined
+        highlightState: _ModuleSupport.HighlightState | undefined
     ): [StylerResult, StylerMarkerOptionsResult] {
         const { fill, fillOpacity, item, styler } = this.properties;
 
+        const selectionState: _ModuleSupport.SelectionState | undefined = this.getDataSelectionState(undefined);
         let stylerResult: AgRangeAreaSeriesStyle & ResolvedStyleMixin = {};
         if (styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState);

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -862,7 +862,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         const highlightState = this.getHighlightState(highlightDatum, false);
         const highlightStyle = this.getHighlightStyle();
         const selectionStyle = this.getSelectionStyle();
-        const seriesStyle = this.getStyle(highlightState, undefined);
+        const seriesStyle = this.getStyle(highlightState);
 
         const { item, stroke, strokeWidth, strokeOpacity, fill, fillOpacity, opacity } = mergeDefaults(
             selectionStyle,
@@ -1036,7 +1036,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         selectionState: _ModuleSupport.SelectionState | undefined,
         datum: RangeAreaMarkerDatum
     ): AgSeriesMarkerStyle {
-        const stylerStyle = series.getStyle(highlightState, selectionState);
+        const stylerStyle = series.getStyle(highlightState);
         const { fill, fillOpacity, item } = stylerStyle;
         const { stroke, strokeWidth, strokeOpacity } = item[datum.itemType];
         const marker = series.properties.item[datum.itemType].marker;
@@ -1365,7 +1365,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         const allowNullKeys = this.properties.allowNullKeys ?? false;
         if (xValue === undefined && !allowNullKeys) return; // eslint-disable-line sonarjs/different-types-comparison
 
-        const stylerStyle = this.getStyle(undefined, undefined);
+        const stylerStyle = this.getStyle(undefined);
         const params = this.makeItemStylerParams(itemType);
         const format = this.getMarkerStyle(
             this.properties.item[itemType].marker,
@@ -1411,7 +1411,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
     }
 
     private legendItemSymbol(): _ModuleSupport.LegendSymbolOptions {
-        const { fill, topLevel } = this.getStyle(undefined, undefined);
+        const { fill, topLevel } = this.getStyle(undefined);
         const { stroke, strokeWidth, strokeOpacity, lineDash, marker } = topLevel;
 
         const markerStyle = {
@@ -1593,7 +1593,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
     }
 
     public getFormattedMarkerStyle(datum: RangeAreaMarkerDatum) {
-        const stylerStyle = this.getStyle(undefined, undefined);
+        const stylerStyle = this.getStyle(undefined);
         const params = this.makeItemStylerParams(datum.itemType);
 
         return this.getMarkerStyle(


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1090

The `selectionState` param in the `getStyle()` method is the wrong value, that's the selection state of the item (i.e. marker), not the selection state of the series itself.

Instead, I've move this to a local variable where the `styler` fn is called.