### PR TITLE
fix: remove duplicate OrganizationSeriesModule entry from module mappings

### DIFF
--- a/packages/ag-charts-website/src/content/module-mappings/modules.json
+++ b/packages/ag-charts-website/src/content/module-mappings/modules.json
@@ -222,12 +222,6 @@
                     "name": "Pyramid Series",
                     "path": "pyramid-series",
                     "isEnterprise": true
-                },
-                {
-                    "moduleName": "OrganizationSeriesModule",
-                    "name": "Organization Series",
-                    "path": "org-chart",
-                    "isEnterprise": true
                 }
             ]
         },


### PR DESCRIPTION
## Summary

- Removes a duplicate `OrganizationSeriesModule` entry from `packages/ag-charts-website/src/content/module-mappings/modules.json`

## Test plan

- [ ] Verify the org chart docs page still renders correctly with the module mapping intact (the first entry remains)