### PR TITLE
Phase 0: Jira agent pipeline access chain end-to-end

### DIFF
--- a/.github/scripts/jira-mcp-shim/server.mjs
+++ b/.github/scripts/jira-mcp-shim/server.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Minimal MCP stdio server for Jira Cloud, scoped to the calls the
+// triage agent needs. Hand-rolled JSON-RPC 2.0 over newline-delimited
+// JSON — zero dependencies so it runs straight on the GHA runner with
+// no install step.
+//
+// Tools exposed:
+//   - jira_get_issue:    GET  /rest/api/3/issue/{key}?fields=summary,status
+//   - jira_add_comment:  POST /rest/api/3/issue/{key}/comment
+//
+// Auth: basic auth from env: JIRA_USER_EMAIL + JIRA_API_TOKEN.
+// Site: JIRA_SITE_URL (e.g. https://ag-grid.atlassian.net).
+//
+// Add more tools as the pipeline grows past Phase 0 (transitions,
+// JQL search, links). Keep the surface deliberately small until then.
+import { createInterface } from 'node:readline';
+
+const PROTOCOL_VERSION = '2025-06-18';
+const SERVER_NAME = 'jira-mcp-shim';
+const SERVER_VERSION = '0.1.0';
+
+const SITE = required('JIRA_SITE_URL').replace(/\/$/, '');
+const EMAIL = required('JIRA_USER_EMAIL');
+const TOKEN = required('JIRA_API_TOKEN');
+const AUTH = 'Basic ' + Buffer.from(`${EMAIL}:${TOKEN}`).toString('base64');
+
+const TOOLS = [
+    {
+        name: 'jira_get_issue',
+        description: 'Fetch a Jira issue by key. Returns summary, status, and description.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                issueKey: { type: 'string', description: 'JIRA issue key, e.g. AG-12345' },
+            },
+            required: ['issueKey'],
+        },
+    },
+    {
+        name: 'jira_add_comment',
+        description: 'Post a plain-text comment on a Jira issue.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                issueKey: { type: 'string', description: 'JIRA issue key, e.g. AG-12345' },
+                body: { type: 'string', description: 'Comment text (rendered as a single ADF paragraph).' },
+            },
+            required: ['issueKey', 'body'],
+        },
+    },
+];
+
+const HANDLERS = {
+    async jira_get_issue({ issueKey }) {
+        const data = await jiraFetch(
+            `/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=summary,status,description`
+        );
+        const summary = data.fields?.summary ?? '(no summary)';
+        const status = data.fields?.status?.name ?? '(unknown status)';
+        return `Issue: ${issueKey}\nSummary: ${summary}\nStatus: ${status}`;
+    },
+    async jira_add_comment({ issueKey, body }) {
+        const adf = {
+            body: {
+                type: 'doc',
+                version: 1,
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: body }] }],
+            },
+        };
+        const data = await jiraFetch(`/rest/api/3/issue/${encodeURIComponent(issueKey)}/comment`, 'POST', adf);
+        return `Comment posted (id: ${data.id ?? 'unknown'})`;
+    },
+};
+
+async function jiraFetch(path, method = 'GET', body) {
+    const res = await fetch(`${SITE}${path}`, {
+        method,
+        headers: {
+            authorization: AUTH,
+            accept: 'application/json',
+            ...(body ? { 'content-type': 'application/json' } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`Jira ${method} ${path} -> HTTP ${res.status}: ${text.slice(0, 500)}`);
+    }
+    if (res.status === 204) return {};
+    return res.json();
+}
+
+function required(name) {
+    const v = process.env[name];
+    if (!v) {
+        console.error(`[jira-mcp-shim] missing required env: ${name}`);
+        process.exit(2);
+    }
+    return v;
+}
+
+function reply(id, result) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
+}
+function replyError(id, code, message) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n');
+}
+
+async function handle(msg) {
+    if (msg.method === 'initialize') {
+        return reply(msg.id, {
+            protocolVersion: PROTOCOL_VERSION,
+            serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+            capabilities: { tools: {} },
+        });
+    }
+    if (msg.method === 'notifications/initialized' || msg.method === 'initialized') {
+        return; // notification — no reply
+    }
+    if (msg.method === 'tools/list') {
+        return reply(msg.id, { tools: TOOLS });
+    }
+    if (msg.method === 'tools/call') {
+        const { name, arguments: args } = msg.params ?? {};
+        const handler = HANDLERS[name];
+        if (!handler) return replyError(msg.id, -32601, `Unknown tool: ${name}`);
+        try {
+            const text = await handler(args ?? {});
+            return reply(msg.id, { content: [{ type: 'text', text }], isError: false });
+        } catch (err) {
+            return reply(msg.id, {
+                content: [{ type: 'text', text: String(err?.message ?? err) }],
+                isError: true,
+            });
+        }
+    }
+    if (msg.id !== undefined) {
+        return replyError(msg.id, -32601, `Method not found: ${msg.method}`);
+    }
+}
+
+const rl = createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let msg;
+    try {
+        msg = JSON.parse(trimmed);
+    } catch (err) {
+        console.error(`[jira-mcp-shim] parse error: ${err.message}`);
+        return;
+    }
+    handle(msg).catch((err) => console.error(`[jira-mcp-shim] handler error: ${err.message}`));
+});

