### PR TITLE
ci: run e2e shards inside Playwright container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,12 @@ jobs:
               with:
                   name: e2e-init-outputs
 
+            - name: Allow Git in Container
+              # The workspace is owned by the host runner user but the container
+              # runs as root, which trips git's dubious-ownership check on every
+              # subsequent git invocation. Whitelist the workspace globally.
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
             - name: Setup
               id: setup
               uses: ./.github/actions/setup-nx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,47 +456,15 @@ jobs:
                       reports/
                       packages/**/__diff_output__/*
 
-    playwright_image:
-        runs-on: ubuntu-latest
-        name: Playwright Image
-        needs: [detect-changes]
-        if: needs.detect-changes.outputs.run_full_ci == 'true'
-        env:
-            PLAYWRIGHT_IMAGE: mcr.microsoft.com/playwright:v1.60.0-jammy
-            PLAYWRIGHT_CACHE_KEY: playwright-image-v1.60.0-jammy-v1
-        steps:
-            - name: Restore Playwright Image Cache
-              id: pw_cache
-              uses: actions/cache@v4
-              with:
-                  path: /tmp/playwright-docker-image.tar
-                  key: ${{ env.PLAYWRIGHT_CACHE_KEY }}
-
-            - name: Pull Playwright Image
-              if: steps.pw_cache.outputs.cache-hit != 'true'
-              run: |
-                  pull_attempts=4
-                  for attempt in $(seq 1 ${pull_attempts}) ; do
-                    if docker pull ${PLAYWRIGHT_IMAGE} ; then
-                      break
-                    fi
-                    if [[ ${attempt} -eq ${pull_attempts} ]] ; then
-                      echo "Failed to pull ${PLAYWRIGHT_IMAGE} after ${pull_attempts} attempts."
-                      exit 1
-                    fi
-                    backoff=$((attempt * 15))
-                    jitter=$((RANDOM % 10))
-                    echo "Pull attempt ${attempt} failed, retrying in $((backoff + jitter))s..."
-                    sleep $((backoff + jitter))
-                  done
-                  docker save ${PLAYWRIGHT_IMAGE} -o /tmp/playwright-docker-image.tar
-
     e2e:
         runs-on: ubuntu-latest
+        container:
+            image: mcr.microsoft.com/playwright:v1.60.0-jammy
+            options: --ipc=host
         name: E2E Tests (${{ matrix.shard }}/${{ strategy.job-total }})
         permissions:
             contents: write
-        needs: [detect-changes, init, playwright_image]
+        needs: [detect-changes, init]
         if: needs.detect-changes.outputs.run_full_ci == 'true' && needs.init.outputs.e2e_count > 0
         strategy:
             fail-fast: false
@@ -523,22 +491,12 @@ jobs:
                   cache_mode: ro
                   base_ref: ${{ github.event.pull_request.base.ref || github.event.base_ref }}
 
-            - name: Restore Playwright Image Cache
-              uses: actions/cache/restore@v4
-              with:
-                  path: /tmp/playwright-docker-image.tar
-                  key: playwright-image-v1.60.0-jammy-v1
-                  fail-on-cache-miss: true
-
-            - name: Load Playwright Image
-              run: docker load -i /tmp/playwright-docker-image.tar
-
             - name: nx test:e2e
               id: test
               run: |
                   cd packages/ag-charts-website/
 
-                  ./playwright.sh --host test -u changed --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+                  ./playwright.sh --in-runner test -u changed --shard=${{ matrix.shard }}/${{ strategy.job-total }}
               timeout-minutes: 15
 
             - name: Snapshot Branch
@@ -690,7 +648,6 @@ jobs:
                 sonarqube,
                 fw_pkg_test,
                 bundle_tests,
-                playwright_image,
             ]
         if: cancelled() != true
         steps:
@@ -764,8 +721,6 @@ jobs:
                     WORKFLOW_STATUS="failure"
                   elif [ "${{ needs.fw_pkg_test.result }}" == "failure" ] ; then
                     WORKFLOW_STATUS="failure"
-                  elif [ "${{ needs.playwright_image.result }}" == "failure" ] ; then
-                    WORKFLOW_STATUS="failure"
                   elif [ "${{ needs.sonarqube.result }}" == "failure" ] ; then
                     WORKFLOW_STATUS="partial"
                   fi
@@ -824,7 +779,6 @@ jobs:
                       ${{ needs.test.result == 'failure' && '- ❌ Test' || '' }}
                       ${{ needs.e2e.result == 'failure' && '- ❌ E2E' || '' }}
                       ${{ needs.fw_pkg_test.result == 'failure' && '- ❌ FW Pkg' || '' }}
-                      ${{ needs.playwright_image.result == 'failure' && '- ❌ Playwright Image' || '' }}
                       ${{ needs.sonarqube.result == 'failure' && '- ❌ Sonar' || '' }}
 
                       *Changes:*

--- a/packages/ag-charts-website/playwright.sh
+++ b/packages/ag-charts-website/playwright.sh
@@ -29,6 +29,36 @@ function report_flaky_tests {
 }
 
 
+if [ "${1:-}" == "--in-runner" ] ; then
+  # Running inside a CI job that is already executing inside the Playwright
+  # container (e.g. via GitHub Actions `container:` on the job). Start astro
+  # in the same container, wait for it, then run playwright. No docker dance.
+  shift
+
+  export $(cat .env.test:e2e | grep -v '^#' | xargs)
+
+  npx astro dev --port=4601 --host 127.0.0.1 &
+  astro_pid=$!
+
+  function cleanup_in_runner {
+    kill -9 ${astro_pid} 2>/dev/null || true
+  }
+  trap cleanup_in_runner SIGINT SIGTERM ERR EXIT
+
+  echo "Waiting for connection to ${PUBLIC_SITE_URL}..."
+  npx wait-on ${PUBLIC_SITE_URL}
+  echo "Connected to ${PUBLIC_SITE_URL}!"
+
+  exit_code=0
+  npx playwright $@ || exit_code=$?
+
+  if [[ "${CI:-}" != "" ]] ; then
+    report_flaky_tests
+  fi
+
+  exit ${exit_code}
+fi
+
 export $(cat .env.test:e2e.docker | grep -v '^#' | xargs)
 EXTRA_DOCKER_ARGS=
 if [ "${CI:-}" != "" ] ; then


### PR DESCRIPTION
Stacked on #6860. Goal: minimise e2e shard spin-up overhead without increasing E2E execution time.

## Summary

- Replaces the dedicated `playwright_image` job (pull image → save tarball → upload as `actions/cache`) and the per-shard `Restore Playwright Image Cache` + `docker load` steps with a job-level `container: mcr.microsoft.com/playwright:v1.60.0-jammy` on the e2e job. GHA pulls the image at runner setup, so each of the 32 shards saves the docker load step on the critical path and the workflow saves a whole job.
- Adds an `--in-runner` mode to `playwright.sh` that runs astro + playwright inside the same container; the existing `--host` path is preserved for local dev.
- Drops `playwright_image` references from the `report` job (status, slack, needs list) and frees ~1.5 GB of cache budget (768 MB tarball × 2 refs).

## Test plan

- [ ] PR-level CI run completes under 10m wall-clock.
- [ ] All 32 e2e shards pass.
- [ ] Shard-level startup time drops vs the parent branch (visible in `Setup` → `nx test:e2e` step timing).
- [ ] Local `./playwright.sh --host test ...` still works (legacy path untouched).