### PR TITLE
AG-17107 Add `DataSelectionService`

### DIFF
--- a/packages/ag-charts-community/src/chart/data/dataSelectionService.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSelectionService.ts
@@ -1,0 +1,7 @@
+import type { DataSet } from './dataSet';
+
+type SeriesLike = { id: string; data: DataSet<unknown> | undefined };
+
+export interface DataSelectionService {
+    getSeriesSelectedCount(series: SeriesLike): number;
+}

--- a/packages/ag-charts-community/src/chart/data/dataSelectionServiceInterface.ts
+++ b/packages/ag-charts-community/src/chart/data/dataSelectionServiceInterface.ts
@@ -1,0 +1,8 @@
+import type { AgChartInstance } from 'ag-charts-types';
+
+export interface IDataSelectionService extends Pick<
+    AgChartInstance,
+    'getSelection' | 'setSelection' | 'clearSelection'
+> {
+    getDataSelectionCount(seriesId: string): number;
+}

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -906,12 +906,9 @@ export abstract class Series<
         return highlightedDatum.datumIndex === datumIndex;
     }
 
-    private getDataSelectionCount(): number {
-        return this.data?.selections?.get(this.id)?.getSelectedCount() ?? 0;
-    }
-
     private hasDataSelection(): boolean {
-        return this.getDataSelectionCount() > 0;
+        const count: number = this.ctx.dataSelectionService?.getSeriesSelectedCount(this) ?? 0;
+        return count > 0;
     }
 
     public getHighlightStyle(

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -52,6 +52,7 @@ export {
     annotationShapeStylesDefs,
     annotationTextStylesDef,
 } from './chart/themes/annotationOptionsDef';
+export type { DataSelectionService } from './chart/data/dataSelectionService';
 export {
     commonAxisThemeTemplate,
     parentLevelAxisThemeTemplate,

--- a/packages/ag-charts-community/src/module/moduleContext.ts
+++ b/packages/ag-charts-community/src/module/moduleContext.ts
@@ -8,6 +8,7 @@ import type { AxisManager } from '../chart/axis/axisManager';
 import type { ChartService } from '../chart/chartService';
 import type { ChartState } from '../chart/chartState';
 import type { CrossLine } from '../chart/crossline/crossLine';
+import type { DataSelectionService } from '../chart/data/dataSelectionService';
 import type { DataService } from '../chart/data/dataService';
 import type { FontManager } from '../chart/fonts/fontManager';
 import type { FormatManager } from '../chart/formatter/formatManager';
@@ -62,6 +63,7 @@ export interface ChartRegistry {
     readonly chartService: ChartService;
     readonly chartTypeOriginator: ChartTypeOriginator;
     readonly dataService: DataService<any>;
+    readonly dataSelectionService?: DataSelectionService;
     readonly layoutManager: LayoutManager;
     readonly optionsGraphService: OptionsGraphService;
 

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionModule.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionModule.ts
@@ -1,10 +1,11 @@
-import type { AgChartSelectionOptions, AgSelectionClickMode } from 'ag-charts-community';
+import type { AgChartSelectionOptions, AgSelectionClickMode, _ModuleSupport } from 'ag-charts-community';
 import { VERSION } from 'ag-charts-community';
 import { type PluginModuleDefinition, boolean, selectionContainmentValidator, strictUnion } from 'ag-charts-core';
 
 import { DataSelection } from './dataSelection';
+import { DataSelectionServiceImp } from './dataSelectionServiceImp';
 
-export const SelectionModule: PluginModuleDefinition<AgChartSelectionOptions> = {
+export const SelectionModule: PluginModuleDefinition<AgChartSelectionOptions, _ModuleSupport.ChartRegistry> = {
     type: 'plugin',
     name: 'selection',
     enterprise: true,
@@ -29,4 +30,8 @@ export const SelectionModule: PluginModuleDefinition<AgChartSelectionOptions> = 
     },
 
     create: (ctx) => new DataSelection(ctx),
+    register: (ctx) => {
+        if (ctx.has('dataSelectionService')) return;
+        ctx.service('dataSelectionService', () => new DataSelectionServiceImp());
+    },
 };

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionServiceImp.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionServiceImp.ts
@@ -3,9 +3,6 @@ import type { _ModuleSupport } from 'ag-charts-community';
 type SeriesLike = { id: string; data: _ModuleSupport.DataSet<unknown> | undefined };
 
 export class DataSelectionServiceImp implements _ModuleSupport.DataSelectionService {
-    constructor() {
-        console.log('debug init');
-    }
     getSeriesSelectedCount(series: SeriesLike): number {
         return series.data?.selections?.get(series.id)?.getSelectedCount() ?? 0;
     }

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionServiceImp.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionServiceImp.ts
@@ -1,0 +1,12 @@
+import type { _ModuleSupport } from 'ag-charts-community';
+
+type SeriesLike = { id: string; data: _ModuleSupport.DataSet<unknown> | undefined };
+
+export class DataSelectionServiceImp implements _ModuleSupport.DataSelectionService {
+    constructor() {
+        console.log('debug init');
+    }
+    getSeriesSelectedCount(series: SeriesLike): number {
+        return series.data?.selections?.get(series.id)?.getSelectedCount() ?? 0;
+    }
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17107

Currently only migrates `Series.getDataSelectionCount`, but eventually more and more data-selection from ag-charts-community will be moved to ag-chart-enterprise through this interface