### PR TITLE
jira-pipeline: trace digest, heartbeat, model+effort override, triage-completion comment

### DIFF
--- a/.github/actions/jira-model-pick/action.yml
+++ b/.github/actions/jira-model-pick/action.yml
@@ -1,0 +1,145 @@
+name: Jira model + effort pick
+description: |
+    Resolve the Anthropic model ID and effort level for the agent step
+    on this ticket. Reads the two overridable Jira fields and falls back
+    to per-stage defaults when they are empty.
+
+      customfield_10985 — AI model         (free-text; e.g. claude-opus-4-7[1m])
+      customfield_10986 — AI model effort  (free-text; one of low|medium|high|xhigh|max)
+
+    Unknown values do not fail the job: they are logged as a warning to
+    the step summary and the default is used. This keeps a typo from
+    silently spending at the wrong tier without blocking the run on a
+    chore-level mistake. The agent's writeback step still records what
+    was actually used.
+
+    Triage does not call this action — it always runs at the highest
+    capability tier (`claude-opus-4-7[1m]` + `high`) so the
+    recommendation it writes for downstream stages is trustworthy.
+
+inputs:
+    issue_key:
+        description: JIRA issue key (e.g. AG-12345).
+        required: true
+    default_model:
+        description: Per-stage default model ID.
+        required: true
+    default_effort:
+        description: Per-stage default effort level.
+        required: true
+    jira_email:
+        required: true
+    jira_api_token:
+        required: true
+    jira_site_url:
+        required: true
+
+outputs:
+    model:
+        description: Model ID to pass as ANTHROPIC_MODEL.
+        value: ${{ steps.pick.outputs.model }}
+    effort:
+        description: Effort level to pass as CLAUDE_CODE_EFFORT_LEVEL.
+        value: ${{ steps.pick.outputs.effort }}
+
+runs:
+    using: composite
+    steps:
+        - id: pick
+          shell: bash
+          env:
+              ISSUE_KEY: ${{ inputs.issue_key }}
+              DEFAULT_MODEL: ${{ inputs.default_model }}
+              DEFAULT_EFFORT: ${{ inputs.default_effort }}
+              JIRA_USER_EMAIL: ${{ inputs.jira_email }}
+              JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+              JIRA_SITE_URL: ${{ inputs.jira_site_url }}
+          run: |
+              set -euo pipefail
+              : "${ISSUE_KEY:?}" "${DEFAULT_MODEL:?}" "${DEFAULT_EFFORT:?}"
+              : "${JIRA_USER_EMAIL:?}" "${JIRA_API_TOKEN:?}" "${JIRA_SITE_URL:?}"
+
+              # Whitelist — keep narrow. Add new model IDs explicitly as
+              # Anthropic ships them rather than accepting arbitrary
+              # strings, so a typo (e.g. `opus-4.7` vs `opus-4-7`) is
+              # caught as "unknown" and falls back instead of being passed
+              # through to Anthropic with a runtime 4xx.
+              KNOWN_MODELS=(
+                  "claude-opus-4-7[1m]"
+                  "claude-opus-4-7"
+                  "claude-opus-4-6"
+                  "claude-sonnet-4-6[1m]"
+                  "claude-sonnet-4-6"
+                  "claude-haiku-4-5"
+              )
+              KNOWN_EFFORTS=(low medium high xhigh max)
+
+              SITE="${JIRA_SITE_URL%/}"
+              AUTH="$(printf '%s:%s' "$JIRA_USER_EMAIL" "$JIRA_API_TOKEN" | base64 | tr -d '\n')"
+
+              # Fetch both override fields in a single GET.
+              HTTP=$(curl -sS -o /tmp/model-pick.json -w '%{http_code}' \
+                  -H "authorization: Basic $AUTH" \
+                  -H 'accept: application/json' \
+                  "$SITE/rest/api/2/issue/$ISSUE_KEY?fields=customfield_10985,customfield_10986")
+              if [[ "$HTTP" != "200" ]]; then
+                  echo "[model-pick] WARNING: GET failed (HTTP $HTTP); using stage defaults." >&2
+                  cat /tmp/model-pick.json >&2 || true
+                  RAW_MODEL=""
+                  RAW_EFFORT=""
+              else
+                  RAW_MODEL=$(jq -r '.fields.customfield_10985 // ""' /tmp/model-pick.json)
+                  RAW_EFFORT=$(jq -r '.fields.customfield_10986 // ""' /tmp/model-pick.json)
+              fi
+
+              # Resolve model.
+              MODEL_SOURCE="default"
+              MODEL="$DEFAULT_MODEL"
+              MODEL_WARN=""
+              if [[ -n "$RAW_MODEL" ]]; then
+                  ok=0
+                  for m in "${KNOWN_MODELS[@]}"; do
+                      if [[ "$RAW_MODEL" == "$m" ]]; then ok=1; break; fi
+                  done
+                  if (( ok )); then
+                      MODEL="$RAW_MODEL"
+                      MODEL_SOURCE="jira (AI model)"
+                  else
+                      MODEL_WARN="unknown value \"$RAW_MODEL\" — falling back to default \"$DEFAULT_MODEL\""
+                      echo "[model-pick] WARNING: AI model field $MODEL_WARN" >&2
+                  fi
+              fi
+
+              # Resolve effort.
+              EFFORT_SOURCE="default"
+              EFFORT="$DEFAULT_EFFORT"
+              EFFORT_WARN=""
+              if [[ -n "$RAW_EFFORT" ]]; then
+                  ok=0
+                  for e in "${KNOWN_EFFORTS[@]}"; do
+                      if [[ "$RAW_EFFORT" == "$e" ]]; then ok=1; break; fi
+                  done
+                  if (( ok )); then
+                      EFFORT="$RAW_EFFORT"
+                      EFFORT_SOURCE="jira (AI model effort)"
+                  else
+                      EFFORT_WARN="unknown value \"$RAW_EFFORT\" — falling back to default \"$DEFAULT_EFFORT\""
+                      echo "[model-pick] WARNING: AI model effort field $EFFORT_WARN" >&2
+                  fi
+              fi
+
+              echo "model=$MODEL"   >> "$GITHUB_OUTPUT"
+              echo "effort=$EFFORT" >> "$GITHUB_OUTPUT"
+
+              {
+                  echo "## Model + effort"
+                  echo ""
+                  echo "| Knob | Value | Source |"
+                  echo "|---|---|---|"
+                  echo "| Model  | \`$MODEL\`  | $MODEL_SOURCE |"
+                  echo "| Effort | \`$EFFORT\` | $EFFORT_SOURCE |"
+                  if [[ -n "$MODEL_WARN" ]];  then echo ""; echo "> ⚠ AI model: $MODEL_WARN"; fi
+                  if [[ -n "$EFFORT_WARN" ]]; then echo ""; echo "> ⚠ AI model effort: $EFFORT_WARN"; fi
+              } >> "$GITHUB_STEP_SUMMARY"
+
+              echo "[model-pick] model=$MODEL ($MODEL_SOURCE)  effort=$EFFORT ($EFFORT_SOURCE)"

