### PR TITLE
AG-16608 BigInt scale conversion and domain narrowing

### DIFF
--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -22,29 +22,50 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
     private domainNeedsValueOf = true; // Safe default
     private d0Cache: number = Number.NaN;
     private d1Cache: number = Number.NaN;
+    // Exact bigint domain endpoints, retained for the full-precision convert() ratio.
+    // Undefined unless the corresponding endpoint was supplied as a bigint.
+    private d0Big: bigint | undefined = undefined;
+    private d1Big: bigint | undefined = undefined;
 
     get domain(): D[] {
         return this._domain;
     }
 
-    set domain(values: D[]) {
-        this._domain = values;
-
-        // Auto-detect if domain values need valueOf() and cache numeric values
-        if (values && values.length >= 2) {
-            const sample = values[0];
-            this.domainNeedsValueOf = sample != null && typeof sample === 'object';
-
-            if (this.domainNeedsValueOf) {
-                this.d0Cache = (values[0] as Date).valueOf();
-                this.d1Cache = (values[1] as Date).valueOf();
-            } else {
-                this.d0Cache = values[0] as unknown as number;
-                this.d1Cache = values[1] as unknown as number;
-            }
-        } else {
+    set domain(values: readonly (D | bigint)[]) {
+        if (!values || values.length < 2) {
+            this._domain = values as D[];
+            this.d0Big = this.d1Big = undefined;
             this.d0Cache = Number.NaN;
             this.d1Cache = Number.NaN;
+            return;
+        }
+
+        const d0 = values[0];
+        const d1 = values[1];
+
+        if (typeof d0 === 'bigint' || typeof d1 === 'bigint') {
+            // Retain the exact bigint endpoints for the full-precision convert() ratio, but expose a
+            // Number-narrowed domain so every Math.min/max(...domain) consumer stays Number-only.
+            this.d0Big = typeof d0 === 'bigint' ? d0 : undefined;
+            this.d1Big = typeof d1 === 'bigint' ? d1 : undefined;
+            this.domainNeedsValueOf = false;
+            this.d0Cache = Number(d0);
+            this.d1Cache = Number(d1);
+            this._domain = values.map((v) => (typeof v === 'bigint' ? Number(v) : v)) as D[];
+            return;
+        }
+
+        this.d0Big = this.d1Big = undefined;
+        this._domain = values as D[];
+
+        // Auto-detect if domain values need valueOf() and cache numeric values
+        this.domainNeedsValueOf = d0 != null && typeof d0 === 'object';
+        if (this.domainNeedsValueOf) {
+            this.d0Cache = (d0 as Date).valueOf();
+            this.d1Cache = (d1 as Date).valueOf();
+        } else {
+            this.d0Cache = d0 as unknown as number;
+            this.d1Cache = d1 as unknown as number;
         }
     }
 
@@ -84,7 +105,7 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         return rangeDistance / Math.max(1, bands);
     }
 
-    convert(value: D | number, options?: { clamp?: boolean }) {
+    convert(value: D | number | bigint, options?: { clamp?: boolean }) {
         const { domain } = this;
         if (!domain || domain.length < 2 || value == null) {
             return Number.NaN;
@@ -93,11 +114,26 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         const { range } = this;
         const clamp = options?.clamp ?? this.defaultClamp;
 
+        // Full-precision BigInt ratio for linear scales: keeps adjacent high-magnitude bigints and
+        // domain spans beyond Number.MAX_SAFE_INTEGER monotonic, where a float64 narrow would collapse
+        // them. Log/time scales (transform != null) narrow to Number below (AG-16608 AC #9).
+        if (typeof value === 'bigint' && this.d0Big != null && this.d1Big != null && this.transform == null) {
+            return convertBigInt(value, this.d0Big, this.d1Big, range, clamp);
+        }
+
         // Use cached domain values to avoid valueOf() calls
         let d0: number = this.d0Cache;
         let d1: number = this.d1Cache;
-        // Conditional valueOf() for input value based on domain type detection
-        let x = typeof value === 'number' ? value : value.valueOf();
+        // Conditional valueOf() for input value based on domain type detection; a bigint reaching
+        // here is on a transform (log/time) scale and narrows to Number — see AG-16608 AC #9.
+        let x: number;
+        if (typeof value === 'number') {
+            x = value;
+        } else if (typeof value === 'bigint') {
+            x = Number(value);
+        } else {
+            x = value.valueOf();
+        }
         if (this.transform) {
             d0 = this.transform(d0);
             d1 = this.transform(d1);
@@ -158,6 +194,40 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         const [a, b] = this.range;
         return Math.abs(b - a);
     }
+}
+
+// Scaling factor for the integer ratio: 10^12 yields ~12 significant digits in [0,1] — far finer
+// than the ~3-4 digits pixel positioning needs — while keeping the intermediate product well below
+// Number.MAX_SAFE_INTEGER once narrowed.
+const BIGINT_RATIO_SCALE = 10n ** 12n;
+
+/**
+ * Linear convert() for bigint values, computed end-to-end in BigInt so neither the value-to-domain
+ * difference nor the domain span loses precision when narrowed. Only the final [0,1] ratio crosses
+ * to Number. Mirrors the equality/clamp short-circuits of the Number path.
+ */
+function convertBigInt(value: bigint, d0: bigint, d1: bigint, range: number[], clamp: boolean): number {
+    const r0 = range[0];
+    const r1 = range[1];
+
+    // Same short-circuit order as the Number path: clamp, then zero-width domain, then endpoints.
+    if (clamp) {
+        const lo = d0 < d1 ? d0 : d1;
+        const hi = d0 < d1 ? d1 : d0;
+        if (value < lo) return r0;
+        if (value > hi) return r1;
+    }
+
+    if (d0 === d1) {
+        return (r0 + r1) / 2;
+    }
+
+    if (value === d0) return r0;
+    if (value === d1) return r1;
+
+    const ratioBig = ((value - d0) * BIGINT_RATIO_SCALE) / (d1 - d0);
+    const ratio = Number(ratioBig) / Number(BIGINT_RATIO_SCALE);
+    return r0 + ratio * (r1 - r0);
 }
 
 export function normalizeContinuousDomains<D extends number | Date>(

--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -22,8 +22,7 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
     private domainNeedsValueOf = true; // Safe default
     private d0Cache: number = Number.NaN;
     private d1Cache: number = Number.NaN;
-    // Exact bigint domain endpoints, retained for the full-precision convert() ratio.
-    // Undefined unless the corresponding endpoint was supplied as a bigint.
+    // Exact bigint domain endpoints, retained for the full-precision convert() ratio (see convertBigInt).
     private d0Big: bigint | undefined = undefined;
     private d1Big: bigint | undefined = undefined;
 
@@ -114,9 +113,8 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         const { range } = this;
         const clamp = options?.clamp ?? this.defaultClamp;
 
-        // Full-precision BigInt ratio for linear scales: keeps adjacent high-magnitude bigints and
-        // domain spans beyond Number.MAX_SAFE_INTEGER monotonic, where a float64 narrow would collapse
-        // them. Log/time scales (transform != null) narrow to Number below (AG-16608 AC #9).
+        // Full-precision BigInt ratio for linear scales: keeps adjacent high-magnitude bigints monotonic
+        // where a float64 narrow would collapse them. Log/time scales narrow to Number below (AC #9).
         if (typeof value === 'bigint' && this.d0Big != null && this.d1Big != null && this.transform == null) {
             return convertBigInt(value, this.d0Big, this.d1Big, range, clamp);
         }
@@ -124,8 +122,7 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         // Use cached domain values to avoid valueOf() calls
         let d0: number = this.d0Cache;
         let d1: number = this.d1Cache;
-        // Conditional valueOf() for input value based on domain type detection; a bigint reaching
-        // here is on a transform (log/time) scale and narrows to Number — see AG-16608 AC #9.
+        // A bigint reaching here is on a transform (log/time) scale and narrows to Number (AC #9).
         let x: number;
         if (typeof value === 'number') {
             x = value;
@@ -196,9 +193,8 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
     }
 }
 
-// Scaling factor for the integer ratio: 10^12 yields ~12 significant digits in [0,1] — far finer
-// than the ~3-4 digits pixel positioning needs — while keeping the intermediate product well below
-// Number.MAX_SAFE_INTEGER once narrowed.
+// Integer ratio scale: 10^12 gives ~12 significant digits in [0,1] — far finer than pixel positioning
+// needs — while keeping the narrowed intermediate product below Number.MAX_SAFE_INTEGER.
 const BIGINT_RATIO_SCALE = 10n ** 12n;
 
 /**

--- a/packages/ag-charts-community/src/scale/linearScale.test.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.test.ts
@@ -284,6 +284,97 @@ describe('LinearScale', () => {
         expect(singlePointFormat(1234.567890123, ' ')).toEqual(' 1234.56789012');
     });
 
+    describe('convert bigint', () => {
+        test('matches the equivalent number conversion', () => {
+            const bigScale = new LinearScale();
+            bigScale.domain = [0n, 100n];
+            bigScale.range = [0, 100];
+
+            const numScale = new LinearScale();
+            numScale.domain = [0, 100];
+            numScale.range = [0, 100];
+
+            for (const v of [0n, 25n, 50n, 75n, 100n]) {
+                expect(bigScale.convert(v)).toBe(numScale.convert(Number(v)));
+            }
+        });
+
+        test('narrows the public domain to Number for spreading consumers', () => {
+            const scale = new LinearScale();
+            scale.domain = [0n, 100n];
+
+            expect(scale.domain).toEqual([0, 100]);
+            expect(scale.domain.every((v) => typeof v === 'number')).toBe(true);
+            expect(() => Math.min(...scale.domain)).not.toThrow();
+        });
+
+        test('clamps to the range bounds', () => {
+            const scale = new LinearScale();
+            scale.domain = [0n, 100n];
+            scale.range = [0, 100];
+
+            expect(scale.convert(-50n, { clamp: true })).toBe(0);
+            expect(scale.convert(150n, { clamp: true })).toBe(100);
+            expect(scale.convert(-50n, { clamp: false })).toBe(-50);
+            expect(scale.convert(150n, { clamp: false })).toBe(150);
+        });
+
+        test('returns the range midpoint for a zero-width domain', () => {
+            const scale = new LinearScale();
+            scale.domain = [100n, 100n];
+            scale.range = [0, 100];
+
+            expect(scale.convert(100n, { clamp: true })).toBe(50);
+            // Clamp takes precedence over the zero-width midpoint, matching the Number path.
+            expect(scale.convert(50n, { clamp: true })).toBe(0);
+            expect(scale.convert(150n, { clamp: true })).toBe(100);
+        });
+
+        test('supports descending domains', () => {
+            const scale = new LinearScale();
+            scale.domain = [100n, 0n];
+            scale.range = [0, 100];
+
+            expect(scale.convert(100n)).toBe(0);
+            expect(scale.convert(0n)).toBe(100);
+            expect(scale.convert(50n)).toBe(50);
+        });
+
+        test('is monotonic for adjacent bigints', () => {
+            const scale = new LinearScale();
+            scale.domain = [0n, 10n];
+            scale.range = [0, 1000];
+
+            let previous = -Infinity;
+            for (let v = 0n; v <= 10n; v++) {
+                const position = scale.convert(v);
+                expect(position).toBeGreaterThan(previous);
+                previous = position;
+            }
+        });
+
+        // AC AG-16608 #16: spans beyond Number.MAX_SAFE_INTEGER stay position-monotonic.
+        test('positions monotonically across a span larger than Number.MAX_SAFE_INTEGER', () => {
+            const span = 10n ** 21n;
+            expect(Number(span)).toBeGreaterThan(Number.MAX_SAFE_INTEGER);
+
+            const scale = new LinearScale();
+            scale.domain = [0n, span];
+            scale.range = [0, 1000];
+
+            expect(scale.convert(0n)).toBe(0);
+            expect(scale.convert(span)).toBe(1000);
+            expect(scale.convert(span / 2n)).toBeCloseTo(500);
+
+            let previous = -Infinity;
+            for (let i = 0n; i <= 10n; i++) {
+                const position = scale.convert((span * i) / 10n);
+                expect(position).toBeGreaterThan(previous);
+                previous = position;
+            }
+        });
+    });
+
     describe('empty domain', () => {
         test('convert does not throw', () => {
             const scale = new LinearScale();

--- a/packages/ag-charts-community/src/scale/logScale.test.ts
+++ b/packages/ag-charts-community/src/scale/logScale.test.ts
@@ -209,4 +209,30 @@ describe('LogScale', () => {
             firstTickIndex: 1,
         });
     });
+
+    // Log scales carry a transform, so bigints narrow to Number through the standard path rather
+    // than the linear bigint ratio — accepted limitation, AG-16608 AC #9.
+    describe('convert bigint', () => {
+        test('positive bigints match the equivalent number conversion', () => {
+            const bigScale = new LogScale();
+            bigScale.domain = [1n, 1000n];
+            bigScale.range = [0, 100];
+
+            const numScale = new LogScale();
+            numScale.domain = [1, 1000];
+            numScale.range = [0, 100];
+
+            for (const v of [1n, 10n, 100n, 1000n]) {
+                expect(bigScale.convert(v)).toBe(numScale.convert(Number(v)));
+            }
+        });
+
+        test('a bigint domain narrows so transform spreading stays Number-only', () => {
+            const scale = new LogScale();
+            scale.domain = [1n, 1000n];
+
+            expect(scale.domain).toEqual([1, 1000]);
+            expect(() => scale.convert(10n)).not.toThrow();
+        });
+    });
 });


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

**PR 2 of the BigInt stacked train**, based on **PR1 (#6937)** — review/merge PR1 first. Scale-only foundation: makes a `bigint` value position correctly on a numeric (linear) axis. No aggregation, tick, or domain-pipeline changes yet (those are PR3).

### Summary

- `ContinuousScale.convert()` — full-precision **end-to-end BigInt ratio** for linear scales: `(value - d0n) * SCALE / (d1n - d0n)` with `SCALE = 10n ** 12n`, narrowing only the final `[0,1]` result. Keeps adjacent high-magnitude bigints and domain spans beyond `Number.MAX_SAFE_INTEGER` monotonic where a float64 narrow would collapse them (AC #16). Mirrors the Number path's clamp / zero-width / endpoint short-circuits.
- Domain setter — retains the exact `bigint` endpoints (`d0Big`/`d1Big`) for that ratio, while exposing a **Number-narrowed** public `domain` so every `Math.min/max(...domain)` consumer (logScale, gradient stops, gauges) stays Number-only.
- Log/time scales carry a `transform`, so bigints narrow to Number through the existing path rather than the linear ratio — positive bigints accepted, tick labels at narrowed-Number precision (documented limitation, AC #9).
- Equality/clamp short-circuit parity with the Number path (audit item).

### Stacked-train note (reviewers)

PR1's description said "PR2 removes the stopgap drops". **That moves to PR3 instead.** Removing the four PR1 bigint drops re-exposes bigint to paths PR3 owns — `ContinuousDomain.extend` (silently drops bigint -> empty domain), `SMALLEST/LARGEST_KEY_INTERVAL` (`Math.abs(bigint)` throws on bigint keys), and aggregation/histogram (`+`/seed throws). A drop is per-value, so it can't be half-removed; removing it safely is coupled to PR3's aggregation/tick/interval work. PR2 therefore delivers the scale **capability**, validated at the scale-unit level (domain set directly); PR3 feeds it real bigint domains and removes the drops. (Recorded in the phased-plan companion doc.)

### Test plan

- New `convert bigint` suites (linearScale + logScale): number-parity, public-domain narrowing, clamp incl. zero-width precedence, descending domains, adjacent-bigint monotonicity, and large-span `[0n, 10n ** 21n]` position-monotonicity (AC #16).
- `yarn nx build:types ag-charts-community` + `ag-charts-enterprise` — pass
- `yarn nx lint ag-charts-community` — pass (0 new errors)
- `yarn nx test ag-charts-community` (3359) — pass

Fix #AG-16608