### PR TITLE
AG-16654 Add AgTimeValue alias, time-axis wiring, JSDoc and v14 notes

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axisLabelUtil.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisLabelUtil.ts
@@ -2,6 +2,7 @@ import { isArray, objectsEqual } from 'ag-charts-core';
 import type {
     AgAxisLabelFormatterParams,
     AgBaseAxisLabelStyleOptions,
+    AgNumericValue,
     AgTimeIntervalUnit,
     DateFormatterStyle,
     FormatterParams,
@@ -39,6 +40,16 @@ export function getAxisLabelSideFlag(mirrored: boolean): ChartAxisLabelFlipFlag 
     return mirrored ? 1 : -1;
 }
 
+/**
+ * Narrows a possibly-`bigint` visible domain to the `[number, number]` form exposed on the public
+ * `AgAxisLabelFormatterParams.visibleDomain`, which is deliberately not widened to `AgNumericValue`.
+ */
+export function toNumberPairDomain(
+    visibleDomain: [AgNumericValue, AgNumericValue] | undefined
+): [number, number] | undefined {
+    return visibleDomain == null ? undefined : [Number(visibleDomain[0]), Number(visibleDomain[1])];
+}
+
 export function formatAxisLabelValue(
     label:
         | (Pick<AgBaseAxisLabelStyleOptions, never> & {
@@ -70,7 +81,7 @@ export function formatAxisLabelValue(
     let result: TextOrSegments | undefined;
     if (formatter != null) {
         const step = params.type === 'date' ? params.step : undefined;
-        const visibleDomain = params.type === 'number' ? params.visibleDomain : undefined;
+        const visibleDomain = toNumberPairDomain(params.type === 'number' ? params.visibleDomain : undefined);
         result = callWithContext(formatter, {
             type,
             value,

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -17,16 +17,34 @@ import {
     lowestGranularityUnitForValue,
     normalisedTimeExtentWithMetadata,
 } from 'ag-charts-core';
-import type { AgTimeInterval, AgTimeIntervalUnit, DateFormatterStyle, FormatterParams } from 'ag-charts-types';
+import type {
+    AgTimeInterval,
+    AgTimeIntervalUnit,
+    AgTimeValue,
+    DateFormatterStyle,
+    FormatterParams,
+} from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../module/moduleContext';
 import { TimeScale } from '../../scale/timeScale';
 import type { FormatDatumParams } from '../chartAxis';
+import { isISO8601 } from '../data/iso8601';
 import type { DatumIndexType, ISeries, ISeriesProperties } from '../series/seriesTypes';
 import type { AxisTickFormatParams } from './axis';
 import { CartesianAxis } from './cartesianAxis';
 
 type TimeBound = Date | number | undefined;
+
+/**
+ * Coerces a user-supplied time-axis bound to the `Date | number` form the internal extent and
+ * granularity helpers expect. `bigint` epochs narrow to `number`; strict ISO 8601 strings parse to
+ * `Date`. Non-time inputs pass through unchanged so existing validation surfaces the error.
+ */
+export function coerceTimeBound(value: AgTimeValue | undefined): TimeBound {
+    if (typeof value === 'bigint') return Number(value);
+    if (isISO8601(value)) return new Date(value);
+    return value;
+}
 
 export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTimeAxisOptions> extends CartesianAxis<
     TimeScale,
@@ -74,7 +92,13 @@ export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTim
 
     override normaliseDataDomain(d: DomainWithMetadata<Date>) {
         const { min, max, preferredMin, preferredMax } = this.options;
-        const { extent, clipped } = normalisedTimeExtentWithMetadata(d, min, max, preferredMin, preferredMax);
+        const { extent, clipped } = normalisedTimeExtentWithMetadata(
+            d,
+            coerceTimeBound(min),
+            coerceTimeBound(max),
+            coerceTimeBound(preferredMin),
+            coerceTimeBound(preferredMax)
+        );
         return { domain: extent, clipped };
     }
 
@@ -83,7 +107,12 @@ export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTim
 
         const { boundSeries, direction } = this;
         const { min, max } = this.options;
-        this.minimumTimeGranularity = minimumTimeAxisDatumGranularity(boundSeries, direction, min, max);
+        this.minimumTimeGranularity = minimumTimeAxisDatumGranularity(
+            boundSeries,
+            direction,
+            coerceTimeBound(min),
+            coerceTimeBound(max)
+        );
     }
 
     override tickFormatParams(

--- a/packages/ag-charts-community/src/chart/axis/unitTimeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/unitTimeAxis.ts
@@ -17,7 +17,7 @@ import { UnitTimeScale } from '../../scale/unitTimeScale';
 import type { FormatDatumParams } from '../chartAxis';
 import type { AxisTickFormatParams } from './axis';
 import { DiscreteTimeAxis } from './discreteTimeAxis';
-import { calculateDefaultUnit } from './timeAxis';
+import { calculateDefaultUnit, coerceTimeBound } from './timeAxis';
 
 type UnitInterval = AgTimeInterval | AgTimeIntervalUnit | undefined;
 
@@ -73,7 +73,7 @@ export class UnitTimeAxis extends DiscreteTimeAxis<UnitTimeScale, NormalisedUnit
         } else {
             const { boundSeries, direction } = this;
             const { min, max } = this.options;
-            defaultUnit = calculateDefaultUnit(boundSeries, direction, min, max);
+            defaultUnit = calculateDefaultUnit(boundSeries, direction, coerceTimeBound(min), coerceTimeBound(max));
         }
 
         if (!objectsEqual(this.defaultUnit, defaultUnit)) {
@@ -89,7 +89,13 @@ export class UnitTimeAxis extends DiscreteTimeAxis<UnitTimeScale, NormalisedUnit
 
     override normaliseDataDomain(d: DomainWithMetadata<Date>) {
         const { min, max, preferredMin, preferredMax } = this.options;
-        const { extent, clipped } = normalisedTimeExtentWithMetadata(d, min, max, preferredMin, preferredMax);
+        const { extent, clipped } = normalisedTimeExtentWithMetadata(
+            d,
+            coerceTimeBound(min),
+            coerceTimeBound(max),
+            coerceTimeBound(preferredMin),
+            coerceTimeBound(preferredMax)
+        );
         return { domain: extent, clipped };
     }
 

--- a/packages/ag-charts-community/src/chart/series/seriesLabelProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesLabelProperties.ts
@@ -15,6 +15,7 @@ import type {
     TextWrap,
 } from 'ag-charts-types';
 
+import { toNumberPairDomain } from '../axis/axisLabelUtil';
 import type { ChartAxisLabel } from '../chartAxis';
 import { FormatManager } from '../formatter/formatManager';
 import { LabelBorder } from '../label';
@@ -142,7 +143,7 @@ export class SeriesLabelProperties extends BaseProperties implements ChartAxisLa
         let result: TextOrSegments | undefined;
         if (formatter != null) {
             const step = params.type === 'date' ? params.step : undefined;
-            const visibleDomain = params.type === 'number' ? params.visibleDomain : undefined;
+            const visibleDomain = toNumberPairDomain(params.type === 'number' ? params.visibleDomain : undefined);
             result = callWithContext(formatter, {
                 type,
                 value,

--- a/packages/ag-charts-types/src/chart/axisOptions.ts
+++ b/packages/ag-charts-types/src/chart/axisOptions.ts
@@ -1,5 +1,6 @@
 import type { LabelBoxOptions, TextOrSegments } from '../series/cartesian/commonOptions';
 import type { RichFormatter, Styler } from './callbackOptions';
+import type { AgTimeValue } from './dataValues';
 import type {
     ContextDefault,
     CssColor,
@@ -92,7 +93,7 @@ export interface AgBaseAxisOptions<LabelType = any, TContext = ContextDefault> {
     interval?: AgAxisBaseIntervalOptions;
 }
 
-export interface AgBaseContinuousAxisOptions<TDatum extends Date | number = number> {
+export interface AgBaseContinuousAxisOptions<TDatum extends AgTimeValue = number> {
     /** The min value for the axis domain. */
     min?: TDatum;
     /** The max value for the axis domain. */
@@ -104,7 +105,7 @@ export interface AgBaseContinuousAxisOptions<TDatum extends Date | number = numb
 }
 
 export interface AgContinuousAxisOptions<
-    TDatum extends Date | number = number,
+    TDatum extends AgTimeValue = number,
     TInterval extends AgTimeInterval | AgTimeIntervalUnit | number = number,
 > extends AgBaseContinuousAxisOptions<TDatum> {
     /** If `true`, the range will be rounded up to ensure nice equal spacing between the ticks.

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -27,6 +27,7 @@ import type {
     AgCrossLineThemeOptions,
 } from './crossLineOptions';
 import type { AgBaseCrosshairLabel, AgCrosshairLabel, AgCrosshairOptions } from './crosshairOptions';
+import type { AgTimeValue } from './dataValues';
 import type { ContextDefault, DatumDefault, Degree, PixelSize, Ratio, TextWrap } from './types';
 
 /** Configuration for axes in cartesian charts. */
@@ -283,7 +284,7 @@ export interface AgTimeAxisOptions<TContext = ContextDefault>
             >,
             'interval'
         >,
-        AgContinuousAxisOptions<Date | number, AgTimeInterval | AgTimeIntervalUnit | number> {
+        AgContinuousAxisOptions<AgTimeValue, AgTimeInterval | AgTimeIntervalUnit | number> {
     type?: 'time';
     /** Options for labels and ticks for the parent level intervals. */
     parentLevel?: AgTimeAxisParentLevel<TContext>;
@@ -299,7 +300,7 @@ export interface AgUnitTimeAxisOptions<TContext = ContextDefault>
             >,
             'interval'
         >,
-        AgBaseContinuousAxisOptions<Date | number> {
+        AgBaseContinuousAxisOptions<AgTimeValue> {
     type?: 'unit-time';
     /** Options for labels and ticks for the parent level intervals. */
     parentLevel?: AgTimeAxisParentLevel<TContext>;

--- a/packages/ag-charts-types/src/chart/dataValues.ts
+++ b/packages/ag-charts-types/src/chart/dataValues.ts
@@ -3,3 +3,11 @@
  * the safe-integer range (beyond `Number.MAX_SAFE_INTEGER`).
  */
 export type AgNumericValue = number | bigint;
+
+/**
+ * A time data value, accepted on time axes only. A `number` or `bigint` is
+ * interpreted as a Unix epoch in milliseconds; a `bigint` may be supplied for
+ * epochs outside the safe-integer range. A `string` must be a strict ISO 8601
+ * date or date-time — other string formats are rejected.
+ */
+export type AgTimeValue = Date | number | bigint | string;

--- a/packages/ag-charts-types/src/chart/formatterOptions.ts
+++ b/packages/ag-charts-types/src/chart/formatterOptions.ts
@@ -80,7 +80,7 @@ export interface NumberFormatterParams<TDatum, TContext> extends BaseFormatterPa
     /** The recommended precision to format the value. */
     fractionDigits: number | undefined;
     /** The currently visible domain. [min, max] */
-    visibleDomain: [number, number] | undefined;
+    visibleDomain: [AgNumericValue, AgNumericValue] | undefined;
 }
 
 export type DateFormatterStyle = 'long' | 'component';


### PR DESCRIPTION
## Summary

Final PR of the AG-16608 (BigInt) + AG-16654 (ISO 8601) stacked train. Caps the public contract: the `AgTimeValue` type alias, time-axis option wiring, JSDoc, and v14 release notes.

JIRA: [AG-16608](https://ag-grid.atlassian.net/browse/AG-16608) · [AG-16654](https://ag-grid.atlassian.net/browse/AG-16654)

Fix #AG-16654

This is the final PR capping the stacked train (PR4 → PR5 → PR6 → **PR7**). The five E2E docs examples (design §E2E) are split into a stacked **PR8** (`AG-16654/pr8-e2e-examples`, based on this branch) to keep each PR within the reviewable LoC cap.

## Changes

- **`AgTimeValue` alias** (`ag-charts-types/src/chart/dataValues.ts`): `Date | number | bigint | string`, exported via `main.ts` (wildcard re-export). `string` = strict ISO 8601, on time axes only.
- **Time-axis wiring**: `AgBaseContinuousAxisOptions<TDatum>` / `AgContinuousAxisOptions<TDatum>` constraint widened from `Date | number` to `AgTimeValue`; `AgTimeAxisOptions` now carries `<AgTimeValue, ...>` and `AgUnitTimeAxisOptions` carries `AgBaseContinuousAxisOptions<AgTimeValue>`. Number/log/polar/radius axes stay `<number, number>`. The widening flows transitively to `min`/`max`/`preferredMin`/`preferredMax`.
- **`NumberFormatterParams.visibleDomain`** widened from `[number, number]` to `[AgNumericValue, AgNumericValue]`.
- **JSDoc** (UK English): `xKey`/`yKey` on line/area/scatter/bubble/bar; `axis.type` (string-driven time-axis prediction); the two aliases and widened formatter field.
- **Release notes**: "Behaviour Changes" populated in `upgrade-to-ag-charts-14/index.mdoc` (three documented behaviour changes).

### Internal fallout (community)

The widened static types forced minimal coercion at internal consumption sites (behaviour identical):
- `timeAxis.ts`: new `coerceTimeBound()` helper (`bigint`→`number`, ISO string→`Date`) applied where axis `min`/`max` feed the extent/granularity helpers; used by `unitTimeAxis.ts` too.
- `axisLabelUtil.ts`: new `toNumberPairDomain()` narrows the widened `visibleDomain` back to `[number, number]` for the deliberately-not-widened `AgAxisLabelFormatterParams.visibleDomain`; reused by `seriesLabelProperties.ts`.

## ⚠️ TS-breaking

This PR is **TypeScript-breaking** for typed callers. Widened surfaces:
- `AgContinuousAxisOptions` / `AgBaseContinuousAxisOptions` (constraint `Date | number` → `AgTimeValue`) — affects time-axis `min`/`max`/`preferredMin`/`preferredMax`.
- `NumberFormatterParams.visibleDomain` (`[number, number]` → `[AgNumericValue, AgNumericValue]`).

(Gauge/number formatter `.value` surfaces were already widened to `AgNumericValue` in PR4.) Typed callers invoking number-only methods on these values must narrow (`typeof x === 'number'`) or coerce (`Number(x)`).

## Outstanding action

The **JIRA Breaking Changes field (customfield_10521)** update is an external write left for the orchestrator/user — **not** touched by this PR.

## Gates

`format`, `build:types` (types/community/enterprise), `lint` (types/community), `test` (community/enterprise), and `validate-examples` (840 examples, no issues) all green. No gallery examples required migration.
