### PR TITLE
Publish per-PR UMD bundles to gh-pages for Plunker live-testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,17 @@ jobs:
               run: |
                   yarn nx ${{ github.event.inputs.nx_command || 'affected' }} -t build --exclude all,ag-charts-website
 
+            - name: Upload UMD bundles for PR preview
+              if: github.event_name == 'pull_request' && steps.build.outcome == 'success'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: pr-preview-umd
+                  if-no-files-found: ignore
+                  retention-days: 14
+                  path: |
+                      packages/ag-charts-community/dist/umd/ag-charts-community.min.js
+                      packages/ag-charts-enterprise/dist/umd/ag-charts-enterprise.min.js
+
     validate:
         runs-on: ubuntu-24.04
         name: Validate Examples
@@ -354,6 +365,81 @@ jobs:
               id: validate
               if: steps.setup.outcome == 'success' || steps.setup.outcome == 'skipped'
               run: yarn nx ${{ github.event.inputs.nx_command || 'affected' }} -t validate-examples --exclude all
+
+    pr_preview:
+        runs-on: ubuntu-24.04
+        name: PR Preview (UMD)
+        needs: [build]
+        if: github.event_name == 'pull_request' && needs.build.outputs.build == 'success'
+        permissions:
+            contents: write
+            pull-requests: write
+        concurrency:
+            group: pr-preview-gh-pages
+            cancel-in-progress: false
+        env:
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+        steps:
+            - name: Download UMD artifact
+              id: download
+              uses: actions/download-artifact@v4
+              continue-on-error: true
+              with:
+                  name: pr-preview-umd
+                  path: _umd
+
+            - name: Stage publish tree
+              id: stage
+              if: steps.download.outcome == 'success'
+              run: |
+                  set -euo pipefail
+                  COMMUNITY="_umd/packages/ag-charts-community/dist/umd/ag-charts-community.min.js"
+                  ENTERPRISE="_umd/packages/ag-charts-enterprise/dist/umd/ag-charts-enterprise.min.js"
+                  if [ ! -f "$COMMUNITY" ] && [ ! -f "$ENTERPRISE" ]; then
+                      echo "No UMD bundles in artifact — likely tooling-only PR; skipping publish."
+                      echo "publish=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+                  if [ ! -f "$COMMUNITY" ] || [ ! -f "$ENTERPRISE" ]; then
+                      echo "ERROR: exactly one UMD bundle present; expected both or neither." >&2
+                      ls -la _umd || true
+                      exit 1
+                  fi
+                  DEST="_publish/pr-${PR_NUMBER}"
+                  mkdir -p "$DEST"
+                  cp "$COMMUNITY" "$ENTERPRISE" "$DEST/"
+                  # .nojekyll at root disables Jekyll on gh-pages; keep_files preserves it across pushes.
+                  touch _publish/.nojekyll
+                  echo "publish=true" >> "$GITHUB_OUTPUT"
+
+            - name: Deploy to gh-pages
+              if: steps.stage.outputs.publish == 'true'
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: _publish
+                  publish_branch: gh-pages
+                  keep_files: true
+                  commit_message: 'pr-preview: publish pr-${{ env.PR_NUMBER }}'
+                  user_name: 'github-actions[bot]'
+                  user_email: 'github-actions[bot]@users.noreply.github.com'
+
+            - name: Post sticky PR comment
+              if: steps.stage.outputs.publish == 'true'
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: pr-preview-umd
+                  message: |
+                      ### Live-test this PR in Plunker
+
+                      Paste these two `<script>` tags into a Plunker (or any vanilla-JS host) to load the UMD bundles built from this PR:
+
+                      ```html
+                      <script src="https://ag-grid.github.io/ag-charts/pr-${{ env.PR_NUMBER }}/ag-charts-community.min.js"></script>
+                      <script src="https://ag-grid.github.io/ag-charts/pr-${{ env.PR_NUMBER }}/ag-charts-enterprise.min.js"></script>
+                      ```
+
+                      Bundles are removed automatically when the PR is closed. Updated on every push.
 
     website_build:
         runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
                       exit 0
                   fi
                   if [ -z "$COMMUNITY" ] || [ -z "$ENTERPRISE" ]; then
-                      echo "ERROR: exactly one UMD bundle present; expected both or neither." >&2
+                      echo "::error exactly one UMD bundle present; expected both or neither." >&2
                       ls -laR _umd || true
                       exit 1
                   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,13 @@ jobs:
         runs-on: ubuntu-24.04
         name: PR Preview (UMD)
         needs: [build]
