### PR TITLE
CRT-1116 - Keep secondary axis tick step on nice values under primary zoom

### DIFF
--- a/packages/ag-charts-community/src/util/secondaryAxisTicks.test.ts
+++ b/packages/ag-charts-community/src/util/secondaryAxisTicks.test.ts
@@ -80,8 +80,6 @@ describe('secondaryAxisTicks', () => {
     });
 
     test('CRT-1116: heavy primary-axis zoom does not produce fractional steps on secondary axis', () => {
-        // Primary's zoomed tick count expands as ~1/visibleRange, so a deeply zoomed primary
-        // requests far more secondary ticks than the secondary's baseStep cleanly divides into.
         const { ticks } = calculateNiceSecondaryAxis(
             scale,
             [27385, 31348],
@@ -91,8 +89,6 @@ describe('secondaryAxisTicks', () => {
         );
 
         expect(ticks.every(Number.isInteger)).toBe(true);
-        // Subdivision must actually happen — otherwise a future regression that skips it would still
-        // produce all-integer ticks and pass the assertion above vacuously.
         expect(ticks.length).toBeGreaterThan(7);
     });
 

--- a/packages/ag-charts-community/src/util/secondaryAxisTicks.test.ts
+++ b/packages/ag-charts-community/src/util/secondaryAxisTicks.test.ts
@@ -79,6 +79,23 @@ describe('secondaryAxisTicks', () => {
         expect(ticks).toEqual([7, 7.5, 8]);
     });
 
+    test('CRT-1116: heavy primary-axis zoom does not produce fractional steps on secondary axis', () => {
+        // Primary's zoomed tick count expands as ~1/visibleRange, so a deeply zoomed primary
+        // requests far more secondary ticks than the secondary's baseStep cleanly divides into.
+        const { ticks } = calculateNiceSecondaryAxis(
+            scale,
+            [27385, 31348],
+            { unzoomed: 7, zoomed: 700 },
+            false,
+            [0, 0.01]
+        );
+
+        expect(ticks.every(Number.isInteger)).toBe(true);
+        // Subdivision must actually happen — otherwise a future regression that skips it would still
+        // produce all-integer ticks and pass the assertion above vacuously.
+        expect(ticks.length).toBeGreaterThan(7);
+    });
+
     test.each([
         // Ensure magnitude is reflected
         { domain: 0.005, expected: [0, 0.002, 0.004, 0.006, 0.008] },

--- a/packages/ag-charts-community/src/util/secondaryAxisTicks.ts
+++ b/packages/ag-charts-community/src/util/secondaryAxisTicks.ts
@@ -71,13 +71,12 @@ export function calculateNiceSecondaryAxis<D extends number>(
     const d: [D, D] = [scale.toDomain(start), scale.toDomain(stop)];
     if (reverse) d.reverse();
 
-    // Subdivide baseStep by a "nice" integer factor (1/2/5 × 10^n) so labels stay on round values,
-    // and rebuild the tick count from that subdivision rather than from the raw zoomed count.
+    // Subdivide baseStep by a nice {1,2,5}*10^n factor so secondary labels stay on round values.
     const zoomedSegments = Math.max(1, Math.floor(primaryTickCount.zoomed) - 1);
-    const rawSubdivision = zoomedSegments / segments;
-    const subdivision = niceSubdivisionFactor(rawSubdivision);
+    const subdivision = niceSubdivisionFactor(zoomedSegments / segments);
     const step = baseStep / subdivision;
-    const ticks = getTicks(start, step, segments * subdivision + 1);
+    const tickCount = Math.min(segments * subdivision + 1, Math.floor(primaryTickCount.zoomed));
+    const ticks = getTicks(start, step, tickCount);
 
     return { domain: d, ticks };
 }

--- a/packages/ag-charts-community/src/util/secondaryAxisTicks.ts
+++ b/packages/ag-charts-community/src/util/secondaryAxisTicks.ts
@@ -71,10 +71,25 @@ export function calculateNiceSecondaryAxis<D extends number>(
     const d: [D, D] = [scale.toDomain(start), scale.toDomain(stop)];
     if (reverse) d.reverse();
 
-    const step = baseStep * ((primaryTickCount.unzoomed - 1) / (primaryTickCount.zoomed - 1));
-    const ticks = getTicks(start, step, Math.floor(primaryTickCount.zoomed));
+    // Subdivide baseStep by a "nice" integer factor (1/2/5 × 10^n) so labels stay on round values,
+    // and rebuild the tick count from that subdivision rather than from the raw zoomed count.
+    const zoomedSegments = Math.max(1, Math.floor(primaryTickCount.zoomed) - 1);
+    const rawSubdivision = zoomedSegments / segments;
+    const subdivision = niceSubdivisionFactor(rawSubdivision);
+    const step = baseStep / subdivision;
+    const ticks = getTicks(start, step, segments * subdivision + 1);
 
     return { domain: d, ticks };
+}
+
+function niceSubdivisionFactor(rawFactor: number): number {
+    if (rawFactor <= 1) return 1;
+    const order = Math.floor(Math.log10(rawFactor));
+    const magnitude = Math.pow(10, order);
+    const m = rawFactor / magnitude;
+    if (m >= 5) return 5 * magnitude;
+    if (m >= 2) return 2 * magnitude;
+    return magnitude;
 }
 
 function domainWithOddTickCount(d0: number, d1: number): [number, number] {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1116