### PR TITLE
jira-agent-pipeline: ghabot-ag- branches filter + ci-success-handler

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -40,10 +40,14 @@ name: Jira Agent Pipeline
 #         {"event_type":"jira-build",      "client_payload":{"issue_key":"AG-XXXXX"}}
 #         {"event_type":"jira-pr-iterate", "client_payload":{"issue_key":"AG-XXXXX"}}
 #
-#   workflow_run (auto — fires when the main CI workflow completes):
-#       Gates inside the ci-failure-preflight job:
-#         - workflow_run.conclusion == 'failure'
-#         - workflow_run.head_branch starts with 'ag-'             (agent branch shape)
+#   workflow_run (auto — fires when the main CI workflow completes on
+#       an agent-shaped branch. The `branches:` filter on the trigger
+#       restricts firings to `ghabot-ag-*` so non-AI PRs don't create
+#       skipped workflow runs in the history):
+#       ci-failure-preflight → ci-failure-iterate (on conclusion=failure)
+#       ci-success-handler                        (on conclusion=success)
+#       Gates inside both jobs:
+#         - workflow_run.head_branch matches 'ghabot-ag-<NNNNN>-<slug>'
 #         - PR author == 'ag-jira-agent-ci[bot]'                   (agent-authored)
 #         - issue's AI status ∈ {draft-pr-open, iterating, pr-iterating}
 #
@@ -93,21 +97,26 @@ on:
                     - build
                     - pr-iterate
     workflow_run:
-        # Auto-iterate when the main CI workflow fails on an agent-authored
-        # draft PR. The ci-failure-preflight job applies the actual gates;
-        # this trigger is intentionally wide so we don't miss eligible runs.
+        # Auto-react when the main CI workflow completes on an agent-authored
+        # branch — failure → ci-failure-iterate, success → ci-success-handler
+        # (Needs-Review transition). The `branches:` filter restricts firings
+        # at the trigger level so non-AI PR completions don't create skipped
+        # workflow runs in the Actions history. The agent branch shape is
+        # `ghabot-ag-<NNNNN>-<slug>` (see ag-dev-prompts modes/ci.md). Globs
+        # are case-sensitive, but the agent always produces lowercase.
         workflows: [CI]
         types: [completed]
+        branches: ['ghabot-ag-*']
 
 permissions:
     contents: read
 
 concurrency:
     # For workflow_run events the dispatch payloads are empty, so fall back
-    # to the failing run's head branch (which encodes the issue key:
-    # `ag-NNNNN/...`). Same group as the dispatch-driven jobs so a fresh
-    # CI-failure iteration queues behind any in-flight pr-iterate for the
-    # same ticket instead of interleaving.
+    # to the failing run's head branch (which encodes the issue key in the
+    # agent branch shape: `ghabot-ag-<NNNNN>-<slug>`). Same group as the
+    # dispatch-driven jobs so a fresh CI-failure iteration queues behind any
+    # in-flight pr-iterate for the same ticket instead of interleaving.
     group: claude-${{ github.event.client_payload.issue_key || inputs.issue_key || github.event.workflow_run.head_branch }}
     cancel-in-progress: false
 
@@ -271,10 +280,13 @@ jobs:
     # @ag-grid/dev-prompts is required to resolve the shared preflight
     # action; skipped runs (no eligible workflow_run) avoid this entirely.
     ci-failure-preflight:
+        # The `branches: ['ghabot-ag-*']` filter on the workflow_run trigger
+        # already constrains the branch shape, so the only gate left here is
+        # the conclusion. The shared preflight action does the full
+        # eligibility walk (PR author + AI status + Jira key extraction).
         if: |
             github.event_name == 'workflow_run' &&
-            github.event.workflow_run.conclusion == 'failure' &&
-            startsWith(github.event.workflow_run.head_branch, 'ag-')
+            github.event.workflow_run.conclusion == 'failure'
         runs-on: ubuntu-latest
         timeout-minutes: 5
         permissions:
