### PR TITLE
AG-17134 Allow OneTrust consent + ZoomInfo blob in charts CSP

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -80,6 +80,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.google.com', // reCAPTCHA (license-pricing trial form)
             'https://www.gstatic.com', // reCAPTCHA
             'https://www.youtube.com', // YouTube iframe JS API (loads into the page)
+            'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
+            'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
             UNSAFE_INLINE,
             UNSAFE_EVAL,
         ],
@@ -106,6 +108,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://js.zi-scripts.com', // ZoomInfo
             'https://*.zoominfo.com', // ZoomInfo
             'https://www.google.com', // reCAPTCHA (api2/clr XHR)
+            'https://cdn.cookielaw.org', // OneTrust config/JSON/asset XHR (GTM-injected, prod-only)
+            'https://*.onetrust.com', // OneTrust geolocation + consent-receipt endpoints
             trialFormOrigin, // trial-licence form fetch POST
         ],
         'frame-src': [


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

A production report-only crawl of `https://www.ag-grid.com/charts/` (16 routes) surfaced two GTM-injected, **production-only** tags that the charts-staging report-only window could not see (GTM is prod-only on charts), so they were missing from the report-only allowlist:

- **OneTrust cookie-consent SDK** — `gtm.js` injects `otSDKStub.js` → `otBannerSdk.js` from `cdn.cookielaw.org`, plus config/JSON/asset XHRs to `cdn.cookielaw.org`, `geolocation.onetrust.com` and `privacyportal-eu.onetrust.com`. (Not in the original charts audit.)
- **ZoomInfo** (already allowlisted) — `zi-tag.js` bootstraps a `blob:` URL script.

Changes to `cspRules.ts`:
- `script-src`: add `https://cdn.cookielaw.org` and `blob:`
- `connect-src`: add `https://cdn.cookielaw.org` and `https://*.onetrust.com`

These are intentional marketing/consent tags, so the tightened report-only policy should allow them. `img-src`/`media-src` already permit `https:`, so OneTrust's logo/SVG is covered.

**Note — `blob:` in `script-src`** is a mild weakening (CSP can't scope `blob:` to an origin); accepted because ZoomInfo needs it and studio made the same call.

**Follow-up:** OneTrust is currently blocked at the SDK stub, so its downstream requests are unknown until it can initialise. A second prod re-crawl is needed after this deploys to catch any second wave. Targeting `b13.3.1` to match production; will port to `latest` afterwards.
