### PR TITLE
AG-16654 Add BigInt and ISO 8601 docs examples

### DIFF
--- a/packages/ag-charts-core/src/utils/data/numbers.test.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.test.ts
@@ -29,6 +29,10 @@ describe('Number Utilities', () => {
         expect(isNegative(0)).toBe(false);
         expect(isNegative(1)).toBe(false);
         expect(isNegative(-0)).toBe(true); // Negative zero check
+        // bigint: Math.sign throws on bigint, so the bigint branch compares directly.
+        expect(isNegative(-4_500_000_000_000_000_000_000n)).toBe(true);
+        expect(isNegative(0n)).toBe(false);
+        expect(isNegative(4_500_000_000_000_000_000_000n)).toBe(false);
     });
 
     test('isInteger', () => {

--- a/packages/ag-charts-core/src/utils/data/numbers.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.ts
@@ -10,7 +10,8 @@ export function isNumberEqual(a: number, b: number, epsilon: number = 1e-10) {
     return a === b || Math.abs(a - b) < epsilon;
 }
 
-export function isNegative(value: number) {
+export function isNegative(value: number | bigint) {
+    if (typeof value === 'bigint') return value < 0n;
     return Math.sign(value) === -1 || Object.is(value, -0);
 }
 

--- a/packages/ag-charts-website/e2e/example-options.ts
+++ b/packages/ag-charts-website/e2e/example-options.ts
@@ -13,6 +13,9 @@ export const EXAMPLE_OPTIONS: Record<string, Record<string, ExampleOverrides>> =
     'axes-labels': {
         'axis-label-rotation': { skipCanvasUpdateCheck: true },
     },
+    'axes-time': {
+        'iso-8601-rejected-input': { ignoreConsoleWarnings: true },
+    },
     'api-create-update': {
         'update-partial': { frameworks: ['vanilla', 'typescript'] },
         'wait-for-update': {

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-rejected-input/index.html
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-rejected-input/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-rejected-input/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-rejected-input/main.ts
@@ -1,0 +1,39 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+    TimeAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([LineSeriesModule, NumberAxisModule, TimeAxisModule]);
+
+// The second and fourth rows carry non-ISO 8601 strings. They are rejected and
+// a warning naming the value is logged to the console; the valid rows still render.
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    title: { text: 'Daily Totals' },
+    subtitle: { text: 'Invalid date strings are skipped — see the browser console' },
+    data: [
+        { date: '2024-03-01', total: 42 },
+        { date: '01/03/2024', total: 51 },
+        { date: '2024-03-03', total: 47 },
+        { date: 'March 4th', total: 60 },
+        { date: '2024-03-05', total: 58 },
+    ],
+    series: [
+        {
+            type: 'line',
+            xKey: 'date',
+            yKey: 'total',
+            yName: 'Total',
+        },
+    ],
+    axes: {
+        x: { type: 'time' },
+        y: { type: 'number' },
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-time-axis/index.html
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-time-axis/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-time-axis/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-time/_examples/iso-8601-time-axis/main.ts
@@ -1,0 +1,40 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+    TimeAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([LineSeriesModule, NumberAxisModule, TimeAxisModule]);
+
+// Dates are supplied as strict ISO 8601 strings rather than Date objects. The
+// time axis parses them on demand; offsets are honoured as written.
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    title: { text: 'Hourly Readings' },
+    subtitle: { text: 'Timestamps provided as ISO 8601 strings' },
+    data: [
+        { time: '2024-01-15T09:00:00Z', value: 12.4 },
+        { time: '2024-01-15T10:00:00Z', value: 13.1 },
+        { time: '2024-01-15T11:00:00Z', value: 14.8 },
+        { time: '2024-01-15T12:00:00Z', value: 14.2 },
+        { time: '2024-01-15T13:00:00Z', value: 15.6 },
+        { time: '2024-01-15T14:00:00Z', value: 16.0 },
+    ],
+    series: [
+        {
+            type: 'line',
+            xKey: 'time',
+            yKey: 'value',
+            yName: 'Reading',
+        },
+    ],
+    axes: {
+        x: { type: 'time' },
+        y: { type: 'number' },
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
@@ -5,7 +5,7 @@ description: 'Use $framework chart time axis to display time-based data in a $fr
 
 Time axes are used to display time-based data in a chart. They can be used to show data at different levels of granularity, such as years, months, days, or even hours and minutes.
 
-Time can be provided as `number` or `Date` objects, where `number` values are interpreted as timestamps derived from Unix time.
+Time can be provided as `number`, `bigint` or `Date` objects, where `number` and `bigint` values are interpreted as timestamps derived from Unix time. Strict [ISO 8601](#iso-8601-strings) strings are also accepted.
 
 There are three methods of displaying time along an axis.
 
@@ -16,6 +16,16 @@ There are three methods of displaying time along an axis.
 The difference between a [Unit Time Axis](#unit-time), an [Ordinal Time Axis](#ordinal-time), and a [Continuous Time Axis](#continuous-time) is demonstrated in the following example:
 
 {% chartExampleRunner title="Time Axis Types" name="time-vs-unit-time-vs-ordinal-time" type="generated" /%}
+
+## ISO 8601 Strings
+
+A time axis accepts strict ISO 8601 date and date-time strings directly, without converting them to `Date` objects first. Time-zone offsets are honoured as written.
+
+{% chartExampleRunner title="ISO 8601 Strings" name="iso-8601-time-axis" type="generated" /%}
+
+Strings that are not valid ISO 8601 are skipped, and a warning naming the value is logged to the console. The remaining rows still render.
+
+{% chartExampleRunner title="Rejected Date Strings" name="iso-8601-rejected-input" type="generated" /%}
 
 ## Unit Time
 

--- a/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-large-magnitude/index.html
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-large-magnitude/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-large-magnitude/main.ts
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-large-magnitude/main.ts
@@ -10,7 +10,8 @@ import {
 ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule]);
 
 // Wei balances exceed Number.MAX_SAFE_INTEGER (2^53 - 1), so they are supplied
-// as bigint to preserve full precision through the data pipeline.
+// as bigint. Data values, aggregated totals, tooltips and axis tick labels stay
+// exact; bar positions are computed at high but finite precision.
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),
     title: { text: 'Wallet Balances' },

--- a/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-large-magnitude/main.ts
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-large-magnitude/main.ts
@@ -1,0 +1,38 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule]);
+
+// Wei balances exceed Number.MAX_SAFE_INTEGER (2^53 - 1), so they are supplied
+// as bigint to preserve full precision through the data pipeline.
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    title: { text: 'Wallet Balances' },
+    subtitle: { text: 'Balances in wei (1 ETH = 10^18 wei), beyond the safe-integer range' },
+    data: [
+        { wallet: 'Treasury', balance: 4_500_000_000_000_000_000_000n },
+        { wallet: 'Staking', balance: 2_750_000_000_000_000_000_000n },
+        { wallet: 'Rewards', balance: 1_125_000_000_000_000_000_000n },
+        { wallet: 'Reserve', balance: 980_000_000_000_000_000_000n },
+    ],
+    series: [
+        {
+            type: 'bar',
+            xKey: 'wallet',
+            yKey: 'balance',
+            yName: 'Balance (wei)',
+        },
+    ],
+    axes: {
+        x: { type: 'category' },
+        y: { type: 'number' },
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-small-magnitude/index.html
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-small-magnitude/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-small-magnitude/main.ts
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/_examples/bigint-small-magnitude/main.ts
@@ -1,0 +1,36 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    title: { text: 'Rows Stored per Table' },
+    subtitle: { text: 'Counts read from a database BIGINT column' },
+    data: [
+        { table: 'events', rows: 1_240_511n },
+        { table: 'sessions', rows: 842_004n },
+        { table: 'users', rows: 318_920n },
+        { table: 'orders', rows: 96_551n },
+    ],
+    series: [
+        {
+            type: 'bar',
+            xKey: 'table',
+            yKey: 'rows',
+            yName: 'Rows',
+        },
+    ],
+    axes: {
+        x: { type: 'category' },
+        y: { type: 'number' },
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
@@ -109,7 +109,7 @@ Numeric values may be supplied as `bigint`. This is useful for integers read str
 
 {% chartExampleRunner title="BigInt Values" name="bigint-small-magnitude" type="generated" /%}
 
-`bigint` also preserves full precision for values beyond the safe-integer range (`Number.MAX_SAFE_INTEGER`, `2^53 - 1`), such as token balances measured in wei.
+`bigint` is also useful for values beyond the safe-integer range (`Number.MAX_SAFE_INTEGER`, `2^53 - 1`), such as token balances measured in wei. Data values, aggregated totals, tooltips and axis tick labels are kept at full precision; series positions are computed at high but finite precision.
 
 {% chartExampleRunner title="Large BigInt Values" name="bigint-large-magnitude" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
@@ -103,6 +103,16 @@ However, to support scenarios where different data sources are needed, each indi
 When a series specifies its own `data` array, it overrides the root-level data option for that series only.
 Other series continue to use root-level data.
 
+## Large Numeric Values with BigInt
+
+Numeric values may be supplied as `bigint`. This is useful for integers read straight from a database `BIGINT` column.
+
+{% chartExampleRunner title="BigInt Values" name="bigint-small-magnitude" type="generated" /%}
+
+`bigint` also preserves full precision for values beyond the safe-integer range (`Number.MAX_SAFE_INTEGER`, `2^53 - 1`), such as token balances measured in wei.
+
+{% chartExampleRunner title="Large BigInt Values" name="bigint-large-magnitude" type="generated" /%}
+
 ## Field Dot Notation
 
 By default, AG Charts supports dot notation for accessing nested properties in your data.

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/bigint-value/index.html
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/bigint-value/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/bigint-value/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/bigint-value/main.ts
@@ -1,0 +1,17 @@
+import { AgCharts, AgRadialGaugeOptions, AllGaugeModule, AnimationModule, ModuleRegistry } from 'ag-charts-enterprise';
+
+ModuleRegistry.registerModules([AllGaugeModule, AnimationModule]);
+
+// The gauge value and scale bounds are supplied as bigint, demonstrating the
+// widened numeric value type. Values are interpreted at full integer precision.
+const options: AgRadialGaugeOptions = {
+    type: 'radial-gauge',
+    container: document.getElementById('myChart'),
+    value: 7_400_000_000n,
+    scale: {
+        min: 0n,
+        max: 10_000_000_000n,
+    },
+};
+
+AgCharts.createGauge(options);

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/bigint-value/main.ts
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/_examples/bigint-value/main.ts
@@ -3,7 +3,8 @@ import { AgCharts, AgRadialGaugeOptions, AllGaugeModule, AnimationModule, Module
 ModuleRegistry.registerModules([AllGaugeModule, AnimationModule]);
 
 // The gauge value and scale bounds are supplied as bigint, demonstrating the
-// widened numeric value type. Values are interpreted at full integer precision.
+// widened numeric value type. The label is shown at full precision; the bar fill
+// is positioned from a ratio computed at high but finite precision.
 const options: AgRadialGaugeOptions = {
     type: 'radial-gauge',
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/index.mdoc
@@ -104,7 +104,7 @@ In this configuration:
 
 ### BigInt Values
 
-`value` and the `scale` bounds accept `bigint`, preserving full precision for integers beyond the safe-integer range.
+`value` and the `scale` bounds accept `bigint` for integers beyond the safe-integer range. The label is shown at full precision; the bar fill is positioned from a ratio computed at high but finite precision.
 
 {% chartExampleRunner title="BigInt Value" name="bigint-value" type="generated" options={ "exampleHeight": 320 } /%}
 

--- a/packages/ag-charts-website/src/content/docs/radial-gauge/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/radial-gauge/index.mdoc
@@ -102,6 +102,12 @@ In this configuration:
 - `scale.max` defines the maximum value of the scale.
 - The data is represented by a coloured bar displayed over a grey scale.
 
+### BigInt Values
+
+`value` and the `scale` bounds accept `bigint`, preserving full precision for integers beyond the safe-integer range.
+
+{% chartExampleRunner title="BigInt Value" name="bigint-value" type="generated" options={ "exampleHeight": 320 } /%}
+
 ## Customisation
 
 ### Needle / Bar


### PR DESCRIPTION
## Summary

Stacked on top of [PR7](https://github.com/ag-grid/ag-charts/pull/6953). Adds the five end-to-end docs examples (design §E2E) demonstrating the AG-16608 (BigInt) + AG-16654 (ISO 8601) feature.

JIRA: [AG-16608](https://ag-grid.atlassian.net/browse/AG-16608) · [AG-16654](https://ag-grid.atlassian.net/browse/AG-16654)

Fix #AG-16654

Split out from PR7 to keep each PR within the reviewable LoC cap. Base = `AG-16654/pr7-type-aliases-docs`.

## Examples

| # | Example | Docs page | Demonstrates |
|---|---------|-----------|--------------|
| 1 | `bigint-small-magnitude` | Data Configuration | Numeric axis, small-magnitude BigInt (DB `BIGINT` column) |
| 2 | `bigint-large-magnitude` | Data Configuration | Numeric axis, BigInt beyond `2^53` (wei; precision preservation) |
| 3 | `iso-8601-time-axis` | Time Axis | Time axis fed strict ISO 8601 strings |
| 4 | `iso-8601-rejected-input` | Time Axis | Mixed valid/invalid ISO strings — invalid rows skipped with a console warning, valid rows render |
| 5 | `bigint-value` | Radial Gauge | Radial gauge with BigInt `value` / `scale` bounds |

Each example is referenced from its page via `chartExampleRunner` and follows the existing `_examples/<name>/` scaffold (`main.ts` + `index.html`).

## Gates

`format`, `format:mdoc`, `lint:spell`, and `validate-examples` (845 examples, no issues — up from 840) all green. Framework-variant generation and full `test:e2e` run in CI.


---

### Update — CI fixes

- **E2E console-warning exemption**: the `iso-8601-rejected-input` example intentionally warns on invalid ISO rows, which tripped the loader's no-console-warning assertion. Added `'axes-time': { 'iso-8601-rejected-input': { ignoreConsoleWarnings: true } }` to `e2e/example-options.ts` (matching the existing `range-area-missing-data` pattern). The map key is the page dir (`axes-time`) + example name, confirmed against the loader's key derivation.
- **Precision wording (Codex P2)**: reworded the four bigint precision claims to state that data values, aggregated totals, tooltips and axis tick labels stay exact, while positional rendering (bar positions, ratio-based gauge fill) is high but finite precision.
- Rebased onto the updated PR7 (`58f4e1ec48`).

---

**Added: core fix surfaced by the large-bigint example.** The `bigint-large-magnitude` bar example crashed at render (`Math.sign` throws on bigint, via `isDatumNegative` → `isNegative` in the bar animation path). Fixed `isNegative` in `ag-charts-core` to compare bigints directly (number path unchanged) + bigint unit test. This is a core fix, included here because it is the PR that surfaced it and the whole train co-lands.