### PR TITLE
AG-16608 Reject stacking on a date-tagged column

### DIFF
--- a/packages/ag-charts-community/src/chart/data/data-model/aggregation/aggregator.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/aggregation/aggregator.ts
@@ -1,4 +1,4 @@
-import { first } from 'ag-charts-core';
+import { Logger, first } from 'ag-charts-core';
 
 import { ContinuousDomain, DiscreteDomain } from '../../dataDomain';
 import type { GroupedData, PropertySelectors, UngroupedData } from '../../dataModelTypes';
@@ -128,9 +128,16 @@ export class Aggregator<D extends object, K extends keyof D & string> {
     postProcessGroups(processedData: GroupedData<any>) {
         const { groupProcessors } = this.ctx;
 
-        const { columnScopes, columns, invalidData } = processedData;
+        const { columnScopes, columns, invalidData, columnValueType } = processedData;
         for (const processor of groupProcessors) {
-            const valueIndexes = this.valueGroupIdxLookup(processor);
+            // AG-16608: stacking / accumulation is not meaningful for date columns. Reject any such
+            // column (warn once and blank it so the series renders empty) and exclude it from the
+            // accumulation below; sibling columns and series are unaffected.
+            const valueIndexes = this.valueGroupIdxLookup(processor).filter((valueIndex) => {
+                if (columnValueType?.[valueIndex] !== 'date') return true;
+                this.rejectDateStackColumn(processedData, valueIndex);
+                return false;
+            });
             const adjustFn = processor.adjust()();
 
             for (let groupIndex = 0; groupIndex < processedData.groups.length; groupIndex++) {
@@ -154,6 +161,22 @@ export class Aggregator<D extends object, K extends keyof D & string> {
                 processedData.domain.values[valueIndex] = domain.getDomain();
             }
         }
+    }
+
+    private rejectDateStackColumn(processedData: GroupedData<any>, valueIndex: number) {
+        const valueDef = this.ctx.values[valueIndex];
+        const columnScope = first(processedData.columnScopes[valueIndex]);
+        Logger.warnOnce(
+            `Series "${String(columnScope)}": column "${String(valueDef.property)}" is date-typed; ` +
+                `stacking is not meaningful for date data. The series renders empty; ` +
+                `other series in this chart are unaffected.`
+        );
+
+        const column = processedData.columns[valueIndex];
+        for (let datumIndex = 0; datumIndex < column.length; datumIndex += 1) {
+            column[datumIndex] = undefined;
+        }
+        processedData.domain.values[valueIndex] = [];
     }
 
     private valueGroupIdxLookup(selector: PropertySelectors) {

--- a/packages/ag-charts-community/src/chart/data/data-model/aggregation/aggregator.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/aggregation/aggregator.ts
@@ -130,9 +130,8 @@ export class Aggregator<D extends object, K extends keyof D & string> {
 
         const { columnScopes, columns, invalidData, columnValueType } = processedData;
         for (const processor of groupProcessors) {
-            // AG-16608: stacking / accumulation is not meaningful for date columns. Reject any such
-            // column (warn once and blank it so the series renders empty) and exclude it from the
-            // accumulation below; sibling columns and series are unaffected.
+            // Stacking/accumulation is meaningless for date columns: reject each (warn once + blank it so
+            // the series renders empty) and exclude from accumulation; siblings unaffected (AG-16608 #14).
             const valueIndexes = this.valueGroupIdxLookup(processor).filter((valueIndex) => {
                 if (columnValueType?.[valueIndex] !== 'date') return true;
                 this.rejectDateStackColumn(processedData, valueIndex);

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1692,6 +1692,51 @@ describe('DataModel', () => {
         });
     });
 
+    describe('stacking on a date column (AG-16608)', () => {
+        it('should reject a stacked date-tagged column with a warning and render empty', () => {
+            // AG-16608 AC #14: stacking/accumulation is not meaningful for date data. The date columns
+            // are blanked (empty domain) so the series renders nothing; sibling series are unaffected.
+            const dataModel = new DataModel<any, any, true>({
+                props: [categoryKey('kp'), ...accumulatedGroupValues(['a', 'b'], 'all')],
+                groupByKeys: true,
+            });
+            const data = basicDataSet([
+                { kp: 'Q1', a: new Date(2024, 0, 1), b: new Date(2024, 0, 2) },
+                { kp: 'Q2', a: new Date(2024, 0, 3), b: new Date(2024, 0, 4) },
+            ]);
+
+            const result = dataModel.processData(data)!;
+
+            expect(result.columnValueType).toEqual(['date', 'date']);
+            expect(result.domain.values[0]).toEqual([]);
+            expect(result.domain.values[1]).toEqual([]);
+            expectWarningsCalls().toMatchInlineSnapshot(`
+[
+  [
+    "AG Charts - Series "test": column "a" is date-typed; stacking is not meaningful for date data. The series renders empty; other series in this chart are unaffected.",
+  ],
+  [
+    "AG Charts - Series "test": column "b" is date-typed; stacking is not meaningful for date data. The series renders empty; other series in this chart are unaffected.",
+  ],
+]
+`);
+        });
+
+        it('should not reject a stacked number column', () => {
+            const dataModel = new DataModel<any, any, true>({
+                props: [categoryKey('kp'), ...accumulatedGroupValues(['a', 'b'], 'all')],
+                groupByKeys: true,
+            });
+            const data = basicDataSet([{ kp: 'Q1', a: 5, b: 7 }]);
+
+            const result = dataModel.processData(data)!;
+
+            expect(result.columnValueType).toEqual(['number', 'number']);
+            expect(resolveGroupColumn(result, 0, 0)).toEqual([5]);
+            expect(resolveGroupColumn(result, 0, 1)).toEqual([12]); // stacked: 5 + 7
+        });
+    });
+
     describe('update operations', () => {
         describe('ungrouped data', () => {
             it('should process updated items correctly', () => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

Final chunk of the original PR3 group of the BigInt (AG-16608) train. Stacked on PR3d (#6946). Implements AC #14.

Stacking / accumulation is not meaningful for date values. When a group accumulation or normalisation processor targets a column tagged `'date'`, the series is now rejected:

- Warn once: *"... column "X" is date-typed; stacking is not meaningful for date data. The series renders empty; other series in this chart are unaffected."*
- Blank the column and clear its domain so the series renders empty; sibling columns and series are unaffected.

Implemented at the `postProcessGroups` chokepoint, which only runs for stacked/accumulated columns — so no separate "is this stacking?" detection is needed (the prior concern about inferring stacking from prop definitions is avoided). Covers all stacking/normalising series: bar, line, area, radial-column, radial-bar, error-bar.

**Scope note:** single-series accumulated-value processors (`accumulativeValueProperty`, used by waterfall/donut) flow through the generic property-processor path and are out of scope for this PR — date-as-value there is already degenerate. Can be a follow-up if required.

### Test plan
- New dataModel tests: a stacked `'date'` column is tagged `'date'`, blanked to empty domains, and emits the warning once per column (inline-snapshot asserted); a stacked `number` column still stacks correctly (5 + 7 = 12).
- Full suites green: community 3378, enterprise 2136. `build:types`, lint (0 errors), format all pass.

Fix #AG-16608