--- a/.github/scripts/jira-mcp-shim/server.mjs
+++ b/.github/scripts/jira-mcp-shim/server.mjs
@@ -1,23 +1,28 @@
 #!/usr/bin/env node
 // Minimal MCP stdio server for Jira Cloud, scoped to the calls the
-// triage agent needs. Hand-rolled JSON-RPC 2.0 over newline-delimited
-// JSON — zero dependencies so it runs straight on the GHA runner with
-// no install step.
+// /fr --ci pipeline makes on a single ticket. Hand-rolled JSON-RPC 2.0
+// over newline-delimited JSON — zero dependencies so it runs straight
+// on the GHA runner with no install step.
+//
+// Tool names match the Atlassian/Rovo MCP server's so `/fr` (which
+// expects mcp__atlassian__*) routes here without any per-tool aliasing.
 //
 // Tools exposed:
-//   - jira_get_issue:    GET  /rest/api/3/issue/{key}?fields=summary,status
-//   - jira_add_comment:  POST /rest/api/3/issue/{key}/comment
+//   - getJiraIssue                — GET  /rest/api/3/issue/{key}
+//   - addCommentToJiraIssue       — POST /rest/api/3/issue/{key}/comment
+//   - getTransitionsForJiraIssue  — GET  /rest/api/3/issue/{key}/transitions
+//   - transitionJiraIssue         — POST /rest/api/3/issue/{key}/transitions
+//   - addAttachmentToJiraIssue    — POST /rest/api/3/issue/{key}/attachments (multipart)
 //
 // Auth: basic auth from env: JIRA_USER_EMAIL + JIRA_API_TOKEN.
 // Site: JIRA_SITE_URL (e.g. https://ag-grid.atlassian.net).
-//
-// Add more tools as the pipeline grows past Phase 0 (transitions,
-// JQL search, links). Keep the surface deliberately small until then.
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 import { createInterface } from 'node:readline';
 
 const PROTOCOL_VERSION = '2025-06-18';
 const SERVER_NAME = 'jira-mcp-shim';
-const SERVER_VERSION = '0.1.0';
+const SERVER_VERSION = '0.2.0';
 
 const SITE = required('JIRA_SITE_URL').replace(/\/$/, '');
 const EMAIL = required('JIRA_USER_EMAIL');
