### PR TITLE
AG-16608 Add validation gate and per-column type tag

### DIFF
--- a/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -11,6 +11,9 @@ exports[`DataModel > grouped processing - calculated grouping > should generated
       "test",
     },
   ],
+  "columnValueType": [
+    "number",
+  ],
   "columns": [
     [
       2548,
@@ -325,6 +328,9 @@ exports[`DataModel > grouped processing - calculated grouping > should generated
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
   ],
   "columns": [
     [
@@ -659,6 +665,9 @@ exports[`DataModel > grouped processing - calculated grouping > should generated
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
   ],
   "columns": [
     [
@@ -999,6 +1008,10 @@ exports[`DataModel > grouped processing - grouped example > should generated the
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
+    "number",
   ],
   "columns": [
     [
@@ -1384,6 +1397,14 @@ exports[`DataModel > grouped processing - stacked and normalised example > shoul
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
   ],
   "columns": [
     [
@@ -2268,6 +2289,14 @@ exports[`DataModel > grouped processing - stacked and normalised example > shoul
       "test",
     },
   ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+    "number",
+  ],
   "columns": [
     [
       100,
@@ -2752,6 +2781,12 @@ exports[`DataModel > grouped processing - stacked example > should generated the
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
   ],
   "columns": [
     [
@@ -3282,6 +3317,12 @@ exports[`DataModel > grouped processing - stacked with accumulation and normalis
       "test",
     },
   ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
+  ],
   "columns": [
     [
       76.09130289903365,
@@ -3811,6 +3852,12 @@ exports[`DataModel > grouped processing - stacked with accumulation example > sh
       "test",
     },
   ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
+  ],
   "columns": [
     [
       4567,
@@ -4290,6 +4337,10 @@ exports[`DataModel > repeated property processing > should generated the expecte
       "test",
     },
   ],
+  "columnValueType": [
+    "number",
+    "number",
+  ],
   "columns": [
     [
       0,
@@ -4420,6 +4471,10 @@ exports[`DataModel > ungrouped processing > should generated the expected result
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
+    "number",
   ],
   "columns": [
     [
@@ -4962,6 +5017,11 @@ exports[`DataModel > ungrouped processing - accumulated and normalised propertie
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
+    "string",
+    "number",
   ],
   "columns": [
     [

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -79,8 +79,7 @@ function valueColumnType(value: unknown): ColumnValueType | undefined {
         case 'string':
             return 'string';
         case 'object':
-            // TODO(AG-16608, PR2): a numeric NumberObject ({ valueOf(): number }) is tagged 'date' here.
-            // Disambiguate via isNumberObject() when PR2 wires the tag into scale dispatch.
+            // TODO(AG-16608, PR2): a numeric NumberObject is tagged 'date' here; disambiguate via isNumberObject().
             return value == null ? undefined : 'date';
         default:
             return undefined;
@@ -94,9 +93,8 @@ function updateColumnTypeTracker(tracker: ColumnTypeTracker, value: unknown, dat
     if (tracker.type == null) {
         tracker.type = observed;
     } else if (tracker.type !== observed && isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
-        // TODO(AG-16654, PR5): number<->date coexistence (e.g. epoch number + Date in one time column)
-        // should promote to the heterogeneous 'date' tag; only number<->bigint mixing is handled today.
-        // A column mixing `number` and `bigint` is rejected at the series level (see ColumnValueType).
+        // TODO(AG-16654, PR5): number<->date coexistence (epoch number + Date in one column) should also
+        // promote to 'date'; only number<->bigint mixing is handled today.
         tracker.mixedAtIndex ??= datumIndex;
         tracker.type = 'mixed-numeric';
     }
@@ -267,9 +265,8 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
                     const result = processKeyValue(data[datumIndex], datumIndex, scope);
 
-                    // PR1 (AG-16608) stopgap: mirrors the value-column drop below. The widened gate
-                    // accepts bigint keys, but the domain/sort/scale arithmetic that consumes them
-                    // lands in PR2; until then treat a bigint key as invalid so it cannot throw.
+                    // PR1 stopgap: drop bigint keys until PR2 wires the scale/sort arithmetic that
+                    // consumes them, else they throw on BigInt maths. Removed in PR2.
                     if (result.valid && typeof result.value !== 'bigint') {
                         keys.push(result.value);
                         // Track ordering/uniqueness for valid keys
@@ -409,10 +406,8 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                     updateColumnTypeTracker(typeTracker, result.value, datumIndex);
                 }
 
-                // PR1 (AG-16608) stopgap: the type tag above observes bigint, but the scale and
-                // aggregation arithmetic that consume it land in the next PR of the stacked train.
-                // Until then, drop bigints (as the pre-widening gate did) so `x - d0` / `0 + value`
-                // cannot throw "Cannot mix BigInt and other types". Remove with the PR2 convert support.
+                // PR1 stopgap: drop bigints until PR2 wires scale/aggregation support, else `x - d0`
+                // throws "Cannot mix BigInt and other types". Removed in PR2.
                 if (typeof value === 'bigint') {
                     this.markScopeDatumInvalid(def.scopes, columnSource, datumIndex, invalidData, invalidDataCount);
                     partialValidDataCount += 1;

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -3,6 +3,7 @@ import { Logger, first, iterate } from 'ag-charts-core';
 import { ContinuousDomain } from '../../dataDomain';
 import {
     COLUMN_SORT_ORDERS,
+    type ColumnValueType,
     DOMAIN_BANDS,
     DOMAIN_RANGES,
     type InternalDatumPropertyDefinition,
@@ -62,6 +63,49 @@ function trackerToSortOrderEntry(tracker: KeyExtractionTracker): SortOrderEntry 
     };
 }
 
+/** Accumulates the resolved {@link ColumnValueType} for a single column as its values are extracted. */
+interface ColumnTypeTracker {
+    type: ColumnValueType | undefined;
+    /** Row index where `number` and `bigint` were first observed to mix; used for the one-shot warning. */
+    mixedAtIndex: number | undefined;
+}
+
+function valueColumnType(value: unknown): ColumnValueType | undefined {
+    switch (typeof value) {
+        case 'number':
+            return 'number';
+        case 'bigint':
+            return 'bigint';
+        case 'string':
+            return 'string';
+        case 'object':
+            // TODO(AG-16608, PR2): a numeric NumberObject ({ valueOf(): number }) is tagged 'date' here.
+            // Disambiguate via isNumberObject() when PR2 wires the tag into scale dispatch.
+            return value == null ? undefined : 'date';
+        default:
+            return undefined;
+    }
+}
+
+function updateColumnTypeTracker(tracker: ColumnTypeTracker, value: unknown, datumIndex: number): void {
+    const observed = valueColumnType(value);
+    if (observed == null) return;
+
+    if (tracker.type == null) {
+        tracker.type = observed;
+    } else if (tracker.type !== observed && isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
+        // TODO(AG-16654, PR5): number<->date coexistence (e.g. epoch number + Date in one time column)
+        // should promote to the heterogeneous 'date' tag; only number<->bigint mixing is handled today.
+        // A column mixing `number` and `bigint` is rejected at the series level (see ColumnValueType).
+        tracker.mixedAtIndex ??= datumIndex;
+        tracker.type = 'mixed-numeric';
+    }
+}
+
+function isNumericColumnType(type: ColumnValueType): boolean {
+    return type === 'number' || type === 'bigint' || type === 'mixed-numeric';
+}
+
 /**
  * DataExtractor handles data extraction from DataSet sources.
  *
@@ -98,15 +142,16 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             keySortOrders,
         } = this.extractKeys(keyDefs, sources, getProcessValue);
 
-        const { columns, columnScopes, columnNeedValueOf, partialValidDataCount, maxDataLength } = this.extractValues(
-            invalidData,
-            invalidDataCount,
-            missingData,
-            valueDefs,
-            sources,
-            invalidKeys,
-            getProcessValue
-        );
+        const { columns, columnScopes, columnNeedValueOf, columnValueType, partialValidDataCount, maxDataLength } =
+            this.extractValues(
+                invalidData,
+                invalidDataCount,
+                missingData,
+                valueDefs,
+                sources,
+                invalidKeys,
+                getProcessValue
+            );
 
         const propertyDomain = (def: InternalDatumPropertyDefinition<K>) => {
             const defDomain = dataDomain.get(def)!;
@@ -128,6 +173,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             columns,
             columnScopes,
             columnNeedValueOf,
+            columnValueType,
             invalidKeys,
             invalidKeyCount,
             invalidData,
@@ -221,7 +267,10 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
                     const result = processKeyValue(data[datumIndex], datumIndex, scope);
 
-                    if (result.valid) {
+                    // PR1 (AG-16608) stopgap: mirrors the value-column drop below. The widened gate
+                    // accepts bigint keys, but the domain/sort/scale arithmetic that consumes them
+                    // lands in PR2; until then treat a bigint key as invalid so it cannot throw.
+                    if (result.valid && typeof result.value !== 'bigint') {
                         keys.push(result.value);
                         // Track ordering/uniqueness for valid keys
                         updateKeyTracker(tracker, result.value);
@@ -319,6 +368,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
         const columns: unknown[][] = [];
         const allColumnScopes: Set<ScopeId>[] = [];
         const columnNeedValueOf: boolean[] = [];
+        const columnValueType: ColumnValueType[] = [];
         let maxDataLength = 0;
         const valueProcessors = valueDefs.map((def) => getProcessValue(def));
 
@@ -336,6 +386,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             const column = new Array<unknown>();
             const invalidKeys = scopeInvalidKeys.get(columnScope);
             let needsValueOf = false;
+            const typeTracker: ColumnTypeTracker = { type: undefined, mixedAtIndex: undefined };
             for (let datumIndex = 0; datumIndex < columnSource.length; datumIndex++) {
                 if (columnSource[datumIndex] == null || typeof columnSource[datumIndex] !== 'object') {
                     // Count non-object items as invalid data
@@ -354,6 +405,18 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                     this.markScopeDatumInvalid(def.scopes, columnSource, datumIndex, invalidData, invalidDataCount);
                 } else if (result.missing) {
                     this.markScopeDatumMissing(def.scopes, columnSource, datumIndex, missingData);
+                } else {
+                    updateColumnTypeTracker(typeTracker, result.value, datumIndex);
+                }
+
+                // PR1 (AG-16608) stopgap: the type tag above observes bigint, but the scale and
+                // aggregation arithmetic that consume it land in the next PR of the stacked train.
+                // Until then, drop bigints (as the pre-widening gate did) so `x - d0` / `0 + value`
+                // cannot throw "Cannot mix BigInt and other types". Remove with the PR2 convert support.
+                if (typeof value === 'bigint') {
+                    this.markScopeDatumInvalid(def.scopes, columnSource, datumIndex, invalidData, invalidDataCount);
+                    partialValidDataCount += 1;
+                    value = invalidValue;
                 }
 
                 if (invalidKey) {
@@ -372,13 +435,33 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                 column[datumIndex] = value;
             }
 
+            if (typeTracker.type === 'mixed-numeric' && typeTracker.mixedAtIndex != null) {
+                this.warnMixedNumericColumn(columnScope, def.property, typeTracker.mixedAtIndex);
+            }
+
             columns.push(column);
             allColumnScopes.push(columnScopes);
             columnNeedValueOf.push(needsValueOf);
+            columnValueType.push(typeTracker.type ?? 'number');
             maxDataLength = Math.max(maxDataLength, column.length);
         }
 
-        return { columns, columnScopes: allColumnScopes, columnNeedValueOf, partialValidDataCount, maxDataLength };
+        return {
+            columns,
+            columnScopes: allColumnScopes,
+            columnNeedValueOf,
+            columnValueType,
+            partialValidDataCount,
+            maxDataLength,
+        };
+    }
+
+    private warnMixedNumericColumn(seriesId: ScopeId, key: K, atIndex: number) {
+        Logger.warnOnce(
+            `Series "${seriesId}": column "${String(key)}" mixes 'number' and 'bigint' values ` +
+                `(first detected at row ${atIndex}). Each column must be uniformly typed. ` +
+                `The series renders empty; other series in this chart are unaffected.`
+        );
     }
 
     warnDataMissingProperties(sources: Map<string, DataSet<unknown>>) {

--- a/packages/ag-charts-community/src/chart/data/data-model/extractor/__snapshots__/dataExtractor.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/data/data-model/extractor/__snapshots__/dataExtractor.test.ts.snap
@@ -23,6 +23,12 @@ exports[`DataExtractor > empty data set processing > should generated the expect
       "test",
     },
   ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
+  ],
   "columns": [
     [],
     [],
@@ -169,6 +175,12 @@ exports[`DataExtractor > missing and invalid data processing > should generated 
     Set {
       "test",
     },
+  ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
   ],
   "columns": [
     [
@@ -509,6 +521,12 @@ exports[`DataExtractor > missing and invalid data processing - multiple scopes >
     Set {
       "series-c",
     },
+  ],
+  "columnValueType": [
+    "number",
+    "number",
+    "number",
+    "number",
   ],
   "columns": [
     [

--- a/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
@@ -513,6 +513,11 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                     insertionCache,
                     (cached) => {
                         const keyResult = cached?.keys.get(defIndex);
+                        // PR1 (AG-16608) stopgap — mirrors the value path: drop bigint keys until PR2
+                        // wires convert, so transactional appends cannot reach BigInt arithmetic.
+                        if (keyResult?.valid && typeof keyResult.value === 'bigint') {
+                            return def.invalidValue;
+                        }
                         return keyResult?.valid ? keyResult.value : def.invalidValue;
                     },
                     (removedValues) => {
@@ -574,6 +579,11 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                         return def.invalidValue;
                     }
                     const valueResult = cached.values.get(defIndex);
+                    // PR1 (AG-16608) stopgap — mirrors dataExtractor.extractValues: drop bigint until
+                    // PR2 wires convert, so transactional appends cannot reach BigInt arithmetic.
+                    if (valueResult?.valid && typeof valueResult.value === 'bigint') {
+                        return def.invalidValue;
+                    }
                     return valueResult?.valid ? valueResult.value : def.invalidValue;
                 }
                 return def.invalidValue;

--- a/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
@@ -513,8 +513,7 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                     insertionCache,
                     (cached) => {
                         const keyResult = cached?.keys.get(defIndex);
-                        // PR1 (AG-16608) stopgap — mirrors the value path: drop bigint keys until PR2
-                        // wires convert, so transactional appends cannot reach BigInt arithmetic.
+                        // PR1 stopgap: drop bigint keys until PR2 wires convert (mirrors dataExtractor).
                         if (keyResult?.valid && typeof keyResult.value === 'bigint') {
                             return def.invalidValue;
                         }
@@ -579,8 +578,7 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                         return def.invalidValue;
                     }
                     const valueResult = cached.values.get(defIndex);
-                    // PR1 (AG-16608) stopgap — mirrors dataExtractor.extractValues: drop bigint until
-                    // PR2 wires convert, so transactional appends cannot reach BigInt arithmetic.
+                    // PR1 stopgap: drop bigint until PR2 wires convert (mirrors dataExtractor.extractValues).
                     if (valueResult?.valid && typeof valueResult.value === 'bigint') {
                         return def.invalidValue;
                     }

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1490,6 +1490,139 @@ describe('DataModel', () => {
         });
     });
 
+    describe('columnValueType tag', () => {
+        it('should tag number-only value columns as "number"', () => {
+            const dataModel = new DataModel<any, any>({
+                props: [categoryKey('id'), value('count'), value('amount')],
+            });
+
+            const data = [
+                { id: 'A', count: 10, amount: 100.5 },
+                { id: 'B', count: 20, amount: 200.3 },
+            ];
+
+            const sources = basicDataSet(data).set('test', new DataSet(data));
+            const processedData = dataModel.processData(sources);
+
+            expect(processedData!.columnValueType).toEqual(['number', 'number']);
+        });
+
+        it('should tag bigint-only value columns as "bigint"', () => {
+            const dataModel = new DataModel<any, any>({
+                props: [categoryKey('id'), value('count')],
+            });
+
+            const data = [
+                { id: 'A', count: 10n },
+                { id: 'B', count: 9007199254740993n },
+            ];
+
+            const sources = basicDataSet(data).set('test', new DataSet(data));
+            const processedData = dataModel.processData(sources);
+
+            expect(processedData!.columnValueType).toEqual(['bigint']);
+        });
+
+        it('should drop bigint values into the column while still tagging them (PR1 stopgap)', () => {
+            // PR1 (AG-16608) tags bigint columns but drops the values, since the scale/aggregation
+            // arithmetic that consumes them lands in PR2. PR2 inverts the column assertion below.
+            const dataModel = new DataModel<any, any>({
+                props: [categoryKey('id'), value('count')],
+            });
+
+            const data = [
+                { id: 'A', count: 10n },
+                { id: 'B', count: 20n },
+            ];
+
+            const sources = basicDataSet(data).set('test', new DataSet(data));
+            const processedData = dataModel.processData(sources)!;
+
+            expect(processedData.columnValueType).toEqual(['bigint']);
+            expect(processedData.columns[0].some((v) => typeof v === 'bigint')).toBe(false);
+        });
+
+        it('should drop bigint keys without throwing on a continuous key (PR1 stopgap)', () => {
+            // PR1 (AG-16608) widens continuous validation to accept bigint, but bigint keys must not
+            // reach domain/sort/scale arithmetic until PR2 wires conversion. PR2 inverts this.
+            const dataModel = new DataModel<any, any>({
+                props: [rangeKey('x'), value('y')],
+            });
+
+            const data = [
+                { x: 1n, y: 10 },
+                { x: 2n, y: 20 },
+            ];
+
+            const sources = basicDataSet(data).set('test', new DataSet(data));
+            const processedData = dataModel.processData(sources)!;
+
+            expect(processedData.keys.flat(Infinity).some((v) => typeof v === 'bigint')).toBe(false);
+        });
+
+        it('should tag Date value columns as "date"', () => {
+            const dataModel = new DataModel<any, any>({
+                props: [categoryKey('id'), value('when')],
+            });
+
+            const data = [
+                { id: 'A', when: new Date(2024, 0, 1) },
+                { id: 'B', when: new Date(2024, 0, 2) },
+            ];
+
+            const sources = basicDataSet(data).set('test', new DataSet(data));
+            const processedData = dataModel.processData(sources);
+
+            expect(processedData!.columnValueType).toEqual(['date']);
+        });
+
+        it('should tag a column mixing number and bigint as "mixed-numeric" and warn once', () => {
+            const dataModel = new DataModel<any, any>({
+                props: [categoryKey('id'), value('count')],
+            });
+
+            const data = [
+                { id: 'A', count: 10 },
+                { id: 'B', count: 20n },
+                { id: 'C', count: 30n },
+            ];
+
+            const sources = basicDataSet(data).set('test', new DataSet(data));
+            const processedData = dataModel.processData(sources);
+
+            expect(processedData!.columnValueType).toEqual(['mixed-numeric']);
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Series "test": column "count" mixes 'number' and 'bigint' values (first detected at row 1). Each column must be uniformly typed. The series renders empty; other series in this chart are unaffected.",
+  ],
+]
+`);
+        });
+
+        it('should preserve the columnValueType tag across incremental reprocessing', () => {
+            const dataModel = new DataModel<any, any>({
+                props: [categoryKey('id'), value('count')],
+            });
+
+            const initialData = [
+                { id: 'A', count: 10n },
+                { id: 'B', count: 20n },
+            ];
+
+            const dataSet = new DataSet(initialData);
+            const sources = basicDataSet(initialData).set('test', dataSet);
+            const processedData = dataModel.processData(sources);
+
+            expect(processedData!.columnValueType).toEqual(['bigint']);
+
+            dataSet.addTransaction({ append: [{ id: 'C', count: 30n }] });
+            const reprocessed = dataModel.reprocessData(processedData!);
+
+            expect(reprocessed.columnValueType).toEqual(['bigint']);
+        });
+    });
+
     describe('update operations', () => {
         describe('ungrouped data', () => {
             it('should process updated items correctly', () => {

--- a/packages/ag-charts-community/src/chart/data/dataModelTypes.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModelTypes.ts
@@ -46,6 +46,13 @@ export const SHARED_ZERO_INDICES: readonly number[] = Object.freeze([0]);
 
 export type ScopeId = string;
 
+/**
+ * Per-column primitive type, set once during extraction. Consumers dispatch off this tag rather than
+ * re-sniffing values. `'mixed-numeric'` flags a column that contains both `number` and `bigint` values,
+ * which is rejected at the series level (see {@link CommonMetadata.columnValueType}).
+ */
+export type ColumnValueType = 'number' | 'bigint' | 'date' | 'string' | 'mixed-numeric';
+
 export type ProcessedValue = { value: unknown; missing: boolean; valid: boolean };
 export type SortOrderEntry = {
     sortOrder: SortOrder;
@@ -94,6 +101,7 @@ export interface CommonMetadata<D> {
     columns: any[][];
     columnScopes: Set<ScopeId>[];
     columnNeedValueOf?: boolean[]; // true if column needs valueOf() (contains Dates/objects), false for primitives
+    columnValueType?: ColumnValueType[]; // per-column primitive type tag, set once during extraction
     domain: {
         keys: any[][];
         values: any[][];

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -46,8 +46,8 @@ function basicContinuousCheckDatumValidation(value: any) {
     return value != null && isContinuous(value);
 }
 
-// Split out from basicContinuousCheckDatumValidation so the time scales can diverge from number/log/color
-// without those scales inadvertently accepting time-only values (e.g. ISO 8601 strings, added in a later PR).
+// Separate from basicContinuousCheckDatumValidation so a later PR can let time scales accept ISO 8601
+// strings without number/log/color scales doing the same.
 function basicTimeCheckDatumValidation(value: any) {
     return value != null && isContinuous(value);
 }

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -46,6 +46,12 @@ function basicContinuousCheckDatumValidation(value: any) {
     return value != null && isContinuous(value);
 }
 
+// Split out from basicContinuousCheckDatumValidation so the time scales can diverge from number/log/color
+// without those scales inadvertently accepting time-only values (e.g. ISO 8601 strings, added in a later PR).
+function basicTimeCheckDatumValidation(value: any) {
+    return value != null && isContinuous(value);
+}
+
 function basicDiscreteCheckDatumValidation(value: any) {
     return value != null;
 }
@@ -56,11 +62,12 @@ function basicDiscreteCheckDatumValidationAllowNull(_value: any) {
 
 function getValidationFn(scaleType?: ScaleType, allowNullKey?: boolean) {
     switch (scaleType) {
-        case 'number':
-        case 'log':
         case 'time':
         case 'unit-time':
         case 'ordinal-time':
+            return basicTimeCheckDatumValidation;
+        case 'number':
+        case 'log':
         case 'color':
             return basicContinuousCheckDatumValidation;
         default:

--- a/packages/ag-charts-core/src/utils/data/value.test.ts
+++ b/packages/ag-charts-core/src/utils/data/value.test.ts
@@ -19,10 +19,16 @@ describe('value module', () => {
                 valueOf: () => '',
             })
         ).toBe(false);
+        expect(isContinuous(0n)).toBe(true);
+        expect(isContinuous(1n)).toBe(true);
+        expect(isContinuous(-1n)).toBe(true);
+        expect(isContinuous(9007199254740993n)).toBe(true);
         expect(isContinuous(Number.NaN)).toBe(false);
         expect(isContinuous(null)).toBe(false);
         expect(isContinuous(undefined)).toBe(false);
         expect(isContinuous('')).toBe(false);
+        expect(isContinuous('2024-01-01')).toBe(false);
+        expect(isContinuous(true)).toBe(false);
         expect(isContinuous([])).toBe(false);
         expect(isContinuous({})).toBe(false);
         expect(isContinuous(Symbol.iterator)).toBe(false);

--- a/packages/ag-charts-core/src/utils/data/value.ts
+++ b/packages/ag-charts-core/src/utils/data/value.ts
@@ -12,8 +12,10 @@ export function isNumberObject(value: unknown): value is NumberObject {
     return value != null && Object.hasOwn(value, 'valueOf') && isFiniteNumber(value.valueOf());
 }
 
-export function isContinuous(value: unknown): value is number | Date | NumberObject {
-    return isFiniteNumber(value) || isValidDate(value) || isNumberObject(value);
+export function isContinuous(value: unknown): value is number | bigint | Date | NumberObject {
+    // An explicit `bigint` branch is required: `BigInt.valueOf()` returns a bigint, not a number,
+    // so `isNumberObject()` does not subsume bigint primitives.
+    return isFiniteNumber(value) || typeof value === 'bigint' || isValidDate(value) || isNumberObject(value);
 }
 
 export function checkDatum<T>(value: T, isContinuousScale: boolean): boolean {

--- a/packages/ag-charts-core/src/utils/data/value.ts
+++ b/packages/ag-charts-core/src/utils/data/value.ts
@@ -13,8 +13,7 @@ export function isNumberObject(value: unknown): value is NumberObject {
 }
 
 export function isContinuous(value: unknown): value is number | bigint | Date | NumberObject {
-    // An explicit `bigint` branch is required: `BigInt.valueOf()` returns a bigint, not a number,
-    // so `isNumberObject()` does not subsume bigint primitives.
+    // Explicit bigint branch: BigInt.valueOf() returns a bigint not a number, so isNumberObject() misses it.
     return isFiniteNumber(value) || typeof value === 'bigint' || isValidDate(value) || isNumberObject(value);
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

**PR 1 of a 7-PR stacked train** delivering BigInt (AG-16608) and ISO 8601 string (AG-16654) data values. This is the shared validation foundation every later PR builds on; it has **no user-visible behavioural change** beyond a new diagnostic warning.

### Summary

- Widen `isContinuous()` to accept `bigint` primitives (explicit branch — `BigInt.valueOf()` returns a bigint, so `isNumberObject()` doesn't subsume it).
- Add a per-column `ColumnValueType` tag (`number | bigint | date | string | mixed-numeric`) to `CommonMetadata`, populated once during extraction. Consumers in later PRs dispatch off this rather than re-sniffing values.
- Warn once per column when a column mixes `number` and `bigint` values.
- Decompose `getValidationFn()` so the time scales route to a dedicated `basicTimeCheckDatumValidation`, keeping `number`/`log`/`color` on the existing validator. **Behaviour-preserving today** — the seam lets PR5 add ISO-string acceptance to time scales without `color` inheriting it.

### Stacked-train note (reviewers)

Opening the validation gate is required here to populate the `bigint`/`mixed-numeric` tag. To avoid `bigint` reaching `convert()`/aggregation (which throws `Cannot mix BigInt and other types`) **before PR2 wires conversion**, this PR observes bigints for the tag and then **drops them at every value *and* key write chokepoint** (full + incremental processing). The result is identical to today's behaviour (bigint silently dropped). **PR2 removes these drops.** Two tag-semantics refinements (NumberObject tagging, number↔date promotion) are intentionally deferred to the consuming PRs via in-code TODOs.

This PR should **co-land with PR2** before any release is cut from `latest`.

### Test plan

- `isContinuous()` accepts bigint, rejects ISO string / boolean.
- New `columnValueType` suite: number/bigint/date tagging, mixed-numeric tag + one-shot warning (inline snapshot), bigint-value drop + bigint-key drop stopgaps, incremental-reprocess tag persistence.
- `yarn nx build:types ag-charts-community` — pass
- `yarn nx lint ag-charts-community` — pass (0 errors)
- `yarn nx test ag-charts-community` (3350) / `ag-charts-enterprise` (2136) — pass

Fix #AG-16608