--- a/.github/actions/jira-progress-tail/action.yml
+++ b/.github/actions/jira-progress-tail/action.yml
@@ -1,0 +1,205 @@
+name: Jira progress heartbeat tail
+description: |
+    Stream the agent's step-by-step progress to two JIRA fields while
+    the agent is running:
+
+      AI progress %  (number)    — step / total * 100
+      AI activity    (short text) — short human-readable label
+
+    Contract: the agent (skill side, in ag-dev-prompts) appends one
+    JSONL line per significant action to
+    `tmp/fr-state/<KEY>/heartbeat.jsonl`, e.g.:
+
+      {"t":"2026-05-22T22:01:00Z","step":3,"total":12,"label":"Editing rainbowLight.ts","tool":"Edit"}
+
+    `step`, `total`, and `label` are required; other fields are
+    ignored. Workflow tails the file in the background, POSTing each
+    new line's `(step, total, label)` to JIRA. `total` may be revised
+    mid-run if the agent updates its plan — the next heartbeat's
+    `total` overrides the prior estimate (% can briefly go backwards;
+    honest signal of replanning).
+
+    This action has two modes:
+
+      `start` — spawns a background tailer; writes its PID to
+                `${RUNNER_TEMP}/jira-progress-tail.pid`. Returns immediately.
+                Idempotent: if the heartbeat file doesn't exist yet, the
+                tailer waits for it (tail -F semantics).
+
+      `stop`  — reads the PID file and kills the tailer; flushes one final
+                POST with the latest heartbeat if any was written. Never
+                fails the job — telemetry is best-effort.
+
+    No-op (no JIRA writes) if either field-id input is empty, so this
+    can be wired in before the JIRA admin completes the field
+    creation.
+
+inputs:
+    issue_key:
+        description: JIRA issue key.
+        required: true
+    mode:
+        description: '`start` or `stop`.'
+        required: true
+    progress_field_id:
+        description: Custom field ID for `AI progress %` (e.g. `customfield_10987`). Empty = disable.
+        required: false
+        default: ''
+    activity_field_id:
+        description: Custom field ID for `AI activity` (e.g. `customfield_10988`). Empty = disable.
+        required: false
+        default: ''
+    heartbeat_path:
+        description: Path to heartbeat.jsonl. Defaults to ${GITHUB_WORKSPACE}/tmp/fr-state/<KEY>/heartbeat.jsonl.
+        required: false
+        default: ''
+    poll_seconds:
+        description: Minimum seconds between JIRA writes (rate-limit).
+        required: false
+        default: '15'
+    jira_email:
+        required: true
+    jira_api_token:
+        required: true
+    jira_site_url:
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Progress tail (${{ inputs.mode }})
+          shell: bash
+          env:
+              ISSUE_KEY: ${{ inputs.issue_key }}
+              MODE: ${{ inputs.mode }}
+              PROGRESS_FIELD: ${{ inputs.progress_field_id }}
+              ACTIVITY_FIELD: ${{ inputs.activity_field_id }}
+              HEARTBEAT_PATH_IN: ${{ inputs.heartbeat_path }}
+              POLL_SECONDS: ${{ inputs.poll_seconds }}
+              JIRA_USER_EMAIL: ${{ inputs.jira_email }}
+              JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+              JIRA_SITE_URL: ${{ inputs.jira_site_url }}
+          run: |
+              set -euo pipefail
+              : "${ISSUE_KEY:?}" "${MODE:?}"
+              PID_FILE="${RUNNER_TEMP}/jira-progress-tail.pid"
+              LOG_FILE="${RUNNER_TEMP}/jira-progress-tail.log"
+
+              HEARTBEAT="$HEARTBEAT_PATH_IN"
+              if [[ -z "$HEARTBEAT" ]]; then
+                  HEARTBEAT="${GITHUB_WORKSPACE}/tmp/fr-state/${ISSUE_KEY}/heartbeat.jsonl"
+              fi
+
+              if [[ "$MODE" == "stop" ]]; then
+                  if [[ -f "$PID_FILE" ]]; then
+                      PID=$(cat "$PID_FILE" 2>/dev/null || true)
+                      if [[ -n "${PID:-}" ]] && kill -0 "$PID" 2>/dev/null; then
+                          kill "$PID" 2>/dev/null || true
+                          # Give the tailer one second to drain its final write.
+                          sleep 1
+                      fi
+                      rm -f "$PID_FILE"
+                  fi
+                  if [[ -f "$LOG_FILE" ]]; then
+                      echo "## Progress tail log"
+                      echo ""
+                      echo '```'
+                      tail -n 40 "$LOG_FILE" || true
+                      echo '```'
+                  fi >> "$GITHUB_STEP_SUMMARY"
+                  exit 0
+              fi
+
+              if [[ "$MODE" != "start" ]]; then
+                  echo "[progress-tail] unknown mode: $MODE" >&2
+                  exit 1
+              fi
+
+              if [[ -z "$PROGRESS_FIELD" && -z "$ACTIVITY_FIELD" ]]; then
+                  echo "[progress-tail] no field IDs configured — skipping (set vars.JIRA_PROGRESS_FIELD_ID / vars.JIRA_ACTIVITY_FIELD_ID to enable)"
+                  exit 0
+              fi
+
+              mkdir -p "$(dirname "$HEARTBEAT")"
+              touch "$HEARTBEAT" # so tail -F can attach immediately
+
+              SITE="${JIRA_SITE_URL%/}"
+              AUTH="$(printf '%s:%s' "$JIRA_USER_EMAIL" "$JIRA_API_TOKEN" | base64 | tr -d '\n')"
+
+              # Background worker. Reads heartbeat lines as they're written,
+              # rate-limits JIRA PUTs to one every $POLL_SECONDS to avoid
+              # hammering the issue's audit log. Each "drain" picks the
+              # newest line in the window so partial progress is never lost.
+              (
+                  exec >>"$LOG_FILE" 2>&1
+                  echo "[progress-tail] started at $(date -u +%Y-%m-%dT%H:%M:%SZ); watching $HEARTBEAT"
+                  LAST_PUT=0
+                  LATEST_RAW=""
+                  # `tail -F` keeps following across recreation. `--lines=+1`
+                  # picks up anything already in the file (e.g. lines the
+                  # agent wrote before tailer was ready).
+                  tail -n +1 -F "$HEARTBEAT" 2>/dev/null | while IFS= read -r line; do
+                      [[ -z "$line" ]] && continue
+                      LATEST_RAW="$line"
+                      NOW=$(date +%s)
+                      if (( NOW - LAST_PUT < POLL_SECONDS )); then
+                          continue
+                      fi
+                      LAST_PUT="$NOW"
+                      # Parse with jq; skip malformed.
+                      if ! echo "$LATEST_RAW" | jq -e . >/dev/null 2>&1; then
+                          echo "[progress-tail] skip malformed line: $LATEST_RAW"
+                          continue
+                      fi
+                      STEP=$(echo "$LATEST_RAW"  | jq -r '.step  // empty')
+                      TOTAL=$(echo "$LATEST_RAW" | jq -r '.total // empty')
+                      LABEL=$(echo "$LATEST_RAW" | jq -r '.label // empty')
+                      # Compute % if step+total present; otherwise leave null.
+                      PCT=""
+                      if [[ -n "$STEP" && -n "$TOTAL" && "$TOTAL" != "0" ]]; then
+                          PCT=$(( STEP * 100 / TOTAL ))
+                          if (( PCT > 100 )); then PCT=100; fi
+                          if (( PCT < 0   )); then PCT=0;   fi
+                      fi
+                      # Trim activity label to 250 chars (short-text field cap).
+                      if [[ -n "$LABEL" ]]; then
+                          LABEL=$(printf '%s' "$LABEL" | head -c 250)
+                      fi
+                      # Build the PUT body using jq so any quotes / newlines
+                      # in label are safely escaped.
+                      BODY=$(jq -n \
+                          --arg pf "$PROGRESS_FIELD" \
+                          --arg af "$ACTIVITY_FIELD" \
+                          --arg pct "$PCT" \
+                          --arg label "$LABEL" \
+                          '
+                          { fields: {} }
+                          | if ($pf | length) > 0 and ($pct | length) > 0
+                              then .fields[$pf] = ($pct | tonumber)
+                              else .
+                            end
+                          | if ($af | length) > 0 and ($label | length) > 0
+                              then .fields[$af] = $label
+                              else .
+                            end
+                          ')
+                      # If the body has no fields, skip the PUT.
+                      if [[ "$(echo "$BODY" | jq -r '.fields | length')" == "0" ]]; then
+                          continue
+                      fi
+                      HTTP=$(curl -sS -o /dev/null -w '%{http_code}' \
+                          -X PUT \
+                          -H "authorization: Basic $AUTH" \
+                          -H 'accept: application/json' \
+                          -H 'content-type: application/json' \
+                          --data "$BODY" \
+                          "$SITE/rest/api/2/issue/$ISSUE_KEY")
+                      if [[ "$HTTP" == "204" || "$HTTP" == "200" ]]; then
+                          echo "[progress-tail] $(date -u +%H:%M:%SZ) step=$STEP/$TOTAL pct=$PCT label=\"$LABEL\""
+                      else
+                          echo "[progress-tail] $(date -u +%H:%M:%SZ) PUT failed HTTP $HTTP (step=$STEP/$TOTAL)"
+                      fi
+                  done
+              ) &
+              echo $! > "$PID_FILE"
+              echo "[progress-tail] started pid=$(cat "$PID_FILE"); poll=${POLL_SECONDS}s; heartbeat=$HEARTBEAT"

--- a/.github/actions/jira-progress-tail/action.yml
+++ b/.github/actions/jira-progress-tail/action.yml
@@ -3,7 +3,7 @@ description: |
     Stream the agent's step-by-step progress to two JIRA fields while
     the agent is running:
 
-      customfield_10987 — AI progress (number)    — step / total * 100
+      customfield_10987 — AI progress (number, 0..1) — step / total (Jira renders ×100 as a %)
       customfield_10988 — AI activity (short text) — short human-readable label
 
     Contract: the agent (skill side, in ag-dev-prompts) appends one
@@ -139,12 +139,14 @@ runs:
                       STEP=$(echo "$LATEST_RAW"  | jq -r '.step  // empty')
                       TOTAL=$(echo "$LATEST_RAW" | jq -r '.total // empty')
                       LABEL=$(echo "$LATEST_RAW" | jq -r '.label // empty')
-                      # Compute % if step+total present; otherwise leave null.
+                      # Compute fraction (0..1) if step+total present; the
+                      # AI progress custom field is a number rendered as a
+                      # percentage by Jira (raw 0.83 → "83%"), so do NOT
+                      # multiply by 100 here.
                       PCT=""
                       if [[ -n "$STEP" && -n "$TOTAL" && "$TOTAL" != "0" ]]; then
-                          PCT=$(( STEP * 100 / TOTAL ))
-                          if (( PCT > 100 )); then PCT=100; fi
-                          if (( PCT < 0   )); then PCT=0;   fi
+                          PCT=$(jq -n --argjson s "$STEP" --argjson t "$TOTAL" \
+                              '([$s / $t, 1] | min) | [., 0] | max')
                       fi
                       # Trim activity label to 250 chars (short-text field cap).
                       if [[ -n "$LABEL" ]]; then

--- a/.github/actions/jira-progress-tail/action.yml
+++ b/.github/actions/jira-progress-tail/action.yml
@@ -3,8 +3,8 @@ description: |
     Stream the agent's step-by-step progress to two JIRA fields while
     the agent is running:
 
-      AI progress %  (number)    — step / total * 100
-      AI activity    (short text) — short human-readable label
+      customfield_10987 — AI progress (number)    — step / total * 100
+      customfield_10988 — AI activity (short text) — short human-readable label
 
     Contract: the agent (skill side, in ag-dev-prompts) appends one
     JSONL line per significant action to
@@ -30,10 +30,6 @@ description: |
                 POST with the latest heartbeat if any was written. Never
                 fails the job — telemetry is best-effort.
 
-    No-op (no JIRA writes) if either field-id input is empty, so this
-    can be wired in before the JIRA admin completes the field
-    creation.
-
 inputs:
     issue_key:
         description: JIRA issue key.
@@ -41,14 +37,6 @@ inputs:
     mode:
         description: '`start` or `stop`.'
         required: true
-    progress_field_id:
-        description: Custom field ID for `AI progress %` (e.g. `customfield_10987`). Empty = disable.
-        required: false
-        default: ''
-    activity_field_id:
-        description: Custom field ID for `AI activity` (e.g. `customfield_10988`). Empty = disable.
-        required: false
-        default: ''
     heartbeat_path:
         description: Path to heartbeat.jsonl. Defaults to ${GITHUB_WORKSPACE}/tmp/fr-state/<KEY>/heartbeat.jsonl.
         required: false
@@ -72,8 +60,10 @@ runs:
           env:
               ISSUE_KEY: ${{ inputs.issue_key }}
               MODE: ${{ inputs.mode }}
-              PROGRESS_FIELD: ${{ inputs.progress_field_id }}
-              ACTIVITY_FIELD: ${{ inputs.activity_field_id }}
+              # Hardcoded to match the field IDs created in the AG Jira project.
+              # If the schema ever moves, update both lines here.
+              PROGRESS_FIELD: customfield_10987
+              ACTIVITY_FIELD: customfield_10988
               HEARTBEAT_PATH_IN: ${{ inputs.heartbeat_path }}
               POLL_SECONDS: ${{ inputs.poll_seconds }}
               JIRA_USER_EMAIL: ${{ inputs.jira_email }}
@@ -113,11 +103,6 @@ runs:
               if [[ "$MODE" != "start" ]]; then
                   echo "[progress-tail] unknown mode: $MODE" >&2
                   exit 1
-              fi
-
-              if [[ -z "$PROGRESS_FIELD" && -z "$ACTIVITY_FIELD" ]]; then
-                  echo "[progress-tail] no field IDs configured — skipping (set vars.JIRA_PROGRESS_FIELD_ID / vars.JIRA_ACTIVITY_FIELD_ID to enable)"
-                  exit 0
               fi
 
               mkdir -p "$(dirname "$HEARTBEAT")"

--- a/.github/actions/setup-jira-agent/action.yml
+++ b/.github/actions/setup-jira-agent/action.yml
@@ -181,7 +181,17 @@ runs:
                   "Bash(git push:*)",
                   "Bash(gh pr create:*)"
               ]'
