### PR TITLE
AG-17134 Allow GA4 regional collect endpoints in charts CSP

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -100,7 +100,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://plausible.io',
             'https://*.algolia.net', // Algolia DocSearch
             'https://*.algolianet.com', // Algolia DocSearch
-            'https://www.google-analytics.com',
+            'https://*.google-analytics.com', // GA4 incl. regional collect endpoints (region1/2.google-analytics.com)
             'https://*.analytics.google.com',
             'https://stats.g.doubleclick.net',
             'https://www.googletagmanager.com',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Follow-up to #7018. Clicking around production charts (e.g. nav events on `/charts/license-pricing/`) fired GA4 `/g/collect` and `/measurement/conversion` XHRs to `region1.google-analytics.com` — a geo-routed regional endpoint not covered by the exact `www.google-analytics.com` connect-src entry, so it reported as a violation.

Broaden `https://www.google-analytics.com` → `https://*.google-analytics.com` in `connect-src`, covering `www` plus all `regionN.google-analytics.com` endpoints.

This is an interaction-triggered, production-only tag (GTM-injected GA4), so the page-load crawl didn't surface it. Targeting `b13.3.1` to match production; will port to `latest` with the rest.

Fix #AG-17134