### PR TITLE
AG-17134 - Allow AG subdomains to embed examples (frame-ancestors)

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -125,7 +125,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://codesandbox.io', // example-runner "Open in CodeSandbox" form POST
             'https://plnkr.co', // example-runner "Open in Plunker" form POST
         ],
-        'frame-ancestors': [SELF],
+        'frame-ancestors': [SELF, AG_GRID_HOSTS], // allow *.ag-grid.com (e.g. blog) to embed examples
     };
 
     if (env === 'dev') {


### PR DESCRIPTION
## What

Widen the CSP `frame-ancestors` directive from `'self'` to `'self' https://*.ag-grid.com` so `blog.ag-grid.com` (and other AG subdomains) can embed examples once the CSP enforces.

## Why

`blog.ag-grid.com` iframes examples from `www.ag-grid.com`. Grid's root `X-Frame-Options: SAMEORIGIN` (which this product inherits as a subdirectory) blocked cross-subdomain framing; it's being removed in the grid PR. This widens the CSP-side control so framing by AG subdomains is allowed while other origins remain refused.

This product does not set `X-Frame-Options` itself — only the `frame-ancestors` widening is needed here. Paired with the grid PR.