### PR TITLE
fix(website): flatten API reference search to avoid stack overflow

### DIFF
--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -88,6 +88,15 @@ test.describe('api-ref-page', () => {
         ]);
     });
 
+    // The themes API page roots its search index at AgChartTheme, whose tree is far larger than the
+    // options page. Regression: building that index overflowed V8's argument limit and the page
+    // failed to load with "Maximum call stack size exceeded". setupIntrinsicAssertions captures any
+    // such pageerror and fails the test; the visible nav tree guards against a silently blank page.
+    test('themes API page loads without overflowing', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('themes-api/'));
+        await expect(getNavigationTree(page).locator(PROPERTY_NAME_SELECTOR).first()).toBeVisible();
+    });
+
     test('shows fallback when search returns no matches', async ({ page }) => {
         await gotoUrl(page, toPageUrl('options/'));
         await waitForApiReady(page);

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractSearchData } from './apiReferenceHelpers';
+
+// Regression for the themes-api page failing to load with "RangeError: Maximum call stack size
+// exceeded". The crash was not infinite recursion — `extractSearchData` builds a finite but very
+// large index (the AgChartTheme tree reaches ~150k entries), and the previous implementation
+// assembled it with `results.push(...childArray)`. Spreading a child array as call arguments
+// overflows V8's argument limit (~125k in Node, lower in browsers) and throws. The fix flattens the
+// recursion into a shared accumulator so no large array is ever spread as arguments.
+//
+// This builds a non-cyclic Root -> Wide -> Leaf structure whose Wide subtree expands to
+// breadth + breadth^2 entries, comfortably above the argument limit, reproducing the overflow.
+function makeLargeReference(breadth: number) {
+    const member = (name: string, type: string) => ({ kind: 'member', name, type, optional: false });
+    const reference: Record<string, unknown> = {
+        Root: { kind: 'interface', name: 'Root', members: [member('wide', 'Wide')] },
+        Wide: {
+            kind: 'interface',
+            name: 'Wide',
+            members: Array.from({ length: breadth }, (_, i) => member(`p${i}`, 'Leaf')),
+        },
+        Leaf: {
+            kind: 'interface',
+            name: 'Leaf',
+            members: Array.from({ length: breadth }, (_, j) => member(`q${j}`, 'string')),
+        },
+    };
+    return new Map<string, any>(Object.entries(reference));
+}
+
+describe('extractSearchData', () => {
+    it('flattens a large reference without overflowing the argument limit', () => {
+        const breadth = 400;
+        const reference = makeLargeReference(breadth);
+
+        const run = () => extractSearchData(reference as any, reference.get('Root'), [{ name: 'r', type: 'Root' }]);
+
+        // Pre-fix this threw "Maximum call stack size exceeded" while spreading the Wide subtree.
+        expect(run).not.toThrow();
+        // Root(1) + Wide members(breadth) + Leaf members per Wide member(breadth^2).
+        expect(run()).toHaveLength(1 + breadth + breadth * breadth);
+    });
+});

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -261,20 +261,37 @@ export function extractSearchData(
     labelPrefix = '',
     genericsMap?: Record<string, TypeNode>
 ): SearchDatum[] {
+    const out: SearchDatum[] = [];
+    collectSearchData(out, reference, interfaceRef, basePath, labelPrefix, genericsMap);
+    return out;
+}
+
+// Appends entries to a shared accumulator rather than returning per-level arrays. The theme search
+// index reaches ~150k entries; assembling it with `result.push(...childArray)` spreads child arrays
+// as call arguments, which overflows V8's argument limit and throws "Maximum call stack size exceeded".
+function collectSearchData(
+    out: SearchDatum[],
+    reference: ApiReferenceType | undefined,
+    interfaceRef: NodeTypes | undefined,
+    basePath: NavigationPath[],
+    labelPrefix: string,
+    genericsMap?: Record<string, TypeNode>
+): void {
     const aliasedUnion = resolveAliasedUnion(interfaceRef, reference);
     if (aliasedUnion) {
-        return extractUnionSearchData(
+        collectUnionSearchData(
+            out,
             reference,
             aliasedUnion.unionType,
             basePath,
             labelPrefix,
             mergeGenericsMaps(genericsMap, aliasedUnion.genericsMap)
         );
+        return;
     }
     if (isInterfaceLikeNode(interfaceRef)) {
-        return extractInterfaceSearchData(reference, interfaceRef, basePath, labelPrefix, genericsMap);
+        collectInterfaceSearchData(out, reference, interfaceRef, basePath, labelPrefix, genericsMap);
     }
-    return [];
 }
 
 export function getOptionsStaticPaths(reference: ApiReferenceType) {
@@ -717,41 +734,38 @@ export function buildTypeArgumentsFromGenericsMap(
     );
 }
 
-function extractInterfaceSearchData(
+function collectInterfaceSearchData(
+    out: SearchDatum[],
     reference: ApiReferenceType | undefined,
     interfaceRef: InterfaceNode | (TypeLiteralNode & { name: string }),
     basePath: NavigationPath[],
     labelPrefix: string,
     parentGenericsMap?: Record<string, TypeNode>
-) {
+): void {
     const genericsMap = mergeGenericsMaps(
         (interfaceRef as HasProperty<NodeTypes, 'genericsMap'>).genericsMap,
         parentGenericsMap
     );
-    return interfaceRef.members.flatMap((member) => {
+    for (const member of interfaceRef.members) {
         const cleanedName = cleanupName(member.name);
         const newPath = { name: cleanedName, type: getMemberType(member) };
         if (basePath.find((p) => p.name === newPath.name && p.type === newPath.type)) {
-            return [];
+            continue;
         }
 
         const navPath = basePath.concat(newPath);
         const label = labelPrefix + cleanedName;
-        const results: SearchDatum[] = [
-            {
-                label,
-                searchable: cleanedName.toLowerCase(),
-                navPath,
-            },
-        ];
+        out.push({
+            label,
+            searchable: cleanedName.toLowerCase(),
+            navPath,
+        });
 
         const referenceTarget = resolveMemberReference(member, reference, genericsMap);
         if (referenceTarget) {
-            results.push(...extractSearchData(reference, referenceTarget, navPath, `${label}.`));
+            collectSearchData(out, reference, referenceTarget, navPath, `${label}.`);
         }
-
-        return results;
-    });
+    }
 }
 
 function resolveMemberReference(
@@ -777,38 +791,40 @@ function resolveMemberReference(
     return resolvedType && reference?.get(resolvedType);
 }
 
-function extractUnionSearchData(
+function collectUnionSearchData(
+    out: SearchDatum[],
     reference: ApiReferenceType | undefined,
     unionType: MultiTypeNode & { kind: 'union' },
     basePath: NavigationPath[],
     labelPrefix: string,
     genericsMap?: Record<string, TypeNode>
-) {
-    return unionType.type
-        .flatMap((typeName) => buildUnionSearchEntries(typeName, reference, basePath, labelPrefix, genericsMap))
-        .filter((item): item is SearchDatum => Boolean(item));
+): void {
+    for (const typeName of unionType.type) {
+        collectUnionSearchEntries(out, typeName, reference, basePath, labelPrefix, genericsMap);
+    }
 }
 
-function buildUnionSearchEntries(
+function collectUnionSearchEntries(
+    out: SearchDatum[],
     typeName: TypeNode,
     reference: ApiReferenceType | undefined,
     basePath: NavigationPath[],
     labelPrefix: string,
     parentGenericsMap?: Record<string, TypeNode>
-) {
+): void {
     const subtypeName = getReferencedTypeName(typeName);
     if (!subtypeName || isInterfaceHidden(subtypeName)) {
-        return [];
+        return;
     }
 
     const subtypeRef = reference?.get(subtypeName);
     if (subtypeRef?.kind !== 'interface') {
-        return [];
+        return;
     }
 
     const typeMember = subtypeRef.members.find((member) => member.name === 'type');
     if (!typeMember) {
-        return [];
+        return;
     }
 
     const label = `${labelPrefix.replace(/\.$/, '')}[type=${typeMember.type as string}]`;
@@ -817,14 +833,12 @@ function buildUnionSearchEntries(
         type: subtypeName,
     });
 
-    return [
-        {
-            label,
-            searchable: cleanupName(getMemberType(typeMember)).toLowerCase(),
-            navPath,
-        },
-        ...extractSearchData(reference, subtypeRef, navPath, `${label}.`, parentGenericsMap),
-    ];
+    out.push({
+        label,
+        searchable: cleanupName(getMemberType(typeMember)).toLowerCase(),
+        navPath,
+    });
+    collectSearchData(out, reference, subtypeRef, navPath, `${label}.`, parentGenericsMap);
 }
 
 function findRequiredRefs(reference: ApiReferenceType) {


### PR DESCRIPTION
The `/themes-api` documentation page failed to load with `RangeError: Maximum call stack size exceeded`.

### Root cause
The page builds its search index by rooting `extractSearchData` at `AgChartTheme`. That tree is finite but large — it expands to ~150k entries (the `overrides` subtree alone is ~149.5k). The previous implementation assembled the index with `results.push(...extractSearchData(...))` and `[leaf, ...extractSearchData(...)]`. Spreading a large array as call arguments overflows V8's argument limit (throws at ~125k in Node, lower in browsers), which surfaces as `Maximum call stack size exceeded` — not an infinite recursion (real recursion depth here is only ~14).

This regressed when generics threading landed in the API-reference helpers: resolving generic member type-params to concrete interfaces grew the `AgChartTheme` index from ~63k entries (under the browser limit, so it still loaded) to ~150k (over the limit → crash). The options page (~1.7k entries) was never close, so it was unaffected.

### Fix
Flatten the four search-extraction helpers (`extractSearchData`, and the interface/union collectors) to push into a single shared accumulator one entry at a time, so no large array is ever spread as arguments. `extractSearchData` keeps its public signature as a thin wrapper.

The produced index is **byte-for-byte identical** to before — verified by comparing serialised output (label + searchable + navPath) for `AgChartTheme`, `AgChartOptions`, and the axis option roots: same counts, matching SHA hashes.

### Test plan
- New unit regression test (`apiReferenceHelpers.test.ts`): a self-contained large finite reference reproduces the argument-spread overflow on the previous code and asserts the flattened version returns the expected entry count without throwing.
- New e2e test (`api-ref-page.spec.ts`): loads `/themes-api` and asserts the navigation tree renders; the suite's intrinsic `pageerror` assertion fails on any uncaught overflow.
- `yarn nx lint ag-charts-website` passes (0 errors); output equivalence verified against the pre-fix implementation.