### PR TITLE
Sync ag-shared from ag-grid sync-ag-shared

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = e28574f98fdffd9a3e1b9f03a63ec844a6d848e8
-	parent = e79317d15c845bd393319cc044829dbe5f60e157
+	commit = d6f93e4d145bf572ede20199bcaf1094aef3cf2c
+	parent = 275062993de33efc991fe7a98baa7823f3421f0d
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.snyk
+++ b/external/ag-shared/.snyk
@@ -1,53 +1,57 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
-
 ignore:
-    SNYK-JS-BRACEEXPANSION-15789759:
-        - '@nx/devkit@18.3.5 > tmp@0.2.1 > rimraf@3.0.2 > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@2.0.2':
-              reason: >-
-                  Used in build & dev - not included in final production build
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-04-15T15:27:57.667Z
-        - glob@8.0.3 > minimatch@5.1.6 > brace-expansion@2.0.2:
-              reason: >-
-                  Used in build & dev - not included in final production build
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-03-27T11:48:29.525Z
-        - '@nx/devkit@18.3.5 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6 > brace-expansion@2.0.2':
-              reason: >-
-                  Used in build & dev - not included in final production build
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-03-27T11:48:29.073Z
-    SNYK-JS-MINIMATCH-15353389:
-        - '@nx/devkit@18.3.5 > tmp@0.2.1 > rimraf@3.0.2 > glob@7.2.3 > minimatch@3.1.2':
-              reason: >-
-                  Used in build & dev - not included in final production build
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-04-15T15:25:15.522Z
-        - '@nx/devkit@18.3.5 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6':
-              reason: >-
-                  Used in build & dev - not included in final production build
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-03-02T10:13:56.777Z
-        - glob@8.0.3 > minimatch@5.1.6:
-              reason: >-
-                  Used in build & dev - not included in final production build
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-03-02T10:13:56.772Z
-    SNYK-JS-MINIMATCH-15309438:
-        - '@nx/devkit@18.3.5 > tmp@0.2.1 > rimraf@3.0.2 > glob@7.2.3 > minimatch@3.1.2':
-              reason: >-
-                  Used in build & dev - not included in final production build
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-04-15T15:24:37.723Z
-        - glob@8.0.3 > minimatch@5.1.6:
-              reason: >-
-                  Used in dev - ReDOS attack would only affect developer machines
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-02-27T18:31:59.780Z
-        - '@nx/devkit@18.3.5 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6':
-              reason: >-
-                  Used in build & dev - ReDOS attack would only affect developer machines
-              expires: 2026-06-08T00:00:00.000Z
-              created: 2026-02-27T18:30:52.350Z
+  SNYK-JS-BRACEEXPANSION-15789759:
+    - glob@8.0.3 > minimatch@5.1.6 > brace-expansion@2.0.2:
+        reason: Used in build & dev - not included in final production build
+        expires: 2026-06-08T00:00:00.000Z
+        created: 2026-03-27T11:48:29.525Z
+    - '@nx/devkit@20.8.4 > minimatch@9.0.3 > brace-expansion@2.0.2':
+        reason: Not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+    - '@nx/devkit@20.8.4 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6 > brace-expansion@2.0.2':
+        reason: Not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+  SNYK-JS-MINIMATCH-15353389:
+    - 'glob@11.1.0 > minimatch@10.1.1':
+        reason: Used in build & dev - not included in final production build
+        expires: 2026-06-08T00:00:00.000Z
+        created: 2026-03-02T10:13:56.772Z
+    - '@nx/devkit@20.8.4 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6':
+        reason: Build dependency - not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+    - '@nx/devkit@20.8.4 > minimatch@9.0.3':
+        reason: Build dependency - not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+  SNYK-JS-MINIMATCH-15309438:
+    - 'glob@11.1.0 > minimatch@10.1.1':
+        reason: Used in dev - ReDOS attack would only affect developer machines
+        expires: 2026-06-08T00:00:00.000Z
+        created: 2026-02-27T18:31:59.780Z
+    - '@nx/devkit@20.8.4 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6':
+        reason: Build dependency - not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+    - '@nx/devkit@20.8.4 > minimatch@9.0.3':
+        reason: Build dependency - not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+  SNYK-JS-ISAACSBRACEEXPANSION-15208653:
+    - 'glob@11.1.0 > minimatch@10.1.1 > @isaacs/brace-expansion@5.0.0':
+        reason: Not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+  SNYK-JS-MINIMATCH-15353387:
+    - 'glob@11.1.0 > minimatch@10.1.1':
+        reason: Build dependency - not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
+    - '@nx/devkit@20.8.4 > minimatch@9.0.3':
+        reason: Build dependency - not included in final production build
+        expires: 2026-08-28T00:00:00.000Z
+        created: 2026-04-28T12:12:51.000Z
 patch: {}