@@ -26,49 +31,143 @@ const AUTH = 'Basic ' + Buffer.from(`${EMAIL}:${TOKEN}`).toString('base64');
 
 const TOOLS = [
     {
-        name: 'jira_get_issue',
-        description: 'Fetch a Jira issue by key. Returns summary, status, and description.',
+        name: 'getJiraIssue',
+        description: 'Fetch a Jira issue. Returns summary, status, labels, and description (ADF flattened to text).',
         inputSchema: {
             type: 'object',
             properties: {
-                issueKey: { type: 'string', description: 'JIRA issue key, e.g. AG-12345' },
+                issueIdOrKey: { type: 'string', description: 'JIRA issue key (e.g. AG-12345) or numeric id.' },
+                responseContentFormat: { type: 'string', description: 'Accepted for compatibility; ignored.' },
             },
-            required: ['issueKey'],
+            required: ['issueIdOrKey'],
         },
     },
     {
-        name: 'jira_add_comment',
-        description: 'Post a plain-text comment on a Jira issue.',
+        name: 'addCommentToJiraIssue',
+        description:
+            'Post a plain-text comment on a Jira issue. The body is rendered as a single ADF paragraph (newlines become hard breaks).',
         inputSchema: {
             type: 'object',
             properties: {
-                issueKey: { type: 'string', description: 'JIRA issue key, e.g. AG-12345' },
-                body: { type: 'string', description: 'Comment text (rendered as a single ADF paragraph).' },
+                issueIdOrKey: { type: 'string', description: 'JIRA issue key or id.' },
+                commentBody: { type: 'string', description: 'Comment text. Plain text only.' },
             },
-            required: ['issueKey', 'body'],
+            required: ['issueIdOrKey', 'commentBody'],
+        },
+    },
+    {
+        name: 'getTransitionsForJiraIssue',
+        description: 'List the workflow transitions available on a Jira issue. Returns id + name pairs.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                issueIdOrKey: { type: 'string', description: 'JIRA issue key or id.' },
+            },
+            required: ['issueIdOrKey'],
+        },
+    },
+    {
+        name: 'transitionJiraIssue',
+        description:
+            'Execute a workflow transition on a Jira issue. Use getTransitionsForJiraIssue to discover the id.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                issueIdOrKey: { type: 'string', description: 'JIRA issue key or id.' },
+                transitionId: { type: 'string', description: 'Transition id from getTransitionsForJiraIssue.' },
+            },
+            required: ['issueIdOrKey', 'transitionId'],
+        },
+    },
+    {
+        name: 'addAttachmentToJiraIssue',
+        description:
+            'Attach a file to a Jira issue. Provide either filePath (read from disk) or fileContent (string body).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                issueIdOrKey: { type: 'string', description: 'JIRA issue key or id.' },
+                filePath: { type: 'string', description: 'Absolute path to a file on the runner.' },
+                fileContent: { type: 'string', description: 'Alternative to filePath: inline content.' },
+                fileName: {
+                    type: 'string',
+                    description: 'Filename to record on the attachment. Defaults to basename(filePath).',
+                },
+            },
+            required: ['issueIdOrKey'],
         },
     },
 ];
 
 const HANDLERS = {
-    async jira_get_issue({ issueKey }) {
+    async getJiraIssue({ issueIdOrKey }) {
         const data = await jiraFetch(
-            `/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=summary,status,description`
+            `/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}?fields=summary,status,labels,description`
         );
-        const summary = data.fields?.summary ?? '(no summary)';
-        const status = data.fields?.status?.name ?? '(unknown status)';
-        return `Issue: ${issueKey}\nSummary: ${summary}\nStatus: ${status}`;
+        return JSON.stringify(
+            {
+                key: data.key,
+                summary: data.fields?.summary ?? null,
+                status: data.fields?.status?.name ?? null,
+                labels: data.fields?.labels ?? [],
+                description: adfToText(data.fields?.description),
+            },
+            null,
+            2
+        );
     },
-    async jira_add_comment({ issueKey, body }) {
+    async addCommentToJiraIssue({ issueIdOrKey, commentBody }) {
         const adf = {
             body: {
                 type: 'doc',
                 version: 1,
-                content: [{ type: 'paragraph', content: [{ type: 'text', text: body }] }],
+                content: textToParagraphs(commentBody),
             },
         };
-        const data = await jiraFetch(`/rest/api/3/issue/${encodeURIComponent(issueKey)}/comment`, 'POST', adf);
+        const data = await jiraFetch(`/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}/comment`, 'POST', adf);
         return `Comment posted (id: ${data.id ?? 'unknown'})`;
+    },
+    async getTransitionsForJiraIssue({ issueIdOrKey }) {
+        const data = await jiraFetch(`/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}/transitions`);
+        const list = (data.transitions ?? []).map((t) => ({ id: t.id, name: t.name, to: t.to?.name }));
+        return JSON.stringify(list, null, 2);
+    },
+    async transitionJiraIssue({ issueIdOrKey, transitionId }) {
+        await jiraFetch(`/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}/transitions`, 'POST', {
+            transition: { id: transitionId },
+        });
+        return `Transition ${transitionId} applied to ${issueIdOrKey}`;
+    },
+    async addAttachmentToJiraIssue({ issueIdOrKey, filePath, fileContent, fileName }) {
+        let buf;
+        let name = fileName;
+        if (filePath) {
+            buf = await readFile(filePath);
+            if (!name) name = basename(filePath);
+        } else if (typeof fileContent === 'string') {
+            buf = Buffer.from(fileContent, 'utf8');
+            if (!name) throw new Error('fileName is required when using fileContent');
+        } else {
+            throw new Error('Provide filePath or fileContent');
+        }
+        const form = new FormData();
+        form.append('file', new Blob([buf]), name);
+        const res = await fetch(`${SITE}/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}/attachments`, {
+            method: 'POST',
+            headers: {
+                authorization: AUTH,
+                accept: 'application/json',
+                'x-atlassian-token': 'no-check',
+            },
+            body: form,
+        });
+        if (!res.ok) {
+            const text = await res.text().catch(() => '');
+            throw new Error(`Attachment upload HTTP ${res.status}: ${text.slice(0, 500)}`);
+        }
+        const data = await res.json();
+        const ids = Array.isArray(data) ? data.map((d) => d.id).join(',') : data.id;
+        return `Attached ${name} (id: ${ids})`;
     },
 };
 
@@ -87,7 +186,34 @@ async function jiraFetch(path, method = 'GET', body) {
         throw new Error(`Jira ${method} ${path} -> HTTP ${res.status}: ${text.slice(0, 500)}`);
     }
     if (res.status === 204) return {};
-    return res.json();
+    const ct = res.headers.get('content-type') ?? '';
+    if (ct.includes('application/json')) return res.json();
+    return {};
+}
+
+// Cheap ADF → text conversion sufficient for issue descriptions.
+// Walks the tree, joins text nodes, separates paragraphs with blank lines.
+function adfToText(node) {
+    if (!node) return '';
+    if (typeof node === 'string') return node;
+    if (node.type === 'text') return node.text ?? '';
+    if (node.type === 'hardBreak') return '\n';
+    const children = (node.content ?? []).map(adfToText).join('');
+    if (['paragraph', 'heading', 'blockquote', 'listItem'].includes(node.type)) {
+        return children + '\n\n';
+    }
+    return children;
+}
+
+function textToParagraphs(text) {
+    return text.split(/\n{2,}/).map((para) => ({
+        type: 'paragraph',
+        content: para.split('\n').flatMap((line, i, arr) => {
+            const t = [{ type: 'text', text: line }];
+            if (i < arr.length - 1) t.push({ type: 'hardBreak' });
+            return t;
+        }),
+    }));
 }
 
 function required(name) {
@@ -115,7 +241,7 @@ async function handle(msg) {
         });
     }
     if (msg.method === 'notifications/initialized' || msg.method === 'initialized') {
-        return; // notification — no reply
+        return;
     }
     if (msg.method === 'tools/list') {
         return reply(msg.id, { tools: TOOLS });

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -227,6 +227,14 @@ jobs:
 
             - name: Write Atlassian MCP config
               id: mcp-config
+              # Use the in-repo Jira MCP shim (.github/scripts/jira-mcp-shim/
+              # server.mjs) — a zero-dep Node stdio server scoped to the
+              # tools the triage agent calls. Atlassian's hosted remote MCP
+              # uses OAuth which we don't have a CI-friendly story for; the
+              # community npm packages we'd otherwise use add cold-start
+              # latency that made the agent give up before the server was
+              # ready. The shim authenticates with the basic-auth credentials
+              # we already provision (JIRA_EMAIL + JIRA_API_TOKEN).
               env:
                   JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
                   JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
@@ -237,14 +245,15 @@ jobs:
                   : "${JIRA_API_TOKEN:?missing}"
                   : "${JIRA_SITE_URL:?missing}"
                   jq -n \
+                      --arg shim "$GITHUB_WORKSPACE/.github/scripts/jira-mcp-shim/server.mjs" \
                       --arg email "$JIRA_EMAIL" \
                       --arg token "$JIRA_API_TOKEN" \
                       --arg site "$JIRA_SITE_URL" \
                       '{
                           mcpServers: {
                               atlassian: {
-                                  command: "npx",
-                                  args: ["-y", "@atlassian/mcp-server"],
+                                  command: "node",
+                                  args: [$shim],
                                   env: {
                                       JIRA_USER_EMAIL: $email,
                                       JIRA_API_TOKEN: $token,
@@ -262,11 +271,15 @@ jobs:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.app-token.outputs.token }}
                   show_full_output: 'true'
-                  # Plugins are declared in .claude/settings.json
-                  # (rendered by setup-prompts.sh during yarn install) — no
-                  # plugin_marketplaces/plugins inputs needed here. Claude
-                  # Code resolves the ag-dev marketplace itself using the
-                  # git credential rewrite configured earlier.
+                  # The SDK doesn't auto-install plugins declared in
+                  # .claude/settings.json — it only loads them once
+                  # installed. Use the action's explicit install inputs;
+                  # the git URL rewrite step above gives the marketplace
+                  # clone the App-token credential it needs.
+                  plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
+                  plugins: |
+                      ag-eng@ag-dev-prompts
+                      ag-product@ag-dev-prompts
                   claude_args: |
                       --mcp-config ${{ runner.temp }}/mcp.json
                       --max-turns 12
@@ -279,12 +292,14 @@ jobs:
                       Do exactly these steps and stop:
 
                         1. Confirm a skill from the ag-dev-prompts marketplace loaded.
-                           Name one skill you can see (e.g. /jira, /pr-review).
-                        2. Using the Atlassian MCP tool, fetch the JIRA issue
-                           ${{ env.ISSUE_KEY }}. Report its summary and status in
-                           your response.
-                        3. Using the Atlassian MCP tool, post a comment to the
-                           issue containing exactly this line:
+                           Name one skill you can see from the ag-eng or
+                           ag-product plugin (e.g. /jira, /pr-review, /fr).
+                        2. Call the MCP tool `mcp__atlassian__jira_get_issue`
+                           with `issueKey="${{ env.ISSUE_KEY }}"`. Report the
+                           returned summary and status.
+                        3. Call `mcp__atlassian__jira_add_comment` with
+                           `issueKey="${{ env.ISSUE_KEY }}"` and `body` set
+                           exactly to:
                              "ag-charts triage pipeline E2E test — run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Marketplace loaded; MCP authenticated."
                         4. Do not transition the ticket. Do not change any other
                            state. Stop.

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -270,8 +270,7 @@ jobs:
                   claude_args: |
                       --mcp-config ${{ runner.temp }}/mcp.json
                       --max-turns 12
-                      --output-format stream-json
-                      --output-format-file ${{ runner.temp }}/trace.json
+                      --debug
                   prompt: |
                       You are validating the Jira-driven agent pipeline on ag-charts.
                       The JIRA ticket key is: ${{ env.ISSUE_KEY }}.

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -237,6 +237,7 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.app-token.outputs.token }}
+                  show_full_output: 'true'
                   # Plugins are declared in .claude/settings.json
                   # (rendered by setup-prompts.sh during yarn install) — no
                   # plugin_marketplaces/plugins inputs needed here. Claude

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -67,14 +67,27 @@ name: Jira Agent Pipeline (Triage E2E)
 #     - ag-dev-prompts missing from the repo list  -> App not installed on
 #       the marketplace repo. Install it.
 #
