### PR TITLE
AG-16608 Compute histogram bins in BigInt for BigInt columns

### DIFF
--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -765,7 +765,7 @@ export function diff(
     };
 }
 
-type KeyType = string | number | boolean | null | undefined;
+type KeyType = string | number | bigint | boolean | null | undefined;
 
 export function createDatumId(key: number): number;
 export function createDatumId(key: boolean): boolean;

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
@@ -359,6 +359,44 @@ describe('HistogramSeries', () => {
         });
     });
 
+    // AG-16608: a BigInt x-column must compute bin boundaries in BigInt arithmetic so values beyond
+    // Number.MAX_SAFE_INTEGER keep full precision (and the series is no longer dropped to empty).
+    describe('bigint bins (AG-16608)', () => {
+        it('computes bin boundaries in BigInt at full precision', async () => {
+            const base = 9_007_199_254_740_993n; // 2^53 + 1 — not representable as a Number
+            const xs = [base, base + 10n, base + 25n, base + 40n, base + 80n];
+            const options: AgChartOptions = {
+                data: xs.map((x) => ({ x })),
+                series: [{ type: 'histogram', xKey: 'x', binCount: 10 }],
+            };
+            prepareTestOptions(options);
+
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const series = deproxy(chart).series[0] as unknown as {
+                calculatedBins: { domain: [bigint, bigint]; frequency: number }[];
+            };
+            const bins = series.calculatedBins;
+
+            expect(bins.length).toBeGreaterThan(0);
+            for (const bin of bins) {
+                expect(typeof bin.domain[0]).toBe('bigint');
+                expect(typeof bin.domain[1]).toBe('bigint');
+            }
+            // Contiguous boundaries and full coverage of the data range, all at exact precision.
+            for (let i = 1; i < bins.length; i++) {
+                expect(bins[i].domain[0]).toBe(bins[i - 1].domain[1]);
+            }
+            expect(bins[0].domain[0] <= base).toBe(true);
+            expect(bins.at(-1)!.domain[1] >= base + 80n).toBe(true);
+
+            // Every datum is bucketed rather than dropped (the pre-fix behaviour rendered empty).
+            const totalFrequency = bins.reduce((acc, bin) => acc + bin.frequency, 0);
+            expect(totalFrequency).toBe(xs.length);
+        });
+    });
+
     // CRT-1043: Invisible histogram series must still populate nodeData so the remove animation
     // has actual positions to animate from rather than empty data (which causes no animation).
     describe('legend toggle nodeData (CRT-1043)', () => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -157,9 +157,8 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         return this.calculatedBins.length > 0;
     }
 