--- a/external/ag-shared/package.json
+++ b/external/ag-shared/package.json
@@ -35,11 +35,11 @@
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.4.5",
-    "glob": "8.0.3",
-    "@nx/devkit": "^18.3.5",
-    "@types/yargs": "^17.0.32",
-    "@swc/helpers": "0.5.3",
-    "tinypool": "^1.0.2",
+    "glob": "^11.1.0",
+    "@nx/devkit": "^20.8.4",
+    "@types/yargs": "^17.0.35",
+    "@swc/helpers": "0.5.21",
+    "tinypool": "^2.1.0",
     "process": "0.11.10",
     "xml-js": "^1.6.11"
   },

--- a/external/ag-shared/scripts/junit-processor/package.json
+++ b/external/ag-shared/scripts/junit-processor/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/ag-grid/ag-website-shared#readme",
   "devDependencies": {
-    "tsx": "^4.7.2"
+    "tsx": "^4.21.0"
   },
   "dependencies": {}
 }

--- a/external/ag-shared/scripts/rulesync-fetch/fetch.sh
+++ b/external/ag-shared/scripts/rulesync-fetch/fetch.sh
@@ -11,7 +11,12 @@
 #   3. gh CLI                  — if `gh auth token` resolves a token, use it
 #                                the same way as GITHUB_TOKEN. Transparent for
 #                                developers already logged in with `gh`.
-#   4. Fallback                 — https clone with no explicit credentials; git's
+#   4. Consumer origin is SSH  — if the consumer repo's `origin` remote points
+#                                at github.com over SSH, mirror that scheme.
+#                                Cheap and local (single `git config` read),
+#                                and a strong signal that the developer has
+#                                working SSH keys for github.com.
+#   5. Fallback                 — https clone with no explicit credentials; git's
 #                                credential helper (osxkeychain, manager, etc.)
 #                                supplies auth. The dev workstation path.
 #
@@ -51,6 +56,12 @@ elif command -v gh >/dev/null 2>&1 && _gh_token="$(gh auth token 2>/dev/null)" &
         AUTH_MODE="gh"
     fi
     unset _gh_token
+elif _origin_url=$(git config --get remote.origin.url 2>/dev/null) && [[ "$_origin_url" =~ ^(git@github\.com:|ssh://git@github\.com/) ]]; then
+    # No gh / GITHUB_TOKEN, but the consumer repo was cloned over SSH. The
+    # developer almost certainly has working SSH keys for github.com, so mirror
+    # that scheme rather than falling through to an HTTPS prompt.
+    AUTH_MODE="origin-ssh"
+    unset _origin_url
 else
     AUTH_MODE="https"
 fi
@@ -72,9 +83,10 @@ fi
 
 resolve_repo_url() {
     case "$AUTH_MODE" in
-        override) echo "$AG_DEV_PROMPTS_REPO" ;;
-        gh-ssh)   echo "git@github.com:${REPO_SLUG}.git" ;;
-        *)        echo "https://github.com/${REPO_SLUG}.git" ;;
+        override)   echo "$AG_DEV_PROMPTS_REPO" ;;
+        gh-ssh)     echo "git@github.com:${REPO_SLUG}.git" ;;
+        origin-ssh) echo "git@github.com:${REPO_SLUG}.git" ;;
+        *)          echo "https://github.com/${REPO_SLUG}.git" ;;
     esac
 }
 
@@ -163,6 +175,36 @@ SSH clone was attempted from $REPO_URL and failed. Likely causes:
   * Prefer HTTPS? Switch gh's git protocol and re-run:
       gh config set -h github.com git_protocol https
       gh auth setup-git
