### PR TITLE
ci: disable git auto-gc to stop shallow-fetch race in job setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ on:
                     - 'run-many'
 
 env:
+    # Disable git's post-fetch background gc/maintenance for every git invocation
+    # (injected via git's GIT_CONFIG_* protocol). Otherwise it rewrites .git/shallow
+    # concurrently with the next chained `git fetch --depth 1`, intermittently failing
+    # job setup with "fatal: shallow file has changed since we read it".
+    GIT_CONFIG_COUNT: 2
+    GIT_CONFIG_KEY_0: gc.auto
+    GIT_CONFIG_VALUE_0: '0'
+    GIT_CONFIG_KEY_1: maintenance.auto
+    GIT_CONFIG_VALUE_1: 'false'
     NX_NO_CLOUD: true
     NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     NX_BRANCH: ${{ github.ref }}


### PR DESCRIPTION
## Summary

Fixes the recurring `fatal: shallow file has changed since we read it` failures during CI job setup (e.g. [this run](https://github.com/ag-grid/ag-charts/actions/runs/26770623682/job/78909540377)).

### Root cause

Every CI job does a shallow `actions/checkout` (`fetch-depth: 1`), then a chain of `git fetch --depth 1 …` calls (the inline "Fetch Refs" step plus more inside the `setup-nx` composite action). On completion, `git fetch` spawns a **detached, background** `git maintenance run --auto` (older git: `git gc --auto`). On a shallow repo that background process rewrites `.git/shallow`. The *next* fetch in the chain reads `.git/shallow`, and when it goes to commit its own update it detects the file changed underneath it and aborts:

```
fatal: shallow file has changed since we read it
```

It's intermittent because it depends on the detached maintenance process from the *previous* fetch overlapping the *next* one — hence "recurring but not every time".

### Fix

Inject `gc.auto=0` and `maintenance.auto=false` into **every** git invocation in the workflow via git's `GIT_CONFIG_*` env protocol (a single top-level `env:` addition). No fetch spawns background maintenance, so the race window disappears entirely. Applied at the workflow level rather than per-fetch because the fetch that *fails* (in `setup-nx`) races with maintenance spawned by an *earlier* step — so the config must be in effect from `checkout` onward, across every git process.

### Test plan

- This only takes effect in CI. Confirmed the YAML parses (`yq`) and the `env` block is intact.
- CI on this PR exercises the same shallow-fetch setup path that was failing.

### Follow-up (not in this PR)

The same shallow-fetch pattern exists in `beta-publish.yml`, `prod-release.yml`, `benchmark.yml`, and the shared `setup-nx` action (when invoked from those workflows). They aren't covered by this workflow-level env and could benefit from the same treatment if they exhibit the failure.