### PR TITLE
fix(ci): always build both UMD bundles for PR preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,15 @@ jobs:
               run: |
                   yarn nx ${{ github.event.inputs.nx_command || 'affected' }} -t build --exclude all,ag-charts-website
 
-            - name: Upload UMD bundles for PR preview
+            # The enterprise UMD loads ag-charts-community at runtime, so publish both even when `nx affected` rebuilt only one.
+            - name: Build UMD bundles for PR preview
+              id: build_umd
               if: github.event_name == 'pull_request' && steps.build.outcome == 'success'
+              run: |
+                  yarn nx run-many -t build:umd -p ag-charts-community ag-charts-enterprise
+
+            - name: Upload UMD bundles for PR preview
+              if: github.event_name == 'pull_request' && steps.build_umd.outcome == 'success'
               uses: actions/upload-artifact@v4
               with:
                   name: pr-preview-umd


### PR DESCRIPTION
## Summary

The **PR Preview (UMD)** job fails on enterprise-only (or community-only) PRs with `::error exactly one UMD bundle present; expected both or neither.` — e.g. [run on #6957](https://github.com/ag-grid/ag-charts/actions/runs/26687182984/job/78657569312).

### Root cause

The build job runs `nx affected -t build`, so only the UMD of the package(s) a PR touches gets rebuilt and uploaded. An enterprise-only change therefore uploads `ag-charts-enterprise.min.js` without a matching `ag-charts-community.min.js`.

The publish step rejected this — **correctly**: the enterprise UMD externalises `ag-charts-community` (`packages/ag-charts-enterprise/project.json`) and is loaded alongside the community UMD as two separate `<script>` tags in the Plunker preview. A one-sided publish would 404 on the community URL and produce a broken preview. The two bundles must always be published together and built from the same checkout to stay version-consistent.

### Fix

Add a PR-only `Build UMD bundles for PR preview` step that forces both UMDs before upload:

```yaml
yarn nx run-many -t build:umd -p ag-charts-community ag-charts-enterprise
```

The unchanged package's `build:umd` is a cheap cache hit. The upload step is now gated on this step's success. The publish step's "exactly one → error" branch stays as a safety net that should no longer trigger.

## Test plan

- [x] Ran the exact workflow command locally — both bundles + sourcemaps produced at the upload paths:
  - `packages/ag-charts-community/dist/umd/ag-charts-community.min.js(.map)`
  - `packages/ag-charts-enterprise/dist/umd/ag-charts-enterprise.min.js(.map)`
- [x] Workflow YAML validated
- [ ] Green PR Preview (UMD) run on this PR (this PR is itself tooling-only, so it exercises the *neither-present* skip path; the *both-present* path is covered by any code PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)