### PR TITLE
AG-17394 Align org chart example itemStyler params with doc snippets

### DIFF
--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
@@ -1,8 +1,6 @@
 import {
     AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesExpanderItemStylerParams,
-    AgOrganizationSeriesNodeItemStylerParams,
     ContextMenuModule,
     ModuleRegistry,
     OrganizationSeriesModule,
@@ -33,27 +31,19 @@ const options: AgChartOptions = {
                     fontWeight: 'bold',
                     color: 'red',
                 },
-                itemStyler: (params: AgOrganizationSeriesExpanderItemStylerParams) => {
-                    if (params.datum.department === 'Technology') {
-                        return { fill: '#e8f5e9', stroke: '#2e7d32' };
-                    }
-                    if (params.datum.department === 'Operations') {
-                        return { fill: '#fff3e0', stroke: '#e65100' };
-                    }
+                itemStyler: ({ datum }) => {
+                    if (datum.department === 'Technology') return { fill: '#e8f5e9', stroke: '#2e7d32' };
+                    if (datum.department === 'Operations') return { fill: '#fff3e0', stroke: '#e65100' };
                 },
             },
             node: {
                 image: { key: 'avatar', position: 'left', height: 50, width: 50, cornerRadius: 25 },
-                itemStyler: (params: AgOrganizationSeriesNodeItemStylerParams) => {
-                    if (params.datum.department === 'Executive') {
-                        return { fill: '#e3f2fd', stroke: '#1565C0', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Technology') {
+                itemStyler: ({ datum }) => {
+                    if (datum.department === 'Executive') return { fill: '#e3f2fd', stroke: '#1565C0', strokeWidth: 2 };
+                    if (datum.department === 'Technology')
                         return { fill: '#e8f5e9', stroke: '#2e7d32', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Operations') {
+                    if (datum.department === 'Operations')
                         return { fill: '#fff3e0', stroke: '#e65100', strokeWidth: 2 };
-                    }
                 },
                 title: { key: 'name' },
                 subtitle: { key: 'job' },

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-label-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-label-customisation/main.ts
@@ -1,7 +1,6 @@
 import {
     AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesNodeTextStylerParams,
     ContextMenuModule,
     ModuleRegistry,
     OrganizationSeriesModule,
@@ -32,8 +31,8 @@ const options: AgChartOptions = {
                     {
                         key: 'status',
                         textAlign: 'right',
-                        itemStyler: (params: AgOrganizationSeriesNodeTextStylerParams) => {
-                            const isRemote = params.datum.status === 'Remote';
+                        itemStyler: ({ datum }) => {
+                            const isRemote = datum.status === 'Remote';
                             return {
                                 fill: isRemote ? '#fff3e0' : '#e8f5e9',
                                 stroke: isRemote ? '#ff9800' : '#4caf50',

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-link-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-link-customisation/main.ts
@@ -1,7 +1,5 @@
 import {
-    AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesLinkItemStylerParams,
     AgOrganizationSeriesOptions,
     AgStandaloneChartOptions,
     ContextMenuModule,
@@ -30,10 +28,10 @@ const options: AgStandaloneChartOptions = {
                 strokeWidth: 2,
                 lineDash: [8, 2],
                 interpolation: { type: 'step', cornerRadius: 8 },
-                itemStyler: (params: AgOrganizationSeriesLinkItemStylerParams) => {
-                    if (params.fromDatum.department === 'Technology') {
+                itemStyler: ({ fromDatum }) => {
+                    if (fromDatum.department === 'Technology') {
                         return { stroke: '#00994d' };
-                    } else if (params.fromDatum.job === 'CEO') {
+                    } else if (fromDatum.job === 'CEO') {
                         return { stroke: '#006f9b', strokeWidth: 4, lineDash: [] };
                     }
                 },

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-node-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-node-customisation/main.ts
@@ -1,7 +1,6 @@
 import {
     AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesNodeItemStylerParams,
     ContextMenuModule,
     ModuleRegistry,
     OrganizationSeriesModule,
@@ -28,16 +27,12 @@ const options: AgChartOptions = {
                 // height: 120,
                 cornerRadius: 12,
                 image: { key: 'avatar', position: 'left', height: 50, width: 50, cornerRadius: 25 },
-                itemStyler: (params: AgOrganizationSeriesNodeItemStylerParams) => {
-                    if (params.datum.department === 'Executive') {
-                        return { fill: '#e3f2fd', stroke: '#1565C0', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Technology') {
+                itemStyler: ({ datum }) => {
+                    if (datum.department === 'Executive') return { fill: '#e3f2fd', stroke: '#1565C0', strokeWidth: 2 };
+                    if (datum.department === 'Technology')
                         return { fill: '#e8f5e9', stroke: '#2e7d32', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Operations') {
+                    if (datum.department === 'Operations')
                         return { fill: '#fff3e0', stroke: '#e65100', strokeWidth: 2 };
-                    }
                 },
                 title: { key: 'name' },
                 subtitle: { key: 'job' },


### PR DESCRIPTION
## Summary

- Destructure `itemStyler` callback params (`{ datum }`, `{ fromDatum }`) in 4 org chart examples to match the inline code snippets in the documentation page
- Remove now-unused explicit param type imports (`AgOrganizationSeriesNodeItemStylerParams`, etc.) — TypeScript infers from the `AgChartOptions` context

## Test plan

- [ ] `yarn nx build:types ag-charts-enterprise` passes (type inference works)
- [ ] Org chart examples render correctly in dev server
- [ ] Generated framework variants (React/Angular/Vue) still transform cleanly