### PR TITLE
Cherry-pick AG-17334 & AG-17394 fixes to b13.3.1

### DIFF
--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -6,7 +6,6 @@ import {
     type DynamicContext,
     Logger,
     type NormalisedSelectionOptions,
-    hasNoModifiers,
 } from 'ag-charts-core';
 
 import {
@@ -222,7 +221,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         if (!this.supportsSelectionDrag()) return;
 
         const { enabled, enableDrag } = this.opts;
-        if (!enabled || !enableDrag || !hasNoModifiers(dragStartEvent.sourceEvent)) return;
+        if (!enabled || !enableDrag || this.hasUnknownModifier(dragStartEvent)) return;
 
         this.dragStartEvent = dragStartEvent;
         this.dragRect.x = dragStartEvent.currentX;
@@ -387,5 +386,9 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
     private allocSelectionChanges(): SelectionChanges {
         if (!this.ctx.chartService.hasListener('selectionChange')) return { countDelta: 0 };
         return { countDelta: 0, added: [], removed: [] };
+    }
+
+    private hasUnknownModifier(event: _Widget.DragWidgetEvent): boolean {
+        return event.sourceEvent.altKey || event.sourceEvent.shiftKey;
     }
 }

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
@@ -46,13 +46,13 @@ const options: AgChartOptions = {
                 image: { key: 'avatar', position: 'left', height: 50, width: 50, cornerRadius: 25 },
                 itemStyler: (params: AgOrganizationSeriesNodeItemStylerParams) => {
                     if (params.datum.department === 'Executive') {
-                        return { fill: '#e3f2fd', stroke: '#1565C0', strokeWidth: 2 };
+                        return { fill: '#76B2DC', fillOpacity: 0.2, stroke: '#1B65BF', strokeWidth: 2 };
                     }
                     if (params.datum.department === 'Technology') {
-                        return { fill: '#e8f5e9', stroke: '#2e7d32', strokeWidth: 2 };
+                        return { fill: '#7AE281', fillOpacity: 0.2, stroke: '#327C35', strokeWidth: 2 };
                     }
                     if (params.datum.department === 'Operations') {
-                        return { fill: '#fff3e0', stroke: '#e65100', strokeWidth: 2 };
+                        return { fill: '#EBB967', fillOpacity: 0.2, stroke: '#A94F1D', strokeWidth: 2 };
                     }
                 },
                 title: { key: 'name' },

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
@@ -1,8 +1,6 @@
 import {
     AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesExpanderItemStylerParams,
-    AgOrganizationSeriesNodeItemStylerParams,
     ContextMenuModule,
     ModuleRegistry,
     OrganizationSeriesModule,
@@ -33,27 +31,20 @@ const options: AgChartOptions = {
                     fontWeight: 'bold',
                     color: 'red',
                 },
-                itemStyler: (params: AgOrganizationSeriesExpanderItemStylerParams) => {
-                    if (params.datum.department === 'Technology') {
-                        return { fill: '#e8f5e9', stroke: '#2e7d32' };
-                    }
-                    if (params.datum.department === 'Operations') {
-                        return { fill: '#fff3e0', stroke: '#e65100' };
-                    }
+                itemStyler: ({ datum }) => {
+                    if (datum.department === 'Technology') return { fill: '#e8f5e9', stroke: '#2e7d32' };
+                    if (datum.department === 'Operations') return { fill: '#fff3e0', stroke: '#e65100' };
                 },
             },
             node: {
                 image: { key: 'avatar', position: 'left', height: 50, width: 50, cornerRadius: 25 },
-                itemStyler: (params: AgOrganizationSeriesNodeItemStylerParams) => {
-                    if (params.datum.department === 'Executive') {
+                itemStyler: ({ datum }) => {
+                    if (datum.department === 'Executive')
                         return { fill: '#76B2DC', fillOpacity: 0.2, stroke: '#1B65BF', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Technology') {
+                    if (datum.department === 'Technology')
                         return { fill: '#7AE281', fillOpacity: 0.2, stroke: '#327C35', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Operations') {
+                    if (datum.department === 'Operations')
                         return { fill: '#EBB967', fillOpacity: 0.2, stroke: '#A94F1D', strokeWidth: 2 };
-                    }
                 },
                 title: { key: 'name' },
                 subtitle: { key: 'job' },

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-label-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-label-customisation/main.ts
@@ -1,7 +1,6 @@
 import {
     AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesNodeTextStylerParams,
     ContextMenuModule,
     ModuleRegistry,
     OrganizationSeriesModule,
@@ -32,8 +31,8 @@ const options: AgChartOptions = {
                     {
                         key: 'status',
                         textAlign: 'right',
-                        itemStyler: (params: AgOrganizationSeriesNodeTextStylerParams) => {
-                            const isRemote = params.datum.status === 'Remote';
+                        itemStyler: ({ datum }) => {
+                            const isRemote = datum.status === 'Remote';
                             return {
                                 fill: isRemote ? '#fff3e0' : '#e8f5e9',
                                 stroke: isRemote ? '#ff9800' : '#4caf50',

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-link-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-link-customisation/main.ts
@@ -1,7 +1,5 @@
 import {
-    AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesLinkItemStylerParams,
     AgOrganizationSeriesOptions,
     AgStandaloneChartOptions,
     ContextMenuModule,
@@ -30,10 +28,10 @@ const options: AgStandaloneChartOptions = {
                 strokeWidth: 2,
                 lineDash: [8, 2],
                 interpolation: { type: 'step', cornerRadius: 8 },
-                itemStyler: (params: AgOrganizationSeriesLinkItemStylerParams) => {
-                    if (params.fromDatum.department === 'Technology') {
+                itemStyler: ({ fromDatum }) => {
+                    if (fromDatum.department === 'Technology') {
                         return { stroke: '#00994d' };
-                    } else if (params.fromDatum.job === 'CEO') {
+                    } else if (fromDatum.job === 'CEO') {
                         return { stroke: '#006f9b', strokeWidth: 4, lineDash: [] };
                     }
                 },

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-node-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-node-customisation/main.ts
@@ -30,13 +30,13 @@ const options: AgChartOptions = {
                 image: { key: 'avatar', position: 'left', height: 50, width: 50, cornerRadius: 25 },
                 itemStyler: (params: AgOrganizationSeriesNodeItemStylerParams) => {
                     if (params.datum.department === 'Executive') {
-                        return { fill: '#e3f2fd', stroke: '#1565C0', strokeWidth: 2 };
+                        return { fill: '#76B2DC', fillOpacity: 0.2, stroke: '#1B65BF', strokeWidth: 2 };
                     }
                     if (params.datum.department === 'Technology') {
-                        return { fill: '#e8f5e9', stroke: '#2e7d32', strokeWidth: 2 };
+                        return { fill: '#7AE281', fillOpacity: 0.2, stroke: '#327C35', strokeWidth: 2 };
                     }
                     if (params.datum.department === 'Operations') {
-                        return { fill: '#fff3e0', stroke: '#e65100', strokeWidth: 2 };
+                        return { fill: '#EBB967', fillOpacity: 0.2, stroke: '#A94F1D', strokeWidth: 2 };
                     }
                 },
                 title: { key: 'name' },

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-node-customisation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-node-customisation/main.ts
@@ -1,7 +1,6 @@
 import {
     AgChartOptions,
     AgCharts,
-    AgOrganizationSeriesNodeItemStylerParams,
     ContextMenuModule,
     ModuleRegistry,
     OrganizationSeriesModule,
@@ -28,16 +27,13 @@ const options: AgChartOptions = {
                 // height: 120,
                 cornerRadius: 12,
                 image: { key: 'avatar', position: 'left', height: 50, width: 50, cornerRadius: 25 },
-                itemStyler: (params: AgOrganizationSeriesNodeItemStylerParams) => {
-                    if (params.datum.department === 'Executive') {
+                itemStyler: ({ datum }) => {
+                    if (datum.department === 'Executive')
                         return { fill: '#76B2DC', fillOpacity: 0.2, stroke: '#1B65BF', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Technology') {
+                    if (datum.department === 'Technology')
                         return { fill: '#7AE281', fillOpacity: 0.2, stroke: '#327C35', strokeWidth: 2 };
-                    }
-                    if (params.datum.department === 'Operations') {
+                    if (datum.department === 'Operations')
                         return { fill: '#EBB967', fillOpacity: 0.2, stroke: '#A94F1D', strokeWidth: 2 };
-                    }
                 },
                 title: { key: 'name' },
                 subtitle: { key: 'job' },

--- a/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
@@ -133,11 +133,11 @@ In this configuration:
                 cornerRadius: 12,
                 itemStyler: ({ datum }) => {
                     if (datum.department === 'Executive')
-                        return { fill: '#e3f2fd', stroke: '#1565C0', strokeWidth: 2 };
+                        return { fill: '#76B2DC', fillOpacity: 0.2, stroke: '#1B65BF', strokeWidth: 2 };
                     if (datum.department === 'Technology')
-                        return { fill: '#e8f5e9', stroke: '#2e7d32', strokeWidth: 2 };
+                        return { fill: '#7AE281', fillOpacity: 0.2, stroke: '#327C35', strokeWidth: 2 };
                     if (datum.department === 'Operations')
-                        return { fill: '#fff3e0', stroke: '#e65100', strokeWidth: 2 };
+                        return { fill: '#EBB967', fillOpacity: 0.2, stroke: '#A94F1D', strokeWidth: 2 };
                 },
             },
         },


### PR DESCRIPTION
Cherry-picks for fix version 35.3.1, as requested by David.

## Summary

- AG-17334 — Ctrl+drag should add to existing data-point selection (#6835)
- AG-17394 — Org chart example dark-mode contrast fix (#6903)
- AG-17394 — Org chart snippet consistency follow-up (#6911)

All three were already merged to `latest` and are cherry-picked here with `-x` for traceability.

## Test plan

- [ ] CI passes on `b13.3.1`
- [ ] Org chart examples render correctly in light + dark mode
- [ ] Ctrl+drag adds to existing selection in data-point selection demo