### PR TITLE
Avoid duplicate shallow success tag fetch

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -74,17 +74,27 @@ runs:
           run: |
               set -x
 
+              fetch_success_tag() {
+                local tag=$1
+                if git show-ref --verify --quiet "refs/tags/${tag}" ; then
+                  echo "Using already-fetched ${tag} tag"
+                  return 0
+                fi
+
+                git fetch origin -f --depth 1 tag "${tag}"
+              }
+
               branch=$(git branch --show-current)
               if [[ ${branch} == 'latest' || ${branch} == 'next' ]] ; then
                 # Latest
                 echo "base=${branch}-success" >> $GITHUB_OUTPUT
                 echo "NX_BASE=${branch}-success" >> $GITHUB_ENV
                 echo "type=latest" >> $GITHUB_OUTPUT
-                git fetch origin -f --depth 1 tag ${branch}-success
+                fetch_success_tag "${branch}-success"
               elif [[ ${branch} =~ b[0-9][0-9]\..+ ]] ; then
                 # Release
                 # Try to use the -success tag if it exists, otherwise fall back to branch name
-                if git fetch origin -f --depth 1 tag ${branch}-success 2>/dev/null; then
+                if fetch_success_tag "${branch}-success" 2>/dev/null; then
                   echo "base=${branch}-success" >> $GITHUB_OUTPUT
                   echo "NX_BASE=${branch}-success" >> $GITHUB_ENV
                 else


### PR DESCRIPTION
Avoid re-fetching the branch success tag in `setup-nx` when it has already been fetched by the workflow's `Fetch Refs` step.

The flaky CI failures were happening inside the composite action on repeated shallow fetches of `latest-success`, with Git reporting `fatal: shallow file has changed since we read it`. This keeps the existing fallback behaviour when a success tag is not already present, while making the common path idempotent.

Verification:
- `bash -n` on the action run block with GitHub expressions substituted locally
- `NX_DAEMON=false yarn nx format:check --files=.github/actions/setup-nx/action.yml`
- Temporary git remote behavioural check for first fetch and already-fetched tag paths
- YAML parse check
- `git diff --check`