### PR TITLE
AG-16608 Fix bigint render crashes in area, heatmap and waterfall

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -116,7 +116,7 @@ interface TickLayout<D, TickLayoutMeta> {
 }
 
 interface TickLayoutCache<D, TickLayoutMeta> {
-    domain: D[];
+    domain: (D | bigint)[];
     rangeExtent: number;
     nice: [boolean, boolean];
     gridLength: number;
@@ -206,7 +206,7 @@ export abstract class Axis<
     mirrored: boolean = false;
     parallel: boolean = false;
 
-    dataDomain: { domain: D[]; clipped: boolean } = { domain: [], clipped: false };
+    dataDomain: { domain: (D | bigint)[]; clipped: boolean } = { domain: [], clipped: false };
     private allowNull = false;
 
     readonly caption = new Caption();
@@ -802,7 +802,7 @@ export abstract class Axis<
     }
 
     abstract calculateTickLayout(
-        domain: D[],
+        domain: (D | bigint)[],
         niceMode: NiceMode[],
         visibleRange: [number, number],
         primaryTickCount?: AxisPrimaryTickCount
@@ -1080,7 +1080,7 @@ export abstract class Axis<
         return { domain, direction, boundSeries, defaultValue: title?.text };
     }
 
-    protected normaliseDataDomain(d: DomainWithMetadata<D>): { domain: D[]; clipped: boolean } {
+    protected normaliseDataDomain(d: DomainWithMetadata<D>): { domain: (D | bigint)[]; clipped: boolean } {
         return { domain: [...d.domain], clipped: false };
     }
 

--- a/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
@@ -39,13 +39,13 @@ export function toKeyString(keys: any[]): string {
  * Fixes a numeric extent to ensure both values are finite numbers.
  * Returns empty array if extent is null or contains non-finite values.
  */
-export function fixNumericExtent(extent: Array<number | Date | bigint> | null): [] | [number, number] {
+export function fixNumericExtent(extent: ReadonlyArray<number | Date | bigint> | null): (number | bigint)[] {
     if (extent == null) return [];
     // Retain exact bigint endpoints so the scale positions and labels them at full precision; Date and
-    // number values still narrow to Number. Downstream consumers branch on `typeof` at runtime.
+    // number values still narrow to Number. The result type carries bigint, so consumers must handle it.
     const mapped = extent.map((v) => (typeof v === 'bigint' ? v : Number(v)));
     const allFinite = mapped.every((v) => typeof v === 'bigint' || Number.isFinite(v));
-    return allFinite ? (mapped as unknown as [number, number]) : [];
+    return allFinite ? mapped : [];
 }
 
 /**

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -107,7 +107,9 @@ function deriveNamedLabels(
     const { domain, range, mode, displayDomain } = colorScale;
     if (range.length === 0) return undefined;
 
-    const [d0, d1] = displayDomain ?? [domain[0], domain.at(-1)!];
+    // The legend axis positions at finite precision, so a bigint displayDomain (AG-16608 heatmap) narrows
+    // to Number here; numeric labels are formatted from the exact value elsewhere.
+    const [d0, d1] = displayDomain ? [Number(displayDomain[0]), Number(displayDomain[1])] : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
     const labels: GradientLegendNamedLabel[] = [];
 
@@ -162,7 +164,9 @@ export function buildGradientLegendDatum(
     series: FormatterBoundSeries[]
 ): GradientLegendDatum {
     const { domain, displayDomain, mode } = colorScale;
-    const axisDomain: [number, number] = displayDomain ?? [domain[0], domain.at(-1)!];
+    const axisDomain: [number, number] = displayDomain
+        ? [Number(displayDomain[0]), Number(displayDomain[1])]
+        : [domain[0], domain.at(-1)!];
     const rawStops = deriveNormalizedStops(colorScale);
     const colorStops =
         mode === 'continuous'

--- a/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
@@ -73,7 +73,12 @@ export abstract class AbstractBarSeries<TTypes extends AbstractBarSeriesTypes> e
     protected padBandExtent(keys: any[], alignStart?: boolean) {
         const ratio = typeof alignStart === 'boolean' ? 1 : 0.5;
         const scalePadding = isFiniteNumber(this.smallestDataInterval) ? this.smallestDataInterval * ratio : 0;
-        const keysExtent = extent(keys) ?? [Number.NaN, Number.NaN];
+        // Band positioning is finite-precision, so a bigint key extent narrows to Number for the padding
+        // arithmetic below (which would otherwise throw on a bigint).
+        const rawExtent = extent(keys);
+        const keysExtent: [number, number] = rawExtent
+            ? [Number(rawExtent[0]), Number(rawExtent[1])]
+            : [Number.NaN, Number.NaN];
         if (typeof alignStart === 'boolean') {
             keysExtent[alignStart ? 0 : 1] -= (alignStart ? 1 : -1) * scalePadding;
         } else {

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -1065,8 +1065,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
 
         scratch.datum = ctx.rawData[datumIndex];
         scratch.yDatum = ctx.yRawValues[datumIndex];
-        scratch.yCumulative = +ctx.yCumulativeValues[datumIndex];
-        scratch.validPoint = Number.isFinite(scratch.yDatum) && ctx.invalidData?.[datumIndex] !== true;
+        // Coerce to Number for positioning (bigint values plot at finite precision); the raw value
+        // is retained on yDatum for tooltips. isContinuous accepts bigint where Number.isFinite would not.
+        scratch.yCumulative = Number(ctx.yCumulativeValues[datumIndex]);
+        scratch.validPoint = isContinuous(scratch.yDatum) && ctx.invalidData?.[datumIndex] !== true;
 
         // Compute marker coordinates
         this.computeMarkerCoordinate(ctx, scratch);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bigintRenderSmoke.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bigintRenderSmoke.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgChartOptions } from 'ag-charts-types';
+
+import { createChart, setupMockCanvas, setupMockConsole, waitForChartStability } from '../../test/utils';
+
+/**
+ * Render smoke test for large `bigint` data values across community cartesian series families.
+ *
+ * Motivation: the `isNegative` crash (Math.sign throws on bigint) reached production through the bar
+ * animation path and was caught only by a browser example — unit/scale tests and example type-checks
+ * missed it because none rendered a real series with out-of-safe-range bigint data. This test renders
+ * each family with bigint values beyond Number.MAX_SAFE_INTEGER and asserts the render completes
+ * without throwing, flushing out any other number-only-math-on-bigint crash of the same class.
+ */
+
+// Beyond Number.MAX_SAFE_INTEGER (2^53 - 1) so values cannot be represented exactly as numbers.
+const BIG = 9_007_199_254_740_993n; // MAX_SAFE_INTEGER + 2
+const NEG_BIG = -9_007_199_254_740_993n; // negative arm exercises the isNegative path
+
+const numericData = [
+    { x: 1, y: BIG, lo: NEG_BIG, hi: BIG },
+    { x: 2, y: BIG * 2n, lo: NEG_BIG, hi: BIG * 2n },
+    { x: 3, y: NEG_BIG, lo: NEG_BIG * 2n, hi: BIG },
+    { x: 4, y: BIG * 3n, lo: NEG_BIG, hi: BIG * 4n },
+];
+
+const numericAxes = { x: { type: 'number' as const }, y: { type: 'number' as const } };
+
+const cases: Array<{ name: string; options: AgChartOptions }> = [
+    {
+        name: 'bar',
+        options: { data: numericData, series: [{ type: 'bar', xKey: 'x', yKey: 'y' }], axes: numericAxes },
+    },
+    {
+        name: 'line',
+        options: { data: numericData, series: [{ type: 'line', xKey: 'x', yKey: 'y' }], axes: numericAxes },
+    },
+    {
+        name: 'area',
+        options: { data: numericData, series: [{ type: 'area', xKey: 'x', yKey: 'y' }], axes: numericAxes },
+    },
+    {
+        name: 'scatter',
+        options: { data: numericData, series: [{ type: 'scatter', xKey: 'x', yKey: 'y' }], axes: numericAxes },
+    },
+    {
+        name: 'bubble',
+        options: {
+            data: numericData,
+            series: [{ type: 'bubble', xKey: 'x', yKey: 'y', sizeKey: 'hi' }],
+            axes: numericAxes,
+        },
+    },
+    {
+        name: 'histogram',
+        options: {
+            data: numericData,
+            series: [{ type: 'histogram', xKey: 'x', yKey: 'y', aggregation: 'sum' }],
+            axes: numericAxes,
+        },
+    },
+];
+
+describe('community series bigint render smoke', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let chart: Awaited<ReturnType<typeof createChart>> | undefined;
+
+    afterEach(() => {
+        chart?.destroy();
+        chart = undefined;
+    });
+
+    it.each(cases)('renders $name with out-of-safe-range bigint values', async ({ options }) => {
+        chart = await createChart(options);
+        await waitForChartStability(chart);
+        expect(chart).toBeDefined();
+    });
+});

--- a/packages/ag-charts-community/src/chart/series/cartesian/bigintRenderSmoke.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bigintRenderSmoke.test.ts
@@ -7,11 +7,9 @@ import { createChart, setupMockCanvas, setupMockConsole, waitForChartStability }
 /**
  * Render smoke test for large `bigint` data values across community cartesian series families.
  *
- * Motivation: the `isNegative` crash (Math.sign throws on bigint) reached production through the bar
- * animation path and was caught only by a browser example — unit/scale tests and example type-checks
- * missed it because none rendered a real series with out-of-safe-range bigint data. This test renders
- * each family with bigint values beyond Number.MAX_SAFE_INTEGER and asserts the render completes
- * without throwing, flushing out any other number-only-math-on-bigint crash of the same class.
+ * The `isNegative` crash (Math.sign throws on bigint) reached production via the bar animation path
+ * because no unit/scale test rendered a real series with out-of-safe-range bigint data. Each family
+ * renders with values beyond Number.MAX_SAFE_INTEGER and must complete without throwing.
  */
 
 // Beyond Number.MAX_SAFE_INTEGER (2^53 - 1) so values cannot be represented exactly as numbers.

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -159,20 +159,22 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
 
     // A BigInt x-column (AG-16608) computes boundaries in BigInt for full precision; everything else
     // keeps the number paths. Explicit `bins` win unless an explicit `binCount` is also set.
-    private computeBins(xExtent: [number | bigint, number | bigint]): BinDomain[] {
-        const bigIntExtent = typeof xExtent[0] === 'bigint' || typeof xExtent[1] === 'bigint';
+    private computeBins(xExtent: (number | bigint)[]): BinDomain[] {
+        const x0 = xExtent[0];
+        const x1 = xExtent[1];
+        const bigIntExtent = typeof x0 === 'bigint' || typeof x1 === 'bigint';
 
         if (isNumber(this.properties.binCount)) {
             return bigIntExtent
-                ? createBigIntBins(xExtent[0] as bigint, xExtent[1] as bigint, this.properties.binCount)
-                : this.calculateNiceBins(xExtent as number[], this.properties.binCount);
+                ? createBigIntBins(BigInt(x0), BigInt(x1), this.properties.binCount)
+                : this.calculateNiceBins([Number(x0), Number(x1)], this.properties.binCount);
         }
 
         return (
             this.properties.bins ??
             (bigIntExtent
-                ? createBigIntBins(xExtent[0] as bigint, xExtent[1] as bigint, defaultBinCount)
-                : this.deriveBins(xExtent as [number, number]))
+                ? createBigIntBins(BigInt(x0), BigInt(x1), defaultBinCount)
+                : this.deriveBins([Number(x0), Number(x1)]))
         );
     }
 

--- a/packages/ag-charts-community/src/scale/colorScale.ts
+++ b/packages/ag-charts-community/src/scale/colorScale.ts
@@ -106,6 +106,11 @@ export class ColorScale extends AbstractScale<number, string> {
     convert(x: number) {
         this.refresh();
 
+        // A bigint colour value (AG-16608 heatmap) narrows to Number; the output colour is derived from
+        // the value's position in the domain, so finite precision is sufficient and arithmetic on a
+        // bigint mixed with the Number domain would throw.
+        x = Number(x);
+
         const { domain, range, parsedRange } = this;
         const d0 = domain[0];
         const d1 = domain.at(-1)!;

--- a/packages/ag-charts-community/src/scale/colorScale.ts
+++ b/packages/ag-charts-community/src/scale/colorScale.ts
@@ -106,9 +106,8 @@ export class ColorScale extends AbstractScale<number, string> {
     convert(x: number) {
         this.refresh();
 
-        // A bigint colour value (AG-16608 heatmap) narrows to Number; the output colour is derived from
-        // the value's position in the domain, so finite precision is sufficient and arithmetic on a
-        // bigint mixed with the Number domain would throw.
+        // A bigint colour value (AG-16608 heatmap) narrows to Number: the colour derives from the value's
+        // position in the domain, so finite precision suffices and bigint/Number mixing would throw.
         x = Number(x);
 
         const { domain, range, parsedRange } = this;

--- a/packages/ag-charts-community/src/scale/colorScale.ts
+++ b/packages/ag-charts-community/src/scale/colorScale.ts
@@ -58,7 +58,7 @@ export class ColorScale extends AbstractScale<number, string> {
      * `domain` (which carries interpolation pivots) so that colour-stop
      * positions do not distort the legend axis range.
      */
-    displayDomain?: [number, number];
+    displayDomain?: [number | bigint, number | bigint];
 
     private parsedRange = this.range.map(convertColorStringToOklcha);
 
@@ -103,12 +103,12 @@ export class ColorScale extends AbstractScale<number, string> {
         return;
     }
 
-    convert(x: number) {
+    convert(x: number | bigint) {
         this.refresh();
 
         // A bigint colour value (AG-16608 heatmap) narrows to Number: the colour derives from the value's
-        // position in the domain, so finite precision suffices and bigint/Number mixing would throw.
-        x = Number(x);
+        // position in the (Number) domain, so finite precision suffices and bigint/Number mixing would throw.
+        const xn = Number(x);
 
         const { domain, range, parsedRange } = this;
         const d0 = domain[0];
@@ -116,11 +116,11 @@ export class ColorScale extends AbstractScale<number, string> {
         const r0 = range[0];
         const r1 = range.at(-1)!;
 
-        if (x <= d0) {
+        if (xn <= d0) {
             return r0;
         }
 
-        if (x >= d1) {
+        if (xn >= d1) {
             return r1;
         }
 
@@ -128,19 +128,19 @@ export class ColorScale extends AbstractScale<number, string> {
         let q: number;
 
         if (domain.length === 2) {
-            const t = (x - d0) / (d1 - d0);
+            const t = (xn - d0) / (d1 - d0);
             const step = 1 / (range.length - 1);
             index = range.length <= 2 ? 0 : Math.min(Math.floor(t * (range.length - 1)), range.length - 2);
             q = (t - index * step) / step;
         } else {
             for (index = 0; index < domain.length - 2; index++) {
-                if (x < domain[index + 1]) {
+                if (xn < domain[index + 1]) {
                     break;
                 }
             }
             const a = domain[index];
             const b = domain[index + 1];
-            q = (x - a) / (b - a);
+            q = (xn - a) / (b - a);
         }
 
         if (this.mode === 'discrete') {

--- a/packages/ag-charts-community/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-community/src/scale/colorScaleUtil.ts
@@ -9,13 +9,15 @@ export function configureColorScale(
         domain?: [number, number];
         mode: ColorScaleMode;
     },
-    dataDomain: number[]
+    dataDomain: (number | bigint)[]
 ): void {
     if (dataDomain.length < 2) return;
     if (colorScaleProps.fills.length === 0) return;
 
-    const domainTuple: [number, number] = [dataDomain[0], dataDomain.at(-1)!];
-    const displayDomain: [number, number] = colorScaleProps.domain ?? domainTuple;
+    // The colour data domain can be bigint (AG-16608 heatmap); computeColorBins narrows it for the
+    // interpolation maths, so the bigint stays type-visible up to that single boundary.
+    const domainTuple: [number | bigint, number | bigint] = [dataDomain[0], dataDomain.at(-1)!];
+    const displayDomain: [number | bigint, number | bigint] = colorScaleProps.domain ?? domainTuple;
 
     const { domain, range } = computeColorBins(colorScaleProps.fills, displayDomain, colorScaleProps.mode);
     colorScale.mode = colorScaleProps.mode;

--- a/packages/ag-charts-core/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-core/src/scale/colorScaleUtil.ts
@@ -29,8 +29,9 @@ export interface ColorScaleState {
      * The user-visible domain shown on the gradient legend axis. Independent
      * of `domain`, which carries interpolation pivots derived from the fill
      * stops. When omitted, defaults to `[domain[0], domain.at(-1)]`.
+     * Can be bigint (AG-16608 heatmap); narrowed to Number where used.
      */
-    displayDomain?: [number, number];
+    displayDomain?: [number | bigint, number | bigint];
 }
 
 function toNumberOrUndefined(stop: number | bigint | undefined): number | undefined {
@@ -112,7 +113,7 @@ interface ColorBins {
  */
 export function computeColorBins(
     fills: ColorScaleColorStop[],
-    domain: [number, number],
+    domain: [number | bigint, number | bigint],
     mode: ColorScaleMode
 ): ColorBins {
     if (fills.length === 0) {
@@ -176,10 +177,9 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
     const { domain, range, mode, displayDomain } = colorScale;
     if (range.length === 0) return [];
 
-    // Normalised stops are [0,1] fractions, so a bigint colour domain (AG-16608 heatmap) narrows to
-    // Number; bigint/Number mixing and the Math-based clamp() below both throw otherwise.
-    const numericDomain = domain.map(Number);
-    const [d0, d1] = displayDomain ? displayDomain.map(Number) : [numericDomain[0], numericDomain.at(-1)!];
+    // `domain` holds Number interpolation pivots. `displayDomain` is the user-visible range and can be
+    // bigint (AG-16608 heatmap), so narrow it to Number for the [0,1] fraction maths below.
+    const [d0, d1] = displayDomain ? [Number(displayDomain[0]), Number(displayDomain[1])] : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
 
     if (mode === 'discrete') {
@@ -187,8 +187,8 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
         // boundaries outside `displayDomain` collapse to the nearest edge.
         const stops: GradientColorStop[] = [];
         for (let i = 0; i < range.length; i++) {
-            const start = clamp(0, (numericDomain[i] - d0) / extent, 1);
-            const end = clamp(0, (numericDomain[i + 1] - d0) / extent, 1);
+            const start = clamp(0, (domain[i] - d0) / extent, 1);
+            const end = clamp(0, (domain[i + 1] - d0) / extent, 1);
             if (end < start) continue;
             stops.push({ stop: start, color: range[i] });
             if (end > start) stops.push({ stop: end, color: range[i] });
@@ -198,12 +198,12 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
 
     // Continuous mode: if domain has fewer entries than range (fallback path
     // with a 2-element domain and N colours), evenly space the stops.
-    if (numericDomain.length < range.length) {
+    if (domain.length < range.length) {
         const count = Math.max(range.length - 1, 1);
         return range.map((color, i) => ({ stop: i / count, color }));
     }
 
-    return numericDomain.map((v, i) => ({ stop: (v - d0) / extent, color: range[i] }));
+    return domain.map((v, i) => ({ stop: (v - d0) / extent, color: range[i] }));
 }
 
 /** Formats a discrete bin range label from its boundaries. */

--- a/packages/ag-charts-core/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-core/src/scale/colorScaleUtil.ts
@@ -119,7 +119,10 @@ export function computeColorBins(
         return { domain: [], range: [], bins: [] };
     }
 
-    const [d0, d1] = domain;
+    // The colour domain originates from the colorKey extent, which can be bigint (AG-16608 heatmap).
+    // Narrow to Number for the interpolation/clamp maths below; mixing bigint with number throws.
+    const d0 = Number(domain[0]);
+    const d1 = Number(domain[1]);
     const isDiscrete = mode === 'discrete';
     const resolvedStops = resolveStopPositions(fills, d0, d1, isDiscrete);
     const resolvedColors = fills.map((fill) => fill.color);
@@ -173,7 +176,10 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
     const { domain, range, mode, displayDomain } = colorScale;
     if (range.length === 0) return [];
 
-    const [d0, d1] = displayDomain ?? [domain[0], domain.at(-1)!];
+    // Normalised stops are [0,1] fractions, so a bigint colour domain (AG-16608 heatmap) narrows to
+    // Number; bigint/Number mixing and the Math-based clamp() below both throw otherwise.
+    const numericDomain = domain.map(Number);
+    const [d0, d1] = displayDomain ? displayDomain.map(Number) : [numericDomain[0], numericDomain.at(-1)!];
     const extent = d1 - d0 || 1;
 
     if (mode === 'discrete') {
@@ -181,8 +187,8 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
         // boundaries outside `displayDomain` collapse to the nearest edge.
         const stops: GradientColorStop[] = [];
         for (let i = 0; i < range.length; i++) {
-            const start = clamp(0, (domain[i] - d0) / extent, 1);
-            const end = clamp(0, (domain[i + 1] - d0) / extent, 1);
+            const start = clamp(0, (numericDomain[i] - d0) / extent, 1);
+            const end = clamp(0, (numericDomain[i + 1] - d0) / extent, 1);
             if (end < start) continue;
             stops.push({ stop: start, color: range[i] });
             if (end > start) stops.push({ stop: end, color: range[i] });
@@ -192,12 +198,12 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
 
     // Continuous mode: if domain has fewer entries than range (fallback path
     // with a 2-element domain and N colours), evenly space the stops.
-    if (domain.length < range.length) {
+    if (numericDomain.length < range.length) {
         const count = Math.max(range.length - 1, 1);
         return range.map((color, i) => ({ stop: i / count, color }));
     }
 
-    return domain.map((v, i) => ({ stop: (v - d0) / extent, color: range[i] }));
+    return numericDomain.map((v, i) => ({ stop: (v - d0) / extent, color: range[i] }));
 }
 
 /** Formats a discrete bin range label from its boundaries. */

--- a/packages/ag-charts-core/src/utils/data/extent.ts
+++ b/packages/ag-charts-core/src/utils/data/extent.ts
@@ -5,7 +5,15 @@ import { isNumber } from '../types/typeGuards';
 // against the Number Infinity seed and between bigints are legal — only +/-/* mixing throws.
 const isFiniteEndpoint = (v: number | bigint) => typeof v === 'bigint' || Number.isFinite(v);
 
-export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, number] | null {
+// Date/number inputs yield a Number extent; only a bigint input carries bigint endpoints. The overloads
+// keep bigint out of the result type for the common (Date/number) callers, so it never percolates falsely.
+export function extent(
+    values: readonly (number | Date | null | undefined)[],
+    sortOrder?: 1 | -1
+): [number, number] | null;
+export function extent(values: readonly (bigint | null | undefined)[], sortOrder?: 1 | -1): [bigint, bigint] | null;
+export function extent(values: readonly unknown[], sortOrder?: 1 | -1): [number | bigint, number | bigint] | null;
+export function extent(values: readonly unknown[], sortOrder?: 1 | -1): [number | bigint, number | bigint] | null {
     if (values.length === 0) {
         return null;
     }
@@ -18,7 +26,7 @@ export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, num
         const v1 = last instanceof Date ? last.getTime() : last;
 
         if ((typeof v0 === 'number' || typeof v0 === 'bigint') && (typeof v1 === 'number' || typeof v1 === 'bigint')) {
-            return (sortOrder === 1 ? [v0, v1] : [v1, v0]) as [number, number];
+            return sortOrder === 1 ? [v0, v1] : [v1, v0];
         }
     }
 
@@ -36,7 +44,7 @@ export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, num
         }
     }
 
-    return isFiniteEndpoint(min) && isFiniteEndpoint(max) ? ([min, max] as [number, number]) : null;
+    return isFiniteEndpoint(min) && isFiniteEndpoint(max) ? [min, max] : null;
 }
 
 export function normalisedExtentWithMetadata<T>(
@@ -51,10 +59,12 @@ export function normalisedExtentWithMetadata<T>(
     let clipped = false;
 
     const domainExtentNumbers = extent(d, sortOrder);
+    // `toValue` is only supplied for Date domains, whose extent is always Number; a bigint number-axis
+    // domain takes the un-mapped branch and passes its exact endpoints straight through as T.
     const domainExtent =
         domainExtentNumbers && toValue
-            ? [toValue(domainExtentNumbers[0]), toValue(domainExtentNumbers[1])]
-            : (domainExtentNumbers as [T, T]);
+            ? [toValue(Number(domainExtentNumbers[0])), toValue(Number(domainExtentNumbers[1]))]
+            : (domainExtentNumbers as [T, T] | null);
 
     if (domainExtent == null) {
         let nullExtent: T[] | undefined;

--- a/packages/ag-charts-enterprise/src/series/bigintRenderSmoke.test.ts
+++ b/packages/ag-charts-enterprise/src/series/bigintRenderSmoke.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setupMockCanvas, setupMockConsole, waitForChartStability } from 'ag-charts-community-test';
+import type { AgChartOptions } from 'ag-charts-types';
+
+import { createEnterpriseChart } from '../test/utils';
+
+/**
+ * Render smoke test for large `bigint` data values across enterprise series families.
+ *
+ * Companion to the community smoke test: the `isNegative` crash (Math.sign throws on bigint) reached
+ * production via a number-only operation on a bigint data value. This renders each enterprise family
+ * with values beyond Number.MAX_SAFE_INTEGER and asserts the render completes without throwing.
+ */
+
+const BIG = 9_007_199_254_740_993n; // MAX_SAFE_INTEGER + 2
+const NEG_BIG = -9_007_199_254_740_993n;
+
+const numericAxes = { x: { type: 'number' as const }, y: { type: 'number' as const } };
+
+const rangeData = [
+    { x: 1, lo: NEG_BIG, hi: BIG },
+    { x: 2, lo: NEG_BIG * 2n, hi: BIG * 2n },
+    { x: 3, lo: NEG_BIG, hi: BIG * 3n },
+];
+
+const boxData = [
+    { x: 1, min: NEG_BIG, q1: NEG_BIG / 2n, median: 0n, q3: BIG / 2n, max: BIG },
+    { x: 2, min: NEG_BIG * 2n, q1: NEG_BIG, median: BIG / 2n, q3: BIG, max: BIG * 2n },
+];
+
+const heatmapData = [
+    { col: 'a', row: 'x', temp: BIG },
+    { col: 'a', row: 'y', temp: NEG_BIG },
+    { col: 'b', row: 'x', temp: BIG * 2n },
+];
+
+const waterfallData = [
+    { x: 'a', amount: BIG },
+    { x: 'b', amount: NEG_BIG },
+    { x: 'c', amount: BIG * 2n },
+];
+
+const cases: Array<{ name: string; options: AgChartOptions }> = [
+    {
+        name: 'range-bar',
+        options: {
+            data: rangeData,
+            series: [{ type: 'range-bar', xKey: 'x', yLowKey: 'lo', yHighKey: 'hi' }],
+            axes: numericAxes,
+        },
+    },
+    {
+        name: 'range-area',
+        options: {
+            data: rangeData,
+            series: [{ type: 'range-area', xKey: 'x', yLowKey: 'lo', yHighKey: 'hi' }],
+            axes: numericAxes,
+        },
+    },
+    {
+        name: 'box-plot',
+        options: {
+            data: boxData,
+            series: [
+                {
+                    type: 'box-plot',
+                    xKey: 'x',
+                    minKey: 'min',
+                    q1Key: 'q1',
+                    medianKey: 'median',
+                    q3Key: 'q3',
+                    maxKey: 'max',
+                },
+            ],
+            axes: { x: { type: 'category' as const }, y: { type: 'number' as const } },
+        },
+    },
+    {
+        name: 'heatmap',
+        options: {
+            data: heatmapData,
+            series: [{ type: 'heatmap', xKey: 'col', yKey: 'row', colorKey: 'temp' }],
+            axes: { x: { type: 'category' as const }, y: { type: 'category' as const } },
+        },
+    },
+    {
+        name: 'waterfall',
+        options: {
+            data: waterfallData,
+            series: [{ type: 'waterfall', xKey: 'x', yKey: 'amount' }],
+            axes: { x: { type: 'category' as const }, y: { type: 'number' as const } },
+        },
+    },
+];
+
+describe('enterprise series bigint render smoke', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let chart: Awaited<ReturnType<typeof createEnterpriseChart>> | undefined;
+
+    afterEach(() => {
+        chart?.destroy();
+        chart = undefined;
+    });
+
+    it.each(cases)('renders $name with out-of-safe-range bigint values', async ({ options }) => {
+        chart = await createEnterpriseChart(options);
+        await waitForChartStability(chart);
+        expect(chart).toBeDefined();
+    });
+});

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -277,7 +277,9 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         } else {
             const yCurrIndex = dataModel.resolveProcessedDataIndexById(this, 'yCurrent');
             const yExtent = values[yCurrIndex];
-            const fixedYExtent = [Math.min(0, yExtent[0]), Math.max(0, yExtent[1])];
+            // The cumulative extent can be bigint; narrow to Number for the domain (finite precision,
+            // consistent with bar) since Math.min/max throw on bigint.
+            const fixedYExtent = [Math.min(0, Number(yExtent[0])), Math.max(0, Number(yExtent[1]))];
             return { domain: fixNumericExtent(fixedYExtent) };
         }
     }


### PR DESCRIPTION
## What

Stacked on #6954 (PR8). A per-family **render smoke test** — added here for community (`bar`, `line`, `area`, `scatter`, `bubble`, `histogram`) and enterprise (`range-bar`, `range-area`, `box-plot`, `heatmap`, `waterfall`) cartesian families — flushed out three `isNegative`-class crashes: number-only math performed on a `bigint` data value, reachable now that the public types (PR4) widened to accept `bigint`.

Only `bar` was render-tested before (via the docs example that caught the original `isNegative` crash). This closes the open question from the AG-16608 plan: *do the other families render large bigint values?* — three did not.

## Crashes fixed

| Family | Site | Cause |
|---|---|---|
| **area** | `areaSeries.ts` `handleDatum` | unary `+` on the cumulative bigint threw; `Number.isFinite(bigint)` also dropped the point |
| **waterfall** | `waterfallSeries.ts` `getSeriesDomain` | `Math.min/max` on the bigint cumulative extent |
| **heatmap** | `colorScaleUtil.ts` `computeColorBins` + `deriveNormalizedStops`, `colorScale.ts` `convert` | bigint colour domain/value mixed with the Number colour maths |

## Approach

Each site narrows `bigint` → `Number` for the **position / colour** arithmetic (finite precision, consistent with how bar positions already work). Raw `bigint` values are untouched on the datum, so tooltips and labels keep full precision. Area validity switches from `Number.isFinite` to the existing `isContinuous` predicate, which accepts `bigint`.

## Verification

- New smoke tests: community 6/6, enterprise 5/5 green.
- No regressions: existing `colorScale`, `colorScaleUtil`, `areaSeries` (328 tests), `heatmap` + `waterfall` (81 tests) suites pass.
- `build:types`, `lint`, `format` clean across core/community/enterprise.