### PR TITLE
AG-16608 BigInt aggregation, formatter, and value-drop removal

### DIFF
--- a/packages/ag-charts-community/src/chart/data/aggregateFunctions.test.ts
+++ b/packages/ag-charts-community/src/chart/data/aggregateFunctions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { accumulatedValue, addAccumulated, trailingAccumulatedValue } from './aggregateFunctions';
+
+describe('aggregateFunctions bigint support (AG-16608)', () => {
+    describe('addAccumulated', () => {
+        it('adds two numbers', () => {
+            expect(addAccumulated(2, 3)).toBe(5);
+        });
+
+        it('promotes a number seed to bigint on the first bigint operand', () => {
+            expect(addAccumulated(0, 5n)).toBe(5n);
+            expect(addAccumulated(5n, 3n)).toBe(8n);
+        });
+    });
+
+    describe('accumulatedValue', () => {
+        it('produces bigint running totals', () => {
+            const acc = accumulatedValue()!();
+            expect(acc(5n, 0)).toBe(5n);
+            expect(acc(3n, 1)).toBe(8n);
+            expect(acc(2n, 2)).toBe(10n);
+        });
+
+        it('clamps negative bigints with onlyPositive', () => {
+            const acc = accumulatedValue(true)!();
+            expect(acc(5n, 0)).toBe(5n);
+            expect(acc(-4n, 1)).toBe(5n);
+            expect(acc(2n, 2)).toBe(7n);
+        });
+    });
+
+    describe('trailingAccumulatedValue', () => {
+        it('emits a 0n first trailing value so the column stays uniformly bigint', () => {
+            const trailing = trailingAccumulatedValue()!();
+            expect(trailing(5n, 0)).toBe(0n);
+            expect(trailing(3n, 1)).toBe(5n);
+            expect(trailing(2n, 2)).toBe(8n);
+        });
+    });
+});

--- a/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -3,6 +3,18 @@ import { isFiniteNumber } from 'ag-charts-core';
 import { ContinuousDomain } from './dataDomain';
 import type { AggregatePropertyDefinition, DatumPropertyDefinition } from './dataModel';
 
