### PR TITLE
AG-17134 - Include .htaccess in charts staging deploy zip

### DIFF
--- a/tools/staging/createAndDeployDocsToTCGH.sh
+++ b/tools/staging/createAndDeployDocsToTCGH.sh
@@ -19,7 +19,14 @@ fi
 FILENAME="charts-staging_${ZIP_PREFIX}_v${ZIP_PREFIX}.zip"
 
 echo "Creating $FILENAME"
-( cd dist/packages/ag-charts-website && zip -qr "../../../$FILENAME" * )
+(
+    cd dist/packages/ag-charts-website
+    zip -qr "../../../$FILENAME" *
+    # The glob above skips dotfiles, so add the generated .htaccess explicitly (present on staging/production builds)
+    if [ -f .htaccess ]; then
+        zip -q "../../../$FILENAME" .htaccess
+    fi
+)
 
 REMOTE_SCRIPT=/tmp/updateChartsStagingRemote.sh
 sed -e "s#@WWW_ROOT_DIR@#${WWW_ROOT_DIR}#g" -e "s#@FILENAME@#${FILENAME}#g" \

--- a/tools/staging/createAndDeployDocsToTCGH.sh
+++ b/tools/staging/createAndDeployDocsToTCGH.sh
@@ -20,6 +20,7 @@ FILENAME="charts-staging_${ZIP_PREFIX}_v${ZIP_PREFIX}.zip"
 
 echo "Creating $FILENAME"
 (
+    set -e
     cd dist/packages/ag-charts-website
     zip -qr "../../../$FILENAME" *
     # The glob above skips dotfiles, so add the generated .htaccess explicitly (present on staging/production builds)


### PR DESCRIPTION
## Problem

Charts staging never receives the CSP `.htaccess` added in #6976.

## Cause

The staging deploy (`tools/staging/createAndDeployDocsToTCGH.sh`, the script CI invokes) packages the build with:

```bash
( cd dist/packages/ag-charts-website && zip -qr "../../../$FILENAME" * )
```

The shell `*` glob **skips dotfiles**, so the generated `.htaccess` is never added to the archive. (`HTACCESS=staging` is new from #6976, so this dotfile only started mattering now.)

## Fix

Add `.htaccess` to the zip explicitly (guarded), matching the studio/grid fix:

```bash
zip -qr "../../../$FILENAME" *
if [ -f .htaccess ]; then
  zip -q "../../../$FILENAME" .htaccess
fi
```

The extract side (`updateChartsStagingRemote.sh`) already swaps into a fresh dir, so unlike studio there's no overwrite issue — only the packaging needed fixing.