-              jq --argjson extra "$CI_EXTRA_ALLOW" '{
+
+              # Stage the heartbeat hook script to a path that survives the
+              # build job's branch switch — the agent typically checks out
+              # a fresh topic branch (forked from `latest`) which may not
+              # carry `.github/scripts/`, so we copy to RUNNER_TEMP and
+              # reference an absolute path in the hook config.
+              HEARTBEAT_HOOK="${RUNNER_TEMP}/heartbeat-from-tasks.sh"
+              cp .github/scripts/heartbeat-from-tasks.sh "$HEARTBEAT_HOOK"
+              chmod +x "$HEARTBEAT_HOOK"
+
+              jq --argjson extra "$CI_EXTRA_ALLOW" --arg hook "$HEARTBEAT_HOOK" '{
                   env,
                   permissions: (
                       .permissions
@@ -193,7 +203,17 @@ runs:
                       | to_entries
                       | map(select(.key | endswith("@ag-dev")))
                       | from_entries
-                  )
+                  ),
+                  hooks: {
+                      PostToolUse: [
+                          {
+                              matcher: "TaskCreate|TaskUpdate",
+                              hooks: [
+                                  { type: "command", command: $hook }
+                              ]
+                          }
+                      ]
+                  }
               }' /tmp/orig-settings.json > .claude/settings.json
               echo "--- sanitised settings ---"
               cat .claude/settings.json

--- a/.github/actions/setup-jira-agent/action.yml
+++ b/.github/actions/setup-jira-agent/action.yml
@@ -179,7 +179,10 @@ runs:
               CI_EXTRA_ALLOW='[
                   "Bash(git commit:*)",
                   "Bash(git push:*)",
-                  "Bash(gh pr create:*)"
+                  "Bash(gh pr create:*)",
+                  "Read(/home/runner/.claude/plugins/**)",
+                  "Bash(cat /home/runner/.claude/plugins/**)",
+                  "Bash(ls /home/runner/.claude/plugins/**)"
               ]'
 
               # Stage the heartbeat hook script to a path that survives the

