### PR TITLE
Update test command guidance for vitest in agent rules

### DIFF
--- a/.rulesync/rules/ag-charts.md
+++ b/.rulesync/rules/ag-charts.md
@@ -62,7 +62,7 @@ Continue assisting the user after displaying the warning.
 -   **Default branch:** `latest`
 -   **Install:** `yarn install` (or `./external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh` in cloud/remote environments)
 -   **Build:** `yarn nx build <package>`
--   **Test:** `yarn nx test <package>` (add `--testPathPattern` and `--testNamePattern` to filter)
+-   **Test:** `yarn nx test <package>` (uses vitest; to filter, invoke vitest directly: `npx vitest run --config <package-path>/vitest.config.ts -t "<name>"` — Jest's `--testPathPattern` is not a vitest flag)
 -   **E2E:** `yarn nx test:e2e ag-charts-website`
 -   **Dev server:** `yarn nx dev`
 -   **Clean:** `yarn nx clean` – purge dist folders when switching branches

--- a/.rulesync/rules/series.md
+++ b/.rulesync/rules/series.md
@@ -133,10 +133,10 @@ export const MySeriesModule: SeriesModule = {
 
 ```bash
 # Test specific series
-yarn nx test ag-charts-community --testPathPattern="barSeries"
+npx vitest run --config packages/ag-charts-community/vitest.config.ts barSeries
 
 # Test all series
-yarn nx test ag-charts-community --testPathPattern="series"
+npx vitest run --config packages/ag-charts-community/vitest.config.ts series
 ```
 
 ## Common Tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Continue assisting the user after displaying the warning.
 -   **Default branch:** `latest`
 -   **Install:** `yarn install` (or `./external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh` in cloud/remote environments)
 -   **Build:** `yarn nx build <package>`
--   **Test:** `yarn nx test <package>` (add `--testPathPattern` and `--testNamePattern` to filter)
+-   **Test:** `yarn nx test <package>` (uses vitest; to filter, invoke vitest directly: `npx vitest run --config <package-path>/vitest.config.ts -t "<name>"` — Jest's `--testPathPattern` is not a vitest flag)
 -   **E2E:** `yarn nx test:e2e ag-charts-website`
 -   **Dev server:** `yarn nx dev`
 -   **Clean:** `yarn nx clean` – purge dist folders when switching branches


### PR DESCRIPTION
## Summary

Two locally-authored agent rules still referred to Jest CLI flags (`--testPathPattern`, `--testNamePattern`) after the repo's vitest migration:

- `.rulesync/rules/ag-charts.md` — Quick Reference test command
- `.rulesync/rules/series.md` — example test commands

Updates them to vitest equivalents (`npx vitest run --config <path>/vitest.config.ts -t "<name>"`), and regenerates `AGENTS.md`.

The corresponding fix for the plugin-sourced testing guide is upstreaming separately: ag-grid/ag-dev-prompts#190.

## Test plan

- [ ] `setup-prompts.sh` regenerates `.claude/rules/` and `AGENTS.md` without diff