### PR TITLE
AG-16608 Let BigInt keys flow through the data pipeline

### DIFF
--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -266,9 +266,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
                     const result = processKeyValue(data[datumIndex], datumIndex, scope);
 
-                    // bigint *values* are supported now, but bigint *keys* stay dropped until a later PR:
-                    // they break SORT_DOMAIN_GROUPS' comparator and need numeric-axis prediction (AC #4).
-                    if (result.valid && typeof result.value !== 'bigint') {
+                    if (result.valid) {
                         keys.push(result.value);
                         // Track ordering/uniqueness for valid keys
                         updateKeyTracker(tracker, result.value);

--- a/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
@@ -513,11 +513,6 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
                     insertionCache,
                     (cached) => {
                         const keyResult = cached?.keys.get(defIndex);
-                        // bigint keys remain dropped (see dataExtractor.extractKeys) until key-sort
-                        // safety and numeric-axis prediction (AC #4) land in a later PR.
-                        if (keyResult?.valid && typeof keyResult.value === 'bigint') {
-                            return def.invalidValue;
-                        }
                         return keyResult?.valid ? keyResult.value : def.invalidValue;
                     },
                     (removedValues) => {

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1543,10 +1543,9 @@ describe('DataModel', () => {
             expect(processedData.domain.values[0]).toEqual([10n, 20n]);
         });
 
-        it('should drop bigint keys without throwing on a continuous key', () => {
-            // AG-16608: bigint *keys* remain dropped — a bigint key reaches SORT_DOMAIN_GROUPS (whose
-            // comparator return is ToNumber-coerced by Array.sort, throwing) and needs numeric-axis
-            // prediction (AC #4); both land in a later PR. Bigint *values* are already supported.
+        it('should retain bigint keys in the key column', () => {
+            // AG-16608: bigint *keys* now flow through extraction unchanged (the SORT_DOMAIN_GROUPS
+            // comparator is bigint-safe), matching the existing support for bigint values.
             const dataModel = new DataModel<any, any>({
                 props: [rangeKey('x'), value('y')],
             });
@@ -1559,7 +1558,27 @@ describe('DataModel', () => {
             const sources = basicDataSet(data).set('test', new DataSet(data));
             const processedData = dataModel.processData(sources)!;
 
-            expect(processedData.keys.flat(Infinity).some((v) => typeof v === 'bigint')).toBe(false);
+            expect(processedData.keys).toEqual(expectedKeys([1n, 2n]));
+        });
+
+        it('should sort grouped bigint keys without throwing', () => {
+            // AG-16608: SORT_DOMAIN_GROUPS compares bigint keys directly; subtraction would yield a
+            // bigint that Array.sort ToNumber-coerces and throws on.
+            const dataModel = new DataModel<any, any, true>({
+                props: [rangeKey('x'), value('y'), SORT_DOMAIN_GROUPS],
+                groupByKeys: true,
+            });
+
+            const data = [
+                { x: 3n, y: 30 },
+                { x: 1n, y: 10 },
+                { x: 2n, y: 20 },
+            ];
+
+            const sources = basicDataSet(data).set('test', new DataSet(data));
+            const processedData = dataModel.processData(sources)!;
+
+            expect(processedData.reduced!.sortedGroupDomain).toEqual([[1n], [2n], [3n]]);
         });
 
         it('should tag Date value columns as "date"', () => {

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -261,13 +261,25 @@ export const LARGEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<'largestKeyIn
     needsOverlap: true,
 };
 
+// Compares two domain-group key values. A column is uniformly typed, so a and b share a type; bigint
+// must be compared directly because subtraction would yield a bigint that Array.sort ToNumber-coerces
+// (which throws). Number and Date keep their existing subtraction-based ordering.
+function compareGroupKeys(a: any, b: any): number {
+    if (typeof a === 'bigint' || typeof b === 'bigint') {
+        if (a < b) return -1;
+        if (a > b) return 1;
+        return 0;
+    }
+    return a - b;
+}
+
 export const SORT_DOMAIN_GROUPS: ProcessorOutputPropertyDefinition<'sortedGroupDomain'> = {
     type: 'processor',
     property: 'sortedGroupDomain',
     calculate: function sortedGroupDomainFn({ domain: { groups } }) {
         return groups?.slice().sort((a, b) => {
             for (let i = 0; i < a.length; i++) {
-                const result = a[i] - b[i];
+                const result = compareGroupKeys(a[i], b[i]);
                 if (result !== 0) {
                     return result;
                 }

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -261,9 +261,8 @@ export const LARGEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<'largestKeyIn
     needsOverlap: true,
 };
 
-// Compares two domain-group key values. A column is uniformly typed, so a and b share a type; bigint
-// must be compared directly because subtraction would yield a bigint that Array.sort ToNumber-coerces
-// (which throws). Number and Date keep their existing subtraction-based ordering.
+// Compares two domain-group key values (a and b share a type — columns are uniform). bigint is compared
+// directly: subtraction yields a bigint that Array.sort ToNumber-coerces (throws). number/Date subtract.
 function compareGroupKeys(a: any, b: any): number {
     if (typeof a === 'bigint' || typeof b === 'bigint') {
         if (a < b) return -1;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

Next chunk of the BigInt (AG-16608) stacked PR train. Stacked on PR3b (#6943).

PR3b retained bigint *values* and rendered them at full precision; this PR lets bigint *keys* flow through the data pipeline safely:

- **`SORT_DOMAIN_GROUPS` comparator is now BigInt-safe.** Subtracting two bigint keys yields a bigint that `Array.sort` ToNumber-coerces and throws on. Bigint keys are now compared directly; number/Date keep their existing subtraction-based ordering.
- **Removed the two remaining PR1 key-side drops** (`dataExtractor.extractKeys` and the incremental processor) so bigint keys are retained rather than discarded — matching the existing bigint value support.

Full bigint-key numeric-axis prediction (AC #4) remains deferred to a later PR; ordering/uniqueness tracking simply skips bigint keys for now (no throw).

Histogram bigint bins (AC #13) and stacking rejection on `'date'`-tagged columns (AC #14) follow as separate PRs (PR3d/PR3e) — each is an independent feature that would exceed the per-PR size cap.

### Test plan
- New/updated unit tests in `dataModel.test.ts`: bigint keys retained in the key column; grouped bigint keys sort correctly without throwing.
- Full suites green: community 3375 passed, enterprise 2136 passed.
- `build:types`, lint (0 errors), and format all pass.

Fix #AG-16608