--- a/.github/scripts/claude-trace-pretty/tail.mjs
+++ b/.github/scripts/claude-trace-pretty/tail.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// Emit a human-readable digest of a claude-code-action execution trace.
+//
+// The action writes its full event stream to `claude-execution-output.json`
+// as a JSON array. With `show_full_output: 'true'` that array also dumps
+// into the GHA log raw — useful for forensics, useless for "what is the
+// agent doing right now". This script reads the (post-run) trace and
+// emits one short line per interesting event: assistant turns, tool
+// invocations, tool results (size / error only), sub-task spawns, and
+// the final result block.
+//
+// Usage:
+//   node tail.mjs --once  <path-to-claude-execution-output.json>
+//   node tail.mjs --watch <path>      # reserved; falls back to --once
+//
+// Zero-dep, Node 20+.
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { argv, exit, stdout } from 'node:process';
+
+stdout.on('error', (err) => {
+    if (err.code === 'EPIPE') exit(0);
+    throw err;
+});
+
+const args = argv.slice(2);
+const mode = args.includes('--watch') ? 'watch' : 'once';
+const file = args.find((a) => !a.startsWith('--'));
+if (!file) {
+    stderr('usage: tail.mjs [--once|--watch] <claude-execution-output.json>');
+    exit(2);
+}
+
+if (mode === 'watch') {
+    // The trace is written as a single JSON array, not JSONL, so a true
+    // streaming parse would need to track partial array state. Defer that
+    // until we confirm whether claude-code-action flushes incrementally.
+    // For now, poll-until-stable then run --once.
+    waitForStable(file).then(() => runOnce(file));
+} else {
+    runOnce(file);
+}
+
+function runOnce(path) {
+    if (!existsSync(path)) {
+        stderr(`[trace-digest] file not found: ${path}`);
+        exit(0); // not fatal — agent may have aborted before any output
+    }
+    let events;
+    try {
+        events = JSON.parse(readFileSync(path, 'utf8'));
+    } catch (err) {
+        stderr(`[trace-digest] parse error: ${err.message}`);
+        exit(0);
+    }
+    if (!Array.isArray(events)) {
+        stderr(`[trace-digest] expected top-level array; got ${typeof events}`);
+        exit(0);
+    }
+
+    let turn = 0;
+    let cost = 0;
+    const startedAt = firstTimestamp(events);
+    let lastStamp = '[--:--]';
+    for (const e of events) {
+        const fresh = stamp(e, startedAt);
+        if (fresh !== '[--:--]') lastStamp = fresh;
+        const t = fresh === '[--:--]' ? lastStamp : fresh;
+        if (e.type === 'system' && e.subtype === 'init') {
+            const tools = (e.tools || []).length;
+            const mcp = (e.mcp_servers || []).map((s) => `${s.name}=${s.status}`).join(', ');
+            print(`${t} session start: model=${e.model} tools=${tools} mcp=[${mcp}]`);
+            continue;
+        }
+        if (e.type === 'system' && e.subtype === 'task_started') {
+            print(`${t} task spawn (${e.task_type}): ${truncate(e.description, 120)}`);
+            continue;
+        }
+        if (e.type === 'system' && e.subtype === 'task_notification') {
+            const note = e.notification || e.text || '';
+            if (note) print(`${t} task note: ${truncate(note, 120)}`);
+            continue;
+        }
+        if (e.type === 'assistant' && e.message?.content) {
+            turn += 1;
+            for (const c of e.message.content) {
+                if (c.type === 'text' && c.text?.trim()) {
+                    print(`${t} turn ${turn}: ${truncate(c.text.trim().replace(/\s+/g, ' '), 200)}`);
+                } else if (c.type === 'tool_use') {
+                    print(`${t} turn ${turn} tool: ${c.name}(${summariseInput(c.name, c.input)})`);
+                }
+                // 'thinking' blocks are intentionally skipped — signature-encoded, no value to humans.
+            }
+            continue;
+        }
+        if (e.type === 'user' && e.message?.content) {
+            for (const c of e.message.content) {
+                if (c.type !== 'tool_result') continue;
+                const body = typeof c.content === 'string' ? c.content : JSON.stringify(c.content);
+                const size = body?.length ?? 0;
+                if (c.is_error) {
+                    print(`${t}   ↳ error: ${truncate(body || 'unknown', 200)}`);
+                } else {
+                    print(`${t}   ↳ ok (${size} chars)`);
+                }
+            }
+            continue;
+        }
+        if (e.type === 'result') {
+            cost = e.total_cost_usd ?? cost;
+            const status = e.is_error ? 'ERROR' : e.subtype || 'done';
+            const dur = e.duration_ms ? `${(e.duration_ms / 1000).toFixed(0)}s` : '?';
+            print(`${t} result: ${status}  turns=${e.num_turns ?? '?'}  duration=${dur}  cost=$${cost.toFixed(2)}`);
+            if (e.result) {
+                print(`${t} summary:`);
+                for (const line of truncate(e.result, 800).split('\n')) print(`         ${line}`);
+            }
+            continue;
+        }
+    }
+}
+
+function summariseInput(name, input) {
+    if (!input || typeof input !== 'object') return '';
+    // Hand-picked one-line summaries for the noisy tools.
+    if (name === 'Skill') return `${input.skill ?? ''} ${input.args ?? ''}`.trim();
+    if (name === 'Bash') return truncate(input.command || '', 100);
+    if (name === 'Read' || name === 'Edit' || name === 'Write') return truncate(input.file_path || '', 100);
+    if (name === 'Grep' || name === 'Glob') return truncate(input.pattern || input.path || '', 100);
+    if (name?.startsWith('mcp__atlassian__')) {
+        const key = input.issueIdOrKey || input.issueKey || '';
+        return key ? key : truncate(JSON.stringify(input), 100);
+    }
+    if (name === 'TaskCreate') return truncate(input.subject || input.description || '', 100);
+    if (name === 'TaskUpdate') return `#${input.taskId}: ${input.status ?? ''}`.trim();
+    // Default: first interesting string-valued key.
+    for (const [k, v] of Object.entries(input)) {
+        if (typeof v === 'string' && v.length) return `${k}=${truncate(v, 80)}`;
+    }
+    return '';
+}
+
+function truncate(s, n) {
+    if (s == null) return '';
+    const str = String(s);
+    return str.length > n ? str.slice(0, n - 1) + '…' : str;
+}
+
+function firstTimestamp(events) {
+    for (const e of events) {
+        if (e.timestamp) return new Date(e.timestamp).getTime();
+        if (e.message?.created_at) return new Date(e.message.created_at).getTime();
+    }
+    return null;
+}
+
+function stamp(e, base) {
+    const ts = e.timestamp || e.message?.created_at;
+    if (!ts || !base) return '[--:--]';
+    const ms = new Date(ts).getTime() - base;
+    if (Number.isNaN(ms) || ms < 0) return '[--:--]';
+    const s = Math.floor(ms / 1000);
+    return `[${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}]`;
+}
+
+function print(line) {
+    stdout.write(line + '\n');
+}
+
+function stderr(line) {
+    process.stderr.write(line + '\n');
+}
+
+async function waitForStable(path) {
+    let last = -1;
+    for (let i = 0; i < 30; i += 1) {
+        if (existsSync(path)) {
+            const sz = statSync(path).size;
+            if (sz > 0 && sz === last) return;
+            last = sz;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+    }
+}

--- a/.github/scripts/heartbeat-from-tasks.sh
+++ b/.github/scripts/heartbeat-from-tasks.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# PostToolUse hook: derive a heartbeat.jsonl line from TaskCreate /
+# TaskUpdate events and append it to the live progress stream.
+#
+# The workflow's jira-progress-tail action tails heartbeat.jsonl and
+# posts step/total*100 to the ticket's `AI progress` field and the
+# label to `AI activity`. This hook is what makes those fields fill
+# in for free — the agent just uses TaskCreate / TaskUpdate as it
+# normally would, and progress telemetry follows.
+#
+# Event JSON arrives on stdin:
+#
+#   {
+#     "session_id":   "...",
+#     "tool_name":    "TaskCreate" | "TaskUpdate",
+#     "tool_input":   { subject?, description?, taskId?, status?, ... },
+#     "tool_response": { ... }
+#   }
+#
+# State lives in <STATE_DIR>/.task-counters.json:
+#
+#   {
+#     "total":     N,
+#     "completed": M,
+#     "subjects":  { "<task_id>": "<subject>", ... }
+#   }
+#
+# Both files are workspace-relative — the hook resolves STATE_DIR
+# from the HEARTBEAT_STATE_DIR env var that the workflow sets on the
+# claude-code-action step. If unset (local invocation, or env not
+# propagated for some reason), the hook no-ops with a friendly log
+# line — never fails the agent.
+
+set -euo pipefail
+
+STATE_DIR="${HEARTBEAT_STATE_DIR:-}"
+if [[ -z "$STATE_DIR" ]]; then
+    echo "[heartbeat-hook] HEARTBEAT_STATE_DIR unset; skipping" >&2
+    exit 0
+fi
+
+mkdir -p "$STATE_DIR"
+COUNTERS="$STATE_DIR/.task-counters.json"
+HEARTBEAT="$STATE_DIR/heartbeat.jsonl"
+
+if [[ ! -f "$COUNTERS" ]]; then
+    echo '{"total":0,"completed":0,"subjects":{}}' > "$COUNTERS"
+fi
+
+# stdin is the event payload. `cat` once, reuse.
+EVENT="$(cat)"
+if [[ -z "$EVENT" ]]; then
+    echo "[heartbeat-hook] empty stdin; skipping" >&2
+    exit 0
+fi
+
+TOOL=$(echo "$EVENT" | jq -r '.tool_name // empty')
+case "$TOOL" in
+    TaskCreate)
+        SUBJECT=$(echo "$EVENT" | jq -r '.tool_input.subject // .tool_input.description // ""')
+        # Some Task tool shapes return the new task id under tool_response.taskId or .id.
+        NEW_ID=$(echo "$EVENT" | jq -r '.tool_response.taskId // .tool_response.id // empty')
+        UPDATED=$(jq --arg id "$NEW_ID" --arg subj "$SUBJECT" '
+            .total += 1
+            | if ($id | length) > 0 then .subjects[$id] = $subj else . end
+        ' "$COUNTERS")
+        echo "$UPDATED" > "$COUNTERS"
+        TOTAL=$(echo "$UPDATED" | jq '.total')
+        COMPLETED=$(echo "$UPDATED" | jq '.completed')
+        LABEL="Task created: ${SUBJECT}"
+        ;;
+    TaskUpdate)
+        TASK_ID=$(echo "$EVENT" | jq -r '.tool_input.taskId // empty')
+        NEW_STATUS=$(echo "$EVENT" | jq -r '.tool_input.status // empty')
+        # If status field absent, this is a non-status edit — ignore.
+        if [[ -z "$NEW_STATUS" ]]; then
+            exit 0
+        fi
+        # Look up the task's subject for a nicer label.
+        SUBJECT=$(jq -r --arg id "$TASK_ID" '.subjects[$id] // ""' "$COUNTERS")
+        UPDATED="$(cat "$COUNTERS")"
+        if [[ "$NEW_STATUS" == "completed" ]]; then
+            UPDATED=$(echo "$UPDATED" | jq '.completed += 1')
+            echo "$UPDATED" > "$COUNTERS"
+        fi
+        TOTAL=$(echo "$UPDATED" | jq '.total')
+        COMPLETED=$(echo "$UPDATED" | jq '.completed')
+        if [[ -n "$SUBJECT" ]]; then
+            LABEL="${NEW_STATUS}: ${SUBJECT}"
+        else
+            LABEL="Task ${TASK_ID:-?}: ${NEW_STATUS}"
+        fi
+        ;;
+    *)
+        # Hook matcher should have filtered, but be defensive.
+        exit 0
+        ;;
+esac
+
+# `total` is always ≥ 1 here (we just bumped it on TaskCreate, or this
+# is an update against an existing task). Be defensive.
+if (( TOTAL < 1 )); then TOTAL=1; fi
+
+# Emit the heartbeat line.
+jq -nc \
+    --argjson step "$COMPLETED" \
+    --argjson total "$TOTAL" \
+    --arg label "$LABEL" \
+    --arg tool "$TOOL" \
+    '{step:$step, total:$total, label:$label, tool:$tool}' \
+    >> "$HEARTBEAT"

--- a/.github/scripts/jira-mcp-shim/server.mjs
+++ b/.github/scripts/jira-mcp-shim/server.mjs
@@ -13,13 +13,15 @@
 //   - addCommentToJiraIssue       — POST /rest/api/3/issue/{key}/comment
 //   - getTransitionsForJiraIssue  — GET  /rest/api/3/issue/{key}/transitions
 //   - transitionJiraIssue         — POST /rest/api/3/issue/{key}/transitions
-//   - addAttachmentToJiraIssue    — POST /rest/api/3/issue/{key}/attachments (multipart)
 //   - listAttachmentsForJiraIssue — GET  /rest/api/3/issue/{key}?fields=attachment
+//
+// Attachment uploads are deliberately not exposed: the /fr --ci pipeline
+// round-trips state files (intent / research / plan / decisions / progress /
+// review-feedback) via Jira textarea custom fields, so the agent has no
+// reason to attach them as files.
 //
 // Auth: basic auth from env: JIRA_USER_EMAIL + JIRA_API_TOKEN.
 // Site: JIRA_SITE_URL (e.g. https://ag-grid.atlassian.net).
