### PR TITLE
Guard scheduled beta bumps during releases

### DIFF
--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -39,8 +39,14 @@ jobs:
             - name: Fetch Refs
               run: git fetch origin --depth 1 latest-success latest
 
+            - name: Check for In-Progress Release Branch
+              id: release_guard
+              if: ${{ github.event_name == 'schedule' }}
+              run: node ./tools/release/checkScheduledBetaBump.js
+
             - name: Setup
               id: setup
+              if: ${{ github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true' }}
               uses: ./.github/actions/setup-nx
               with:
                   cache_mode: ro
@@ -49,6 +55,7 @@ jobs:
 
             - name: Calculate Next Beta Version
               id: next_version
+              if: ${{ github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true' }}
               run: |
                   NEW_VERSION=$(node ./tools/calculate-next-version.js)
                   echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
@@ -56,25 +63,26 @@ jobs:
                   echo "tag=b${NEW_VERSION}" >> $GITHUB_OUTPUT
 
             - name: Bump Beta Package Version
+              if: ${{ github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true' }}
               run: ./tools/bump-versions.sh ${NEW_VERSION}
 
             - name: Commit Changes
               uses: EndBug/add-and-commit@v9
-              if: success()
+              if: ${{ success() && (github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true') }}
               with:
                   default_author: github_actions
                   message: Automated package version bump to ${{ steps.next_version.outputs.version }}.
 
             - name: Tag Latest Successful Commit
               uses: EndBug/latest-tag@latest
-              if: success()
+              if: ${{ success() && (github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true') }}
               with:
                   ref: ${{ steps.next_version.outputs.tag }}
                   description: Latest commit to pass GitHub Actions workflow on latest branch.
 
             - name: Tag Latest Successful Commit
               uses: EndBug/latest-tag@latest
-              if: success()
+              if: ${{ success() && (github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true') }}
               with:
                   ref: latest-beta-version
                   description: Latest commit to pass GitHub Actions workflow on latest branch.

--- a/tools/release/checkScheduledBetaBump.js
+++ b/tools/release/checkScheduledBetaBump.js
@@ -1,0 +1,153 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+function git(args, options = {}) {
+    const result = execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...options });
+    return result == null ? '' : result.trim();
+}
+
+function hasLocalRef(ref) {
+    try {
+        git(['show-ref', '--verify', '--quiet', ref], { stdio: 'ignore' });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function hasRemoteTag(tag) {
+    if (hasLocalRef(`refs/tags/${tag}`)) {
+        return true;
+    }
+
+    try {
+        git(['ls-remote', '--exit-code', '--tags', 'origin', `refs/tags/${tag}`], { stdio: 'ignore' });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function ensureRemoteBranchFetched(branch) {
+    if (hasLocalRef(`refs/remotes/origin/${branch}`)) {
+        return;
+    }
+
+    git(['fetch', 'origin', '--depth', '1', `+refs/heads/${branch}:refs/remotes/origin/${branch}`], {
+        stdio: ['ignore', 'inherit', 'inherit'],
+    });
+}
+
+function getPackageVersion(ref = undefined) {
+    const packageJson = ref == null ? fs.readFileSync('package.json', 'utf8') : git(['show', `${ref}:package.json`]);
+    return JSON.parse(packageJson).version;
+}
+
+function getReleaseBranches() {
+    const branchRefPrefix = 'refs/heads/';
+    let refs;
+
+    try {
+        const output = git(['ls-remote', '--heads', 'origin']);
+        refs = output.split('\n').map((line) => line.split(/\s+/)[1]);
+    } catch {
+        if (process.env.GITHUB_ACTIONS === 'true') {
+            throw new Error('Unable to list remote release branches.');
+        }
+
+        const output = git(['for-each-ref', '--format=%(refname)', 'refs/remotes/origin']);
+        refs = output.split('\n').map((ref) => ref.replace('refs/remotes/origin/', branchRefPrefix));
+    }
+
+    return refs
+        .filter((ref) => ref?.startsWith(branchRefPrefix))
+        .map((ref) => ref.slice(branchRefPrefix.length))
+        .filter((branch) => /^b\d+\.\d+\.\d+$/.test(branch));
+}
+
+function getReleaseVersion(version) {
+    return version.replace(/-.*/, '');
+}
+
+function parseVersion(version) {
+    return version.split('.').map((part) => Number(part));
+}
+
+function compareVersions(a, b) {
+    const versionA = parseVersion(a);
+    const versionB = parseVersion(b);
+
+    for (let index = 0; index < Math.max(versionA.length, versionB.length); index += 1) {
+        const partA = versionA[index] ?? 0;
+        const partB = versionB[index] ?? 0;
+
+        if (partA !== partB) {
+            return partA - partB;
+        }
+    }
+
+    return 0;
+}
+
+function setOutput(name, value) {
+    const output = `${name}=${value}\n`;
+
+    if (process.env.GITHUB_OUTPUT != null) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, output);
+    } else {
+        process.stdout.write(output);
+    }
+}
+
+function allowBump(reason) {
+    console.log(reason);
+    setOutput('can_bump', 'true');
+}
+
+function skipBump(reason) {
+    console.log(reason);
+    setOutput('can_bump', 'false');
+}
+
+const currentVersion = getPackageVersion();
+const currentReleaseVersion = getReleaseVersion(currentVersion);
+const isBetaVersion =
+    currentVersion !== currentReleaseVersion && currentVersion.startsWith(`${currentReleaseVersion}-beta.`);
+
+if (!isBetaVersion) {
+    allowBump(`Current version ${currentVersion} is not a beta version.`);
+    process.exit(0);
+}
+
+const blockingReleaseBranches = [];
+for (const branch of getReleaseBranches()) {
+    const releaseVersion = branch.slice(1);
+    if (compareVersions(releaseVersion, currentReleaseVersion) < 0) {
+        continue;
+    }
+
+    if (hasRemoteTag(`release-${releaseVersion}`)) {
+        continue;
+    }
+
+    ensureRemoteBranchFetched(branch);
+
+    const branchPackageReleaseVersion = getReleaseVersion(getPackageVersion(`origin/${branch}`));
+    if (branchPackageReleaseVersion === releaseVersion) {
+        blockingReleaseBranches.push(branch);
+    }
+}
+
+if (blockingReleaseBranches.length > 0) {
+    const releaseBranches = blockingReleaseBranches.join(', ');
+    setOutput('release_branch', releaseBranches);
+    skipBump(
+        [
+            `Skipping scheduled beta bump for ${currentVersion}.`,
+            `Release branch ${releaseBranches} exists without a matching release tag, which indicates a release is still in progress.`,
+            'Publish the release before creating another scheduled beta version bump on latest.',
+        ].join('\n')
+    );
+} else {
+    allowBump(`No in-progress release branches found at or after ${currentReleaseVersion}.`);
+}

--- a/tools/release/checkScheduledBetaBump.js
+++ b/tools/release/checkScheduledBetaBump.js
@@ -70,7 +70,19 @@ function getReleaseVersion(version) {
 }
 
 function parseVersion(version) {
-    return version.split('.').map((part) => Number(part));
+    const parts = version.split('.');
+    if (parts.length !== 3) {
+        throw new Error(`Invalid release version: ${version}`);
+    }
+
+    return parts.map((part) => {
+        const parsedPart = Number(part);
+        if (!Number.isInteger(parsedPart) || parsedPart < 0) {
+            throw new Error(`Invalid release version: ${version}`);
+        }
+
+        return parsedPart;
+    });
 }
 
 function compareVersions(a, b) {
@@ -111,6 +123,7 @@ function skipBump(reason) {
 
 const currentVersion = getPackageVersion();
 const currentReleaseVersion = getReleaseVersion(currentVersion);
+parseVersion(currentReleaseVersion);
 const isBetaVersion =
     currentVersion !== currentReleaseVersion && currentVersion.startsWith(`${currentReleaseVersion}-beta.`);
 
@@ -133,6 +146,8 @@ for (const branch of getReleaseBranches()) {
     ensureRemoteBranchFetched(branch);
 
     const branchPackageReleaseVersion = getReleaseVersion(getPackageVersion(`origin/${branch}`));
+    parseVersion(branchPackageReleaseVersion);
+
     if (branchPackageReleaseVersion === releaseVersion) {
         blockingReleaseBranches.push(branch);
     }


### PR DESCRIPTION
## Summary

- Add a scheduled-run guard to the beta version bump workflow.
- Skip the bump when an exact \`bX.Y.Z\` release branch at or ahead of the current beta base exists without a matching \`release-X.Y.Z\` tag.
- Keep manual \`workflow_dispatch\` runs unchanged.

## Validation

- \`node --check ./tools/release/checkScheduledBetaBump.js\`
- \`node ./tools/release/checkScheduledBetaBump.js\`
- \`yarn prettier --check .github/workflows/beta-publish.yml tools/release/checkScheduledBetaBump.js\`
- \`git diff --check origin/latest...HEAD\`
- Historical b13.3.0 spot-check: allowed before branch cut, blocked the Sunday scheduled run and pre-release Tuesday window, allowed after \`release-13.3.0\` existed.

## Note

\`NX_DAEMON=false yarn nx format --files .github/workflows/beta-publish.yml tools/release/checkScheduledBetaBump.js\` currently fails before formatting with an Nx project graph error: \`Cannot read properties of undefined (reading 'split')\`. Direct Prettier validation passes.