+      yarn
+
+Verify SSH access directly:
+  ssh -T git@github.com
+EOF
+            ;;
+        origin-ssh)
+            cat >&2 <<EOF
+Auth path: SSH inferred from the consumer repo's origin remote.
+
+No GITHUB_TOKEN and no \`gh\` login were found, but this repo's \`origin\`
+points at github.com over SSH, so we tried the same scheme for
+${REPO_SLUG} and it failed. Likely causes:
+
+  * SSH key not loaded into ssh-agent:
+      ssh-add -l
+      ssh-add ~/.ssh/id_ed25519     # or your key path
+
+  * SSH key registered with GitHub but missing SAML SSO authorization
+    for the ag-grid org:
+      # Authorize: https://github.com/organizations/ag-grid/sso
+
+  * Prefer HTTPS instead? Install gh and authenticate:
+      brew install gh
+      gh auth login --hostname github.com --git-protocol https --web
+      gh auth setup-git
+      yarn
+
+  * Or supply a token directly:
+      export GITHUB_TOKEN=ghp_...
       yarn
 
 Verify SSH access directly:

--- a/external/ag-shared/scripts/shard/calculate-pkg-shards.js
+++ b/external/ag-shared/scripts/shard/calculate-pkg-shards.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { execSync } = require('child_process');
 

--- a/external/ag-shared/scripts/shard/calculate-shards.js
+++ b/external/ag-shared/scripts/shard/calculate-shards.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');

--- a/external/ag-shared/scripts/shard/shard-projects.js
+++ b/external/ag-shared/scripts/shard/shard-projects.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { execSync } = require('child_process');
 const yargs = require('yargs/yargs');

--- a/external/ag-shared/scripts/snyk-viewer/ui-browse.js
+++ b/external/ag-shared/scripts/snyk-viewer/ui-browse.js
@@ -477,7 +477,7 @@
             const list = document.getElementById('vuln-list');
             const countBar = document.getElementById('count-bar');
 
-            let html = '';
+            let html;
             if (state.groupBy === 'vuln') html = renderByVuln(filtered);
             else if (state.groupBy === 'package') html = renderByPackage(filtered);
             else html = renderByProject(filtered);

--- a/external/ag-shared/scripts/sonar/sync-sonar-issues.ts
+++ b/external/ag-shared/scripts/sonar/sync-sonar-issues.ts
@@ -176,7 +176,7 @@ function createIssueSignature(issue: Issue, projectKey: string): string {
 async function fetchAllIssues(projectKey: string, statuses: string[]): Promise<Issue[]> {
     const allIssues: Issue[] = [];
     let page = 1;
-    let total = 0;
+    let total: number;
 
     do {
         const statusParam = statuses.join(',');

--- a/external/ag-shared/scripts/subrepo/package.json
+++ b/external/ag-shared/scripts/subrepo/package.json
@@ -19,11 +19,11 @@
   "homepage": "https://github.com/ag-grid/ag-website-shared#readme",
   "devDependencies": {
     "@types/prompts": "^2.4.9",
-    "@types/yargs": "^17.0.32",
-    "tsx": "^4.7.2"
+    "@types/yargs": "^17.0.35",
+    "tsx": "^4.21.0"
   },
   "dependencies": {
     "prompts": "^2.4.2",
-    "yargs": "^17.7.2"
+    "yargs": "^18.0.0"
   }
 }

--- a/external/ag-shared/scripts/watch/watch.js
+++ b/external/ag-shared/scripts/watch/watch.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * Watch nx dev environments in a queue

--- a/external/ag-shared/tsconfig.spec.json
+++ b/external/ag-shared/tsconfig.spec.json
@@ -2,12 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "types": ["jest", "node"],
+    "types": ["node"],
     "noEmit": true
   },
   "include": [
-    "jest.config.ts",
-    "jest.setup.ts",
     "src/typings.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",

--- a/external/ag-shared/tsconfig.types.test.json
+++ b/external/ag-shared/tsconfig.types.test.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": true,
     "types": ["node"]
   },
-  "include": ["jest.config.ts", "jest.setup.ts", "src/main-test.ts", "**/*.test.ts", "**/test/**"]
+  "include": ["src/main-test.ts", "**/*.test.ts", "**/test/**"]
 }


### PR DESCRIPTION
## Summary
Sync ag-shared subrepo from ag-grid@sync-ag-shared.

### Changes
- **rulesync-fetch SSH fallback** — `fetch.sh` now detects when the consumer repo's `origin` remote uses SSH and mirrors that scheme for plugin fetches
- **snyk-viewer fix** — `addSnykIgnoreEntry()` collapses `ignore: {}` to `ignore:` before inserting vuln blocks; coloured URL in server startup
- **snykClean.mjs** — deletes `.snyk` files that become empty after cleanup

## Cross-repo PRs
- Source: https://github.com/ag-grid/ag-grid/pull/13753
- ag-studio: https://github.com/ag-grid/ag-studio/pull/1468

## Test plan
- [ ] Verify ag-shared content matches source
- [ ] Run setup-prompts verification