### PR TITLE
AG-17306 Update cross lines module registration docs

### DIFF
--- a/packages/ag-charts-website/src/content/docs/axes-cross-lines/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-cross-lines/index.mdoc
@@ -78,7 +78,9 @@ In this configuration:
 
 Cross Lines are also available for Polar Axes. These have the same configuration as the Cartesian Cross Lines.
 
-Polar charts use a separate `PolarCrossLinesModule` (Enterprise). Register it instead of `CrossLinesModule` on polar charts, or register both when an application mixes Cartesian and Polar charts.
+{% note %}
+Polar Cross Lines are not included in `CrossLinesModule`. Register `PolarCrossLinesModule` separately when using [module imports](/module-registry).
+{% /note %}
 
 {% chartExampleRunner title="Polar Axis Angle Crosslines" name="polar-axes-crosslines-angle" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/axes-cross-lines/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-cross-lines/index.mdoc
@@ -79,7 +79,7 @@ In this configuration:
 Cross Lines are also available for Polar Axes. These have the same configuration as the Cartesian Cross Lines.
 
 {% note %}
-Polar Cross Lines are not included in `CrossLinesModule`. Register `PolarCrossLinesModule` separately when using [module imports](/module-registry).
+Polar Cross Lines are not included in `CrossLinesModule`. Register `PolarCrossLinesModule` separately when using [module imports](./module-registry/).
 {% /note %}
 
 {% chartExampleRunner title="Polar Axis Angle Crosslines" name="polar-axes-crosslines-angle" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -47,7 +47,7 @@ The full list of breaking changes across all features for version {% migrationVe
 
 This release includes the following breaking changes:
 
-- `CrossLinesModule` and `PolarCrossLinesModule` must be explicitly registered, if not using `AllCommunityModule` or `AllEnterpriseModule`.
+- `CrossLinesModule` and `PolarCrossLinesModule` must be explicitly registered, if not using module bundles.
 
 {% /expandingSection %}
 

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -37,21 +37,19 @@ DO NOT TOUCH.
 
 <!-- If breaking changes do *not* exist, add the following: -->
 
-There are no breaking changes in AG Charts version {% migrationVersion() %}.
+<!-- There are no breaking changes in AG Charts version {% migrationVersion() %}. -->
 
 <!-- Otherwise -->
-<!--
+
 The full list of breaking changes across all features for version {% migrationVersion() %}.
 
 {% expandingSection headerText="Breaking Changes" %}
+
 This release includes the following breaking changes:
 
-### Breaking changes section Name
-
-- item...
+- `CrossLinesModule` and `PolarCrossLinesModule` must be explicitly registered, if not using `AllCommunityModule` or `AllEnterpriseModule`.
 
 {% /expandingSection %}
--->
 
 ## Behaviour Changes
 

--- a/packages/ag-charts-website/src/content/module-mappings/modules.json
+++ b/packages/ag-charts-website/src/content/module-mappings/modules.json
@@ -306,6 +306,11 @@
             "name": "Data Elements",
             "children": [
                 {
+                    "moduleName": "CrossLinesModule",
+                    "name": "Cross Lines",
+                    "path": "axes-cross-lines"
+                },
+                {
                     "moduleName": "LegendModule",
                     "name": "Legend",
                     "path": "legend"
@@ -314,17 +319,6 @@
                     "moduleName": "AnnotationsModule",
                     "name": "Annotations",
                     "path": "annotations",
-                    "isEnterprise": true
-                },
-                {
-                    "moduleName": "CrossLinesModule",
-                    "name": "Cross Lines",
-                    "path": "axes-cross-lines"
-                },
-                {
-                    "moduleName": "PolarCrossLinesModule",
-                    "name": "Polar Cross Lines",
-                    "path": "axes-cross-lines/#polar-axes-cross-lines",
                     "isEnterprise": true
                 },
                 {
@@ -337,6 +331,12 @@
                     "moduleName": "GradientLegendModule",
                     "name": "Gradient Legend",
                     "path": "heatmap-series/#gradient-legend",
+                    "isEnterprise": true
+                },
+                {
+                    "moduleName": "PolarCrossLinesModule",
+                    "name": "Polar Cross Lines",
+                    "path": "axes-cross-lines/#polar-axes-cross-lines",
                     "isEnterprise": true
                 }
             ]
@@ -374,6 +374,12 @@
                     "isEnterprise": true
                 },
                 {
+                    "moduleName": "SelectionModule",
+                    "name": "Data Selection",
+                    "path": "selection",
+                    "isEnterprise": true
+                },
+                {
                     "moduleName": "FlashOnUpdateModule",
                     "name": "Flash On Update",
                     "path": "flash-on-update",
@@ -395,12 +401,6 @@
                     "moduleName": "ScrollbarModule",
                     "name": "Scrollbar",
                     "path": "scrollbar",
-                    "isEnterprise": true
-                },
-                {
-                    "moduleName": "SelectionModule",
-                    "name": "Data Selection",
-                    "path": "selection",
                     "isEnterprise": true
                 },
                 {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17306

- Rewrite the polar cross lines module registration note as a `{% note %}` callout for clarity
- Add `CrossLinesModule` and `PolarCrossLinesModule` explicit registration as a breaking change in the v14 upgrade guide
- Reorder `modules.json` entries to group cross lines and selection modules more logically

Fix #AG-17306