### PR TITLE
AG-16608 BigInt full-precision axis ticks and labels

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -53,7 +53,10 @@ export class NumberAxis<
     }
 
     protected getVisibleDomain(domain: number[]): [number, number] {
-        const [d0, d1] = domain;
+        // Narrow to Number: a bigint domain reaches here as formatter-context metadata only — the tick
+        // label itself carries the exact bigint value, so this range context can narrow safely.
+        const d0 = Number(domain[0]);
+        const d1 = Number(domain[1]);
         const [r0, r1] = this.visibleRange;
         const length = d1 - d0;
         return [d0 + r0 * length, d1 - (1 - r1) * length];

--- a/packages/ag-charts-community/src/chart/axis/numberAxisBigInt.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxisBigInt.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgCartesianChartOptions, AgChartInstance } from 'ag-charts-types';
+
+import { AgCharts } from '../../api/agCharts';
+import { deproxy, prepareTestOptions, setupMockCanvas, setupMockConsole, waitForChartStability } from '../test/utils';
+
+// AG-16608 — BigInt numeric-axis ticks render at full precision (AC #15e, #16). These tests drive a
+// real chart so the bigint values flow through domain extraction, scale conversion, tick generation
+// and the axis label formatter end-to-end.
+describe('NumberAxis BigInt labels', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let chart: AgChartInstance;
+
+    afterEach(() => {
+        if (chart) {
+            chart.destroy();
+            (chart as unknown) = undefined;
+        }
+    });
+
+    const yAxisLabelText = (chartInstance: AgChartInstance): string[] => {
+        const axis = deproxy(chartInstance as any).axes.find((a: any) => a.direction === 'y') as any;
+        expect(axis).toBeDefined();
+        return Array.from(axis.tickLabelGroupSelection.nodes() as Iterable<any>)
+            .map((node) => node.text)
+            .filter((text): text is string => text != null && text !== '');
+    };
+
+    const createChart = async (data: unknown[]): Promise<AgChartInstance> => {
+        const options: AgCartesianChartOptions = {
+            data: data as AgCartesianChartOptions['data'],
+            series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+        };
+        prepareTestOptions(options);
+        const instance = AgCharts.create(options);
+        await waitForChartStability(instance);
+        return instance;
+    };
+
+    it('renders exact labels for a span larger than Number.MAX_SAFE_INTEGER (AC #16)', async () => {
+        const span = 10n ** 21n;
+        chart = await createChart([
+            { x: 0, y: 0n },
+            { x: 1, y: span },
+        ]);
+
+        const labels = yAxisLabelText(chart);
+        // 2 × 10^20 — exact only if the tick value reached the formatter as a BigInt.
+        expect(labels).toContain('200,000,000,000,000,000,000');
+        expect(labels).toContain('1,000,000,000,000,000,000,000');
+    });
+
+    it('preserves precision past the float64 boundary (AC #15e)', async () => {
+        // A unit-span window straddling 2^53: each integer is its own tick. Odd values above 2^53
+        // (…991, …993, …995) are unrepresentable as Number — they would collapse onto an even
+        // neighbour — so their exact labels prove the tick value reached the formatter as a BigInt.
+        chart = await createChart([
+            { x: 0, y: 9_007_199_254_740_990n },
+            { x: 1, y: 9_007_199_254_740_995n },
+        ]);
+
+        const labels = yAxisLabelText(chart);
+        expect(labels).toContain('9,007,199,254,740,991');
+        expect(labels).toContain('9,007,199,254,740,993');
+        expect(labels).toContain('9,007,199,254,740,995');
+    });
+});

