### PR TITLE
AG-14484 model cross-line options as a value-typed discriminated union

### DIFF
--- a/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
+++ b/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
@@ -37,6 +37,7 @@ import {
     themeOperator,
     timeInterval,
     timeIntervalUnit,
+    typeUnion,
     undocumented,
     union,
 } from 'ag-charts-core';
@@ -55,8 +56,9 @@ import type {
     AgBaseCrossLineOptions,
     AgBaseCrosshairLabel,
     AgCartesianAxisLabelOptions,
-    AgCartesianCrossLineOptions,
+    AgCartesianCrossLineLabelOptions,
     AgCategoryAxisOptions,
+    AgCommonCrossLineOptions,
     AgContinuousAxisOptions,
     AgCrosshairLabel,
     AgCrosshairLabelRendererResult,
@@ -65,6 +67,7 @@ import type {
     AgGroupedCategoryDepthOptions,
     AgLogAxisOptions,
     AgNumberAxisOptions,
+    AgRadiusCrossLineLabelOptions,
     AgTimeAxisFormattableLabelFormat,
     AgTimeAxisFormattableLabelUnitFormat,
     AgTimeAxisOptions,
@@ -82,54 +85,63 @@ export const commonCrossLineLabelOptionsDefs: OptionsDefs<AgBaseCrossLineLabelOp
     ...fillOptionsDef,
 };
 
-export const commonCrossLineOptionsDefs = attachDescription<AgBaseCrossLineOptions>(
-    {
-        enabled: boolean,
-        type: required(union('line', 'range')),
-        range: and(
-            attachDescription((_, { options }) => options.type === 'range', "crossLine type to be 'range'"),
-            arrayOf(defined),
-            arrayLength(2, 2)
-        ),
-        value: and(
-            attachDescription((_, { options }) => options.type === 'line', "crossLine type to be 'line'"),
-            defined
-        ),
-        label: commonCrossLineLabelOptionsDefs,
-        fill: color,
-        fillOpacity: ratio,
-        ...strokeOptionsDef,
-        ...lineDashOptionsDef,
-    },
-    'cross-line options'
-);
-
-export const cartesianCrossLineOptionsDefs: OptionsDefs<AgCartesianCrossLineOptions> = {
-    ...commonCrossLineOptionsDefs,
-    label: {
-        ...commonCrossLineLabelOptionsDefs,
-        position: union(
-            'top',
-            'left',
-            'right',
-            'bottom',
-            'top-left',
-            'top-right',
-            'bottom-left',
-            'bottom-right',
-            'inside',
-            'inside-left',
-            'inside-right',
-            'inside-top',
-            'inside-bottom',
-            'inside-top-left',
-            'inside-bottom-left',
-            'inside-top-right',
-            'inside-bottom-right'
-        ),
-        rotation: number,
-    },
+// The style options shared by both cross-line variants and by theme overrides (which carry
+// neither `type` nor `value` and supply their own `label`).
+export const crossLineStyleOptionsDefs: OptionsDefs<Omit<AgCommonCrossLineOptions, 'label'>> = {
+    enabled: boolean,
+    fill: color,
+    fillOpacity: ratio,
+    ...strokeOptionsDef,
+    ...lineDashOptionsDef,
 };
+
+export const radiusCrossLineLabelOptionsDefs: OptionsDefs<AgRadiusCrossLineLabelOptions> = {
+    ...commonCrossLineLabelOptionsDefs,
+    positionAngle: number,
+};
+
+// Builds the cross-line options schema as a discriminated union on `type`, so the value is
+// validated against the axis it's attached to: `line` carries a single `value`, `range` a
+// two-item `range` tuple, both checked with the supplied per-axis `value` validator.
+export function crossLineOptionsDefs(
+    value: Validator,
+    labelDefs: OptionsDefs<AgBaseCrossLineLabelOptions>
+): OptionsDefs<AgBaseCrossLineOptions> {
+    const style = { ...crossLineStyleOptionsDefs, label: labelDefs };
+    return typeUnion<AgBaseCrossLineOptions>(
+        {
+            line: { value: required(value), ...style },
+            range: { range: and(required(arrayOf(value)), arrayLength(2, 2)), ...style },
+        },
+        'cross-line options'
+    );
+}
+
+export const cartesianCrossLineLabelOptionsDefs: OptionsDefs<AgCartesianCrossLineLabelOptions> = {
+    ...commonCrossLineLabelOptionsDefs,
+    position: union(
+        'top',
+        'left',
+        'right',
+        'bottom',
+        'top-left',
+        'top-right',
+        'bottom-left',
+        'bottom-right',
+        'inside',
+        'inside-left',
+        'inside-right',
+        'inside-top',
+        'inside-bottom',
+        'inside-top-left',
+        'inside-bottom-left',
+        'inside-top-right',
+        'inside-bottom-right'
+    ),
+    rotation: number,
+};
+
+export const cartesianCrossLineOptionsDefs = crossLineOptionsDefs(defined, cartesianCrossLineLabelOptionsDefs);
 
 export const commonAxisLabelOptionsDefs: OptionsDefs<AgBaseAxisLabelOptions> = {
     enabled: boolean,
@@ -399,6 +411,10 @@ export const numberAxisOptionsDefs: OptionsDefs<AgNumberAxisOptions> = {
     type: constant('number'),
     label: cartesianNumericAxisLabel,
     crosshair: cartesianAxisCrosshairOptions(true),
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(number, cartesianCrossLineLabelOptionsDefs),
+        'a cross-line options array'
+    ),
 };
 
 export const logAxisOptionsDefs: OptionsDefs<AgLogAxisOptions> = {
@@ -411,6 +427,10 @@ export const logAxisOptionsDefs: OptionsDefs<AgLogAxisOptions> = {
     ),
     label: cartesianNumericAxisLabel,
     crosshair: cartesianAxisCrosshairOptions(true),
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(number, cartesianCrossLineLabelOptionsDefs),
+        'a cross-line options array'
+    ),
 };
 
 export const timeAxisOptionsDefs: OptionsDefs<AgTimeAxisOptions> = {
@@ -420,6 +440,10 @@ export const timeAxisOptionsDefs: OptionsDefs<AgTimeAxisOptions> = {
     label: cartesianTimeAxisLabel,
     parentLevel: cartesianTimeAxisParentLevel,
     crosshair: cartesianAxisCrosshairOptions(true, true),
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(or(number, date), cartesianCrossLineLabelOptionsDefs),
+        'a cross-line options array'
+    ),
 };
 
 export const unitTimeAxisOptionsDefs: OptionsDefs<AgUnitTimeAxisOptions> = {
@@ -440,4 +464,8 @@ export const unitTimeAxisOptionsDefs: OptionsDefs<AgUnitTimeAxisOptions> = {
     preferredMin: and(or(number, date), lessThan('preferredMax'), lessThan('max')),
     preferredMax: and(or(number, date), greaterThan('preferredMin'), greaterThan('min')),
     interval: discreteTimeAxisIntervalOptionsDefs,
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(or(number, date), cartesianCrossLineLabelOptionsDefs),
+        'a cross-line options array'
+    ),
 };

--- a/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
+++ b/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
@@ -111,7 +111,7 @@ export function crossLineOptionsDefs(
     return typeUnion<AgBaseCrossLineOptions>(
         {
             line: { value: required(value), ...style },
-            range: { range: and(required(arrayOf(value)), arrayLength(2, 2)), ...style },
+            range: { range: required(and(arrayOf(value), arrayLength(2, 2))), ...style },
         },
         'cross-line options'
     );

--- a/packages/ag-charts-community/src/chart/axesOptionsEnterpriseDefs.ts
+++ b/packages/ag-charts-community/src/chart/axesOptionsEnterpriseDefs.ts
@@ -3,8 +3,11 @@ import {
     arrayOfDefs,
     boolean,
     constant,
+    date,
+    defined,
     number,
     numberFormatValidator,
+    or,
     ratio,
     union,
 } from 'ag-charts-core';
@@ -13,7 +16,6 @@ import type {
     AgAngleNumberAxisOptions,
     AgOrdinalTimeAxisOptions,
     AgRadiusCategoryAxisOptions,
-    AgRadiusCrossLineOptions,
     AgRadiusNumberAxisOptions,
 } from 'ag-charts-types';
 
@@ -21,15 +23,17 @@ import {
     cartesianAxisBandHighlightOptions,
     cartesianAxisCrosshairOptions,
     cartesianAxisOptionsDefs,
+    cartesianCrossLineLabelOptionsDefs,
     cartesianTimeAxisLabel,
     cartesianTimeAxisParentLevel,
     commonAxisCaptionOptionsDefs,
     commonAxisLabelOptionsDefs,
     commonAxisOptionsDefs,
     commonCrossLineLabelOptionsDefs,
-    commonCrossLineOptionsDefs,
     continuousAxisOptions,
+    crossLineOptionsDefs,
     discreteTimeAxisIntervalOptionsDefs,
+    radiusCrossLineLabelOptionsDefs,
 } from './axesOptionsDefs';
 
 export const ordinalTimeAxisOptionsDefs: OptionsDefs<AgOrdinalTimeAxisOptions> = {
@@ -42,6 +46,10 @@ export const ordinalTimeAxisOptionsDefs: OptionsDefs<AgOrdinalTimeAxisOptions> =
     parentLevel: cartesianTimeAxisParentLevel,
     interval: discreteTimeAxisIntervalOptionsDefs,
     crosshair: cartesianAxisCrosshairOptions(true, true),
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(or(number, date), cartesianCrossLineLabelOptionsDefs),
+        'a cross-line options array'
+    ),
     bandHighlight: cartesianAxisBandHighlightOptions,
     bandAlignment: union('justify', 'start', 'center', 'end'),
     skipNullBars: boolean,
@@ -51,7 +59,10 @@ export const angleNumberAxisOptionsDefs: OptionsDefs<AgAngleNumberAxisOptions> =
     ...commonAxisOptionsDefs,
     ...continuousAxisOptions(number),
     type: constant('angle-number'),
-    crossLines: arrayOfDefs(commonCrossLineOptionsDefs),
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(number, commonCrossLineLabelOptionsDefs),
+        'a cross-line options array'
+    ),
     startAngle: number,
     endAngle: number,
     label: {
@@ -71,7 +82,10 @@ export const angleCategoryAxisOptionsDefs: OptionsDefs<AgAngleCategoryAxisOption
     ...commonAxisOptionsDefs,
     type: constant('angle-category'),
     shape: union('polygon', 'circle'),
-    crossLines: arrayOfDefs(commonCrossLineOptionsDefs),
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(defined, commonCrossLineLabelOptionsDefs),
+        'a cross-line options array'
+    ),
     startAngle: number,
     endAngle: number,
     paddingInner: ratio,
@@ -93,15 +107,9 @@ export const radiusNumberAxisOptionsDefs: OptionsDefs<AgRadiusNumberAxisOptions>
     positionAngle: number,
     innerRadiusRatio: ratio,
     title: commonAxisCaptionOptionsDefs,
-    crossLines: arrayOfDefs<AgRadiusCrossLineOptions>(
-        {
-            ...commonCrossLineOptionsDefs,
-            label: {
-                ...commonCrossLineLabelOptionsDefs,
-                positionAngle: number,
-            },
-        },
-        'cross-line options'
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(number, radiusCrossLineLabelOptionsDefs),
+        'a cross-line options array'
     ),
     label: {
         ...commonAxisLabelOptionsDefs,
@@ -119,15 +127,9 @@ export const radiusCategoryAxisOptionsDefs: OptionsDefs<AgRadiusCategoryAxisOpti
     groupPaddingInner: ratio,
     label: commonAxisLabelOptionsDefs,
     title: commonAxisCaptionOptionsDefs,
-    crossLines: arrayOfDefs<AgRadiusCrossLineOptions>(
-        {
-            ...commonCrossLineOptionsDefs,
-            label: {
-                ...commonCrossLineLabelOptionsDefs,
-                positionAngle: number,
-            },
-        },
-        'cross-line options'
+    crossLines: arrayOfDefs(
+        crossLineOptionsDefs(defined, radiusCrossLineLabelOptionsDefs),
+        'a cross-line options array'
     ),
 };
 

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -44,11 +44,11 @@ const labelPositions: AgCrossLineLabelPosition[] = [
 ];
 
 const flipCrossLinesRange = (crossLineOptions: AgCartesianCrossLineOptions): AgCartesianCrossLineOptions => {
-    const flippedRange: [any, any] = [crossLineOptions.range?.[1], crossLineOptions.range?.[0]];
+    const range = (crossLineOptions as { range?: [any, any] }).range;
     return {
         ...crossLineOptions,
-        range: flippedRange,
-    };
+        range: [range?.[1], range?.[0]],
+    } as AgCartesianCrossLineOptions;
 };
 
 const applyCrossLinesLabelPosition = (
@@ -273,7 +273,7 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
             seriesTypes: repeat('line', 2),
         }),
         warningMessages: [
-            "AG Charts - Option `axes.y.crossLines[0].range` cannot be set to `[null,134]`; expecting crossLine type to be 'range', a defined value array and an array of exactly 2 items, ignoring.",
+            'AG Charts - Option `axes.y.crossLines[0][type=range].range` cannot be set to `[null,134]`; expecting a number array and an array of exactly 2 items, ignoring.',
         ],
     },
     INVALID_RANGE_LENGTH_CROSSLINE: {
@@ -283,7 +283,7 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
             seriesTypes: repeat('line', 2),
         }),
         warningMessages: [
-            "AG Charts - Option `axes.y.crossLines[0].range` cannot be set to `[128,134,135]`; expecting crossLine type to be 'range', a defined value array and an array of exactly 2 items, ignoring.",
+            'AG Charts - Option `axes.y.crossLines[0][type=range].range` cannot be set to `[128,134,135]`; expecting a number array and an array of exactly 2 items, ignoring.',
         ],
     },
     INVALID_RANGE_WITHOUT_TYPE_CROSSLINE: {
@@ -294,7 +294,6 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
         }),
         warningMessages: [
             "AG Charts - Option `axes.y.crossLines[0].type` is required and has not been provided; expecting a keyword such as 'line' or 'range', ignoring.",
-            "AG Charts - Option `axes.y.crossLines[0].range` cannot be set to `[128,134]`; expecting crossLine type to be 'range', a defined value array and an array of exactly 2 items, ignoring.",
         ],
     },
     INVALID_LINE_VALUE_CROSSLINES: {
@@ -303,7 +302,9 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
             axisTypes: { x: 'unit-time', y: 'number' },
             seriesTypes: repeat('line', 2),
         }),
