### PR TITLE
AG-16608 Widen public types to accept BigInt numeric values

### DIFF
--- a/packages/ag-charts-core/src/state/memento.test.ts
+++ b/packages/ag-charts-core/src/state/memento.test.ts
@@ -150,6 +150,27 @@ describe('Memento Caretaker', () => {
         expect(originator.restored).toStrictEqual({ count: bigValue });
     });
 
+    it('should not throw on a malformed bigint payload and leave it un-decoded', () => {
+        const blobMalformedBigInt = {
+            version: '10.0.0',
+            test: {
+                data: {
+                    fractional: { __type: 'bigint', value: '12.3' },
+                    nonString: { __type: 'bigint', value: 5 },
+                },
+                type: 'test',
+            },
+        };
+
+        expect(() => caretaker.restore(blobMalformedBigInt, originator)).not.toThrow();
+        // Malformed payloads are left un-decoded (not converted to bigint), mirroring how an
+        // invalid date payload flows through to guardMemento rather than aborting the restore.
+        expect(originator.restored).toStrictEqual({
+            fractional: { __type: 'bigint', value: '12.3' },
+            nonString: { __type: 'bigint', value: 5 },
+        });
+    });
+
     it('should migrate older versioned mementos', () => {
         caretaker.restore(
             {

--- a/packages/ag-charts-core/src/state/memento.test.ts
+++ b/packages/ag-charts-core/src/state/memento.test.ts
@@ -117,6 +117,39 @@ describe('Memento Caretaker', () => {
         });
     });
 
+    it('should save and restore data with bigints', () => {
+        const bigValue = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2, beyond Number precision.
+        originator.data = { hello: 'world', count: bigValue };
+
+        const blob = caretaker.save(originator);
+        caretaker.restore(blob, originator);
+
+        expect(blob).toStrictEqual({
+            version: '10.0.0',
+            test: {
+                data: {
+                    hello: 'world',
+                    count: { __type: 'bigint', value: '9007199254740993' },
+                },
+                type: 'test',
+            },
+        });
+        expect(originator.restored).toStrictEqual({ hello: 'world', count: bigValue });
+
+        const blobBigIntTypes = {
+            version: '10.0.0',
+            test: {
+                data: {
+                    count: { __type: 'bigint', value: '9007199254740993' },
+                },
+                type: 'test',
+            },
+        };
+
+        caretaker.restore(blobBigIntTypes, originator);
+        expect(originator.restored).toStrictEqual({ count: bigValue });
+    });
+
     it('should migrate older versioned mementos', () => {
         caretaker.restore(
             {

--- a/packages/ag-charts-core/src/state/memento.ts
+++ b/packages/ag-charts-core/src/state/memento.ts
@@ -106,7 +106,12 @@ export class MementoCaretaker {
                 return new Date(this[key].value);
             }
             if (this[key].__type === 'bigint') {
-                return BigInt(this[key].value);
+                // Untrusted input: only decode a valid base-10 integer string, otherwise leave the
+                // value un-decoded so guardMemento rejects it via the warn-and-ignore path.
+                const bigintValue = this[key].value;
+                if (typeof bigintValue === 'string' && /^-?\d+$/.test(bigintValue)) {
+                    return BigInt(bigintValue);
+                }
             }
         }
         return value;

--- a/packages/ag-charts-core/src/state/memento.ts
+++ b/packages/ag-charts-core/src/state/memento.ts
@@ -93,12 +93,21 @@ export class MementoCaretaker {
         if (isDate(this[key])) {
             return { __type: 'date', value: this[key].toISOString() };
         }
+        if (typeof this[key] === 'bigint') {
+            // Encode as a base-10 string; JSON numbers cannot represent bigints beyond 2^53 without precision loss.
+            return { __type: 'bigint', value: this[key].toString() };
+        }
         return value;
     }
 
     private static decodeTypes(this: any, key: any, value: any) {
-        if (isObject(this[key]) && '__type' in this[key] && this[key].__type === 'date') {
-            return new Date(this[key].value);
+        if (isObject(this[key]) && '__type' in this[key]) {
+            if (this[key].__type === 'date') {
+                return new Date(this[key].value);
+            }
+            if (this[key].__type === 'bigint') {
+                return BigInt(this[key].value);
+            }
         }
         return value;
     }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.test.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.test.ts
@@ -720,4 +720,42 @@ describe('Annotations', () => {
             await compare();
         });
     });
+
+    describe('bigint coordinates (AG-16608)', () => {
+        // Number.MAX_SAFE_INTEGER + 2, beyond Number precision. Supplied in the serialisable
+        // `AgStateSerializableBigInt` form, mirroring how date coordinates are supplied as `{ __type: 'date' }`.
+        const BIGINT_X = 9007199254740993n;
+
+        const NUMERIC_AXIS_OPTIONS: AgCartesianChartOptions = {
+            data: [
+                { x: 9007199254740992n, y: 5 },
+                { x: 9007199254740994n, y: 95 },
+            ],
+            series: [{ type: 'scatter', xKey: 'x', yKey: 'y' }],
+            axes: { y: { type: 'number' }, x: { type: 'number' } },
+            annotations: { enabled: true, toolbar: { enabled: false } },
+        };
+
+        it('should round-trip a bigint annotation coordinate through chart state', async () => {
+            const serialisedValue = { __type: 'bigint' as const, value: BIGINT_X.toString() };
+
+            await prepareChart(
+                {
+                    annotations: [
+                        {
+                            type: 'vertical-line',
+                            value: serialisedValue,
+                        },
+                    ],
+                },
+                NUMERIC_AXIS_OPTIONS
+            );
+
+            // `getState()` re-encodes the internally-decoded bigint, so a faithful round-trip
+            // returns the same serialisable `{ __type: 'bigint' }` form that was restored.
+            const state = chart.getState();
+            expect(state.annotations).toHaveLength(1);
+            expect(state.annotations![0]).toMatchObject({ type: 'vertical-line', value: serialisedValue });
+        });
+    });
 });

--- a/packages/ag-charts-types/src/api/initialStateOptions.ts
+++ b/packages/ag-charts-types/src/api/initialStateOptions.ts
@@ -4,7 +4,7 @@ import type { Ratio } from '../chart/types';
 import type { AgAutoScaledAxes } from '../chart/zoomOptions';
 import type { AgPriceVolumeChartType } from '../presets/financial/priceVolumeOptions';
 import type { AgActiveState } from './activeState';
-import type { AgStateSerializableDate } from './stateTypes';
+import type { AgStateSerializableBigInt, AgStateSerializableDate } from './stateTypes';
 
 // Theme
 export interface AgInitialStateThemeableOptions {
@@ -47,9 +47,9 @@ export interface AgInitialStateZoomOptions {
 
 export interface AgInitialStateZoomRange {
     /** The start value of the zoom range. */
-    start?: AgStateSerializableDate | string | number;
+    start?: AgStateSerializableDate | AgStateSerializableBigInt | string | number | bigint;
     /** The end value of the zoom range. */
-    end?: AgStateSerializableDate | string | number;
+    end?: AgStateSerializableDate | AgStateSerializableBigInt | string | number | bigint;
 }
 
 export interface AgInitialStateZoomRatio {

--- a/packages/ag-charts-types/src/api/stateTypes.ts
+++ b/packages/ag-charts-types/src/api/stateTypes.ts
@@ -4,3 +4,10 @@ export interface AgStateSerializableDate {
     /** The date value as an ISO 8601 string or Unix timestamp. */
     value: string | number;
 }
+
+export interface AgStateSerializableBigInt {
+    /** Type discriminator for serialisable bigint objects. */
+    __type: 'bigint';
+    /** The bigint value as a base-10 string, preserving full integer precision. */
+    value: string;
+}

--- a/packages/ag-charts-types/src/chart/annotationsOptions.ts
+++ b/packages/ag-charts-types/src/chart/annotationsOptions.ts
@@ -1,4 +1,4 @@
-import type { AgStateSerializableDate } from '../api/stateTypes';
+import type { AgStateSerializableBigInt, AgStateSerializableDate } from '../api/stateTypes';
 import type {
     FillOptions,
     LineDashOptions,
@@ -516,7 +516,7 @@ interface Extendable {
     extendEnd?: boolean;
 }
 
-export type ValueType = string | number | AgStateSerializableDate;
+export type ValueType = string | number | bigint | AgStateSerializableDate | AgStateSerializableBigInt;
 export type AgAnnotationValue = ValueType | AgGroupingValueType;
 export interface AgGroupingValueType {
     /** The value at the annotation position. */

--- a/packages/ag-charts-types/src/chart/dataValues.ts
+++ b/packages/ag-charts-types/src/chart/dataValues.ts
@@ -1,0 +1,6 @@
+/**
+ * A numeric data value. `bigint` is accepted alongside `number` so that
+ * integer values exceeding `Number.MAX_SAFE_INTEGER` can be represented and
+ * rendered without loss of precision.
+ */
+export type AgNumericValue = number | bigint;

--- a/packages/ag-charts-types/src/chart/dataValues.ts
+++ b/packages/ag-charts-types/src/chart/dataValues.ts
@@ -1,6 +1,5 @@
 /**
- * A numeric data value. `bigint` is accepted alongside `number` so that
- * integer values exceeding `Number.MAX_SAFE_INTEGER` can be represented and
- * rendered without loss of precision.
+ * A numeric data value. A `bigint` may be supplied for integer values outside
+ * the safe-integer range (beyond `Number.MAX_SAFE_INTEGER`).
  */
 export type AgNumericValue = number | bigint;

--- a/packages/ag-charts-types/src/chart/formatterOptions.ts
+++ b/packages/ag-charts-types/src/chart/formatterOptions.ts
@@ -1,5 +1,6 @@
 import type { TextValue } from '../series/cartesian/commonOptions';
 import type { AgTimeIntervalUnit } from './axisOptions';
+import type { AgNumericValue } from './dataValues';
 import type { ContextDefault, DatumDefault, DatumKey } from './types';
 
 export type FormatterPropertyType =
@@ -73,7 +74,7 @@ interface BaseFormatterParams<TDatum, TContext, Value> {
     context?: TContext;
 }
 
-export interface NumberFormatterParams<TDatum, TContext> extends BaseFormatterParams<TDatum, TContext, number> {
+export interface NumberFormatterParams<TDatum, TContext> extends BaseFormatterParams<TDatum, TContext, AgNumericValue> {
     /** Configuration for a number-formatted value. */
     type: 'number';
     /** The recommended precision to format the value. */

--- a/packages/ag-charts-types/src/main.ts
+++ b/packages/ag-charts-types/src/main.ts
@@ -10,6 +10,7 @@ export * from './chart/callbackOptions';
 export * from './chart/chartOptions';
 export * from './chart/chartToolbarOptions';
 export * from './chart/contextMenuOptions';
+export * from './chart/dataValues';
 export * from './chart/crossLineOptions';
 export * from './chart/crosshairOptions';
 export * from './chart/bandHighlightOptions';

--- a/packages/ag-charts-types/src/presets/gauge/commonOptions.ts
+++ b/packages/ag-charts-types/src/presets/gauge/commonOptions.ts
@@ -1,5 +1,6 @@
 import type { AgAxisLabelFormatterParams, AgBaseAxisLabelOptions } from '../../chart/axisOptions';
 import type { Formatter } from '../../chart/callbackOptions';
+import type { AgNumericValue } from '../../chart/dataValues';
 import type { AgSelectionOptions, AgSelectionStyleOptions } from '../../chart/selectionOptions';
 import type {
     ContextDefault,
@@ -74,9 +75,9 @@ __VERIFY_AXIS_LABEL_OPTIONS = __AXIS_LABEL_OPTIONS;
 
 export interface AgGaugeSegmentationInterval {
     /** The segmentation interval. If the configured interval results in too many items given the chart size, it will be ignored. */
-    step?: number;
+    step?: AgNumericValue;
     /** Array of values for specified intervals along the gauge. */
-    values?: number[];
+    values?: AgNumericValue[];
     /** Number of evenly-divided segments in the gauge. */
     count?: number;
 }
@@ -98,7 +99,7 @@ export interface AgGaugeColorStop {
     /** Colour of this category. */
     color?: string;
     /** Stop value of this category. Defaults the maximum value if unset. */
-    stop?: number;
+    stop?: AgNumericValue;
 }
 
 export interface FillsOptions {

--- a/packages/ag-charts-types/src/presets/gauge/linearGaugeOptions.ts
+++ b/packages/ag-charts-types/src/presets/gauge/linearGaugeOptions.ts
@@ -1,3 +1,4 @@
+import type { AgNumericValue } from '../../chart/dataValues';
 import type { AgChartAutoSizedLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip, AgSeriesTooltipRendererParams } from '../../chart/tooltipOptions';
 import type { AgMarkerShape, ContextDefault, DatumDefault, Degree, Direction, PixelSize } from '../../chart/types';
@@ -16,9 +17,9 @@ export interface AgLinearGaugeSeriesStyle extends FillOptions, StrokeOptions, Li
 
 export interface AgLinearGaugeScaleInterval {
     /** Array of values in scale units for specified intervals along the scale. The values in this array must be compatible with the scale type. */
-    values?: number[];
+    values?: AgNumericValue[];
     /** The scale interval. Expressed in the units of the scale. If the configured interval results in too many items given the chart size, it will be ignored. */
-    step?: number;
+    step?: AgNumericValue;
 }
 
 export interface AgLinearGaugeScaleLabel<TContext = ContextDefault> extends AgGaugeScaleLabel<TContext> {
@@ -28,9 +29,9 @@ export interface AgLinearGaugeScaleLabel<TContext = ContextDefault> extends AgGa
 
 export interface AgLinearGaugeScale<TContext = ContextDefault> extends AgLinearGaugeSeriesStyle, FillsOptions {
     /** Maximum value of the scale. Any values exceeding this number will be clipped to this maximum. */
-    min?: number;
+    min?: AgNumericValue;
     /** Minimum value of the scale. Any values exceeding this number will be clipped to this minimum. */
-    max?: number;
+    max?: AgNumericValue;
     /** Configuration for the scale labels. */
     label?: AgLinearGaugeScaleLabel<TContext>;
     /** Configuration for the ticks interval. */
@@ -42,7 +43,7 @@ export interface AgLinearGaugeTooltipRendererParams extends AgSeriesTooltipRende
     ContextDefault
 > {
     /** Value of the Gauge */
-    value: number;
+    value: AgNumericValue;
 }
 
 export interface AgLinearGaugeBarStyle extends AgLinearGaugeSeriesStyle, FillsOptions {
@@ -58,7 +59,7 @@ export type AgLinearGaugeMarkerShape = AgMarkerShape | 'line';
 
 export interface AgLinearGaugeTarget extends AgLinearGaugeSeriesStyle {
     /** Value to use to position the target */
-    value: number;
+    value: AgNumericValue;
     /** Text to use for the target label. */
     text?: string;
     /** The shape to use for the markers. You can also supply a custom marker by providing a `AgMarkerShapeFn` function. */
@@ -128,7 +129,7 @@ export interface AgLinearGaugePreset<TContext = ContextDefault> extends AgLinear
     /** Configuration for the Linear Gauge. */
     type: 'linear-gauge';
     /** Value of the Linear Gauge. */
-    value: number;
+    value: AgNumericValue;
     /** Scale of the Linear Gauge. */
     scale?: AgLinearGaugeScale<TContext>;
     /** Configuration for the targets. */

--- a/packages/ag-charts-types/src/presets/gauge/radialGaugeOptions.ts
+++ b/packages/ag-charts-types/src/presets/gauge/radialGaugeOptions.ts
@@ -1,3 +1,4 @@
+import type { AgNumericValue } from '../../chart/dataValues';
 import type {
     AgChartAutoSizedLabelOptions,
     AgChartAutoSizedSecondaryLabelOptions,
@@ -17,14 +18,14 @@ import type {
 export type AgRadialGaugeTargetPlacement = 'inside' | 'outside' | 'middle';
 
 export interface AgRadialGaugeLabelFormatterParams {
-    value: number;
+    value: AgNumericValue;
 }
 
 export interface AgRadialGaugeScaleInterval {
     /** Array of values in scale units for specified intervals along the scale. The values in this array must be compatible with the scale type. */
-    values?: number[];
+    values?: AgNumericValue[];
     /** The scale interval. Expressed in the units of the scale. If the configured interval results in too many items given the chart size, it will be ignored. */
-    step?: number;
+    step?: AgNumericValue;
 }
 
 export interface AgRadialGaugeScaleLabel<TContext = ContextDefault> extends AgGaugeScaleLabel<TContext> {}
@@ -33,9 +34,9 @@ export interface AgRadialGaugeSeriesStyle extends FillOptions, StrokeOptions, Li
 
 export interface AgRadialGaugeScale<TContext = ContextDefault> extends FillsOptions, AgRadialGaugeSeriesStyle {
     /** Maximum value of the scale. Any values exceeding this number will be clipped to this maximum. */
-    min?: number;
+    min?: AgNumericValue;
     /** Minimum value of the scale. Any values exceeding this number will be clipped to this minimum. */
-    max?: number;
+    max?: AgNumericValue;
     /** Configuration for the scale labels. */
     label?: AgRadialGaugeScaleLabel<TContext>;
     /** Configuration for the ticks interval. */
@@ -47,7 +48,7 @@ export interface AgRadialGaugeTooltipRendererParams extends AgSeriesTooltipRende
     ContextDefault
 > {
     /** Value of the Gauge */
-    value: number;
+    value: AgNumericValue;
 }
 
 export interface AgRadialGaugeBarStyle extends FillsOptions, AgRadialGaugeSeriesStyle {
@@ -73,7 +74,7 @@ export interface AgRadialGaugeTargetLabelOptions extends AgChartLabelOptions<nev
 
 export interface AgRadialGaugeTarget extends AgRadialGaugeSeriesStyle {
     /** Value to use to position the target */
-    value: number;
+    value: AgNumericValue;
     /** Text to use for the target label. */
     text?: string;
     /** The shape to use for the markers. You can also supply a custom marker by providing a `AgMarkerShapeFn` function. */
@@ -153,7 +154,7 @@ export interface AgRadialGaugePreset<TContext = ContextDefault> extends AgRadial
     /** Configuration for the Radial Gauge. */
     type: 'radial-gauge';
     /** Value of the Radial Gauge. */
-    value: number;
+    value: AgNumericValue;
     /** Configuration for the targets. */
     targets?: AgRadialGaugeTarget[];
 }

--- a/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
@@ -148,7 +148,7 @@ const options: AgCartesianChartOptions = {
         const { value, type } = params;
 
         if (type === 'number' && params.property === 'y') {
-            return `${value.toFixed(1)} Mtoe`;
+            return `${Number(value).toFixed(1)} Mtoe`;
         }
 
         if (type === 'date') {

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-negative-values/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-negative-values/main.ts
@@ -78,13 +78,13 @@ const options: AgCartesianChartOptions = {
     formatter: {
         x: (params) => {
             if (params.type !== 'number') return;
-            const degrees = Math.trunc(params.value);
+            const degrees = Math.trunc(Number(params.value));
             const orientation = degrees > 0 ? 'E' : degrees < 0 ? 'W' : '';
             return `${Math.abs(degrees)}° ${orientation}`;
         },
         y: (params) => {
             if (params.type !== 'number') return;
-            const degrees = Math.trunc(params.value);
+            const degrees = Math.trunc(Number(params.value));
             const orientation = degrees > 0 ? 'N' : degrees < 0 ? 'S' : '';
             return `${Math.abs(degrees)}° ${orientation}`;
         },

--- a/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
@@ -51,8 +51,9 @@ const options: AgChartOptions<DataType> = {
         const { value, type } = params;
 
         if (type === 'number') {
-            if (Math.abs(value) >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
-            return value.toLocaleString();
+            const numericValue = Number(value);
+            if (Math.abs(numericValue) >= 1e3) return `${(numericValue / 1e3).toFixed(1)}K`;
+            return numericValue.toLocaleString();
         }
     },
 };

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
@@ -54,7 +54,7 @@ const options: AgLinearGaugeOptions = {
     tooltip: {
         enabled: true,
         renderer: (params) => {
-            const currentValue = params.value;
+            const currentValue = Number(params.value);
             const targetValue = 80;
             const performance = performanceStages[Math.floor((currentValue / 100) * performanceStages.length)];
             const gap =

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-scatter-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-scatter-series/main.ts
@@ -236,7 +236,7 @@ const options: AgChartOptions = {
             if (params.type !== 'number') return;
             let fractionDigits = params.fractionDigits ?? 0;
             fractionDigits = Math.max(fractionDigits - 1, 0);
-            return `${(params.value / 1000).toFixed(fractionDigits)}K`;
+            return `${(Number(params.value) / 1000).toFixed(fractionDigits)}K`;
         },
     },
 };

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
@@ -26,8 +26,8 @@ const data = getData();
 const allSalaries = data.flatMap((d) => [d.low, d.high]);
 const avgSalary = allSalaries.reduce((a, b) => a + b, 0) / allSalaries.length;
 
-const formatter = ({ value }: { value: number | Date | string | string[] }) =>
-    value.toLocaleString('en-GB', {
+const formatter = ({ value }: { value: number | bigint | Date | string | string[] }) =>
+    Number(value).toLocaleString('en-GB', {
         style: 'currency',
         currency: 'GBP',
         notation: 'compact',

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
@@ -160,7 +160,7 @@ const options: AgCartesianChartOptions = {
         },
         y: (params) => {
             if (params.type !== 'number') return;
-            const value = params.value / 1000;
+            const value = Number(params.value) / 1000;
             const fractionDigits = params.source === 'tooltip' ? 1 : 0;
 
             if (value >= 100) {

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-large-data/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-large-data/main.ts
@@ -116,8 +116,9 @@ const options: AgChartOptions = {
     formatter: {
         y(params) {
             if (params.type !== 'number') return;
-            const pq = params.value < 0 ? 'p' : 'q';
-            return `${pq}${Math.abs(params.value).toFixed(params.fractionDigits)}`;
+            const numericValue = Number(params.value);
+            const pq = numericValue < 0 ? 'p' : 'q';
+            return `${pq}${Math.abs(numericValue).toFixed(params.fractionDigits)}`;
         },
     },
 };

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
@@ -56,8 +56,8 @@ const options: AgLinearGaugeOptions = {
             title: 'Chemical Concentration',
             data: [
                 { label: 'Measured Value', value: `${value} mol/L` },
-                { label: 'Status', value: getStatusForValue(value) },
-                { label: 'Range', value: getRangeForValue(value) },
+                { label: 'Status', value: getStatusForValue(Number(value)) },
+                { label: 'Range', value: getRangeForValue(Number(value)) },
             ],
         }),
     },

--- a/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-utils.ts
+++ b/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-utils.ts
@@ -150,6 +150,7 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
 
     switch (node.kind) {
         case ts.SyntaxKind.AnyKeyword:
+        case ts.SyntaxKind.BigIntKeyword:
         case ts.SyntaxKind.BooleanKeyword:
         case ts.SyntaxKind.ConstructSignature:
         case ts.SyntaxKind.Identifier:


### PR DESCRIPTION
## Summary

PR4 of the AG-16608 BigInt train. Theme: **static public type surface + state serialization**. Stacked on top of PR3e.

JIRA: https://ag-grid.atlassian.net/browse/AG-16608

Fix #AG-16608

### What changed

- **New `AgNumericValue = number | bigint`** (`ag-charts-types/src/chart/dataValues.ts`), exported from `main.ts`. (Numeric alias only — the time alias is PR7.)
- **Gauge option types widened** (radial + linear) to `AgNumericValue`: `value`, `scale.min`, `scale.max`, `scale.interval.step`/`scale.interval.values`, `target.value`, and the label/tooltip formatter params (`AgRadialGaugeLabelFormatterParams.value`, `AgRadial/LinearGaugeTooltipRendererParams.value`). Also the shared gauge types `AgGaugeSegmentationInterval.step`/`.values` (`.count` stays `number`) and `AgGaugeColorStop.stop`.
- **`NumberFormatterParams.value`** widened to `AgNumericValue` (its `visibleDomain` stays `[number, number]`).
- **State serialization**:
  - New `AgStateSerializableBigInt` (`{ __type: 'bigint'; value: string }`) in `stateTypes.ts`.
  - `memento.ts` `encodeTypes`/`decodeTypes` gain a `bigint` arm using the existing tagged-union pattern; encoded as a base-10 **string** to preserve precision beyond 2^53. Decode is non-throwing on untrusted input: only a valid base-10 integer string is converted, otherwise the value is left un-decoded so it flows to `guardMemento` via the warn-and-ignore path (mirrors the date arm).
  - `AgInitialStateZoomRange.start`/`end` and the annotation `ValueType` widened to accept `bigint` and `AgStateSerializableBigInt`.
- **Tests**: memento bigint round-trip + malformed-payload (fractional / non-string) tolerance (core); annotation bigint coordinate round-trip through `getState()` (enterprise).

### ⚠️ TS-breaking

This PR **widens the public TypeScript API** and is intentionally TS-breaking. Fields widened from `number` to `number | bigint` (`AgNumericValue`), plus state types widened to accept `bigint`/`AgStateSerializableBigInt`:

- `AgRadialGaugePreset.value`, `AgRadialGaugeScale.min`, `AgRadialGaugeScale.max`, `AgRadialGaugeScaleInterval.step`, `AgRadialGaugeScaleInterval.values`, `AgRadialGaugeTarget.value`, `AgRadialGaugeLabelFormatterParams.value`, `AgRadialGaugeTooltipRendererParams.value`
- `AgLinearGaugePreset.value`, `AgLinearGaugeScale.min`, `AgLinearGaugeScale.max`, `AgLinearGaugeScaleInterval.step`, `AgLinearGaugeScaleInterval.values`, `AgLinearGaugeTarget.value`, `AgLinearGaugeTooltipRendererParams.value`
- `AgGaugeSegmentationInterval.step`, `AgGaugeSegmentationInterval.values` (shared radial + linear; `.count` stays `number`)
- `AgGaugeColorStop.stop` (shared radial + linear)
- `NumberFormatterParams.value`
- `AgInitialStateZoomRange.start`, `AgInitialStateZoomRange.end`
- annotation `ValueType` (`string | number | bigint | AgStateSerializableDate | AgStateSerializableBigInt`)

### Enterprise gauge `Math.min/max(...)` — verify-only findings

Per scope item 3, these were verified, not re-implemented:

- `gauge-util/segmentation.ts` (`Math.min(...scale.domain)` / `Math.max(...scale.domain)`) and the radial-gauge series `Math.min/max(...scale.domain)` sites operate on `Scale.domain`, which PR2 narrows: the `domain` setter maps any `bigint` endpoint to `Number` (comment in `continuousScale.ts`: "Number-narrowed domain so every `Math.min/max(...domain)` consumer stays Number-only") and `get domain(): D[]` returns the narrowed `number[]`. These sites are therefore protected by PR2 and need no change in PR4.

### Runtime caveat (out of PR4 scope)

PR4 lays down the **static type surface** for gauges per the phased plan. The gauge **runtime** does not yet coerce `bigint` end-to-end: the core gauge preset validators (`ag-charts-core/src/config/gaugePreset.ts`) still validate `value`/`scale.min`/`scale.max`/`interval`/`target.value` as `number` (reject `bigint`), and `gauge-util/label.ts` `formatLabel` reads `scale.min`/`scale.max` directly and calls `Math.abs(...)` on them (throws on `bigint`). Wiring bigint through the gauge runtime (validator widening + `formatLabel`/series property coercion) is a separate, larger runtime change deliberately not included in this static-type-surface PR. As a result no behavioural gauge bigint test is included here — it would require those out-of-scope runtime changes. Flagged for a follow-up runtime PR.

### Pre-commit gates (all green)

- `yarn nx format`
- `build:types`: ag-charts-types, ag-charts-community, ag-charts-enterprise — all pass
- `lint`: ag-charts-types, ag-charts-community, ag-charts-enterprise — all pass (only pre-existing unrelated warnings)
- `test`: ag-charts-community (3378), ag-charts-enterprise (2137), ag-charts-core (530) — all pass

AC coverage: AG-16608 #8, #11, #17; Cross-cutting #6.


