### PR TITLE
AG-16654 Predict ISO/bigint time axes; warn on mixed timezones

### DIFF
--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -114,6 +114,25 @@ function isDateColumnType(type: ColumnValueType): boolean {
     return type === 'date';
 }
 
+// An ISO 8601 string carries an explicit timezone iff it ends with `Z` or a trailing `±HH:MM` offset.
+// Date-only (`2024-01-15`) and offset-less date-times (`2024-01-15T10:30:00`) are timezone-implicit.
+const ISO_8601_EXPLICIT_TZ = /(Z|[+-]\d{2}:\d{2})$/;
+
+/** First-seen examples of explicit- and implicit-timezone ISO strings within a single column. */
+interface TimezoneTracker {
+    explicit: { value: string; index: number } | undefined;
+    implicit: { value: string; index: number } | undefined;
+}
+
+function updateTimezoneTracker(tracker: TimezoneTracker, value: unknown, datumIndex: number): void {
+    if (typeof value !== 'string' || !isISO8601(value)) return;
+    if (ISO_8601_EXPLICIT_TZ.test(value)) {
+        tracker.explicit ??= { value, index: datumIndex };
+    } else {
+        tracker.implicit ??= { value, index: datumIndex };
+    }
+}
+
 /**
  * DataExtractor handles data extraction from DataSet sources.
  *
@@ -245,6 +264,8 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
             // Track ordering/uniqueness for this key definition
             const tracker = createKeyTracker();
+            const typeTracker: ColumnTypeTracker = { type: undefined, mixedAtIndex: undefined };
+            const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
 
             for (const scope of keyScopes ?? []) {
                 const data = sources.get(scope)?.data ?? [];
@@ -279,6 +300,8 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                         keys.push(result.value);
                         // Track ordering/uniqueness for valid keys
                         updateKeyTracker(tracker, result.value);
+                        updateColumnTypeTracker(typeTracker, result.value, datumIndex);
+                        updateTimezoneTracker(tzTracker, result.value, datumIndex);
                         continue;
                     }
 
@@ -310,6 +333,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
             // Store the computed sort order entry for this key definition
             keySortOrders.set(keyDefIndex, trackerToSortOrderEntry(tracker));
+            this.warnMixedTimezoneColumn(keyDef.property, typeTracker.type, tzTracker);
         }
         return {
             invalidData,
@@ -392,6 +416,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             const invalidKeys = scopeInvalidKeys.get(columnScope);
             let needsValueOf = false;
             const typeTracker: ColumnTypeTracker = { type: undefined, mixedAtIndex: undefined };
+            const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
             for (let datumIndex = 0; datumIndex < columnSource.length; datumIndex++) {
                 if (columnSource[datumIndex] == null || typeof columnSource[datumIndex] !== 'object') {
                     // Count non-object items as invalid data
@@ -412,6 +437,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                     this.markScopeDatumMissing(def.scopes, columnSource, datumIndex, missingData);
                 } else {
                     updateColumnTypeTracker(typeTracker, result.value, datumIndex);
+                    updateTimezoneTracker(tzTracker, result.value, datumIndex);
                 }
 
                 if (invalidKey) {
@@ -433,6 +459,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             if (typeTracker.type === 'mixed-numeric' && typeTracker.mixedAtIndex != null) {
                 this.warnMixedNumericColumn(columnScope, def.property, typeTracker.mixedAtIndex);
             }
+            this.warnMixedTimezoneColumn(def.property, typeTracker.type, tzTracker);
 
             columns.push(column);
             allColumnScopes.push(columnScopes);
@@ -456,6 +483,17 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             `Series "${seriesId}": column "${String(key)}" mixes 'number' and 'bigint' values ` +
                 `(first detected at row ${atIndex}). Each column must be uniformly typed. ` +
                 `The series renders empty; other series in this chart are unaffected.`
+        );
+    }
+
+    private warnMixedTimezoneColumn(key: K, columnType: ColumnValueType | undefined, tracker: TimezoneTracker) {
+        const { explicit, implicit } = tracker;
+        // Only a date-tagged column interprets ISO strings as instants; a plain category column keeps them
+        // as opaque labels, so mixed offsets there are not a timezone-ambiguity concern.
+        if (columnType !== 'date' || explicit == null || implicit == null) return;
+        // AC #9: mixed timezone semantics are defined-but-surprising, so warn once and still render.
+        Logger.warnOnce(
+            `Time axis: column "${String(key)}" contains both timezone-explicit values (e.g. "${explicit.value}", row ${explicit.index}) and timezone-implicit values (e.g. "${implicit.value}", row ${implicit.index}). Ambiguous timezone semantics may produce unexpected positions — points without an explicit offset are interpreted as local time. Use explicit offsets (Z or ±HH:MM) for cross-environment determinism.`
         );
     }
 

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -2880,13 +2880,13 @@ describe('DataModel', () => {
             const result = model.processData(
                 basicDataSet([
                     { x: '2024-01-15', y: 1 },
-                    { x: '2024-02-15T10:30:00Z', y: 2 },
+                    { x: '2024-02-15T10:30:00', y: 2 },
                 ])
             )!;
 
             // AC #7: the raw column retains the original ISO string, not a parsed Date.
             const keys = [...result.keys[0].get(ISO_SCOPE)!];
-            expect(keys).toEqual(['2024-01-15', '2024-02-15T10:30:00Z']);
+            expect(keys).toEqual(['2024-01-15', '2024-02-15T10:30:00']);
         });
 
         it('rejects a non-ISO string on a time axis with a format-naming warning', () => {
@@ -2935,6 +2935,71 @@ describe('DataModel', () => {
             const invalid = result.invalidData?.get(ISO_SCOPE) ?? [];
             expect(invalid[1]).toBe(true);
             expect(drainWarnings()).toContain('invalid value of type [string]');
+        });
+
+        it('warns once when a column mixes timezone-explicit and timezone-implicit ISO strings', () => {
+            const model = timeKeyModel();
+            const result = model.processData(
+                basicDataSet([
+                    { x: '2024-01-15T10:30:00Z', y: 1 },
+                    { x: '2024-02-15', y: 2 },
+                    { x: '2024-03-15T08:00:00+05:30', y: 3 },
+                ])
+            )!;
+
+            // The chart still renders: every value parses and is retained.
+            const keys = [...result.keys[0].get(ISO_SCOPE)!];
+            expect(keys).toEqual(['2024-01-15T10:30:00Z', '2024-02-15', '2024-03-15T08:00:00+05:30']);
+
+            const warnings = drainWarnings();
+            expect(warnings).toContain('column "x"');
+            expect(warnings).toContain('timezone-explicit');
+            expect(warnings).toContain('timezone-implicit');
+            expect(warnings).toContain('local time');
+            // Names an example of each kind with its row.
+            expect(warnings).toContain('2024-01-15T10:30:00Z');
+            expect(warnings).toContain('2024-02-15');
+            // Warns exactly once for the column despite multiple offending rows.
+            expect(warnings.match(/timezone-explicit/g)).toHaveLength(1);
+        });
+
+        it('does not warn for an all-timezone-explicit ISO column', () => {
+            const model = timeKeyModel();
+            model.processData(
+                basicDataSet([
+                    { x: '2024-01-15T10:30:00Z', y: 1 },
+                    { x: '2024-02-15T08:00:00+05:30', y: 2 },
+                ])
+            );
+
+            expect(drainWarnings()).not.toContain('timezone-explicit');
+        });
+
+        it('does not warn for an all-timezone-implicit ISO column', () => {
+            const model = timeKeyModel();
+            model.processData(
+                basicDataSet([
+                    { x: '2024-01-15', y: 1 },
+                    { x: '2024-02-15T08:00:00', y: 2 },
+                ])
+            );
+
+            expect(drainWarnings()).not.toContain('timezone-explicit');
+        });
+
+        it('does not warn for Date + UTC-explicit ISO + epoch values (all unambiguous UTC instants)', () => {
+            const model = timeKeyModel();
+            const result = model.processData(
+                basicDataSet([
+                    { x: new Date('2024-01-01T00:00:00Z'), y: 1 },
+                    { x: '2024-02-01T00:00:00Z', y: 2 },
+                    { x: Date.UTC(2024, 2, 1), y: 3 },
+                ])
+            )!;
+
+            // Renders unchanged and emits no timezone diagnostic.
+            expect([...result.keys[0].get(ISO_SCOPE)!]).toHaveLength(3);
+            expect(drainWarnings()).not.toContain('timezone-explicit');
         });
 
         it('uses ISO 8601 strings as-is on a category axis (no time validation, no parsing)', () => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/util.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/util.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { CARTESIAN_AXIS_TYPE, ChartAxisDirection } from 'ag-charts-core';
+import type { AgCartesianSeriesOptions } from 'ag-charts-types';
+
+import { predictCartesianAxis, predictCartesianFinancialAxis } from './util';
+
+// A representative time-named key and a non-time-named key, to exercise the TIME_AXIS_KEYS guard.
+const TIME_KEY = 'date';
+const NON_TIME_KEY = 'category';
+
+function lineSeries(xKey: string): AgCartesianSeriesOptions {
+    return { type: 'line', xKey, yKey: 'value' };
+}
+
+function candlestickSeries(xKey: string): AgCartesianSeriesOptions {
+    return { type: 'candlestick', xKey } as AgCartesianSeriesOptions;
+}
+
+describe('predictCartesianAxis time-axis prediction', () => {
+    const cases: Array<[label: string, key: string, value: unknown, expected: string | undefined]> = [
+        ['Date under a time key', TIME_KEY, new Date('2024-01-15'), CARTESIAN_AXIS_TYPE.TIME],
+        ['number under a time key', TIME_KEY, 1_700_000_000_000, CARTESIAN_AXIS_TYPE.TIME],
+        ['bigint under a time key', TIME_KEY, BigInt(1_700_000_000_000), CARTESIAN_AXIS_TYPE.TIME],
+        ['strict ISO string under a time key', TIME_KEY, '2024-01-15T10:30:00Z', CARTESIAN_AXIS_TYPE.TIME],
+        ['date-only ISO string under a time key', TIME_KEY, '2024-01-15', CARTESIAN_AXIS_TYPE.TIME],
+        // Non-ISO strings must not predict a time axis (false-positive guard).
+        ['non-ISO string under a time key', TIME_KEY, 'Q1', CARTESIAN_AXIS_TYPE.CATEGORY],
+        // ISO under a non-time-named key must not predict a time axis.
+        ['ISO string under a non-time key', NON_TIME_KEY, '2024-01-15', CARTESIAN_AXIS_TYPE.CATEGORY],
+    ];
+
+    it.each(cases)('predicts %s', (_label, key, value, expected) => {
+        const result = predictCartesianAxis(ChartAxisDirection.X, { [key]: value }, lineSeries(key));
+        expect(result?.type).toBe(expected);
+    });
+});
+
+describe('predictCartesianFinancialAxis ordinal-time prediction', () => {
+    const cases: Array<[label: string, key: string, value: unknown, expected: string | undefined]> = [
+        ['Date under a time key', TIME_KEY, new Date('2024-01-15'), CARTESIAN_AXIS_TYPE.ORDINAL_TIME],
+        ['number under a time key', TIME_KEY, 1_700_000_000_000, CARTESIAN_AXIS_TYPE.ORDINAL_TIME],
+        ['bigint under a time key', TIME_KEY, BigInt(1_700_000_000_000), CARTESIAN_AXIS_TYPE.ORDINAL_TIME],
+        ['strict ISO string under a time key', TIME_KEY, '2024-01-15T10:30:00Z', CARTESIAN_AXIS_TYPE.ORDINAL_TIME],
+        ['date-only ISO string under a time key', TIME_KEY, '2024-01-15', CARTESIAN_AXIS_TYPE.ORDINAL_TIME],
+        // Non-ISO strings fall through to the category branch.
+        ['non-ISO string under a time key', TIME_KEY, 'Q1', CARTESIAN_AXIS_TYPE.CATEGORY],
+        // ISO under a non-time-named key is treated as a category, not ordinal-time.
+        ['ISO string under a non-time key', NON_TIME_KEY, '2024-01-15', CARTESIAN_AXIS_TYPE.CATEGORY],
+    ];
+
+    it.each(cases)('predicts %s', (_label, key, value, expected) => {
+        const result = predictCartesianFinancialAxis(ChartAxisDirection.X, { [key]: value }, candlestickSeries(key));
+        expect(result?.type).toBe(expected);
+    });
+});

--- a/packages/ag-charts-community/src/chart/series/cartesian/util.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/util.ts
@@ -20,6 +20,7 @@ import type {
 
 import { BBox } from '../../../scene/bbox';
 import type { ChartAxis } from '../../chartAxis';
+import { isISO8601 } from '../../data/iso8601';
 
 function isAxisReversed(axis: ChartAxis) {
     return axis.isReversed() !== axis.range[1] < axis.range[0];
@@ -194,14 +195,18 @@ function predictGroupedCategoryAxisType(value: unknown) {
     }
 }
 
+function isTimeNumeric(value: unknown): value is number | bigint {
+    return isNumber(value) || typeof value === 'bigint';
+}
+
 function predictTimeAxisType(key: string, value: unknown) {
-    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && isNumber(value))) {
+    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && (isTimeNumeric(value) || isISO8601(value)))) {
         return CARTESIAN_AXIS_TYPE.TIME;
     }
 }
 
 function predictOrdinalTimeAxisType(key: string, value: unknown) {
-    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && isNumber(value))) {
+    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && (isTimeNumeric(value) || isISO8601(value)))) {
         return CARTESIAN_AXIS_TYPE.ORDINAL_TIME;
     }
 }


### PR DESCRIPTION
JIRA: https://ag-grid.atlassian.net/browse/AG-16654

Fix #AG-16654

Stacks on the AG-16608 / AG-16654 bigint + ISO 8601 train (base: `AG-16654/pr5-iso-time-scale`).

## Summary

PR6 of the train. Two features:

1. **Axis-type prediction** (`chart/series/cartesian/util.ts`) — AG-16654 #6, AG-16608 #4
   - Extracted `isTimeNumeric(value) = isNumber(value) || typeof value === 'bigint'`, so a **bigint** under a time-named key (`time`/`timestamp`/`date`/`datetime`) now predicts a time axis (previously bigint keys never predicted).
   - Added an ISO branch: a strict ISO 8601 string under a time-named key predicts a time axis. Reuses the strict `isISO8601` detector from PR5 (no reimplementation). The strict regex rejects `'Jan'`, `'Q1'`, etc., so false-positive risk is near-zero, and there is no behaviour change for non-time-named keys or non-ISO strings.

2. **Mixed-timezone diagnostic** (`chart/data/data-model/extraction/dataExtractor.ts`) — AG-16654 #9
   - When a single date-tagged time column contains both timezone-explicit ISO strings (suffix `Z` or `±HH:MM`) and timezone-implicit ones (no offset), emits one `Logger.warnOnce` per column naming an explicit example + row and an implicit example + row, explaining offset-less points are interpreted in local time. The chart still renders — all values parse.
   - Detection lives in the existing per-column extraction loop (key and value paths), so it runs once per column per pass with zero impact on validation-function identity / request merging.
   - **Asymmetry (intentional):** mixed `number`/`bigint` is rejected (undefined arithmetic); mixed-timezone only warns (defined-but-surprising). Mixed Date + UTC-explicit ISO + epoch numbers do **not** warn — all unambiguous UTC instants.

## Release notes callout

This **reverses the original AG-16654 AC 2** (which stipulated no string-driven prediction). String-driven prediction is now enabled by design review. Please flag for release notes.

## Tests

- Prediction matrix in `util.test.ts` for both `predictCartesianAxis` and `predictCartesianFinancialAxis`: under a time-named key — Date/number/bigint/strict-ISO → time(/ordinal-time); non-ISO string → category; ISO under a non-time key → category.
- Mixed-timezone cases in `iso8601.dataModel.test.ts`: mixed explicit+implicit warns once and still renders; all-explicit / all-implicit / Date+UTC+epoch do not warn.
