### PR TITLE
jira-pipeline: repoint progress.md round-trip to new field ID

### DIFF
--- a/.github/actions/jira-state-sync/action.yml
+++ b/.github/actions/jira-state-sync/action.yml
@@ -13,7 +13,7 @@ description: |
       customfield_10944 — AI intent             <-> intent.md
       customfield_10945 — AI plan               <-> plan.md
       customfield_10949 — AI decisions          <-> decisions.md
-      customfield_10950 — AI progress           <-> progress.md
+      customfield_11054 — AI progress (md)      <-> progress.md
       customfield_10951 — AI Review Feedback    <-> review-feedback.md
 
     Modes:
@@ -81,7 +81,7 @@ runs:
                   "customfield_10944 intent.md"
                   "customfield_10945 plan.md"
                   "customfield_10949 decisions.md"
-                  "customfield_10950 progress.md"
+                  "customfield_11054 progress.md"
                   "customfield_10951 review-feedback.md"
               )
 

--- a/.github/scripts/jira-test-helpers/reset-ai-state.sh
+++ b/.github/scripts/jira-test-helpers/reset-ai-state.sh
@@ -35,7 +35,7 @@ FIELDS_JSON='{"fields":{
     "customfield_10947": null,
     "customfield_10948": null,
     "customfield_10949": null,
-    "customfield_10950": null,
+    "customfield_11054": null,
     "customfield_10951": null
 }}'
 if [[ "${KEEP_COST:-1}" == "0" ]]; then


### PR DESCRIPTION
## Summary

The JIRA writeback in `jira-state-sync` round-tripped `progress.md` to `customfield_10950` ("AI progress"), which collided in name with the live numeric `customfield_10987` ("AI progress", heartbeat-driven). The duplicate textarea field has been deleted on the JIRA side; a new paragraph field "AI progress (md)" at `customfield_11054` now holds the round-trip body.

Triage runs since the deletion have been failing the `state-sync push` step with:

> `Field 'customfield_10950' cannot be set. It is not on the appropriate screen, or unknown.`

This PR swaps the stale ID in the two callers that target the textarea round-trip — `jira-state-sync` and `reset-ai-state`. The live numeric `customfield_10987` and `AI activity` (`customfield_10988`) are untouched.

## Test plan

- [ ] Confirm `customfield_11054` is on the AG Task edit screen on the JIRA side (the previous failure mode reappears if the field exists but isn't on the screen).
- [ ] Trigger a fresh `jira-triage` repository_dispatch against an `ai-eligible` ticket and verify the `state-sync push` step writes all six textarea fields with HTTP 204.
- [ ] Verify `reset-ai-state.sh` clears the new field cleanly on the next test reset.