+/**
+ * Adds two accumulator operands, promoting to bigint when either is a bigint. Columns are uniformly
+ * typed (a mixed number/bigint column is rejected at the series level), so for a bigint column the
+ * number-typed `0` seed promotes to `0n` on the first value and stays bigint thereafter.
+ */
+export function addAccumulated(acc: number | bigint, value: number | bigint): number | bigint {
+    if (typeof acc === 'bigint' || typeof value === 'bigint') {
+        return BigInt(acc) + BigInt(value);
+    }
+    return acc + value;
+}
+
 export function sumValues(values: any[], accumulator: [number, number] = [0, 0]) {
     for (const value of values) {
         if (typeof value !== 'number') {
@@ -123,14 +135,18 @@ export function area(id: string, aggFn: AggregatePropertyDefinition<any, any>, m
 
 export function accumulatedValue(onlyPositive?: boolean): DatumPropertyDefinition<any>['processor'] {
     return () => {
-        let value = 0;
+        let value: number | bigint = 0;
 
         return (datum: any) => {
+            if (typeof datum === 'bigint') {
+                value = addAccumulated(value, onlyPositive && datum < 0n ? 0n : datum);
+                return value;
+            }
             if (!isFiniteNumber(datum)) {
                 return datum;
             }
 
-            value += onlyPositive ? Math.max(0, datum) : datum;
+            value = addAccumulated(value, onlyPositive ? Math.max(0, datum) : datum);
             return value;
         };
     };
@@ -138,15 +154,20 @@ export function accumulatedValue(onlyPositive?: boolean): DatumPropertyDefinitio
 
 export function trailingAccumulatedValue(): DatumPropertyDefinition<any>['processor'] {
     return () => {
-        let value = 0;
+        let value: number | bigint = 0;
 
         return (datum: any) => {
-            if (!isFiniteNumber(datum)) {
+            if (typeof datum !== 'bigint' && !isFiniteNumber(datum)) {
                 return datum;
+            }
+            // Promote the seed before capturing the trailing value so a bigint column's first
+            // trailing entry is 0n, keeping the whole column uniformly bigint (AG-16608 AC #10).
+            if (typeof datum === 'bigint' && typeof value !== 'bigint') {
+                value = 0n;
             }
 
             const trailingValue = value;
-            value += datum;
+            value = addAccumulated(value, datum);
             return trailingValue;
         };
     };

--- a/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -4,9 +4,8 @@ import { ContinuousDomain } from './dataDomain';
 import type { AggregatePropertyDefinition, DatumPropertyDefinition } from './dataModel';
 
 /**
- * Adds two accumulator operands, promoting to bigint when either is a bigint. Columns are uniformly
- * typed (a mixed number/bigint column is rejected at the series level), so for a bigint column the
- * number-typed `0` seed promotes to `0n` on the first value and stays bigint thereafter.
+ * Adds two accumulator operands, promoting to bigint when either operand is. Columns are uniformly
+ * typed, so a bigint column's number `0` seed promotes to `0n` on the first value and stays bigint.
  */
 export function addAccumulated(acc: number | bigint, value: number | bigint): number | bigint {
     if (typeof acc === 'bigint' || typeof value === 'bigint') {

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -1,4 +1,4 @@
-import { Logger, first, iterate } from 'ag-charts-core';
+import { Logger, first, isNumberObject, iterate } from 'ag-charts-core';
 
 import { ContinuousDomain } from '../../dataDomain';
 import {
@@ -79,8 +79,9 @@ function valueColumnType(value: unknown): ColumnValueType | undefined {
         case 'string':
             return 'string';
         case 'object':
-            // TODO(AG-16608, PR2): a numeric NumberObject is tagged 'date' here; disambiguate via isNumberObject().
-            return value == null ? undefined : 'date';
+            if (value == null) return undefined;
+            // A NumberObject ({ valueOf(): number }) is numeric, not a date.
+            return isNumberObject(value) ? 'number' : 'date';
         default:
             return undefined;
     }
@@ -265,8 +266,8 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
                     const result = processKeyValue(data[datumIndex], datumIndex, scope);
 
-                    // PR1 stopgap: drop bigint keys until PR2 wires the scale/sort arithmetic that
-                    // consumes them, else they throw on BigInt maths. Removed in PR2.
+                    // bigint *values* are supported now, but bigint *keys* stay dropped until a later PR:
+                    // they break SORT_DOMAIN_GROUPS' comparator and need numeric-axis prediction (AC #4).
                     if (result.valid && typeof result.value !== 'bigint') {
                         keys.push(result.value);
                         // Track ordering/uniqueness for valid keys
@@ -404,14 +405,6 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                     this.markScopeDatumMissing(def.scopes, columnSource, datumIndex, missingData);
                 } else {
                     updateColumnTypeTracker(typeTracker, result.value, datumIndex);
-                }
-
-                // PR1 stopgap: drop bigints until PR2 wires scale/aggregation support, else `x - d0`
-                // throws "Cannot mix BigInt and other types". Removed in PR2.
-                if (typeof value === 'bigint') {
-                    this.markScopeDatumInvalid(def.scopes, columnSource, datumIndex, invalidData, invalidDataCount);
-                    partialValidDataCount += 1;
-                    value = invalidValue;
                 }
 
                 if (invalidKey) {

--- a/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
@@ -513,7 +513,8 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                     insertionCache,
                     (cached) => {
                         const keyResult = cached?.keys.get(defIndex);
-                        // PR1 stopgap: drop bigint keys until PR2 wires convert (mirrors dataExtractor).
+                        // bigint keys remain dropped (see dataExtractor.extractKeys) until key-sort
+                        // safety and numeric-axis prediction (AC #4) land in a later PR.
                         if (keyResult?.valid && typeof keyResult.value === 'bigint') {
                             return def.invalidValue;
                         }
@@ -578,10 +579,6 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                         return def.invalidValue;
                     }
                     const valueResult = cached.values.get(defIndex);
-                    // PR1 stopgap: drop bigint until PR2 wires convert (mirrors dataExtractor.extractValues).
-                    if (valueResult?.valid && typeof valueResult.value === 'bigint') {
-                        return def.invalidValue;
-                    }
                     return valueResult?.valid ? valueResult.value : def.invalidValue;
                 }
                 return def.invalidValue;

--- a/packages/ag-charts-community/src/chart/data/dataDomain.ts
+++ b/packages/ag-charts-community/src/chart/data/dataDomain.ts
@@ -168,7 +168,10 @@ export class DiscreteDomain implements IDataDomain {
 }
 
 export class ContinuousDomain<T extends number | Date> implements IDataDomain<T> {
-    private domain = [Infinity, -Infinity] as [T, T];
+    // Endpoints may be bigint: a bigint column retains its exact endpoints here so the scale's
+    // full-precision convert() ratio can use them. Comparisons against the Infinity seed (or other
+    // bigints) are legal — only +/-/* mixing of bigint and number throws.
+    private domain = [Infinity, -Infinity] as [T | bigint, T | bigint];
 
     static is<T extends number | Date = any>(value: unknown): value is ContinuousDomain<T> {
         return value instanceof ContinuousDomain;
@@ -176,21 +179,30 @@ export class ContinuousDomain<T extends number | Date> implements IDataDomain<T>
 
     static extendDomain(values: unknown[], domain: [number, number] = [Infinity, -Infinity]) {
         for (const value of values) {
-            if (typeof value !== 'number') {
+            // Aggregation/stacked domains are derived and feed further arithmetic in the aggregator,
+            // so bigint is narrowed to Number here (unlike the instance `extend`, which retains the
+            // exact endpoints of a raw column for the scale's full-precision convert()). Stacked
+            // totals themselves stay bigint in the column (AG-16608 AC #10).
+            let n: number;
+            if (typeof value === 'number') {
+                n = value;
+            } else if (typeof value === 'bigint') {
+                n = Number(value);
+            } else {
                 continue;
             }
-            if (domain[0] > value) {
-                domain[0] = value;
+            if (domain[0] > n) {
+                domain[0] = n;
             }
-            if (domain[1] < value) {
-                domain[1] = value;
+            if (domain[1] < n) {
+                domain[1] = n;
             }
         }
         return domain;
     }
 
-    extend(value: T) {
-        if (typeof value !== 'number' && !(value instanceof Date)) {
+    extend(value: T | bigint) {
+        if (typeof value !== 'number' && typeof value !== 'bigint' && !(value instanceof Date)) {
             return;
         }
         if (this.domain[0] > value) {
@@ -202,7 +214,9 @@ export class ContinuousDomain<T extends number | Date> implements IDataDomain<T>
     }
 
     getDomain() {
-        return [...this.domain];
+        // The scale's domain setter and other consumers branch on `typeof` at runtime, so a retained
+        // bigint endpoint is handled correctly despite the declared `T` element type.
+        return [...this.domain] as T[];
     }
 }
 

--- a/packages/ag-charts-community/src/chart/data/dataDomain.ts
+++ b/packages/ag-charts-community/src/chart/data/dataDomain.ts
@@ -168,9 +168,8 @@ export class DiscreteDomain implements IDataDomain {
 }
 
 export class ContinuousDomain<T extends number | Date> implements IDataDomain<T> {
-    // Endpoints may be bigint: a bigint column retains its exact endpoints here so the scale's
-    // full-precision convert() ratio can use them. Comparisons against the Infinity seed (or other
-    // bigints) are legal — only +/-/* mixing of bigint and number throws.
+    // Endpoints may be bigint: a bigint column retains exact endpoints here for the scale's full-precision
+    // convert(). Comparisons against the Infinity seed are legal — only +/-/* bigint/number mixing throws.
     private domain = [Infinity, -Infinity] as [T | bigint, T | bigint];
 
     static is<T extends number | Date = any>(value: unknown): value is ContinuousDomain<T> {
@@ -179,10 +178,8 @@ export class ContinuousDomain<T extends number | Date> implements IDataDomain<T>
 
     static extendDomain(values: unknown[], domain: [number, number] = [Infinity, -Infinity]) {
         for (const value of values) {
-            // Aggregation/stacked domains are derived and feed further arithmetic in the aggregator,
-            // so bigint is narrowed to Number here (unlike the instance `extend`, which retains the
-            // exact endpoints of a raw column for the scale's full-precision convert()). Stacked
-            // totals themselves stay bigint in the column (AG-16608 AC #10).
+            // Derived aggregation/stacked domains feed further arithmetic, so narrow bigint to Number here
+            // (unlike instance `extend`, which retains raw-column endpoints for the scale's convert()).
             let n: number;
             if (typeof value === 'number') {
                 n = value;

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1523,9 +1523,9 @@ describe('DataModel', () => {
             expect(processedData!.columnValueType).toEqual(['bigint']);
         });
 
-        it('should drop bigint values into the column while still tagging them (PR1 stopgap)', () => {
-            // PR1 (AG-16608) tags bigint columns but drops the values, since the scale/aggregation
-            // arithmetic that consumes them lands in PR2. PR2 inverts the column assertion below.
+        it('should retain bigint values in the column and continuous domain', () => {
+            // AG-16608: bigint values now flow into the column and build a bigint ContinuousDomain
+            // (the scale/aggregation arithmetic that consumes them is bigint-safe).
             const dataModel = new DataModel<any, any>({
                 props: [categoryKey('id'), value('count')],
             });
@@ -1539,12 +1539,14 @@ describe('DataModel', () => {
             const processedData = dataModel.processData(sources)!;
 
             expect(processedData.columnValueType).toEqual(['bigint']);
-            expect(processedData.columns[0].some((v) => typeof v === 'bigint')).toBe(false);
+            expect(processedData.columns[0]).toEqual([10n, 20n]);
+            expect(processedData.domain.values[0]).toEqual([10n, 20n]);
         });
 
-        it('should drop bigint keys without throwing on a continuous key (PR1 stopgap)', () => {
-            // PR1 (AG-16608) widens continuous validation to accept bigint, but bigint keys must not
-            // reach domain/sort/scale arithmetic until PR2 wires conversion. PR2 inverts this.
+        it('should drop bigint keys without throwing on a continuous key', () => {
+            // AG-16608: bigint *keys* remain dropped — a bigint key reaches SORT_DOMAIN_GROUPS (whose
+            // comparator return is ToNumber-coerced by Array.sort, throwing) and needs numeric-axis
+            // prediction (AC #4); both land in a later PR. Bigint *values* are already supported.
             const dataModel = new DataModel<any, any>({
                 props: [rangeKey('x'), value('y')],
             });
@@ -1620,6 +1622,54 @@ describe('DataModel', () => {
             const reprocessed = dataModel.reprocessData(processedData!);
 
             expect(reprocessed.columnValueType).toEqual(['bigint']);
+        });
+    });
+
+    describe('bigint aggregation (AG-16608)', () => {
+        it('should accumulate a bigint value column into bigint running totals', () => {
+            const dataModel = new DataModel<any, any>({
+                props: [rangeKey('kp'), accumulatedPropertyValue('vp')],
+            });
+            const data = basicDataSet([
+                { kp: 1, vp: 5n },
+                { kp: 2, vp: 3n },
+                { kp: 3, vp: 2n },
+            ]);
+
+            const result = dataModel.processData(data)!;
+
+            expect(result.columnValueType).toEqual(['bigint']);
+            expect(result.columns[0]).toEqual([5n, 8n, 10n]);
+        });
+
+        it('should clamp negative bigints when accumulating with onlyPositive', () => {
+            // accumulatedPropertyValue uses accumulatedValue(true): a negative bigint contributes 0n.
+            const dataModel = new DataModel<any, any>({
+                props: [rangeKey('kp'), accumulatedPropertyValue('vp')],
+            });
+            const data = basicDataSet([
+                { kp: 1, vp: 5n },
+                { kp: 2, vp: -4n },
+                { kp: 3, vp: 2n },
+            ]);
+
+            const result = dataModel.processData(data)!;
+
+            expect(result.columns[0]).toEqual([5n, 5n, 7n]);
+        });
+
+        it('should stack bigint value columns into bigint totals', () => {
+            const dataModel = new DataModel<any, any, true>({
+                props: [categoryKey('kp'), ...accumulatedGroupValues(['a', 'b'], 'all'), range('all')],
+                groupByKeys: true,
+            });
+            const data = basicDataSet([{ kp: 'Q1', a: 5n, b: 7n }]);
+
+            const result = dataModel.processData(data)!;
+
+            expect(result.type).toEqual('grouped');
+            expect(resolveGroupColumn(result, 0, 0)).toEqual([5n]); // first stack layer
+            expect(resolveGroupColumn(result, 0, 1)).toEqual([12n]); // stacked on top: 5n + 7n
         });
     });
 

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -8,7 +8,7 @@ import {
     transformIntegratedCategoryValue,
 } from 'ag-charts-core';
 
-import { accumulatedValue, range, trailingAccumulatedValue } from './aggregateFunctions';
+import { accumulatedValue, addAccumulated, range, trailingAccumulatedValue } from './aggregateFunctions';
 import {
     type DataGroup,
     type DatumPropertyDefinition,
@@ -534,8 +534,9 @@ function buildGroupAccFn({ mode, separateNegative }: { mode: 'normal' | 'trailin
                 dataGroup: DataGroup,
                 groupIndex: number
             ) {
-                // Datum scope.
-                const acc = [0, 0];
+                // Datum scope. Seeds are number `0`; a bigint column promotes them to bigint via
+                // addAccumulated so stacked totals retain full precision (AG-16608 AC #10).
+                const acc: [number | bigint, number | bigint] = [0, 0];
                 for (const valueIdx of valueIndexes) {
                     const datumIndices = dataGroup.datumIndices[valueIdx];
                     if (datumIndices == null) continue;
@@ -550,19 +551,21 @@ function buildGroupAccFn({ mode, separateNegative }: { mode: 'normal' | 'trailin
                         // (relative index is offset from group start, absolute is for the entire column)
                         const datumIndex = groupIndex + relativeDatumIndex;
                         const currentVal = column[datumIndex];
-                        if (!isFiniteNumber(currentVal)) continue;
+                        const isBigInt = typeof currentVal === 'bigint';
+                        if (!isBigInt && !isFiniteNumber(currentVal)) continue;
 
-                        const useNegative = separateNegative && isNegative(currentVal);
+                        // isNegative() uses Math.sign(), which throws on bigint — compare directly.
+                        const useNegative = separateNegative && (isBigInt ? currentVal < 0n : isNegative(currentVal));
                         const accValue = useNegative ? stackNegative : stackPositive;
                         if (mode === 'normal') {
-                            column[datumIndex] = accValue + currentVal;
+                            column[datumIndex] = addAccumulated(accValue, currentVal);
                         } else {
                             column[datumIndex] = accValue;
                         }
 
                         if (!didAccumulate) {
                             const accIndex = useNegative ? 0 : 1;
-                            acc[accIndex] = accValue + currentVal;
+                            acc[accIndex] = addAccumulated(accValue, currentVal);
 
                             didAccumulate = true;
                         }

--- a/packages/ag-charts-core/src/utils/format/format.util.test.ts
+++ b/packages/ag-charts-core/src/utils/format/format.util.test.ts
@@ -22,6 +22,12 @@ describe('Format utils', () => {
         expect(formatValue(true)).toBe('true');
     });
 
+    test('formatValue renders bigint at full precision (AG-16608)', () => {
+        expect(formatValue(9007199254740993n)).toBe('9,007,199,254,740,993');
+        expect(formatValue(-9007199254740993n)).toBe('-9,007,199,254,740,993');
+        expect(formatValue(0n)).toBe('0');
+    });
+
     test('formatPercent', () => {
         expect(formatPercent(0.25)).toBe('25%');
         expect(formatPercent(1)).toBe('100%');

--- a/packages/ag-charts-core/src/utils/format/format.util.ts
+++ b/packages/ag-charts-core/src/utils/format/format.util.ts
@@ -13,6 +13,11 @@ export function formatValue(value: unknown, maximumFractionDigits: number = 2): 
     if (typeof value === 'number') {
         return formatNumber(value, maximumFractionDigits);
     }
+    if (typeof value === 'bigint') {
+        // Full-precision locale-grouped output (e.g. "9,007,199,254,740,993") for the default
+        // tooltip / label path, without narrowing through Number (AG-16608 AC #7).
+        return value.toLocaleString('en-US');
+    }
     return typeof value === 'string' ? value : String(value ?? '');
 }
 

--- a/packages/ag-charts-core/src/utils/format/numberFormat.test.ts
+++ b/packages/ag-charts-core/src/utils/format/numberFormat.test.ts
@@ -10,6 +10,11 @@ describe('number format', () => {
         expect(createNumberFormatter('.4f')!(123)).toBe('123.0000');
         expect(createNumberFormatter('f')!(0.1234567890123456)).toBe('0.123457');
     });
+    test('bigint values format at full precision without throwing (AG-16608)', () => {
+        expect(createNumberFormatter('.2f')!(9007199254740993n)).toBe('9,007,199,254,740,993');
+        expect(createNumberFormatter(',.0f')!(9007199254740993n)).toBe('9,007,199,254,740,993');
+        expect(createNumberFormatter('f')!(-9007199254740993n)).toBe('-9,007,199,254,740,993');
+    });
     test('rounded percentage', () => {
         const f = createNumberFormatter('.0%')!;
         expect(f(0.3)).toBe('30%');

--- a/packages/ag-charts-core/src/utils/format/numberFormat.ts
+++ b/packages/ag-charts-core/src/utils/format/numberFormat.ts
@@ -58,8 +58,12 @@ export function parseNumberFormat(format: string): FormatterOptions | undefined 
     };
 }
 
-export function createNumberFormatter(format: FormatterOptions): (n: number, fractionDigits?: number) => string;
-export function createNumberFormatter(format: string): ((n: number, fractionDigits?: number) => string) | undefined;
+export function createNumberFormatter(
+    format: FormatterOptions
+): (n: number | bigint, fractionDigits?: number) => string;
+export function createNumberFormatter(
+    format: string
+): ((n: number | bigint, fractionDigits?: number) => string) | undefined;
 export function createNumberFormatter(format: string | FormatterOptions) {
     const options = typeof format === 'string' ? parseNumberFormat(format) : format;
     if (options == null) return;
@@ -94,7 +98,13 @@ export function createNumberFormatter(format: string | FormatterOptions) {
         padAlign ??= '=';
     }
 
-    return (n: number, fractionDigits?: number) => {
+    return (n: number | bigint, fractionDigits?: number) => {
+        // A bigint can reach here through an `any`-typed value path (e.g. a number format specifier
+        // applied to a bigint column); the formatting body below uses Math/toFixed which throw on
+        // bigint, so emit a locale-grouped string directly (AG-16608 AC #6/#8).
+        if (typeof n === 'bigint') {
+            return `${prefix}${n.toLocaleString('en-US')}${suffix}`;
+        }
         // When a format type is specified and no precision is in the format string:
         // - For 'f' and '%' types, fractionDigits can be used (it represents decimal places)
         // - For other types (s, r, g, e, etc.), use default precision (fractionDigits represents tick step, not format precision)

--- a/packages/ag-charts-core/src/utils/format/numberFormat.ts
+++ b/packages/ag-charts-core/src/utils/format/numberFormat.ts
@@ -99,9 +99,8 @@ export function createNumberFormatter(format: string | FormatterOptions) {
     }
 
     return (n: number | bigint, fractionDigits?: number) => {
-        // A bigint can reach here through an `any`-typed value path (e.g. a number format specifier
-        // applied to a bigint column); the formatting body below uses Math/toFixed which throw on
-        // bigint, so emit a locale-grouped string directly (AG-16608 AC #6/#8).
+        // A bigint can reach here via an `any`-typed value path; the body below uses Math/toFixed which
+        // throw on bigint, so emit a locale-grouped string directly (AG-16608 AC #6/#8).
         if (typeof n === 'bigint') {
             return `${prefix}${n.toLocaleString('en-US')}${suffix}`;
         }


### PR DESCRIPTION
## Summary

PR3a of the stacked BigInt train (AG-16608). Makes bigint **values** flow end-to-end through the data model and render correctly. Full-precision axis ticks (`createBigIntTicks`) and histogram bins follow in **PR3b**.

Stacked on #6940 (PR2). Merge order: PR1 → PR2 → **PR3a** → PR3b.

### Changes

- **`ContinuousDomain`** — `extend` retains a raw column's exact bigint endpoints so the scale's full-precision `convert()` ratio (PR2) receives them. The static `extendDomain` narrows *derived* aggregation/stacked domains to Number (they feed further arithmetic in the aggregator; the type-widening ripple there isn't worth the two-boundary precision benefit).
- **Aggregation (AC #10)** — stacking (`accumulateGroup`) and accumulated-value processors seed `0n` and produce bigint totals via a shared `addAccumulated` helper. `trailingAccumulatedValue` promotes its seed before capturing the first trailing value so the column stays uniformly bigint.
- **Formatter (AC #7, #8)** — `formatValue` and `createNumberFormatter` emit locale-grouped bigint output via `toLocaleString('en-US')`. Covers the default tooltip path and guards the formatter body's `Math`/`toFixed` (which throw on bigint) when a number format specifier lands on a bigint column.
- **Drops** — removes the two PR1 **value-side** stopgap drops (full extraction + incremental append). Resolves the `NumberObject → 'number'` type-tag TODO.

### Scope refinement vs the plan

The phased plan had PR3 "remove all four drops". This PR removes only the **value** drops. Bigint **keys** stay dropped because a bigint key reaches `SORT_DOMAIN_GROUPS` — whose comparator returns a bigint that `Array.sort` coerces via `ToNumber`, throwing — and also needs numeric-axis prediction (AC #4). Both land in a later PR. Histogram BigInt bins (AC #13) and stacking-on-`date` rejection (AC #14) also move to PR3b/later, grouped with the work they depend on.

### AC coverage

AG-16608 **#7** (tooltip full precision), **#8** (no throw), **#10** (bigint stacking/accumulated totals). Partial **#1** (bigint values render on numeric axes). Axis-label precision (#6, #15, #16) and histogram (#13) are PR3b.

## Test plan

- `aggregateFunctions.test.ts` (new) — `addAccumulated`, `accumulatedValue`, `trailingAccumulatedValue` bigint behaviour.
- `dataModel.test.ts` — bigint value retention + non-empty `ContinuousDomain`; bigint accumulation, negative-clamp, and stacking; inverted the former "drop bigint values" stopgap test.
- `format.util.test.ts` / `numberFormat.test.ts` — `9007199254740993n` → `"9,007,199,254,740,993"` full precision.
- Full suites green: `build:types` (core/community/enterprise), `lint` (0 errors), `test ag-charts-community` (3362), `test ag-charts-enterprise` (2136).

Fix #AG-16608