-        warningMessages: [],
+        warningMessages: [
+            'AG Charts - Option `axes.y.crossLines[0][type=line].value` cannot be set to `"a string instead of number"`; expecting a number, ignoring.',
+        ],
     },
     INVALID_RANGE_WITH_LINE_TYPE_CROSSLINE: {
         options: examples.INVALID_RANGE_WITH_LINE_TYPE_CROSSLINE,
@@ -312,7 +313,8 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
             seriesTypes: repeat('line', 2),
         }),
         warningMessages: [
-            "AG Charts - Option `axes.y.crossLines[0].range` cannot be set to `[128,134]`; expecting crossLine type to be 'range', a defined value array and an array of exactly 2 items, ignoring.",
+            'AG Charts - Option `axes.y.crossLines[0][type=line].value` is required and has not been provided; expecting a number, ignoring.',
+            'AG Charts - Unknown option `axes.y.crossLines[0][type=line].range`, ignoring.',
         ],
     },
     INVALID_LINE_WITHOUT_TYPE_CROSSLINE: {
@@ -323,7 +325,6 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
         }),
         warningMessages: [
             "AG Charts - Option `axes.y.crossLines[0].type` is required and has not been provided; expecting a keyword such as 'line' or 'range', ignoring.",
-            "AG Charts - Option `axes.y.crossLines[0].value` cannot be set to `128`; expecting crossLine type to be 'line' and a defined value, ignoring.",
         ],
     },
     INVALID_LINE_WITH_RANGE_TYPE_CROSSLINE: {
@@ -332,9 +333,7 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
             axisTypes: { x: 'unit-time', y: 'number' },
             seriesTypes: repeat('line', 2),
         }),
-        warningMessages: [
-            "AG Charts - Option `axes.y.crossLines[0].value` cannot be set to `128`; expecting crossLine type to be 'line' and a defined value, ignoring.",
-        ],
+        warningMessages: ['AG Charts - Unknown option `axes.y.crossLines[0][type=range].value`, ignoring.'],
     },
 };
 

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -333,7 +333,10 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
             axisTypes: { x: 'unit-time', y: 'number' },
             seriesTypes: repeat('line', 2),
         }),
-        warningMessages: ['AG Charts - Unknown option `axes.y.crossLines[0][type=range].value`, ignoring.'],
+        warningMessages: [
+            'AG Charts - Option `axes.y.crossLines[0][type=range].range` is required and has not been provided; expecting a number array and an array of exactly 2 items, ignoring.',
+            'AG Charts - Unknown option `axes.y.crossLines[0][type=range].value`, ignoring.',
+        ],
     },
 };
 

--- a/packages/ag-charts-community/src/chart/crossline/test/examples.ts
+++ b/packages/ag-charts-community/src/chart/crossline/test/examples.ts
@@ -12,7 +12,8 @@ const AREA_GRAPH_WITH_NEGATIVE_VALUES_EXAMPLE: AgCartesianChartOptions =
     loadExampleOptions('area-with-negative-values');
 
 type CrossLinesRangeConfig = Record<string, { vertical: [Date, Date]; horizontal: [number, number] }>;