-    // Resolves the bin boundaries from the user's configuration and the x-domain. A BigInt x-column
-    // (AG-16608) computes its boundaries in BigInt arithmetic for full precision; everything else keeps
-    // the existing number paths. Explicit `bins` win unless an explicit `binCount` is also set.
+    // A BigInt x-column (AG-16608) computes boundaries in BigInt for full precision; everything else
+    // keeps the number paths. Explicit `bins` win unless an explicit `binCount` is also set.
     private computeBins(xExtent: [number | bigint, number | bigint]): BinDomain[] {
         const bigIntExtent = typeof xExtent[0] === 'bigint' || typeof xExtent[1] === 'bigint';
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -5,6 +5,7 @@ import {
     type Mutable,
     type Point,
     type RequireOptional,
+    createBigIntBins,
     createTicks,
     deepClone,
     findMinMax,
@@ -88,8 +89,11 @@ const defaultBinCount = 10;
 
 type HistogramAnimationData = CartesianAnimationDataOf<HistogramSeriesTypes>;
 
+/** Bin boundaries are `bigint` for a BigInt x-column (AG-16608) and `number` otherwise. */
+type BinDomain = [number | bigint, number | bigint];
+
 interface CalculatedBin {
-    domain: [number, number];
+    domain: BinDomain;
     groupIndex: number;
     datum: any[];
     frequency: number;
@@ -151,6 +155,26 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
 
     override get hasData(): boolean {
         return this.calculatedBins.length > 0;
+    }
+
+    // Resolves the bin boundaries from the user's configuration and the x-domain. A BigInt x-column
+    // (AG-16608) computes its boundaries in BigInt arithmetic for full precision; everything else keeps
+    // the existing number paths. Explicit `bins` win unless an explicit `binCount` is also set.
+    private computeBins(xExtent: [number | bigint, number | bigint]): BinDomain[] {
+        const bigIntExtent = typeof xExtent[0] === 'bigint' || typeof xExtent[1] === 'bigint';
+
+        if (isNumber(this.properties.binCount)) {
+            return bigIntExtent
+                ? createBigIntBins(xExtent[0] as bigint, xExtent[1] as bigint, this.properties.binCount)
+                : this.calculateNiceBins(xExtent as number[], this.properties.binCount);
+        }
+
+        return (
+            this.properties.bins ??
+            (bigIntExtent
+                ? createBigIntBins(xExtent[0] as bigint, xExtent[1] as bigint, defaultBinCount)
+                : this.deriveBins(xExtent as [number, number]))
+        );
     }
 
     // During processData phase, used to unify different ways of the user specifying
@@ -252,7 +276,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             props.push(aggProp);
         }
 
-        let calculatedBinDomains: [number, number][] = [];
+        let calculatedBinDomains: BinDomain[] = [];
         const groupByFn: GroupByFn = (dataSet) => {
             const xExtent = fixNumericExtent(dataSet.domain.keys[0]);
             if (xExtent.length === 0) {
@@ -261,9 +285,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                 return () => [];
             }
 
-            const bins = isNumber(this.properties.binCount)
-                ? this.calculateNiceBins(xExtent, this.properties.binCount)
-                : (this.properties.bins ?? this.deriveBins(xExtent));
+            const bins = this.computeBins(xExtent);
             const binCount = bins.length;
             calculatedBinDomains = [...bins];
 
@@ -272,7 +294,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                 if (isDate(xValue)) {
                     xValue = xValue.getTime();
                 }
-                if (!isNumber(xValue)) return [];
+                if (!isNumber(xValue) && typeof xValue !== 'bigint') return [];
 
                 for (let i = 0; i < binCount; i++) {
                     const nextBin = bins[i];

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
@@ -27,7 +27,7 @@ export interface HistogramNodeDatum extends CartesianSeriesNodeDatum {
     readonly clipBBox?: BBox;
     readonly aggregatedValue: number;
     readonly frequency: number;
-    readonly domain: [number, number];
+    readonly domain: [number | bigint, number | bigint];
     readonly label?: {
         readonly text: TextOrSegments;
         readonly x: number;

--- a/packages/ag-charts-core/src/utils/time/ticks.test.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.test.ts
@@ -1,4 +1,4 @@
-import { createBigIntTicks, createTicks, niceBigIntDomain } from './ticks';
+import { createBigIntBins, createBigIntTicks, createTicks, niceBigIntDomain } from './ticks';
 
 describe('ticks', () => {
     test('createTicks', () => {
@@ -96,5 +96,43 @@ describe('niceBigIntDomain', () => {
 
     test('leaves already-nice bounds unchanged', () => {
         expect(niceBigIntDomain(0n, 100n, 5)).toEqual([0n, 100n]);
+    });
+});
+
+describe('createBigIntBins', () => {
+    test('produces contiguous equal-width bins covering a nice domain', () => {
+        expect(createBigIntBins(0n, 100n, 5)).toEqual([
+            [0n, 20n],
+            [20n, 40n],
+            [40n, 60n],
+            [60n, 80n],
+            [80n, 100n],
+        ]);
+    });
+
+    test('extends a non-nice domain outward to step multiples', () => {
+        const bins = createBigIntBins(13n, 97n, 5);
+        expect(bins[0][0]).toBe(0n);
+        expect(bins.at(-1)![1]).toBe(100n);
+    });
+
+    test('returns contiguous bins (each bin starts where the previous ends)', () => {
+        const bins = createBigIntBins(-37n, 91n, 6);
+        for (let i = 1; i < bins.length; i++) {
+            expect(bins[i][0]).toBe(bins[i - 1][1]);
+        }
+    });
+
+    test('returns a single bin for a degenerate domain', () => {
+        expect(createBigIntBins(42n, 42n, 5)).toEqual([[42n, 42n]]);
+    });
+
+    test('stays exact for spans beyond Number.MAX_SAFE_INTEGER', () => {
+        const bins = createBigIntBins(0n, 10n ** 21n, 5);
+        expect(bins[0][0]).toBe(0n);
+        expect(bins.at(-1)![1]).toBe(10n ** 21n);
+        for (let i = 1; i < bins.length; i++) {
+            expect(bins[i][0]).toBe(bins[i - 1][1]);
+        }
     });
 });

--- a/packages/ag-charts-core/src/utils/time/ticks.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.ts
@@ -293,6 +293,28 @@ export function createBigIntTicks(start: bigint, stop: bigint, count: number): b
     return ascending ? ticks : ticks.reverse();
 }
 
+/**
+ * Contiguous, equal-width BigInt bins covering the domain, for histogram bucketing. Reuses the nice
+ * step picker so boundaries land on nice multiples and the outer bins extend to the surrounding step
+ * multiples (like {@link niceBigIntDomain}). Always returns at least one bin.
+ */
+export function createBigIntBins(start: bigint, stop: bigint, count: number): [bigint, bigint][] {
+    const lo = start < stop ? start : stop;
+    const hi = start < stop ? stop : start;
+
+    const step = lo === hi ? 0n : bigIntTickStep(hi - lo, count);
+    if (step <= 0n) return [[lo, hi]];
+
+    const niceLo = floorToStep(lo, step);
+    const niceHi = ceilToStep(hi, step);
+
+    const bins: [bigint, bigint][] = [];
+    for (let edge = niceLo; edge < niceHi; edge += step) {
+        bins.push([edge, edge + step]);
+    }
+    return bins.length > 0 ? bins : [[niceLo, niceHi]];
+}
+
 /** Nice BigInt domain bounds — extends the endpoints outward to the surrounding step multiples. */
 export function niceBigIntDomain(start: bigint, stop: bigint, count: number): [bigint, bigint] {
     if (start === stop) return [start, stop];


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

Next chunk of the BigInt (AG-16608) stacked PR train. Stacked on PR3c (#6945). Implements AC #13.

A histogram with a `bigint` x-column previously rendered **empty**: bin boundaries were computed with `Math.floor`/`Math.log10`/`Math.pow` (NaN on bigint) and bigint x-values failed the `isNumber()` bucket gate, so every datum was dropped.

- **New `createBigIntBins(start, stop, count)` in `ag-charts-core`** — reuses the existing `bigIntTickStep`/`ceilToStep`/`floorToStep` helpers (added in PR3b) to produce contiguous, nice-aligned BigInt bins covering the domain.
- **Histogram branches onto it when the x-extent is bigint** (`computeBins`), preserving the existing number/Date paths exactly and the explicit-`bins`/`binCount` precedence.
- Bin boundaries are retained at **full precision** and converted to pixels by the already bigint-safe scale (PR2/PR3b), so values beyond `Number.MAX_SAFE_INTEGER` bucket exactly.
- Widened `CalculatedBin`/`HistogramNodeDatum` `domain` and `createDatumId`'s `KeyType` to accept bigint.

### Test plan
- New core unit tests for `createBigIntBins` (contiguity, nice extension, degenerate domain, spans beyond `Number.MAX_SAFE_INTEGER`).
- New histogram integration test: a `2^53 + 1`-based bigint column produces bigint bin boundaries at full precision, contiguous, with every datum bucketed (not dropped).
- Full suites green: core ticks 22, community 3376, enterprise 2136. `build:types`, lint (0 errors), format all pass.

Fix #AG-16608