-        if: github.event_name == 'pull_request' && needs.build.outputs.build == 'success'
+        # Same-repo PRs only — fork PRs get a read-only token from GitHub, so
+        # the deploy-to-gh-pages and sticky-comment steps would fail. Mirrors
+        # the fork-PR gate used in pr-review.yml.
+        if: |
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            needs.build.outputs.build == 'success'
         permissions:
             contents: write
             pull-requests: write
@@ -393,16 +399,20 @@ jobs:
               if: steps.download.outcome == 'success'
               run: |
                   set -euo pipefail
-                  COMMUNITY="_umd/packages/ag-charts-community/dist/umd/ag-charts-community.min.js"
-                  ENTERPRISE="_umd/packages/ag-charts-enterprise/dist/umd/ag-charts-enterprise.min.js"
-                  if [ ! -f "$COMMUNITY" ] && [ ! -f "$ENTERPRISE" ]; then
+                  # actions/upload-artifact@v4 strips the least-common-ancestor
+                  # of uploaded paths, so the two bundles land somewhere under
+                  # _umd/ but not at a predictable absolute path. Find them by
+                  # filename instead.
+                  COMMUNITY=$(find _umd -type f -name 'ag-charts-community.min.js' -print -quit)
+                  ENTERPRISE=$(find _umd -type f -name 'ag-charts-enterprise.min.js' -print -quit)
+                  if [ -z "$COMMUNITY" ] && [ -z "$ENTERPRISE" ]; then
                       echo "No UMD bundles in artifact — likely tooling-only PR; skipping publish."
                       echo "publish=false" >> "$GITHUB_OUTPUT"
                       exit 0
                   fi
-                  if [ ! -f "$COMMUNITY" ] || [ ! -f "$ENTERPRISE" ]; then
+                  if [ -z "$COMMUNITY" ] || [ -z "$ENTERPRISE" ]; then
                       echo "ERROR: exactly one UMD bundle present; expected both or neither." >&2
-                      ls -la _umd || true
+                      ls -laR _umd || true
                       exit 1
                   fi
                   DEST="_publish/pr-${PR_NUMBER}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
                   COMMUNITY=$(find _umd -type f -name 'ag-charts-community.min.js' -print -quit)
                   ENTERPRISE=$(find _umd -type f -name 'ag-charts-enterprise.min.js' -print -quit)
                   if [ -z "$COMMUNITY" ] && [ -z "$ENTERPRISE" ]; then
-                      echo "No UMD bundles in artifact — likely tooling-only PR; skipping publish."
+                      echo "::warning No UMD bundles in artifact — likely tooling-only PR; skipping publish."
                       echo "publish=false" >> "$GITHUB_OUTPUT"
                       exit 0
                   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,9 @@ jobs:
                   retention-days: 14
                   path: |
                       packages/ag-charts-community/dist/umd/ag-charts-community.min.js
+                      packages/ag-charts-community/dist/umd/ag-charts-community.min.js.map
                       packages/ag-charts-enterprise/dist/umd/ag-charts-enterprise.min.js
+                      packages/ag-charts-enterprise/dist/umd/ag-charts-enterprise.min.js.map
 
     validate:
         runs-on: ubuntu-24.04
@@ -418,6 +420,12 @@ jobs:
                   DEST="_publish/pr-${PR_NUMBER}"
                   mkdir -p "$DEST"
                   cp "$COMMUNITY" "$ENTERPRISE" "$DEST/"
+                  # Sourcemaps are emitted alongside each .min.js by the build:umd
+                  # post-minification plugin (see esbuild.config.cjs). Copy them if
+                  # present so Plunker stack traces resolve to original sources.
+                  for MAP in "${COMMUNITY}.map" "${ENTERPRISE}.map"; do
+                      [ -f "$MAP" ] && cp "$MAP" "$DEST/"
+                  done
                   # .nojekyll at root disables Jekyll on gh-pages; keep_files preserves it across pushes.
                   touch _publish/.nojekyll
                   echo "publish=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -400,3 +400,14 @@ jobs:
                   jira_email: ${{ secrets.JIRA_EMAIL }}
                   jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
                   jira_site_url: ${{ vars.JIRA_SITE_URL }}