-type InvalidCrossLineConfig = Record<string, Partial<AgCartesianCrossLineOptions>>;
+// Deliberately malformed cross-line options used to exercise validation warnings.
+type InvalidCrossLineConfig = Record<string, Record<string, unknown>>;
 
 const baseChartOptions: AgCartesianChartOptions = {
     data: DATA_OIL_PETROLEUM,
@@ -70,7 +71,7 @@ const baseChartOptions: AgCartesianChartOptions = {
     },
 };
 
-const baseCrossLineOptions: AgCartesianCrossLineOptions = {
+const baseCrossLineOptions = {
     type: 'range',
     fill: '#dbddf0',
     stroke: '#5157b7',
@@ -90,7 +91,7 @@ const createChartOptions = (rangeConfig: CrossLinesRangeConfig): Record<string, 
             ...baseChartOptions,
             axes: mapValues(baseChartOptions['axes'] ?? {}, (axis) => {
                 const range = axis.position === 'bottom' ? rangeConfig[name].vertical : rangeConfig[name].horizontal;
-                return { ...axis, crossLines: [{ ...baseCrossLineOptions, range }] };
+                return { ...axis, crossLines: [{ ...baseCrossLineOptions, range }] as AgCartesianCrossLineOptions[] };
             }),
         };
     }
