### PR TITLE
Update v13.3.0 release date to 12th May 2026

### DIFF
--- a/packages/ag-charts-website/public/changelog/releases/13_3_0.md
+++ b/packages/ag-charts-website/public/changelog/releases/13_3_0.md
@@ -1,1 +1,1 @@
-#### 13th May 2026 - Charts v13.3.0
+#### 12th May 2026 - Charts v13.3.0

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "13.3.0",
-        "date": "May 13th, 2026",
+        "date": "May 12th, 2026",
         "highlights": [
             {
                 "text": "Colour Scale",


### PR DESCRIPTION
## Summary
- Update changelog and versions JSON to reflect release date of 12th May 2026 for v13.3.0.

## Test plan
- [ ] Verify release date displays correctly on the website.