+#   Step: Configure git credentials for ag-dev-prompts clones
+#     - Step succeeds independently; failures here usually mean a downstream
+#       clone surfaces "HTTPS authentication failed" (App token lacks
+#       contents:read on ag-dev-prompts).
+#
+#   Step: Install dependencies
+#     - rulesync-fetch failure cloning ag-dev-prompts  -> App-token git
+#       rewrite missing or App lacks contents:read on the marketplace repo.
+#     - Missing .claude/settings.json  -> setup-prompts.sh did not render
+#       (check $AG_PRODUCT / package.json .name).
+#     - yarn install times out / dependency resolution errors  -> usually
+#       transient registry; re-run.
+#
 #   Step: Write MCP config
 #     - JIRA_* env vars empty  -> secret/variable not set on this repo.
 #
 #   Step: claude-code-action
-#     - "Could not clone ag-grid/ag-dev-prompts"  -> App token lacks
-#       contents:read on the marketplace, OR the action does not forward
-#       github_token to its marketplace clone (claude-code-action #664).
-#     - "401 from api.anthropic.com"  -> ANTHROPIC_API_KEY missing/revoked.
+#     - "401 from api.anthropic.com"  -> ANTHROPIC_API_KEY missing/revoked,
+#       or org-secret repo-access policy excludes ag-charts (public repo).
+#     - Plugin marketplace clone fails inside Claude Code  -> git URL
+#       rewrite step did not run, or App token expired mid-run.
 #     - Agent reports MCP fetch failed  -> JIRA_API_TOKEN scope, or wrong
 #       JIRA_EMAIL, or @atlassian/mcp-server package name wrong.
 #