@@ -155,7 +156,7 @@ const invalidCrossLinesOptions: InvalidCrossLineConfig = {
     },
     INVALID_RANGE_LENGTH_CROSSLINE: {
         type: 'range',
-        range: [128, 134, 135] as any,
+        range: [128, 134, 135],
     },
     INVALID_RANGE_WITHOUT_TYPE_CROSSLINE: {
         range: [128, 134],

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1619,7 +1619,7 @@ describe('DataModel', () => {
             expect(processedData!.columnValueType).toEqual(['bigint']);
 
             dataSet.addTransaction({ append: [{ id: 'C', count: 30n }] });
-            const reprocessed = dataModel.reprocessData(processedData!);
+            const reprocessed = dataModel.reprocessData(processedData!, undefined, undefined);
 
             expect(reprocessed.columnValueType).toEqual(['bigint']);
         });

--- a/packages/ag-charts-community/src/chart/themes/themeOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/themes/themeOptionsDef.ts
@@ -54,13 +54,14 @@ import type {
 } from 'ag-charts-types';
 
 import {
-    cartesianCrossLineOptionsDefs,
+    cartesianCrossLineLabelOptionsDefs,
     categoryAxisOptionsDefs,
     commonCrossLineLabelOptionsDefs,
-    commonCrossLineOptionsDefs,
+    crossLineStyleOptionsDefs,
     groupedCategoryAxisOptionsDefs,
     logAxisOptionsDefs,
     numberAxisOptionsDefs,
+    radiusCrossLineLabelOptionsDefs,
     timeAxisOptionsDefs,
     unitTimeAxisOptionsDefs,
 } from '../axesOptionsDefs';
@@ -230,7 +231,10 @@ export const scrollbarOptionsDef: OptionsDefs<AgScrollbarOptions> = {
     vertical: scrollbarVerticalOrientationOptionsDef,
 };
 
-const cartesianCrossLineThemeableOptionsDefs = without(cartesianCrossLineOptionsDefs, ['type', 'value', 'range']);
+const cartesianCrossLineThemeableOptionsDefs = {
+    ...crossLineStyleOptionsDefs,
+    label: cartesianCrossLineLabelOptionsDefs,
+};
 
 const cartesianAxesThemeDef: OptionsDefs<AgCartesianAxesTheme> = {
     number: {
@@ -294,31 +298,19 @@ const cartesianAxesThemeDef: OptionsDefs<AgCartesianAxesTheme> = {
 const polarAxesThemeDef: OptionsDefs<AgPolarAxesTheme> = {
     'angle-category': {
         ...without(angleCategoryAxisOptionsDefs, ['type', 'crossLines']),
-        crossLines: without(commonCrossLineOptionsDefs, ['type']),
+        crossLines: { ...crossLineStyleOptionsDefs, label: commonCrossLineLabelOptionsDefs },
     },
     'angle-number': {
         ...without(angleNumberAxisOptionsDefs, ['type', 'crossLines']),
-        crossLines: without(commonCrossLineOptionsDefs, ['type']),
+        crossLines: { ...crossLineStyleOptionsDefs, label: commonCrossLineLabelOptionsDefs },
     },
     'radius-category': {
         ...without(radiusCategoryAxisOptionsDefs, ['type', 'crossLines']),
-        crossLines: {
-            ...without(commonCrossLineOptionsDefs, ['type']),
-            label: {
-                ...commonCrossLineLabelOptionsDefs,
-                positionAngle: number,
-            },
-        },
+        crossLines: { ...crossLineStyleOptionsDefs, label: radiusCrossLineLabelOptionsDefs },
     },
     'radius-number': {
         ...without(radiusNumberAxisOptionsDefs, ['type', 'crossLines']),
-        crossLines: {
-            ...without(commonCrossLineOptionsDefs, ['type']),
-            label: {
-                ...commonCrossLineLabelOptionsDefs,
-                positionAngle: number,
-            },
-        },
+        crossLines: { ...crossLineStyleOptionsDefs, label: radiusCrossLineLabelOptionsDefs },
     },
 };
 

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -318,6 +318,7 @@ const ENABLED_FALSE_OPTIONS: AgCartesianChartOptions = {
                 {
                     enabled: false,
                     type: 'range',
+                    range: [new Date('2019-01-01'), new Date('2019-06-01')],
                     label: {
                         enabled: false,
                         text: 'Custom Crossline Label',
@@ -401,6 +402,7 @@ const INTRINSIC_ENABLE_CROSSLINE_OPTIONS: AgCartesianChartOptions = {
             crossLines: [
                 {
                     type: 'range',
+                    range: [new Date('2019-01-01'), new Date('2019-06-01')],
                     label: {
                         text: 'Custom Crossline Label',
                     },

--- a/packages/ag-charts-core/src/state/validation.test.ts
+++ b/packages/ag-charts-core/src/state/validation.test.ts
@@ -341,6 +341,39 @@ describe('Validation utils', () => {
         });
     });
 
+    describe('Disabled nodes (enabled: false)', () => {
+        const defs = { enabled: boolean, value: required(number) };
+
+        test('skips required-field enforcement when enabled is false', () => {
+            const { cleared, invalid } = validate({ enabled: false }, defs);
+            expect(invalid).toEqual([]);
+            expect(cleared).toEqual({ enabled: false });
+        });
+
+        test('still enforces required fields when not disabled', () => {
+            expect(validate({ enabled: true }, defs).invalid).not.toEqual([]);
+            expect(validate({}, defs).invalid).not.toEqual([]);
+        });
+
+        test('skips the discriminant requirement for a disabled type-union node', () => {
+            const unionDefs = typeUnion<
+                { type: 'a'; enabled?: boolean; aa?: boolean } | { type: 'b'; enabled?: boolean; bb: number }
+            >({ a: { enabled: boolean, aa: boolean }, b: { enabled: boolean, bb: required(number) } }, 'an object');
+
+            // Disabled with no `type`: no "type is required" error, `enabled` flag preserved.
+            const noType = validate({ enabled: false }, unionDefs);
+            expect(noType.invalid).toEqual([]);
+            expect(noType.cleared).toEqual({ enabled: false });
+
+            // Disabled, matching branch but missing its required field: no error.
+            expect(validate({ type: 'b', enabled: false }, unionDefs).invalid).toEqual([]);
+
+            // Enabled equivalents still warn about the missing discriminant / required field.
+            expect(validate({}, unionDefs).invalid).not.toEqual([]);
+            expect(validate({ type: 'b' }, unionDefs).invalid).not.toEqual([]);
+        });
+    });
+
     describe('Conditional Validators', () => {
         const axisSchema: OptionsDefs<any> = {
             min: and(number, lessThan('max')),

--- a/packages/ag-charts-core/src/state/validation.ts
+++ b/packages/ag-charts-core/src/state/validation.ts
@@ -186,6 +186,11 @@ export function validate<T>(
     const optionsKeys = new Set(Object.keys(options));
     const unusedKeys = [];
 
+    // A node with `enabled: false` has its remaining properties stripped by
+    // `removeDisabledOptions`, so enforcing required fields on it would warn about values that
+    // are about to be discarded.
+    const optionsDisabled = (options as { enabled?: unknown }).enabled === false;
+
     let schemaKeys = schemaKeyCache.get(optionsDefs);
     if (schemaKeys === undefined) {
         schemaKeys = Object.keys(optionsDefs);
@@ -207,6 +212,10 @@ export function validate<T>(
                 error.setUnionType(type, path);
             }
             invalid.push(...nestedResult.invalid);
+        } else if (optionsDisabled) {
+            // Disabled node with no resolvable discriminant: its properties are about to be
+            // stripped, so preserve only the `enabled` flag and skip the `type` requirement.
+            Object.assign(cleared, { enabled: false });
         } else {
             const keywords = joinFormatted(validTypes, 'or', (val) => `'${val}'`);
             invalid.push(
@@ -226,7 +235,7 @@ export function validate<T>(
             if (!validatorOrDefs[undocumentedSymbol]) {
                 unusedKeys.push(key);
             }
-            if (!required) continue;
+            if (!required || optionsDisabled) continue;
         }
 
         const keyPath = extendPath(path, key);

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -27,7 +27,7 @@ import type {
     AgCrossLineThemeOptions,
 } from './crossLineOptions';
 import type { AgBaseCrosshairLabel, AgCrosshairLabel, AgCrosshairOptions } from './crosshairOptions';
-import type { ContextDefault, DatumDefault, Degree, PixelSize, Ratio, TextWrap } from './types';
+import type { AxisValue, ContextDefault, DatumDefault, Degree, PixelSize, Ratio, TextWrap } from './types';
 
 /** Configuration for axes in cartesian charts. */
 export interface AgBaseCartesianAxisOptions<
@@ -40,7 +40,7 @@ export interface AgBaseCartesianAxisOptions<
     /** Value on the first perpendicular axis' domain where this axis should intersect. */
     crossAt?: AgCartesianAxisCrossAt;
     /** Add cross-lines or regions corresponding to data values. */
-    crossLines?: AgCartesianCrossLineOptions[];
+    crossLines?: AgCartesianCrossLineOptions<AxisValue>[];
     /** Sets the axis thickness regardless of its content. */
     thickness?: PixelSize;
     /**
@@ -287,6 +287,8 @@ export interface AgTimeAxisOptions<TContext = ContextDefault>
     type?: 'time';
     /** Options for labels and ticks for the parent level intervals. */
     parentLevel?: AgTimeAxisParentLevel<TContext>;
+    /** Add cross-lines or regions corresponding to data values. */
+    crossLines?: AgCartesianCrossLineOptions<Date | number>[];
 }
 
 export interface AgUnitTimeAxisOptions<TContext = ContextDefault>
@@ -301,6 +303,8 @@ export interface AgUnitTimeAxisOptions<TContext = ContextDefault>
         >,
         AgBaseContinuousAxisOptions<Date | number> {
     type?: 'unit-time';
+    /** Add cross-lines or regions corresponding to data values. */
+    crossLines?: AgCartesianCrossLineOptions<Date | number>[];
     /** Options for labels and ticks for the parent level intervals. */
     parentLevel?: AgTimeAxisParentLevel<TContext>;
     /** The size of each band. */
@@ -335,6 +339,8 @@ export interface AgOrdinalTimeAxisOptions<TContext = ContextDefault> extends AgB
     TContext
 > {
     type?: 'ordinal-time';
+    /** Add cross-lines or regions corresponding to data values. */
+    crossLines?: AgCartesianCrossLineOptions<Date | number>[];
     /** Options for labels and ticks for the parent level intervals. */
     parentLevel?: AgTimeAxisParentLevel<TContext>;
     /** Configuration for the axis ticks interval. */
@@ -373,6 +379,8 @@ export interface AgNumberAxisOptions<TContext = ContextDefault>
         >,
         AgContinuousAxisOptions<number, number> {
     type?: 'number';
+    /** Add cross-lines or regions corresponding to data values. */
+    crossLines?: AgCartesianCrossLineOptions<number>[];
 }
 
 export interface AgLogAxisOptions<TContext = ContextDefault>
@@ -389,6 +397,8 @@ export interface AgLogAxisOptions<TContext = ContextDefault>
     type?: 'log';
     /** The base of the logarithm used. */
     base?: number;
+    /** Add cross-lines or regions corresponding to data values. */
+    crossLines?: AgCartesianCrossLineOptions<number>[];
 }
 
 export type AgCartesianAxisPosition = 'top' | 'right' | 'bottom' | 'left';
@@ -505,7 +515,10 @@ export interface AgUnitTimeAxisThemeOptions<CrossLineLabelType = AgBaseCrossLine
         AgCartesianAxisThemeOptions<AgUnitTimeAxisOptions<TContext>>,
         AgCartesianAxesCrossLineThemeOptions<CrossLineLabelType> {}
 
-export interface AgCartesianCrossLineOptions extends AgBaseCrossLineOptions<AgCartesianCrossLineLabelOptions> {}
+export type AgCartesianCrossLineOptions<TValue = AxisValue> = AgBaseCrossLineOptions<
+    TValue,
+    AgCartesianCrossLineLabelOptions
+>;
 
 export interface AgCartesianCrossLineLabelOptions extends AgBaseCrossLineLabelOptions {
     /** The position of the Cross Line label. */

--- a/packages/ag-charts-types/src/chart/crossLineOptions.ts
+++ b/packages/ag-charts-types/src/chart/crossLineOptions.ts
@@ -1,20 +1,9 @@
 import type { AgChartLabelStyleOptions } from './labelOptions';
 import type { AxisValue, CssColor, FontFamilyFull, Opacity, PixelSize } from './types';
 
-export interface AgCrossLineThemeOptions<LabelType = AgBaseCrossLineLabelOptions> extends Omit<
-    AgBaseCrossLineOptions<LabelType>,
-    'type' | 'value' | 'range'
-> {}
-
-export interface AgBaseCrossLineOptions<LabelType = AgBaseCrossLineLabelOptions> {
+export interface AgCommonCrossLineOptions<LabelType = AgBaseCrossLineLabelOptions> {
     /** Whether to show the Cross Line. */
     enabled?: boolean;
-    /** Type of Cross Line to render, defaults to `line`. */
-    type: 'line' | 'range';
-    /** The data value at which the line should be positioned. This property is used if the Cross Line type is `line`. */
-    value?: AxisValue;
-    /** The range of values from the data used to display lines at a desired chart region. This property is only used for Cross Line type `range`. */
-    range?: [AxisValue, AxisValue];
     /** The colour to use for the fill of the range. */
     fill?: CssColor;
     /** The opacity of the fill for the range. */
@@ -30,6 +19,34 @@ export interface AgBaseCrossLineOptions<LabelType = AgBaseCrossLineLabelOptions>
     /** Configuration for the Cross Line label. */
     label?: LabelType;
 }
+
+export interface AgLineCrossLineOptions<
+    TValue = AxisValue,
+    LabelType = AgBaseCrossLineLabelOptions,
+> extends AgCommonCrossLineOptions<LabelType> {
+    /** Renders the Cross Line as a single line positioned at `value`. */
+    type: 'line';
+    /** The data value at which the line should be positioned. */
+    value: TValue;
+}
+
+export interface AgRangeCrossLineOptions<
+    TValue = AxisValue,
+    LabelType = AgBaseCrossLineLabelOptions,
+> extends AgCommonCrossLineOptions<LabelType> {
+    /** Renders the Cross Line as a shaded band spanning `range`. */
+    type: 'range';
+    /** The `[start, end]` data values bounding the shaded region. */
+    range: [TValue, TValue];
+}
+
+export type AgBaseCrossLineOptions<TValue = AxisValue, LabelType = AgBaseCrossLineLabelOptions> =
+    | AgLineCrossLineOptions<TValue, LabelType>
+    | AgRangeCrossLineOptions<TValue, LabelType>;
+
+export interface AgCrossLineThemeOptions<
+    LabelType = AgBaseCrossLineLabelOptions,
+> extends AgCommonCrossLineOptions<LabelType> {}
 
 export interface AgBaseCrossLineLabelOptions extends Omit<AgChartLabelStyleOptions, 'fontFamily'> {
     /** The text to show in the label. */

--- a/packages/ag-charts-types/src/chart/polarAxisOptions.ts
+++ b/packages/ag-charts-types/src/chart/polarAxisOptions.ts
@@ -5,7 +5,7 @@ import type {
     AgNumericAxisFormattableLabelOptions,
 } from './axisOptions';
 import type { AgBaseCrossLineLabelOptions, AgBaseCrossLineOptions, AgCrossLineThemeOptions } from './crossLineOptions';
-import type { ContextDefault, Degree, Ratio } from './types';
+import type { AxisValue, ContextDefault, Degree, Ratio } from './types';
 
 export type AgPolarAxisShape = 'polygon' | 'circle';
 
@@ -21,7 +21,7 @@ export interface AgAngleCategoryAxisOptions<TContext = ContextDefault> extends A
     /** Angle in degrees to end ticks positioning at. */
     endAngle?: Degree;
     /** Add cross lines or regions corresponding to data values. */
-    crossLines?: AgAngleCrossLineOptions[];
+    crossLines?: AgAngleCrossLineOptions<AxisValue>[];
     /**
      * This property is for grouped polar series plotted on a angle category axis.
      * It is a proportion between 0 and 1 which determines the size of the gap between the items within a single group along the angle axis.
@@ -48,7 +48,7 @@ export interface AgAngleNumberAxisOptions<TContext = ContextDefault>
     /** Angle in degrees to end ticks positioning at. It should be greater than `startAngle`. */
     endAngle?: Degree;
     /** Add cross lines or regions corresponding to data values. */
-    crossLines?: AgAngleCrossLineOptions[];
+    crossLines?: AgAngleCrossLineOptions<number>[];
 }
 
 export type AgAngleAxisLabelOrientation = 'fixed' | 'parallel' | 'perpendicular';
@@ -70,5 +70,5 @@ export interface AgAngleAxisFormattableLabelOptions<TContext = ContextDefault>
 export interface AgAngleAxisLabelOptions<TContext = ContextDefault>
     extends AgBaseAxisLabelOptions<TContext>, OrientableLabel {}
 
-export interface AgAngleCrossLineOptions extends AgBaseCrossLineOptions<AgBaseCrossLineLabelOptions> {}
+export type AgAngleCrossLineOptions<TValue = AxisValue> = AgBaseCrossLineOptions<TValue, AgBaseCrossLineLabelOptions>;
 export interface AgAngleCrossLineThemeOptions extends AgCrossLineThemeOptions<AgBaseCrossLineLabelOptions> {}

--- a/packages/ag-charts-types/src/chart/radiusAxisOptions.ts
+++ b/packages/ag-charts-types/src/chart/radiusAxisOptions.ts
@@ -5,9 +5,9 @@ import type {
     AgContinuousAxisOptions,
     AgNumericAxisFormattableLabelOptions,
 } from './axisOptions';
-import type { AgBaseCrossLineLabelOptions, AgBaseCrossLineOptions } from './crossLineOptions';
+import type { AgBaseCrossLineLabelOptions, AgBaseCrossLineOptions, AgCrossLineThemeOptions } from './crossLineOptions';
 import type { AgPolarAxisShape } from './polarAxisOptions';
-import type { ContextDefault, Degree, Ratio } from './types';
+import type { AxisValue, ContextDefault, Degree, Ratio } from './types';
 
 interface AgRadiusAxisFormattableLabelOptions<
     TContext = ContextDefault,
@@ -27,7 +27,7 @@ export interface AgRadiusNumberAxisOptions<TContext = ContextDefault>
     /** Configuration for the title shown next to the axis. */
     title?: AgAxisCaptionOptions;
     /** Add cross lines or regions corresponding to data values. */
-    crossLines?: AgRadiusCrossLineOptions[];
+    crossLines?: AgRadiusCrossLineOptions<number>[];
     /**
      * The ratio of the inner radius of the axis as a proportion of the overall radius.
      *  Used to create an inner circle.
@@ -45,7 +45,7 @@ export interface AgRadiusCategoryAxisOptions<TContext = ContextDefault> extends 
     /** Configuration for the title shown next to the axis. */
     title?: AgAxisCaptionOptions;
     /** Add cross lines or regions corresponding to data values. */
-    crossLines?: AgRadiusCrossLineOptions[];
+    crossLines?: AgRadiusCrossLineOptions<AxisValue>[];
     /**
      * The ratio of the inner radius of the axis as a proportion of the overall radius.
      *  Used to create an inner circle.
@@ -68,13 +68,16 @@ export interface AgRadiusCategoryAxisOptions<TContext = ContextDefault> extends 
     paddingOuter?: Ratio;
 }
 
-export interface AgRadiusCrossLineOptions extends AgBaseCrossLineOptions<AgRadiusCrossLineLabelOptions> {}
-export interface AgRadiusCrossLineThemeOptions extends Omit<AgRadiusCrossLineOptions, 'type'> {}
+export type AgRadiusCrossLineOptions<TValue = AxisValue> = AgBaseCrossLineOptions<
+    TValue,
+    AgRadiusCrossLineLabelOptions
+>;
+export interface AgRadiusCrossLineThemeOptions extends AgCrossLineThemeOptions<AgRadiusCrossLineLabelOptions> {}
 
 export interface AgRadiusAxesCrossLineThemeOptions {
     crossLines?: AgRadiusCrossLineThemeOptions;
 }
 
-interface AgRadiusCrossLineLabelOptions extends AgBaseCrossLineLabelOptions {
+export interface AgRadiusCrossLineLabelOptions extends AgBaseCrossLineLabelOptions {
     positionAngle?: Degree;
 }

--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -175,6 +175,56 @@ test.describe('api-ref-page', () => {
         await expect(getNavigationProperty(page, /^xKey$/)).toBeVisible();
     });
 
+    test('expands an axis cross-line member into its discriminated variants', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/axes/number/'));
+        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR).first()).toBeVisible();
+
+        const crossLines = getNavigationProperty(page, /^crossLines/);
+        await expect(crossLines).toBeVisible();
+        await crossLines.locator(PROPERTY_EXPANDER_SELECTOR).click();
+
+        await expect(getNavigationProperty(page, /type\s*= 'line'/)).toBeVisible();
+        await expect(getNavigationProperty(page, /type\s*= 'range'/)).toBeVisible();
+    });
+
+    test('expands a cross-line variant to its own properties, not the axis properties', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/axes/number/'));
+        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR).first()).toBeVisible();
+
+        const crossLines = getNavigationProperty(page, /^crossLines/);
+        await crossLines.locator(PROPERTY_EXPANDER_SELECTOR).click();
+
+        const lineVariant = getNavigationProperty(page, /type\s*= 'line'/);
+        await lineVariant.locator(PROPERTY_EXPANDER_SELECTOR).click();
+
+        // `value` is a cross-line line-variant property; it is absent from the axis interface, so
+        // its presence proves the variant resolved to the cross-line type rather than the axis type.
+        await expect(getNavigationProperty(page, /^value$/)).toBeVisible();
+    });
+
+    test('keeps cross-line variants collapsed after refreshing on another axis property', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/axes/number/#reference-AgNumberAxisOptions-nice'));
+        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR).first()).toBeVisible();
+
+        const crossLines = getNavigationProperty(page, /^crossLines/);
+        await crossLines.locator(PROPERTY_EXPANDER_SELECTOR).click();
+
+        // The variant branches show, but selecting an unrelated axis property must not auto-expand
+        // them, even though they share the axis page.
+        await expect(getNavigationProperty(page, /type\s*= 'line'/)).toBeVisible();
+        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR, { hasText: /^value$/ })).toHaveCount(0);
+    });
+
+    test('renders a cross-line member as a plain array, like series', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/axes/number/'));
+
+        const crossLines = getNavigationProperty(page, /^crossLines/);
+        await expect(crossLines).toBeVisible();
+        // A discriminated-union array reads as a plain array, not an array wrapping an object (`[{ }]`).
+        await expect(crossLines).toContainText('[ ... ]');
+        await expect(crossLines).not.toContainText('[{');
+    });
+
     test('child properties toggle reveals nested rows for padding', async ({ page }) => {
         await gotoUrl(page, toPageUrl('options/'));
         await waitForApiReady(page);

--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -175,9 +175,14 @@ test.describe('api-ref-page', () => {
         await expect(getNavigationProperty(page, /^xKey$/)).toBeVisible();
     });
 
+    // On the number-axis page the `crossLines` member sits under the `{ type = 'number' ... }`
+    // nav node, which is collapsed by default. Deep-linking to a sibling axis property auto-expands
+    // that node (the path to the selection) so `crossLines` is reachable in the navigation tree,
+    // while leaving `crossLines` itself collapsed.
+    const NUMBER_AXIS_URL = 'options/axes/number/#reference-AgNumberAxisOptions-nice';
+
     test('expands an axis cross-line member into its discriminated variants', async ({ page }) => {
-        await gotoUrl(page, toPageUrl('options/axes/number/'));
-        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR).first()).toBeVisible();
+        await gotoUrl(page, toPageUrl(NUMBER_AXIS_URL));
 
         const crossLines = getNavigationProperty(page, /^crossLines/);
         await expect(crossLines).toBeVisible();
@@ -188,10 +193,10 @@ test.describe('api-ref-page', () => {
     });
 
     test('expands a cross-line variant to its own properties, not the axis properties', async ({ page }) => {
-        await gotoUrl(page, toPageUrl('options/axes/number/'));
-        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR).first()).toBeVisible();
+        await gotoUrl(page, toPageUrl(NUMBER_AXIS_URL));
 
         const crossLines = getNavigationProperty(page, /^crossLines/);
+        await expect(crossLines).toBeVisible();
         await crossLines.locator(PROPERTY_EXPANDER_SELECTOR).click();
 
         const lineVariant = getNavigationProperty(page, /type\s*= 'line'/);
@@ -203,10 +208,10 @@ test.describe('api-ref-page', () => {
     });
 
     test('keeps cross-line variants collapsed after refreshing on another axis property', async ({ page }) => {
-        await gotoUrl(page, toPageUrl('options/axes/number/#reference-AgNumberAxisOptions-nice'));
-        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR).first()).toBeVisible();
+        await gotoUrl(page, toPageUrl(NUMBER_AXIS_URL));
 
         const crossLines = getNavigationProperty(page, /^crossLines/);
+        await expect(crossLines).toBeVisible();
         await crossLines.locator(PROPERTY_EXPANDER_SELECTOR).click();
 
         // The variant branches show, but selecting an unrelated axis property must not auto-expand
@@ -216,7 +221,7 @@ test.describe('api-ref-page', () => {
     });
 
     test('renders a cross-line member as a plain array, like series', async ({ page }) => {
-        await gotoUrl(page, toPageUrl('options/axes/number/'));
+        await gotoUrl(page, toPageUrl(NUMBER_AXIS_URL));
 
         const crossLines = getNavigationProperty(page, /^crossLines/);
         await expect(crossLines).toBeVisible();

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -258,13 +258,21 @@ export function extractSearchData(
     reference?: ApiReferenceType,
     interfaceRef?: NodeTypes,
     basePath: NavigationPath[] = [],
-    labelPrefix = ''
+    labelPrefix = '',
+    genericsMap?: Record<string, TypeNode>
 ): SearchDatum[] {
-    if (isInterfaceLikeNode(interfaceRef)) {
-        return extractInterfaceSearchData(reference, interfaceRef, basePath, labelPrefix);
+    const aliasedUnion = resolveAliasedUnion(interfaceRef, reference);
+    if (aliasedUnion) {
+        return extractUnionSearchData(
+            reference,
+            aliasedUnion.unionType,
+            basePath,
+            labelPrefix,
+            mergeGenericsMaps(genericsMap, aliasedUnion.genericsMap)
+        );
     }
-    if (isUnionTypeAlias(interfaceRef)) {
-        return extractUnionSearchData(reference, interfaceRef, basePath, labelPrefix);
+    if (isInterfaceLikeNode(interfaceRef)) {
+        return extractInterfaceSearchData(reference, interfaceRef, basePath, labelPrefix, genericsMap);
     }
     return [];
 }
@@ -612,13 +620,114 @@ function isUnionTypeAlias(
     return Boolean(interfaceRef?.kind === 'typeAlias' && isUnionNode(interfaceRef.type));
 }
 
+/** Resolves the referenced type name from a node that may be a bare string or a typeRef. */
+export function getReferencedTypeName(type?: TypeNode): string | undefined {
+    if (typeof type === 'string') {
+        return type;
+    }
+    if (type && isTypeReferenceNode(type)) {
+        return type.type;
+    }
+    return undefined;
+}
+
+/**
+ * Resolves a reference that represents a union, whether directly (a union type alias) or
+ * indirectly. Axis-specific cross-line aliases (e.g. `AgCartesianCrossLineOptions`) are
+ * emitted as an interface with no own members whose single heritage is a union type alias
+ * (`AgBaseCrossLineOptions`); without this they resolve to zero members and disappear from
+ * the navigation and options page. The alias' `genericsMap` is returned so generic members
+ * of the union variants (e.g. `label`) resolve to the per-axis type.
+ */
+export function resolveAliasedUnion(
+    interfaceRef?: NodeTypes,
+    reference?: ApiReferenceType
+): { unionType: MultiTypeNode & { kind: 'union' }; genericsMap?: Record<string, TypeNode> } | undefined {
+    if (isUnionTypeAlias(interfaceRef)) {
+        return { unionType: interfaceRef.type, genericsMap: interfaceRef.genericsMap };
+    }
+    if (
+        interfaceRef?.kind === 'interface' &&
+        interfaceRef.members.length === 0 &&
+        interfaceRef.heritage?.length === 1
+    ) {
+        const [heritage] = interfaceRef.heritage;
+        const heritageName = getReferencedTypeName(heritage);
+        const target = heritageName ? reference?.get(heritageName) : undefined;
+        if (isUnionTypeAlias(target)) {
+            return { unionType: target.type, genericsMap: interfaceRef.genericsMap };
+        }
+    }
+    return undefined;
+}
+
+function mergeGenericsMaps(
+    base?: Record<string, TypeNode>,
+    overrides?: Record<string, TypeNode>
+): Record<string, TypeNode> | undefined {
+    if (!base) return overrides;
+    if (!overrides) return base;
+    return { ...base, ...overrides };
+}
+
+/**
+ * Resolves the discriminated variants of an aliased union (see {@link resolveAliasedUnion}) into
+ * `{ name, type }` navigation entries — `name` being the variant's `type` discriminator value and
+ * `type` its interface name. Returns the alias' `genericsMap` so callers can resolve generic
+ * members (e.g. the per-axis `label`) when rendering each variant. Mirrors the shape produced for
+ * direct union aliases so both can feed the same typed-union navigation rendering.
+ */
+export function getAliasedUnionVariants(
+    interfaceRef?: NodeTypes,
+    reference?: ApiReferenceType
+): { variants: NavigationPath[]; genericsMap?: Record<string, TypeNode> } | undefined {
+    const aliasedUnion = resolveAliasedUnion(interfaceRef, reference);
+    if (!aliasedUnion) {
+        return undefined;
+    }
+
+    const variants = aliasedUnion.unionType.type
+        .map((subType) => {
+            const subtypeName = getReferencedTypeName(subType);
+            const subtypeRef = subtypeName ? reference?.get(subtypeName) : undefined;
+            if (subtypeRef?.kind === 'interface') {
+                const typeMember = subtypeRef.members.find((member) => member.name === 'type');
+                if (typeof typeMember?.type === 'string') {
+                    return { name: cleanupName(typeMember.type), type: subtypeName! };
+                }
+            }
+            return undefined;
+        })
+        .filter((variant): variant is NavigationPath => variant != null);
+
+    return variants.length ? { variants, genericsMap: aliasedUnion.genericsMap } : undefined;
+}
+
+/** Builds positional type arguments for an interface from a generics map keyed by type-param name. */
+export function buildTypeArgumentsFromGenericsMap(
+    interfaceRef: NodeTypes,
+    genericsMap?: Record<string, TypeNode>
+): string[] | undefined {
+    const typeParams = (interfaceRef as HasProperty<NodeTypes, 'typeParams'>).typeParams;
+    if (!genericsMap || !typeParams) {
+        return undefined;
+    }
+    return typeParams.map((typeParam) =>
+        normalizeType(genericsMap[typeParam.name] ?? typeParam.default ?? typeParam.name)
+    );
+}
+
 function extractInterfaceSearchData(
     reference: ApiReferenceType | undefined,
     interfaceRef: InterfaceNode | (TypeLiteralNode & { name: string }),
     basePath: NavigationPath[],
-    labelPrefix: string
+    labelPrefix: string,
+    parentGenericsMap?: Record<string, TypeNode>
 ) {
-    const { genericsMap } = interfaceRef as HasProperty<NodeTypes, 'genericsMap'>;
+    const genericsMap = mergeGenericsMaps(
+        (interfaceRef as HasProperty<NodeTypes, 'genericsMap'>).genericsMap,
+        parentGenericsMap
+    );
     return interfaceRef.members.flatMap((member) => {
         const cleanedName = cleanupName(member.name);
         const newPath = { name: cleanedName, type: getMemberType(member) };
@@ -670,12 +779,13 @@ function resolveMemberReference(
 
 function extractUnionSearchData(
     reference: ApiReferenceType | undefined,
-    interfaceRef: TypeAliasNode & { type: MultiTypeNode & { kind: 'union' } },
+    unionType: MultiTypeNode & { kind: 'union' },
     basePath: NavigationPath[],
-    labelPrefix: string
+    labelPrefix: string,
+    genericsMap?: Record<string, TypeNode>
 ) {
-    return interfaceRef.type.type
-        .flatMap((typeName) => buildUnionSearchEntries(typeName, reference, basePath, labelPrefix))
+    return unionType.type
+        .flatMap((typeName) => buildUnionSearchEntries(typeName, reference, basePath, labelPrefix, genericsMap))
         .filter((item): item is SearchDatum => Boolean(item));
 }
 
@@ -683,13 +793,15 @@ function buildUnionSearchEntries(
     typeName: TypeNode,
     reference: ApiReferenceType | undefined,
     basePath: NavigationPath[],
-    labelPrefix: string
+    labelPrefix: string,
+    parentGenericsMap?: Record<string, TypeNode>
 ) {
-    if (typeof typeName !== 'string' || isInterfaceHidden(typeName)) {
+    const subtypeName = getReferencedTypeName(typeName);
+    if (!subtypeName || isInterfaceHidden(subtypeName)) {
         return [];
     }
 
-    const subtypeRef = reference?.get(typeName);
+    const subtypeRef = reference?.get(subtypeName);
     if (subtypeRef?.kind !== 'interface') {
         return [];
     }
@@ -702,7 +814,7 @@ function buildUnionSearchEntries(
     const label = `${labelPrefix.replace(/\.$/, '')}[type=${typeMember.type as string}]`;
     const navPath = basePath.concat({
         name: cleanupName(getMemberType(typeMember)),
-        type: typeName,
+        type: subtypeName,
     });
 
     return [
@@ -711,7 +823,7 @@ function buildUnionSearchEntries(
             searchable: cleanupName(getMemberType(typeMember)).toLowerCase(),
             navPath,
         },
-        ...extractSearchData(reference, subtypeRef, navPath, `${label}.`),
+        ...extractSearchData(reference, subtypeRef, navPath, `${label}.`, parentGenericsMap),
     ];
 }
 

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
@@ -24,10 +24,12 @@ import {
     cleanupName,
     formatTypeToCode,
     getMemberType,
+    getReferencedTypeName,
     isInterfaceHidden,
     normalizeType,
     parseJsDocs,
     processMembers,
+    resolveAliasedUnion,
 } from '../apiReferenceHelpers';
 import { SelectionContext } from './OptionsNavigation';
 import { type CollapsibleType, PropertyTitle, PropertyType } from './Properties';
@@ -365,6 +367,30 @@ function useMemberAdditionalDetails(member: MemberNode): NodeTypes | NodeTypes[]
         resolveReferenceType(reference, resolveType);
 
     const resolvedDetails = resolve(memberType);
+
+    // An axis-specific cross-line alias resolves to an interface with no own members whose
+    // heritage is a union type alias; expand it to its variants so the union renders.
+    const aliasedUnion = resolveAliasedUnion(
+        resolvedDetails && !Array.isArray(resolvedDetails) ? resolvedDetails : undefined,
+        reference
+    );
+    if (aliasedUnion) {
+        const unionTypes = aliasedUnion.unionType.type
+            .flatMap((unionType) => {
+                const typeName = getReferencedTypeName(unionType);
+                return typeName ? resolve(typeName) : undefined;
+            })
+            .filter(
+                (apiNode): apiNode is NodeTypes =>
+                    typeof apiNode === 'object' &&
+                    (apiNode.kind === 'typeAlias' || apiNode.kind === 'interface') &&
+                    !isInterfaceHidden(apiNode.name)
+            );
+        if (unionTypes.length) {
+            return unionTypes;
+        }
+    }
+
     if (resolvedDetails) {
         return resolvedDetails;
     }

--- a/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
@@ -4,6 +4,7 @@ import type {
     ApiReferenceNode,
     ApiReferenceType,
     MemberNode,
+    TypeNode,
 } from '@generate-code-reference-plugin/doc-interfaces/types';
 import { useToggle } from '@utils/hooks/useToggle';
 import classnames from 'classnames';
@@ -28,8 +29,10 @@ import {
     type NavigationPath,
     type SearchIndex,
     type SearchIndexDatum,
+    buildTypeArgumentsFromGenericsMap,
     cleanupName,
     extractSearchData,
+    getAliasedUnionVariants,
     getMemberType,
     getNavigationDataFromPath,
     isInterfaceHidden,
@@ -180,6 +183,13 @@ function NavProperty({
     const isInterfaceArray = config.specialTypes?.[memberType] === 'InterfaceArray';
     const isInterfaceRecord = config.specialTypes?.[memberType] === 'InterfaceRecord';
     const hasNestedPages = config.specialTypes?.[memberType] === 'NestedPage';
+    // An axis-specific cross-line alias resolves to an empty interface whose heritage is a union
+    // type alias; expand it into its discriminated variants rather than its (empty) members.
+    const unionVariants =
+        isInterface && !isInterfaceArray && !isInterfaceRecord
+            ? getAliasedUnionVariants(interfaceRef, reference)
+            : undefined;
+    const isTypedUnion = Boolean(unionVariants);
     const expandable = isInterface || isInterfaceArray || isInterfaceRecord;
     const isObjectArray =
         !isInterfaceArray &&
@@ -188,6 +198,9 @@ function NavProperty({
         member.type.kind === 'array' &&
         reference?.has(memberType) &&
         !isInterfaceHidden(memberType);
+    // A discriminated-union array renders like `series`: a plain array of `{ type=... }` branches,
+    // not an array wrapping a single object literal (`[{ }]`).
+    const isUnionArray = isTypedUnion && isObjectArray;
 
     const navData = getNavigationDataFromPath(path, config.specialTypes);
 
@@ -283,8 +296,8 @@ function NavProperty({
                     {expandable && (
                         <OpeningBrackets
                             isOpen={isExpanded}
-                            isArray={isInterfaceArray}
-                            isObjectArray={isObjectArray}
+                            isArray={isInterfaceArray || isUnionArray}
+                            isObjectArray={isObjectArray && !isUnionArray}
                             onClick={toggleExpanded}
                         />
                     )}
@@ -293,7 +306,7 @@ function NavProperty({
             {expandable && isExpanded && (
                 <>
                     <NavGroup depth={depth + 1}>
-                        {isInterface
+                        {isInterface && !isTypedUnion
                             ? processMembers(interfaceRef, config, typeArguments)
                                   .filter((childMember) => !skip?.includes(childMember.name))
                                   .map((childMember) => (
@@ -309,17 +322,24 @@ function NavProperty({
                                           onClick={onClick}
                                       />
                                   ))
-                            : getInterfaceArrayTypes(reference, interfaceRef).map(({ name, type }) => (
-                                  <NavTypedUnionProperty
-                                      key={type}
-                                      depth={depth + 1}
-                                      path={path.concat({ name, type })}
-                                      isRecordUnion={isInterfaceRecord}
-                                      onClick={onClick}
-                                  />
-                              ))}
+                            : (unionVariants?.variants ?? getInterfaceArrayTypes(reference, interfaceRef)).map(
+                                  ({ name, type }) => (
+                                      <NavTypedUnionProperty
+                                          key={type}
+                                          depth={depth + 1}
+                                          path={path.concat({ name, type })}
+                                          isRecordUnion={isInterfaceRecord}
+                                          genericsMap={unionVariants?.genericsMap}
+                                          onClick={onClick}
+                                      />
+                                  )
+                              )}
                     </NavGroup>
-                    <ClosingBrackets depth={depth} isArray={isInterfaceArray} isObjectArray={isObjectArray} />
+                    <ClosingBrackets
+                        depth={depth}
+                        isArray={isInterfaceArray || isUnionArray}
+                        isObjectArray={isObjectArray && !isUnionArray}
+                    />
                 </>
             )}
         </>
@@ -330,25 +350,40 @@ function NavTypedUnionProperty({
     depth = 0,
     path,
     isRecordUnion,
+    genericsMap,
     onClick,
 }: {
     depth?: number;
     path: NavigationPath[];
     isRecordUnion: boolean;
+    genericsMap?: Record<string, TypeNode>;
     onClick?: (navData: NavigationData) => void;
 }) {
     const selection = useContext(SelectionContext);
     const reference = useContext(ApiReferenceContext);
     const config = useContext(ApiReferenceConfigContext);
     const navData = getNavigationDataFromPath(path, config.specialTypes);
-    const interfaceRef = reference?.get(navData.pageInterface);
+    // The variant interface is the terminal path entry. `navData.pageInterface` only advances to
+    // the variant for members registered as InterfaceArray/Record special types; an inline aliased
+    // union (e.g. a cross-line member) leaves it pointing at the page's root interface, so resolving
+    // from it would render the root interface's members instead of the variant's.
+    const variantType = path[path.length - 1].type;
+    const interfaceRef = reference?.get(variantType);
+    // An inline aliased-union variant shares its page with the root interface, so a page-level match
+    // would auto-expand it for any selection on that page. Require the selection to sit inside this
+    // variant's own subtree instead. Separate-page variants (InterfaceArray) keep the page-match.
+    const isInlineUnion = navData.pageInterface !== variantType;
 
-    const [isExpanded, toggleExpanded] = useAutoExpand(
-        () =>
+    const [isExpanded, toggleExpanded] = useAutoExpand(() => {
+        const isWithinPage =
             selection?.selection.pageInterface === navData.pageInterface &&
             Boolean(selection?.selection.hash) &&
-            selection?.selection.hash !== navData.hash
-    );
+            selection?.selection.hash !== navData.hash;
+        if (!isWithinPage) {
+            return false;
+        }
+        return isInlineUnion ? Boolean(selection?.selection.hash?.startsWith(navData.hash)) : true;
+    });
 
     if (interfaceRef?.kind !== 'interface') {
         return null;
@@ -358,6 +393,8 @@ function NavTypedUnionProperty({
         !isExpanded &&
         selection?.selection.pageInterface === navData.pageInterface &&
         selection?.selection.hash === navData.hash;
+
+    const typeArguments = buildTypeArgumentsFromGenericsMap(interfaceRef, genericsMap);
 
     return (
         <>
@@ -394,7 +431,7 @@ function NavTypedUnionProperty({
             {isExpanded && (
                 <>
                     <NavGroup depth={depth + 1}>
-                        {processMembers(interfaceRef, config).map((member) => (
+                        {processMembers(interfaceRef, config, typeArguments).map((member) => (
                             <NavProperty
                                 key={member.name}
                                 member={member}

--- a/packages/ag-charts-website/src/components/api-documentation/crossLineNav.test.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/crossLineNav.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { entries } from 'ag-charts-core';
+
+import {
+    buildTypeArgumentsFromGenericsMap,
+    extractSearchData,
+    getAliasedUnionVariants,
+    processMembers,
+} from './apiReferenceHelpers';
+
+// Mirrors how the type generator emits an axis-specific cross-line option: an alias
+// (`AgCartesianCrossLineOptions`) emitted as an interface with no own members whose single heritage
+// is a union type alias (`AgBaseCrossLineOptions`) of discriminated variants. The per-axis label
+// type is supplied via the alias' genericsMap, so the variants' generic `label` member resolves to
+// it rather than to the base label type.
+const reference = new Map<string, any>(
+    entries({
+        AgCartesianCrossLineOptions: {
+            kind: 'interface',
+            name: 'AgCartesianCrossLineOptions',
+            members: [],
+            heritage: [
+                {
+                    kind: 'typeRef',
+                    type: 'AgBaseCrossLineOptions',
+                    typeArguments: ['TValue', 'AgCartesianCrossLineLabelOptions'],
+                },
+            ],
+            genericsMap: { TValue: 'AxisValue', LabelType: 'AgCartesianCrossLineLabelOptions' },
+        },
+        AgBaseCrossLineOptions: {
+            kind: 'typeAlias',
+            name: 'AgBaseCrossLineOptions',
+            type: {
+                kind: 'union',
+                type: [
+                    { kind: 'typeRef', type: 'AgLineCrossLineOptions', typeArguments: ['TValue', 'LabelType'] },
+                    { kind: 'typeRef', type: 'AgRangeCrossLineOptions', typeArguments: ['TValue', 'LabelType'] },
+                ],
+            },
+            genericsMap: { TValue: 'AxisValue', LabelType: 'AgCartesianCrossLineLabelOptions' },
+        },
+        AgLineCrossLineOptions: {
+            kind: 'interface',
+            name: 'AgLineCrossLineOptions',
+            members: [
+                { kind: 'member', name: 'type', type: "'line'", optional: false },
+                { kind: 'member', name: 'value', type: 'TValue', optional: false },
+                { kind: 'member', name: 'stroke', type: 'CssColor', optional: true },
+                { kind: 'member', name: 'label', type: 'LabelType', optional: true },
+            ],
+            typeParams: [
+                { kind: 'typeParam', name: 'TValue', default: 'AxisValue' },
+                { kind: 'typeParam', name: 'LabelType', default: 'AgBaseCrossLineLabelOptions' },
+            ],
+            genericsMap: { TValue: 'AxisValue', LabelType: 'AgBaseCrossLineLabelOptions' },
+        },
+        AgRangeCrossLineOptions: {
+            kind: 'interface',
+            name: 'AgRangeCrossLineOptions',
+            members: [
+                { kind: 'member', name: 'type', type: "'range'", optional: false },
+                { kind: 'member', name: 'range', type: { kind: 'tuple', type: ['TValue', 'TValue'] }, optional: false },
+                { kind: 'member', name: 'stroke', type: 'CssColor', optional: true },
+                { kind: 'member', name: 'label', type: 'LabelType', optional: true },
+            ],
+            typeParams: [
+                { kind: 'typeParam', name: 'TValue', default: 'AxisValue' },
+                { kind: 'typeParam', name: 'LabelType', default: 'AgBaseCrossLineLabelOptions' },
+            ],
+            genericsMap: { TValue: 'AxisValue', LabelType: 'AgBaseCrossLineLabelOptions' },
+        },
+        AgCartesianCrossLineLabelOptions: {
+            kind: 'interface',
+            name: 'AgCartesianCrossLineLabelOptions',
+            members: [
+                { kind: 'member', name: 'position', type: 'string', optional: true },
+                { kind: 'member', name: 'rotation', type: 'number', optional: true },
+            ],
+        },
+    })
+);
+
+const crossLineInterface = () => reference.get('AgCartesianCrossLineOptions');
+
+describe('cross-line union navigation', () => {
+    describe('search index (extractSearchData)', () => {
+        const labels = () =>
+            extractSearchData(reference as any, crossLineInterface(), [
+                { name: 'x', type: 'AgCartesianCrossLineOptions' },
+            ]).map((d) => d.label);
+
+        it('expands an alias-to-union interface into discriminated branches', () => {
+            const result = labels();
+            expect(result.some((l) => l.includes("[type='line']"))).toBe(true);
+            expect(result.some((l) => l.includes("[type='range']"))).toBe(true);
+            expect(result.some((l) => l.endsWith("[type='line'].value"))).toBe(true);
+            expect(result.some((l) => l.endsWith("[type='range'].range"))).toBe(true);
+            expect(result.some((l) => l.endsWith("[type='line'].stroke"))).toBe(true);
+        });
+
+        it("resolves the variants' generic label member to the per-axis label type", () => {
+            const result = labels();
+            expect(result.some((l) => l.endsWith("[type='line'].label.position"))).toBe(true);
+            expect(result.some((l) => l.endsWith("[type='line'].label.rotation"))).toBe(true);
+        });
+    });
+
+    describe('nav tree variant resolution', () => {
+        it('resolves the alias interface to its discriminated variants', () => {
+            const union = getAliasedUnionVariants(crossLineInterface(), reference as any);
+            expect(union?.variants.map((v) => v.name).sort()).toEqual(['line', 'range']);
+            expect(union?.variants.map((v) => v.type).sort()).toEqual([
+                'AgLineCrossLineOptions',
+                'AgRangeCrossLineOptions',
+            ]);
+        });
+
+        it("threads the alias genericsMap so a variant's label resolves to the per-axis type", () => {
+            const union = getAliasedUnionVariants(crossLineInterface(), reference as any)!;
+            const lineRef = reference.get('AgLineCrossLineOptions');
+            const typeArguments = buildTypeArgumentsFromGenericsMap(lineRef, union.genericsMap);
+            const labelMember = processMembers(lineRef, {}, typeArguments).find((m) => m.name === 'label');
+            expect(labelMember?.type).toBe('AgCartesianCrossLineLabelOptions');
+        });
+    });
+});


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14484

Replace the legacy single cross-line interface (a `type` discriminator with loosely-typed `value`/`range` siblings validated by bespoke conditional checks) with a proper discriminated union:

- `AgLineCrossLineOptions` carries a scalar `value: TValue`; `AgRangeCrossLineOptions` carries a `range: [TValue, TValue]` tuple. Both are generic over the value type.
- **Per-axis static typing**: number/log axes type the value as `number`, time/unit-time/ordinal-time as `Date | number`, category axes stay general (`AxisValue`).
- **Per-axis validation**: built from the `typeUnion()` helper via a `crossLineOptionsDefs(value, labelDefs)` factory, so each axis injects its own value validator (`number`, `or(number, date)`, `defined`) and the cross-line value is validated against the axis it is attached to. The discriminant field (`value` for `line`, `range` for `range`) is required at the top level, so omitting it warns consistently.

This is API-compatible — `value` (line) and `range` (range) property names are unchanged — but the option types are now generic and the discriminant is required.

**Validation fix for disabled nodes:** because validation runs before `removeDisabledOptions` strips a disabled node's properties, a node with `enabled: false` previously warned about its now-required fields (e.g. a disabled `range` cross-line missing its `range`). `validate()` now skips required-field enforcement when `enabled === false` — missing required fields are ignored, and a disabled discriminated-union node with no resolvable `type` preserves only the `enabled` flag instead of warning. This is a general rule that pairs with the global disabled-option stripping; covered by new tests in `validation.test.ts`.

Also aligns a pre-existing bigint reprocessing test with the 3-arg `reprocessData` signature so the community type-check passes.

Fix #AG-14484
