### PR TITLE
CRT-1117 Drop saved zoom when axis type changes on chart update

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/zoomManager.ts
@@ -53,6 +53,7 @@ export type SimpleAxis = {
 };
 
 export type CartesianAxisLike = SimpleAxis & {
+    type: string;
     visibleRange: [number, number];
     scale: Scale<any, any>;
     range: [number, number];
@@ -377,6 +378,13 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
         // recreates axes with the same IDs.
         const oldState = this.state;
 
+        // Saved {min,max} ratios don't translate across a scale-type change; preserving them lets
+        // downstream `preserveDomain` collapse to a degenerate zoom.
+        const previousTypeByAxisId = new Map<AxisID, string>();
+        for (const axis of this.axes) {
+            previousTypeByAxisId.set(axis.id, axis.type);
+        }
+
         const { axes, allAxes } = this;
         axes.length = 0;
         allAxes.length = 0;
@@ -387,7 +395,15 @@ export class ZoomManager extends BaseManager implements MementoOriginator<ZoomMe
             }
         }
 
-        const changes = refreshCoreState(nextAxes, oldState);
+        const adjustedOldState: Record<AxisID, CoreZoomEntry | undefined> = { ...oldState };
+        for (const axis of axes) {
+            const prevType = previousTypeByAxisId.get(axis.id);
+            if (prevType !== undefined && prevType !== axis.type) {
+                delete adjustedOldState[axis.id];
+            }
+        }
+
+        const changes = refreshCoreState(nextAxes, adjustedOldState);
         this.state = changes;
 
         this.updateChanges({ source: 'chart-update', sourceDetail: 'internal-setAxes', changes, isReset: false });

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
@@ -775,6 +775,44 @@ describe('Zoom', () => {
             // Chart should not be blank
             await compare();
         });
+
+        it('CRT-1117 should reset zoom on an axis whose scale type changes', async () => {
+            const boxPlotOptions: AgChartOptions = {
+                data: [
+                    { department: 'Sales', min: 1052, q1: 4465, median: 5765, q3: 8834, max: 14852 },
+                    { department: 'R&D', min: 1009, q1: 2741, median: 4377, q3: 7725, max: 14814 },
+                    { department: 'HR', min: 1555, q1: 2696, median: 4071, q3: 9756, max: 19717 },
+                ],
+                series: [
+                    {
+                        type: 'box-plot',
+                        xKey: 'department',
+                        minKey: 'min',
+                        q1Key: 'q1',
+                        medianKey: 'median',
+                        q3Key: 'q3',
+                        maxKey: 'max',
+                    },
+                ],
+                zoom: { enabled: true, scrollingStep: 0.1 },
+            };
+            await prepareChart(undefined, { ratioX: { start: 0.1, end: 1 } }, boxPlotOptions, false);
+            await waitForChartStability(chart);
+
+            await chart.update({
+                ...boxPlotOptions,
+                data: Array.from({ length: 200 }, (_, i) => ({ age: 17 + (i % 17) })),
+                series: [{ type: 'histogram', xKey: 'age' }],
+                axes: {
+                    x: { type: 'number' },
+                    y: { type: 'number' },
+                },
+            } as AgChartOptions);
+            await waitForChartStability(chart);
+
+            const xZoom = chart.getState().zoom?.ratioX;
+            expect(xZoom).toEqual({ start: 0, end: 1 });
+        });
     });
 
     describe('autoScaling', () => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1117

`chart.update()` that swaps an axis to a different scale type (e.g. category → number) used to leave the chart blank: ZoomManager preserved the saved `{min,max}` ratio against the new axis, and the downstream `preserveDomain` strategy then reinterpreted the captured visible range against the populated domain, collapsing the x zoom to `{0,0}`.

`ZoomManager.setAxes` now snapshots each axis's `type` before the swap and drops any saved entry whose type changed across the swap, so the new axis starts fully zoomed-out and `preserveDomain` no longer captures stale state.

## Notes for review

- Behaviour change for the `preserveRatios` strategy on a type swap: previously the original ratio survived (geometrically meaningless across a unit change); it now resets to `{0,1}` like every other strategy. `preserveDomain` (the default) is unaffected on axis-id reuse without a type change.
- Regression test added to the existing `data changes during zoom` suite in `zoom.test.ts`; full zoom suite (66 tests, 67 snapshots) passes.

Fix #CRT-1117