### PR TITLE
AG-17419 Add JSON-LD structured data for AI and SEO

### DIFF
--- a/external/ag-website-shared/src/components/structured-data/JsonLd.astro
+++ b/external/ag-website-shared/src/components/structured-data/JsonLd.astro
@@ -1,0 +1,13 @@
+---
+import { buildJsonLdDocument, serializeJsonLd, type JsonLdObject } from '@ag-website-shared/utils/structuredData';
+
+interface Props {
+    data: JsonLdObject | JsonLdObject[];
+}
+
+const { data } = Astro.props;
+const nodes = Array.isArray(data) ? data : [data];
+const document = buildJsonLdDocument(nodes);
+---
+
+{nodes.length > 0 && <script type="application/ld+json" set:html={serializeJsonLd(document)} />}

--- a/external/ag-website-shared/src/utils/structuredData.test.ts
+++ b/external/ag-website-shared/src/utils/structuredData.test.ts
@@ -1,0 +1,226 @@
+import {
+    buildBreadcrumbList,
+    buildJsonLdDocument,
+    buildOrganization,
+    buildSoftwareApplication,
+    buildTechArticle,
+    buildWebSite,
+    getSoftwareApplicationId,
+    serializeJsonLd,
+} from './structuredData';
+
+const CANONICAL_URL_BASE = 'https://www.ag-grid.com';
+
+describe('buildOrganization', () => {
+    test('takes name, url, logo and sameAs from inputs (no @context — supplied by document wrapper)', () => {
+        const result = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://twitter.com/ag_grid'],
+        });
+
+        expect(result).toEqual({
+            '@type': 'Organization',
+            '@id': `${CANONICAL_URL_BASE}/#organization`,
+            name: 'AG Grid',
+            url: `${CANONICAL_URL_BASE}/`,
+            logo: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: ['https://github.com/ag-grid/ag-grid', 'https://twitter.com/ag_grid'],
+        });
+        expect(result['@context']).toBeUndefined();
+    });
+});
+
+describe('buildWebSite', () => {
+    test('references the Organization by @id', () => {
+        const result = buildWebSite({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            description: 'A feature-rich data grid.',
+        });
+
+        expect(result['@type']).toBe('WebSite');
+        expect(result['@id']).toBe(`${CANONICAL_URL_BASE}/#website`);
+        expect(result.publisher).toEqual({ '@id': `${CANONICAL_URL_BASE}/#organization` });
+        expect(result.inLanguage).toBe('en');
+    });
+});
+
+describe('canonicalUrlBase normalisation', () => {
+    test('a trailing slash on canonicalUrlBase does not duplicate in IDs or URLs', () => {
+        const withSlash = buildOrganization({
+            canonicalUrlBase: `${CANONICAL_URL_BASE}/`,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+        });
+        const withoutSlash = buildOrganization({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            logoUrl: `${CANONICAL_URL_BASE}/images/logo.png`,
+            sameAs: [],
+        });
+
+        expect(withSlash).toEqual(withoutSlash);
+        expect(withSlash['@id']).toBe(`${CANONICAL_URL_BASE}/#organization`);
+        expect(withSlash.url).toBe(`${CANONICAL_URL_BASE}/`);
+    });
+
+    test('subpath canonical bases (AG Charts / AG Studio) retain the subpath in IDs and URLs', () => {
+        const chartsBase = 'https://www.ag-grid.com/charts';
+
+        const org = buildOrganization({
+            canonicalUrlBase: chartsBase,
+            name: 'AG Charts',
+            logoUrl: `${chartsBase}/images/logo.png`,
+            sameAs: [],
+        });
+
+        expect(org['@id']).toBe('https://www.ag-grid.com/charts/#organization');
+        expect(org.url).toBe('https://www.ag-grid.com/charts/');
+    });
+});
+
+describe('buildSoftwareApplication', () => {
+    test('uses default applicationCategory and operatingSystem when not provided, and omits offers when empty', () => {
+        const result = buildSoftwareApplication({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            version: '34.0.0',
+        });
+
+        expect(result['@type']).toBe('SoftwareApplication');
+        expect(result.applicationCategory).toBe('DeveloperApplication');
+        expect(result.operatingSystem).toBe('Web Browser');
+        expect(result.softwareVersion).toBe('34.0.0');
+        expect(result.publisher).toEqual({ '@id': `${CANONICAL_URL_BASE}/#organization` });
+        expect(result.offers).toBeUndefined();
+    });
+
+    test('honours caller-supplied applicationCategory, operatingSystem and offers', () => {
+        const result = buildSoftwareApplication({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            name: 'AG Grid',
+            version: '34.0.0',
+            applicationCategory: 'BusinessApplication',
+            operatingSystem: 'iOS',
+            offers: [{ '@type': 'Offer', price: '0', priceCurrency: 'USD' }],
+        });
+
+        expect(result.applicationCategory).toBe('BusinessApplication');
+        expect(result.operatingSystem).toBe('iOS');
+        expect(result.offers).toEqual([{ '@type': 'Offer', price: '0', priceCurrency: 'USD' }]);
+    });
+});
+
+describe('buildTechArticle', () => {
+    test('always links isPartOf to WebSite and publisher to Organization', () => {
+        const pageUrl = `${CANONICAL_URL_BASE}/react-data-grid/getting-started/`;
+        const result = buildTechArticle({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            pageUrl,
+            title: 'Getting Started',
+            description: 'Get started with AG Grid for React.',
+        });
+
+        expect(result['@type']).toBe('TechArticle');
+        expect(result['@id']).toBe(`${pageUrl}#article`);
+        expect(result.headline).toBe('Getting Started');
+        expect(result.url).toBe(pageUrl);
+        expect(result.mainEntityOfPage).toEqual({ '@type': 'WebPage', '@id': pageUrl });
+        expect(result.isPartOf).toEqual({ '@id': `${CANONICAL_URL_BASE}/#website` });
+        expect(result.publisher).toEqual({ '@id': `${CANONICAL_URL_BASE}/#organization` });
+        expect(result.about).toBeUndefined();
+    });
+
+    test('emits an about reference when aboutEntityId is provided', () => {
+        const pageUrl = `${CANONICAL_URL_BASE}/react-data-grid/getting-started/`;
+        const result = buildTechArticle({
+            canonicalUrlBase: CANONICAL_URL_BASE,
+            pageUrl,
+            title: 'Getting Started',
+            description: 'Get started with AG Grid for React.',
+            aboutEntityId: getSoftwareApplicationId(CANONICAL_URL_BASE),
+        });
+
+        expect(result.about).toEqual({ '@id': `${CANONICAL_URL_BASE}/#software-application` });
+    });
+});
+
+describe('buildBreadcrumbList', () => {
+    test('numbers ListItem positions starting from 1', () => {
+        const pageUrl = `${CANONICAL_URL_BASE}/react-data-grid/getting-started/`;
+        const result = buildBreadcrumbList({
+            pageUrl,
+            items: [
+                { name: 'Home', url: `${CANONICAL_URL_BASE}/` },
+                { name: 'React Data Grid', url: `${CANONICAL_URL_BASE}/react-data-grid/` },
+                { name: 'Getting Started', url: pageUrl },
+            ],
+        });
+
+        expect(result['@type']).toBe('BreadcrumbList');
+        expect(result['@id']).toBe(`${pageUrl}#breadcrumb`);
+        expect(result.itemListElement).toEqual([
+            { '@type': 'ListItem', position: 1, name: 'Home', item: `${CANONICAL_URL_BASE}/` },
+            {
+                '@type': 'ListItem',
+                position: 2,
+                name: 'React Data Grid',
+                item: `${CANONICAL_URL_BASE}/react-data-grid/`,
+            },
+            { '@type': 'ListItem', position: 3, name: 'Getting Started', item: pageUrl },
+        ]);
+    });
+});
+
+describe('buildJsonLdDocument', () => {
+    test('inlines a single node under @context (no @graph wrapper)', () => {
+        const node = { '@type': 'Thing', name: 'AG Grid' };
+
+        const result = buildJsonLdDocument([node]);
+
+        expect(result).toEqual({
+            '@context': 'https://schema.org',
+            '@type': 'Thing',
+            name: 'AG Grid',
+        });
+        expect(result['@graph']).toBeUndefined();
+    });
+
+    test('wraps multiple nodes in a single @graph with a shared @context', () => {
+        const org = { '@type': 'Organization', name: 'AG Grid' };
+        const site = { '@type': 'WebSite', name: 'ag-grid.com' };
+
+        const result = buildJsonLdDocument([org, site]);
+
+        expect(result).toEqual({
+            '@context': 'https://schema.org',
+            '@graph': [org, site],
+        });
+    });
+});
+
+describe('serializeJsonLd', () => {
+    test('produces valid JSON', () => {
+        const data = { '@type': 'Thing', name: 'AG Grid' };
+
+        const serialised = serializeJsonLd(data);
+
+        expect(JSON.parse(serialised)).toEqual(data);
+    });
+
+    test('escapes </script> sequences to prevent script tag injection', () => {
+        const data = {
+            '@type': 'Thing',
+            description: 'Some text </script><script>alert(1)</script>',
+        };
+
+        const serialised = serializeJsonLd(data);
+
+        expect(serialised).not.toContain('</script>');
+        expect(serialised).toContain('<\\/script>');
+        expect(JSON.parse(serialised)).toEqual(data);
+    });
+});

