### PR TITLE
AG-17474 Add async data documentation page with examples and loading overlay docs

### DIFF
--- a/packages/ag-charts-types/src/chart/dataSourceOptions.ts
+++ b/packages/ag-charts-types/src/chart/dataSourceOptions.ts
@@ -6,9 +6,9 @@ export interface AgDataSourceOptions<TDatum = DatumDefault, TContext = ContextDe
 }
 
 export interface AgDataSourceCallbackParams<TContext = ContextDefault> {
-    /** The start of the visible window, if a time axis is available. */
+    /** The start of the visible window on the x-axis. `undefined` on the initial load if no axis bounds have been established. */
     windowStart?: Date | number | string;
-    /** The end of the visible window, if a time axis is available. */
+    /** The end of the visible window on the x-axis. `undefined` on the initial load if no axis bounds have been established. */
     windowEnd?: Date | number | string;
     /** Chart context object. */
     context?: TContext;

--- a/packages/ag-charts-website/src/content/docs-nav/nav.json
+++ b/packages/ag-charts-website/src/content/docs-nav/nav.json
@@ -110,6 +110,12 @@
                             "type": "item",
                             "title": "Transactions",
                             "path": "transactions"
+                        },
+                        {
+                            "type": "item",
+                            "title": "Asynchronous Data",
+                            "path": "async-data",
+                            "isEnterprise": true
                         }
                     ]
                 },

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/data.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/data.ts
@@ -1,0 +1,40 @@
+import { createSeededRandom } from './seededRandom';
+
+/**
+ * This fake database generates and returns randomised data of objects with time, price and quantity. If you are a
+ * frontend developer you can safely ignore this part of the example.
+ */
+export const Database = {
+    get: () => (data ??= generate()),
+};
+
+export const minute = 1000 * 60;
+export const hour = minute * 60;
+export const day = hour * 24;
+export const week = day * 7;
+export const month = day * 30;
+
+export const dataStart = new Date('2019-01-01 00:00:00').getTime();
+export const dataEnd = new Date('2024-12-30 23:59:59').getTime();
+
+let data: Array<Datum> | undefined;
+
+function generate(): Array<Datum> {
+    const random = createSeededRandom(1);
+    const result: Array<Datum> = [];
+    for (let time = dataStart; time < dataEnd; time += hour) {
+        let price;
+        if (result.length === 0) {
+            price = 1000 + random() * 100;
+        } else if (result.length < 5) {
+            price = result[result.length - 1].price + random() * 20 - 10;
+        } else {
+            const avg = result.slice(result.length - 5).reduce((a, v) => a + v.price, 0) / 5;
+            price = avg + (random() * 50 - 25);
+        }
+        result.push({ time, price });
+    }
+    return result;
+}
+
+export type Datum = { time: number; price: number };

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/fakeServer.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/fakeServer.ts
@@ -7,8 +7,6 @@ import { random } from './seededRandom';
  */
 export const FakeServer = {
     get: async function (params: { windowStart?: Date | number | string; windowEnd?: Date | number | string }) {
-        if (typeof params.windowStart !== 'object' || typeof params.windowEnd !== 'object') return [];
-
         // Simulate a real server with a random 2000-2500ms delay
         const delayTime = 2000 + Math.floor(random() * 500);
         await delay(delayTime);
@@ -19,13 +17,20 @@ export const FakeServer = {
         // Format the data ready for the chart
         const formattedData = formatData(
             data,
-            params.windowStart?.getTime() ?? dataStart,
-            params.windowEnd?.getTime() ?? dataEnd
+            toTimestamp(params.windowStart) ?? dataStart,
+            toTimestamp(params.windowEnd) ?? dataEnd
         );
 
         return formattedData;
     },
 };
+
+function toTimestamp(value: Date | number | string | undefined): number | undefined {
+    if (value === undefined) return undefined;
+    if (value instanceof Date) return value.getTime();
+    if (typeof value === 'number') return value;
+    return new Date(value).getTime();
+}
 
 function delay(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/fakeServer.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/fakeServer.ts
@@ -1,0 +1,49 @@
+import { Database, Datum, dataEnd, dataStart, day, hour, week } from './data';
+import { random } from './seededRandom';
+
+/**
+ * This fake server mimics how a real server api chart service may get and format data for charts. If you are a
+ * frontend developer you can safely ignore this part of the example.
+ */
+export const FakeServer = {
+    get: async function (params: { windowStart?: Date | number | string; windowEnd?: Date | number | string }) {
+        if (typeof params.windowStart !== 'object' || typeof params.windowEnd !== 'object') return [];
+
+        // Simulate a real server with a random 2000-2500ms delay
+        const delayTime = 2000 + Math.floor(random() * 500);
+        await delay(delayTime);
+
+        // Fetch the data from the fake database
+        const data = Database.get();
+
+        // Format the data ready for the chart
+        const formattedData = formatData(
+            data,
+            params.windowStart?.getTime() ?? dataStart,
+            params.windowEnd?.getTime() ?? dataEnd
+        );
+
+        return formattedData;
+    },
+};
+
+function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatData(data: Datum[], windowStart: number, windowEnd: number) {
+    const diff = windowEnd - windowStart;
+    let granularity = week * 4;
+    if (diff < week * 2) {
+        granularity = hour;
+    } else if (diff < week * 13) {
+        granularity = day;
+    } else if (diff < week * 52) {
+        granularity = week;
+    }
+    return data.filter(({ time }) => {
+        const isCoarse = (time - dataStart) % (week * 4) === 0;
+        const isFineWithinWindow = (time - dataStart) % granularity === 0 && time >= windowStart && time <= windowEnd;
+        return isCoarse || isFineWithinWindow;
+    });
+}

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/main.ts
@@ -1,0 +1,80 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    DataSourceModule,
+    LegendModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NavigatorModule,
+    NumberAxisModule,
+    TimeAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+import { FakeServer } from './fakeServer';
+
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    DataSourceModule,
+    LegendModule,
+    LineSeriesModule,
+    NavigatorModule,
+    NumberAxisModule,
+    TimeAxisModule,
+    ZoomModule,
+    ContextMenuModule,
+]);
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    dataSource: {
+        getData: ({ windowStart, windowEnd }) => {
+            // Request the data from the server, this is an asynchronous call which may take up to 2500ms. In your
+            // application, replace this with a call to your server api.
+            return FakeServer.get({ windowStart, windowEnd });
+        },
+    },
+    navigator: {
+        enabled: true,
+    },
+    zoom: {
+        enabled: true,
+    },
+    series: [
+        {
+            type: 'line',
+            xKey: 'time',
+            yKey: 'price',
+            yName: 'Price',
+        },
+    ],
+    axes: {
+        y: {
+            type: 'number',
+            min: 400,
+            max: 1600,
+        },
+        x: {
+            type: 'time',
+            min: new Date('2019-01-01 00:00:00'),
+            max: new Date('2024-12-30 23:59:59'),
+            interval: {
+                minSpacing: 100,
+                maxSpacing: 200,
+            },
+            label: {
+                formatter: ({ value }) =>
+                    Intl.DateTimeFormat('en-GB', {
+                        day: '2-digit',
+                        month: 'short',
+                        year: '2-digit',
+                    }).format(new Date(value)),
+            },
+        },
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/seededRandom.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/seededRandom.ts
@@ -1,0 +1,1 @@
+../../../../_shared/seededRandom.ts

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/loading-custom/index.html
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/loading-custom/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/loading-custom/main.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/loading-custom/main.ts
@@ -1,0 +1,89 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    DataSourceModule,
+    LegendModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-enterprise';
+
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    DataSourceModule,
+    LegendModule,
+    LineSeriesModule,
+    NumberAxisModule,
+    ContextMenuModule,
+]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    dataSource: {
+        getData: () =>
+            new Promise(() => {
+                // Never resolve so the loading spinner remains
+            }),
+    },
+    overlays: {
+        loading: {
+            renderer: () => {
+                const container = document.createElement('div');
+                container.style.display = 'flex';
+                container.style.alignItems = 'flex-end';
+                container.style.justifyContent = 'flex-start';
+                container.style.flexDirection = 'column';
+                container.style.height = '100%';
+                container.style.boxSizing = 'border-box';
+                container.style.userSelect = 'none';
+                container.style.animation = 'loading 250ms linear 50ms both';
+
+                const spinner = document.createElement('div');
+                spinner.style.width = '20px';
+                spinner.style.height = '20px';
+                spinner.style.backgroundImage = [
+                    'linear-gradient(#333, #333)',
+                    'linear-gradient(#999, #999)',
+                    'linear-gradient(#ccc, #ccc)',
+                ].join(', ');
+                spinner.style.backgroundPosition = '0% 0%, 0% 100%, 100% 100%';
+                spinner.style.backgroundSize = '50% 50%';
+                spinner.style.backgroundRepeat = 'no-repeat';
+                spinner.style.animation = 'loading-spinner 1s infinite';
+
+                const animation = document.createElement('style');
+                animation.innerText = [
+                    '@keyframes loading { from { opacity: 0 } to { opacity: 1 } }',
+                    '@keyframes loading-spinner {',
+                    '  0% { background-position: 0% 0%, 0% 100%, 100% 100%; }',
+                    '  25% { background-position: 100% 0%, 0% 0%, 0% 100%; }',
+                    '  50% { background-position: 100% 100%, 100% 0%, 0% 0%; }',
+                    '  75% { background-position: 0% 100%, 100% 100%, 100% 0%; }',
+                    '  100% { background-position: 0% 0%, 0% 100%, 100% 100%; }',
+                    '}',
+                ].join(' ');
+
+                container.replaceChildren(spinner, animation);
+
+                return container;
+            },
+        },
+    },
+    series: [
+        {
+            type: 'line',
+            xKey: 'year',
+            yKey: 'spending',
+        },
+    ],
+    axes: {
+        x: { type: 'number', title: { text: 'Year' } },
+        y: { type: 'number', title: { text: 'Spending' } },
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/loading/index.html
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/loading/index.html
@@ -1,0 +1,12 @@
+<div class="example-controls">
+    <div class="controls-row">
+        Loading:
+        <button onclick="setLoading(true)"><code>true</code></button>
+        <button onclick="setLoading(false)"><code>false</code></button>
+        <button onclick="setLoading(undefined)"><code>undefined</code></button>
+    </div>
+    <div class="controls-row">
+        <button onclick="reload()">Reload</button>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/loading/main.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/loading/main.ts
@@ -1,0 +1,65 @@
+import {
+    AgChartOptions,
+    AgCharts,
+    AnimationModule,
+    ContextMenuModule,
+    CrosshairModule,
+    DataSourceModule,
+    LegendModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-enterprise';
+
+ModuleRegistry.registerModules([
+    AnimationModule,
+    CrosshairModule,
+    DataSourceModule,
+    LegendModule,
+    LineSeriesModule,
+    NumberAxisModule,
+    ContextMenuModule,
+]);
+
+const datasets = [
+    [120, 145, 98, 160, 135],
+    [200, 175, 220, 190, 210],
+    [80, 95, 70, 110, 85],
+    [155, 130, 180, 145, 165],
+];
+
+let loadIndex = 0;
+
+function getData() {
+    const values = datasets[loadIndex % datasets.length];
+    loadIndex++;
+    return values.map((spending, i) => ({ year: 2020 + i, spending }));
+}
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    dataSource: {
+        getData: () => new Promise((resolve) => setTimeout(() => resolve(getData()), 2000)),
+    },
+    series: [
+        {
+            type: 'line',
+            xKey: 'year',
+            yKey: 'spending',
+        },
+    ],
+    axes: {
+        x: { type: 'number', title: { text: 'Year' } },
+        y: { type: 'number', title: { text: 'Spending' } },
+    },
+};
+
+const chart = AgCharts.create(options);
+
+function setLoading(value: boolean | undefined) {
+    chart.updateDelta({ loading: value });
+}
+
+function reload() {
+    chart.updateDelta({});
+}

--- a/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
@@ -1,0 +1,84 @@
+---
+title: 'Asynchronous Data'
+description: 'Load $framework chart data asynchronously using a data source callback, with automatic loading overlay display.'
+enterprise: true
+---
+
+Asynchronous Data allows charts to load data on demand, supporting progressive detail loading and server-side paging
+when used with [Zoom](./zoom/) or the [Scrollbar](./scrollbar/).
+
+## Data Source
+
+Use the `dataSource` option to provide an asynchronous `getData` callback. The chart calls this function when it needs
+data, and displays the loading overlay until the returned promise resolves.
+
+{% chartExampleRunner title="Async Data" name="async-data" type="generated" /%}
+
+```js format="snippet"
+{
+    dataSource: {
+        getData: ({ windowStart, windowEnd }) => {
+            return FakeServer.get({ windowStart, windowEnd });
+        },
+    },
+}
+```
+
+In this example, the fake server returns coarse data covering the full date range alongside finer-grained data for the
+visible window. As the user zooms in, `getData` is re-invoked with updated `windowStart` and `windowEnd` values and
+the server returns higher-resolution data for that range.
+
+The `getData` callback receives an `AgDataSourceCallbackParams` object with:
+
+- `windowStart`: the start of the visible window.
+- `windowEnd`: the end of the visible window.
+- `context`: the chart context object, if one has been provided.
+
+`windowStart` and `windowEnd` reflect the current visible window and are `undefined` on the initial load if no axis
+bounds have been established.
+
+This pattern supports both progressive detail loading by returning finer data
+as the window narrows, as well as server-side paging where only the visible range is fetched from the server on each
+zoom or scroll.
+
+The returned data must include the first and last data points so the chart can establish the axis domain, unless the
+axis has explicit `min` and `max` values.
+
+### Triggering a Reload
+
+Calling `updateDelta({})` with an empty object triggers `getData` to be called again, which is useful for refreshing
+data on demand.
+
+```js format="snippet"
+{
+    chart.updateDelta({});
+}
+```
+
+## Loading Overlay
+
+While `getData` is in progress, the chart displays a [Loading Overlay](./overlays/#loading-data-overlay)
+automatically. The overlay can be customised through the `overlays.loading` option; see [Overlays](./overlays/) for
+text customisation and custom renderers.
+
+### Manual Control
+
+Set `loading` on the chart options to control the overlay independently of `dataSource`.
+
+{% chartExampleRunner title="Loading Overlay" name="loading" type="generated" /%}
+
+Use the buttons to override the loading state.
+
+```js format="snippet"
+{
+    loading: true,
+}
+```
+
+- `true` - force the overlay on.
+- `false` - force the overlay off.
+- `undefined` - automatic, shown while `getData` is pending and hidden when it resolves.
+
+## API Reference
+
+{% apiReference id="AgDataSourceOptions" /%}

--- a/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
@@ -49,10 +49,8 @@ axis has explicit `min` and `max` values.
 Calling `updateDelta({})` with an empty object triggers `getData` to be called again, which is useful for refreshing
 data on demand.
 
-```js format="snippet"
-{
-    chart.updateDelta({});
-}
+```js
+chart.updateDelta({});
 ```
 
 ## Loading Overlay

--- a/packages/ag-charts-website/src/content/docs/overlays/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/overlays/index.mdoc
@@ -18,7 +18,8 @@ A message is also displayed when all series are hidden:
 
 ## Loading Data Overlay
 
-When using [Asynchronous Loading](./zoom/#asynchronous-loading), a loading data animation is shown while waiting for a response.
+When using [Asynchronous Data](./async-data/), a loading data animation is shown while waiting for a response.
+The overlay can also be shown or hidden manually using the `loading` option. See [Asynchronous Data — Manual Control](./async-data/#manual-control) for details.
 
 {% chartExampleRunner title="Loading Data" name="loading" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/zoom/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/zoom/index.mdoc
@@ -418,27 +418,7 @@ For more information see the [API Reference section](#reference-AgZoomOptions-bu
 
 ## Asynchronous Loading
 
-Use the `dataSource` option to asynchronously load in new data as the chart is zoomed.
-
-{% chartExampleRunner title="Asynchronous Loading" name="zoom-async" type="generated" /%}
-
-```js format="snippet"
-{
-    dataSource: {
-        getData: ({ windowStart, windowEnd }) => {
-            return FakeServer.get(windowStart, windowEnd);
-        },
-    },
-}
-```
-
-In this example, the `getData` function returns both the coarse data plus additional finer grained data for the visible time window.
-
-The data returned from the `getData` function should always include the coarse data set to ensure the chart knows the full extent of the data.
-
-{% note %}
-The `windowStart` and `windowEnd` parameters will be `undefined` if the chart does not have a time axis. They will also be `undefined` on the first call to `dataSource.getData()` if no `axis[].min` and `axis[].max` are provided on the time axis.
-{% /note %}
+For loading data asynchronously as the user zooms and pans, see [Asynchronous Data](./async-data/).
 
 ## Save & Restore
 

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -4,7 +4,8 @@
         "date": "June 24th, 2026",
         "highlights": [
             {
-                "text": "Async Data"
+                "text": "Async Data",
+                "path": "./async-data/"
             },
             {
                 "text": "Image in Label"


### PR DESCRIPTION
## Summary

- Adds new `async-data` documentation page covering the `dataSource` API, progressive detail loading, and server-side paging patterns
- Adds three examples: `async-data` (full demo with fake server), `loading` (manual loading overlay), and `loading-custom` (custom loading renderer)
- Updates `overlays/index.mdoc` and `zoom/index.mdoc` with cross-references to the new page
- Updates `dataSourceOptions.ts` JSDocs to clarify `windowStart`/`windowEnd` undefined behaviour on initial load
- Adds the async data page to `nav.json`

## Test plan

- [ ] Dev server: verify the async-data docs page renders and examples work
- [ ] Verify nav entry appears correctly
- [ ] Verify cross-links from overlays and zoom pages

Fix #AG-17474