### PR TITLE
AG-16801 Fix bubble series hit-testing distance calculation

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -1034,7 +1034,7 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         }
 
         if (minDistanceSquared != null) {
-            const radius: number = closestDatum?.point?.size ?? 0 / 2;
+            const radius: number = (closestDatum?.point?.size ?? 0) / 2;
             const distanceFromHitPoint = Math.sqrt(minDistanceSquared);
             return { datum: closestDatum, distance: Math.max(distanceFromHitPoint - radius, 0) };
         }

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -1034,7 +1034,9 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         }
 
         if (minDistanceSquared != null) {
-            return { datum: closestDatum, distance: Math.sqrt(minDistanceSquared) };
+            const radius: number = closestDatum?.point?.size ?? 0 / 2;
+            const distanceFromHitPoint = Math.sqrt(minDistanceSquared);
+            return { datum: closestDatum, distance: Math.max(distanceFromHitPoint - radius, 0) };
         }
     }
 
@@ -1072,8 +1074,7 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         }
 
         if (closestDatum) {
-            const distance = Math.max(minDistance - (closestDatum.point?.size ?? 0) / 2, 0);
-            return { datum: closestDatum, distance };
+            return { datum: closestDatum, distance: minDistance };
         }
     }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16801

`BubbleSeries` overrides `pickNodeDataClosestDatum` to use a QuadTree for faster hit-testing. The QuadTree relies on `Marker.distanceSquared`, which represents the squared distance from the marker's center to the edge (circumference) of the circle, or 0 if the point lies inside the circle. The radius is `size / 2`.

Subtracting the radius in `pickNodeClosestDatum()` again therefore results in an incorrect distance calculation. This radius subtraction has been moved to the base implementation of `pickNodeDataClosestDatum()` for other series types that depend on it.