@@ -150,6 +163,49 @@ jobs:
                   grep -qx 'ag-grid/ag-dev-prompts' /tmp/repos.txt
                   echo "ok=true" >> "$GITHUB_OUTPUT"
 
+            - name: Configure git credentials for ag-dev-prompts clones
+              # claude-code-action does NOT forward github_token to its plugin
+              # marketplace clone (OQ#1 — confirmed empirically by an earlier
+              # dry-run that hit "HTTPS authentication failed"). A global git
+              # URL rewrite installs the App-installation token as the
+              # credential for any github.com HTTPS clone — covers both
+              # setup-prompts.sh's fetch.sh (postinstall) and Claude Code's
+              # marketplace resolver at agent runtime, without leaking the
+              # token into env vars consumed by other steps.
+              env:
+                  APP_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: |
+                  set -euo pipefail
+                  git config --global \
+                      "url.https://x-access-token:${APP_TOKEN}@github.com/.insteadOf" \
+                      https://github.com/
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: package.json
+                  cache: yarn
+
+            - name: Install dependencies (runs setup-prompts.sh postinstall)
+              id: install
+              # AG_WORKTREE_FAST_PATH=1 skips the heavy postinstall steps
+              # (apply-patches, nx daemon shuffles, plugin build) while still
+              # running postinstall:setup-prompts — that script renders
+              # .claude/settings.json (with the ag-dev marketplace declared)
+              # and invokes rulesync. We rely on the in-tree settings for
+              # claude-code-action to pick up project skills at runtime; the
+              # marketplace clone Claude Code performs is authenticated by
+              # the git URL rewrite configured above.
+              env:
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+                  AG_WORKTREE_FAST_PATH: '1'
+                  AG_PRODUCT: ag-charts
+              run: |
+                  set -euo pipefail
+                  yarn install --immutable
+                  test -f .claude/settings.json
+                  jq -e '.extraKnownMarketplaces."ag-dev"' .claude/settings.json >/dev/null
+
             - name: Write Atlassian MCP config
               id: mcp-config
               env:
@@ -186,10 +242,11 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.app-token.outputs.token }}
-                  plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
-                  plugins: |
-                      ag-eng@ag-dev-prompts
-                      ag-product@ag-dev-prompts
+                  # Plugins are declared in .claude/settings.json
+                  # (rendered by setup-prompts.sh during yarn install) — no
+                  # plugin_marketplaces/plugins inputs needed here. Claude
+                  # Code resolves the ag-dev marketplace itself using the
+                  # git credential rewrite configured earlier.
                   claude_args: |
                       --mcp-config ${{ runner.temp }}/mcp.json
                       --max-turns 12
@@ -228,6 +285,7 @@ jobs:
                   ISSUE_KEY_OK: ${{ steps.validate-issue-key.outcome }}
                   TOKEN_OK: ${{ steps.app-token.outcome }}
                   VALIDATE_OK: ${{ steps.validate-token.outcome }}
+                  INSTALL_OK: ${{ steps.install.outcome }}
                   MCP_OK: ${{ steps.mcp-config.outcome }}
                   CLAUDE_OK: ${{ steps.claude.outcome }}
               run: |
