### PR TITLE
AG-17390 Align org-chart formatter types with public RichFormatter

### DIFF
--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -9,7 +9,7 @@ import {
     type AgOrganizationSeriesNodeStyle,
     type AgOrganizationSeriesNodeTextStyle,
     type AgOrganizationSeriesNodeTextStylerParams,
-    type Formatter,
+    type RichFormatter,
     type Styler,
     type TextOrSegments,
     _ModuleSupport,
@@ -732,7 +732,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
 
     private formatText(
         text: TextOrSegments | undefined,
-        formatter: Formatter<AgOrganizationNodeTextFormatterParams> | undefined,
+        formatter: RichFormatter<AgOrganizationNodeTextFormatterParams> | undefined,
         datumIndex: number | undefined,
         isCollapsed: boolean
     ) {

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeriesProperties.ts
@@ -13,8 +13,8 @@ import {
     type FontSize,
     type FontStyle,
     type FontWeight,
-    type Formatter,
     type OverflowStrategy,
+    type RichFormatter,
     type Styler,
     type TextAlign,
     type TextWrap,
@@ -110,7 +110,7 @@ class OrganizationSeriesExpanderTextProperties extends BaseProperties {
     fontWeight!: FontWeight;
 
     @Property
-    formatter?: Formatter<AgOrganizationNodeTextFormatterParams<unknown, unknown>>;
+    formatter?: RichFormatter<AgOrganizationNodeTextFormatterParams<unknown, unknown>>;
 
     @Property
     textAlign: TextAlign = 'left';
@@ -249,7 +249,7 @@ export class OrganizationSeriesNodeTextProperties extends BaseProperties {
     fontWeight!: FontWeight;
 
     @Property
-    formatter?: Formatter<AgOrganizationNodeTextFormatterParams<unknown, unknown>>;
+    formatter?: RichFormatter<AgOrganizationNodeTextFormatterParams<unknown, unknown>>;
 
     @Property
     itemStyler?: Styler<AgOrganizationSeriesNodeTextStylerParams<unknown>, AgOrganizationSeriesNodeTextStyle>;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17390

The public option `series[].node.title.formatter` (and analogous `subtitle` / `labels`) is declared in `ag-charts-types` as `RichFormatter<...>` — returning `TextOrSegments | undefined`. The internal `OrganizationSeriesNodeTextProperties` and the `formatText` helper in `organizationSeries.ts` declared the same field as `Formatter<...>`, returning only `TextValue | undefined`.

Runtime already supports `TextOrSegments` (segments are passed through `node.update` and rendered correctly); the internal types were just under-reporting the supported behaviour. Audited every other `RichFormatter` site in `ag-charts-types` (`AgChartLabelOptions`, axis label/caption, navigator label) — they consume via classes that already use `RichFormatter`, so no other drift to fix.

Fix #AG-17390