### PR TITLE
AG-16920 - Simplify series highlighting docs and JSDoc

### DIFF
--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -162,7 +162,7 @@ export type AgChartHighlightRange = 'tooltip' | 'node';
 
 export interface AgChartHighlightOptions {
     /**
-     * Set to `false` to disable highlighting for all series. Individual series can re-enable it with `series[].highlight.enabled`.
+     * Set to `false` to disable highlighting for all series in the chart.
      *
      * Default: `true`
      */

--- a/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
@@ -12,20 +12,7 @@ In the above example:
 - Hovering a bar segment in one series will dim the other series.
 - Hovering a legend item will dim the other series.
 
-Highlighting is enabled by default. Set chart-level `highlight.enabled` to `false` to disable it for every series, then re-enable it for an individual series with `series[].highlight.enabled`.
-
-```js format="snippet"
-{
-    highlight: {
-        enabled: false,
-    },
-    series: [
-        { type: 'bar', xKey: 'quarter', yKey: 'iphone' },
-        // Re-enable highlighting for this series only.
-        { type: 'bar', xKey: 'quarter', yKey: 'mac', highlight: { enabled: true } },
-    ],
-}
-```
+Highlighting is enabled by default. Use `highlight.enabled` to configure it globally, or `series[].highlight.enabled` to override it per series
 
 ## Bring to Front
 


### PR DESCRIPTION
## Summary

- Simplify `highlight.enabled` JSDoc: remove the inaccurate claim that individual series can re-enable it via `series[].highlight.enabled` (the old description was misleading).
- Remove the per-series re-enable code snippet from the series highlighting docs page and replace it with a concise one-liner that accurately describes both the chart-level and per-series controls.

## Test plan

- [ ] Confirm the `highlight.enabled` JSDoc in `ag-charts-types` reads cleanly in IDE autocomplete.
- [ ] Visually review the updated series-highlighting docs page to confirm the simplified description is accurate and no content gap is introduced.

Fix #AG-16920