### PR TITLE
Sync ag-shared from AG-3390 (slack CI notification updates)

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 0b8e14cb8d43c71b30c42d15781161416a2d9d3a
-	parent = 142c18d23c865f2fe8b2ddc48c9839906b032397
+	commit = 7b4b9d71a3880fa8cc5f0454a7c8b7c593b269f2
+	parent = a8da62bc9917432306544e83b98e052709a7107b
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = b58d16718703968196596465077722df9695aa6e
-	parent = 44801f3b888dd2389f9343fbb59939bf9a182db7
+	commit = 0b8e14cb8d43c71b30c42d15781161416a2d9d3a
+	parent = 142c18d23c865f2fe8b2ddc48c9839906b032397
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 7b4b9d71a3880fa8cc5f0454a7c8b7c593b269f2
-	parent = a8da62bc9917432306544e83b98e052709a7107b
+	commit = 0fcb776d02e516c7a938e4691b5a94d86535a0ac
+	parent = cb821b46306c4e479f193c8d7471279ef2b0cb6a
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/github/actions/slack-ci-notification/action.yml
+++ b/external/ag-shared/github/actions/slack-ci-notification/action.yml
@@ -36,7 +36,10 @@ inputs:
         description: Slack channel that receives debug messages with raw run context.
         required: false
     WEBSITE_STATUS_CHANNEL:
-        description: Slack channel that receives the staging-deploy notification.
+        description: Slack channel that receives the staging-deploy notification (shared across libraries, e.g. #website-status).
+        required: false
+    LIBRARY_WEBSITE_STATUS_CHANNEL:
+        description: Additional library-specific Slack channel that also receives the staging-deploy notification (e.g. #grid-website-status). Optional.
         required: false
     REPORT_URL:
         description: Optional URL for the test report.
@@ -78,5 +81,6 @@ runs:
               CURRENT_SHA: ${{ github.sha }}
               LAST_SUCCESSFUL_SHA: ${{ inputs.LAST_SUCCESSFUL_SHA }}
               WEBSITE_STATUS_CHANNEL: ${{ inputs.WEBSITE_STATUS_CHANNEL }}
+              LIBRARY_WEBSITE_STATUS_CHANNEL: ${{ inputs.LIBRARY_WEBSITE_STATUS_CHANNEL }}
               DEPLOY_TO_STAGING: ${{ inputs.DEPLOY_TO_STAGING }}
           run: node ./external/ag-shared/scripts/slack/notify-staging-deploy.mjs

--- a/external/ag-shared/scripts/slack/_ci-notification-utils.mjs
+++ b/external/ag-shared/scripts/slack/_ci-notification-utils.mjs
@@ -18,7 +18,7 @@ const LIBRARY_CONFIG = {
     AgStudio: {
         githubBaseUrl: 'https://github.com/ag-grid/ag-studio',
         stagingUrl: 'https://studio-staging.ag-grid.com',
-        emoji: ':puzzle:',
+        emoji: ':jigsaw:',
     },
     Blog: {
         githubBaseUrl: 'https://github.com/ag-grid/ag-blog-content',

--- a/external/ag-shared/scripts/slack/notify-staging-deploy.mjs
+++ b/external/ag-shared/scripts/slack/notify-staging-deploy.mjs
@@ -20,6 +20,7 @@ const {
     CURRENT_SHA,
     LAST_SUCCESSFUL_SHA,
     WEBSITE_STATUS_CHANNEL,
+    LIBRARY_WEBSITE_STATUS_CHANNEL,
     DEPLOY_TO_STAGING,
 } = process.env;
 
@@ -66,19 +67,27 @@ for (const [name, value] of Object.entries(required)) {
     const stagingUrl = getStagingUrl(AG_PROJECT);
     const emoji = getEmoji(AG_PROJECT);
 
-    // Post to shared #website-status channel using author names (no slack mentions)
-    // so the channel post doesn't ping contributors. Skip when no channel is configured.
-    if (WEBSITE_STATUS_CHANNEL) {
+    // Post to website-status channels using author names (no slack mentions) so the
+    // channel post doesn't ping contributors. Library channel is opt-in so consuming
+    // repos can fan out to a per-library feed (e.g. #grid-website-status) alongside
+    // the shared #website-status channel.
+    const channels = [WEBSITE_STATUS_CHANNEL, LIBRARY_WEBSITE_STATUS_CHANNEL].filter(Boolean);
+    if (channels.length > 0) {
         const { changesText: channelChangesText } = buildChangesData('name');
         const channelText = `:rocket: ${emoji} ${AG_PROJECT} changes were deployed to ${stagingUrl} (<${webUrl}|#${RUN_ID}>)\n${channelChangesText}`;
-        await sendSlackMessage({
-            authToken: SLACK_BOT_OAUTH_TOKEN,
-            data: { channel: WEBSITE_STATUS_CHANNEL, text: channelText, unfurl_links: false },
-        });
+        await Promise.all(
+            channels.map((channel) =>
+                sendSlackMessage({
+                    authToken: SLACK_BOT_OAUTH_TOKEN,
+                    data: { channel, text: channelText, unfurl_links: false },
+                })
+            )
+        );
     } else {
-        ghaWarning('WEBSITE_STATUS_CHANNEL is not set; skipping shared-channel post (opt-in DMs will still be sent).', {
-            title: 'Staging deploy notification: no shared channel',
-        });
+        ghaWarning(
+            'Neither WEBSITE_STATUS_CHANNEL nor LIBRARY_WEBSITE_STATUS_CHANNEL is set; skipping channel post (opt-in DMs will still be sent).',
+            { title: 'Staging deploy notification: no channels configured' }
+        );
     }
 
     // DM each opt-in user whose changes are in this deploy. The DM keeps slack

--- a/external/ag-shared/tsconfig.json
+++ b/external/ag-shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "esnext",
+    "module": "ESNext",
     "useDefineForClassFields": false,
     "strict": true,
     "forceConsistentCasingInFileNames": false,


### PR DESCRIPTION
## Summary

Sync `external/ag-shared/` to upstream `0b8e14cb8d4`. Companion to the ag-grid AG-3390 work.

### Changes pulled in

- `github/actions/slack-ci-notification/action.yml` — adds `LIBRARY_WEBSITE_STATUS_CHANNEL` input so consumer repos can fan staging-deploy notifications out to a per-library channel alongside the shared `#website-status` channel
- `scripts/slack/notify-staging-deploy.mjs` — posts to both `WEBSITE_STATUS_CHANNEL` and `LIBRARY_WEBSITE_STATUS_CHANNEL` when set (opt-in for the library channel)
- `external/ag-shared/.gitrepo` — bookkeeping

Most of the slack CI notification work landed in ag-charts via #6866; this PR pulls the trailing refinements.

## Cross-repo PRs

- ag-grid (source): https://github.com/ag-grid/ag-grid/pull/13816
- ag-studio: https://github.com/ag-grid/ag-studio/pull/1507

## Test plan

- [ ] `git subrepo status external/ag-shared` reports `Upstream Ref: 0b8e14cb8`
- [ ] `./external/ag-shared/scripts/setup-prompts/verify-rulesync.sh` passes
- [ ] `.claude/settings.json` includes `ag-eng@ag-dev` and `ag-product@ag-dev` (regenerated locally via `setup-prompts.sh`; `.claude/` is gitignored)
- [ ] **Per-repo follow-up (separate PR)**: ag-charts `.github/workflows/ci.yml` Slack step migration + secrets, if not already complete