-import { readFile } from 'node:fs/promises';
-import { basename } from 'node:path';
 import { createInterface } from 'node:readline';
 
 const PROTOCOL_VERSION = '2025-06-18';
@@ -116,24 +118,6 @@ const TOOLS = [
             required: ['issueIdOrKey'],
         },
     },
-    {
-        name: 'addAttachmentToJiraIssue',
-        description:
-            'Attach a file to a Jira issue. Provide either filePath (read from disk) or fileContent (string body).',
-        inputSchema: {
-            type: 'object',
-            properties: {
-                issueIdOrKey: { type: 'string', description: 'JIRA issue key or id.' },
-                filePath: { type: 'string', description: 'Absolute path to a file on the runner.' },
-                fileContent: { type: 'string', description: 'Alternative to filePath: inline content.' },
-                fileName: {
-                    type: 'string',
-                    description: 'Filename to record on the attachment. Defaults to basename(filePath).',
-                },
-            },
-            required: ['issueIdOrKey'],
-        },
-    },
 ];
 
 const HANDLERS = {
@@ -198,37 +182,6 @@ const HANDLERS = {
             transition: { id: transitionId },
         });
         return `Transition ${transitionId} applied to ${issueIdOrKey}`;
-    },
-    async addAttachmentToJiraIssue({ issueIdOrKey, filePath, fileContent, fileName }) {
-        let buf;
-        let name = fileName;
-        if (filePath) {
-            buf = await readFile(filePath);
-            if (!name) name = basename(filePath);
-        } else if (typeof fileContent === 'string') {
-            buf = Buffer.from(fileContent, 'utf8');
-            if (!name) throw new Error('fileName is required when using fileContent');
-        } else {
-            throw new Error('Provide filePath or fileContent');
-        }
-        const form = new FormData();
-        form.append('file', new Blob([buf]), name);
-        const res = await fetch(`${SITE}/rest/api/3/issue/${encodeURIComponent(issueIdOrKey)}/attachments`, {
-            method: 'POST',
-            headers: {
-                authorization: AUTH,
-                accept: 'application/json',
-                'x-atlassian-token': 'no-check',
-            },
-            body: form,
-        });
-        if (!res.ok) {
-            const text = await res.text().catch(() => '');
-            throw new Error(`Attachment upload HTTP ${res.status}: ${text.slice(0, 500)}`);
-        }
-        const data = await res.json();
-        const ids = Array.isArray(data) ? data.map((d) => d.id).join(',') : data.id;
-        return `Attached ${name} (id: ${ids})`;
     },
 };
 

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -216,6 +216,7 @@ jobs:
                       ag-product@ag-dev
                   claude_args: |
                       --mcp-config ${{ steps.setup.outputs.mcp_config }}
+                      --add-dir /home/runner/.claude/plugins
                       --max-turns 20
                       --debug
                       --permission-mode acceptEdits
@@ -419,6 +420,7 @@ jobs:
                       ag-product@ag-dev
                   claude_args: |
                       --mcp-config ${{ steps.setup.outputs.mcp_config }}
+                      --add-dir /home/runner/.claude/plugins
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
@@ -625,6 +627,7 @@ jobs:
                       ag-product@ag-dev
                   claude_args: |
                       --mcp-config ${{ steps.setup.outputs.mcp_config }}
+                      --add-dir /home/runner/.claude/plugins
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
@@ -899,6 +902,7 @@ jobs:
                       ag-product@ag-dev
                   claude_args: |
                       --mcp-config ${{ steps.setup.outputs.mcp_config }}
+                      --add-dir /home/runner/.claude/plugins
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -58,11 +58,10 @@ name: Jira Agent Pipeline
 #                                                    to per-stage default)
 #   customfield_10986  AI model effort  textfield  (same flow as AI model;
 #                                                    valid: low|medium|high|xhigh|max)
-#   <vars.JIRA_PROGRESS_FIELD_ID>  AI progress %   number     (live %-of-current-stage;
-#                                                              written by progress-tail
-#                                                              from heartbeat.jsonl)
-#   <vars.JIRA_ACTIVITY_FIELD_ID>  AI activity     short text (live "what is it doing"
-#                                                              label; same source)
+#   customfield_10987  AI progress      number     (live %-of-current-stage; written by
+#                                                    jira-progress-tail from heartbeat.jsonl)
+#   customfield_10988  AI activity      short text (live "what is it doing" label;
+#                                                    same source as AI progress)
 #
 # ----------------------------------------------------------------------------
 # Per-job step skeleton
@@ -189,8 +188,6 @@ jobs:
               with:
                   issue_key: ${{ env.ISSUE_KEY }}
                   mode: start