--- a/external/ag-website-shared/src/utils/structuredData.ts
+++ b/external/ag-website-shared/src/utils/structuredData.ts
@@ -1,0 +1,187 @@
+/**
+ * Builders for schema.org JSON-LD structured data emitted in the page <head>.
+ *
+ * Builders return graph-node objects without `@context` — the surrounding
+ * `<JsonLd>` component supplies a single `@context` at the top of the emitted
+ * `@graph`. Stable `@id` URIs (derived from `canonicalUrlBase`) let nodes
+ * reference each other (Organization, WebSite, SoftwareApplication).
+ *
+ * Shared across AG Grid, AG Charts, and AG Studio. Brand-specific values
+ * (organisation name, product name, offers, etc.) are passed in by the caller.
+ */
+
+export type JsonLdObject = Record<string, unknown>;
+
+interface OrgInput {
+    canonicalUrlBase: string;
+    name: string;
+    logoUrl: string;
+    sameAs: string[];
+}
+
+interface WebSiteInput {
+    canonicalUrlBase: string;
+    name: string;
+    description: string;
+}
+
+interface SoftwareApplicationInput {
+    canonicalUrlBase: string;
+    name: string;
+    version: string;
+    applicationCategory?: string;
+    operatingSystem?: string;
+    offers?: JsonLdObject[];
+}
+
+interface TechArticleInput {
+    canonicalUrlBase: string;
+    pageUrl: string;
+    title: string;
+    description: string;
+    /**
+     * Optional `@id` of the entity this article is about (e.g. a
+     * SoftwareApplication emitted elsewhere on the site). When omitted,
+     * `about` is not set.
+     */
+    aboutEntityId?: string;
+}
+
+export interface BreadcrumbItem {
+    name: string;
+    url: string;
+}
+
+interface BreadcrumbListInput {
+    pageUrl: string;
+    items: BreadcrumbItem[];
+}
+
+/**
+ * Return `canonicalUrlBase` with a trailing slash, so callers can append a
+ * site-root-relative path or fragment without worrying about the input form
+ * or doubled slashes. Works for both host-level bases (`https://example.com`)
+ * and subpath bases (`https://example.com/charts`) — both produce the same
+ * output as their trailing-slash equivalents.
+ *
+ * `new URL('/x', base)` is NOT a safe substitute for subpath bases — the
+ * absolute path resolves against the host and discards the subpath segment.
+ */
+export function siteRootUrl(canonicalUrlBase: string): string {
+    return canonicalUrlBase.endsWith('/') ? canonicalUrlBase : `${canonicalUrlBase}/`;
+}
+
+export const getOrganizationId = (canonicalUrlBase: string): string => `${siteRootUrl(canonicalUrlBase)}#organization`;
+export const getWebSiteId = (canonicalUrlBase: string): string => `${siteRootUrl(canonicalUrlBase)}#website`;
+export const getSoftwareApplicationId = (canonicalUrlBase: string): string =>
+    `${siteRootUrl(canonicalUrlBase)}#software-application`;
+
+const ARTICLE_ID_FRAGMENT = '#article';
+const BREADCRUMB_ID_FRAGMENT = '#breadcrumb';
+
+export function buildOrganization({ canonicalUrlBase, name, logoUrl, sameAs }: OrgInput): JsonLdObject {
+    return {
+        '@type': 'Organization',
+        '@id': getOrganizationId(canonicalUrlBase),
+        name,
+        url: siteRootUrl(canonicalUrlBase),
+        logo: logoUrl,
+        sameAs,
+    };
+}
+
+export function buildWebSite({ canonicalUrlBase, name, description }: WebSiteInput): JsonLdObject {
+    return {
+        '@type': 'WebSite',
+        '@id': getWebSiteId(canonicalUrlBase),
+        url: siteRootUrl(canonicalUrlBase),
+        name,
+        description,
+        inLanguage: 'en',
+        publisher: { '@id': getOrganizationId(canonicalUrlBase) },
+    };
+}
+
+export function buildSoftwareApplication({
+    canonicalUrlBase,
+    name,
+    version,
+    applicationCategory = 'DeveloperApplication',
+    operatingSystem = 'Web Browser',
+    offers,
+}: SoftwareApplicationInput): JsonLdObject {
+    const result: JsonLdObject = {
+        '@type': 'SoftwareApplication',
+        '@id': getSoftwareApplicationId(canonicalUrlBase),
+        name,
+        applicationCategory,
+        operatingSystem,
+        softwareVersion: version,
+        url: siteRootUrl(canonicalUrlBase),
+        publisher: { '@id': getOrganizationId(canonicalUrlBase) },
+    };
+    if (offers && offers.length > 0) {
+        result.offers = offers;
+    }
+    return result;
+}
+
+export function buildTechArticle({
+    canonicalUrlBase,
+    pageUrl,
+    title,
+    description,
+    aboutEntityId,
+}: TechArticleInput): JsonLdObject {
+    const result: JsonLdObject = {
+        '@type': 'TechArticle',
+        '@id': `${pageUrl}${ARTICLE_ID_FRAGMENT}`,
+        headline: title,
+        description,
+        inLanguage: 'en',
+        url: pageUrl,
+        mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl },
+        isPartOf: { '@id': getWebSiteId(canonicalUrlBase) },
+        publisher: { '@id': getOrganizationId(canonicalUrlBase) },
+    };
+    if (aboutEntityId) {
+        result.about = { '@id': aboutEntityId };
+    }
+    return result;
+}
+
+export function buildBreadcrumbList({ pageUrl, items }: BreadcrumbListInput): JsonLdObject {
+    return {
+        '@type': 'BreadcrumbList',
+        '@id': `${pageUrl}${BREADCRUMB_ID_FRAGMENT}`,
+        itemListElement: items.map((item, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: item.name,
+            item: item.url,
+        })),
+    };
+}
+
+/**
+ * Wrap one or more graph-node objects into a single JSON-LD document with a
+ * shared `@context`. Multiple nodes are combined under `@graph`; a single node
+ * is inlined alongside `@context`.
+ */
+export function buildJsonLdDocument(nodes: JsonLdObject[]): JsonLdObject {
+    if (nodes.length === 1) {
+        return { '@context': 'https://schema.org', ...nodes[0] };
+    }
+    return { '@context': 'https://schema.org', '@graph': nodes };
+}
+
+/**
+ * Serialise a JSON-LD object for embedding inside <script type="application/ld+json">.
+ *
+ * Escapes `</` to `<\/` so a stray `</script>` inside any string field cannot
+ * close the script tag prematurely. `set:html` does not escape inside script
+ * bodies, so the caller must.
+ */
+export function serializeJsonLd(data: JsonLdObject): string {
+    return JSON.stringify(data).replace(/<\//g, '<\\/');
+}

--- a/packages/ag-charts-website/src/layouts/Layout.astro
+++ b/packages/ag-charts-website/src/layouts/Layout.astro
@@ -11,10 +11,18 @@ import { ApiTopBar } from '@components/top-bar/ApiTopBar';
 import { getIsProduction, getIsArchive, getIsStaging, getIsDev } from '@utils/env';
 import { isDynamicFrameworkPath, isDynamicFrameworkPathMatch, replaceDynamicFrameworkPath } from '@utils/framework';
 import Plausible from '../components/Plausible.astro';
-import { FRAMEWORKS, SITE_BASE_URL, PUBLIC_GTM_ID, PUBLIC_GTM_AUTH, PUBLIC_GTM_PREVIEW } from '@constants';
+import { FRAMEWORKS, SITE_BASE_URL, PUBLIC_GTM_ID, PUBLIC_GTM_AUTH, PUBLIC_GTM_PREVIEW, agChartsVersion } from '@constants';
 import { DevTools } from '@ag-website-shared/components/dev-tools/DevTools';
 import GoogleTagManager from '@ag-website-shared/components/google-tag-manager/GoogleTagManager.astro';
 import GoogleTagManagerBody from '@ag-website-shared/components/google-tag-manager/GoogleTagManagerBody.astro';
+import JsonLd from '@ag-website-shared/components/structured-data/JsonLd.astro';
+import {
+    buildOrganization,
+    buildSoftwareApplication,
+    buildWebSite,
+    siteRootUrl,
+    type JsonLdObject,
+} from '@ag-website-shared/utils/structuredData';
 
 export interface Props {
     title?: string;
@@ -24,6 +32,8 @@ export interface Props {
     showDocsNav?: boolean;
     hideHeader?: boolean;
     hideFooter?: boolean;
+    noIndex?: boolean;
+    pageStructuredData?: JsonLdObject[];
 }
 
 const { data: metadata } = await getEntry('metadata', 'metadata') as CollectionEntry<'metadata'>;
@@ -36,7 +46,8 @@ const {
     showDocsNav,
     hideHeader,
     hideFooter,
-    noIndex
+    noIndex,
+    pageStructuredData,
 } = Astro.props;
 
 const path = Astro.url.pathname;
@@ -85,6 +96,49 @@ const lightModeCSSUrl = `url("${urlWithBaseUrl('/images/sun.svg')}")`;
 const darkModeCSSUrl = `url("${urlWithBaseUrl('/images/moon.svg')}")`;
 
 const isHomepage = Astro.url.pathname.replaceAll('/', '') === SITE_BASE_URL.replaceAll('/', '');
+
+const includeStructuredData = !noIndex && !isArchive;
+const sameAsUrls = includeStructuredData
+    ? footerItems.flatMap((group) => group.links.filter((link) => link.iconName).map((link) => link.url))
+    : [];
+const siteRoot = siteRootUrl(metadata.canonicalUrlBase);
+const organizationLogoUrl = `${siteRoot}images/ag-charts-social.png`;
+const licensePricingUrl = `${siteRoot}license-pricing/`;
+const structuredData: JsonLdObject[] = includeStructuredData
+    ? [
+          buildOrganization({
+              canonicalUrlBase: metadata.canonicalUrlBase,
+              name: 'AG Charts',
+              logoUrl: organizationLogoUrl,
+              sameAs: sameAsUrls,
+          }),
+          buildWebSite({
+              canonicalUrlBase: metadata.canonicalUrlBase,
+              name: metadata.title,
+              description: metadata.description,
+          }),
+          buildSoftwareApplication({
+              canonicalUrlBase: metadata.canonicalUrlBase,
+              name: 'AG Charts',
+              version: agChartsVersion.split('-')[0],
+              offers: [
+                  {
+                      '@type': 'Offer',
+                      name: 'AG Charts Community',
+                      price: '0',
+                      priceCurrency: 'USD',
+                      url: licensePricingUrl,
+                  },
+                  {
+                      '@type': 'Offer',
+                      name: 'AG Charts Enterprise',
+                      url: licensePricingUrl,
+                  },
+              ],
+          }),
+          ...(pageStructuredData ?? []),
+      ]
+    : [];
 ---
 
 <!doctype html>
@@ -126,6 +180,8 @@ const isHomepage = Astro.url.pathname.replaceAll('/', '') === SITE_BASE_URL.repl
         <meta name="twitter:title" content={title}>
         <meta name="twitter:description" content={description}>
         <meta name="twitter:image" content={socialImage}>
+
+        {structuredData.length > 0 && <JsonLd data={structuredData} />}
 
         {
             !getIsDev() && (

--- a/packages/ag-charts-website/src/pages/[framework]/[pageName].astro
+++ b/packages/ag-charts-website/src/pages/[framework]/[pageName].astro
@@ -12,13 +12,6 @@ import { agLibraryVersion } from '@constants';
 import { DocsNav } from '@ag-website-shared/components/docs-navigation/DocsNav';
 import styles from '@ag-website-shared/components/page-styles/docs.module.scss';
 import { parseVersion } from '@ag-website-shared/utils/parseVersion';
-import {
-    buildBreadcrumbList,
-    buildTechArticle,
-    getSoftwareApplicationId,
-    siteRootUrl,
-    type JsonLdObject,
-} from '@ag-website-shared/utils/structuredData';
 import { DOCS_TAB_ITEM_ID_PREFIX, MIGRATION_DOCUMENTATION_NAV_DATA } from '@ag-website-shared/constants';
 
 export async function getStaticPaths() {
@@ -65,7 +58,6 @@ const headings =
 const { data: docsNavData } = (await getEntry('docsNav', 'nav')) as CollectionEntry<'docsNav'>;
 const { data: siteHeaderData } = (await getEntry('siteHeader', 'header')) as CollectionEntry<'siteHeader'>;
 const siteHeaderItems = Object.values(siteHeaderData);
-const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 
 const { data: versionsData } = (await getEntry('versions', 'ag-charts-versions')) as CollectionEntry<'versions'>;
 const version = versionsData[0]?.version;
@@ -75,26 +67,6 @@ const description = page.data.description
     ? page.data.description.replaceAll('$framework', frameworkDisplayText) // Use front-matter description
     : getFirstParagraphText(page.body, currentFramework); // Default to 1st paragraph text
 const descriptionWithSeoTagline = `${description} ${seoTagline}`;
-
-const siteRoot = siteRootUrl(metadata.canonicalUrlBase);
-const pageUrl = `${siteRoot}${currentFramework}/${pageName}/`;
-const pageStructuredData: JsonLdObject[] = [
-    buildTechArticle({
-        canonicalUrlBase: metadata.canonicalUrlBase,
-        pageUrl,
-        title,
-        description: descriptionWithSeoTagline,
-        aboutEntityId: getSoftwareApplicationId(metadata.canonicalUrlBase),
-    }),
-    buildBreadcrumbList({
-        pageUrl,
-        items: [
-            { name: 'Home', url: siteRoot },
-            { name: `${frameworkDisplayText} Charts`, url: `${siteRoot}${currentFramework}/` },
-            { name: title, url: pageUrl },
-        ],
-    }),
-];
 ---
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -107,7 +79,6 @@ const pageStructuredData: JsonLdObject[] = [
     showTopBar={true}
     showSearchBar={true}
     showDocsNav={!hidePageMenu}
-    pageStructuredData={pageStructuredData}
 >
     <div class:list={[hidePageMenu && styles.noLeftMenu, styles.contentViewport, 'layout-grid', { largeExamples }]}>
         {

--- a/packages/ag-charts-website/src/pages/[framework]/[pageName].astro
+++ b/packages/ag-charts-website/src/pages/[framework]/[pageName].astro
@@ -12,6 +12,13 @@ import { agLibraryVersion } from '@constants';
 import { DocsNav } from '@ag-website-shared/components/docs-navigation/DocsNav';
 import styles from '@ag-website-shared/components/page-styles/docs.module.scss';
 import { parseVersion } from '@ag-website-shared/utils/parseVersion';
+import {
+    buildBreadcrumbList,
+    buildTechArticle,
+    getSoftwareApplicationId,
+    siteRootUrl,
+    type JsonLdObject,
+} from '@ag-website-shared/utils/structuredData';
 import { DOCS_TAB_ITEM_ID_PREFIX, MIGRATION_DOCUMENTATION_NAV_DATA } from '@ag-website-shared/constants';
 
 export async function getStaticPaths() {
@@ -58,6 +65,7 @@ const headings =
 const { data: docsNavData } = (await getEntry('docsNav', 'nav')) as CollectionEntry<'docsNav'>;
 const { data: siteHeaderData } = (await getEntry('siteHeader', 'header')) as CollectionEntry<'siteHeader'>;
 const siteHeaderItems = Object.values(siteHeaderData);
+const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 
 const { data: versionsData } = (await getEntry('versions', 'ag-charts-versions')) as CollectionEntry<'versions'>;
 const version = versionsData[0]?.version;
@@ -67,6 +75,26 @@ const description = page.data.description
     ? page.data.description.replaceAll('$framework', frameworkDisplayText) // Use front-matter description
     : getFirstParagraphText(page.body, currentFramework); // Default to 1st paragraph text
 const descriptionWithSeoTagline = `${description} ${seoTagline}`;
+
+const siteRoot = siteRootUrl(metadata.canonicalUrlBase);
+const pageUrl = `${siteRoot}${currentFramework}/${pageName}/`;
+const pageStructuredData: JsonLdObject[] = [
+    buildTechArticle({
+        canonicalUrlBase: metadata.canonicalUrlBase,
+        pageUrl,
+        title,
+        description: descriptionWithSeoTagline,
+        aboutEntityId: getSoftwareApplicationId(metadata.canonicalUrlBase),
+    }),
+    buildBreadcrumbList({
+        pageUrl,
+        items: [
+            { name: 'Home', url: siteRoot },
+            { name: `${frameworkDisplayText} Charts`, url: `${siteRoot}${currentFramework}/` },
+            { name: title, url: pageUrl },
+        ],
+    }),
+];
 ---
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -79,6 +107,7 @@ const descriptionWithSeoTagline = `${description} ${seoTagline}`;
     showTopBar={true}
     showSearchBar={true}
     showDocsNav={!hidePageMenu}
+    pageStructuredData={pageStructuredData}
 >
     <div class:list={[hidePageMenu && styles.noLeftMenu, styles.contentViewport, 'layout-grid', { largeExamples }]}>
         {


### PR DESCRIPTION
## Summary

JIRA: [AG-17419](https://ag-grid.atlassian.net/browse/AG-17419) — *Structured Data — no Schema Present. Adding JSON-LD would improve how AI systems understand and represent AG products.*

Mirrors the change shipped for AG Grid in [ag-grid#13851](https://github.com/ag-grid/ag-grid/pull/13851), so AI crawlers (Google AI Overviews, ChatGPT browsing, Perplexity) and SEO consumers (Google rich results, link unfurlers, voice assistants) see a machine-readable description of AG Charts on every indexable page.

- **All indexable pages** — single `<script type="application/ld+json">` containing one `@graph` with: `Organization`, `WebSite`, and `SoftwareApplication`.
- **Docs pages** (`/charts/[framework]/[pageName]/`) — add `TechArticle` (with `about` resolving to the local SoftwareApplication node) and `BreadcrumbList` (`Home → {Framework} Charts → page title`).
- `SoftwareApplication.softwareVersion` is the released form (pre-release suffix stripped, eg `13.3.0-beta.X` → `13.3.0`); Community/Enterprise `Offer`s link to `/charts/license-pricing/`.
- Gated off for `noIndex` pages and `isArchive` builds. `sameAs` is derived from the existing footer social links (no duplication).

The shared `JsonLd` component and builders live in `external/ag-website-shared/` and are identical to the copies landing in AG Grid and AG Studio (same `@id` scheme, same `siteRootUrl` normaliser that's safe for the `/charts` subpath canonical base).

## Test plan

- [x] `yarn nx test ag-website-shared` — 13 structuredData tests pass (incl. subpath-base case for `/charts`).
- [x] `yarn nx lint ag-charts-website` clean.
- [x] `yarn nx format --sort-root-tsconfig-paths=false`.
- [x] Live dev server (`https://localhost:4600/charts/`) — `view-source` shows one `<script type="application/ld+json">` containing `@graph` with Organization + WebSite + SoftwareApplication; URLs and `@id`s all carry the `/charts` subpath.
- [x] Live dev server `/charts/javascript/quick-start/` — `@graph` adds TechArticle + BreadcrumbList; `TechArticle.about` resolves to the in-graph SoftwareApplication.
- [ ] Validate against [Schema.org validator](https://validator.schema.org/) and [Google Rich Results Test](https://search.google.com/test/rich-results) once a preview is up.