### PR TITLE
Fix docs typos (CRT-1103)

### DIFF
--- a/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/create-a-basic-chart/index.mdoc
@@ -337,8 +337,8 @@ const options = ref<AgChartOptions>({
 Let's breakdown what's happening here:
 
 - **`axes.{key}`:** The key used to reference the axis, which should match the `yKeyAxis` property on the series.
-- **`Type`:** The type of axis to use - one of [Category](./axes-types/#category), [Number](./axes-types/#number), [Time](./axes-types/#time) or [Log](./axes-types/#log).
-- **`Position`:** The position on the chart where the axis should be rendered, e.g. 'top', 'bottom', 'right' or 'left'.
+- **`type`:** The type of axis to use - one of [Category](./axes-types/#category), [Number](./axes-types/#number), [Time](./axes-types/#time) or [Log](./axes-types/#log).
+- **`position`:** The position on the chart where the axis should be rendered, e.g. 'top', 'bottom', 'right' or 'left'.
 
 Now when we run our chart, we should see both series and three axes.
 

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/index.mdoc
@@ -143,7 +143,7 @@ In the above configuration:
 
 ### Labels
 
-An label can be configured with the `label` property.
+A label can be configured with the `label` property.
 
 {% chartExampleRunner title="Labels" name="labels" type="generated" options={ "exampleHeight": 300 } /%}
 


### PR DESCRIPTION
## Summary
- Fix capitalised property names (`Type` → `type`, `Position` → `position`) on create-a-basic-chart page
- Fix 'An label' → 'A label' on linear-gauge page

[CRT-1103](https://ag-grid.atlassian.net/browse/CRT-1103)