### PR TITLE
AG-16654 ISO 8601 strings and bigint epochs on time axes

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -101,14 +101,14 @@ export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTim
     }
 
     override datumFormatParams(
-        value: number | Date,
+        value: number | bigint | string | Date,
         params: FormatDatumParams,
         _fractionDigits: number | undefined,
         timeInterval: AgTimeInterval | AgTimeIntervalUnit | undefined,
         style: DateFormatterStyle
     ): FormatterParams<any> {
-        if (typeof value === 'number') {
-            value = new Date(value);
+        if (!(value instanceof Date)) {
+            value = new Date(typeof value === 'bigint' ? Number(value) : value);
         }
 
         if (timeInterval == null) {

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -14,6 +14,7 @@ import {
     type UngroupedData,
 } from '../../dataModelTypes';
 import type { DataSet } from '../../dataSet';
+import { isISO8601 } from '../../iso8601';
 import type { DataModelContext } from '../dataModelContext';
 import type { DomainManager } from '../domain/domainManager';
 import type { SpecializedProcessValueFn } from '../domain/processValueFactory';
@@ -77,7 +78,8 @@ function valueColumnType(value: unknown): ColumnValueType | undefined {
         case 'bigint':
             return 'bigint';
         case 'string':
-            return 'string';
+            // A strict ISO 8601 string is a date value; any other string is a plain category.
+            return isISO8601(value) ? 'date' : 'string';
         case 'object':
             if (value == null) return undefined;
             // A NumberObject ({ valueOf(): number }) is numeric, not a date.
@@ -91,11 +93,14 @@ function updateColumnTypeTracker(tracker: ColumnTypeTracker, value: unknown, dat
     const observed = valueColumnType(value);
     if (observed == null) return;
 
-    if (tracker.type == null) {
+    if (tracker.type == null || tracker.type === observed) {
         tracker.type = observed;
-    } else if (tracker.type !== observed && isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
-        // TODO(AG-16654, PR5): number<->date coexistence (epoch number + Date in one column) should also
-        // promote to 'date'; only number<->bigint mixing is handled today.
+    } else if (isDateColumnType(tracker.type) || isDateColumnType(observed)) {
+        // Date, ISO string and epoch number/bigint coexist as the heterogeneous 'date' tag; each value
+        // normalises to a Date at convert() time.
+        tracker.type = 'date';
+    } else if (isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
+        // A column mixing `number` and `bigint` (with no date values) is rejected at the series level.
         tracker.mixedAtIndex ??= datumIndex;
         tracker.type = 'mixed-numeric';
     }
@@ -103,6 +108,10 @@ function updateColumnTypeTracker(tracker: ColumnTypeTracker, value: unknown, dat
 
 function isNumericColumnType(type: ColumnValueType): boolean {
     return type === 'number' || type === 'bigint' || type === 'mixed-numeric';
+}
+
+function isDateColumnType(type: ColumnValueType): boolean {
+    return type === 'date';
 }
 
 /**

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { type Mock, describe, expect, it } from 'vitest';
 
 import { DATA_BROWSER_MARKET_SHARE } from '../test/data';
 import * as examples from '../test/examples';
@@ -28,7 +28,27 @@ import {
 import type { GroupByFn } from './dataModel';
 import { DataModel, KEY_SORT_ORDERS, getPathComponents } from './dataModel';
 import { DataSet } from './dataSet';
-import { SMALLEST_KEY_INTERVAL, SORT_DOMAIN_GROUPS, rangedValueProperty } from './processors';
+import {
+    SMALLEST_KEY_INTERVAL,
+    SORT_DOMAIN_GROUPS,
+    keyProperty,
+    rangedValueProperty,
+    valueProperty,
+} from './processors';
+
+const ISO_SCOPE = 'test';
+
+function scoped<T extends object>(def: T): T & { scopes: string[] } {
+    return { ...def, scopes: [ISO_SCOPE] };
+}
+
+/** Returns all `console.warn` call arguments joined into one string and clears the mock. */
+function drainWarnings(): string {
+    const warnMock = console.warn as Mock;
+    const text = warnMock.mock.calls.flat().join('\n');
+    warnMock.mockClear();
+    return text;
+}
 
 describe('DataModel', () => {
     setupMockConsole();
@@ -2845,6 +2865,92 @@ describe('DataModel', () => {
             expect(domainTimes.length).toBeGreaterThan(0);
             expect(domainTimes.at(0)).toBeLessThanOrEqual(earliestInitial);
             expect(domainTimes.at(-1)).toBeGreaterThanOrEqual(latestSeen);
+        });
+    });
+
+    describe('ISO 8601 / time-axis data extraction', () => {
+        function timeKeyModel() {
+            return new DataModel<any, any>({
+                props: [scoped(keyProperty('x', 'time')), scoped(valueProperty('y', 'number'))],
+            });
+        }
+
+        it('accepts ISO 8601 strings on a time axis and preserves the original string', () => {
+            const model = timeKeyModel();
+            const result = model.processData(
+                basicDataSet([
+                    { x: '2024-01-15', y: 1 },
+                    { x: '2024-02-15T10:30:00Z', y: 2 },
+                ])
+            )!;
+
+            // AC #7: the raw column retains the original ISO string, not a parsed Date.
+            const keys = [...result.keys[0].get(ISO_SCOPE)!];
+            expect(keys).toEqual(['2024-01-15', '2024-02-15T10:30:00Z']);
+        });
+
+        it('rejects a non-ISO string on a time axis with a format-naming warning', () => {
+            const model = timeKeyModel();
+            model.processData(
+                basicDataSet([
+                    { x: '2024-01-15', y: 1 },
+                    { x: 'not a date', y: 2 },
+                ])
+            );
+
+            const warnings = drainWarnings();
+            expect(warnings).toContain('not a date');
+            expect(warnings).toContain('row 1');
+            expect(warnings).toContain('ISO 8601');
+        });
+
+        it("promotes a column mixing Date, ISO string and epoch number/bigint to the 'date' tag", () => {
+            const model = new DataModel<any, any>({
+                props: [scoped(valueProperty('v', 'time'))],
+            });
+            const result = model.processData(
+                basicDataSet([
+                    { v: new Date('2024-01-01T00:00:00Z') },
+                    { v: '2024-02-01' },
+                    { v: Date.UTC(2024, 2, 1) },
+                    { v: BigInt(Date.UTC(2024, 3, 1)) },
+                ])
+            )!;
+
+            expect(result.columnValueType).toEqual(['date']);
+        });
+
+        it('rejects ISO 8601 strings on a numeric axis', () => {
+            const model = new DataModel<any, any>({
+                props: [scoped(keyProperty('x', 'number')), scoped(valueProperty('y', 'number'))],
+            });
+            const result = model.processData(
+                basicDataSet([
+                    { x: 1, y: 1 },
+                    { x: '2024-01-15', y: 2 },
+                ])
+            )!;
+
+            // The ISO string is invalid data on a numeric axis: its row is marked invalid and warned.
+            const invalid = result.invalidData?.get(ISO_SCOPE) ?? [];
+            expect(invalid[1]).toBe(true);
+            expect(drainWarnings()).toContain('invalid value of type [string]');
+        });
+
+        it('uses ISO 8601 strings as-is on a category axis (no time validation, no parsing)', () => {
+            const model = new DataModel<any, any, false>({
+                props: [scoped(keyProperty('x')), scoped(valueProperty('y', 'number'))],
+                groupByKeys: false,
+            });
+            const result = model.processData(
+                basicDataSet([
+                    { x: '2024-01-15', y: 1 },
+                    { x: 'not a date', y: 2 },
+                ])
+            )!;
+
+            const keys = [...result.keys[0].get(ISO_SCOPE)!];
+            expect(keys).toEqual(['2024-01-15', 'not a date']);
         });
     });
 });

--- a/packages/ag-charts-community/src/chart/data/iso8601.test.ts
+++ b/packages/ag-charts-community/src/chart/data/iso8601.test.ts
@@ -9,6 +9,10 @@ describe('isISO8601', () => {
         '2024-01-15T10:30:00+05:30',
         '2024-01-15T10:30:00.123Z',
         '2024-01-15T10:30:00',
+        // Minute-precision (seconds optional)
+        '2024-01-15T10:30Z',
+        '2024-01-15T10:30',
+        '2024-01-15T10:30+05:30',
     ];
 
     const rejected = [
@@ -21,6 +25,9 @@ describe('isISO8601', () => {
         '20240115',
         '2024-W03',
         '2024-015',
+        // Basic/short offsets are intentionally rejected; only colon offsets (+HH:MM) are accepted.
+        '2024-01-15T10:30:00+0530',
+        '2024-01-15T10:30+05',
     ];
 
     it.each(accepted)('accepts %s', (value) => {

--- a/packages/ag-charts-community/src/chart/data/iso8601.test.ts
+++ b/packages/ag-charts-community/src/chart/data/iso8601.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { isISO8601 } from './iso8601';
+
+describe('isISO8601', () => {
+    const accepted = [
+        '2024-01-15',
+        '2024-01-15T10:30:00Z',
+        '2024-01-15T10:30:00+05:30',
+        '2024-01-15T10:30:00.123Z',
+        '2024-01-15T10:30:00',
+    ];
+
+    const rejected = [
+        'Dec 2024',
+        '01/02/2024',
+        'January 15, 2024',
+        '2024-13-01',
+        '2024-02-30',
+        '2024-01-15 10:30:00',
+        '20240115',
+        '2024-W03',
+        '2024-015',
+    ];
+
+    it.each(accepted)('accepts %s', (value) => {
+        expect(isISO8601(value)).toBe(true);
+    });
+
+    it.each(rejected)('rejects %s', (value) => {
+        expect(isISO8601(value)).toBe(false);
+    });
+
+    it.each([null, undefined, 1705314600000, 1705314600000n, new Date(), {}])(
+        'rejects non-string value %s',
+        (value) => {
+            expect(isISO8601(value)).toBe(false);
+        }
+    );
+
+    it('does not accept an offset form whose UTC day differs from the wall-clock day', () => {
+        // 02:00+05:30 lands on the previous UTC day; the date portion must still be honoured.
+        expect(isISO8601('2024-01-15T02:00:00+05:30')).toBe(true);
+    });
+});

--- a/packages/ag-charts-community/src/chart/data/iso8601.ts
+++ b/packages/ag-charts-community/src/chart/data/iso8601.ts
@@ -3,15 +3,12 @@
 const ISO_8601 = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/;
 
 /**
- * Returns true only for strings that are valid, canonical ISO 8601 date / date-time values.
+ * Returns true only for valid, canonical ISO 8601 date / date-time strings.
  *
- * The regex alone is insufficient: V8 silently rolls impossible calendar dates such as `"2024-02-30"`
- * forward to `"2024-03-01"`. We round-trip the leading `YYYY-MM-DD` (which the regex guarantees is
- * present) through `Date`: parsing the date portion alone fixes it at UTC midnight, so re-deriving the
- * calendar components in UTC and requiring them to match catches any silent rollover. Parsing the date
- * portion in isolation deliberately ignores any time-zone offset — comparing UTC components against the
- * full instant would wrongly reject valid offset forms such as `"2024-01-15T02:00:00+05:30"`, which land
- * on the previous UTC day.
+ * The regex alone is insufficient — V8 silently rolls impossible dates (`"2024-02-30"` → `"2024-03-01"`),
+ * so we round-trip the leading `YYYY-MM-DD` through `Date` (UTC midnight) and require the calendar
+ * components to match. The date portion is parsed in isolation so an offset form landing on the previous
+ * UTC day (e.g. `"2024-01-15T02:00:00+05:30"`) is not wrongly rejected.
  */
 export function isISO8601(value: unknown): value is string {
     if (typeof value !== 'string' || !ISO_8601.test(value)) return false;

--- a/packages/ag-charts-community/src/chart/data/iso8601.ts
+++ b/packages/ag-charts-community/src/chart/data/iso8601.ts
@@ -1,0 +1,27 @@
+// Strict ISO 8601 detection. String parsing is a time-axis concern, not a general one, so this lives
+// alongside the data pipeline rather than in the shared value utilities.
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/;
+
+/**
+ * Returns true only for strings that are valid, canonical ISO 8601 date / date-time values.
+ *
+ * The regex alone is insufficient: V8 silently rolls impossible calendar dates such as `"2024-02-30"`
+ * forward to `"2024-03-01"`. We round-trip the leading `YYYY-MM-DD` (which the regex guarantees is
+ * present) through `Date`: parsing the date portion alone fixes it at UTC midnight, so re-deriving the
+ * calendar components in UTC and requiring them to match catches any silent rollover. Parsing the date
+ * portion in isolation deliberately ignores any time-zone offset — comparing UTC components against the
+ * full instant would wrongly reject valid offset forms such as `"2024-01-15T02:00:00+05:30"`, which land
+ * on the previous UTC day.
+ */
+export function isISO8601(value: unknown): value is string {
+    if (typeof value !== 'string' || !ISO_8601.test(value)) return false;
+    if (Number.isNaN(new Date(value).getTime())) return false;
+    const datePart = value.slice(0, 10);
+    const d = new Date(datePart);
+    if (Number.isNaN(d.getTime())) return false;
+    const y = d.getUTCFullYear();
+    const m = d.getUTCMonth() + 1;
+    const day = d.getUTCDate();
+    const canonical = `${String(y).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    return datePart === canonical;
+}

--- a/packages/ag-charts-community/src/chart/data/iso8601.ts
+++ b/packages/ag-charts-community/src/chart/data/iso8601.ts
@@ -1,6 +1,6 @@
 // Strict ISO 8601 detection. String parsing is a time-axis concern, not a general one, so this lives
 // alongside the data pipeline rather than in the shared value utilities.
-const ISO_8601 = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/;
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/;
 
 /**
  * Returns true only for strings that are valid, canonical ISO 8601 date / date-time values.

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -1,4 +1,5 @@
 import {
+    Logger,
     type ScaleType,
     clamp,
     isContinuous,
@@ -24,6 +25,7 @@ import {
     UNDEFINED_KEY_STRING,
     datumKeys,
 } from './dataModel';
+import { isISO8601 } from './iso8601';
 
 export const MAX_ANIMATABLE_NODES = 1000;
 
@@ -46,10 +48,22 @@ function basicContinuousCheckDatumValidation(value: any) {
     return value != null && isContinuous(value);
 }
 
-// Separate from basicContinuousCheckDatumValidation so a later PR can let time scales accept ISO 8601
-// strings without number/log/color scales doing the same.
-function basicTimeCheckDatumValidation(value: any) {
-    return value != null && isContinuous(value);
+const TIME_AXIS_ACCEPTED_FORMATS =
+    "Date, epoch number/bigint, or strict ISO 8601 string (e.g. '2024-01-15', '2024-01-15T10:30:00Z')";
+
+// Split out from basicContinuousCheckDatumValidation so the time scales accept time-only values (ISO 8601
+// strings) that must never be accepted by number/log/color scales.
+function basicTimeCheckDatumValidation(value: any, _datum?: any, index?: number) {
+    if (value == null) return false;
+    if (isContinuous(value) || isISO8601(value)) return true;
+    if (typeof value === 'string') {
+        // warnOnce dedupes by message; embedding the value + row makes it fire once per offending datum
+        // per chart pass (Logger is reset each pass), satisfying the per-column diagnostic requirement.
+        Logger.warnOnce(
+            `unsupported value [${value}] at row ${index ?? '?'} on a time axis; expected ${TIME_AXIS_ACCEPTED_FORMATS}. The value is ignored.`
+        );
+    }
+    return false;
 }
 
 function basicDiscreteCheckDatumValidation(value: any) {

--- a/packages/ag-charts-community/src/scale/discreteTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/discreteTimeScale.ts
@@ -62,8 +62,8 @@ export abstract class DiscreteTimeScale extends BandScale<Date, AgTimeInterval |
         visibleRange?: [number, number]
     ): { ticks: Date[]; count: number | undefined; firstTickIndex?: number } | undefined;
 
-    override toDomain(value: number): Date {
-        return new Date(value);
+    override toDomain(value: number | bigint): Date {
+        return new Date(typeof value === 'bigint' ? Number(value) : value);
     }
 
     protected get reversed(): boolean {
@@ -76,10 +76,13 @@ export abstract class DiscreteTimeScale extends BandScale<Date, AgTimeInterval |
         return this.bands.map((d) => d.valueOf());
     }
 
-    override convert(value: Date, options?: { clamp?: boolean; alignment?: ScaleAlignment }): number {
+    override convert(
+        value: Date | number | bigint | string,
+        options?: { clamp?: boolean; alignment?: ScaleAlignment }
+    ): number {
         this.refresh();
 
-        if (!(value instanceof Date)) value = new Date(value);
+        if (!(value instanceof Date)) value = new Date(typeof value === 'bigint' ? Number(value) : value);
         const { domain, reversed } = this;
         const numericBands = this.numericBands;
         const bandCount = numericBands.length;

--- a/packages/ag-charts-community/src/scale/ordinalTimeScale.test.ts
+++ b/packages/ag-charts-community/src/scale/ordinalTimeScale.test.ts
@@ -554,6 +554,27 @@ describe('OrdinalTimeScale', () => {
         });
     });
 
+    describe('value coercion', () => {
+        function bandedScale() {
+            const scale = new OrdinalTimeScale();
+            scale.domain = [
+                new Date(Date.UTC(2024, 0, 1)),
+                new Date(Date.UTC(2024, 1, 1)),
+                new Date(Date.UTC(2024, 2, 1)),
+            ];
+            scale.range = [0, 300];
+            return scale;
+        }
+
+        it('coerces ISO string and bigint epoch to the same band as the equivalent Date', () => {
+            const scale = bandedScale();
+            const date = new Date(Date.UTC(2024, 1, 1));
+            const expected = scale.convert(date);
+            expect(scale.convert('2024-02-01T00:00:00Z')).toBeCloseTo(expected);
+            expect(scale.convert(BigInt(date.valueOf()))).toBeCloseTo(expected);
+        });
+    });
+
     describe('stepTicks', () => {
         it('should return ticks for the given band step', () => {
             const domain = Array.from({ length: 60 }, (_, i) => new Date(2024, 0, i + 1));

--- a/packages/ag-charts-community/src/scale/timeScale.test.ts
+++ b/packages/ag-charts-community/src/scale/timeScale.test.ts
@@ -188,4 +188,38 @@ describe('TimeScale', () => {
             });
         });
     });
+
+    describe('convert coercion', () => {
+        function scaleOverYear() {
+            const scale = new TimeScale();
+            scale.range = [0, 600];
+            scale.domain = [new Date(Date.UTC(2024, 0, 1)), new Date(Date.UTC(2024, 11, 31))];
+            return scale;
+        }
+
+        it('coerces ISO 8601 strings to the same position as the equivalent Date', () => {
+            const scale = scaleOverYear();
+            const iso = scale.convert('2024-07-01T00:00:00Z');
+            const date = scale.convert(new Date('2024-07-01T00:00:00Z'));
+            expect(iso).toBeCloseTo(date);
+            expect(Number.isFinite(iso)).toBe(true);
+        });
+
+        it('coerces a bigint epoch to the same position as the equivalent number', () => {
+            const scale = scaleOverYear();
+            const epoch = Date.UTC(2024, 6, 1);
+            expect(scale.convert(BigInt(epoch))).toBeCloseTo(scale.convert(epoch));
+        });
+
+        it('returns NaN for an out-of-range bigint epoch', () => {
+            const scale = scaleOverYear();
+            // Far beyond Date's representable range (±8.64e15 ms) -> Invalid Date.
+            expect(Number.isNaN(scale.convert(10n ** 30n))).toBe(true);
+        });
+
+        it('returns NaN for a non-ISO string', () => {
+            const scale = scaleOverYear();
+            expect(Number.isNaN(scale.convert('not a date'))).toBe(true);
+        });
+    });
 });

--- a/packages/ag-charts-community/src/scale/timeScale.ts
+++ b/packages/ag-charts-community/src/scale/timeScale.ts
@@ -8,6 +8,7 @@ import {
     intervalRangeStartIndex,
     intervalStep,
     isDenseInterval,
+    timeValueToNumber,
 } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
 
@@ -30,8 +31,8 @@ export class TimeScale extends ContinuousScale<Date, AgTimeInterval | AgTimeInte
         return new Date(d);
     }
 
-    override convert(value: Date | number, options?: { clamp: boolean }): number {
-        return super.convert(typeof value === 'number' ? value : (value?.valueOf() ?? Number.NaN), options);
+    override convert(value: Date | number | bigint | string, options?: { clamp: boolean }): number {
+        return super.convert(value == null ? Number.NaN : timeValueToNumber(value), options);
     }
 
     override invert(value: number): Date {

--- a/packages/ag-charts-community/src/scale/unitTimeScale.test.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.test.ts
@@ -40,6 +40,18 @@ describe('UnitTimeScale', () => {
         expect(convertedValue).toBeCloseTo(92, 0);
     });
 
+    it('coerces ISO string and bigint epoch to the same position as the equivalent Date', () => {
+        const scale = new UnitTimeScale();
+        scale.range = [0, 100];
+        scale.domain = [new Date(Date.UTC(2022, 0, 1)), new Date(Date.UTC(2022, 11, 1))];
+        scale.interval = 'month';
+
+        const date = new Date(Date.UTC(2022, 5, 15));
+        const expected = scale.convert(date);
+        expect(scale.convert('2022-06-15T00:00:00Z')).toBeCloseTo(expected);
+        expect(scale.convert(BigInt(date.valueOf()))).toBeCloseTo(expected);
+    });
+
     describe('ticksFromNumericBands equivalence', () => {
         it('produces ticks for daily interval with year tick step', () => {
             const domain: [Date, Date] = [new Date(2020, 0, 1), new Date(2024, 0, 1)];

--- a/packages/ag-charts-community/src/scale/unitTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.ts
@@ -316,10 +316,13 @@ export class UnitTimeScale extends DiscreteTimeScale {
      * Uses linear params for fast bounds checking while delegating actual
      * conversion to parent for accuracy in edge cases.
      */
-    override convert(value: Date, options?: { clamp?: boolean; alignment?: ScaleAlignment }): number {
+    override convert(
+        value: Date | number | bigint | string,
+        options?: { clamp?: boolean; alignment?: ScaleAlignment }
+    ): number {
         this.refresh();
 
-        if (!(value instanceof Date)) value = new Date(value);
+        if (!(value instanceof Date)) value = new Date(typeof value === 'bigint' ? Number(value) : value);
 
         const { domain, interval } = this;
         if (domain.length < 2) return Number.NaN;

--- a/packages/ag-charts-core/src/utils/time/timeFormatDefaults.ts
+++ b/packages/ag-charts-core/src/utils/time/timeFormatDefaults.ts
@@ -7,6 +7,19 @@ export function dateToNumber(value: any) {
     return value instanceof Date ? value.getTime() : value;
 }
 
+/**
+ * Coerces a time-axis value (Date, epoch number/bigint, or ISO 8601 string) to epoch milliseconds.
+ * Returns `NaN` for out-of-range bigint epochs and any value `Date` cannot parse, so callers can treat
+ * the result like any other off-domain time value rather than letting an Invalid Date propagate.
+ */
+export function timeValueToNumber(value: Date | number | bigint | string): number {
+    if (typeof value === 'number') return value;
+    const ms = typeof value === 'bigint' ? Number(value) : value;
+    const date = ms instanceof Date ? ms : new Date(ms);
+    const time = date.getTime();
+    return Number.isNaN(time) ? Number.NaN : time;
+}
+
 export function lowestGranularityForInterval(interval: number) {
     if (interval < durationSecond) {
         return 'millisecond';


### PR DESCRIPTION
JIRA: https://ag-grid.atlassian.net/browse/AG-16654

Fix #AG-16654

Stacks on the AG-16608 BigInt train (PR1 -> ... -> PR4b); base is `AG-16608/pr4b-gauge-bigint-runtime`. Opens the second ticket (AG-16654, ISO 8601 on time axes).

## Summary

- **Strict ISO 8601 detection** (`isISO8601`, new internal util in `chart/data/iso8601.ts`): regex + canonical round-trip that catches V8's silent calendar rollover (`2024-02-30` -> `2024-03-01`) and correctly handles timezone-offset forms.
- **Time-axis validation** (`basicTimeCheckDatumValidation`): accepts existing valid time values OR ISO strings; non-ISO strings on a time axis warn once (naming value, row index, accepted-format set). ISO on numeric/color axes stays rejected; ISO on category axes is used as-is.
- **Scale coercion**: `timeScale`, `unitTimeScale`, `discreteTimeScale` and `timeAxis` coerce Date / epoch number / bigint / ISO string to Date at `convert()`. Out-of-range bigint epochs resolve to `NaN` instead of an Invalid Date. Shared `timeValueToNumber` helper added to `ag-charts-core`.
- **Heterogeneous `'date'` tag**: a column mixing Date, ISO string and epoch number/bigint now promotes to `'date'` (resolves the PR1 `TODO(AG-16654, PR5)`); `number<->bigint` mixing without dates is still rejected. Original values are preserved in the column, so `params.xValue` returns the raw ISO string.

## Accepted / rejected ISO 8601 forms

Strict ISO 8601 **extended** format only. The date portion is always required; the time portion is optional, with **optional seconds** and **colon offsets only**.

- **Accepted**: `2024-01-15`, `2024-01-15T10:30Z`, `2024-01-15T10:30`, `2024-01-15T10:30+05:30`, `2024-01-15T10:30:00`, `2024-01-15T10:30:00Z`, `2024-01-15T10:30:00.123Z`, `2024-01-15T10:30:00+05:30`. (Fractional seconds are allowed only when seconds are present.)
- **Rejected**: non-ISO strings (`Dec 2024`, `01/02/2024`, `January 15, 2024`, `2024-01-15 10:30:00`), impossible/normalised dates (`2024-13-01`, `2024-02-30`), non-extended forms (`20240115`, `2024-W03`, `2024-015`), and **basic/short offsets** (`+0530`, `+05`) — rejected by design for consistency with the strict extended-format policy (which already rejects basic-format dates).

## Tests

- `isISO8601` unit test (accepted/rejected sets per AC #3, including minute-precision and basic-offset rejection, plus offset round-trip).
- Time-scale coercion tests across all three scales (ISO + bigint parity with Date, out-of-range bigint -> NaN, non-ISO -> NaN).
- DataModel integration: ISO accepted + preserved on time axis, non-ISO warns, `'date'` promotion, ISO rejected on numeric, ISO used as-is on category.

## Out of scope

Axis-type prediction (#6) and mixed-timezone diagnostics (#9) are PR6.
