### PR TITLE
AG-14484 revert enabled-false validation bypass in validate()

### DIFF
--- a/packages/ag-charts-core/src/state/validation.test.ts
+++ b/packages/ag-charts-core/src/state/validation.test.ts
@@ -341,39 +341,6 @@ describe('Validation utils', () => {
         });
     });
 
-    describe('Disabled nodes (enabled: false)', () => {
-        const defs = { enabled: boolean, value: required(number) };
-
-        test('skips required-field enforcement when enabled is false', () => {
-            const { cleared, invalid } = validate({ enabled: false }, defs);
-            expect(invalid).toEqual([]);
-            expect(cleared).toEqual({ enabled: false });
-        });
-
-        test('still enforces required fields when not disabled', () => {
-            expect(validate({ enabled: true }, defs).invalid).not.toEqual([]);
-            expect(validate({}, defs).invalid).not.toEqual([]);
-        });
-
-        test('skips the discriminant requirement for a disabled type-union node', () => {
-            const unionDefs = typeUnion<
-                { type: 'a'; enabled?: boolean; aa?: boolean } | { type: 'b'; enabled?: boolean; bb: number }
-            >({ a: { enabled: boolean, aa: boolean }, b: { enabled: boolean, bb: required(number) } }, 'an object');
-
-            // Disabled with no `type`: no "type is required" error, `enabled` flag preserved.
-            const noType = validate({ enabled: false }, unionDefs);
-            expect(noType.invalid).toEqual([]);
-            expect(noType.cleared).toEqual({ enabled: false });
-
-            // Disabled, matching branch but missing its required field: no error.
-            expect(validate({ type: 'b', enabled: false }, unionDefs).invalid).toEqual([]);
-
-            // Enabled equivalents still warn about the missing discriminant / required field.
-            expect(validate({}, unionDefs).invalid).not.toEqual([]);
-            expect(validate({ type: 'b' }, unionDefs).invalid).not.toEqual([]);
-        });
-    });
-
     describe('Conditional Validators', () => {
         const axisSchema: OptionsDefs<any> = {
             min: and(number, lessThan('max')),

--- a/packages/ag-charts-core/src/state/validation.ts
+++ b/packages/ag-charts-core/src/state/validation.ts
@@ -186,11 +186,6 @@ export function validate<T>(
     const optionsKeys = new Set(Object.keys(options));
     const unusedKeys = [];
 
-    // A node with `enabled: false` has its remaining properties stripped by
-    // `removeDisabledOptions`, so enforcing required fields on it would warn about values that
-    // are about to be discarded.
-    const optionsDisabled = (options as { enabled?: unknown }).enabled === false;
-
     let schemaKeys = schemaKeyCache.get(optionsDefs);
     if (schemaKeys === undefined) {
         schemaKeys = Object.keys(optionsDefs);
@@ -212,10 +207,6 @@ export function validate<T>(
                 error.setUnionType(type, path);
             }
             invalid.push(...nestedResult.invalid);
-        } else if (optionsDisabled) {
-            // Disabled node with no resolvable discriminant: its properties are about to be
-            // stripped, so preserve only the `enabled` flag and skip the `type` requirement.
-            Object.assign(cleared, { enabled: false });
         } else {
             const keywords = joinFormatted(validTypes, 'or', (val) => `'${val}'`);
             invalid.push(
@@ -235,7 +226,7 @@ export function validate<T>(
             if (!validatorOrDefs[undocumentedSymbol]) {
                 unusedKeys.push(key);
             }
-            if (!required || optionsDisabled) continue;
+            if (!required) continue;
         }
 
         const keyPath = extendPath(path, key);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14484

Reverts the `enabled: false` shortcut introduced in #6977. That change caused `validate()` to skip required-field enforcement and discriminated-union type checks whenever a node had `enabled: false`.

Removed:
- `optionsDisabled` local variable and its two uses in `validate()`
- The "Disabled nodes (enabled: false)" describe block in `validation.test.ts`

Required-field and type-union checks now run unconditionally again, matching the pre-#6977 behaviour.

Fix #AG-14484