@@ -241,6 +299,7 @@ jobs:
                     echo "| Issue key validated                 | $(marker "$ISSUE_KEY_OK") |"
                     echo "| GitHub App token mint               | $(marker "$TOKEN_OK") |"
                     echo "| Token covers both repos             | $(marker "$VALIDATE_OK") |"
+                    echo "| yarn install + setup-prompts        | $(marker "$INSTALL_OK") |"
                     echo "| Atlassian MCP config written        | $(marker "$MCP_OK") |"
                     echo "| Claude run (marketplace + MCP call) | $(marker "$CLAUDE_OK") |"
                     echo ""

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -72,13 +72,16 @@ name: Jira Agent Pipeline (Triage E2E)
 #       clone surfaces "HTTPS authentication failed" (App token lacks
 #       contents:read on ag-dev-prompts).
 #
-#   Step: Install dependencies
+#   Step: Setup Nx (yarn install + postinstall)
 #     - rulesync-fetch failure cloning ag-dev-prompts  -> App-token git
 #       rewrite missing or App lacks contents:read on the marketplace repo.
-#     - Missing .claude/settings.json  -> setup-prompts.sh did not render
-#       (check $AG_PRODUCT / package.json .name).
-#     - yarn install times out / dependency resolution errors  -> usually
-#       transient registry; re-run.
+#     - node_modules cache miss + slow install on cold runners is normal;
+#       subsequent runs hit the shared cache populated by ci.yml.
+#
+#   Step: Verify setup-prompts rendered .claude/settings.json
+#     - Missing file / missing ag-dev marketplace key -> setup-prompts.sh
+#       did not run or failed silently (check $AG_PRODUCT / package.json
+#       .name resolution inside the script).
 #
 #   Step: Write MCP config
 #     - JIRA_* env vars empty  -> secret/variable not set on this repo.
@@ -180,29 +183,21 @@ jobs:
                       "url.https://x-access-token:${APP_TOKEN}@github.com/.insteadOf" \
                       https://github.com/
 
-            - name: Setup Node
-              uses: actions/setup-node@v4
-              with:
-                  node-version-file: package.json
-                  cache: yarn
-
-            - name: Install dependencies (runs setup-prompts.sh postinstall)
+            - name: Setup Nx (yarn install + node_modules cache + postinstall)
               id: install
-              # AG_WORKTREE_FAST_PATH=1 skips the heavy postinstall steps
-              # (apply-patches, nx daemon shuffles, plugin build) while still
-              # running postinstall:setup-prompts — that script renders
-              # .claude/settings.json (with the ag-dev marketplace declared)
-              # and invokes rulesync. We rely on the in-tree settings for
-              # claude-code-action to pick up project skills at runtime; the
-              # marketplace clone Claude Code performs is authenticated by
-              # the git URL rewrite configured above.
-              env:
-                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-                  AG_WORKTREE_FAST_PATH: '1'
-                  AG_PRODUCT: ag-charts
+              # setup-nx handles node_modules cache, nx cache, node setup, and
+              # `yarn postinstall` — which runs setup-prompts.sh and renders
+              # .claude/settings.json (with the ag-dev marketplace declared).
+              # cache_mode: ro because we only consume the shared cache here;
+              # rebuilding it is the CI workflow's job.
+              uses: ./.github/actions/setup-nx
+              with:
+                  cache_mode: ro
+                  fetch_base: skip
+
+            - name: Verify setup-prompts rendered .claude/settings.json
               run: |
                   set -euo pipefail
-                  yarn install --immutable
                   test -f .claude/settings.json
                   jq -e '.extraKnownMarketplaces."ag-dev"' .claude/settings.json >/dev/null
 

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -278,8 +278,8 @@ jobs:
                   # clone the App-token credential it needs.
                   plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
                   plugins: |
-                      ag-eng@ag-dev-prompts
-                      ag-product@ag-dev-prompts
+                      ag-eng@ag-dev
+                      ag-product@ag-dev
                   claude_args: |
                       --mcp-config ${{ runner.temp }}/mcp.json
                       --max-turns 12

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -271,7 +271,10 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: claude-trace-${{ env.ISSUE_KEY }}-${{ github.run_id }}
-                  path: ${{ runner.temp }}/trace.json
+                  path: |
+                      ${{ runner.temp }}/trace.json
+                      ${{ runner.temp }}/claude-execution-output.json
+                      ${{ runner.temp }}/claude-prompts/
                   if-no-files-found: warn
                   retention-days: 14
 

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -183,9 +183,8 @@ jobs:
             - name: Run Claude triage agent
               id: claude
               uses: anthropics/claude-code-action@v1
-              env:
-                  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
               with:
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.app-token.outputs.token }}
                   plugin_marketplaces: ag-grid/ag-dev-prompts@latest
                   plugins: ag-eng@ag-dev-prompts ag-product@ag-dev-prompts

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -201,6 +201,30 @@ jobs:
                   test -f .claude/settings.json
                   jq -e '.extraKnownMarketplaces."ag-dev"' .claude/settings.json >/dev/null
 
