### PR TITLE
AG-17134 - Allow CodeSandbox/Plunker open-in form POSTs

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -118,7 +118,13 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         'worker-src': [SELF, 'blob:'],
         'object-src': [NONE],
         'base-uri': [SELF],
-        'form-action': [SELF, trialFormOrigin, salesforceFormOrigin],
+        'form-action': [
+            SELF,
+            trialFormOrigin,
+            salesforceFormOrigin,
+            'https://codesandbox.io', // example-runner "Open in CodeSandbox" form POST
+            'https://plnkr.co', // example-runner "Open in Plunker" form POST
+        ],
         'frame-ancestors': [SELF],
     };
 


### PR DESCRIPTION
## Problem

The example-runner "Open in CodeSandbox" / "Open in Plunker" buttons submit a native `<form>` POST to external hosts, which `form-action` governs. With the tightened CSP this reports (and would, under enforce, block):

```
Sending form data to 'https://codesandbox.io/api/v1/sandboxes/define' violates ... "form-action 'self' ..."
Sending form data to 'https://plnkr.co/edit/?preview&open=index.tsx' violates ... "form-action 'self' ..."
```

These are **interaction-only** (clicking the button), so the page-load report-only crawl never exercised them — found manually on studio, but the example-runner open-in is shared, so all three products are affected.

## Fix

Add `https://codesandbox.io` and `https://plnkr.co` to `form-action`. (StackBlitz is a defined-but-unused `OpenInCTA` type — no `stackblitz.com/run` usage — so it's not included.)