### PR TITLE
AG-17306: fix polar-crosslines, restore theme defaults in TS/ESM mode

### DIFF
--- a/libraries/ag-charts-eslint-rules/rules/module-mappings.mjs
+++ b/libraries/ag-charts-eslint-rules/rules/module-mappings.mjs
@@ -94,6 +94,9 @@ export const axisPluginToModule = new Map([
     ['bandHighlight', 'BandHighlightModule'],
 ]);
 
+// Polar-specific overrides for axisPluginToModule
+export const polarAxisPluginToModule = new Map([['crossLines', 'PolarCrossLinesModule']]);
+
 // Nested series plugin option → Module ID
 export const seriesPluginToModule = new Map([['errorBar', 'ErrorBarsModule']]);
 
@@ -246,6 +249,7 @@ export const enterpriseModules = new Set([
     'ErrorBarsModule',
     'GradientLegendModule',
     'NavigatorModule',
+    'PolarCrossLinesModule',
     'RangesModule',
     'ScrollbarModule',
     'SelectionModule',

--- a/libraries/ag-charts-eslint-rules/rules/validate-module-registration.mjs
+++ b/libraries/ag-charts-eslint-rules/rules/validate-module-registration.mjs
@@ -12,6 +12,7 @@ import {
     intrinsicDefaults,
     moduleToPackage,
     pluginOptionToModule,
+    polarAxisPluginToModule,
     polarSeriesModules,
     seriesChartType,
     seriesDefaultAxes,
@@ -319,8 +320,8 @@ export default {
                         continue;
                     }
                     const moduleId =
-                        keyName === 'crossLines' && isPolarAxis
-                            ? 'PolarCrossLinesModule'
+                        isPolarAxis && polarAxisPluginToModule.has(keyName)
+                            ? polarAxisPluginToModule.get(keyName)
                             : axisPluginToModule.get(keyName);
                     requireModule(moduleId, `axis option '${keyName}'`, prop);
                 }

--- a/packages/ag-charts-community/src/chart/factory/processModuleOptions.ts
+++ b/packages/ag-charts-community/src/chart/factory/processModuleOptions.ts
@@ -51,13 +51,26 @@ export function __clearSanitizedThemeCacheForTests() {
 function sanitizeThemeModulesUncached(theme: ChartTheme): ChartTheme {
     const missingModules = new Map<string, Set<string>>();
 
-    for (const [name, { type }] of ExpectedModules) {
+    // Keys already covered by at least one registered axis-plugin module. A missing
+    // module must not prune a theme key that a *different* registered module also owns
+    // (e.g. `CrossLinesModule` absent should not prune `crossLines` when
+    // `PolarCrossLinesModule` — which shares `optionsKey: 'crossLines'` — is present).
+    const coveredAxisPluginKeys = new Set<string>(
+        [...ModuleRegistry.listModulesByType(ModuleType.AxisPlugin)].map((m) => m.optionsKey ?? m.name)
+    );
+
+    for (const [name, { type, optionsKey }] of ExpectedModules) {
         if (ModuleRegistry.hasModule(name)) continue;
 
+        // For axis-plugin modules, store the optionsKey that would be pruned from
+        // theme axis configs. Skip if another registered module already covers that key.
+        const pruneKey = type === ModuleType.AxisPlugin ? (optionsKey ?? name) : name;
+        if (type === ModuleType.AxisPlugin && coveredAxisPluginKeys.has(pruneKey)) continue;
+
         if (missingModules.has(type)) {
-            missingModules.get(type)!.add(name);
+            missingModules.get(type)!.add(pruneKey);
         } else {
-            missingModules.set(type, new Set<string>([name]));
+            missingModules.set(type, new Set<string>([pruneKey]));
         }
     }
 

--- a/packages/ag-charts-website/src/content/module-mappings/modules.json
+++ b/packages/ag-charts-website/src/content/module-mappings/modules.json
@@ -317,6 +317,17 @@
                     "isEnterprise": true
                 },
                 {
+                    "moduleName": "CrossLinesModule",
+                    "name": "Cross Lines",
+                    "path": "axes-cross-lines"
+                },
+                {
+                    "moduleName": "PolarCrossLinesModule",
+                    "name": "Polar Cross Lines",
+                    "path": "axes-cross-lines/#polar-axes-cross-lines",
+                    "isEnterprise": true
+                },
+                {
                     "moduleName": "ErrorBarsModule",
                     "name": "Error Bars",
                     "path": "error-bars",
@@ -354,17 +365,6 @@
                     "moduleName": "ContextMenuModule",
                     "name": "Context Menu",
                     "path": "context-menu",
-                    "isEnterprise": true
-                },
-                {
-                    "moduleName": "CrossLinesModule",
-                    "name": "Cross Lines",
-                    "path": "axes-cross-lines"
-                },
-                {
-                    "moduleName": "PolarCrossLinesModule",
-                    "name": "Polar Cross Lines",
-                    "path": "axes-cross-lines/#polar-axes-cross-lines",
                     "isEnterprise": true
                 },
                 {


### PR DESCRIPTION
## Problem

Polar cross-lines worked with the JavaScript (UMD) bundle but were invisible in TypeScript/ESM and all framework builds. The chart loaded without errors and `PolarCrossLinesModule` was registered, but no crosslines appeared.

## Root cause

`sanitizeThemeModulesUncached` in `processModuleOptions.ts` prunes theme defaults for unregistered modules. It tracked missing axis-plugin modules by **name** — so when `CrossLinesModule` (name: `'crossLines'`) was absent, `'crossLines'` was added to the prune set and deleted from every polar axis theme config. That deleted the `$apply` block that `PolarCrossLinesModule` had written there, which is what injects `stroke`, `fill`, `strokeWidth`, and `enabled: true`.

The user's `crossLines: [...]` options survived (user options are not affected), so instances were created — but with `stroke: undefined`, `fill: undefined` they rendered zero visible pixels.

In UMD, `CrossLinesModule` is bundled and auto-registered, so its name never entered the prune set.

## Fix

### `processModuleOptions.ts`
Before adding a missing axis-plugin module's optionsKey to the prune set, check whether any *registered* module already covers that same key. `PolarCrossLinesModule` (registered) shares `optionsKey: 'crossLines'` with `CrossLinesModule` (absent), so `'crossLines'` is now skipped and the theme defaults are preserved.

### `module-mappings.mjs` (ESLint rule)
- `PolarCrossLinesModule` was missing from `enterpriseModules`, causing auto-fix to emit `import { PolarCrossLinesModule } from 'ag-charts-community'` — a module that doesn't exist there, breaking the TS import.
- Added `polarAxisPluginToModule` map so the polar-specific lookup is data-driven rather than hardcoded in the rule.

### `modules.json`
Moved `CrossLinesModule` and `PolarCrossLinesModule` from the "Interactivity" section to "Data Elements" in the module selector, matching the docs nav.