### PR TITLE
CRT-1094 Fix redo after quick-measure undo

### DIFF
--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -106,6 +106,7 @@ export class Annotations extends AbstractModuleInstance {
     private yAxis?: AnnotationAxis;
 
     private postUpdateFns: Array<() => void> = [];
+    private isRestoringMemento = false;
 
     constructor(private readonly ctx: DynamicContext<_ModuleSupport.ChartRegistry>) {
         super();
@@ -709,13 +710,18 @@ export class Annotations extends AbstractModuleInstance {
                 return current != null && current.type === (annotation.type as AnnotationType);
             });
 
-        if (canPatchInPlace) {
-            for (let i = 0; i < annotations.length; i += 1) {
-                this.annotationData[i].set(annotations[i]);
+        this.isRestoringMemento = true;
+        try {
+            if (canPatchInPlace) {
+                for (let i = 0; i < annotations.length; i += 1) {
+                    this.annotationData[i].set(annotations[i]);
+                }
+            } else {
+                this.reset();
+                this.annotationData.set(annotations);
             }
-        } else {
-            this.reset();
-            this.annotationData.set(annotations);
+        } finally {
+            this.isRestoringMemento = false;
         }
 
         this.postUpdateFns.push(() => {
@@ -835,6 +841,10 @@ export class Annotations extends AbstractModuleInstance {
         } = this;
         const annotationManager = ctx.annotationManager;
         if (!annotationManager) return;
+
+        // Suppress history records caused by side-effects of restoring a memento (undo/redo) — recording them
+        // would truncate the redo stack. See CRT-1094.
+        if (this.isRestoringMemento) return;
 
         const originators = types.map((type) => (type === 'defaults' ? defaults : annotationManager));
         this.postUpdateFns.push(() => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1094

## Summary

- Undoing a quick-measure Create produced a stale "Delete ephemeral annotations" history entry, truncating the redo stack so Cmd+Shift+Z became a no-op.
- `onRestoreAnnotations` calls `reset()` -> `deleteEphemeralAnnotations`, which queued the spurious record. Gate `recordActionAfterNextUpdate` on a new `isRestoringMemento` flag set around the restore.

## Test plan

- [ ] Open the financial-charts showcase, create a quick measure, Cmd+Z to undo, Cmd+Shift+Z to redo — measurement reappears.
- [ ] Regular (non-quick) measure/annotation undo+redo still works.
- [ ] Repeated undo/redo across mixed annotation types remains consistent.

Fix #CRT-1094