@@ -349,6 +361,42 @@ jobs:
                   jira_agent_app_id: ${{ vars.JIRA_AGENT_APP_ID }}
                   jira_agent_app_private_key: ${{ secrets.JIRA_AGENT_APP_PRIVATE_KEY }}
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  jira_email: ${{ secrets.JIRA_EMAIL }}
+                  jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+                  jira_site_url: ${{ vars.JIRA_SITE_URL }}
+
+    # -------------------------------------------------- ci-success-handler
+    # Symmetric counterpart to ci-failure-preflight. Fires on the same
+    # workflow_run trigger but when the upstream CI finished successfully.
+    # No agent invocation — pure REST work: verify the run is still the
+    # PR head, transition the JIRA workflow to Needs Review, mark AI
+    # status: done, clear AI failure, zero the recovery counter. See the
+    # shared action for the full eligibility walk.
+    ci-success-handler:
+        if: |
+            github.event_name == 'workflow_run' &&
+            github.event.workflow_run.conclusion == 'success'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            pull-requests: read
+            packages: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+
+            - name: Install @ag-grid/dev-prompts
+              uses: ./.github/actions/install-ag-dev-prompts
+              with:
+                  channel: ${{ env.DEV_PROMPTS_CHANNEL }}
+
+            - uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/jira-ci-success-handler
+              with:
+                  head_branch: ${{ github.event.workflow_run.head_branch }}
+                  head_sha: ${{ github.event.workflow_run.head_sha }}
+                  run_url: ${{ github.event.workflow_run.html_url }}
                   jira_email: ${{ secrets.JIRA_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}


### PR DESCRIPTION
## Summary

Lockstep companion to **ag-grid/ag-dev-prompts#254**. Three changes to the consumer stub.

### 1. `workflow_run.branches: ['ghabot-ag-*']` filter on the trigger

The workflow no longer fires at all on non-agent CI completions. Today every CI completion on every PR creates a `Jira Agent Pipeline` workflow_run that immediately `if:`-skips all jobs — wasted history rows + minimal but real quota use. With the filter at trigger level, non-matching head branches skip the workflow entirely.

### 2. New `ci-success-handler` job

Symmetric to `ci-failure-preflight`. Fires on `conclusion == 'success'`, invokes the new `jira-ci-success-handler` shared action (in #254). Transitions the JIRA workflow status to `Needs Review` and marks `AI status: done` **only when CI on the agent's draft PR is actually green** — replacing the previous Phase-5 agent-side transition that pinged humans the moment a draft PR opened, before CI had reported.

### 3. `ci-failure-preflight` `if:` simplified

The branch-shape check (`startsWith(head_branch, 'ag-')`) moves to the trigger-level `branches:` filter. The only remaining job-level condition is `conclusion == 'failure'`.

## Branch-shape change

The agent's `--ci` branch shape is moving from `<jira-key>/<slug>` (human convention) to **`ghabot-ag-<NNNNN>-<slug>`** in #254. The new prefix is the load-bearing pipeline signal:

- Distinctive enough that humans don't accidentally match it (humans use `<jira-key>/<slug>`, slashed)
- The `branches:` filter glob `ghabot-ag-*` cleanly scopes the workflow_run trigger
- The shared preflight/success-handler regex `^ghabot-ag-([0-9]+)-` extracts the JIRA key

## Dependency / ordering

Depends on **ag-grid/ag-dev-prompts#254**. Sequence:

1. #254 merges to canary
2. Canary auto-publishes; ag-charts (pinned to `DEV_PROMPTS_CHANNEL: canary`) picks up the new action on the next workflow run
3. This PR merges to ag-charts/`latest`
4. JIRA test ticket dispatched via the agent → produces a `ghabot-ag-*` branch → CI runs → green CI fires `ci-success-handler` → ticket transitions to `Needs Review`

Held as **draft** until #254 lands.

## Test plan

- [ ] Merge ag-dev-prompts#254; verify canary publishes
- [ ] Mark this PR ready-for-review; verify CI passes (YAML validation, no runtime change yet)
- [ ] Merge this PR
- [ ] Dispatch a test JIRA ticket → verify agent creates `ghabot-ag-*` branch
- [ ] Verify CI completion on a non-`ghabot-ag-*` branch does NOT create a Jira Agent Pipeline workflow run
- [ ] Verify CI green on the test ticket's draft PR → `ci-success-handler` fires → ticket moves to Needs Review
- [ ] Verify CI failure on the test ticket's draft PR → `ci-failure-iterate` fires (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)