### PR TITLE
AG-17227 Fix sparkline context aliasing across cache hits

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.test.ts
+++ b/packages/ag-charts-community/src/api/agCharts.test.ts
@@ -87,9 +87,8 @@ describe('AgCharts', () => {
             height: sparklineOptions.height! + 50,
             data: sparklineOptions.data!.toReversed(),
             container: () => getDocument().createElement('div'),
-            // `context` change must take the fast path — the Grid sparkline cell
-            // renderer passes a fresh per-row `context` on every `update()`, so
-            // forcing slow setup here would defeat the cell-recycling perf win.
+            // A `context` change must stay on the fast path: the Grid cell renderer passes
+            // a fresh per-row `context` on every `update()`, and slow setup would negate it.
             context: { row: 1, cellData: 0.42 },
         };
 

--- a/packages/ag-charts-community/src/api/agCharts.test.ts
+++ b/packages/ag-charts-community/src/api/agCharts.test.ts
@@ -87,6 +87,10 @@ describe('AgCharts', () => {
             height: sparklineOptions.height! + 50,
             data: sparklineOptions.data!.toReversed(),
             container: () => getDocument().createElement('div'),
+            // `context` change must take the fast path — the Grid sparkline cell
+            // renderer passes a fresh per-row `context` on every `update()`, so
+            // forcing slow setup here would defeat the cell-recycling perf win.
+            context: { row: 1, cellData: 0.42 },
         };
 
         describe('#__createSparkline', () => {

--- a/packages/ag-charts-community/src/api/preset/sparkline.ts
+++ b/packages/ag-charts-community/src/api/preset/sparkline.ts
@@ -276,6 +276,18 @@ function gridLinePreset(
     return gridLineOpts;
 }
 
+// `datumKey === 'y'` is set by `sparklineDataPreset` for raw number-array input,
+// where the x value is a synthesised index rather than a user-meaningful key.
+// For all other shapes (user-supplied `xKey` on object data, tuple-array input
+// with the original tuple exposed under `'datum'`), the x value is real and
+// belongs in the default tooltip content.
+const shouldShowXValue = (datumKey?: string) => datumKey !== 'y';
+
+const defaultTooltipContent = (xValue: unknown, yValue: unknown, datumKey?: string): string => {
+    const formattedY = typeof yValue === 'number' ? yValue.toFixed(2) : String(yValue);
+    return shouldShowXValue(datumKey) && xValue != null ? `${String(xValue)} ${formattedY}` : formattedY;
+};
+
 const tooltipRendererFn = simpleMemorize((tooltip?: AgSparklineTooltip<any>, datumKey?: string) => {
     return (
         params: AgBarSeriesTooltipRendererParams | AgLineSeriesTooltipRendererParams | AgAreaSeriesTooltipRendererParams
@@ -293,11 +305,13 @@ const tooltipRendererFn = simpleMemorize((tooltip?: AgSparklineTooltip<any>, dat
             return toTextString(userContent);
         }
 
-        // `userContent === undefined` (renderer absent or returning `undefined`) falls through
-        // naturally: optional chaining on `userContent?.content` / `userContent?.title` yields
-        // undefined and the default `yValue.toFixed(2)` content is used. Per the Renderer<P, R>
-        // contract this is the documented "fall through to default" behaviour.
-        const content = userContent?.content ?? yValue.toFixed(2);
+        // `userContent === undefined` (renderer absent or returning `undefined`) falls
+        // through naturally: optional chaining on `userContent?.content` /
+        // `userContent?.title` yields undefined and the default content is used. The
+        // default includes the x value when it is user-meaningful, so callers that
+        // only want yValue formatting don't need to install a custom renderer just to
+        // suppress an auto-synthesised index.
+        const content = userContent?.content ?? defaultTooltipContent(xValue, yValue, datumKey);
 
         return userContent?.title
             ? {

--- a/packages/ag-charts-community/src/api/preset/sparkline.ts
+++ b/packages/ag-charts-community/src/api/preset/sparkline.ts
@@ -276,11 +276,8 @@ function gridLinePreset(
     return gridLineOpts;
 }
 
-// `datumKey === 'y'` is set by `sparklineDataPreset` for raw number-array input,
-// where the x value is a synthesised index rather than a user-meaningful key.
-// For all other shapes (user-supplied `xKey` on object data, tuple-array input
-// with the original tuple exposed under `'datum'`), the x value is real and
-// belongs in the default tooltip content.
+// `datumKey === 'y'` marks number-array input, where the x value is a synthesised
+// index rather than a user-meaningful key, so it is omitted from the default content.
 const defaultTooltipContent = (xValue: unknown, yValue: unknown, datumKey?: string): string => {
     const formattedY = typeof yValue === 'number' ? yValue.toFixed(2) : String(yValue);
     const showXValue = datumKey !== 'y' && xValue != null;
@@ -295,21 +292,15 @@ const tooltipRendererFn = simpleMemorize((tooltip?: AgSparklineTooltip<any>, dat
         const yValue = params.datum[params.yKey];
         const datum = datumKey == null ? params.datum : params.datum[datumKey];
 
-        // `params.context` is populated by `callWithContext` from `chart.context`, so
-        // the wrapper does not need to capture context at wrap time. This lets the
-        // structural-options cache share the wrapper across chart instances safely.
+        // Read `context` from params (set per-chart by `callWithContext`) rather than
+        // capturing it at wrap time, so the structural cache can share this wrapper.
         const userContent = tooltip?.renderer?.({ context: params.context, datum, xValue, yValue });
 
         if (isString(userContent) || isNumber(userContent) || isDate(userContent)) {
             return toTextString(userContent);
         }
 
-        // `userContent === undefined` (renderer absent or returning `undefined`) falls
-        // through naturally: optional chaining on `userContent?.content` /
-        // `userContent?.title` yields undefined and the default content is used. The
-        // default includes the x value when it is user-meaningful, so callers that
-        // only want yValue formatting don't need to install a custom renderer just to
-        // suppress an auto-synthesised index.
+        // Absent renderer or one returning `undefined` falls through to the default content.
         const content = userContent?.content ?? defaultTooltipContent(xValue, yValue, datumKey);
 
         return userContent?.title

--- a/packages/ag-charts-community/src/api/preset/sparkline.ts
+++ b/packages/ag-charts-community/src/api/preset/sparkline.ts
@@ -276,12 +276,19 @@ function gridLinePreset(
     return gridLineOpts;
 }
 
-// `datumKey === 'y'` marks number-array input, where the x value is a synthesised
-// index rather than a user-meaningful key, so it is omitted from the default content.
-const defaultTooltipContent = (xValue: unknown, yValue: unknown, datumKey?: string): string => {
-    const formattedY = typeof yValue === 'number' ? yValue.toFixed(2) : String(yValue);
-    const showXValue = datumKey !== 'y' && xValue != null;
-    return showXValue ? `${String(xValue)} ${formattedY}` : formattedY;
+// The x value is prepended to the default content only when it is both meaningful and
+// has somewhere to go, matching the Grid's historical sparkline default tooltip:
+//  - `datumKey === 'y'` marks number-array input, where x is a synthesised index — omit it.
+//  - a user-supplied title takes the label slot, leaving the value as y-only.
+// y is rendered raw (no `.toFixed(2)`) to match that Grid default.
+const defaultTooltipContent = (
+    xValue: unknown,
+    yValue: unknown,
+    datumKey: string | undefined,
+    hasUserTitle: boolean
+): string => {
+    const showXValue = !hasUserTitle && datumKey !== 'y' && xValue != null;
+    return showXValue ? `${String(xValue)} ${String(yValue)}` : String(yValue);
 };
 
 const tooltipRendererFn = simpleMemorize((tooltip?: AgSparklineTooltip<any>, datumKey?: string) => {
@@ -301,7 +308,8 @@ const tooltipRendererFn = simpleMemorize((tooltip?: AgSparklineTooltip<any>, dat
         }
 
         // Absent renderer or one returning `undefined` falls through to the default content.
-        const content = userContent?.content ?? defaultTooltipContent(xValue, yValue, datumKey);
+        const hasUserTitle = userContent?.title != null;
+        const content = userContent?.content ?? defaultTooltipContent(xValue, yValue, datumKey, hasUserTitle);
 
         return userContent?.title
             ? {

--- a/packages/ag-charts-community/src/api/preset/sparkline.ts
+++ b/packages/ag-charts-community/src/api/preset/sparkline.ts
@@ -281,11 +281,10 @@ function gridLinePreset(
 // For all other shapes (user-supplied `xKey` on object data, tuple-array input
 // with the original tuple exposed under `'datum'`), the x value is real and
 // belongs in the default tooltip content.
-const shouldShowXValue = (datumKey?: string) => datumKey !== 'y';
-
 const defaultTooltipContent = (xValue: unknown, yValue: unknown, datumKey?: string): string => {
     const formattedY = typeof yValue === 'number' ? yValue.toFixed(2) : String(yValue);
-    return shouldShowXValue(datumKey) && xValue != null ? `${String(xValue)} ${formattedY}` : formattedY;
+    const showXValue = datumKey !== 'y' && xValue != null;
+    return showXValue ? `${String(xValue)} ${formattedY}` : formattedY;
 };
 
 const tooltipRendererFn = simpleMemorize((tooltip?: AgSparklineTooltip<any>, datumKey?: string) => {

--- a/packages/ag-charts-community/src/api/preset/sparkline.ts
+++ b/packages/ag-charts-community/src/api/preset/sparkline.ts
@@ -276,7 +276,7 @@ function gridLinePreset(
     return gridLineOpts;
 }
 
-const tooltipRendererFn = simpleMemorize((context: any, tooltip?: AgSparklineTooltip<any>, datumKey?: string) => {
+const tooltipRendererFn = simpleMemorize((tooltip?: AgSparklineTooltip<any>, datumKey?: string) => {
     return (
         params: AgBarSeriesTooltipRendererParams | AgLineSeriesTooltipRendererParams | AgAreaSeriesTooltipRendererParams
     ): AgTooltipRendererResult | string => {
@@ -284,7 +284,10 @@ const tooltipRendererFn = simpleMemorize((context: any, tooltip?: AgSparklineToo
         const yValue = params.datum[params.yKey];
         const datum = datumKey == null ? params.datum : params.datum[datumKey];
 
-        const userContent = tooltip?.renderer?.({ context, datum, xValue, yValue });
+        // `params.context` is populated by `callWithContext` from `chart.context`, so
+        // the wrapper does not need to capture context at wrap time. This lets the
+        // structural-options cache share the wrapper across chart instances safely.
+        const userContent = tooltip?.renderer?.({ context: params.context, datum, xValue, yValue });
 
         if (isString(userContent) || isNumber(userContent) || isDate(userContent)) {
             return toTextString(userContent);
@@ -338,6 +341,7 @@ export function sparkline(opts: AgSparklineOptions): AgCartesianChartOptions {
     const chartOpts: AgCartesianChartOptions & SparklineUndocumentedProperties = {
         background,
         container,
+        context,
         foreground,
         height,
         listeners: listeners as AgCartesianChartOptions['listeners'],
@@ -358,7 +362,7 @@ export function sparkline(opts: AgSparklineOptions): AgCartesianChartOptions {
     }
     seriesConfig.tooltip = {
         ...tooltip,
-        renderer: tooltipRendererFn(context, tooltip, datumKey),
+        renderer: tooltipRendererFn(tooltip, datumKey),
     };
 
     chartOpts.theme = setInitialBaseTheme(baseTheme, SPARKLINE_THEME) as AgChartTheme; // TODO: Remove cast when `WithThemeParams` is public

--- a/packages/ag-charts-community/src/chart/sparkline.test.ts
+++ b/packages/ag-charts-community/src/chart/sparkline.test.ts
@@ -408,7 +408,7 @@ describe('Sparkline', () => {
             // sparklineDataPreset maps numbers to { x: index, y: value } with datumKey: 'y'.
             const result: any = renderDefaultTooltip(chart, { x: 1, y: 20 }, 'x', 'y');
             const html = JSON.stringify(result);
-            expect(html).toContain('20.00');
+            expect(html).toContain('20');
             expect(html).not.toContain('1 20'); // would indicate the synthesised index leaked through
         });
 
@@ -428,7 +428,7 @@ describe('Sparkline', () => {
             // tuple data → datumKey: 'datum' (preserved original tuple). xValue is real.
             const result: any = renderDefaultTooltip(chart, { x: 1, y: 20, datum: [1, 20] }, 'x', 'y');
             const html = JSON.stringify(result);
-            expect(html).toContain('1 20.00');
+            expect(html).toContain('1 20');
         });
 
         it('includes the x value for user-supplied xKey on object data', async () => {
@@ -449,7 +449,32 @@ describe('Sparkline', () => {
             // object data with user xKey → datumKey undefined. xValue is real.
             const result: any = renderDefaultTooltip(chart, { date: 'Feb', value: 20 }, 'date', 'value');
             const html = JSON.stringify(result);
-            expect(html).toContain('Feb 20.00');
+            expect(html).toContain('Feb 20');
+        });
+
+        it('omits the x value when a user renderer supplies only a title', async () => {
+            // Regression (AG-17227): a title-only renderer must not let the default content
+            // leak the x value into the value slot — the Grid suppressed x when a title was set.
+            const instance = AgCharts.__createSparkline({
+                type: 'line',
+                data: [
+                    [0, 10],
+                    [1, 20],
+                ],
+                width: 200,
+                height: 100,
+                tooltip: {
+                    renderer: () => ({ title: 'sym' }),
+                },
+            });
+            chart = deproxy(instance);
+            await waitForChartStability(chart);
+
+            const result: any = renderDefaultTooltip(chart, { x: 1, y: 20, datum: [1, 20] }, 'x', 'y');
+            const html = JSON.stringify(result);
+            expect(html).toContain('sym');
+            expect(html).toContain('20');
+            expect(html).not.toContain('1 20'); // x suppressed because a title was supplied
         });
     });
 });

--- a/packages/ag-charts-community/src/chart/sparkline.test.ts
+++ b/packages/ag-charts-community/src/chart/sparkline.test.ts
@@ -287,14 +287,8 @@ describe('Sparkline', () => {
     });
 
     describe('chart-level context propagation (AG-17227)', () => {
-        // Verifies that chart-level `context` reaches tooltip renderer params via
-        // `callWithContext`, replacing the per-callback context injection pattern.
-        // Sparkline preset's tooltip wrapper must not capture context at wrap time,
-        // otherwise structural-cache hits would alias context across charts.
-
-        // Invokes the series tooltip path directly. JSDOM cannot canvas-pick, so a
-        // synthesised hover would not reach the renderer; calling formatTooltip
-        // through the public series API mirrors what hover would otherwise trigger.
+        // JSDOM cannot canvas-pick, so a synthesised hover never reaches the renderer;
+        // invoking `formatTooltip` directly mirrors what hover would otherwise trigger.
         const invokeTooltipRenderer = (c: Chart) => {
             const series = c.series[0] as any;
             const tooltip = series.properties.tooltip;
@@ -356,11 +350,8 @@ describe('Sparkline', () => {
                 tooltip: { renderer },
             };
 
-            // Two sparklines share a single user renderer reference but have distinct
-            // chart-level `context` payloads. Each invocation must receive its own
-            // chart's context — never the other's — regardless of whether the
-            // structural cache hits (the user renderer prevents that today) or the
-            // sparkline preset's memoised wrapper happens to be shared.
+            // A shared renderer reference must not let one chart's context leak into the
+            // other's, whether or not the structural cache or memoised wrapper is shared.
             const instanceA = AgCharts.__createSparkline({ ...baseOptions, context: contextA });
             const chartA = deproxy(instanceA);
             await waitForChartStability(chartA);
@@ -383,11 +374,8 @@ describe('Sparkline', () => {
     });
 
     describe('default tooltip content (AG-17227)', () => {
-        // The chart-side preset must produce a useful default tooltip without the
-        // consumer (e.g. the Grid sparkline cell renderer) needing to install a
-        // function at `tooltip.renderer`. A function in user options poisons the
-        // structural-options cache key, so this default-in-the-preset behaviour is
-        // what lets the cache hit for the common Grid case.
+        // The preset must produce a useful default tooltip without a user `renderer`
+        // function, which would otherwise poison the structural-cache key for the Grid case.
 
         const renderDefaultTooltip = (c: Chart, datum: any, xKey: string, yKey: string) => {
             const series = c.series[0] as any;

--- a/packages/ag-charts-community/src/chart/sparkline.test.ts
+++ b/packages/ag-charts-community/src/chart/sparkline.test.ts
@@ -419,7 +419,7 @@ describe('Sparkline', () => {
 
             // sparklineDataPreset maps numbers to { x: index, y: value } with datumKey: 'y'.
             const result: any = renderDefaultTooltip(chart, { x: 1, y: 20 }, 'x', 'y');
-            const html = result.rawHtmlString ?? JSON.stringify(result);
+            const html = JSON.stringify(result);
             expect(html).toContain('20.00');
             expect(html).not.toContain('1 20'); // would indicate the synthesised index leaked through
         });
@@ -439,7 +439,7 @@ describe('Sparkline', () => {
 
             // tuple data → datumKey: 'datum' (preserved original tuple). xValue is real.
             const result: any = renderDefaultTooltip(chart, { x: 1, y: 20, datum: [1, 20] }, 'x', 'y');
-            const html = result.rawHtmlString ?? JSON.stringify(result);
+            const html = JSON.stringify(result);
             expect(html).toContain('1 20.00');
         });
 
@@ -460,7 +460,7 @@ describe('Sparkline', () => {
 
             // object data with user xKey → datumKey undefined. xValue is real.
             const result: any = renderDefaultTooltip(chart, { date: 'Feb', value: 20 }, 'date', 'value');
-            const html = result.rawHtmlString ?? JSON.stringify(result);
+            const html = JSON.stringify(result);
             expect(html).toContain('Feb 20.00');
         });
     });

--- a/packages/ag-charts-community/src/chart/sparkline.test.ts
+++ b/packages/ag-charts-community/src/chart/sparkline.test.ts
@@ -241,5 +241,144 @@ describe('Sparkline', () => {
             chartB.destroy();
             chart = chartA;
         });
+
+        it('does not alias context across cache-hit instances with same shape, different context', async () => {
+            const baseOptions = { type: 'line' as const, width: 200, height: 100, data: [1, 2, 3] };
+            const contextA = { row: 1, cellValue: 'A' };
+            const contextB = { row: 2, cellValue: 'B' };
+
+            const instanceA = AgCharts.__createSparkline({ ...baseOptions, context: contextA });
+            const chartA = deproxy(instanceA);
+            await waitForChartStability(chartA);
+
+            const instanceB = AgCharts.__createSparkline({ ...baseOptions, context: contextB });
+            const chartB = deproxy(instanceB);
+            await waitForChartStability(chartB);
+
+            expect(chartA.context).toBe(contextA);
+            expect(chartB.context).toBe(contextB);
+
+            chartB.destroy();
+            chart = chartA;
+        });
+
+        it('does not alias container across cache-hit instances with same shape, different container', async () => {
+            const baseOptions = { type: 'line' as const, width: 200, height: 100, data: [1, 2, 3] };
+            const containerA = document.createElement('div');
+            const containerB = document.createElement('div');
+            document.body.append(containerA, containerB);
+
+            const instanceA = AgCharts.__createSparkline({ ...baseOptions, container: containerA });
+            const chartA = deproxy(instanceA);
+            await waitForChartStability(chartA);
+
+            const instanceB = AgCharts.__createSparkline({ ...baseOptions, container: containerB });
+            const chartB = deproxy(instanceB);
+            await waitForChartStability(chartB);
+
+            expect(chartA.container).toBe(containerA);
+            expect(chartB.container).toBe(containerB);
+
+            chartB.destroy();
+            containerA.remove();
+            containerB.remove();
+            chart = chartA;
+        });
+    });
+
+    describe('chart-level context propagation (AG-17227)', () => {
+        // Verifies that chart-level `context` reaches tooltip renderer params via
+        // `callWithContext`, replacing the per-callback context injection pattern.
+        // Sparkline preset's tooltip wrapper must not capture context at wrap time,
+        // otherwise structural-cache hits would alias context across charts.
+
+        // Invokes the series tooltip path directly. JSDOM cannot canvas-pick, so a
+        // synthesised hover would not reach the renderer; calling formatTooltip
+        // through the public series API mirrors what hover would otherwise trigger.
+        const invokeTooltipRenderer = (c: Chart) => {
+            const series = c.series[0] as any;
+            const tooltip = series.properties.tooltip;
+            const params: any = {
+                datum: { x: 0, y: 1 },
+                xKey: 'x',
+                yKey: 'y',
+                xValue: 0,
+                yValue: 1,
+                seriesId: series.id,
+                title: undefined,
+                color: undefined,
+            };
+            tooltip.formatTooltip([series.properties, series.ctx.chartService], { data: [] }, params);
+        };
+
+        it('passes chart-level context to tooltip.renderer params', async () => {
+            const seen: unknown[] = [];
+            const userContext = { tag: 'row-42' };
+            const instance = AgCharts.__createSparkline({
+                type: 'line',
+                data: [1, 2, 3],
+                width: 200,
+                height: 100,
+                context: userContext,
+                tooltip: {
+                    renderer: (params) => {
+                        seen.push(params.context);
+                        return { content: String(params.yValue) };
+                    },
+                },
+            });
+            chart = deproxy(instance);
+            await waitForChartStability(chart);
+
+            invokeTooltipRenderer(chart);
+
+            expect(seen.length).toBeGreaterThan(0);
+            for (const ctxValue of seen) {
+                expect(ctxValue).toBe(userContext);
+            }
+        });
+
+        it('does not alias context between sparklines sharing a user renderer reference', async () => {
+            const seen: unknown[] = [];
+            const renderer = (params: any) => {
+                seen.push(params.context);
+                return { content: String(params.yValue) };
+            };
+
+            const contextA = { tag: 'row-A' };
+            const contextB = { tag: 'row-B' };
+
+            const baseOptions = {
+                type: 'line' as const,
+                data: [1, 2, 3],
+                width: 200,
+                height: 100,
+                tooltip: { renderer },
+            };
+
+            // Two sparklines share a single user renderer reference but have distinct
+            // chart-level `context` payloads. Each invocation must receive its own
+            // chart's context — never the other's — regardless of whether the
+            // structural cache hits (the user renderer prevents that today) or the
+            // sparkline preset's memoised wrapper happens to be shared.
+            const instanceA = AgCharts.__createSparkline({ ...baseOptions, context: contextA });
+            const chartA = deproxy(instanceA);
+            await waitForChartStability(chartA);
+
+            const instanceB = AgCharts.__createSparkline({ ...baseOptions, context: contextB });
+            const chartB = deproxy(instanceB);
+            await waitForChartStability(chartB);
+
+            invokeTooltipRenderer(chartA);
+            const seenForA = seen.length;
+            invokeTooltipRenderer(chartB);
+
+            expect(seen.length).toBeGreaterThan(seenForA);
+            for (let i = 0; i < seenForA; i++) expect(seen[i]).toBe(contextA);
+            for (let i = seenForA; i < seen.length; i++) expect(seen[i]).toBe(contextB);
+
+            chartB.destroy();
+            chart = chartA;
+        });
     });
 });

--- a/packages/ag-charts-community/src/chart/sparkline.test.ts
+++ b/packages/ag-charts-community/src/chart/sparkline.test.ts
@@ -381,4 +381,87 @@ describe('Sparkline', () => {
             chart = chartA;
         });
     });
+
+    describe('default tooltip content (AG-17227)', () => {
+        // The chart-side preset must produce a useful default tooltip without the
+        // consumer (e.g. the Grid sparkline cell renderer) needing to install a
+        // function at `tooltip.renderer`. A function in user options poisons the
+        // structural-options cache key, so this default-in-the-preset behaviour is
+        // what lets the cache hit for the common Grid case.
+
+        const renderDefaultTooltip = (c: Chart, datum: any, xKey: string, yKey: string) => {
+            const series = c.series[0] as any;
+            const tooltip = series.properties.tooltip;
+            const xValue = datum[xKey];
+            const yValue = datum[yKey];
+            const params: any = {
+                datum,
+                xKey,
+                yKey,
+                xValue,
+                yValue,
+                seriesId: series.id,
+                title: undefined,
+                color: undefined,
+            };
+            return tooltip.formatTooltip([series.properties, series.ctx.chartService], { data: [] }, params);
+        };
+
+        it('omits the synthesised x index from number-array data', async () => {
+            const instance = AgCharts.__createSparkline({
+                type: 'line',
+                data: [10, 20, 30],
+                width: 200,
+                height: 100,
+            });
+            chart = deproxy(instance);
+            await waitForChartStability(chart);
+
+            // sparklineDataPreset maps numbers to { x: index, y: value } with datumKey: 'y'.
+            const result: any = renderDefaultTooltip(chart, { x: 1, y: 20 }, 'x', 'y');
+            const html = result.rawHtmlString ?? JSON.stringify(result);
+            expect(html).toContain('20.00');
+            expect(html).not.toContain('1 20'); // would indicate the synthesised index leaked through
+        });
+
+        it('includes the x value for tuple-array data', async () => {
+            const instance = AgCharts.__createSparkline({
+                type: 'line',
+                data: [
+                    [0, 10],
+                    [1, 20],
+                ],
+                width: 200,
+                height: 100,
+            });
+            chart = deproxy(instance);
+            await waitForChartStability(chart);
+
+            // tuple data → datumKey: 'datum' (preserved original tuple). xValue is real.
+            const result: any = renderDefaultTooltip(chart, { x: 1, y: 20, datum: [1, 20] }, 'x', 'y');
+            const html = result.rawHtmlString ?? JSON.stringify(result);
+            expect(html).toContain('1 20.00');
+        });
+
+        it('includes the x value for user-supplied xKey on object data', async () => {
+            const instance = AgCharts.__createSparkline({
+                type: 'line',
+                xKey: 'date',
+                yKey: 'value',
+                data: [
+                    { date: 'Jan', value: 10 },
+                    { date: 'Feb', value: 20 },
+                ],
+                width: 200,
+                height: 100,
+            });
+            chart = deproxy(instance);
+            await waitForChartStability(chart);
+
+            // object data with user xKey → datumKey undefined. xValue is real.
+            const result: any = renderDefaultTooltip(chart, { date: 'Feb', value: 20 }, 'date', 'value');
+            const html = result.rawHtmlString ?? JSON.stringify(result);
+            expect(html).toContain('Feb 20.00');
+        });
+    });
 });

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -57,7 +57,12 @@ import { getChartTheme } from '../chart/mapping/themes';
 import { detectChartType } from '../chart/mapping/types';
 import { ChartTheme } from '../chart/themes/chartTheme';
 import { type OptionsGraphAccessor, createOptionsGraph, createOptionsGraphFn } from './optionsGraph';
-import { computeStructuralCacheKey, getStructuralCacheEntry, setStructuralCacheEntry } from './optionsStructuralCache';
+import {
+    VOLATILE_KEYS,
+    computeStructuralCacheKey,
+    getStructuralCacheEntry,
+    setStructuralCacheEntry,
+} from './optionsStructuralCache';
 
 export interface ChartSpecialOverrides {
     document: Document;
@@ -320,7 +325,16 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
                 // Shallow-clone the top level only — the existing dev-mode deepFreeze on
                 // ChartOptions has confirmed no path mutates nested processedOptions, and
                 // sharing frozen nested refs across charts is the whole point of the cache.
+                // VOLATILE_KEYS are re-attached from this chart's `userOptions` to avoid
+                // aliasing per-instance values (container, user context payload) across
+                // charts that share the cache entry.
+                const userOpts = this.userOptions as Record<string, unknown>;
                 const processedOptions = { ...(cached.processedOptions as object), data: resolvedData } as T;
+                for (const key of VOLATILE_KEYS) {
+                    if (key in userOpts) {
+                        (processedOptions as any)[key] = userOpts[key];
+                    }
+                }
                 // Un-memoized graph — each chart needs its own resolution state for stylers' resolvePartial.
                 const optionsGraph = createOptionsGraphFn(activeTheme, processedOptions as PlainObject);
                 return {
@@ -443,9 +457,15 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         ChartOptions.debug(() => ['ChartOptions.slowSetup() - processed options', deepClone(processedOptions)]);
 
         if (cacheKey !== undefined) {
-            const { data: _cachedData, ...processedOptionsWithoutData } = processedOptions as Record<string, unknown>;
+            // Strip `data` and the per-instance VOLATILE_KEYS before caching so cache hits
+            // do not alias them across charts. The read path re-attaches each from this
+            // chart's `userOptions`.
+            const { data: _cachedData, ...rest } = processedOptions as Record<string, unknown>;
+            for (const key of VOLATILE_KEYS) {
+                delete rest[key];
+            }
             setStructuralCacheEntry(cacheKey, {
-                processedOptions: processedOptionsWithoutData,
+                processedOptions: rest,
                 themeParameters,
                 googleFonts: googleFonts.size > 0 ? new Set(googleFonts) : undefined,
                 annotationThemes,

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -122,7 +122,16 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
 
     private static readonly perfDebug = Debug.create(true, 'perf');
 
-    private static readonly FAST_PATH_OPTIONS = new Set<keyof AgChartOptions>(['data', 'width', 'height', 'container']);
+    private static readonly FAST_PATH_OPTIONS = new Set<keyof AgChartOptions>([
+        'data',
+        'width',
+        'height',
+        'container',
+        // `context` is a user pass-through consumed only by `callWithContext` at
+        // callback time — preset/theme processing does not branch on it, so
+        // context-only deltas can take the fast merge path.
+        'context',
+    ]);
     private static isFastPathDelta(deltaOptions: DeepPartial<AgChartOptions> | null) {
         for (const key of Object.keys(deltaOptions ?? {})) {
             if (!this.FAST_PATH_OPTIONS.has(key as keyof AgChartOptions)) {

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -127,9 +127,8 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         'width',
         'height',
         'container',
-        // `context` is a user pass-through consumed only by `callWithContext` at
-        // callback time — preset/theme processing does not branch on it, so
-        // context-only deltas can take the fast merge path.
+        // `context` is a pass-through consumed only at callback time; no preset/theme
+        // processing branches on it, so context-only deltas can take the fast path.
         'context',
     ]);
     private static isFastPathDelta(deltaOptions: DeepPartial<AgChartOptions> | null) {
@@ -334,9 +333,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
                 // Shallow-clone the top level only — the existing dev-mode deepFreeze on
                 // ChartOptions has confirmed no path mutates nested processedOptions, and
                 // sharing frozen nested refs across charts is the whole point of the cache.
-                // VOLATILE_KEYS are re-attached from this chart's `userOptions` to avoid
-                // aliasing per-instance values (container, user context payload) across
-                // charts that share the cache entry.
+                // Re-attach VOLATILE_KEYS from this chart's `userOptions` (see their definition).
                 const userOpts = this.userOptions as Record<string, unknown>;
                 const processedOptions = { ...(cached.processedOptions as object), data: resolvedData } as T;
                 for (const key of VOLATILE_KEYS) {
@@ -466,9 +463,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         ChartOptions.debug(() => ['ChartOptions.slowSetup() - processed options', deepClone(processedOptions)]);
 
         if (cacheKey !== undefined) {
-            // Strip `data` and the per-instance VOLATILE_KEYS before caching so cache hits
-            // do not alias them across charts. The read path re-attaches each from this
-            // chart's `userOptions`.
+            // Strip `data` and VOLATILE_KEYS before caching; the read path re-attaches them.
             const { data: _cachedData, ...rest } = processedOptions as Record<string, unknown>;
             for (const key of VOLATILE_KEYS) {
                 delete rest[key];

--- a/packages/ag-charts-community/src/module/optionsStructuralCache.ts
+++ b/packages/ag-charts-community/src/module/optionsStructuralCache.ts
@@ -2,13 +2,11 @@ import { type ChartModuleDefinition, Debug, LRUCache, ModuleRegistry, deepFreeze
 import type { AgChartThemeParams } from 'ag-charts-types';
 
 // Structural-output cache for `ChartOptions.slowSetup`, gated by callers on
-// `domMode: 'minimal'`. `processedOptions` is cached with per-instance keys
-// (data/container/context) stripped — callers re-attach them from `userOptions`
-// on hit so two charts with the same option shape but different per-instance
-// values do not alias.
+// `domMode: 'minimal'`. Per-instance keys are stripped before caching and
+// re-attached on hit; see `VOLATILE_KEYS`.
 
 export interface StructuralCacheEntry {
-    /** `processedOptions` with `data` and `VOLATILE_KEYS` stripped — caller re-attaches them on read. */
+    /** `processedOptions` with `data` and `VOLATILE_KEYS` stripped. */
     processedOptions: unknown;
     themeParameters: AgChartThemeParams;
     googleFonts: Set<string> | undefined;
@@ -21,17 +19,14 @@ const structuralCache = new LRUCache<StructuralCacheEntry>(STRUCTURAL_CACHE_MAX)
 let structuralCacheRevision = -1;
 const structuralCacheDebug = Debug.create(true, 'perf', 'opts');
 
-// Keys that vary per chart instance — must not contribute to the cache key.
-// `document`/`window`/`styleContainer` are extracted to `specialOverrides` before
-// `slowSetup` runs so they never reach `processedOptions`; the others are
-// re-attached from `userOptions` on cache hit (see `VOLATILE_KEYS`).
+// Per-instance keys excluded from the cache key. `document`/`window`/`styleContainer`
+// are extracted to `specialOverrides` before `slowSetup`; the rest are VOLATILE_KEYS.
 const IGNORED_SIGNATURE_KEYS = new Set(['data', 'container', 'document', 'window', 'styleContainer', 'context']);
 
 /**
- * Keys that survive into `processedOptions` but are intrinsically per-instance — they
- * must be stripped before cache write and re-attached from the consuming chart's
- * `userOptions` on cache hit, otherwise charts that share a cache entry would alias
- * each other's container reference / user-supplied context payload.
+ * Per-instance keys that reach `processedOptions`. Stripped before caching and re-attached
+ * from the chart's `userOptions` on hit, otherwise charts sharing an entry would alias each
+ * other's container reference and user-supplied context payload.
  */
 export const VOLATILE_KEYS = ['container', 'context'] as const;
 

--- a/packages/ag-charts-community/src/module/optionsStructuralCache.ts
+++ b/packages/ag-charts-community/src/module/optionsStructuralCache.ts
@@ -8,7 +8,7 @@ import type { AgChartThemeParams } from 'ag-charts-types';
 // values do not alias.
 
 export interface StructuralCacheEntry {
-    /** `processedOptions` with `VOLATILE_KEYS` stripped — caller re-attaches them from `userOptions` on read. */
+    /** `processedOptions` with `data` and `VOLATILE_KEYS` stripped — caller re-attaches them on read. */
     processedOptions: unknown;
     themeParameters: AgChartThemeParams;
     googleFonts: Set<string> | undefined;

--- a/packages/ag-charts-community/src/module/optionsStructuralCache.ts
+++ b/packages/ag-charts-community/src/module/optionsStructuralCache.ts
@@ -2,12 +2,13 @@ import { type ChartModuleDefinition, Debug, LRUCache, ModuleRegistry, deepFreeze
 import type { AgChartThemeParams } from 'ag-charts-types';
 
 // Structural-output cache for `ChartOptions.slowSetup`, gated by callers on
-// `domMode: 'minimal'`. `processedOptions` is cached WITHOUT `data` — the per-call
-// data is re-attached on hit so two charts with the same option shape but different
-// data arrays do not alias.
+// `domMode: 'minimal'`. `processedOptions` is cached with per-instance keys
+// (data/container/context) stripped — callers re-attach them from `userOptions`
+// on hit so two charts with the same option shape but different per-instance
+// values do not alias.
 
 export interface StructuralCacheEntry {
-    /** `processedOptions` with `data` stripped — caller splices in fresh data on read. */
+    /** `processedOptions` with `VOLATILE_KEYS` stripped — caller re-attaches them from `userOptions` on read. */
     processedOptions: unknown;
     themeParameters: AgChartThemeParams;
     googleFonts: Set<string> | undefined;
@@ -20,7 +21,19 @@ const structuralCache = new LRUCache<StructuralCacheEntry>(STRUCTURAL_CACHE_MAX)
 let structuralCacheRevision = -1;
 const structuralCacheDebug = Debug.create(true, 'perf', 'opts');
 
+// Keys that vary per chart instance — must not contribute to the cache key.
+// `document`/`window`/`styleContainer` are extracted to `specialOverrides` before
+// `slowSetup` runs so they never reach `processedOptions`; the others are
+// re-attached from `userOptions` on cache hit (see `VOLATILE_KEYS`).
 const IGNORED_SIGNATURE_KEYS = new Set(['data', 'container', 'document', 'window', 'styleContainer', 'context']);
+
+/**
+ * Keys that survive into `processedOptions` but are intrinsically per-instance — they
+ * must be stripped before cache write and re-attached from the consuming chart's
+ * `userOptions` on cache hit, otherwise charts that share a cache entry would alias
+ * each other's container reference / user-supplied context payload.
+ */
+export const VOLATILE_KEYS = ['container', 'context'] as const;
 
 export function computeStructuralCacheKey(options: object): string | undefined {
     let unsafe = false;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17227

Unblocks the optimised creation path for Grid sparkline cells, and fixes a latent context/container aliasing bug exposed by it.

- `optionsStructuralCache.ts` / `optionsModule.ts` — strip `container` and `context` from cached `processedOptions` on write and re-attach from `userOptions` on hit, matching the existing pattern for `data` (`VOLATILE_KEYS`).
- `optionsModule.ts` — add `context` to `FAST_PATH_OPTIONS` so per-row context deltas don't force slow setup on every cell refresh.
- `sparkline.ts` preset — stop capturing `context` in the memoised tooltip wrapper (read from `params.context` instead), emit user-supplied `context` onto `chartOpts`, and include `xValue` in the default tooltip content when `datumKey !== 'y'` so consumers don't need to install a renderer purely for that.

Companion Grid PR: ag-grid/ag-grid#13874. Land this first.

Fix #AG-17227