### PR TITLE
AG-17156 - Clean up sitemap for SEO

### DIFF
--- a/packages/ag-charts-website/src/utils/sitemap.ts
+++ b/packages/ag-charts-website/src/utils/sitemap.ts
@@ -70,8 +70,12 @@ const filterIgnoredPages = (page: string) => {
 export function getSitemapConfig() {
     return {
         filter: filterIgnoredPages,
-        changefreq: 'daily',
-        priority: 0.7,
         lastmod: new Date(),
+        namespaces: {
+            news: false,
+            xhtml: false,
+            image: false,
+            video: false,
+        },
     };
 }


### PR DESCRIPTION
## Summary

Port of ag-grid/ag-grid#13832 to ag-charts. SEO clean-up of the generated `sitemap-0.xml`:

- Drop the `changefreq: 'daily'` and `priority: 0.7` defaults (Google ignores both).
- Disable the unused `xmlns:news`, `xmlns:xhtml`, `xmlns:image`, `xmlns:video` namespaces on the root `<urlset>` element via the `namespaces` option of `@astrojs/sitemap` (3.7.2).

The charts site doesn't emit news, image, video, or `<xhtml:link>` (hreflang) entries, so none of those namespaces are needed.

## Test plan

- [ ] `nx build ag-charts-website --clean-cache=true --run-second-build=true` and inspect `dist/charts/sitemap-0.xml` — confirm the `<urlset>` no longer carries the four `xmlns:*` attributes, and that `<url>` entries no longer contain `<changefreq>` or `<priority>`.
- [ ] Verify the `<loc>` list is unchanged compared to `latest`.