### PR TITLE
AG-17377 Fix docs: highlight.enabled references and series/axes update warning

### DIFF
--- a/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
@@ -61,6 +61,10 @@ The following example demonstrates both create and update cases:
 
 To assist with state management, the complete applied options state can be retrieved by calling the `getOptions()` method on the `AgChartInstance`.
 
+{% warning %}
+When updating `series` or `axes` options, the complete array must be supplied with all the properties for each item.
+{% /warning %}
+
 {% apiReference id="_AgChartInstanceInterface" include=["updateDelta", "getOptions"] hideHeader=true hideRequired=true /%}
 
 The following example demonstrates:

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/index.mdoc
@@ -177,7 +177,7 @@ In this configuration:
 
 {% chartExampleRunner title="Highlighting" name="highlight" type="generated" /%}
 
-Each sunburst highlight state exposes a separate style object. Set `highlight.enabled` to `false` to suppress highlighting entirely.
+Each sunburst highlight state exposes a separate style object.
 
 - `highlightedItem` – the hovered segment.
 - `highlightedBranch` – All segments that share the same root node.

--- a/packages/ag-charts-website/src/content/docs/treemap-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/index.mdoc
@@ -224,7 +224,7 @@ Treemap Series supports multiple levels within a hierarchy.
 
 {% chartExampleRunner title="Highlighting" name="highlight" type="generated" /%}
 
-Treemaps leaf tiles are configured via `tile.highlight`, while group rectangles use `group.highlight`. Set `tile.highlight.enabled` or `group.highlight.enabled` to `false` to suppress highlighting for that element type.
+Treemaps leaf tiles are configured via `tile.highlight`, while group rectangles use `group.highlight`.
 
 The leaf tiles support the following states:
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17377

- Remove incorrect `highlight.enabled` references from Treemap and Sunburst series docs (this option does not exist on these series types).
- Add a warning on the Create/Update page clarifying that when updating `series` or `axes` options, the complete array must be supplied with all properties for each item.

Fix #AG-17377