### PR TITLE
AG-16608 Make scale/axis bigint types honest; sum aggregates exactly

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -11,7 +11,7 @@ import { CartesianAxis } from './cartesianAxis';
 
 export class NumberAxis<
     TOptions extends NormalisedNumberAxisOptions = NormalisedNumberAxisOptions,
-> extends CartesianAxis<LinearScale | LogScale, number, TOptions> {
+> extends CartesianAxis<LinearScale | LogScale, number | bigint, TOptions> {
     static readonly className: string = 'NumberAxis';
     static readonly type: string = 'number';
 

--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -33,7 +33,7 @@ export class NumberAxis<
         return this.options.label.format;
     }
 
-    override normaliseDataDomain(d: DomainWithMetadata<number>) {
+    override normaliseDataDomain(d: DomainWithMetadata<number | bigint>) {
         const { min, max, preferredMin, preferredMax } = this.options;
         const { extent, clipped } = normalisedExtentWithMetadata(
             d.domain,
@@ -52,7 +52,7 @@ export class NumberAxis<
         return [this.options.min == null && this.nice, this.options.max == null && this.nice];
     }
 
-    protected getVisibleDomain(domain: number[]): [number, number] {
+    protected getVisibleDomain(domain: (number | bigint)[]): [number, number] {
         // Narrow to Number: a bigint domain reaches here as formatter-context metadata only — the tick
         // label itself carries the exact bigint value, so this range context can narrow safely.
         const d0 = Number(domain[0]);
@@ -62,7 +62,11 @@ export class NumberAxis<
         return [d0 + r0 * length, d1 - (1 - r1) * length];
     }
 
-    override tickFormatParams(domain: number[], _ticks: number[], fractionDigits?: number): AxisTickFormatParams {
+    override tickFormatParams(
+        domain: (number | bigint)[],
+        _ticks: (number | bigint)[],
+        fractionDigits?: number
+    ): AxisTickFormatParams {
         return { type: 'number', visibleDomain: this.getVisibleDomain(domain), fractionDigits };
     }
 

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -16,6 +16,7 @@ import {
     lowestGranularityUnitForTicks,
     lowestGranularityUnitForValue,
     normalisedTimeExtentWithMetadata,
+    timeValueToNumber,
 } from 'ag-charts-core';
 import type {
     AgTimeInterval,
@@ -137,7 +138,7 @@ export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTim
         style: DateFormatterStyle
     ): FormatterParams<any> {
         if (!(value instanceof Date)) {
-            value = new Date(typeof value === 'bigint' ? Number(value) : value);
+            value = new Date(timeValueToNumber(value));
         }
 
         if (timeInterval == null) {

--- a/packages/ag-charts-community/src/chart/data/aggregateFunctions.test.ts
+++ b/packages/ag-charts-community/src/chart/data/aggregateFunctions.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from 'vitest';
 
-import { accumulatedValue, addAccumulated, trailingAccumulatedValue } from './aggregateFunctions';
+import { accumulatedValue, addAccumulated, sumValues, trailingAccumulatedValue } from './aggregateFunctions';
 
 describe('aggregateFunctions bigint support (AG-16608)', () => {
+    describe('sumValues', () => {
+        it('splits numbers into negative and positive sums', () => {
+            expect(sumValues([1, -2, 3, -4])).toEqual([-6, 4]);
+        });
+
+        it('sums bigint values in bigint so a large-magnitude total stays exact', () => {
+            // The negative side keeps its untouched Number seed; the positive side promotes to bigint.
+            expect(sumValues([2n, -3n, 5n])).toEqual([-3n, 7n]);
+        });
+
+        it('preserves precision beyond Number.MAX_SAFE_INTEGER', () => {
+            const big = 9_007_199_254_740_993n; // 2^53 + 1, not representable as a Number
+            expect(sumValues([big, big])).toEqual([0, 18_014_398_509_481_986n]);
+        });
+    });
+
     describe('addAccumulated', () => {
         it('adds two numbers', () => {
             expect(addAccumulated(2, 3)).toBe(5);

--- a/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -14,23 +14,29 @@ export function addAccumulated(acc: number | bigint, value: number | bigint): nu
     return acc + value;
 }
 
-export function sumValues(values: any[], accumulator: [number, number] = [0, 0]) {
+export function sumValues(
+    values: any[],
+    accumulator: [number | bigint, number | bigint] = [0, 0]
+): [number | bigint, number | bigint] {
     for (const value of values) {
-        if (typeof value !== 'number') {
+        if (typeof value !== 'number' && typeof value !== 'bigint') {
             continue;
         }
+        // Sum in bigint when a value is bigint so a large-magnitude total stays exact (addAccumulated
+        // promotes the 0 seed). The opposite-sign side keeps its untouched Number seed — hence the mixed
+        // accumulator type; downstream consumers recombine the two sides with addAccumulated.
         if (value < 0) {
-            accumulator[0] += value;
+            accumulator[0] = addAccumulated(accumulator[0], value);
         }
         if (value > 0) {
-            accumulator[1] += value;
+            accumulator[1] = addAccumulated(accumulator[1], value);
         }
     }
     return accumulator;
 }
 
 export function sum(id: string, matchGroupId: string) {
-    const result: AggregatePropertyDefinition<any, any> = {
+    const result: AggregatePropertyDefinition<any, any, [number | bigint, number | bigint]> = {
         id,
         matchGroupIds: [matchGroupId],
         type: 'aggregate',
@@ -43,7 +49,7 @@ export function sum(id: string, matchGroupId: string) {
 export function groupSum(
     id: string,
     opts?: { matchGroupId?: string; visible?: boolean }
-): AggregatePropertyDefinition<any, any> {
+): AggregatePropertyDefinition<any, any, [number | bigint, number | bigint]> {
     const visible = opts?.visible ?? true;
     return {
         id,
@@ -52,8 +58,8 @@ export function groupSum(
         aggregateFunction: (values) => sumValues(values),
         groupAggregateFunction: (next, acc = [0, 0]) => {
             if (visible) {
-                acc[0] += next?.[0] ?? 0;
-                acc[1] += next?.[1] ?? 0;
+                acc[0] = addAccumulated(acc[0], next?.[0] ?? 0);
+                acc[1] = addAccumulated(acc[1], next?.[1] ?? 0);
             }
             return acc;
         },
@@ -89,21 +95,27 @@ export function groupCount(id: string, opts?: { visible?: boolean }): AggregateP
 
 export function groupAverage(id: string, opts?: { matchGroupId?: string; visible?: boolean }) {
     const visible = opts?.visible ?? true;
-    const def: AggregatePropertyDefinition<any, any, [number, number], [number, number, number]> = {
+    const def: AggregatePropertyDefinition<
+        any,
+        any,
+        [number | bigint, number | bigint],
+        [number | bigint, number | bigint, number]
+    > = {
         id,
         matchGroupIds: opts?.matchGroupId ? [opts?.matchGroupId] : undefined,
         type: 'aggregate',
         aggregateFunction: (values) => sumValues(values),
         groupAggregateFunction: (next, acc = [0, 0, -1]) => {
             if (visible) {
-                acc[0] += next?.[0] ?? 0;
+                acc[0] = addAccumulated(acc[0], next?.[0] ?? 0);
                 acc[2]++;
-                acc[1] += next?.[1] ?? 0;
+                acc[1] = addAccumulated(acc[1], next?.[1] ?? 0);
             }
             return acc;
         },
         finalFunction: (acc = [0, 0, 0]) => {
-            const result = acc[0] + acc[1];
+            // A mean is fractional, so narrow the bigint sums to Number for the division.
+            const result = Number(acc[0]) + Number(acc[1]);
             if (result >= 0) {
                 return [0, result / acc[2]];
             }
@@ -114,14 +126,19 @@ export function groupAverage(id: string, opts?: { matchGroupId?: string; visible
     return def;
 }
 
-export function area(id: string, aggFn: AggregatePropertyDefinition<any, any>, matchGroupId?: string) {
+export function area(id: string, aggFn: AggregatePropertyDefinition<any, any, any>, matchGroupId?: string) {
     const result: AggregatePropertyDefinition<any, any> = {
         id,
         matchGroupIds: matchGroupId ? [matchGroupId] : undefined,
         type: 'aggregate',
         aggregateFunction: (values, keyRange = []) => {
-            const keyWidth = keyRange[1] - keyRange[0];
-            return aggFn.aggregateFunction(values).map((v) => v / keyWidth) as [number, number];
+            // Area is a density (value / key-width) → fractional, so narrow bigint sums and bigint keys to
+            // Number for the division.
+            const keyWidth = Number(keyRange[1]) - Number(keyRange[0]);
+            return aggFn.aggregateFunction(values).map((v: number | bigint) => Number(v) / keyWidth) as [
+                number,
+                number,
+            ];
         },
     };
 

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -4,6 +4,7 @@ import {
     type PluginModuleInstance,
     deriveNormalizedStops,
     formatColorBinLabel,
+    toFiniteNumber,
 } from 'ag-charts-core';
 import type {
     AgChartLegendListeners,
@@ -109,7 +110,9 @@ function deriveNamedLabels(
 
     // The legend axis positions at finite precision, so a bigint displayDomain (AG-16608 heatmap) narrows
     // to Number here; numeric labels are formatted from the exact value elsewhere.
-    const [d0, d1] = displayDomain ? [Number(displayDomain[0]), Number(displayDomain[1])] : [domain[0], domain.at(-1)!];
+    const [d0, d1] = displayDomain
+        ? [toFiniteNumber(displayDomain[0]), toFiniteNumber(displayDomain[1])]
+        : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
     const labels: GradientLegendNamedLabel[] = [];
 
@@ -165,7 +168,7 @@ export function buildGradientLegendDatum(
 ): GradientLegendDatum {
     const { domain, displayDomain, mode } = colorScale;
     const axisDomain: [number, number] = displayDomain
-        ? [Number(displayDomain[0]), Number(displayDomain[1])]
+        ? [toFiniteNumber(displayDomain[0]), toFiniteNumber(displayDomain[1])]
         : [domain[0], domain.at(-1)!];
     const rawStops = deriveNormalizedStops(colorScale);
     const colorStops =

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -4,7 +4,7 @@ import {
     type PluginModuleInstance,
     deriveNormalizedStops,
     formatColorBinLabel,
-    toFiniteNumber,
+    toNumber,
 } from 'ag-charts-core';
 import type {
     AgChartLegendListeners,
@@ -111,7 +111,7 @@ function deriveNamedLabels(
     // The legend axis positions at finite precision, so a bigint displayDomain (AG-16608 heatmap) narrows
     // to Number here; numeric labels are formatted from the exact value elsewhere.
     const [d0, d1] = displayDomain
-        ? [toFiniteNumber(displayDomain[0]), toFiniteNumber(displayDomain[1])]
+        ? [toNumber(displayDomain[0]), toNumber(displayDomain[1])]
         : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
     const labels: GradientLegendNamedLabel[] = [];
@@ -168,7 +168,7 @@ export function buildGradientLegendDatum(
 ): GradientLegendDatum {
     const { domain, displayDomain, mode } = colorScale;
     const axisDomain: [number, number] = displayDomain
-        ? [toFiniteNumber(displayDomain[0]), toFiniteNumber(displayDomain[1])]
+        ? [toNumber(displayDomain[0]), toNumber(displayDomain[1])]
         : [domain[0], domain.at(-1)!];
     const rawStops = deriveNormalizedStops(colorScale);
     const colorStops =

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -16,7 +16,7 @@ import {
     isContinuous,
     isDefined,
     mergeDefaults,
-    toFiniteNumber,
+    toNumber,
 } from 'ag-charts-core';
 import {
     type AgAreaSeriesLabelFormatterParams,
@@ -1067,9 +1067,9 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         scratch.datum = ctx.rawData[datumIndex];
         scratch.yDatum = ctx.yRawValues[datumIndex];
         // Coerce to Number for positioning (bigint values plot at finite precision); the raw value
-        // is retained on yDatum for tooltips. toFiniteNumber guards bigints beyond Number.MAX_VALUE
-        // that would otherwise become Infinity. isContinuous accepts bigint where Number.isFinite would not.
-        scratch.yCumulative = toFiniteNumber(ctx.yCumulativeValues[datumIndex]);
+        // is retained on yDatum for tooltips. toNumber warns once if a bigint beyond Number.MAX_VALUE
+        // coerces to Infinity. isContinuous accepts bigint where Number.isFinite would not.
+        scratch.yCumulative = toNumber(ctx.yCumulativeValues[datumIndex]);
         scratch.validPoint = isContinuous(scratch.yDatum) && ctx.invalidData?.[datumIndex] !== true;
 
         // Compute marker coordinates

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -16,6 +16,7 @@ import {
     isContinuous,
     isDefined,
     mergeDefaults,
+    toFiniteNumber,
 } from 'ag-charts-core';
 import {
     type AgAreaSeriesLabelFormatterParams,
@@ -1066,8 +1067,9 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         scratch.datum = ctx.rawData[datumIndex];
         scratch.yDatum = ctx.yRawValues[datumIndex];
         // Coerce to Number for positioning (bigint values plot at finite precision); the raw value
-        // is retained on yDatum for tooltips. isContinuous accepts bigint where Number.isFinite would not.
-        scratch.yCumulative = Number(ctx.yCumulativeValues[datumIndex]);
+        // is retained on yDatum for tooltips. toFiniteNumber guards bigints beyond Number.MAX_VALUE
+        // that would otherwise become Infinity. isContinuous accepts bigint where Number.isFinite would not.
+        scratch.yCumulative = toFiniteNumber(ctx.yCumulativeValues[datumIndex]);
         scratch.validPoint = isContinuous(scratch.yDatum) && ctx.invalidData?.[datumIndex] !== true;
 
         // Compute marker coordinates

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
@@ -173,6 +173,35 @@ describe('HistogramSeries', () => {
         });
     });
 
+    describe('bigint aggregation (AG-16608)', () => {
+        setupMockCanvas();
+
+        it('sums a bigint yKey column at full precision (aggregation: sum)', async () => {
+            const big = 9_007_199_254_740_993n; // 2^53 + 1, not exactly representable as a Number
+            const options: AgCartesianChartOptions = {
+                data: [
+                    { x: 1, y: big },
+                    { x: 2, y: big },
+                    { x: 3, y: big },
+                ],
+                series: [{ type: 'histogram', xKey: 'x', yKey: 'y', aggregation: 'sum', bins: [[0, 10]] }],
+            };
+            prepareTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const series = chart.series.find((v: any) => v.type === 'histogram');
+            expect(series).toBeDefined();
+
+            const context: SeriesNodeDataContext<any, any> = (series as any)['contextNodeData'];
+            const bin = context.nodeData.find((n: any) => n.aggregatedValue != null);
+            expect(bin).toBeDefined();
+            // 3 × (2^53 + 1) — a narrowing convert() would round this; the bigint sum keeps it exact.
+            expect(bin!.aggregatedValue).toBe(3n * big);
+        });
+    });
+
     describe('Series Labels', () => {
         const examples = {
             HISTOGRAM_SERIES_LABELS: {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -31,7 +31,7 @@ import { Rect } from '../../../scene/shape/rect';
 import type { Text } from '../../../scene/shape/text';
 import type { QuadtreeNearest } from '../../../scene/util/quadtree';
 import type { ChartAxis } from '../../chartAxis';
-import { area, groupAverage, groupCount, groupSum } from '../../data/aggregateFunctions';
+import { addAccumulated, area, groupAverage, groupCount, groupSum } from '../../data/aggregateFunctions';
 import type { DataController } from '../../data/dataController';
 import type {
     AggregatePropertyDefinition,
@@ -97,7 +97,9 @@ interface CalculatedBin {
     groupIndex: number;
     datum: any[];
     frequency: number;
-    total: number;
+    // bigint when summing a bigint yKey column (aggregation 'sum'); the y-scale narrows it for positioning
+    // while the exact value reaches the tooltip via the bin datum's aggregatedValue.
+    total: number | bigint;
 }
 
 interface HistogramSeriesNodeDataContext extends CartesianSeriesNodeDataContext<HistogramNodeDatum> {
@@ -333,7 +335,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                 const [[negativeAgg, positiveAgg] = [0, 0]] = group.aggregation;
                 const datum = [...dataModel.forEachDatum(this, processedData, group, groupIndex)];
                 const frequency = this.frequency(group);
-                const total = negativeAgg + positiveAgg;
+                const total = addAccumulated(negativeAgg, positiveAgg);
                 return { domain, datum, groupIndex, frequency, total };
             } else {
                 return { domain, datum: [], groupIndex: -1, frequency: 0, total: 0 };
@@ -381,7 +383,8 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             const [x0, x1] = findMinMax([xScale.convert(xDomainMin), xScale.convert(xDomainMax)]);
 
             if (x1 >= r0 && x0 <= r1) {
-                const total = negativeAgg + positiveAgg;
+                // Pixel range only: narrow any bigint sum to Number for Math.max.
+                const total = Number(negativeAgg) + Number(positiveAgg);
                 yMax = Math.max(yMax, total);
             }
         }
@@ -772,7 +775,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         const frequency = this.frequency(group);
         const domain = keys;
         const [rangeMin, rangeMax]: number[] = domain;
-        const aggregatedValue = negativeAgg + positiveAgg;
+        const aggregatedValue = addAccumulated(negativeAgg, positiveAgg);
         const datum: AgHistogramBinDatum<any> = {
             data: [...dataModel.forEachDatum(this, processedData, group, datumIndex)],
             aggregatedValue,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
@@ -25,7 +25,7 @@ export interface HistogramNodeDatum extends CartesianSeriesNodeDatum {
     readonly bottomRightCornerRadius: boolean;
     readonly bottomLeftCornerRadius: boolean;
     readonly clipBBox?: BBox;
-    readonly aggregatedValue: number;
+    readonly aggregatedValue: number | bigint;
     readonly frequency: number;
     readonly domain: [number | bigint, number | bigint];
     readonly label?: {

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -419,7 +419,7 @@ export interface HighlightNodeDatum<I extends DatumIndexType = DatumIndexType> e
     readonly radiusKey?: string;
     readonly colorValue?: number;
     readonly cumulativeValue?: number;
-    readonly aggregatedValue?: number;
+    readonly aggregatedValue?: number | bigint;
     readonly domain?: [number, number];
     readonly legendItemName?: string;
 }

--- a/packages/ag-charts-community/src/scale/abstractScale.ts
+++ b/packages/ag-charts-community/src/scale/abstractScale.ts
@@ -17,6 +17,12 @@ export abstract class AbstractScale<D, R, I = number> implements Scale<D, R, I> 
     abstract convert(value: D, options: { clamp?: boolean; alignment?: ScaleAlignment }): R;
     abstract invert(value: R, nearest?: boolean): D | undefined;
     abstract getDomainMinMax(): [D, D] | [undefined, undefined];
+    get domainMin(): D | undefined {
+        return this.getDomainMinMax()[0];
+    }
+    get domainMax(): D | undefined {
+        return this.getDomainMinMax()[1];
+    }
     ticks(
         _ticks: ScaleTickParams<I>,
         _domain?: D[],

--- a/packages/ag-charts-community/src/scale/colorScale.ts
+++ b/packages/ag-charts-community/src/scale/colorScale.ts
@@ -1,5 +1,5 @@
 import type { DomainWithMetadata, NormalizedDomain } from 'ag-charts-core';
-import { Color, Logger, clamp, toFiniteNumber } from 'ag-charts-core';
+import { Color, Logger, clamp, toNumber } from 'ag-charts-core';
 
 import { AbstractScale } from './abstractScale';
 import { Invalidating } from './invalidating';
@@ -108,7 +108,7 @@ export class ColorScale extends AbstractScale<number, string> {
 
         // A bigint colour value (AG-16608 heatmap) narrows to Number: the colour derives from the value's
         // position in the (Number) domain, so finite precision suffices and bigint/Number mixing would throw.
-        const xn = toFiniteNumber(x);
+        const xn = toNumber(x);
 
         const { domain, range, parsedRange } = this;
         const d0 = domain[0];

--- a/packages/ag-charts-community/src/scale/colorScale.ts
+++ b/packages/ag-charts-community/src/scale/colorScale.ts
@@ -1,5 +1,5 @@
 import type { DomainWithMetadata, NormalizedDomain } from 'ag-charts-core';
-import { Color, Logger, clamp } from 'ag-charts-core';
+import { Color, Logger, clamp, toFiniteNumber } from 'ag-charts-core';
 
 import { AbstractScale } from './abstractScale';
 import { Invalidating } from './invalidating';
@@ -108,7 +108,7 @@ export class ColorScale extends AbstractScale<number, string> {
 
         // A bigint colour value (AG-16608 heatmap) narrows to Number: the colour derives from the value's
         // position in the (Number) domain, so finite precision suffices and bigint/Number mixing would throw.
-        const xn = Number(x);
+        const xn = toFiniteNumber(x);
 
         const { domain, range, parsedRange } = this;
         const d0 = domain[0];

--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -4,7 +4,11 @@ import { findMinMax } from 'ag-charts-core';
 import { AbstractScale } from './abstractScale';
 import { unpackDomainMinMax } from './scaleUtil';
 
-export abstract class ContinuousScale<D extends number | Date, I = number> extends AbstractScale<D, number, I> {
+export abstract class ContinuousScale<D extends number | bigint | Date, I = number> extends AbstractScale<
+    D,
+    number,
+    I
+> {
     static is(value: unknown): value is ContinuousScale<any, any> {
         return value instanceof ContinuousScale;
     }
@@ -187,6 +191,22 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         return unpackDomainMinMax(this.domain);
     }
 
+    // True min/max (order-independent), returning the exact endpoint so a bigint domain flows through
+    // as bigint. d0Cache/d1Cache give the ordering even when the bigint endpoints narrow to equal Numbers.
+    private exactEndpoint(index: 0 | 1): D {
+        return ((index === 0 ? this.d0Big : this.d1Big) ?? this._domain[index]) as D;
+    }
+
+    override get domainMin(): D | undefined {
+        if (this._domain.length < 2) return this._domain.at(0);
+        return this.exactEndpoint(this.d0Cache <= this.d1Cache ? 0 : 1);
+    }
+
+    override get domainMax(): D | undefined {
+        if (this._domain.length < 2) return this._domain.at(0);
+        return this.exactEndpoint(this.d0Cache <= this.d1Cache ? 1 : 0);
+    }
+
     protected getPixelRange() {
         const [a, b] = this.range;
         return Math.abs(b - a);
@@ -226,7 +246,7 @@ function convertBigInt(value: bigint, d0: bigint, d1: bigint, range: number[], c
     return r0 + ratio * (r1 - r0);
 }
 
-export function normalizeContinuousDomains<D extends number | Date>(
+export function normalizeContinuousDomains<D extends number | bigint | Date>(
     ...domains: DomainWithMetadata<D>[]
 ): NormalizedDomain<D> {
     let min: D | undefined;
@@ -237,7 +257,8 @@ export function normalizeContinuousDomains<D extends number | Date>(
     for (const input of domains) {
         const domain = input.domain;
         for (const d of domain) {
-            const value = d.valueOf();
+            // Narrow only for min/max selection; the retained endpoint `d` stays exact (incl. bigint).
+            const value = Number(d.valueOf());
             if (value < minValue) {
                 minValue = value;
                 min = d;

--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -36,7 +36,7 @@ export abstract class ContinuousScale<D extends number | bigint | Date, I = numb
 
     set domain(values: readonly (D | bigint)[]) {
         if (!values || values.length < 2) {
-            this._domain = values as D[];
+            this._domain = narrowStoredDomain(values);
             this.d0Big = this.d1Big = undefined;
             this.d0Cache = Number.NaN;
             this.d1Cache = Number.NaN;
@@ -54,12 +54,12 @@ export abstract class ContinuousScale<D extends number | bigint | Date, I = numb
             this.domainNeedsValueOf = false;
             this.d0Cache = Number(d0);
             this.d1Cache = Number(d1);
-            this._domain = values.map((v) => (typeof v === 'bigint' ? Number(v) : v)) as D[];
+            this._domain = narrowStoredDomain(values);
             return;
         }
 
         this.d0Big = this.d1Big = undefined;
-        this._domain = values as D[];
+        this._domain = narrowStoredDomain(values);
 
         // Auto-detect if domain values need valueOf() and cache numeric values
         this.domainNeedsValueOf = d0 != null && typeof d0 === 'object';
@@ -67,8 +67,8 @@ export abstract class ContinuousScale<D extends number | bigint | Date, I = numb
             this.d0Cache = (d0 as Date).valueOf();
             this.d1Cache = (d1 as Date).valueOf();
         } else {
-            this.d0Cache = d0 as unknown as number;
-            this.d1Cache = d1 as unknown as number;
+            this.d0Cache = Number(d0);
+            this.d1Cache = Number(d1);
         }
     }
 
@@ -211,6 +211,14 @@ export abstract class ContinuousScale<D extends number | bigint | Date, I = numb
         const [a, b] = this.range;
         return Math.abs(b - a);
     }
+}
+
+// The stored domain narrows any bigint endpoint to Number (the exact bigint is retained separately in
+// d0Big/d1Big). A narrowed bigint is a Number, which is a valid D for every concrete continuous scale
+// (D is number, number|bigint, or Date — and a Date scale never receives bigint input here), so this is
+// the single assertion that bridges the generic base's storage type.
+function narrowStoredDomain<D extends number | bigint | Date>(values: readonly (D | bigint)[]): D[] {
+    return values.map((v) => (typeof v === 'bigint' ? Number(v) : v)) as D[];
 }
 
 // Integer ratio scale: 10^12 gives ~12 significant digits in [0,1] — far finer than pixel positioning

--- a/packages/ag-charts-community/src/scale/discreteTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/discreteTimeScale.ts
@@ -1,4 +1,4 @@
-import { ScaleAlignment, type ScaleTickParams, findMaxIndex, findMinIndex } from 'ag-charts-core';
+import { ScaleAlignment, type ScaleTickParams, findMaxIndex, findMinIndex, timeValueToNumber } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
 
 import { BandScale } from './bandScale';
@@ -63,7 +63,7 @@ export abstract class DiscreteTimeScale extends BandScale<Date, AgTimeInterval |
     ): { ticks: Date[]; count: number | undefined; firstTickIndex?: number } | undefined;
 
     override toDomain(value: number | bigint): Date {
-        return new Date(typeof value === 'bigint' ? Number(value) : value);
+        return new Date(timeValueToNumber(value));
     }
 
     protected get reversed(): boolean {
@@ -82,7 +82,7 @@ export abstract class DiscreteTimeScale extends BandScale<Date, AgTimeInterval |
     ): number {
         this.refresh();
 
-        if (!(value instanceof Date)) value = new Date(typeof value === 'bigint' ? Number(value) : value);
+        if (!(value instanceof Date)) value = new Date(timeValueToNumber(value));
         const { domain, reversed } = this;
         const numericBands = this.numericBands;
         const bandCount = numericBands.length;

--- a/packages/ag-charts-community/src/scale/linearScale.test.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.test.ts
@@ -375,6 +375,45 @@ describe('LinearScale', () => {
         });
     });
 
+    describe('domainMin / domainMax', () => {
+        test('returns the true min/max of a Number domain regardless of order', () => {
+            const scale = new LinearScale();
+            scale.domain = [100, 0];
+
+            expect(scale.domainMin).toBe(0);
+            expect(scale.domainMax).toBe(100);
+        });
+
+        test('flows the exact bigint endpoints through (no Number narrowing)', () => {
+            const scale = new LinearScale();
+            scale.domain = [0n, 100n];
+
+            expect(scale.domainMin).toBe(0n);
+            expect(scale.domainMax).toBe(100n);
+        });
+
+        test('orders bigint endpoints by value for a descending domain', () => {
+            const scale = new LinearScale();
+            scale.domain = [100n, 0n];
+
+            expect(scale.domainMin).toBe(0n);
+            expect(scale.domainMax).toBe(100n);
+        });
+
+        // The exact bigint must survive even where a Number narrow would collapse adjacent values.
+        test('preserves bigint precision beyond Number.MAX_SAFE_INTEGER', () => {
+            const lo = 10n ** 18n;
+            const hi = lo + 1n;
+            expect(Number(lo)).toBe(Number(hi)); // both collapse to the same Number
+
+            const scale = new LinearScale();
+            scale.domain = [lo, hi];
+
+            expect(scale.domainMin).toBe(lo);
+            expect(scale.domainMax).toBe(hi);
+        });
+    });
+
     describe('ticks bigint', () => {
         const tickParams: ScaleTickParams<number> = {
             nice: [true, true],
@@ -388,22 +427,20 @@ describe('LinearScale', () => {
             const scale = new LinearScale();
             scale.range = [0, 600];
 
-            const { ticks } = scale.ticks(tickParams, [0n, 100n] as unknown as number[]);
+            const { ticks } = scale.ticks(tickParams, [0n, 100n]);
             expect(ticks).toEqual([0n, 20n, 40n, 60n, 80n, 100n]);
         });
 
         test('nices a BigInt domain outward to step multiples', () => {
             const scale = new LinearScale();
-            expect(scale.niceDomain(tickParams, [13n, 97n] as unknown as number[])).toEqual([0n, 100n]);
+            expect(scale.niceDomain(tickParams, [13n, 97n])).toEqual([0n, 100n]);
         });
 
         test('honours a custom interval when nicing a BigInt domain', () => {
             const scale = new LinearScale();
             // With interval 30 the bounds must snap to multiples of 30 (Number path), not the auto
             // bigint step that would otherwise produce [0, 100].
-            expect(scale.niceDomain({ ...tickParams, interval: 30 }, [13n, 97n] as unknown as number[])).toEqual([
-                0, 120,
-            ]);
+            expect(scale.niceDomain({ ...tickParams, interval: 30 }, [13n, 97n])).toEqual([0, 120]);
         });
 
         // AC AG-16608 #15e / #16: ticks beyond Number.MAX_SAFE_INTEGER keep exact values.
@@ -412,7 +449,7 @@ describe('LinearScale', () => {
             scale.range = [0, 600];
 
             const span = 10n ** 21n;
-            const { ticks } = scale.ticks(tickParams, [0n, span] as unknown as number[]);
+            const { ticks } = scale.ticks(tickParams, [0n, span]);
             expect(ticks).toEqual([0n, 2n * 10n ** 20n, 4n * 10n ** 20n, 6n * 10n ** 20n, 8n * 10n ** 20n, span]);
         });
 
@@ -421,7 +458,7 @@ describe('LinearScale', () => {
             scale.range = [0, 100];
 
             // A custom interval is a Number concept; the bigint domain narrows and the Number path runs.
-            const { ticks } = scale.ticks({ ...tickParams, interval: 25 }, [0n, 100n] as unknown as number[]);
+            const { ticks } = scale.ticks({ ...tickParams, interval: 25 }, [0n, 100n]);
             expect(ticks).toEqual([0, 25, 50, 75, 100]);
         });
     });

--- a/packages/ag-charts-community/src/scale/linearScale.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.ts
@@ -14,7 +14,7 @@ import { ContinuousScale } from './continuousScale';
 /**
  * Maps continuous domain to a continuous range.
  */
-export class LinearScale extends ContinuousScale<number> {
+export class LinearScale extends ContinuousScale<number | bigint> {
     static override is(value: unknown): value is LinearScale {
         return value instanceof LinearScale;
     }
@@ -37,24 +37,24 @@ export class LinearScale extends ContinuousScale<number> {
 
     override ticks(
         { interval, tickCount = ContinuousScale.defaultTickCount, minTickCount, maxTickCount }: ScaleTickParams<number>,
-        domain: number[] = this.domain,
+        domain: (number | bigint)[] = this.domain,
         visibleRange?: [number, number]
-    ): { ticks: number[]; count: number; firstTickIndex?: number } {
+    ): { ticks: (number | bigint)[]; count: number; firstTickIndex?: number } {
         if (!domain || domain.length < 2 || tickCount < 1) {
             return { ticks: [], count: 0, firstTickIndex: 0 };
         }
-        const [b0, b1] = domain as readonly (number | bigint)[];
+        const [b0, b1] = domain;
         const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
 
         // Full-precision BigInt ticks for the full (unzoomed) domain. A custom interval or zoomed
         // sub-range falls through to the Number path below — documented limitation (AG-16608 AC #17).
         const fullRange = visibleRange == null || (visibleRange[0] === 0 && visibleRange[1] === 1);
         if (isBigIntDomain && !interval && fullRange) {
-            const ticks = createBigIntTicks(b0, b1, tickCount) as unknown as number[];
+            const ticks = createBigIntTicks(b0, b1, tickCount);
             return { ticks, count: ticks.length, firstTickIndex: 0 };
         }
 
-        const numericDomain = isBigIntDomain ? domain.map(Number) : domain;
+        const numericDomain: number[] = isBigIntDomain ? domain.map(Number) : (domain as number[]);
         if (!numericDomain.every(Number.isFinite)) {
             return { ticks: [], count: 0, firstTickIndex: 0 };
         }
@@ -73,22 +73,25 @@ export class LinearScale extends ContinuousScale<number> {
         return createTicks(d0, d1, tickCount, minTickCount, maxTickCount, visibleRange);
     }
 
-    override niceDomain(ticks: ScaleTickParams<number>, domain: number[] = this.domain) {
+    override niceDomain(
+        ticks: ScaleTickParams<number>,
+        domain: (number | bigint)[] = this.domain
+    ): (number | bigint)[] {
         if (domain.length < 2) return [];
 
         const { tickCount = ContinuousScale.defaultTickCount } = ticks;
 
-        const [b0, b1] = domain as readonly (number | bigint)[];
+        const [b0, b1] = domain;
         const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
 
         // Bigint nicing only for the auto-step path; a custom interval is a Number concept (matches
         // ticks()), so it falls through below — else bounds would snap to an unrelated auto step.
         if (isBigIntDomain && ticks.interval == null) {
             const [n0, n1] = niceBigIntDomain(b0, b1, tickCount);
-            return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1] as unknown as number[];
+            return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1];
         }
 
-        const numericDomain = isBigIntDomain ? domain.map(Number) : domain;
+        const numericDomain: number[] = isBigIntDomain ? domain.map(Number) : (domain as number[]);
         let [start, stop] = numericDomain;
 
         if (tickCount === 1) {

--- a/packages/ag-charts-community/src/scale/linearScale.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.ts
@@ -54,7 +54,7 @@ export class LinearScale extends ContinuousScale<number | bigint> {
             return { ticks, count: ticks.length, firstTickIndex: 0 };
         }
 
-        const numericDomain: number[] = isBigIntDomain ? domain.map(Number) : (domain as number[]);
+        const numericDomain: number[] = domain.map(Number);
         if (!numericDomain.every(Number.isFinite)) {
             return { ticks: [], count: 0, firstTickIndex: 0 };
         }
@@ -91,7 +91,7 @@ export class LinearScale extends ContinuousScale<number | bigint> {
             return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1];
         }
 
-        const numericDomain: number[] = isBigIntDomain ? domain.map(Number) : (domain as number[]);
+        const numericDomain: number[] = domain.map(Number);
         let [start, stop] = numericDomain;
 
         if (tickCount === 1) {

--- a/packages/ag-charts-community/src/scale/ordinalTimeScale.test.ts
+++ b/packages/ag-charts-community/src/scale/ordinalTimeScale.test.ts
@@ -570,8 +570,8 @@ describe('OrdinalTimeScale', () => {
             const scale = bandedScale();
             const date = new Date(Date.UTC(2024, 1, 1));
             const expected = scale.convert(date);
-            expect(scale.convert('2024-02-01T00:00:00Z')).toBeCloseTo(expected);
-            expect(scale.convert(BigInt(date.valueOf()))).toBeCloseTo(expected);
+            expect(scale.convert('2024-02-01T00:00:00Z')).toBe(expected);
+            expect(scale.convert(BigInt(date.valueOf()))).toBe(expected);
         });
     });
 

--- a/packages/ag-charts-community/src/scale/unitTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.ts
@@ -18,6 +18,7 @@ import {
     intervalRange,
     intervalRangeCount,
     intervalRangeNumeric,
+    timeValueToNumber,
     toTimeInterval,
 } from 'ag-charts-core';
 import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
@@ -322,7 +323,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
     ): number {
         this.refresh();
 
-        if (!(value instanceof Date)) value = new Date(typeof value === 'bigint' ? Number(value) : value);
+        if (!(value instanceof Date)) value = new Date(timeValueToNumber(value));
 
         const { domain, interval } = this;
         if (domain.length < 2) return Number.NaN;

--- a/packages/ag-charts-core/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-core/src/scale/colorScaleUtil.ts
@@ -1,6 +1,6 @@
 import type { AgColorScaleColorStop } from 'ag-charts-types';
 
-import { clamp } from '../utils/data/numbers';
+import { clamp, toFiniteNumber } from '../utils/data/numbers';
 
 /** Colour mode for colour scale operations. */
 export type ColorScaleMode = 'continuous' | 'discrete';
@@ -122,8 +122,8 @@ export function computeColorBins(
 
     // The colour domain originates from the colorKey extent, which can be bigint (AG-16608 heatmap).
     // Narrow to Number for the interpolation/clamp maths below; mixing bigint with number throws.
-    const d0 = Number(domain[0]);
-    const d1 = Number(domain[1]);
+    const d0 = toFiniteNumber(domain[0]);
+    const d1 = toFiniteNumber(domain[1]);
     const isDiscrete = mode === 'discrete';
     const resolvedStops = resolveStopPositions(fills, d0, d1, isDiscrete);
     const resolvedColors = fills.map((fill) => fill.color);
@@ -179,7 +179,9 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
 
     // `domain` holds Number interpolation pivots. `displayDomain` is the user-visible range and can be
     // bigint (AG-16608 heatmap), so narrow it to Number for the [0,1] fraction maths below.
-    const [d0, d1] = displayDomain ? [Number(displayDomain[0]), Number(displayDomain[1])] : [domain[0], domain.at(-1)!];
+    const [d0, d1] = displayDomain
+        ? [toFiniteNumber(displayDomain[0]), toFiniteNumber(displayDomain[1])]
+        : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
 
     if (mode === 'discrete') {

--- a/packages/ag-charts-core/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-core/src/scale/colorScaleUtil.ts
@@ -1,6 +1,6 @@
 import type { AgColorScaleColorStop } from 'ag-charts-types';
 
-import { clamp, toFiniteNumber } from '../utils/data/numbers';
+import { clamp, toNumber } from '../utils/data/numbers';
 
 /** Colour mode for colour scale operations. */
 export type ColorScaleMode = 'continuous' | 'discrete';
@@ -122,8 +122,8 @@ export function computeColorBins(
 
     // The colour domain originates from the colorKey extent, which can be bigint (AG-16608 heatmap).
     // Narrow to Number for the interpolation/clamp maths below; mixing bigint with number throws.
-    const d0 = toFiniteNumber(domain[0]);
-    const d1 = toFiniteNumber(domain[1]);
+    const d0 = toNumber(domain[0]);
+    const d1 = toNumber(domain[1]);
     const isDiscrete = mode === 'discrete';
     const resolvedStops = resolveStopPositions(fills, d0, d1, isDiscrete);
     const resolvedColors = fills.map((fill) => fill.color);
@@ -180,7 +180,7 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
     // `domain` holds Number interpolation pivots. `displayDomain` is the user-visible range and can be
     // bigint (AG-16608 heatmap), so narrow it to Number for the [0,1] fraction maths below.
     const [d0, d1] = displayDomain
-        ? [toFiniteNumber(displayDomain[0]), toFiniteNumber(displayDomain[1])]
+        ? [toNumber(displayDomain[0]), toNumber(displayDomain[1])]
         : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
 

--- a/packages/ag-charts-core/src/state/validation.ts
+++ b/packages/ag-charts-core/src/state/validation.ts
@@ -484,7 +484,7 @@ export const number = attachDescription(isFiniteNumber, 'a number');
 // (AG-16608 AC #11) — do NOT widen the global `number` validator, or every numeric option accepts bigint.
 export const numericValue = attachDescription(
     (value): value is number | bigint => isFiniteNumber(value) || typeof value === 'bigint',
-    'a number'
+    'a number or bigint'
 );
 export const object = attachDescription(isObject, 'an object');
 export const string = attachDescription(isString, 'a string');

--- a/packages/ag-charts-core/src/types/scales.ts
+++ b/packages/ag-charts-core/src/types/scales.ts
@@ -68,6 +68,10 @@ export interface Scale<D, R, I = number> {
     domain: D[];
     range: R[];
     getDomainMinMax(): [D, D] | [undefined, undefined];
+    /** Domain minimum, preserving the domain value type (so a bigint domain flows through as bigint). */
+    readonly domainMin: D | undefined;
+    /** Domain maximum, preserving the domain value type (so a bigint domain flows through as bigint). */
+    readonly domainMax: D | undefined;
     normalizeDomains(...domains: DomainWithMetadata<D>[]): NormalizedDomain<D>;
     toDomain(value: number): D | undefined;
     convert(value: D, options?: { clamp?: boolean; alignment?: ScaleAlignment; alignmentExclusive?: boolean }): R;

--- a/packages/ag-charts-core/src/utils/data/numbers.test.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.test.ts
@@ -1,4 +1,17 @@
-import { clamp, countFractionDigits, inRange, isInteger, isNegative, isNumberEqual, modulus, roundTo } from './numbers';
+import { vi } from 'vitest';
+
+import * as Logger from '../../logging/logger';
+import {
+    clamp,
+    countFractionDigits,
+    inRange,
+    isInteger,
+    isNegative,
+    isNumberEqual,
+    modulus,
+    roundTo,
+    toFiniteNumber,
+} from './numbers';
 
 describe('Number Utilities', () => {
     test('clamp', () => {
@@ -56,6 +69,28 @@ describe('Number Utilities', () => {
         expect(modulus(-7, 3)).toBe(2);
         expect(modulus(7, -3)).toBe(1);
         expect(modulus(-5, -3)).toBe(1);
+    });
+
+    test('toFiniteNumber', () => {
+        const warnOnce = vi.spyOn(Logger, 'warnOnce').mockImplementation(() => {});
+        try {
+            // Numbers pass through unchanged.
+            expect(toFiniteNumber(5)).toBe(5);
+            expect(toFiniteNumber(-5.25)).toBe(-5.25);
+            expect(toFiniteNumber(Number.MAX_VALUE)).toBe(Number.MAX_VALUE);
+
+            // In-range bigints coerce (lossy beyond MAX_SAFE_INTEGER, but finite) without warning.
+            expect(toFiniteNumber(42n)).toBe(42);
+            expect(toFiniteNumber(-9_000_000_000_000_000_000n)).toBe(-9_000_000_000_000_000_000);
+            expect(warnOnce).not.toHaveBeenCalled();
+
+            // Bigints beyond Number.MAX_VALUE would become Infinity; clamp to ±MAX_VALUE and warn.
+            expect(toFiniteNumber(10n ** 400n)).toBe(Number.MAX_VALUE);
+            expect(toFiniteNumber(-(10n ** 400n))).toBe(-Number.MAX_VALUE);
+            expect(warnOnce).toHaveBeenCalled();
+        } finally {
+            warnOnce.mockRestore();
+        }
     });
 
     test('countFractionDigits', () => {

--- a/packages/ag-charts-core/src/utils/data/numbers.test.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.test.ts
@@ -10,7 +10,7 @@ import {
     isNumberEqual,
     modulus,
     roundTo,
-    toFiniteNumber,
+    toNumber,
 } from './numbers';
 
 describe('Number Utilities', () => {
@@ -71,22 +71,22 @@ describe('Number Utilities', () => {
         expect(modulus(-5, -3)).toBe(1);
     });
 
-    test('toFiniteNumber', () => {
+    test('toNumber', () => {
         const warnOnce = vi.spyOn(Logger, 'warnOnce').mockImplementation(() => {});
         try {
             // Numbers pass through unchanged.
-            expect(toFiniteNumber(5)).toBe(5);
-            expect(toFiniteNumber(-5.25)).toBe(-5.25);
-            expect(toFiniteNumber(Number.MAX_VALUE)).toBe(Number.MAX_VALUE);
+            expect(toNumber(5)).toBe(5);
+            expect(toNumber(-5.25)).toBe(-5.25);
+            expect(toNumber(Number.MAX_VALUE)).toBe(Number.MAX_VALUE);
 
             // In-range bigints coerce (lossy beyond MAX_SAFE_INTEGER, but finite) without warning.
-            expect(toFiniteNumber(42n)).toBe(42);
-            expect(toFiniteNumber(-9_000_000_000_000_000_000n)).toBe(-9_000_000_000_000_000_000);
+            expect(toNumber(42n)).toBe(42);
+            expect(toNumber(-9_000_000_000_000_000_000n)).toBe(-9_000_000_000_000_000_000);
             expect(warnOnce).not.toHaveBeenCalled();
 
-            // Bigints beyond Number.MAX_VALUE would become Infinity; clamp to ±MAX_VALUE and warn.
-            expect(toFiniteNumber(10n ** 400n)).toBe(Number.MAX_VALUE);
-            expect(toFiniteNumber(-(10n ** 400n))).toBe(-Number.MAX_VALUE);
+            // Bigints beyond Number.MAX_VALUE coerce to ±Infinity (dropped from rendering) and warn once.
+            expect(toNumber(10n ** 400n)).toBe(Infinity);
+            expect(toNumber(-(10n ** 400n))).toBe(-Infinity);
             expect(warnOnce).toHaveBeenCalled();
         } finally {
             warnOnce.mockRestore();

--- a/packages/ag-charts-core/src/utils/data/numbers.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.ts
@@ -1,5 +1,23 @@
+import * as Logger from '../../logging/logger';
+
 export function clamp(min: number, value: number, max: number) {
     return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Coerces a `number | bigint` to a `number` for rendering/positioning maths, where finite precision is
+ * sufficient (the exact value is retained elsewhere for tooltips and tick labels). A `bigint` magnitude
+ * beyond `Number.MAX_VALUE` coerces to `Infinity`, which would poison downstream scale arithmetic, so we
+ * warn once and clamp to `±Number.MAX_VALUE` to keep the result finite.
+ */
+export function toFiniteNumber(value: number | bigint): number {
+    if (typeof value === 'number') return value;
+
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+
+    Logger.warnOnce(`the value ${value} exceeds the representable Number range and was clamped for rendering.`);
+    return value < 0n ? -Number.MAX_VALUE : Number.MAX_VALUE;
 }
 
 export function inRange(value: number, range: [number, number], epsilon: number = 1e-10) {

--- a/packages/ag-charts-core/src/utils/data/numbers.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.ts
@@ -7,17 +7,17 @@ export function clamp(min: number, value: number, max: number) {
 /**
  * Coerces a `number | bigint` to a `number` for rendering/positioning maths, where finite precision is
  * sufficient (the exact value is retained elsewhere for tooltips and tick labels). A `bigint` magnitude
- * beyond `Number.MAX_VALUE` coerces to `Infinity`, which would poison downstream scale arithmetic, so we
- * warn once and clamp to `±Number.MAX_VALUE` to keep the result finite.
+ * beyond `Number.MAX_VALUE` coerces to `Infinity`; the result is then handled as any other non-finite value
+ * (dropped from rendering), and we warn once so the precision-loss is observable rather than silent.
  */
-export function toFiniteNumber(value: number | bigint): number {
+export function toNumber(value: number | bigint): number {
     if (typeof value === 'number') return value;
 
     const n = Number(value);
-    if (Number.isFinite(n)) return n;
-
-    Logger.warnOnce(`the value ${value} exceeds the representable Number range and was clamped for rendering.`);
-    return value < 0n ? -Number.MAX_VALUE : Number.MAX_VALUE;
+    if (!Number.isFinite(n)) {
+        Logger.warnOnce(`the value ${value} exceeds the representable Number range and cannot be rendered.`);
+    }
+    return n;
 }
 
 export function inRange(value: number, range: [number, number], epsilon: number = 1e-10) {

--- a/packages/ag-charts-enterprise/src/axes/angle-number/angleNumberAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/angleNumberAxis.ts
@@ -12,7 +12,7 @@ import type { AngleAxisLabelDatum } from '../angle/angleAxis';
 import { AngleAxis } from '../angle/angleAxis';
 import { LinearAngleScale } from './linearAngleScale';
 
-export class AngleNumberAxis extends AngleAxis<number, LinearAngleScale, NormalisedAngleNumberAxisOptions> {
+export class AngleNumberAxis extends AngleAxis<number | bigint, LinearAngleScale, NormalisedAngleNumberAxisOptions> {
     static readonly className = 'AngleNumberAxis';
     static readonly type = 'angle-number' as const;
 

--- a/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
@@ -4,8 +4,8 @@ import { type ScaleTickParams, isDenseInterval, isNumberEqual, range } from 'ag-
 const { LinearScale } = _ModuleSupport;
 
 export class LinearAngleScale extends LinearScale {
-    static getNiceStepAndTickCount(ticks: ScaleTickParams<number>, domain: number[]) {
-        const [start, stop] = domain;
+    static getNiceStepAndTickCount(ticks: ScaleTickParams<number>, domain: (number | bigint)[]) {
+        const [start, stop] = domain.map(Number);
         let step = LinearScale.getTickStep(start, stop, ticks);
         const maxTickCount = Number.isNaN(ticks.maxTickCount) ? Infinity : ticks.maxTickCount;
         const expectedTickCount = Math.abs(stop - start) / step;
@@ -19,15 +19,22 @@ export class LinearAngleScale extends LinearScale {
 
     arcLength: number = 0;
 
-    override ticks(ticks: ScaleTickParams<number>, domain: number[] = this.domain): { ticks: number[]; count: number } {
+    override ticks(
+        ticks: ScaleTickParams<number>,
+        domain: (number | bigint)[] = this.domain
+    ): { ticks: number[]; count: number } {
         const { arcLength } = this;
 
-        if (!domain || domain.length < 2 || domain.some((d) => !Number.isFinite(d)) || arcLength <= 0) {
+        // Angle scales nice-step in Number space (log2/pow); a bigint domain narrows here — a documented
+        // limitation in the same class as custom intervals (AC #17). Value positioning stays full-precision
+        // via convert()'s bigint path; only these tick *label* values are Number-precision.
+        const numericDomain = domain.map(Number);
+        if (numericDomain.length < 2 || numericDomain.some((d) => !Number.isFinite(d)) || arcLength <= 0) {
             return { ticks: [], count: 0 };
         }
 
         const { nice, interval } = ticks;
-        const [d0, d1] = domain;
+        const [d0, d1] = numericDomain;
 
         if (interval) {
             // A custom interval step is a Number concept (AG-16608 AC #17); narrow a bigint step.
@@ -57,13 +64,18 @@ export class LinearAngleScale extends LinearScale {
         return niceRanges.some((r) => isNumberEqual(r, sortedRange[1] - sortedRange[0]));
     }
 
-    override niceDomain(ticks: ScaleTickParams<number>, domain: number[] = this.domain): number[] {
+    override niceDomain(
+        ticks: ScaleTickParams<number>,
+        domain: (number | bigint)[] = this.domain
+    ): (number | bigint)[] {
         const linearNiceDomain = super.niceDomain(ticks, domain);
 
         if (!this.hasNiceRange()) return linearNiceDomain;
 
-        const reversed = linearNiceDomain[0] > linearNiceDomain[1];
-        const start = reversed ? linearNiceDomain[1] : linearNiceDomain[0];
+        // Extend the nice domain in Number space (see ticks() — bigint narrows here, AC #17).
+        const [n0, n1] = linearNiceDomain.map(Number);
+        const reversed = n0 > n1;
+        const start = reversed ? n1 : n0;
         const { step, count } = LinearAngleScale.getNiceStepAndTickCount(ticks, linearNiceDomain);
         const s = 1 / step; // Prevent floating point error
         const stop = step >= 1 ? Math.ceil(start / step + count) * step : Math.ceil((start + count * step) * s) / s;

--- a/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
@@ -1,11 +1,11 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { type ScaleTickParams, isDenseInterval, isNumberEqual, range, toFiniteNumber } from 'ag-charts-core';
+import { type ScaleTickParams, isDenseInterval, isNumberEqual, range, toNumber } from 'ag-charts-core';
 
 const { LinearScale } = _ModuleSupport;
 
 export class LinearAngleScale extends LinearScale {
     static getNiceStepAndTickCount(ticks: ScaleTickParams<number>, domain: (number | bigint)[]) {
-        const [start, stop] = domain.map(toFiniteNumber);
+        const [start, stop] = domain.map(toNumber);
         let step = LinearScale.getTickStep(start, stop, ticks);
         const maxTickCount = Number.isNaN(ticks.maxTickCount) ? Infinity : ticks.maxTickCount;
         const expectedTickCount = Math.abs(stop - start) / step;
@@ -28,7 +28,7 @@ export class LinearAngleScale extends LinearScale {
         // Angle scales nice-step in Number space (log2/pow); a bigint domain narrows here — a documented
         // limitation in the same class as custom intervals (AC #17). Value positioning stays full-precision
         // via convert()'s bigint path; only these tick *label* values are Number-precision.
-        const numericDomain = domain.map(toFiniteNumber);
+        const numericDomain = domain.map(toNumber);
         if (numericDomain.length < 2 || numericDomain.some((d) => !Number.isFinite(d)) || arcLength <= 0) {
             return { ticks: [], count: 0 };
         }
@@ -38,7 +38,7 @@ export class LinearAngleScale extends LinearScale {
 
         if (interval) {
             // A custom interval step is a Number concept (AG-16608 AC #17); narrow a bigint step.
-            const step = Math.abs(toFiniteNumber(interval));
+            const step = Math.abs(toNumber(interval));
             const availableRange = this.getPixelRange();
             if (!isDenseInterval((d1 - d0) / step, availableRange)) {
                 const result = range(d0, d1, step);
@@ -73,7 +73,7 @@ export class LinearAngleScale extends LinearScale {
         if (!this.hasNiceRange()) return linearNiceDomain;
 
         // Extend the nice domain in Number space (see ticks() — bigint narrows here, AC #17).
-        const [n0, n1] = linearNiceDomain.map(toFiniteNumber);
+        const [n0, n1] = linearNiceDomain.map(toNumber);
         const reversed = n0 > n1;
         const start = reversed ? n1 : n0;
         const { step, count } = LinearAngleScale.getNiceStepAndTickCount(ticks, linearNiceDomain);

--- a/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
@@ -1,11 +1,11 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { type ScaleTickParams, isDenseInterval, isNumberEqual, range } from 'ag-charts-core';
+import { type ScaleTickParams, isDenseInterval, isNumberEqual, range, toFiniteNumber } from 'ag-charts-core';
 
 const { LinearScale } = _ModuleSupport;
 
 export class LinearAngleScale extends LinearScale {
     static getNiceStepAndTickCount(ticks: ScaleTickParams<number>, domain: (number | bigint)[]) {
-        const [start, stop] = domain.map(Number);
+        const [start, stop] = domain.map(toFiniteNumber);
         let step = LinearScale.getTickStep(start, stop, ticks);
         const maxTickCount = Number.isNaN(ticks.maxTickCount) ? Infinity : ticks.maxTickCount;
         const expectedTickCount = Math.abs(stop - start) / step;
@@ -28,7 +28,7 @@ export class LinearAngleScale extends LinearScale {
         // Angle scales nice-step in Number space (log2/pow); a bigint domain narrows here — a documented
         // limitation in the same class as custom intervals (AC #17). Value positioning stays full-precision
         // via convert()'s bigint path; only these tick *label* values are Number-precision.
-        const numericDomain = domain.map(Number);
+        const numericDomain = domain.map(toFiniteNumber);
         if (numericDomain.length < 2 || numericDomain.some((d) => !Number.isFinite(d)) || arcLength <= 0) {
             return { ticks: [], count: 0 };
         }
@@ -38,7 +38,7 @@ export class LinearAngleScale extends LinearScale {
 
         if (interval) {
             // A custom interval step is a Number concept (AG-16608 AC #17); narrow a bigint step.
-            const step = Math.abs(Number(interval));
+            const step = Math.abs(toFiniteNumber(interval));
             const availableRange = this.getPixelRange();
             if (!isDenseInterval((d1 - d0) / step, availableRange)) {
                 const result = range(d0, d1, step);
@@ -73,7 +73,7 @@ export class LinearAngleScale extends LinearScale {
         if (!this.hasNiceRange()) return linearNiceDomain;
 
         // Extend the nice domain in Number space (see ticks() — bigint narrows here, AC #17).
-        const [n0, n1] = linearNiceDomain.map(Number);
+        const [n0, n1] = linearNiceDomain.map(toFiniteNumber);
         const reversed = n0 > n1;
         const start = reversed ? n1 : n0;
         const { step, count } = LinearAngleScale.getNiceStepAndTickCount(ticks, linearNiceDomain);

--- a/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
@@ -14,7 +14,7 @@ interface TickDatum {
 
 export class RadiusNumberAxis extends RadiusAxis<
     _ModuleSupport.LinearScale,
-    number,
+    number | bigint,
     NormalisedRadiusNumberAxisOptions
 > {
     static readonly className = 'RadiusNumberAxis';

--- a/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
@@ -270,10 +270,15 @@ export class AxisTicks {
         const ticks: TickDatum[] = [];
         const domain = tickParams.nice ? this.scale.niceDomain(tickParams) : this.scale.domain;
         const rawTicks = this.scale.ticks(tickParams, domain)?.ticks ?? [];
-        const fractionDigits = rawTicks.reduce((max, tick) => Math.max(max, countFractionDigits(tick)), 0);
+        const fractionDigits = rawTicks.reduce<number>(
+            (max, tick) => Math.max(max, countFractionDigits(Number(tick))),
+            0
+        );
         const idGenerator = createIdsGenerator();
 
-        const tickFormatter = this.tickFormatter(domain, rawTicks, false, fractionDigits);
+        // domain/ticks are formatter-context metadata only (narrowed to Number per the documented
+        // pattern); the per-tick label below keeps the exact value, so bigint labels stay full-precision.
+        const tickFormatter = this.tickFormatter(domain.map(Number), rawTicks.map(Number), false, fractionDigits);
 
         for (let index = 0; index < rawTicks.length; index++) {
             const tick = rawTicks[index];

--- a/packages/ag-charts-enterprise/src/series/gauge-util/segmentation.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/segmentation.ts
@@ -10,10 +10,12 @@ class GaugeSegmentationIntervalProperties extends BaseProperties {
     @Property
     count?: number;
 
-    getSegments(scale: Scale<number, number>, maxTicks: number) {
+    getSegments(scale: Scale<number | bigint, number>, maxTicks: number) {
         const { values, step, count } = this;
-        const d0 = Math.min(...scale.domain);
-        const d1 = Math.max(...scale.domain);
+        // Segment boundaries that survive full-precision (explicit values, scale.ticks) are kept as bigint
+        // below; these domain *bounds* are only used for Number-space stepping/filtering, so narrow them.
+        const d0 = Number(scale.domainMin);
+        const d1 = Number(scale.domainMax);
 
         let ticks: Array<number | bigint> | undefined;
         if (values != null) {

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -384,7 +384,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         };
     }
 
-    labelDatum(label: LinearGaugeLabelProperties, value: number): LinearGaugeLabelDatum {
+    labelDatum(label: LinearGaugeLabelProperties, value: number | bigint): LinearGaugeLabelDatum {
         const {
             placement,
             avoidCollisions,
@@ -608,8 +608,10 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         const scaleStyle = scaleProps.getStyle(bar.enabled, defaultColorRange, horizontal, scale);
 
         if (segments == null && cornersOnAllItems) {
-            const segmentStart = Math.min(...scale.domain);
-            const segmentEnd = Math.max(...scale.domain);
+            // Visual corner-segment bounds spanning the whole domain; convert() maps the exact endpoints
+            // to the range ends regardless, so a Number-narrow here is precision-safe.
+            const segmentStart = Number(scale.domainMin);
+            const segmentEnd = Number(scale.domainMax);
             const datum = { value, segmentStart, segmentEnd };
 
             if (bar.enabled) {

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
@@ -388,7 +388,8 @@ export function createLinearGradient(
     scale: _ModuleSupport.LinearScale,
     horizontal: boolean
 ): InternalAgGradientColor {
-    const colorStops = getColorStops(fills, defaultColorRange, scale.domain, fillMode);
+    // Colour-stop positions are fractional thresholds — Number is correct (no bigint precision benefit).
+    const colorStops = getColorStops(fills, defaultColorRange, scale.domain.map(Number), fillMode);
     return {
         type: 'gradient',
         gradient: 'linear',

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -567,8 +567,10 @@ export class RadialGaugeSeries
         const scaleStyle = scaleProps.getStyle(bar.enabled, defaultColorRange, scale);
 
         if (segments == null && cornersOnAllItems) {
-            const segmentStart = Math.min(...scale.domain);
-            const segmentEnd = Math.max(...scale.domain);
+            // Visual corner-segment bounds spanning the whole domain; convert() maps the exact endpoints
+            // to the range ends regardless, so a Number-narrow here is precision-safe.
+            const segmentStart = Number(scale.domainMin);
+            const segmentEnd = Number(scale.domainMax);
             const datum = { value, segmentStart, segmentEnd };
             const appliedCornerRadius = Math.min(cornerRadius, (outerRadius - innerRadius) / 2);
             const angleInset = appliedCornerRadius / ((innerRadius + outerRadius) / 2);
@@ -740,7 +742,9 @@ export class RadialGaugeSeries
             const target = targets[i];
             const { value: targetValue, text, size, shape, style } = target;
 
-            if (targetValue < Math.min(...scale.domain) || targetValue > Math.max(...scale.domain)) {
+            // Exact bigint comparison: domainMin/Max flow the domain value type through unchanged.
+            const { domainMin, domainMax } = scale;
+            if (domainMin == null || domainMax == null || targetValue < domainMin || targetValue > domainMax) {
                 continue;
             }
 

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
@@ -448,7 +448,8 @@ export function createConicGradient(
     const conicAngle = normalizeAngle360((startAngle + endAngle) / 2 + Math.PI);
     const sweepAngle = normalizeAngle360Inclusive(endAngle - startAngle);
 
-    const colorStops = getColorStops(fills, defaultColorRange, domain, fillMode).map(
+    // Colour-stop positions are fractional thresholds — Number is correct (no bigint precision benefit).
+    const colorStops = getColorStops(fills, defaultColorRange, domain.map(Number), fillMode).map(
         ({ color, stop }): GradientColorStop => {
             stop = Math.min(Math.max(stop, 0), 1);
             const angle = startAngle + sweepAngle * stop;

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -19,6 +19,7 @@ import {
     easeOut,
     isContinuous,
     mergeDefaults,
+    toFiniteNumber,
 } from 'ag-charts-core';
 
 import type { WaterfallSeriesItem, WaterfallSeriesTotal } from './waterfallSeriesProperties';
@@ -278,8 +279,9 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
             const yCurrIndex = dataModel.resolveProcessedDataIndexById(this, 'yCurrent');
             const yExtent = values[yCurrIndex];
             // The cumulative extent can be bigint; narrow to Number for the domain (finite precision,
-            // consistent with bar) since Math.min/max throw on bigint.
-            const fixedYExtent = [Math.min(0, Number(yExtent[0])), Math.max(0, Number(yExtent[1]))];
+            // consistent with bar) since Math.min/max throw on bigint. toFiniteNumber guards bigints
+            // beyond Number.MAX_VALUE that would otherwise become Infinity.
+            const fixedYExtent = [Math.min(0, toFiniteNumber(yExtent[0])), Math.max(0, toFiniteNumber(yExtent[1]))];
             return { domain: fixNumericExtent(fixedYExtent) };
         }
     }

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -19,7 +19,7 @@ import {
     easeOut,
     isContinuous,
     mergeDefaults,
-    toFiniteNumber,
+    toNumber,
 } from 'ag-charts-core';
 
 import type { WaterfallSeriesItem, WaterfallSeriesTotal } from './waterfallSeriesProperties';
@@ -279,9 +279,9 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
             const yCurrIndex = dataModel.resolveProcessedDataIndexById(this, 'yCurrent');
             const yExtent = values[yCurrIndex];
             // The cumulative extent can be bigint; narrow to Number for the domain (finite precision,
-            // consistent with bar) since Math.min/max throw on bigint. toFiniteNumber guards bigints
-            // beyond Number.MAX_VALUE that would otherwise become Infinity.
-            const fixedYExtent = [Math.min(0, toFiniteNumber(yExtent[0])), Math.max(0, toFiniteNumber(yExtent[1]))];
+            // consistent with bar) since Math.min/max throw on bigint. toNumber warns once if a bigint
+            // beyond Number.MAX_VALUE coerces to Infinity (fixNumericExtent then sanitises it).
+            const fixedYExtent = [Math.min(0, toNumber(yExtent[0])), Math.max(0, toNumber(yExtent[1]))];
             return { domain: fixNumericExtent(fixedYExtent) };
         }
     }

--- a/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
@@ -1,3 +1,4 @@
+import type { AgNumericValue } from '../../chart/dataValues';
 import type { AgDropShadowOptions } from '../../chart/dropShadowOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip } from '../../chart/tooltipOptions';
@@ -29,7 +30,8 @@ export type AgHistogramSeriesLabelFormatterParams<TDatum = DatumDefault> = AgHis
 
 export interface AgHistogramBinDatum<TDatum> {
     data: TDatum[];
-    aggregatedValue: number;
+    /** Aggregated value for the bin. A `bigint` when a bigint `yKey` column is summed (`aggregation: 'sum'`). */
+    aggregatedValue: AgNumericValue;
     frequency: number;
     domain: [number, number];
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

Stacked on #6955 (PR9). Follow-up to a reviewer type-confusion flag: the runtime threaded `bigint` through `number`-typed scale/axis signatures, so the load-bearing coercions looked like dead defensive code. This makes `D` itself bigint-capable through the continuous-scale and number-axis surface, so the compiler now flags every site that narrows a bigint domain to Number.

## Summary
- `ContinuousScale<D extends number|bigint|Date>`, `LinearScale extends ContinuousScale<number|bigint>`; `ticks()`/`niceDomain()` honestly take and return `(number|bigint)[]` — the `as unknown as number[]` casts are removed.
- `NumberAxis`/`AngleNumberAxis`/`RadiusNumberAxis` `D` widened to `number|bigint`. Zero cascade into the ~50 generic `Scale<>` consumers (the `Axis<S=Scale<any>>` defaults absorb it; `convert()` returns Number pixels; ticks flow to the bigint-aware formatter).
- New `Scale.domainMin`/`domainMax` accessors: `AbstractScale` derives them from `getDomainMinMax()`; `ContinuousScale` returns the true (order-independent) min/max preserving the exact bigint endpoint — replacing the `Math.min/max(...domain.map(Number))` ceremony at the gauge sites. `getDomainMinMax()`'s narrowed contract is left intact for its zoom consumers.
- Gauge/segmentation/gradient-legend narrow only at genuine Number-space maths; the per-tick label keeps the exact value. `linear-gauge` `labelDatum` stops narrowing bigint (its datum field and `formatLabel` were already bigint-capable), preserving label precision.
- `LinearAngleScale` documents its Number-precision nice-stepping limitation (AC #17); value positioning stays full-precision via `convert()`.

Precision note: forcing the bigint through surfaced no latent precision bug — `convert()` already positions exactly via `d0Big`/`d1Big`/`convertBigInt` even where narrowed endpoints would collapse. The remaining narrows are genuinely Number-space quantities.

## Follow-up: cast tightening + bigint aggregation precision

Two further commits, from a full audit of bigint→number coercion across the PR1–PR10 train:

- **Type honesty (no behaviour change).** Consolidated the three scattered `as D[]` domain casts in `ContinuousScale` into one documented narrowing helper, replaced `d0/d1 as unknown as number` with `Number()`, and turned `linearScale`'s `domain as number[]` into an honest `domain.map(Number)`. Widened `NumberAxis.getVisibleDomain`/`tickFormatParams`/`normaliseDataDomain` params from `number` to `number|bigint`, matching the bigint-capable axis `D`. Full bigint retention in `_domain` was investigated and **rejected** — it is semantically wrong for `LogScale` (`D=number`) and `TimeScale` (`D=Date`), where Number-narrowing is correct, and would cascade crashes into `logScale`/`radialBar`. Exact bigint stays exposed (cast-free) via `domainMin`/`domainMax`.
- **Bigint aggregation precision.** `sumValues` silently dropped bigint y-values, so a histogram summing a bigint `yKey` column produced zero-height bins. It now sums in bigint via `addAccumulated`, widening the aggregation result surface (`[number, number]` → `[number | bigint, number | bigint]`) through `sum`/`groupSum`/`groupAverage`/`area`. Narrowing happens only at genuine Number points: the mean and area-density divisions, histogram `getSeriesRange`'s pixel `Math.max`, and the y-scale position. The exact total reaches the bin tooltip via `aggregatedValue` (widened to `AgNumericValue`). Also fixes a latent throw for an areaPlot histogram over bigint bins (`keyWidth`).

## Test plan
- New `domainMin`/`domainMax` unit block (bigint flow-through, true min/max ordering, precision beyond `Number.MAX_SAFE_INTEGER`).
- New `sumValues` bigint unit tests (incl. a >2^53 case) and an end-to-end histogram test asserting an exact bigint bin total (3 × (2^53 + 1)).
- `build:types` + `lint` + `format` green on types/community/enterprise.
- `bigintRenderSmoke` (community + enterprise), colour-scale, `numberAxisBigInt`, `aggregateFunctions`, core `extent`/`ticks` suites green. Pre-existing `dataModel`/histogram image-snapshot failures in the worktree are unrelated (baseline-confirmed; CI re-validates).

Fix #AG-16608