### PR TITLE
AG-17296 Add colorRange removal to 14.0.0 migration guide

### DIFF
--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -78,20 +78,19 @@ This release includes the following behaviour changes:
 
 <!-- If there are *no* deprecated APIs, add the following: -->
 
-There are no deprecated APIs removed in AG Charts version {% migrationVersion() %}.
+<!-- There are no deprecated APIs removed in AG Charts version {% migrationVersion() %}. -->
 
 <!-- Otherwise: -->
-<!--
+
 The following APIs have been deprecated since version 13 and have now been removed.
 
 {% expandingSection headerText="Removed Deprecated APIs" %}
 
-### Deprecated APIs section Name
+<!-- ### Deprecated APIs section Name -->
 
-- item...
+- `colorRange` is removed from `heatmap`, `treemap`, `sunburst`, `map-marker` and `map-shape` series. Use `colorScale.fills` instead.
 
 {% /expandingSection %}
--->
 
 ## Deprecations
 


### PR DESCRIPTION
## Summary

- Documents the removal of the deprecated `colorRange` option in the 14.0.0 upgrade guide
- Affects heatmap, treemap, sunburst, map-marker and map-shape series — users should migrate to `colorScale.fills`
- Follows the terse bullet style used in the v12 migration guide

## Test plan

- [ ] Migration page renders correctly in dev server
- [ ] Expanding section opens and shows the bullet