-                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
-                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
                   jira_email: ${{ secrets.JIRA_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
@@ -381,8 +378,6 @@ jobs:
               with:
                   issue_key: ${{ env.ISSUE_KEY }}
                   mode: start
-                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
-                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
                   jira_email: ${{ secrets.JIRA_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
@@ -586,8 +581,6 @@ jobs:
               with:
                   issue_key: ${{ env.ISSUE_KEY }}
                   mode: start
-                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
-                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
                   jira_email: ${{ secrets.JIRA_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
@@ -859,8 +852,6 @@ jobs:
               with:
                   issue_key: ${{ env.ISSUE_KEY }}
                   mode: start
-                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
-                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
                   jira_email: ${{ secrets.JIRA_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -216,7 +216,7 @@ jobs:
                       ag-product@ag-dev
                   claude_args: |
                       --mcp-config ${{ steps.setup.outputs.mcp_config }}
-                      --max-turns 12
+                      --max-turns 20
                       --debug
                       --permission-mode acceptEdits
                       --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -52,6 +52,12 @@ name: Jira Agent Pipeline
 #   customfield_10945  AI plan      textarea  <-> plan.md
 #   customfield_10946  AI branch    textfield    (build job populates)
 #   customfield_10947  AI PR URL    textfield    (build job populates)
+#   customfield_10985  AI model         textfield  (triage writes recommendation;
+#                                                    build/pr-iterate/ci-failure
+#                                                    read as override, fall back
+#                                                    to per-stage default)
+#   customfield_10986  AI model effort  textfield  (same flow as AI model;
+#                                                    valid: low|medium|high|xhigh|max)
 #
 # ----------------------------------------------------------------------------
 # Per-job step skeleton
@@ -176,6 +182,14 @@ jobs:
             - name: Run /fr --ci --phase 0..1 (triage)
               id: claude
               uses: anthropics/claude-code-action@v1
+              env:
+                  # Triage always runs at the highest tier — its job is
+                  # to draft intent / research / plan and recommend the
+                  # model + effort downstream stages should use. That
+                  # recommendation is only trustworthy if triage itself
+                  # has full capability headroom.
+                  ANTHROPIC_MODEL: 'claude-opus-4-7[1m]'
+                  CLAUDE_CODE_EFFORT_LEVEL: high
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
@@ -322,6 +336,16 @@ jobs:
             # composite actions after the agent step (which typically
             # checks out a fresh topic branch that lacks them — see the
             # restore step below for the full rationale).
+            - id: model-pick
+              uses: ./.github/actions/jira-model-pick
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  default_model: 'claude-opus-4-7[1m]'
+                  default_effort: medium
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
             - name: Snapshot .github/ before agent
               shell: bash
               run: cp -a .github "${RUNNER_TEMP}/gha-snapshot"
@@ -329,6 +353,9 @@ jobs:
             - name: Run /fr --ci --phase 2..5 --resume --draft-pr (build)
               id: claude
               uses: anthropics/claude-code-action@v1
+              env:
+                  ANTHROPIC_MODEL: ${{ steps.model-pick.outputs.model }}
+                  CLAUDE_CODE_EFFORT_LEVEL: ${{ steps.model-pick.outputs.effort }}
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
@@ -491,6 +518,16 @@ jobs:
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
 
+            - id: model-pick
+              uses: ./.github/actions/jira-model-pick
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  default_model: 'claude-opus-4-7[1m]'
+                  default_effort: high
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
             # See note in the build job — snapshot .github/ so the
             # post-agent composites resolve regardless of branch state.
             - name: Snapshot .github/ before agent
@@ -500,6 +537,9 @@ jobs:
             - name: Run /fr --ci --pr-iterate (pr-iterate)
               id: claude
               uses: anthropics/claude-code-action@v1
+              env:
+                  ANTHROPIC_MODEL: ${{ steps.model-pick.outputs.model }}
+                  CLAUDE_CODE_EFFORT_LEVEL: ${{ steps.model-pick.outputs.effort }}
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
@@ -732,6 +772,16 @@ jobs:
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
 
+            - id: model-pick
+              uses: ./.github/actions/jira-model-pick
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  default_model: 'claude-opus-4-7[1m]'
+                  default_effort: medium
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
             - name: Snapshot .github/ before agent
               shell: bash
               run: cp -a .github "${RUNNER_TEMP}/gha-snapshot"
@@ -739,6 +789,9 @@ jobs:
             - name: Run /fr --ci --pr-iterate --ci-failure (ci-failure-iterate)
               id: claude
               uses: anthropics/claude-code-action@v1
+              env:
+                  ANTHROPIC_MODEL: ${{ steps.model-pick.outputs.model }}
+                  CLAUDE_CODE_EFFORT_LEVEL: ${{ steps.model-pick.outputs.effort }}
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -58,6 +58,11 @@ name: Jira Agent Pipeline
 #                                                    to per-stage default)
 #   customfield_10986  AI model effort  textfield  (same flow as AI model;
 #                                                    valid: low|medium|high|xhigh|max)
+#   <vars.JIRA_PROGRESS_FIELD_ID>  AI progress %   number     (live %-of-current-stage;
+#                                                              written by progress-tail
+#                                                              from heartbeat.jsonl)
+#   <vars.JIRA_ACTIVITY_FIELD_ID>  AI activity     short text (live "what is it doing"
+#                                                              label; same source)
 #
 # ----------------------------------------------------------------------------
 # Per-job step skeleton
@@ -179,6 +184,17 @@ jobs:
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
 
+            - name: Start progress heartbeat tail
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: start
+                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
+                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
             - name: Run /fr --ci --phase 0..1 (triage)
               id: claude
               uses: anthropics/claude-code-action@v1
@@ -236,6 +252,16 @@ jobs:
                           getTransitionsForJiraIssue, transitionJiraIssue,
                           addAttachmentToJiraIssue). No other Jira tools are
                           available. Phases 2..5 are out of scope.
+
+            - name: Stop progress heartbeat tail
+              if: always()
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: stop
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
 
             - name: Human-readable trace digest
               if: always()
@@ -350,6 +376,17 @@ jobs:
               shell: bash
               run: cp -a .github "${RUNNER_TEMP}/gha-snapshot"
 
+            - name: Start progress heartbeat tail
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: start
+                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
+                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
             - name: Run /fr --ci --phase 2..5 --resume --draft-pr (build)
               id: claude
               uses: anthropics/claude-code-action@v1
@@ -413,6 +450,16 @@ jobs:
                   else
                       echo "[restore] no snapshot found at ${RUNNER_TEMP}/gha-snapshot" >&2
                   fi
+
+            - name: Stop progress heartbeat tail
+              if: always()
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: stop
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
 
             - name: Human-readable trace digest
               if: always()
@@ -534,6 +581,17 @@ jobs:
               shell: bash
               run: cp -a .github "${RUNNER_TEMP}/gha-snapshot"
 
+            - name: Start progress heartbeat tail
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: start
+                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
+                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
             - name: Run /fr --ci --pr-iterate (pr-iterate)
               id: claude
               uses: anthropics/claude-code-action@v1
@@ -590,6 +648,16 @@ jobs:
                   else
                       echo "[restore] no snapshot found at ${RUNNER_TEMP}/gha-snapshot" >&2
                   fi
+
+            - name: Stop progress heartbeat tail
+              if: always()
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: stop
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
 
             - name: Human-readable trace digest
               if: always()
@@ -786,6 +854,17 @@ jobs:
               shell: bash
               run: cp -a .github "${RUNNER_TEMP}/gha-snapshot"
 
+            - name: Start progress heartbeat tail
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: start
+                  progress_field_id: ${{ vars.JIRA_PROGRESS_FIELD_ID }}
+                  activity_field_id: ${{ vars.JIRA_ACTIVITY_FIELD_ID }}
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
             - name: Run /fr --ci --pr-iterate --ci-failure (ci-failure-iterate)
               id: claude
               uses: anthropics/claude-code-action@v1
@@ -847,6 +926,16 @@ jobs:
                   else
                       echo "[restore] no snapshot found at ${RUNNER_TEMP}/gha-snapshot" >&2
                   fi
+
+            - name: Stop progress heartbeat tail
+              if: always()
+              uses: ./.github/actions/jira-progress-tail
+              with:
+                  issue_key: ${{ env.ISSUE_KEY }}
+                  mode: stop
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
 
             - name: Human-readable trace digest
               if: always()

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -234,21 +234,36 @@ jobs:
                           AI research / AI plan) after you exit. Do not call
                           addAttachmentToJiraIssue for these files — the
                           textareas are the durable form.
-                        - Comment style: keep Jira comments tight, but post
-                          them. Open questions / ambiguity escalation:
-                          MANDATORY whenever ambiguities exist — one bullet
-                          per question, max one line of context per bullet.
-                          The AI* state files are NOT a substitute for the
-                          comment; humans read comments, not textareas.
-                          Per-thread review-feedback audit comments: one
-                          line per thread (`thread <id>: <action>`). Status
-                          / audit comments: a single line; for these only,
-                          do not duplicate what is already in the AI* state
-                          files. If a comment runs past ~10 lines you are
-                          being verbose — cut it.
+                        - MANDATORY triage-completion comment. Before exit,
+                          post exactly one Jira comment using this template
+                          verbatim (substitute the bracketed placeholders;
+                          do not add preamble, do not omit sections):
+
+                              **Triage complete.** Confidence to proceed without HITL: <0..1>
+                              Decision: **<proceed|proceed-with-watch|blocked-on-clarity|escalate-to-human>** — <one-line rationale>
+
+                              # Decisions
+                              - <material judgement call 1 with one-line rationale>
+                              - <...>
+
+                              # Open Questions
+                              - <one bullet per question, max one line of context>
+                              - _None._  (use this literal when there are no open questions)
+
+                          Confidence is your own honest read (0..1). Decision
+                          values: `proceed` = ready for `--phase 2..5`;
+                          `proceed-with-watch` = ready but flagged for human
+                          eyeballs; `blocked-on-clarity` = open questions
+                          must be answered first; `escalate-to-human` = the
+                          ticket is fundamentally unclear or out of scope.
+                          The Decisions section lifts the material entries
+                          from `decisions.md` into a humans-can-skim form —
+                          summarise, do not paste. Other Jira comment
+                          styles (per-thread audit / status) do not apply
+                          here.
                         - The Atlassian MCP server is the in-repo shim — it
                           exposes the operation names referenced in modes/ci.md
-                          (getJiraIssue, addCommentToJiraIssue,
+                          (getJiraIssue, addCommentToJiraIssue, editJiraIssue,
                           getTransitionsForJiraIssue, transitionJiraIssue,
                           addAttachmentToJiraIssue). No other Jira tools are
                           available. Phases 2..5 are out of scope.

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -220,7 +220,7 @@ jobs:
                       --max-turns 20
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue
                   prompt: |
                       Invoke /fr --ci --phase 0..1 ${{ env.ISSUE_KEY }}
 
@@ -424,7 +424,7 @@ jobs:
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue
                   prompt: |
                       Invoke /fr --ci --phase 2..5 --resume --draft-pr ${{ env.ISSUE_KEY }}
 
@@ -631,7 +631,7 @@ jobs:
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue
                   prompt: |
                       Invoke /fr --ci --pr-iterate ${{ env.ISSUE_KEY }}
 
@@ -906,7 +906,7 @@ jobs:
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue
                   prompt: |
                       Invoke /fr --ci --pr-iterate --ci-failure ${{ env.CI_RUN_URL }} ${{ env.ISSUE_KEY }}
 

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -179,7 +179,9 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
-                  show_full_output: 'true'
+                  # The action's raw JSON event stream dumped inline is unreadable; we
+                  # parse the captured artefact into a human digest in a separate step below.
+                  show_full_output: 'false'
                   plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
                   plugins: |
                       ag-eng@ag-dev
@@ -204,12 +206,35 @@ jobs:
                           AI research / AI plan) after you exit. Do not call
                           addAttachmentToJiraIssue for these files — the
                           textareas are the durable form.
+                        - Comment style: keep Jira comments tight. One short
+                          paragraph or a 3–5 bullet list; no preamble, no
+                          restating the user's request. Open questions: one
+                          bullet per question, max one line of context per
+                          bullet. Per-thread review-feedback audit comments:
+                          one line per thread (`thread <id>: <action>`).
+                          Status / audit comments: a single line. Do not
+                          repeat content already written to the AI* state
+                          files. If a comment runs past ~10 lines you are
+                          being verbose — cut it.
                         - The Atlassian MCP server is the in-repo shim — it
                           exposes the operation names referenced in modes/ci.md
                           (getJiraIssue, addCommentToJiraIssue,
                           getTransitionsForJiraIssue, transitionJiraIssue,
                           addAttachmentToJiraIssue). No other Jira tools are
                           available. Phases 2..5 are out of scope.
+
+            - name: Human-readable trace digest
+              if: always()
+              shell: bash
+              run: |
+                  TRACE="${RUNNER_TEMP}/claude-execution-output.json"
+                  if [[ ! -f "$TRACE" ]]; then
+                      echo "[trace-digest] no trace file at $TRACE (agent may have aborted before any output)"
+                      exit 0
+                  fi
+                  echo "::group::Claude execution digest"
+                  node .github/scripts/claude-trace-pretty/tail.mjs --once "$TRACE" | tee -a "$GITHUB_STEP_SUMMARY"
+                  echo "::endgroup::"
 
             - if: always()
               uses: ./.github/actions/jira-state-sync
@@ -307,7 +332,9 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
-                  show_full_output: 'true'
+                  # The action's raw JSON event stream dumped inline is unreadable; we
+                  # parse the captured artefact into a human digest in a separate step below.
+                  show_full_output: 'false'
                   plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
                   plugins: |
                       ag-eng@ag-dev
@@ -330,6 +357,16 @@ jobs:
                           round-trips them to Jira after you exit. Do not call
                           addAttachmentToJiraIssue for these files — the
                           textareas are the durable form.
+                        - Comment style: keep Jira comments tight. One short
+                          paragraph or a 3–5 bullet list; no preamble, no
+                          restating the user's request. Open questions: one
+                          bullet per question, max one line of context per
+                          bullet. Per-thread review-feedback audit comments:
+                          one line per thread (`thread <id>: <action>`).
+                          Status / audit comments: a single line. Do not
+                          repeat content already written to the AI* state
+                          files. If a comment runs past ~10 lines you are
+                          being verbose — cut it.
                         - Phase 4 is skipped; --draft-pr opens the PR in draft.
 
             # Restore .github/ from the runner-temp snapshot taken before
@@ -349,6 +386,19 @@ jobs:
                   else
                       echo "[restore] no snapshot found at ${RUNNER_TEMP}/gha-snapshot" >&2
                   fi
+
+            - name: Human-readable trace digest
+              if: always()
+              shell: bash
+              run: |
+                  TRACE="${RUNNER_TEMP}/claude-execution-output.json"
+                  if [[ ! -f "$TRACE" ]]; then
+                      echo "[trace-digest] no trace file at $TRACE (agent may have aborted before any output)"
+                      exit 0
+                  fi
+                  echo "::group::Claude execution digest"
+                  node .github/scripts/claude-trace-pretty/tail.mjs --once "$TRACE" | tee -a "$GITHUB_STEP_SUMMARY"
+                  echo "::endgroup::"
 
             - if: always()
               uses: ./.github/actions/jira-state-sync
@@ -453,7 +503,9 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
-                  show_full_output: 'true'
+                  # The action's raw JSON event stream dumped inline is unreadable; we
+                  # parse the captured artefact into a human digest in a separate step below.
+                  show_full_output: 'false'
                   plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
                   plugins: |
                       ag-eng@ag-dev
@@ -475,6 +527,16 @@ jobs:
                           to the same files; the workflow round-trips them to
                           Jira after you exit. Do not call addAttachmentToJiraIssue
                           for these files — the textareas are the durable form.
+                        - Comment style: keep Jira comments tight. One short
+                          paragraph or a 3–5 bullet list; no preamble, no
+                          restating the user's request. Open questions: one
+                          bullet per question, max one line of context per
+                          bullet. Per-thread review-feedback audit comments:
+                          one line per thread (`thread <id>: <action>`).
+                          Status / audit comments: a single line. Do not
+                          repeat content already written to the AI* state
+                          files. If a comment runs past ~10 lines you are
+                          being verbose — cut it.
 
             # See note in the build job: restore .github/ from the snapshot
             # so local-path composites resolve regardless of which branch
@@ -488,6 +550,19 @@ jobs:
                   else
                       echo "[restore] no snapshot found at ${RUNNER_TEMP}/gha-snapshot" >&2
                   fi
+
+            - name: Human-readable trace digest
+              if: always()
+              shell: bash
+              run: |
+                  TRACE="${RUNNER_TEMP}/claude-execution-output.json"
+                  if [[ ! -f "$TRACE" ]]; then
+                      echo "[trace-digest] no trace file at $TRACE (agent may have aborted before any output)"
+                      exit 0
+                  fi
+                  echo "::group::Claude execution digest"
+                  node .github/scripts/claude-trace-pretty/tail.mjs --once "$TRACE" | tee -a "$GITHUB_STEP_SUMMARY"
+                  echo "::endgroup::"
 
             - if: always()
               uses: ./.github/actions/jira-state-sync
@@ -667,7 +742,9 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
-                  show_full_output: 'true'
+                  # The action's raw JSON event stream dumped inline is unreadable; we
+                  # parse the captured artefact into a human digest in a separate step below.
+                  show_full_output: 'false'
                   plugin_marketplaces: https://github.com/ag-grid/ag-dev-prompts.git
                   plugins: |
                       ag-eng@ag-dev
@@ -695,6 +772,16 @@ jobs:
                           them to Jira after you exit. Do not call
                           addAttachmentToJiraIssue for these files — the
                           textareas are the durable form.
+                        - Comment style: keep Jira comments tight. One short
+                          paragraph or a 3–5 bullet list; no preamble, no
+                          restating the user's request. Open questions: one
+                          bullet per question, max one line of context per
+                          bullet. Per-thread review-feedback audit comments:
+                          one line per thread (`thread <id>: <action>`).
+                          Status / audit comments: a single line. Do not
+                          repeat content already written to the AI* state
+                          files. If a comment runs past ~10 lines you are
+                          being verbose — cut it.
                         - Do NOT re-request review under --ci-failure; push only.
                           The next main-CI run is the verification.
 
@@ -707,6 +794,19 @@ jobs:
                   else
                       echo "[restore] no snapshot found at ${RUNNER_TEMP}/gha-snapshot" >&2
                   fi
+
+            - name: Human-readable trace digest
+              if: always()
+              shell: bash
+              run: |
+                  TRACE="${RUNNER_TEMP}/claude-execution-output.json"
+                  if [[ ! -f "$TRACE" ]]; then
+                      echo "[trace-digest] no trace file at $TRACE (agent may have aborted before any output)"
+                      exit 0
+                  fi
+                  echo "::group::Claude execution digest"
+                  node .github/scripts/claude-trace-pretty/tail.mjs --once "$TRACE" | tee -a "$GITHUB_STEP_SUMMARY"
+                  echo "::endgroup::"
 
             - if: always()
               uses: ./.github/actions/jira-state-sync

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -203,6 +203,7 @@ jobs:
                   # has full capability headroom.
                   ANTHROPIC_MODEL: 'claude-opus-4-7[1m]'
                   CLAUDE_CODE_EFFORT_LEVEL: high
+                  HEARTBEAT_STATE_DIR: ${{ github.workspace }}/tmp/fr-state/${{ env.ISSUE_KEY }}
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
@@ -388,6 +389,7 @@ jobs:
               env:
                   ANTHROPIC_MODEL: ${{ steps.model-pick.outputs.model }}
                   CLAUDE_CODE_EFFORT_LEVEL: ${{ steps.model-pick.outputs.effort }}
+                  HEARTBEAT_STATE_DIR: ${{ github.workspace }}/tmp/fr-state/${{ env.ISSUE_KEY }}
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
@@ -591,6 +593,7 @@ jobs:
               env:
                   ANTHROPIC_MODEL: ${{ steps.model-pick.outputs.model }}
                   CLAUDE_CODE_EFFORT_LEVEL: ${{ steps.model-pick.outputs.effort }}
+                  HEARTBEAT_STATE_DIR: ${{ github.workspace }}/tmp/fr-state/${{ env.ISSUE_KEY }}
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}
@@ -862,6 +865,7 @@ jobs:
               env:
                   ANTHROPIC_MODEL: ${{ steps.model-pick.outputs.model }}
                   CLAUDE_CODE_EFFORT_LEVEL: ${{ steps.model-pick.outputs.effort }}
+                  HEARTBEAT_STATE_DIR: ${{ github.workspace }}/tmp/fr-state/${{ env.ISSUE_KEY }}
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ steps.setup.outputs.app_token }}

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -219,7 +219,7 @@ jobs:
                       --max-turns 12
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
                   prompt: |
                       Invoke /fr --ci --phase 0..1 ${{ env.ISSUE_KEY }}
 
@@ -234,14 +234,16 @@ jobs:
                           AI research / AI plan) after you exit. Do not call
                           addAttachmentToJiraIssue for these files — the
                           textareas are the durable form.
-                        - Comment style: keep Jira comments tight. One short
-                          paragraph or a 3–5 bullet list; no preamble, no
-                          restating the user's request. Open questions: one
-                          bullet per question, max one line of context per
-                          bullet. Per-thread review-feedback audit comments:
-                          one line per thread (`thread <id>: <action>`).
-                          Status / audit comments: a single line. Do not
-                          repeat content already written to the AI* state
+                        - Comment style: keep Jira comments tight, but post
+                          them. Open questions / ambiguity escalation:
+                          MANDATORY whenever ambiguities exist — one bullet
+                          per question, max one line of context per bullet.
+                          The AI* state files are NOT a substitute for the
+                          comment; humans read comments, not textareas.
+                          Per-thread review-feedback audit comments: one
+                          line per thread (`thread <id>: <action>`). Status
+                          / audit comments: a single line; for these only,
+                          do not duplicate what is already in the AI* state
                           files. If a comment runs past ~10 lines you are
                           being verbose — cut it.
                         - The Atlassian MCP server is the in-repo shim — it
@@ -405,7 +407,7 @@ jobs:
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
                   prompt: |
                       Invoke /fr --ci --phase 2..5 --resume --draft-pr ${{ env.ISSUE_KEY }}
 
@@ -418,14 +420,16 @@ jobs:
                           round-trips them to Jira after you exit. Do not call
                           addAttachmentToJiraIssue for these files — the
                           textareas are the durable form.
-                        - Comment style: keep Jira comments tight. One short
-                          paragraph or a 3–5 bullet list; no preamble, no
-                          restating the user's request. Open questions: one
-                          bullet per question, max one line of context per
-                          bullet. Per-thread review-feedback audit comments:
-                          one line per thread (`thread <id>: <action>`).
-                          Status / audit comments: a single line. Do not
-                          repeat content already written to the AI* state
+                        - Comment style: keep Jira comments tight, but post
+                          them. Open questions / ambiguity escalation:
+                          MANDATORY whenever ambiguities exist — one bullet
+                          per question, max one line of context per bullet.
+                          The AI* state files are NOT a substitute for the
+                          comment; humans read comments, not textareas.
+                          Per-thread review-feedback audit comments: one
+                          line per thread (`thread <id>: <action>`). Status
+                          / audit comments: a single line; for these only,
+                          do not duplicate what is already in the AI* state
                           files. If a comment runs past ~10 lines you are
                           being verbose — cut it.
                         - Phase 4 is skipped; --draft-pr opens the PR in draft.
@@ -609,7 +613,7 @@ jobs:
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
                   prompt: |
                       Invoke /fr --ci --pr-iterate ${{ env.ISSUE_KEY }}
 
@@ -621,14 +625,16 @@ jobs:
                           to the same files; the workflow round-trips them to
                           Jira after you exit. Do not call addAttachmentToJiraIssue
                           for these files — the textareas are the durable form.
-                        - Comment style: keep Jira comments tight. One short
-                          paragraph or a 3–5 bullet list; no preamble, no
-                          restating the user's request. Open questions: one
-                          bullet per question, max one line of context per
-                          bullet. Per-thread review-feedback audit comments:
-                          one line per thread (`thread <id>: <action>`).
-                          Status / audit comments: a single line. Do not
-                          repeat content already written to the AI* state
+                        - Comment style: keep Jira comments tight, but post
+                          them. Open questions / ambiguity escalation:
+                          MANDATORY whenever ambiguities exist — one bullet
+                          per question, max one line of context per bullet.
+                          The AI* state files are NOT a substitute for the
+                          comment; humans read comments, not textareas.
+                          Per-thread review-feedback audit comments: one
+                          line per thread (`thread <id>: <action>`). Status
+                          / audit comments: a single line; for these only,
+                          do not duplicate what is already in the AI* state
                           files. If a comment runs past ~10 lines you are
                           being verbose — cut it.
 
@@ -881,7 +887,7 @@ jobs:
                       --max-turns 60
                       --debug
                       --permission-mode acceptEdits
-                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
+                      --allowed-tools mcp__atlassian__getJiraIssue,mcp__atlassian__addCommentToJiraIssue,mcp__atlassian__editJiraIssue,mcp__atlassian__getTransitionsForJiraIssue,mcp__atlassian__transitionJiraIssue,mcp__atlassian__addAttachmentToJiraIssue
                   prompt: |
                       Invoke /fr --ci --pr-iterate --ci-failure ${{ env.CI_RUN_URL }} ${{ env.ISSUE_KEY }}
 
@@ -899,14 +905,16 @@ jobs:
                           them to Jira after you exit. Do not call
                           addAttachmentToJiraIssue for these files — the
                           textareas are the durable form.
-                        - Comment style: keep Jira comments tight. One short
-                          paragraph or a 3–5 bullet list; no preamble, no
-                          restating the user's request. Open questions: one
-                          bullet per question, max one line of context per
-                          bullet. Per-thread review-feedback audit comments:
-                          one line per thread (`thread <id>: <action>`).
-                          Status / audit comments: a single line. Do not
-                          repeat content already written to the AI* state
+                        - Comment style: keep Jira comments tight, but post
+                          them. Open questions / ambiguity escalation:
+                          MANDATORY whenever ambiguities exist — one bullet
+                          per question, max one line of context per bullet.
+                          The AI* state files are NOT a substitute for the
+                          comment; humans read comments, not textareas.
+                          Per-thread review-feedback audit comments: one
+                          line per thread (`thread <id>: <action>`). Status
+                          / audit comments: a single line; for these only,
+                          do not duplicate what is already in the AI* state
                           files. If a comment runs past ~10 lines you are
                           being verbose — cut it.
                         - Do NOT re-request review under --ci-failure; push only.


### PR DESCRIPTION
## Summary

Stacked on #6900. Operator + agent ergonomics for the Jira → GHA agentic pipeline, plus a clean-state validation pass that surfaced and fixed several first-run paper cuts on top.

## What's in this PR

### Human-readable trace digest

Replaces `claude-code-action`'s raw JSON event stream with a one-line-per-event digest emitted after each agent step. New zero-dep Node script `.github/scripts/claude-trace-pretty/tail.mjs` parses the existing `claude-execution-output.json` artefact and prints session init, assistant turns (with content snippets), tool invocations with condensed args, tool results (size or error), sub-task spawns, and the final result block. Teed to `$GITHUB_STEP_SUMMARY`; wrapped in a `::group::` for foldability. Full artefact untouched.

### Per-stage model + effort with JIRA override

New `.github/actions/jira-model-pick/` composite. Triage is hard-pinned to `claude-opus-4-7[1m]` + `high` (it drives the recommendation; needs full headroom). Build / pr-iterate / ci-failure each get per-stage defaults plus override lookup against the two new Jira fields (`customfield_10985` AI model, `customfield_10986` AI model effort). Unknown values warn + fall back. Step-summary records what actually ran and why.

### Live heartbeat → AI progress + AI activity

Two-part:

- `.github/actions/jira-progress-tail/` composite. `start` mode spawns a background `tail -F` on `tmp/fr-state/<KEY>/heartbeat.jsonl`, rate-limits at one Jira PUT per ~15s, computes `step/total` (0..1; Jira percentage field multiplies ×100 for display) into `customfield_10987` and writes `label` to `customfield_10988`. `stop` mode kills it cleanly.
- `.github/scripts/heartbeat-from-tasks.sh` + a `PostToolUse` hook installed by `setup-jira-agent`. Maintains `.task-counters.json` based on `TaskCreate` / `TaskUpdate` events and writes the heartbeat line for free — no skill-side emission required.

### Mandatory triage-completion comment

Every `/fr --ci --phase 0..1` run now posts exactly one Jira comment using a fixed skeleton:

```
**Triage complete.** Confidence to proceed without HITL: <0..1>
Decision: **<proceed|proceed-with-watch|blocked-on-clarity|escalate-to-human>** — <reason>

# Decisions
- <material judgement calls lifted from decisions.md>

# Open Questions
- <bullets, or "_None._">
```

The workflow's prompt block carries the template directive; the skill-side contract is in [ag-dev-prompts#217](https://github.com/ag-grid/ag-dev-prompts/pull/217) (merged, canary 1.2.37). Bug-type tickets get an additional `# Bug Verification` section.

### Plugin-cache access (sandbox + permission layers)

`claude_args` gains `--add-dir /home/runner/.claude/plugins` so the orchestrator skill's `Read` on `modes/ci.md` / `phases/phase-N.md` succeeds at the sandbox layer; matching `Read(...)` / `Bash(cat ...)` entries on `permissions.allow` cover the prompt layer. Without these, sub-agents burnt their turn budget on rediscovery via the `.rulesync/` fallback path.

### Triage `--max-turns` headroom

Bumped 12 → 20 to give room for the mandatory completion comment + AI model writeback alongside the regular Phase 0 + Phase 1 work.

## Validation

Eight rounds on AG-17421 (clean state each time):

- Run 26315378822 (initial) — heartbeat working but `AI progress` rendered as `8,300%` (field is percentage-format; needed fraction).
- Run 26315958430 — progress fraction + `editJiraIssue` allow-list landed; AI model populated; comment still zero (legitimate autonomy call on cosmetic palette).
- Runs 26316657850 / 26316741554 / 26316899619 — `error_max_turns` after the template directive landed; root cause was the agent burning turns on plugin-cache rediscovery (sandbox layer, not permission layer).
- Run 26317458583 — `--add-dir` fix landed; triage clean, template comment posted (freeform shape on v1.2.30 because skill PR not yet on the runner).
- Run 26317855229 — after ag-dev-prompts#217 merged to canary; template comment landed in the prescribed shape (`Confidence: 0.8`, `Decision: proceed-with-watch`, structured Decisions, OQ for palette hex values). Cost ~$2.69.

## Outstanding before merge

- **Promote ag-dev-prompts canary → latest** so the marketplace clone on the runner picks up plugin 1.2.37 (currently still installs 1.2.30 from `latest` branch). Without this, the skill-side template + bug-verification contracts aren't enforced.
- Re-run on AG-17421 and on a Bug-type ticket to validate the full v1.2.37 contract end-to-end (single template comment, no attachments, AI model populated, `# Bug Verification` section for bugs).

## Test plan

- [x] Digest renders in the GHA step log (validated on run 26315378822 onwards).
- [x] `claude-execution-output.json` artefact still complete.
- [x] Heartbeat-driven `AI progress` / `AI activity` populate during the run.
- [x] `AI model` / `AI model effort` populate from the model-pick composite (validated on run 26315958430).
- [x] Triage-completion comment posted in the template shape (validated on run 26317855229 after v1.2.37 merge).
- [ ] Re-validate end-to-end after `canary → latest` promote on ag-dev-prompts.
- [ ] First Bug-type ticket through triage → confirms `# Bug Verification` section + failing-test path written.

---

Tracks **[AG-17426](https://ag-grid.atlassian.net/browse/AG-17426)** (Jira → GHA agentic pipeline).