+            - name: Sanitise .claude/settings.json for CI
+              # Local-dev settings include hooks that reference scripts whose
+              # side effects are inappropriate for a triage job (SessionStart
+              # → install-for-cloud.sh, PostToolUse → yarn nx format on every
+              # edit, WorktreeCreate/Remove). Strip them. Keep env (NX_DAEMON
+              # off), the ag-dev marketplace + enabledPlugins (so /fr et al
+              # load), and a minimal permissions block (claude-code-action
+              # manages its own permissions for the agent surface).
+              run: |
+                  set -euo pipefail
+                  cp .claude/settings.json /tmp/orig-settings.json
+                  jq '{
+                      env,
+                      extraKnownMarketplaces: { "ag-dev": .extraKnownMarketplaces."ag-dev" },
+                      enabledPlugins: (
+                          .enabledPlugins
+                          | to_entries
+                          | map(select(.key | endswith("@ag-dev")))
+                          | from_entries
+                      )
+                  }' /tmp/orig-settings.json > .claude/settings.json
+                  echo "--- sanitised settings ---"
+                  cat .claude/settings.json
+
             - name: Write Atlassian MCP config
               id: mcp-config
               env:

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -284,6 +284,7 @@ jobs:
                       --mcp-config ${{ runner.temp }}/mcp.json
                       --max-turns 12
                       --debug
+                      --allowed-tools mcp__atlassian__jira_get_issue,mcp__atlassian__jira_add_comment
                   prompt: |
                       You are validating the Jira-driven agent pipeline on ag-charts.
                       The JIRA ticket key is: ${{ env.ISSUE_KEY }}.

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -186,8 +186,10 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.app-token.outputs.token }}
-                  plugin_marketplaces: ag-grid/ag-dev-prompts@latest
-                  plugins: ag-eng@ag-dev-prompts ag-product@ag-dev-prompts
+                  plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
+                  plugins: |
+                      ag-eng@ag-dev-prompts
+                      ag-product@ag-dev-prompts
                   claude_args: |
                       --mcp-config ${{ runner.temp }}/mcp.json
                       --max-turns 12

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -205,15 +205,18 @@ jobs:
               # Local-dev settings include hooks that reference scripts whose
               # side effects are inappropriate for a triage job (SessionStart
               # → install-for-cloud.sh, PostToolUse → yarn nx format on every
-              # edit, WorktreeCreate/Remove). Strip them. Keep env (NX_DAEMON
-              # off), the ag-dev marketplace + enabledPlugins (so /fr et al
-              # load), and a minimal permissions block (claude-code-action
-              # manages its own permissions for the agent surface).
+              # edit, WorktreeCreate/Remove). Strip the hooks block; keep
+              # env, the ag-dev marketplace, enabledPlugins (filtered to
+              # ag-dev only — codex/skill-creator marketplaces add cold-
+              # start latency we don't need), and the permissions allow
+              # list (covers Bash/Edit/Write/WebFetch/Skill — needed by
+              # /fr et al).
               run: |
                   set -euo pipefail
                   cp .claude/settings.json /tmp/orig-settings.json
                   jq '{
                       env,
