### PR TITLE
AG-17134 - Include hidden files in charts staging build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,9 @@ jobs:
               with:
                   name: website-staging-dist
                   path: dist/packages/ag-charts-website/
+                  # upload-artifact@v4 excludes hidden files by default, which would drop the
+                  # generated .htaccess (CSP + redirects) before the deploy job zips it.
+                  include-hidden-files: true
                   retention-days: 1
 
     test:


### PR DESCRIPTION
## Problem

After merging the CSP work, charts staging has **no `.htaccess`** — despite the build generating it, the packaging fix (#6991) including it, and the extract using a fresh-dir swap.

## Cause

Charts splits build and deploy across two CI jobs and hands the build over via an artifact:

```yaml
- name: Persist website build for staging deploy
  uses: actions/upload-artifact@v4
  with:
      name: website-staging-dist
      path: dist/packages/ag-charts-website/
```

`actions/upload-artifact@v4` **excludes hidden files by default**, so the generated `.htaccess` is stripped from the artifact. The deploy job downloads the (already `.htaccess`-less) artifact and zips it — so the `if [ -f .htaccess ]` guard from #6991 finds nothing to add. The dotfile was gone before the zip ran.

## Fix

```yaml
      include-hidden-files: true
```

so the `.htaccess` survives the build→deploy artifact handoff.

## Note

Studio is unaffected — it builds and deploys in the same job (no artifact round-trip), so its `.htaccess` was preserved once the `unzip -qo` overwrite (#1601) landed. Grid should be checked for the same split-job pattern.