### PR TITLE
Sync ag-shared: dep bumps, SSH auth, ag-eng/ag-product plugins, examples-ab-smoke skill

### DIFF
--- a/.rulesync/README.md
+++ b/.rulesync/README.md
@@ -6,7 +6,7 @@ Most skills, agents, commands, and shared rules come from the [`ag-grid/ag-dev-p
 
 | Channel                                                              | Claude Code                          | Cursor / Codex / Gemini / Copilot                           |
 | -------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------- |
-| Plugin marketplace (`ag-dev` → `ag-charts`, `ag-prodeng`, `ag-core`) | Loaded directly as a plugin          | N/A                                                         |
+| Plugin marketplace (`ag-dev` → `ag-charts`, `ag-prodeng`, `ag-core`, `ag-eng`, `ag-product`) | Loaded directly as a plugin          | N/A                                                         |
 | `.rulesync/` (this directory)                                        | Rules + a few product-specific items | Everything — staged from ag-dev-prompts by `rulesync-fetch` |
 
 Plugin content is mirrored into `.rulesync/` by `external/ag-shared/scripts/rulesync-fetch/stage.py` so non-Claude tools receive the same surface via `rulesync generate`. Staged items are gitignored (`.rulesync/.gitignore`); only the AG Charts-local items below are tracked here.

--- a/external/ag-shared/.claude-settings.template.json
+++ b/external/ag-shared/.claude-settings.template.json
@@ -142,6 +142,8 @@
   "enabledPlugins": {
     "ag-core@ag-dev": true,
     "ag-prodeng@ag-dev": true,
+    "ag-eng@ag-dev": true,
+    "ag-product@ag-dev": true,
     "${PRODUCT}@ag-dev": true,
     "codex@openai-codex": true,
     "skill-creator@claude-plugins-official": true

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = d6f93e4d145bf572ede20199bcaf1094aef3cf2c
-	parent = 275062993de33efc991fe7a98baa7823f3421f0d
+	commit = 4b9d55be168c53e75143e99ec39208099f76f939
+	parent = 3bf6172b42572cc6492ed100d61d14bd10e5e95e
 	method = rebase
 	cmdver = 0.4.9


### PR DESCRIPTION
## Summary

- Pulls latest ag-shared changes: NX 18→20 dep bumps, SSH auth mode for rulesync-fetch, lint fixes
- Adds `ag-eng@ag-dev` and `ag-product@ag-dev` to `.claude-settings.template.json` `enabledPlugins`
- Adds `.rulesync/skills/examples-ab-smoke/` — new A/B smoke test skill for comparing doc site examples

## ag-shared changes (committed via previous pull)

- `.snyk` — reformatted + updated NX 20.x dependency paths
- `package.json` — `@nx/devkit` 18→20, `glob` 8→11, `tsx` 4.7→4.21, `yargs` 17→18, `tinypool` 1→2
- `scripts/rulesync-fetch/fetch.sh` — new SSH auth mode: detects SSH-cloned consumer repos and mirrors scheme
- `scripts/shard/*.js`, `watch/watch.js` — remove stale `no-var-requires` eslint-disable comments
- `tsconfig.spec.json`, `tsconfig.types.test.json` — remove jest references
- `scripts/snyk-viewer/ui-browse.js`, `scripts/sonar/sync-sonar-issues.ts` — minor lint fixes

## Cross-repo PRs

- ag-grid: https://github.com/ag-grid/ag-grid/pull/13765
- ag-studio: https://github.com/ag-grid/ag-studio/pull/1481

## Test plan

- [ ] Verify ag-shared content matches source
- [ ] `setup-prompts.sh` runs cleanly
- [ ] `verify-rulesync.sh` passes