--- a/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
@@ -42,8 +42,7 @@ export function toKeyString(keys: any[]): string {
 export function fixNumericExtent(extent: Array<number | Date | bigint> | null): [] | [number, number] {
     if (extent == null) return [];
     // Retain exact bigint endpoints so the scale positions and labels them at full precision; Date and
-    // number values still narrow to Number. Maps every element (callers may pass multi-value domains);
-    // downstream consumers branch on `typeof` at runtime.
+    // number values still narrow to Number. Downstream consumers branch on `typeof` at runtime.
     const mapped = extent.map((v) => (typeof v === 'bigint' ? v : Number(v)));
     const allFinite = mapped.every((v) => typeof v === 'bigint' || Number.isFinite(v));
     return allFinite ? (mapped as unknown as [number, number]) : [];

--- a/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
@@ -39,9 +39,14 @@ export function toKeyString(keys: any[]): string {
  * Fixes a numeric extent to ensure both values are finite numbers.
  * Returns empty array if extent is null or contains non-finite values.
  */
-export function fixNumericExtent(extent: Array<number | Date> | null): [] | [number, number] {
-    const numberExtent = extent?.map(Number) as [number, number] | undefined;
-    return numberExtent?.every(Number.isFinite) ? numberExtent : [];
+export function fixNumericExtent(extent: Array<number | Date | bigint> | null): [] | [number, number] {
+    if (extent == null) return [];
+    // Retain exact bigint endpoints so the scale positions and labels them at full precision; Date and
+    // number values still narrow to Number. Maps every element (callers may pass multi-value domains);
+    // downstream consumers branch on `typeof` at runtime.
+    const mapped = extent.map((v) => (typeof v === 'bigint' ? v : Number(v)));
+    const allFinite = mapped.every((v) => typeof v === 'bigint' || Number.isFinite(v));
+    return allFinite ? (mapped as unknown as [number, number]) : [];
 }
 
 /**

--- a/packages/ag-charts-community/src/scale/linearScale.test.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.test.ts
@@ -375,6 +375,48 @@ describe('LinearScale', () => {
         });
     });
 
+    describe('ticks bigint', () => {
+        const tickParams: ScaleTickParams<number> = {
+            nice: [true, true],
+            interval: undefined,
+            tickCount: undefined,
+            minTickCount: 0,
+            maxTickCount: Infinity,
+        };
+
+        test('generates full-precision BigInt ticks for a BigInt domain', () => {
+            const scale = new LinearScale();
+            scale.range = [0, 600];
+
+            const { ticks } = scale.ticks(tickParams, [0n, 100n] as unknown as number[]);
+            expect(ticks).toEqual([0n, 20n, 40n, 60n, 80n, 100n]);
+        });
+
+        test('nices a BigInt domain outward to step multiples', () => {
+            const scale = new LinearScale();
+            expect(scale.niceDomain(tickParams, [13n, 97n] as unknown as number[])).toEqual([0n, 100n]);
+        });
+
+        // AC AG-16608 #15e / #16: ticks beyond Number.MAX_SAFE_INTEGER keep exact values.
+        test('keeps exact tick values for spans larger than Number.MAX_SAFE_INTEGER', () => {
+            const scale = new LinearScale();
+            scale.range = [0, 600];
+
+            const span = 10n ** 21n;
+            const { ticks } = scale.ticks(tickParams, [0n, span] as unknown as number[]);
+            expect(ticks).toEqual([0n, 2n * 10n ** 20n, 4n * 10n ** 20n, 6n * 10n ** 20n, 8n * 10n ** 20n, span]);
+        });
+
+        test('narrows to the Number path when an interval is supplied', () => {
+            const scale = new LinearScale();
+            scale.range = [0, 100];
+
+            // A custom interval is a Number concept; the bigint domain narrows and the Number path runs.
+            const { ticks } = scale.ticks({ ...tickParams, interval: 25 }, [0n, 100n] as unknown as number[]);
+            expect(ticks).toEqual([0, 25, 50, 75, 100]);
+        });
+    });
+
     describe('empty domain', () => {
         test('convert does not throw', () => {
             const scale = new LinearScale();

--- a/packages/ag-charts-community/src/scale/linearScale.test.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.test.ts
@@ -397,6 +397,15 @@ describe('LinearScale', () => {
             expect(scale.niceDomain(tickParams, [13n, 97n] as unknown as number[])).toEqual([0n, 100n]);
         });
 
+        test('honours a custom interval when nicing a BigInt domain', () => {
+            const scale = new LinearScale();
+            // With interval 30 the bounds must snap to multiples of 30 (Number path), not the auto
+            // bigint step that would otherwise produce [0, 100].
+            expect(scale.niceDomain({ ...tickParams, interval: 30 }, [13n, 97n] as unknown as number[])).toEqual([
+                0, 120,
+            ]);
+        });
+
         // AC AG-16608 #15e / #16: ticks beyond Number.MAX_SAFE_INTEGER keep exact values.
         test('keeps exact tick values for spans larger than Number.MAX_SAFE_INTEGER', () => {
             const scale = new LinearScale();

--- a/packages/ag-charts-community/src/scale/linearScale.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.ts
@@ -1,5 +1,13 @@
 import type { ScaleTickParams } from 'ag-charts-core';
-import { createTicks, isDenseInterval, niceTicksDomain, range, tickStep } from 'ag-charts-core';
+import {
+    createBigIntTicks,
+    createTicks,
+    isDenseInterval,
+    niceBigIntDomain,
+    niceTicksDomain,
+    range,
+    tickStep,
+} from 'ag-charts-core';
 
 import { ContinuousScale } from './continuousScale';
 
@@ -31,10 +39,28 @@ export class LinearScale extends ContinuousScale<number> {
         domain: number[] = this.domain,
         visibleRange?: [number, number]
     ): { ticks: number[]; count: number; firstTickIndex?: number } {
-        if (!domain || domain.length < 2 || tickCount < 1 || !domain.every(Number.isFinite)) {
+        if (!domain || domain.length < 2 || tickCount < 1) {
             return { ticks: [], count: 0, firstTickIndex: 0 };
         }
-        const [d0, d1] = domain;
+        const [b0, b1] = domain as readonly (number | bigint)[];
+        const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
+
+        // Full-precision BigInt ticks for the full (unzoomed) domain: the convert() bigint path
+        // positions them and the formatter renders exact labels. A custom interval or a zoomed
+        // sub-range falls through to the Number path, narrowing the domain below — the zoomed
+        // sub-domain renders at Number precision (documented limitation, AG-16608 AC #17).
+        const fullRange = visibleRange == null || (visibleRange[0] === 0 && visibleRange[1] === 1);
+        if (isBigIntDomain && !interval && fullRange) {
+            const ticks = createBigIntTicks(b0, b1, tickCount) as unknown as number[];
+            return { ticks, count: ticks.length, firstTickIndex: 0 };
+        }
+
+        const numericDomain = isBigIntDomain ? domain.map(Number) : domain;
+        if (!numericDomain.every(Number.isFinite)) {
+            return { ticks: [], count: 0, firstTickIndex: 0 };
+        }
+
+        const [d0, d1] = numericDomain;
 
         if (interval) {
             const step = Math.abs(interval);
@@ -50,6 +76,13 @@ export class LinearScale extends ContinuousScale<number> {
         if (domain.length < 2) return [];
 
         const { tickCount = ContinuousScale.defaultTickCount } = ticks;
+
+        const [b0, b1] = domain as readonly (number | bigint)[];
+        if (typeof b0 === 'bigint' && typeof b1 === 'bigint') {
+            const [n0, n1] = niceBigIntDomain(b0, b1, tickCount);
+            return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1] as unknown as number[];
+        }
+
         let [start, stop] = domain;
 
         if (tickCount === 1) {

--- a/packages/ag-charts-community/src/scale/linearScale.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.ts
@@ -78,12 +78,18 @@ export class LinearScale extends ContinuousScale<number> {
         const { tickCount = ContinuousScale.defaultTickCount } = ticks;
 
         const [b0, b1] = domain as readonly (number | bigint)[];
-        if (typeof b0 === 'bigint' && typeof b1 === 'bigint') {
+        const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
+
+        // Full-precision bigint nicing only for the auto-step path. A custom interval is a Number
+        // concept (matches ticks(), which narrows for intervals), so fall through to the Number path
+        // on the narrowed domain below — otherwise the bounds would snap to an unrelated auto step.
+        if (isBigIntDomain && ticks.interval == null) {
             const [n0, n1] = niceBigIntDomain(b0, b1, tickCount);
             return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1] as unknown as number[];
         }
 
-        let [start, stop] = domain;
+        const numericDomain = isBigIntDomain ? domain.map(Number) : domain;
+        let [start, stop] = numericDomain;
 
         if (tickCount === 1) {
             [start, stop] = niceTicksDomain(start, stop);
@@ -96,7 +102,7 @@ export class LinearScale extends ContinuousScale<number> {
                 const prev0 = start;
                 const prev1 = stop;
                 const step = LinearScale.getTickStep(start, stop, ticks);
-                const [d0, d1] = domain;
+                const [d0, d1] = numericDomain;
 
                 start = roundStart(d0 / step) * step;
                 stop = roundStop(d1 / step) * step;
@@ -105,6 +111,6 @@ export class LinearScale extends ContinuousScale<number> {
             }
         }
 
-        return [ticks.nice[0] ? start : domain[0], ticks.nice[1] ? stop : domain[1]];
+        return [ticks.nice[0] ? start : numericDomain[0], ticks.nice[1] ? stop : numericDomain[1]];
     }
 }

--- a/packages/ag-charts-community/src/scale/linearScale.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.ts
@@ -45,10 +45,8 @@ export class LinearScale extends ContinuousScale<number> {
         const [b0, b1] = domain as readonly (number | bigint)[];
         const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
 
-        // Full-precision BigInt ticks for the full (unzoomed) domain: the convert() bigint path
-        // positions them and the formatter renders exact labels. A custom interval or a zoomed
-        // sub-range falls through to the Number path, narrowing the domain below — the zoomed
-        // sub-domain renders at Number precision (documented limitation, AG-16608 AC #17).
+        // Full-precision BigInt ticks for the full (unzoomed) domain. A custom interval or zoomed
+        // sub-range falls through to the Number path below — documented limitation (AG-16608 AC #17).
         const fullRange = visibleRange == null || (visibleRange[0] === 0 && visibleRange[1] === 1);
         if (isBigIntDomain && !interval && fullRange) {
             const ticks = createBigIntTicks(b0, b1, tickCount) as unknown as number[];
@@ -80,9 +78,8 @@ export class LinearScale extends ContinuousScale<number> {
         const [b0, b1] = domain as readonly (number | bigint)[];
         const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
 
-        // Full-precision bigint nicing only for the auto-step path. A custom interval is a Number
-        // concept (matches ticks(), which narrows for intervals), so fall through to the Number path
-        // on the narrowed domain below — otherwise the bounds would snap to an unrelated auto step.
+        // Bigint nicing only for the auto-step path; a custom interval is a Number concept (matches
+        // ticks()), so it falls through below — else bounds would snap to an unrelated auto step.
         if (isBigIntDomain && ticks.interval == null) {
             const [n0, n1] = niceBigIntDomain(b0, b1, tickCount);
             return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1] as unknown as number[];

--- a/packages/ag-charts-core/src/utils/data/extent.test.ts
+++ b/packages/ag-charts-core/src/utils/data/extent.test.ts
@@ -59,6 +59,18 @@ describe('extent module', () => {
             expect(result?.[1]).toBe(latest);
         });
 
+        test('retains exact bigint endpoints (AG-16608)', () => {
+            const result = extent([0n, 5n, 9_007_199_254_740_993n, 2n]);
+            expect(result?.[0]).toBe(0n);
+            expect(result?.[1]).toBe(9_007_199_254_740_993n);
+        });
+
+        test('retains bigint endpoints via the sorted fast path', () => {
+            const result = extent([0n, 10n ** 21n], 1);
+            expect(result?.[0]).toBe(0n);
+            expect(result?.[1]).toBe(10n ** 21n);
+        });
+
         test('returns earliest and latest timestamp for mixed Dates and numbers', () => {
             const earliest = 5270400000;
             const latest = 1568468277000;

--- a/packages/ag-charts-core/src/utils/data/extent.ts
+++ b/packages/ag-charts-core/src/utils/data/extent.ts
@@ -1,6 +1,11 @@
 import type { DomainWithMetadata } from '../../types/scales';
 import { isNumber } from '../types/typeGuards';
 
+// bigint endpoints are retained so a bigint column's exact extent reaches the scale (the domain
+// setter and tick generation branch on `typeof` at runtime). Comparisons against the Number Infinity
+// seed and between bigints are legal — only +/-/* mixing throws — so min/max selection is safe.
+const isFiniteEndpoint = (v: number | bigint) => typeof v === 'bigint' || Number.isFinite(v);
+
 export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, number] | null {
     if (values.length === 0) {
         return null;
@@ -13,17 +18,17 @@ export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, num
         const v0 = first instanceof Date ? first.getTime() : first;
         const v1 = last instanceof Date ? last.getTime() : last;
 
-        if (typeof v0 === 'number' && typeof v1 === 'number') {
-            return sortOrder === 1 ? [v0, v1] : [v1, v0];
+        if ((typeof v0 === 'number' || typeof v0 === 'bigint') && (typeof v1 === 'number' || typeof v1 === 'bigint')) {
+            return (sortOrder === 1 ? [v0, v1] : [v1, v0]) as [number, number];
         }
     }
 
-    let min = Infinity;
-    let max = -Infinity;
+    let min: number | bigint = Infinity;
+    let max: number | bigint = -Infinity;
 
     for (const n of values) {
         const v = n instanceof Date ? n.getTime() : n;
-        if (typeof v !== 'number') continue;
+        if (typeof v !== 'number' && typeof v !== 'bigint') continue;
         if (v < min) {
             min = v;
         }
@@ -32,8 +37,7 @@ export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, num
         }
     }
 
-    const result: [number, number] = [min, max];
-    return result.every(Number.isFinite) ? result : null;
+    return isFiniteEndpoint(min) && isFiniteEndpoint(max) ? ([min, max] as [number, number]) : null;
 }
 
 export function normalisedExtentWithMetadata<T>(

--- a/packages/ag-charts-core/src/utils/data/extent.ts
+++ b/packages/ag-charts-core/src/utils/data/extent.ts
@@ -1,9 +1,8 @@
 import type { DomainWithMetadata } from '../../types/scales';
 import { isNumber } from '../types/typeGuards';
 
-// bigint endpoints are retained so a bigint column's exact extent reaches the scale (the domain
-// setter and tick generation branch on `typeof` at runtime). Comparisons against the Number Infinity
-// seed and between bigints are legal — only +/-/* mixing throws — so min/max selection is safe.
+// bigint endpoints are retained so a bigint column's exact extent reaches the scale. Comparisons
+// against the Number Infinity seed and between bigints are legal — only +/-/* mixing throws.
 const isFiniteEndpoint = (v: number | bigint) => typeof v === 'bigint' || Number.isFinite(v);
 
 export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, number] | null {

--- a/packages/ag-charts-core/src/utils/time/ticks.test.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.test.ts
@@ -73,6 +73,16 @@ describe('createBigIntTicks', () => {
     test('returns a single tick for a zero-width domain', () => {
         expect(createBigIntTicks(42n, 42n, 5)).toEqual([42n]);
     });
+
+    test('stays bounded for spans far beyond Number.MAX_VALUE', () => {
+        // The nice-step picker keeps step ∝ extent/count, so the tick count never explodes even when
+        // the span dwarfs Number.MAX_VALUE (where a naive Number(extent) would be Infinity).
+        for (const exp of [100, 400]) {
+            const ticks = createBigIntTicks(0n, 10n ** BigInt(exp), 5);
+            expect(ticks.length).toBeGreaterThanOrEqual(5);
+            expect(ticks.length).toBeLessThanOrEqual(15);
+        }
+    });
 });
 
 describe('niceBigIntDomain', () => {

--- a/packages/ag-charts-core/src/utils/time/ticks.test.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.test.ts
@@ -1,4 +1,4 @@
-import { createTicks } from './ticks';
+import { createBigIntTicks, createTicks, niceBigIntDomain } from './ticks';
 
 describe('ticks', () => {
     test('createTicks', () => {
@@ -25,5 +25,66 @@ describe('ticks', () => {
         expect(createTicks(1.1e-11, 1.4e-11, 7).ticks).toEqual([
             1.1e-11, 1.15e-11, 1.2e-11, 1.25e-11, 1.3e-11, 1.35e-11, 1.4e-11,
         ]);
+    });
+});
+
+describe('createBigIntTicks', () => {
+    test('produces nice, evenly-spaced ticks (AC #15a)', () => {
+        expect(createBigIntTicks(0n, 100n, 5)).toEqual([0n, 20n, 40n, 60n, 80n, 100n]);
+    });
+
+    test.each([
+        { d0: 0n, d1: 100n, count: 5 },
+        { d0: 0n, d1: 1000n, count: 5 },
+        { d0: 13n, d1: 9871n, count: 7 },
+        { d0: 0n, d1: 10n ** 21n, count: 5 },
+        { d0: -(10n ** 15n), d1: 10n ** 15n, count: 10 },
+    ])('keeps tick count within 5–15 regardless of span ($d0..$d1) (AC #15a)', ({ d0, d1, count }) => {
+        // Mirror the axis pipeline: nice the domain outward, then generate ticks across nice bounds.
+        const [n0, n1] = niceBigIntDomain(d0, d1, count);
+        const ticks = createBigIntTicks(n0, n1, count);
+        expect(ticks.length).toBeGreaterThanOrEqual(5);
+        expect(ticks.length).toBeLessThanOrEqual(15);
+    });
+
+    test('includes 0n when the domain crosses zero (AC #15b)', () => {
+        expect(createBigIntTicks(-50n, 50n, 5)).toContain(0n);
+        expect(createBigIntTicks(-37n, 91n, 6)).toContain(0n);
+    });
+
+    test('supports descending domains (AC #15c)', () => {
+        const ascending = createBigIntTicks(-50n, 50n, 5);
+        const descending = createBigIntTicks(50n, -50n, 5);
+        expect(descending).toEqual([...ascending].reverse());
+    });
+
+    test('handles sub-step ranges via Number-computed steps (AC #15d)', () => {
+        expect(createBigIntTicks(0n, 5n, 5)).toEqual([0n, 1n, 2n, 3n, 4n, 5n]);
+        expect(createBigIntTicks(0n, 7n, 7)).toEqual([0n, 1n, 2n, 3n, 4n, 5n, 6n, 7n]);
+    });
+
+    test('keeps exact values for spans beyond Number.MAX_SAFE_INTEGER (AC #16)', () => {
+        const ticks = createBigIntTicks(0n, 10n ** 21n, 5);
+        expect(ticks).toEqual([0n, 2n * 10n ** 20n, 4n * 10n ** 20n, 6n * 10n ** 20n, 8n * 10n ** 20n, 10n ** 21n]);
+        // Every tick is a true multiple — no float64 collapse of adjacent high-magnitude values.
+        expect(ticks.every((t) => t % (2n * 10n ** 20n) === 0n)).toBe(true);
+    });
+
+    test('returns a single tick for a zero-width domain', () => {
+        expect(createBigIntTicks(42n, 42n, 5)).toEqual([42n]);
+    });
+});
+
+describe('niceBigIntDomain', () => {
+    test('extends endpoints outward to step multiples', () => {
+        expect(niceBigIntDomain(13n, 97n, 5)).toEqual([0n, 100n]);
+    });
+
+    test('preserves orientation for descending domains', () => {
+        expect(niceBigIntDomain(97n, 13n, 5)).toEqual([100n, 0n]);
+    });
+
+    test('leaves already-nice bounds unchanged', () => {
+        expect(niceBigIntDomain(0n, 100n, 5)).toEqual([0n, 100n]);
     });
 });

--- a/packages/ag-charts-core/src/utils/time/ticks.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.ts
@@ -223,6 +223,92 @@ export function tickFormat(ticks: any[], format?: string): ((n: number | { value
     return (n) => formatter(Number(n));
 }
 
+function bigIntTickStep(extent: bigint, count: number): bigint {
+    // Sub-step ranges (fewer than 4 bits) fit comfortably in 53 bits, so the float nice-multiplier
+    // picker is exact here; we then convert the chosen step back to BigInt.
+    if (extent.toString(2).length < 4) {
+        return BigInt(Math.max(1, Math.round(tickStep(0, Number(extent), count))));
+    }
+
+    const target = extent / BigInt(Math.max(1, Math.round(count)));
+    let pow10 = 1n;
+    while (pow10 * 10n <= target) {
+        pow10 *= 10n;
+    }
+
+    // Pick the nice multiplier whose resulting tick count is closest to the requested count.
+    let best = pow10;
+    let bestDiff = Infinity;
+    for (const multiplier of TickMultipliers) {
+        const step = BigInt(multiplier) * pow10;
+        const ticks = Number(extent / step) + 1;
+        const diff = Math.abs(ticks - count);
+        if (diff < bestDiff) {
+            bestDiff = diff;
+            best = step;
+        }
+    }
+    return best;
+}
+
+// BigInt division truncates toward zero, so rounding to a step multiple is sign-dependent: a positive
+// remainder rounds up with +step, a negative one rounds down with -step.
+function ceilToStep(value: bigint, step: bigint): bigint {
+    const remainder = value % step;
+    if (remainder === 0n) return value;
+    return value > 0n ? value - remainder + step : value - remainder;
+}
+
+function floorToStep(value: bigint, step: bigint): bigint {
+    const remainder = value % step;
+    if (remainder === 0n) return value;
+    return value < 0n ? value - remainder - step : value - remainder;
+}
+
+/**
+ * Full-precision integer ticks for a BigInt domain, mirroring {@link createTicks} but staying in
+ * BigInt end-to-end so high-magnitude endpoints and spans beyond `Number.MAX_SAFE_INTEGER` keep
+ * exact label values. Descending domains (`start > stop`) are supported; `0n` is always a step
+ * multiple, so it appears whenever the domain crosses zero.
+ */
+export function createBigIntTicks(start: bigint, stop: bigint, count: number): bigint[] {
+    if (start === stop) return [start];
+    if (count < 2) return [start, stop];
+
+    const ascending = start < stop;
+    const lo = ascending ? start : stop;
+    const hi = ascending ? stop : start;
+
+    const step = bigIntTickStep(hi - lo, count);
+    if (step <= 0n) return [start, stop];
+
+    const first = ceilToStep(lo, step);
+    const last = floorToStep(hi, step);
+
+    const ticks: bigint[] = [];
+    for (let tick = first; tick <= last; tick += step) {
+        ticks.push(tick);
+    }
+
+    return ascending ? ticks : ticks.reverse();
+}
+
+/** Nice BigInt domain bounds — extends the endpoints outward to the surrounding step multiples. */
+export function niceBigIntDomain(start: bigint, stop: bigint, count: number): [bigint, bigint] {
+    if (start === stop) return [start, stop];
+
+    const ascending = start < stop;
+    const lo = ascending ? start : stop;
+    const hi = ascending ? stop : start;
+
+    const step = bigIntTickStep(hi - lo, count);
+    if (step <= 0n) return [start, stop];
+
+    const niceLo = floorToStep(lo, step);
+    const niceHi = ceilToStep(hi, step);
+    return ascending ? [niceLo, niceHi] : [niceHi, niceLo];
+}
+
 export function range(
     start: number,
     end: number,

--- a/packages/ag-charts-core/src/utils/time/ticks.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.ts
@@ -236,9 +236,8 @@ function bigIntTickStep(extent: bigint, count: number): bigint {
         pow10 *= 10n;
     }
 
-    // Pick the nice multiplier whose resulting tick count is closest to the requested count.
-    // `extent / step` is bounded by ~count*10 for any span (pow10 ≈ extent/count by construction),
-    // so the Number() narrowing is exact here regardless of how large `extent` is.
+    // Pick the nice multiplier whose tick count is closest to `count`. `extent / step` is bounded by
+    // ~count*10 for any span (pow10 ≈ extent/count), so the Number() narrowing stays exact.
     let best = pow10;
     let bestDiff = Infinity;
     for (const multiplier of TickMultipliers) {
@@ -268,10 +267,9 @@ function floorToStep(value: bigint, step: bigint): bigint {
 }
 
 /**
- * Full-precision integer ticks for a BigInt domain, mirroring {@link createTicks} but staying in
- * BigInt end-to-end so high-magnitude endpoints and spans beyond `Number.MAX_SAFE_INTEGER` keep
- * exact label values. Descending domains (`start > stop`) are supported; `0n` is always a step
- * multiple, so it appears whenever the domain crosses zero.
+ * Full-precision integer ticks for a BigInt domain, mirroring {@link createTicks} but staying in BigInt
+ * end-to-end so spans beyond `Number.MAX_SAFE_INTEGER` keep exact label values. Descending domains are
+ * supported; `0n` is always a step multiple, so it appears whenever the domain crosses zero.
  */
 export function createBigIntTicks(start: bigint, stop: bigint, count: number): bigint[] {
     if (start === stop) return [start];

--- a/packages/ag-charts-core/src/utils/time/ticks.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.ts
@@ -237,6 +237,8 @@ function bigIntTickStep(extent: bigint, count: number): bigint {
     }
 
     // Pick the nice multiplier whose resulting tick count is closest to the requested count.
+    // `extent / step` is bounded by ~count*10 for any span (pow10 ≈ extent/count by construction),
+    // so the Number() narrowing is exact here regardless of how large `extent` is.
     let best = pow10;
     let bestDiff = Infinity;
     for (const multiplier of TickMultipliers) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

PR3b in the stacked BigInt train (← PR3a `AG-16608/pr3-bigint-arithmetic`). The originally-planned PR3b overflowed the 600-LoC cap, so it was split (pre-authorised) along the clean presentation/data seam: **PR3b = full-precision axis ticks + labels** (this PR); **PR3c = histogram bins, key-drop removal, stacking-on-date reject** (next).

## What changed

- **`ag-charts-core` `ticks.ts`** — new `createBigIntTicks(d0n, d1n, count)` + `niceBigIntDomain`. Nice-step picker runs in BigInt; sub-step ranges (`bitLength < 4`) Number-compute the step then convert back; ceil/floor-to-step account for BigInt division truncating toward zero. Descending domains supported; `0n` always appears when the domain crosses zero.
- **`LinearScale.ticks()` / `niceDomain()`** — dispatch to the BigInt path for a bigint domain. The existing `convert()` bigint path (PR2) positions the ticks and `formatValue` (PR3a, `toLocaleString`) renders exact labels.
- **Domain plumbing** — `extent()` (core) and `fixNumericExtent()` (community) now **retain** bigint endpoints instead of dropping/narrowing them, so the bigint domain actually reaches the scale. This is the link PR2 deferred ("until PR3 feeds it real bigint domains"). Behaviour is byte-identical for number/Date data (verified: full community + enterprise suites green).
- **`numberAxis.getVisibleDomain()`** narrows a bigint domain to Number — formatter-context metadata only; the tick label keeps the exact value. A zoomed sub-range or explicit `interval` also narrows to Number (documented limitation, AC #17).

## AC coverage

AG-16608 #6 (labels), #15 (createBigIntTicks behavioural a–e), #16 (span beyond `Number.MAX_SAFE_INTEGER` renders position-monotonic with exact labels).

## Test plan

- `createBigIntTicks` / `niceBigIntDomain` unit tests (#15a–d, #16).
- `extent` bigint-retention tests.
- `LinearScale` bigint ticks/niceDomain tests.
- Real-chart integration test (`numberAxisBigInt.test.ts`) asserting exact axis labels for a `[0n, 10n**21n]` span (#16) and across the float64 boundary `9007199254740991/993/995n` (#15e).
- Full `ag-charts-community` (3373) + `ag-charts-enterprise` (2136) + `ag-charts-core` suites green; format/lint/type-check clean.

Fix #AG-16608