+                  # Live-test snippet — the ci.yml `pr_preview` job publishes
+                  # per-PR UMD bundles to gh-pages, so the reviewer can paste
+                  # these two <script> tags into a vanilla-JS Plunker to
+                  # exercise the actual built library from this PR.
+                  success_comment_body: |
+                      Live-test this PR in Plunker — paste these into a vanilla-JS sandbox:
+
+                      <script src="https://ag-grid.github.io/ag-charts/pr-{PR_NUMBER}/ag-charts-community.min.js"></script>
+                      <script src="https://ag-grid.github.io/ag-charts/pr-{PR_NUMBER}/ag-charts-enterprise.min.js"></script>
+
+                      Bundles auto-cleanup on PR close. PR: {PR_URL}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -45,3 +45,39 @@ jobs:
                   fi
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    gh_pages_cleanup:
+        runs-on: ubuntu-24.04
+        name: Remove PR preview from gh-pages
+        permissions:
+            contents: write
+        concurrency:
+            group: pr-preview-gh-pages
+            cancel-in-progress: false
+        env:
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+        steps:
+            - name: Check out gh-pages branch
+              id: checkout
+              uses: actions/checkout@v4
+              continue-on-error: true
+              with:
+                  ref: gh-pages
+                  fetch-depth: 1
+
+            - name: Remove PR directory
+              if: steps.checkout.outcome == 'success'
+              run: |
+                  set -euo pipefail
+                  DIR="pr-${PR_NUMBER}"
+                  if [ ! -d "$DIR" ]; then
+                      echo "No $DIR directory on gh-pages; nothing to clean up."
+                      exit 0
+                  fi
+                  git config user.name 'github-actions[bot]'
+                  git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git rm -rf "$DIR"
+                  git commit -m "pr-preview: cleanup pr-${PR_NUMBER}"
+                  # Retry once on push race; the concurrency group should already serialise us,
+                  # but a publish could have landed between our checkout and push.
+                  git push origin gh-pages || (git pull --rebase origin gh-pages && git push origin gh-pages)


### PR DESCRIPTION
## Summary

End-to-end flow so per-PR library changes can be live-tested in Plunker, with the URLs surfaced both on the PR and inside the JIRA ticket when an agent-authored PR transitions to Needs Review.

### CI publish + cleanup (this repo)

- **`build` job (ci.yml)** now uploads `ag-charts-community.min.js` + `ag-charts-enterprise.min.js` as the `pr-preview-umd` artifact on PR runs (`if-no-files-found: ignore` so tooling-only PRs that don't affect those packages are silently skipped).
- **New `pr_preview` job (ci.yml)** downloads the artifact, stages it as `_publish/pr-<NUMBER>/`, touches `.nojekyll` at the publish root for self-bootstrap, deploys to the `gh-pages` branch via `peaceiris/actions-gh-pages@v3` with `keep_files: true`, and posts a sticky PR comment with the two `<script>` tag URLs. Cross-PR serialisation via the `pr-preview-gh-pages` concurrency group. Gated on same-repo PRs only (`head.repo.full_name == github.repository`) — fork PRs get a read-only token and would fail the gh-pages push.
- **`pr-cleanup.yml`** gains a `gh_pages_cleanup` job in the same concurrency group that removes `pr-<NUMBER>/` from `gh-pages` on PR close, with a rebase-and-retry guard against late-landing publishes.

URL pattern: `https://ag-grid.github.io/ag-charts/pr-<NUMBER>/ag-charts-{community,enterprise}.min.js`

The `gh-pages` branch is already bootstrapped with `.nojekyll` + a minimal `index.html` landing page; GH Pages must be enabled in repo settings (Settings → Pages → Source: `gh-pages` branch, `/` root) for the URLs to resolve.

### JIRA pipeline integration

- **`jira-agent-pipeline.yml`** now passes `success_comment_body` to the shared `jira-ci-success-handler` action (capability added in [ag-dev-prompts#259](https://github.com/ag-grid/ag-dev-prompts/pull/259)). When an agent-authored PR's CI goes green and the ticket transitions to Needs Review, the handler posts a JIRA comment containing the two `<script>` tags with `{PR_NUMBER}`/`{PR_URL}` substituted — reviewer can paste straight into a Plunker without leaving JIRA.

## Test plan

- [ ] Repo settings: Pages enabled on `gh-pages` branch.
- [ ] This PR's `pr_preview` job runs successfully and posts a sticky comment.
- [ ] `https://ag-grid.github.io/ag-charts/pr-<this-PR-#>/ag-charts-community.min.js` loads in a browser with `Content-Type: text/javascript`.
- [ ] Same for `ag-charts-enterprise.min.js`.
- [ ] Paste both `<script>` tags into a Plunker and confirm `agCharts.AgCharts.create({...})` renders.
- [ ] Force-push a follow-up commit; sticky comment updates in place rather than duplicating.
- [ ] On PR close, `gh_pages_cleanup` runs and the URL 404s afterwards.
- [ ] JIRA flow: spin up a `/fr --ci` cycle on a test ticket, let it open a draft PR, let CI go green; confirm the Needs-Review transition posts the JIRA comment with the substituted URLs.