+                      permissions,
                       extraKnownMarketplaces: { "ag-dev": .extraKnownMarketplaces."ag-dev" },
                       enabledPlugins: (
                           .enabledPlugins
@@ -284,26 +287,19 @@ jobs:
                       --mcp-config ${{ runner.temp }}/mcp.json
                       --max-turns 12
                       --debug
-                      --allowed-tools mcp__atlassian__jira_get_issue,mcp__atlassian__jira_add_comment
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
                   prompt: |
-                      You are validating the Jira-driven agent pipeline on ag-charts.
-                      The JIRA ticket key is: ${{ env.ISSUE_KEY }}.
-                      The Actions run URL is: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+                      Invoke /fr --ci --phase 0..1 ${{ env.ISSUE_KEY }}
 
-                      Do exactly these steps and stop:
-
-                        1. Confirm a skill from the ag-dev-prompts marketplace loaded.
-                           Name one skill you can see from the ag-eng or
-                           ag-product plugin (e.g. /jira, /pr-review, /fr).
-                        2. Call the MCP tool `mcp__atlassian__jira_get_issue`
-                           with `issueKey="${{ env.ISSUE_KEY }}"`. Report the
-                           returned summary and status.
-                        3. Call `mcp__atlassian__jira_add_comment` with
-                           `issueKey="${{ env.ISSUE_KEY }}"` and `body` set
-                           exactly to:
-                             "ag-charts triage pipeline E2E test — run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Marketplace loaded; MCP authenticated."
-                        4. Do not transition the ticket. Do not change any other
-                           state. Stop.
+                      Context:
+                        - JIRA ticket: ${{ env.ISSUE_KEY }}
+                        - Actions run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                        - The Atlassian MCP server is the in-repo shim — it
+                          exposes the operation names referenced in modes/ci.md
+                          (getJiraIssue, addCommentToJiraIssue,
+                          getTransitionsForJiraIssue, transitionJiraIssue,
+                          addAttachmentToJiraIssue). No other Jira tools are
+                          available. Phases 2..5 are out of scope.
 
             - name: Upload Claude trace artefact
               if: always()


### PR DESCRIPTION
## Summary

Closes out **Phase 0** of the Jira → GHA agentic pipeline: the full triage access chain is green end-to-end against AG-17421.

Started as a one-line `ANTHROPIC_API_KEY` env → with fix; grew as each dry-run surfaced the next downstream issue. Final state: all five access surfaces validated, `/fr --ci --phase 0..1` runs the full skill contract from a Jira `repository_dispatch`, posts a structured ambiguity comment, attaches `intent.md` / `research.md` / `plan.md`, and transitions the ticket.

## What landed

- `ANTHROPIC_API_KEY` passed via `with:` (action ignores env-level keys).
- `plugin_marketplaces` switched to full HTTPS `.git` URL form (shorthand rejected by the action).
- Global `git config url.<token>.insteadOf` bridge for the marketplace clone — **resolves OQ#1**: `claude-code-action` does not forward `github_token` to its plugin marketplace clone. Bridge covers both `setup-prompts.sh`'s `fetch.sh` (postinstall) and Claude Code's marketplace resolver at agent runtime.
- In-repo Jira MCP shim (`.github/scripts/jira-mcp-shim/server.mjs`) — **resolves OQ#2**: `@atlassian/mcp-server` doesn't exist; Atlassian's hosted MCP is OAuth-only (incompatible with our basic-auth credentials). Zero-dep Node stdio server exposing the five operations `/fr --ci` calls (`getJiraIssue`, `addCommentToJiraIssue`, `getTransitionsForJiraIssue`, `transitionJiraIssue`, `addAttachmentToJiraIssue`).
- `setup-nx` reused; `.claude/settings.json` sanitised for CI (strip local-dev hooks; keep `permissions.allow`, marketplace, ag-dev-only plugins).
- Dropped invalid `--output-format-file` / `--output-format stream-json` `claude` CLI flags (caused SDK init crash); rely on `claude-execution-output.json` artefact instead.
- Plugin install uses settings-declared name `ag-dev` (not the URL-derived `ag-dev-prompts`).
- `--allowed-tools` whitelist for the five MCP shim operations (CI is non-interactive — un-whitelisted tools fail closed).
- `validate-issue-key` step + per-surface PASS/FAIL summary table.

## Verification

| Surface | Result |
|---|---|
| Issue key validated | ✅ |
| GitHub App token mint | ✅ |
| Token covers both repos | ✅ |
| `yarn install` + setup-prompts | ✅ |
| Atlassian MCP config written | ✅ |
| Claude run (marketplace + MCP call) | ✅ |

- Run [26282352398](https://github.com/ag-grid/ag-charts/actions/runs/26282352398) — first full green; marketplace skills visible, shim tools called, comment posted on AG-17421.
- Runs [26282685024](https://github.com/ag-grid/ag-charts/actions/runs/26282685024) + [26282686190](https://github.com/ag-grid/ag-charts/actions/runs/26282686190) — **AC7 (concurrency)**: two dispatches with same `issue_key`, second held `pending` ~83s, both succeeded, no interleaving.
- Run [26283357741](https://github.com/ag-grid/ag-charts/actions/runs/26283357741) — `/fr --ci --phase 0..1` end-to-end against AG-17421: **7m56s, $4.11**. Skill produced `intent.md` / `research.md` / `plan.md` as Jira attachments, posted structured open-questions comment (4 questions), transitioned `To Do` → `Needs Review`, exited 0.

## Open questions resolved

- **OQ#1** (`github_token` forwarded to marketplace clone) — **No**. Bridge via `git config url.insteadOf` with the App-installation token.
- **OQ#2** (`@atlassian/mcp-server` package name) — **Package doesn't exist**; replaced with in-repo Node stdio shim.
- **OQ#3** (YAML literal-block `claude_args` arrives multi-line) — **Yes**, confirmed in the action's input echo.
- **OQ#4** (`@latest` vs `@canary` marketplace ref) — Neither passed via action input; channel is pinned in `.claude/settings.json` by `setup-prompts.sh`.

## Out of scope (follow-up branch)

- Build stage (`/fr --ci --phase 2..5 --resume --draft-pr`).
- PR-iterate workflow on `pull_request_review_comment`.
- Cost writeback (`customfield_ai_cost_usd_total`) — composite action.
- AI status custom field (`customfield_ai_status`).
- Mechanical Jira-attachment pull/push around the agent run.
- Jira Automation rule (label → dispatch) — deferred; dry-run path used so far.
- Node-24 actions bump (June 2026 forced upgrade; mechanical).

## Tracking

[AG-17426](https://ag-grid.atlassian.net/browse/AG-17426).
