### PR TITLE
AG-16926 add getDataId callback for non-1:1 series (histogram, sankey/chord)

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { mapValues } from 'ag-charts-core';
 import type { AgCartesianChartOptions, AgChartOptions } from 'ag-charts-types';
@@ -11,6 +11,7 @@ import {
     IMAGE_SNAPSHOT_DEFAULTS,
     cartesianChartAssertions,
     deproxy,
+    expectWarningsCalls,
     extractImageData,
     hoverAction,
     prepareTestOptions,
@@ -170,6 +171,110 @@ describe('HistogramSeries', () => {
             await waitForChartStability(chart);
 
             await compare();
+        });
+    });
+
+    describe('getDataId', () => {
+        const nodeDataOf = (c: any) => (deproxy(c).series[0] as any).getNodeData() as any[];
+        const itemIdsOf = (c: any) => nodeDataOf(c).map((n) => n.itemId);
+
+        const createBinnedChart = (
+            series: Partial<NonNullable<AgCartesianChartOptions['series']>[number]> = {},
+            data?: any[]
+        ) => {
+            const options: AgCartesianChartOptions = {
+                data: data ?? [{ x: 1 }, { x: 5 }, { x: 12 }, { x: 18 }],
+                series: [
+                    {
+                        type: 'histogram',
+                        xKey: 'x',
+                        bins: [
+                            [0, 10],
+                            [10, 20],
+                        ],
+                        ...(series as object),
+                    },
+                ],
+            };
+            prepareTestOptions(options as any);
+            return AgCharts.create(options);
+        };
+
+        it('auto-generates an id from the bin boundaries', async () => {
+            chart = createBinnedChart();
+            await waitForChartStability(chart);
+
+            expect(itemIdsOf(chart)).toEqual(['bin:0,10', 'bin:10,20']);
+        });
+
+        it('disambiguates negative and fractional bin boundaries', async () => {
+            chart = createBinnedChart(
+                {
+                    bins: [
+                        [-10, -5],
+                        [-5, 0.5],
+                    ],
+                },
+                [{ x: -8 }, { x: -1 }]
+            );
+            await waitForChartStability(chart);
+
+            expect(itemIdsOf(chart)).toEqual(['bin:-10,-5', 'bin:-5,0.5']);
+        });
+
+        it('uses the getDataId callback to override the id', async () => {
+            const getDataId = vi.fn((p: { binStart: number; binEnd: number; binIndex: number }) => `b${p.binIndex}`);
+            chart = createBinnedChart({ getDataId });
+            await waitForChartStability(chart);
+
+            expect(itemIdsOf(chart)).toEqual(['b0', 'b1']);
+            expect(getDataId).toHaveBeenCalledWith(expect.objectContaining({ binStart: 0, binEnd: 10, binIndex: 0 }));
+        });
+
+        it('passes the chart context to the callback', async () => {
+            const context = { tenant: 'acme' };
+            const getDataId = vi.fn((p: { context?: any }) => `${p.context?.tenant}`);
+            chart = createBinnedChart({ context, getDataId });
+            await waitForChartStability(chart);
+
+            expect(itemIdsOf(chart)).toEqual(['acme', 'acme']);
+        });
+
+        it('keeps ids stable across a data update that preserves bin boundaries', async () => {
+            chart = createBinnedChart();
+            await waitForChartStability(chart);
+            const before = itemIdsOf(chart);
+            const frequenciesBefore = nodeDataOf(chart).map((n) => n.frequency);
+
+            await chart.update({
+                data: [{ x: 2 }, { x: 3 }, { x: 14 }],
+                series: [
+                    {
+                        type: 'histogram',
+                        xKey: 'x',
+                        bins: [
+                            [0, 10],
+                            [10, 20],
+                        ],
+                    },
+                ],
+            });
+            await waitForChartStability(chart);
+
+            // The update changes bin contents (so it definitely applied) but not boundaries.
+            expect(nodeDataOf(chart).map((n) => n.frequency)).not.toEqual(frequenciesBefore);
+            expect(itemIdsOf(chart)).toEqual(before);
+        });
+
+        it('falls back to the default id when the callback throws', async () => {
+            const getDataId = () => {
+                throw new Error('boom');
+            };
+            chart = createBinnedChart({ getDataId });
+            await waitForChartStability(chart);
+
+            expect(itemIdsOf(chart)).toEqual(['bin:0,10', 'bin:10,20']);
+            expectWarningsCalls().toHaveLength(1);
         });
     });
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -458,9 +458,17 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
     private createSkeletonNodeDatum(ctx: HistogramSeriesNodeDatumContext, bin: CalculatedBin): HistogramNodeDatum {
         const { xKey, yKey } = ctx;
         const { domain, datum, groupIndex, frequency, total } = bin;
+        const [binStart, binEnd] = domain;
+        const { getDataId } = this.properties;
+        const customId =
+            getDataId == null
+                ? undefined
+                : this.cachedCallWithContext(getDataId, { binStart, binEnd, binIndex: groupIndex });
+        const itemId = customId ?? `bin:${binStart},${binEnd}`;
 
         return {
             series: this,
+            itemId,
             datumIndex: groupIndex,
             datum,
             aggregatedValue: total,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesOptionsDef.ts
@@ -2,6 +2,7 @@ import {
     type OptionsDefs,
     arrayOf,
     boolean,
+    callbackOf,
     commonSeriesOptionsDefs,
     commonSeriesThemeableOptionsDefs,
     constant,
@@ -48,4 +49,5 @@ export const histogramSeriesOptionsDef: OptionsDefs<AgHistogramSeriesOptions> = 
     yKeyAxis: string,
     xName: string,
     yName: string,
+    getDataId: callbackOf(string),
 };

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
@@ -1,6 +1,7 @@
 import type { InternalAgColorType, RequireOptional } from 'ag-charts-core';
 import { Property } from 'ag-charts-core';
 import type {
+    AgHistogramSeriesGetDataIdParams,
     AgHistogramSeriesLabelFormatterParams,
     AgHistogramSeriesOptions,
     AgHistogramSeriesStyle,
@@ -16,6 +17,9 @@ import { CartesianSeriesProperties } from './cartesianSeries';
 import type { CartesianSeriesNodeDatum } from './cartesianSeriesTypes';
 
 export interface HistogramNodeDatum extends CartesianSeriesNodeDatum {
+    // Bins are aggregated from many datums, so they carry an explicit stable id rather than
+    // relying on the data-model `datumIndex`/`dataIdKey` matching used by 1:1 series.
+    readonly itemId: string;
     readonly x: number;
     readonly y: number;
     readonly width: number;
@@ -87,6 +91,9 @@ export class HistogramSeriesProperties extends CartesianSeriesProperties<AgHisto
 
     @Property
     binCount?: number;
+
+    @Property
+    getDataId?: (params: AgHistogramSeriesGetDataIdParams) => string = undefined;
 
     @Property
     readonly shadow = new DropShadow();

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -16,7 +16,9 @@ import { type DatumIndexType, SelectionState, type SeriesNodeDatum } from './ser
 import { findNodeDatumInArray } from './util';
 
 export interface DataModelSeriesNodeDatum extends SeriesNodeDatum<number> {
-    itemId?: never;
+    // Data-model series identify nodes by their numeric `datumIndex` (and chart-level `dataIdKey`).
+    // The exception is aggregated series such as histogram, whose bins carry an explicit stable id.
+    itemId?: string;
 }
 
 export interface DataModelSeriesNodeDataContext<TDatum, TLabel = TDatum> extends SeriesNodeDataContext<

--- a/packages/ag-charts-enterprise/src/__snapshots__/callbacks.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/__snapshots__/callbacks.test.ts.snap
@@ -597,7 +597,7 @@ exports[`AG-15850 activeChange > chord > mouse 3`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-0",
+        "itemId": "A",
         "seriesId": "ChordSeries-1",
         "type": "series-node",
       },
@@ -617,7 +617,7 @@ exports[`AG-15850 activeChange > chord > mouse 4`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-4",
+        "itemId": "E",
         "seriesId": "ChordSeries-1",
         "type": "series-node",
       },
@@ -685,7 +685,7 @@ exports[`AG-15850 activeChange > chord > setState 3`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-0",
+        "itemId": "A",
         "seriesId": "ChordSeries-1",
         "type": "series-node",
       },
@@ -705,7 +705,7 @@ exports[`AG-15850 activeChange > chord > setState 4`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-4",
+        "itemId": "E",
         "seriesId": "ChordSeries-1",
         "type": "series-node",
       },
@@ -1163,7 +1163,7 @@ exports[`AG-15850 activeChange > sankey > mouse 3`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-0",
+        "itemId": "A",
         "seriesId": "SankeySeries-1",
         "type": "series-node",
       },
@@ -1183,7 +1183,7 @@ exports[`AG-15850 activeChange > sankey > mouse 4`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-4",
+        "itemId": "E",
         "seriesId": "SankeySeries-1",
         "type": "series-node",
       },
@@ -1251,7 +1251,7 @@ exports[`AG-15850 activeChange > sankey > setState 3`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-0",
+        "itemId": "A",
         "seriesId": "SankeySeries-1",
         "type": "series-node",
       },
@@ -1271,7 +1271,7 @@ exports[`AG-15850 activeChange > sankey > setState 4`] = `
   [
     {
       "activeItem": {
-        "itemId": "node-4",
+        "itemId": "E",
         "seriesId": "SankeySeries-1",
         "type": "series-node",
       },

--- a/packages/ag-charts-enterprise/src/callbacks.test.ts
+++ b/packages/ag-charts-enterprise/src/callbacks.test.ts
@@ -2126,13 +2126,13 @@ describe('AG-15850 activeChange', () => {
             // Hover on a node (A)
             await hover(43, 119);
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-0');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('A');
             expect(calls).toMatchSnapshot();
 
             // Hover on another node (E)
             await hover(757, 357);
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-4');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('E');
             expect(calls).toMatchSnapshot();
 
             // Hover miss
@@ -2153,14 +2153,14 @@ describe('AG-15850 activeChange', () => {
             expect(calls?.[0]?.[0]?.datum).toEqual({ myFrom: 'B', myTo: 'E', mySize: 25 });
             expect(calls).toMatchSnapshot();
 
-            await setActiveItem({ type: 'series-node', itemId: 'node-0', seriesId: 'SankeySeries-1' });
+            await setActiveItem({ type: 'series-node', itemId: 'A', seriesId: 'SankeySeries-1' });
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-0');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('A');
             expect(calls).toMatchSnapshot();
 
-            await setActiveItem({ type: 'series-node', itemId: 'node-4', seriesId: 'SankeySeries-1' });
+            await setActiveItem({ type: 'series-node', itemId: 'E', seriesId: 'SankeySeries-1' });
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-4');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('E');
             expect(calls).toMatchSnapshot();
 
             await setActiveItem(undefined);
@@ -2171,7 +2171,7 @@ describe('AG-15850 activeChange', () => {
             await setActiveItem({ type: 'series-node', itemId: 'link-1', seriesId: 'SankeySeries-1' });
             expect(popCalls().length).toBe(1);
 
-            await setActiveItem({ type: 'series-node', itemId: 'node-0', seriesId: 'SankeySeries-2' });
+            await setActiveItem({ type: 'series-node', itemId: 'A', seriesId: 'SankeySeries-2' });
             expectWarningsCalls().toEqual([['AG Charts - Cannot find seriesId: "SankeySeries-2"']]);
             expect(popCalls()).toEqual([[INACTIVE_SETSTATE_EVENT]]);
         });
@@ -2239,13 +2239,13 @@ describe('AG-15850 activeChange', () => {
             // Hover on a node (A)
             await hover(640, 404);
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-0');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('A');
             expect(calls).toMatchSnapshot();
 
             // Hover on another node (E)
             await hover(565, 98);
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-4');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('E');
             expect(calls).toMatchSnapshot();
 
             // Hover miss
@@ -2266,14 +2266,14 @@ describe('AG-15850 activeChange', () => {
             expect(calls?.[0]?.[0]?.datum).toEqual({ myFrom: 'B', myTo: 'E', mySize: 25 });
             expect(calls).toMatchSnapshot();
 
-            await setActiveItem({ type: 'series-node', itemId: 'node-0', seriesId: 'ChordSeries-1' });
+            await setActiveItem({ type: 'series-node', itemId: 'A', seriesId: 'ChordSeries-1' });
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-0');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('A');
             expect(calls).toMatchSnapshot();
 
-            await setActiveItem({ type: 'series-node', itemId: 'node-4', seriesId: 'ChordSeries-1' });
+            await setActiveItem({ type: 'series-node', itemId: 'E', seriesId: 'ChordSeries-1' });
             calls = popCalls();
-            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('node-4');
+            expect(calls?.[0]?.[0]?.activeItem?.itemId).toEqual('E');
             expect(calls).toMatchSnapshot();
 
             await setActiveItem(undefined);
@@ -2281,16 +2281,16 @@ describe('AG-15850 activeChange', () => {
         });
 
         test('setState series-area seriesId not found', async () => {
-            await setActiveItem({ type: 'series-node', itemId: 'node-0', seriesId: 'ChordSeries-1' });
+            await setActiveItem({ type: 'series-node', itemId: 'A', seriesId: 'ChordSeries-1' });
             expect(popCalls().length).toBe(1);
 
-            await setActiveItem({ type: 'series-node', itemId: 'node-0', seriesId: 'ChordSeries-2' });
+            await setActiveItem({ type: 'series-node', itemId: 'A', seriesId: 'ChordSeries-2' });
             expectWarningsCalls().toEqual([['AG Charts - Cannot find seriesId: "ChordSeries-2"']]);
             expect(popCalls()).toEqual([[INACTIVE_SETSTATE_EVENT]]);
         });
 
         test('setState series-area link not found', async () => {
-            await setActiveItem({ type: 'series-node', itemId: 'node-0', seriesId: 'ChordSeries-1' });
+            await setActiveItem({ type: 'series-node', itemId: 'A', seriesId: 'ChordSeries-1' });
             expect(popCalls().length).toBe(1);
 
             await setActiveItem({ type: 'series-node', itemId: 'link-1000', seriesId: 'ChordSeries-1' });
@@ -2299,7 +2299,7 @@ describe('AG-15850 activeChange', () => {
         });
 
         test('setState series-area node not found', async () => {
-            await setActiveItem({ type: 'series-node', itemId: 'node-0', seriesId: 'ChordSeries-1' });
+            await setActiveItem({ type: 'series-node', itemId: 'A', seriesId: 'ChordSeries-1' });
             expect(popCalls().length).toBe(1);
 
             await setActiveItem({ type: 'series-node', itemId: 'node-1000', seriesId: 'ChordSeries-1' });

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeries.test.ts
@@ -111,6 +111,61 @@ describe('ChordSeries', () => {
         });
     });
 
+    describe('getDataId', () => {
+        const DATA = [
+            { from: 'A', to: 'B', size: 5 },
+            { from: 'B', to: 'C', size: 5 },
+        ];
+        const getNodeItemIds = (c: any) =>
+            c.series[0].contextNodeData.nodeData
+                .filter((n: any) => n.type === FlowProportionDatumType.Node)
+                .map((n: any) => n.itemId)
+                .sort();
+
+        it('defaults a node itemId to its name', async () => {
+            const options: AgChartOptions = {
+                data: DATA,
+                series: [{ type: 'chord', fromKey: 'from', toKey: 'to', sizeKey: 'size' }],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(getNodeItemIds(chart)).toEqual(['A', 'B', 'C']);
+        });
+
+        it('uses the getDataId callback to override the node itemId', async () => {
+            const getDataId = vi.fn((p: { nodeName: string }) => `node:${p.nodeName}`);
+            const options: AgChartOptions = {
+                data: DATA,
+                series: [{ type: 'chord', fromKey: 'from', toKey: 'to', sizeKey: 'size', getDataId }],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(getNodeItemIds(chart)).toEqual(['node:A', 'node:B', 'node:C']);
+            expect(getDataId).toHaveBeenCalledWith(expect.objectContaining({ nodeName: 'A' }));
+        });
+
+        it('passes the chart context to the callback', async () => {
+            const context = { tenant: 'acme' };
+            const getDataId = vi.fn((p: { nodeName: string; context?: any }) => `${p.context?.tenant}:${p.nodeName}`);
+            const options: AgChartOptions = {
+                data: DATA,
+                series: [{ type: 'chord', fromKey: 'from', toKey: 'to', sizeKey: 'size', context, getDataId }],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(getNodeItemIds(chart)).toEqual(['acme:A', 'acme:B', 'acme:C']);
+        });
+    });
+
     const testPointerEvents = (testParams: {
         seriesOptions: any;
         chartOptions?: any;

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeriesOptionsDef.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeriesOptionsDef.ts
@@ -1,6 +1,7 @@
 import { type AgChordSeriesOptions, _ModuleSupport } from 'ag-charts-community';
 import {
     type OptionsDefs,
+    callbackOf,
     commonSeriesOptionsDefs,
     constant,
     fillGradientDefaults,
@@ -21,6 +22,7 @@ export const chordSeriesOptionsDef: OptionsDefs<AgChordSeriesOptions> = {
     toKey: required(string),
     sizeKey: string,
     sizeName: string,
+    getDataId: callbackOf(string),
 };
 
 // @ts-expect-error undocumented option

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeriesProperties.ts
@@ -1,4 +1,5 @@
 import {
+    type AgChordSeriesGetDataIdParams,
     type AgChordSeriesLabelFormatterParams,
     type AgChordSeriesLinkItemStylerParams,
     type AgChordSeriesLinkStyle,
@@ -142,6 +143,9 @@ export class ChordSeriesProperties extends SeriesProperties<AgChordSeriesOptions
 
     @Property
     nodes: any[] | undefined = undefined;
+
+    @Property
+    getDataId?: (params: AgChordSeriesGetDataIdParams) => string = undefined;
 
     @Property
     readonly fillGradientDefaults = new FillGradientDefaults();

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionProperties.ts
@@ -1,5 +1,6 @@
 import type {
     AgChordSeriesTooltipRendererParams,
+    AgSankeySeriesGetDataIdParams,
     AgSankeySeriesTooltipRendererParams,
     _ModuleSupport,
 } from 'ag-charts-community';
@@ -22,4 +23,5 @@ export interface FlowProportionSeriesProperties<
     tooltip: _ModuleSupport.SeriesTooltip<
         AgChordSeriesTooltipRendererParams<any> & AgSankeySeriesTooltipRendererParams<any>
     >;
+    getDataId?: (params: AgSankeySeriesGetDataIdParams<any, any>) => string;
 }

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -260,7 +260,7 @@ export abstract class FlowProportionSeries<
 
                 return {
                     series: this,
-                    itemId: `node-${datumIndex}`,
+                    itemId: this.callGetDataId({ nodeName: id, index: datumIndex, datum: {} }) ?? id,
                     datum: {}, // Must be a referential object for tooltips
                     datumIndex: { type: FlowProportionDatumType.Node, index: datumIndex },
                     type: FlowProportionDatumType.Node,
@@ -323,10 +323,11 @@ export abstract class FlowProportionSeries<
 
                     const nodeDatumIndex = { type: FlowProportionDatumType.Node, index: datumIndex };
                     const nodeIdValue = nodeDataIdKey == null ? undefined : (datum as any)[nodeDataIdKey];
+                    const computedId = this.callGetDataId({ nodeName: id, index: datumIndex, datum });
 
                     processedNodes.set(id, {
                         series: this,
-                        itemId: nodeIdValue == null ? `node-${datumIndex}` : String(nodeIdValue),
+                        itemId: computedId ?? (nodeIdValue == null ? id : String(nodeIdValue)),
                         datum,
                         datumIndex: nodeDatumIndex,
                         type: FlowProportionDatumType.Node,
@@ -347,6 +348,11 @@ export abstract class FlowProportionSeries<
         }
 
         this.processedNodes = processedNodes;
+    }
+
+    private callGetDataId(params: { nodeName: string; index: number; datum: unknown }): string | undefined {
+        const { getDataId } = this.properties;
+        return getDataId == null ? undefined : this.cachedCallWithContext(getDataId, params);
     }
 
     override findNodeDatum(itemId: AgActiveItemState['itemId']): TDatum<TNodeDatum, TLinkDatum> | undefined {

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.test.ts
@@ -303,6 +303,82 @@ describe('SankeySeries', () => {
         });
     });
 
+    describe('getDataId', () => {
+        const DATA = [
+            { from: 'A', to: 'B', size: 5 },
+            { from: 'B', to: 'C', size: 5 },
+        ];
+        const getNodeItemIds = (c: any) =>
+            (deproxy(c).series[0] as any).contextNodeData.nodeData
+                .filter((n: any) => n.type === FlowProportionDatumType.Node)
+                .map((n: any) => n.itemId)
+                .sort();
+
+        it('defaults a node itemId to its name', async () => {
+            const options: AgStandaloneChartOptions = {
+                data: DATA,
+                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size' }],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(getNodeItemIds(chart)).toEqual(['A', 'B', 'C']);
+        });
+
+        it('uses the getDataId callback to override the node itemId', async () => {
+            const getDataId = vi.fn((p: { nodeName: string }) => `node:${p.nodeName}`);
+            const options: AgStandaloneChartOptions = {
+                data: DATA,
+                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size', getDataId }],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(getNodeItemIds(chart)).toEqual(['node:A', 'node:B', 'node:C']);
+            expect(getDataId).toHaveBeenCalledWith(expect.objectContaining({ nodeName: 'A' }));
+        });
+
+        it('passes the chart context to the callback', async () => {
+            const context = { tenant: 'acme' };
+            const getDataId = vi.fn((p: { nodeName: string; context?: any }) => `${p.context?.tenant}:${p.nodeName}`);
+            const options: AgStandaloneChartOptions = {
+                data: DATA,
+                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size', context, getDataId }],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            expect(getNodeItemIds(chart)).toEqual(['acme:A', 'acme:B', 'acme:C']);
+        });
+
+        it('keeps node itemIds stable across a data update', async () => {
+            const options: AgStandaloneChartOptions = {
+                data: DATA,
+                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size' }],
+            };
+            prepareEnterpriseTestOptions(options as any);
+
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+            expect(getNodeItemIds(chart)).toEqual(['A', 'B', 'C']);
+
+            await chart.update({
+                data: [...DATA, { from: 'C', to: 'D', size: 5 }],
+                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size' }],
+            } as AgStandaloneChartOptions);
+            await waitForChartStability(chart);
+
+            // The new node D appears (so the update applied), while existing name-derived ids are unchanged.
+            expect(getNodeItemIds(chart)).toEqual(['A', 'B', 'C', 'D']);
+        });
+    });
+
     const testPointerEvents = (testParams: {
         seriesOptions: any;
         chartOptions?: any;

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesOptionsDef.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesOptionsDef.ts
@@ -2,6 +2,7 @@ import { type AgSankeySeriesOptions, _ModuleSupport } from 'ag-charts-community'
 import {
     type OptionsDefs,
     arrayOf,
+    callbackOf,
     color,
     commonSeriesOptionsDefs,
     constant,
@@ -23,6 +24,7 @@ export const sankeySeriesOptionsDef: OptionsDefs<AgSankeySeriesOptions> = {
     toKey: required(string),
     sizeKey: string,
     sizeName: string,
+    getDataId: callbackOf(string),
 };
 
 // @ts-expect-error undocumented option

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesProperties.ts
@@ -1,4 +1,5 @@
 import {
+    type AgSankeySeriesGetDataIdParams,
     type AgSankeySeriesLabelFormatterParams,
     type AgSankeySeriesLinkItemStylerParams,
     type AgSankeySeriesLinkOptions,
@@ -157,6 +158,9 @@ export class SankeySeriesProperties extends SeriesProperties<AgSankeySeriesOptio
 
     @Property
     sizeName: string | undefined = undefined;
+
+    @Property
+    getDataId?: (params: AgSankeySeriesGetDataIdParams) => string = undefined;
 
     @Property
     readonly fillGradientDefaults = new FillGradientDefaults();

--- a/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
@@ -1,3 +1,4 @@
+import type { ContextCallbackParams } from '../../chart/callbackOptions';
 import type { AgDropShadowOptions } from '../../chart/dropShadowOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip } from '../../chart/tooltipOptions';
@@ -32,6 +33,15 @@ export interface AgHistogramBinDatum<TDatum> {
     aggregatedValue: number;
     frequency: number;
     domain: [number, number];
+}
+
+export interface AgHistogramSeriesGetDataIdParams<TContext = ContextDefault> extends ContextCallbackParams<TContext> {
+    /** The lower bound of the bin. */
+    binStart: number;
+    /** The upper bound of the bin. */
+    binEnd: number;
+    /** The index of the bin. */
+    binIndex: number;
 }
 
 export interface AgHistogramSeriesStyle extends FillOptions, StrokeOptions, LineDashOptions {
@@ -90,4 +100,12 @@ export interface AgHistogramSeriesOptions<TDatum = DatumDefault, TContext = Cont
         AgHistogramSeriesThemeableOptions<TDatum, TContext> {
     /** Configuration for Histogram Series. */
     type: 'histogram';
+    /**
+     * A callback to provide a stable identifier for each bin, exposed as `itemId` in events and active state.
+     *
+     * The returned identifier must be unique across all bins in the series.
+     *
+     * If not supplied, an identifier is generated from the bin boundaries.
+     */
+    getDataId?: (params: AgHistogramSeriesGetDataIdParams<TContext>) => string;
 }

--- a/packages/ag-charts-types/src/series/standalone/chordOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/chordOptions.ts
@@ -16,7 +16,8 @@ export interface AgChordSeriesOptions<TDatum = DatumDefault, TContext = ContextD
     /**
      * A callback to provide a stable identifier for each node, exposed as `itemId` in events and active state.
      *
-     * The returned identifier must be unique across all nodes in the series.
+     * The returned identifier must be unique across nodes and links, which share one `itemId` namespace
+     * (links default to `link-<index>`).
      *
      * If not supplied, the node name is used as its identifier.
      */

--- a/packages/ag-charts-types/src/series/standalone/chordOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/chordOptions.ts
@@ -13,6 +13,26 @@ export interface AgChordSeriesOptions<TDatum = DatumDefault, TContext = ContextD
         AgChordSeriesThemeableOptions<TDatum, TContext> {
     /** Configuration for the Chord Series. */
     type: 'chord';
+    /**
+     * A callback to provide a stable identifier for each node, exposed as `itemId` in events and active state.
+     *
+     * The returned identifier must be unique across all nodes in the series.
+     *
+     * If not supplied, the node name is used as its identifier.
+     */
+    getDataId?: (params: AgChordSeriesGetDataIdParams<TDatum, TContext>) => string;
+}
+
+export interface AgChordSeriesGetDataIdParams<
+    TDatum = DatumDefault,
+    TContext = ContextDefault,
+> extends ContextCallbackParams<TContext> {
+    /** The name of the node, derived from the `fromKey`/`toKey` values or the supplied `nodes`. */
+    nodeName: string;
+    /** The index of the node, in the order nodes are first encountered. Not a stable identifier. */
+    index: number;
+    /** The node datum, or an empty object for nodes derived implicitly from link data. */
+    datum: TDatum;
 }
 
 export interface AgChordSeriesLinkItemStylerParams<TDatum, TContext = ContextDefault>

--- a/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
@@ -16,7 +16,8 @@ export interface AgSankeySeriesOptions<TDatum = DatumDefault, TContext = Context
     /**
      * A callback to provide a stable identifier for each node, exposed as `itemId` in events and active state.
      *
-     * The returned identifier must be unique across all nodes in the series.
+     * The returned identifier must be unique across nodes and links, which share one `itemId` namespace
+     * (links default to `link-<index>`).
      *
      * If not supplied, the node name is used as its identifier.
      */

--- a/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
@@ -13,6 +13,26 @@ export interface AgSankeySeriesOptions<TDatum = DatumDefault, TContext = Context
         AgSankeySeriesThemeableOptions<TDatum, TContext> {
     /** Configuration for the Sankey Series. */
     type: 'sankey';
+    /**
+     * A callback to provide a stable identifier for each node, exposed as `itemId` in events and active state.
+     *
+     * The returned identifier must be unique across all nodes in the series.
+     *
+     * If not supplied, the node name is used as its identifier.
+     */
+    getDataId?: (params: AgSankeySeriesGetDataIdParams<TDatum, TContext>) => string;
+}
+
+export interface AgSankeySeriesGetDataIdParams<
+    TDatum = DatumDefault,
+    TContext = ContextDefault,
+> extends ContextCallbackParams<TContext> {
+    /** The name of the node, derived from the `fromKey`/`toKey` values or the supplied `nodes`. */
+    nodeName: string;
+    /** The index of the node, in the order nodes are first encountered. Not a stable identifier. */
+    index: number;
+    /** The node datum, or an empty object for nodes derived implicitly from link data. */
+    datum: TDatum;
 }
 
 export interface AgSankeySeriesLinkItemStylerParams<TDatum, TContext = ContextDefault>

--- a/packages/ag-charts-website/e2e/state.spec.ts
+++ b/packages/ag-charts-website/e2e/state.spec.ts
@@ -1749,7 +1749,7 @@ test.describe('state', () => {
                     state = await getChartState(page);
                     expect(state.active).toEqual({
                         frozen: false,
-                        activeItem: { type: 'series-node', itemId: 'node-1', seriesId: 'SankeySeries-1' },
+                        activeItem: { type: 'series-node', itemId: 'C', seriesId: 'SankeySeries-1' },
                     });
                     const hoverLinkState: AgChartState = state;
 

--- a/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
@@ -81,6 +81,23 @@ The styling of all links can be customised using the `link` property.
 }
 ```
 
+## Node Identifiers
+
+Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across the nodes in the series.
+
+```js format="snippet"
+{
+    series: [
+        {
+            type: 'chord',
+            fromKey: 'from',
+            toKey: 'to',
+            getDataId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
+        },
+    ],
+}
+```
+
 ## API Reference
 
 {% tabs %}

--- a/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
@@ -83,7 +83,7 @@ The styling of all links can be customised using the `link` property.
 
 ## Node Identifiers
 
-Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across the nodes in the series.
+Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
 
 ```js format="snippet"
 {

--- a/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
@@ -128,6 +128,22 @@ The default aggregation method is `sum`. Use the `aggregation` option to change 
 }
 ```
 
+## Bin Identifiers
+
+Each bin has a stable identifier, surfaced as the `itemId` in node events and active state. By default this identifier is generated from the bin boundaries. Use `getDataId` to map a bin to an identifier from your own domain. The returned value must be unique across the bins in the series.
+
+```js format="snippet"
+{
+    series: [
+        {
+            type: 'histogram',
+            xKey: 'age',
+            getDataId: ({ binStart, binEnd }) => `${binStart}-${binEnd}yrs`,
+        },
+    ],
+}
+```
+
 ## API Reference
 
 {% tabs %}

--- a/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
@@ -167,7 +167,7 @@ The styling of all links can be customised using the `link` property.
 
 ## Node Identifiers
 
-Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across the nodes in the series.
+Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
 
 ```js format="snippet"
 {

--- a/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
@@ -165,6 +165,23 @@ The styling of all links can be customised using the `link` property.
 }
 ```
 
+## Node Identifiers
+
+Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across the nodes in the series.
+
+```js format="snippet"
+{
+    series: [
+        {
+            type: 'sankey',
+            fromKey: 'from',
+            toKey: 'to',
+            getDataId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
+        },
+    ],
+}
+```
+
 ## API Reference
 
 {% tabs %}


### PR DESCRIPTION
## Summary

Adds a `getDataId` callback to the **histogram**, **sankey** and **chord** series so aggregated nodes (which don't map 1:1 to datums) carry a stable, user-facing identifier, surfaced as `itemId` in events (`seriesNodeClick`, `activeChange`, `selectionChange`) and active state. Builds on the existing `dataIdKey` datum-id infrastructure (AG-14484 / AG-16076).

Jira: [AG-16926](https://ag-grid.atlassian.net/browse/AG-16926)

## What changed

- **Histogram**: bins now default to `bin:<start>,<end>` (previously the numeric group index).
- **Sankey/Chord**: nodes now default to the **node name** from `fromKey`/`toKey` (previously index-based `node-N`), so ids stay stable when nodes are added/reordered.
- **`getDataId`** overrides the default. Invoked via `cachedCallWithContext`, so the chart `context` is passed to the callback and a throwing callback is contained (falls back to the default id).
- Relaxed `DataModelSeriesNodeDatum.itemId` from `never` to `string` so the aggregated histogram bin can carry an explicit id (required by the `CartesianSeriesTypes` generic bound; runtime-identical for other cartesian series, which never set it).
- Public types added to `ag-charts-types`; docs updated on all three series pages.

## ⚠️ Behavioural change

The emitted `itemId` default changes for these series:
- Histogram bins: numeric group index → `bin:<start>,<end>` string.
- Sankey/chord nodes: `node-<index>` → node name.

Consumers reading these ids from events/active state, or passing them to `setActiveItem`, are affected. The `callbacks.test.ts` assertions/snapshots were updated accordingly.

## Acceptance criteria

- [x] Histogram bins have auto-generated ids exposed in events and active state
- [x] Sankey/chord nodes have auto-generated ids (from node names) exposed in events and active state
- [x] `getDataId` overrides the auto-generated id when provided
- [x] Ids remain stable when bin boundaries / node names don't change
- [x] API docs updated; types added to `ag-charts-types`

## Testing

- New `getDataId` tests (default, override, context passthrough, stability across update, negative/fractional bins, throwing-callback fallback) for all three series.
- `yarn nx test ag-charts-community` (3374 passed) and `yarn nx test ag-charts-enterprise` (2184 passed).
- `build:types`, `build:test`, and `lint` clean across types/community/enterprise.