### PR TITLE
AG-16608, AG-16654 Bigint/ISO render hardening — core (1/3)

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/numberAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/numberAxis.ts
@@ -1,6 +1,6 @@
 import type { AxisID, DomainWithMetadata, DynamicContext, NormalisedNumberAxisOptions } from 'ag-charts-core';
 import { normalisedExtentWithMetadata } from 'ag-charts-core';
-import type { FormatterParams } from 'ag-charts-types';
+import type { AgNumericValue, FormatterParams } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../module/moduleContext';
 import { LinearScale } from '../../scale/linearScale';
@@ -11,7 +11,7 @@ import { CartesianAxis } from './cartesianAxis';
 
 export class NumberAxis<
     TOptions extends NormalisedNumberAxisOptions = NormalisedNumberAxisOptions,
-> extends CartesianAxis<LinearScale | LogScale, number, TOptions> {
+> extends CartesianAxis<LinearScale | LogScale, AgNumericValue, TOptions> {
     static readonly className: string = 'NumberAxis';
     static readonly type: string = 'number';
 
@@ -33,7 +33,7 @@ export class NumberAxis<
         return this.options.label.format;
     }
 
-    override normaliseDataDomain(d: DomainWithMetadata<number>) {
+    override normaliseDataDomain(d: DomainWithMetadata<AgNumericValue>) {
         const { min, max, preferredMin, preferredMax } = this.options;
         const { extent, clipped } = normalisedExtentWithMetadata(
             d.domain,
@@ -52,7 +52,7 @@ export class NumberAxis<
         return [this.options.min == null && this.nice, this.options.max == null && this.nice];
     }
 
-    protected getVisibleDomain(domain: number[]): [number, number] {
+    protected getVisibleDomain(domain: AgNumericValue[]): [number, number] {
         // Narrow to Number: a bigint domain reaches here as formatter-context metadata only — the tick
         // label itself carries the exact bigint value, so this range context can narrow safely.
         const d0 = Number(domain[0]);
@@ -62,7 +62,11 @@ export class NumberAxis<
         return [d0 + r0 * length, d1 - (1 - r1) * length];
     }
 
-    override tickFormatParams(domain: number[], _ticks: number[], fractionDigits?: number): AxisTickFormatParams {
+    override tickFormatParams(
+        domain: AgNumericValue[],
+        _ticks: AgNumericValue[],
+        fractionDigits?: number
+    ): AxisTickFormatParams {
         return { type: 'number', visibleDomain: this.getVisibleDomain(domain), fractionDigits };
     }
 

--- a/packages/ag-charts-community/src/chart/axis/timeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/timeAxis.ts
@@ -12,12 +12,20 @@ import {
     intervalMilliseconds,
     intervalStep,
     intervalUnit,
+    isISO8601,
     lowestGranularityForInterval,
     lowestGranularityUnitForTicks,
     lowestGranularityUnitForValue,
     normalisedTimeExtentWithMetadata,
+    timeValueToNumber,
 } from 'ag-charts-core';
-import type { AgTimeInterval, AgTimeIntervalUnit, DateFormatterStyle, FormatterParams } from 'ag-charts-types';
+import type {
+    AgTimeInterval,
+    AgTimeIntervalUnit,
+    AgTimeValue,
+    DateFormatterStyle,
+    FormatterParams,
+} from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../module/moduleContext';
 import { TimeScale } from '../../scale/timeScale';
@@ -27,6 +35,13 @@ import type { AxisTickFormatParams } from './axis';
 import { CartesianAxis } from './cartesianAxis';
 
 type TimeBound = Date | number | undefined;
+
+// Coerces a time-axis bound to `Date | number`; non-time inputs pass through so existing validation surfaces the error.
+export function coerceTimeBound(value: AgTimeValue | undefined): TimeBound {
+    if (typeof value === 'bigint') return Number(value);
+    if (isISO8601(value)) return new Date(value);
+    return value;
+}
 
 export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTimeAxisOptions> extends CartesianAxis<
     TimeScale,
@@ -74,7 +89,13 @@ export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTim
 
     override normaliseDataDomain(d: DomainWithMetadata<Date>) {
         const { min, max, preferredMin, preferredMax } = this.options;
-        const { extent, clipped } = normalisedTimeExtentWithMetadata(d, min, max, preferredMin, preferredMax);
+        const { extent, clipped } = normalisedTimeExtentWithMetadata(
+            d,
+            coerceTimeBound(min),
+            coerceTimeBound(max),
+            coerceTimeBound(preferredMin),
+            coerceTimeBound(preferredMax)
+        );
         return { domain: extent, clipped };
     }
 
@@ -83,7 +104,12 @@ export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTim
 
         const { boundSeries, direction } = this;
         const { min, max } = this.options;
-        this.minimumTimeGranularity = minimumTimeAxisDatumGranularity(boundSeries, direction, min, max);
+        this.minimumTimeGranularity = minimumTimeAxisDatumGranularity(
+            boundSeries,
+            direction,
+            coerceTimeBound(min),
+            coerceTimeBound(max)
+        );
     }
 
     override tickFormatParams(
@@ -101,14 +127,14 @@ export class TimeAxis<TOptions extends NormalisedTimeAxisOptions = NormalisedTim
     }
 
     override datumFormatParams(
-        value: number | Date,
+        value: AgTimeValue,
         params: FormatDatumParams,
         _fractionDigits: number | undefined,
         timeInterval: AgTimeInterval | AgTimeIntervalUnit | undefined,
         style: DateFormatterStyle
     ): FormatterParams<any> {
-        if (typeof value === 'number') {
-            value = new Date(value);
+        if (!(value instanceof Date)) {
+            value = new Date(timeValueToNumber(value));
         }
 
         if (timeInterval == null) {

--- a/packages/ag-charts-community/src/chart/axis/unitTimeAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/unitTimeAxis.ts
@@ -17,7 +17,7 @@ import { UnitTimeScale } from '../../scale/unitTimeScale';
 import type { FormatDatumParams } from '../chartAxis';
 import type { AxisTickFormatParams } from './axis';
 import { DiscreteTimeAxis } from './discreteTimeAxis';
-import { calculateDefaultUnit } from './timeAxis';
+import { calculateDefaultUnit, coerceTimeBound } from './timeAxis';
 
 type UnitInterval = AgTimeInterval | AgTimeIntervalUnit | undefined;
 
@@ -73,7 +73,7 @@ export class UnitTimeAxis extends DiscreteTimeAxis<UnitTimeScale, NormalisedUnit
         } else {
             const { boundSeries, direction } = this;
             const { min, max } = this.options;
-            defaultUnit = calculateDefaultUnit(boundSeries, direction, min, max);
+            defaultUnit = calculateDefaultUnit(boundSeries, direction, coerceTimeBound(min), coerceTimeBound(max));
         }
 
         if (!objectsEqual(this.defaultUnit, defaultUnit)) {
@@ -89,7 +89,13 @@ export class UnitTimeAxis extends DiscreteTimeAxis<UnitTimeScale, NormalisedUnit
 
     override normaliseDataDomain(d: DomainWithMetadata<Date>) {
         const { min, max, preferredMin, preferredMax } = this.options;
-        const { extent, clipped } = normalisedTimeExtentWithMetadata(d, min, max, preferredMin, preferredMax);
+        const { extent, clipped } = normalisedTimeExtentWithMetadata(
+            d,
+            coerceTimeBound(min),
+            coerceTimeBound(max),
+            coerceTimeBound(preferredMin),
+            coerceTimeBound(preferredMax)
+        );
         return { domain: extent, clipped };
     }
 

--- a/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/data/__snapshots__/dataModel.test.ts.snap
@@ -667,7 +667,7 @@ exports[`DataModel > grouped processing - calculated grouping > should generated
     },
   ],
   "columnValueType": [
-    "number",
+    undefined,
   ],
   "columns": [
     [

--- a/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
+++ b/packages/ag-charts-community/src/chart/data/aggregateFunctions.ts
@@ -1,36 +1,35 @@
-import { isFiniteNumber } from 'ag-charts-core';
+import { addValues, isFiniteNumber, subtractValues } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { ContinuousDomain } from './dataDomain';
 import type { AggregatePropertyDefinition, DatumPropertyDefinition } from './dataModel';
 
-/**
- * Adds two accumulator operands, promoting to bigint when either operand is. Columns are uniformly
- * typed, so a bigint column's number `0` seed promotes to `0n` on the first value and stays bigint.
- */
-export function addAccumulated(acc: number | bigint, value: number | bigint): number | bigint {
-    if (typeof acc === 'bigint' || typeof value === 'bigint') {
-        return BigInt(acc) + BigInt(value);
-    }
-    return acc + value;
+/** Adds two operands, promoting to bigint when either is, so a bigint column's `0` seed stays exact. */
+export function addAccumulated(acc: AgNumericValue, value: AgNumericValue): AgNumericValue {
+    return addValues(acc, value);
 }
 
-export function sumValues(values: any[], accumulator: [number, number] = [0, 0]) {
+export function sumValues(
+    values: any[],
+    accumulator: [AgNumericValue, AgNumericValue] = [0, 0]
+): [AgNumericValue, AgNumericValue] {
     for (const value of values) {
-        if (typeof value !== 'number') {
+        if (typeof value !== 'number' && typeof value !== 'bigint') {
             continue;
         }
+        // addAccumulated keeps bigint totals exact; the unused-sign side retains its Number seed (mixed accumulator type).
         if (value < 0) {
-            accumulator[0] += value;
+            accumulator[0] = addAccumulated(accumulator[0], value);
         }
         if (value > 0) {
-            accumulator[1] += value;
+            accumulator[1] = addAccumulated(accumulator[1], value);
         }
     }
     return accumulator;
 }
 
 export function sum(id: string, matchGroupId: string) {
-    const result: AggregatePropertyDefinition<any, any> = {
+    const result: AggregatePropertyDefinition<any, any, [AgNumericValue, AgNumericValue]> = {
         id,
         matchGroupIds: [matchGroupId],
         type: 'aggregate',
@@ -43,7 +42,7 @@ export function sum(id: string, matchGroupId: string) {
 export function groupSum(
     id: string,
     opts?: { matchGroupId?: string; visible?: boolean }
-): AggregatePropertyDefinition<any, any> {
+): AggregatePropertyDefinition<any, any, [AgNumericValue, AgNumericValue]> {
     const visible = opts?.visible ?? true;
     return {
         id,
@@ -52,8 +51,8 @@ export function groupSum(
         aggregateFunction: (values) => sumValues(values),
         groupAggregateFunction: (next, acc = [0, 0]) => {
             if (visible) {
-                acc[0] += next?.[0] ?? 0;
-                acc[1] += next?.[1] ?? 0;
+                acc[0] = addAccumulated(acc[0], next?.[0] ?? 0);
+                acc[1] = addAccumulated(acc[1], next?.[1] ?? 0);
             }
             return acc;
         },
@@ -61,7 +60,7 @@ export function groupSum(
 }
 
 export function range(id: string, matchGroupId: string) {
-    const result: AggregatePropertyDefinition<any, any> = {
+    const result: AggregatePropertyDefinition<any, any, [AgNumericValue, AgNumericValue]> = {
         id,
         matchGroupIds: [matchGroupId],
         type: 'aggregate',
@@ -71,7 +70,10 @@ export function range(id: string, matchGroupId: string) {
     return result;
 }
 
-export function groupCount(id: string, opts?: { visible?: boolean }): AggregatePropertyDefinition<any, any> {
+export function groupCount(
+    id: string,
+    opts?: { visible?: boolean }
+): AggregatePropertyDefinition<any, any, [number, number]> {
     const visible = opts?.visible ?? true;
     return {
         id,
@@ -89,21 +91,27 @@ export function groupCount(id: string, opts?: { visible?: boolean }): AggregateP
 
 export function groupAverage(id: string, opts?: { matchGroupId?: string; visible?: boolean }) {
     const visible = opts?.visible ?? true;
-    const def: AggregatePropertyDefinition<any, any, [number, number], [number, number, number]> = {
+    const def: AggregatePropertyDefinition<
+        any,
+        any,
+        [AgNumericValue, AgNumericValue],
+        [AgNumericValue, AgNumericValue, number]
+    > = {
         id,
         matchGroupIds: opts?.matchGroupId ? [opts?.matchGroupId] : undefined,
         type: 'aggregate',
         aggregateFunction: (values) => sumValues(values),
         groupAggregateFunction: (next, acc = [0, 0, -1]) => {
             if (visible) {
-                acc[0] += next?.[0] ?? 0;
+                acc[0] = addAccumulated(acc[0], next?.[0] ?? 0);
                 acc[2]++;
-                acc[1] += next?.[1] ?? 0;
+                acc[1] = addAccumulated(acc[1], next?.[1] ?? 0);
             }
             return acc;
         },
         finalFunction: (acc = [0, 0, 0]) => {
-            const result = acc[0] + acc[1];
+            // A mean is fractional, so narrow the bigint sums to Number for the division.
+            const result = Number(acc[0]) + Number(acc[1]);
             if (result >= 0) {
                 return [0, result / acc[2]];
             }
@@ -114,14 +122,15 @@ export function groupAverage(id: string, opts?: { matchGroupId?: string; visible
     return def;
 }
 
-export function area(id: string, aggFn: AggregatePropertyDefinition<any, any>, matchGroupId?: string) {
-    const result: AggregatePropertyDefinition<any, any> = {
+export function area(id: string, aggFn: AggregatePropertyDefinition<any, any, any>, matchGroupId?: string) {
+    const result: AggregatePropertyDefinition<any, any, [number, number]> = {
         id,
         matchGroupIds: matchGroupId ? [matchGroupId] : undefined,
         type: 'aggregate',
         aggregateFunction: (values, keyRange = []) => {
-            const keyWidth = keyRange[1] - keyRange[0];
-            return aggFn.aggregateFunction(values).map((v) => v / keyWidth) as [number, number];
+            // Subtract bigint key edges before narrowing: narrowing first collapses the width to 0 beyond a double's ULP.
+            const keyWidth = Number(subtractValues(keyRange[1], keyRange[0]));
+            return aggFn.aggregateFunction(values).map((v: AgNumericValue) => Number(v) / keyWidth) as [number, number];
         },
     };
 
@@ -134,7 +143,7 @@ export function area(id: string, aggFn: AggregatePropertyDefinition<any, any>, m
 
 export function accumulatedValue(onlyPositive?: boolean): DatumPropertyDefinition<any>['processor'] {
     return () => {
-        let value: number | bigint = 0;
+        let value: AgNumericValue = 0;
 
         return (datum: any) => {
             if (typeof datum === 'bigint') {
@@ -153,7 +162,7 @@ export function accumulatedValue(onlyPositive?: boolean): DatumPropertyDefinitio
 
 export function trailingAccumulatedValue(): DatumPropertyDefinition<any>['processor'] {
     return () => {
-        let value: number | bigint = 0;
+        let value: AgNumericValue = 0;
 
         return (datum: any) => {
             if (typeof datum !== 'bigint' && !isFiniteNumber(datum)) {

--- a/packages/ag-charts-community/src/chart/data/data-model/aggregation/aggregator.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/aggregation/aggregator.ts
@@ -1,4 +1,5 @@
-import { first } from 'ag-charts-core';
+import { Logger, first } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { ContinuousDomain, DiscreteDomain } from '../../dataDomain';
 import type { GroupedData, PropertySelectors, UngroupedData } from '../../dataModelTypes';
@@ -38,7 +39,7 @@ export class Aggregator<D extends object, K extends keyof D & string> {
      * Each datum gets its own aggregation result.
      */
     aggregateUngroupedData(processedData: UngroupedData<any>) {
-        const domainAggValues = this.ctx.aggregates.map((): [number, number] => [Infinity, -Infinity]);
+        const domainAggValues = this.ctx.aggregates.map((): [AgNumericValue, AgNumericValue] => [Infinity, -Infinity]);
         processedData.domain.aggValues = domainAggValues;
 
         const { columns, dataSources } = processedData;
@@ -49,7 +50,7 @@ export class Aggregator<D extends object, K extends keyof D & string> {
         // Check if any key definition allows null values
         const allowNull = this.ctx.keys.some((keyDef) => keyDef.allowNullKey === true);
         processedData.aggregation = rawData?.map((_, datumIndex) => {
-            const aggregation: [number, number][] = [];
+            const aggregation: [AgNumericValue, AgNumericValue][] = [];
 
             for (const [index, def] of this.ctx.aggregates.entries()) {
                 const indices = this.valueGroupIdxLookup(def);
@@ -78,7 +79,7 @@ export class Aggregator<D extends object, K extends keyof D & string> {
      * Multiple datums in a group share aggregation results.
      */
     aggregateGroupedData(processedData: GroupedData<any>) {
-        const domainAggValues = this.ctx.aggregates.map((): [number, number] => [Infinity, -Infinity]);
+        const domainAggValues = this.ctx.aggregates.map((): [AgNumericValue, AgNumericValue] => [Infinity, -Infinity]);
         processedData.domain.aggValues = domainAggValues;
 
         const { columns } = processedData;
@@ -128,9 +129,14 @@ export class Aggregator<D extends object, K extends keyof D & string> {
     postProcessGroups(processedData: GroupedData<any>) {
         const { groupProcessors } = this.ctx;
 
-        const { columnScopes, columns, invalidData } = processedData;
+        const { columnScopes, columns, invalidData, columnValueType } = processedData;
         for (const processor of groupProcessors) {
-            const valueIndexes = this.valueGroupIdxLookup(processor);
+            // Stacking is meaningless for date columns: reject and exclude them from accumulation.
+            const valueIndexes = this.valueGroupIdxLookup(processor).filter((valueIndex) => {
+                if (columnValueType?.[valueIndex] !== 'date') return true;
+                this.rejectDateStackColumn(processedData, valueIndex);
+                return false;
+            });
             const adjustFn = processor.adjust()();
 
             for (let groupIndex = 0; groupIndex < processedData.groups.length; groupIndex++) {
@@ -154,6 +160,22 @@ export class Aggregator<D extends object, K extends keyof D & string> {
                 processedData.domain.values[valueIndex] = domain.getDomain();
             }
         }
+    }
+
+    private rejectDateStackColumn(processedData: GroupedData<any>, valueIndex: number) {
+        const valueDef = this.ctx.values[valueIndex];
+        const columnScope = first(processedData.columnScopes[valueIndex]);
+        Logger.warnOnce(
+            `Series "${String(columnScope)}": column "${String(valueDef.property)}" is date-typed; ` +
+                `stacking is not meaningful for date data. The series renders empty; ` +
+                `other series in this chart are unaffected.`
+        );
+
+        const column = processedData.columns[valueIndex];
+        for (let datumIndex = 0; datumIndex < column.length; datumIndex += 1) {
+            column[datumIndex] = undefined;
+        }
+        processedData.domain.values[valueIndex] = [];
     }
 
     private valueGroupIdxLookup(selector: PropertySelectors) {

--- a/packages/ag-charts-community/src/chart/data/data-model/domain/domainInitializer.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/domain/domainInitializer.ts
@@ -24,11 +24,12 @@ export class DomainInitializer<K extends string> {
         sortOrderEntry?: SortOrderEntry
     ): IDataDomain {
         const isDiscrete = def.valueType === 'category';
+        const coerceDates = def.timeDomain === true;
 
         let domain = bandedDomains.get(def);
         if (!domain && this.ctx.bandingConfig?.enableBanding !== false) {
             domain = new BandedDomain(
-                isDiscrete ? () => new DiscreteDomain() : () => new ContinuousDomain(),
+                isDiscrete ? () => new DiscreteDomain(coerceDates) : () => new ContinuousDomain(),
                 this.ctx.bandingConfig,
                 isDiscrete
             );
@@ -45,7 +46,7 @@ export class DomainInitializer<K extends string> {
             return domain;
         }
 
-        return isDiscrete ? new DiscreteDomain() : new ContinuousDomain();
+        return isDiscrete ? new DiscreteDomain(coerceDates) : new ContinuousDomain();
     }
 
     /**

--- a/packages/ag-charts-community/src/chart/data/data-model/domain/domainManager.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/domain/domainManager.ts
@@ -343,7 +343,7 @@ export class DomainManager<D extends object, K extends keyof D & string> {
             // First, create domains for key definitions
             for (const def of keyDefs) {
                 if (def.valueType === 'category') {
-                    dataDomain.set(def, new DiscreteDomain());
+                    dataDomain.set(def, new DiscreteDomain(def.timeDomain === true));
                 } else {
                     dataDomain.set(def, new ContinuousDomain());
                 }
@@ -362,7 +362,7 @@ export class DomainManager<D extends object, K extends keyof D & string> {
                 }
 
                 if (def.valueType === 'category') {
-                    dataDomain.set(def, new DiscreteDomain());
+                    dataDomain.set(def, new DiscreteDomain(def.timeDomain === true));
                 } else {
                     dataDomain.set(def, new ContinuousDomain());
                     allScopesHaveSameDefs &&= (def.scopes?.length ?? 0) === scopes.size;

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -1,4 +1,4 @@
-import { Logger, first, isNumberObject, iterate } from 'ag-charts-core';
+import { Logger, first, isISO8601, isNumberObject, iterate } from 'ag-charts-core';
 
 import { ContinuousDomain } from '../../dataDomain';
 import {
@@ -76,33 +76,63 @@ function valueColumnType(value: unknown): ColumnValueType | undefined {
             return 'number';
         case 'bigint':
             return 'bigint';
+        case 'boolean':
+            return 'boolean';
         case 'string':
-            return 'string';
+            return isISO8601(value) ? 'date' : 'string';
         case 'object':
             if (value == null) return undefined;
-            // A NumberObject ({ valueOf(): number }) is numeric, not a date.
-            return isNumberObject(value) ? 'number' : 'date';
+            if (value instanceof Date) return 'date';
+            return isNumberObject(value) ? 'number' : 'object';
         default:
             return undefined;
     }
 }
 
-function updateColumnTypeTracker(tracker: ColumnTypeTracker, value: unknown, datumIndex: number): void {
+function updateColumnTypeTracker(
+    tracker: ColumnTypeTracker,
+    value: unknown,
+    datumIndex: number
+): ColumnValueType | undefined {
     const observed = valueColumnType(value);
-    if (observed == null) return;
+    if (observed == null) return undefined;
 
-    if (tracker.type == null) {
+    if (tracker.type == null || tracker.type === observed) {
         tracker.type = observed;
-    } else if (tracker.type !== observed && isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
-        // TODO(AG-16654, PR5): number<->date coexistence (epoch number + Date in one column) should also
-        // promote to 'date'; only number<->bigint mixing is handled today.
+    } else if (isDateColumnType(tracker.type) || isDateColumnType(observed)) {
+        tracker.type = 'date';
+    } else if (isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
+        // Mixed number/bigint narrows bigints to Number (lossy beyond ±2^53); warned once at series level.
         tracker.mixedAtIndex ??= datumIndex;
         tracker.type = 'mixed-numeric';
     }
+
+    return observed;
 }
 
 function isNumericColumnType(type: ColumnValueType): boolean {
     return type === 'number' || type === 'bigint' || type === 'mixed-numeric';
+}
+
+function isDateColumnType(type: ColumnValueType): boolean {
+    return type === 'date';
+}
+
+// Explicit timezone iff the ISO string ends with `Z` or a trailing `±HH:MM` offset.
+const ISO_8601_EXPLICIT_TZ = /(Z|[+-]\d{2}:\d{2})$/;
+
+interface TimezoneTracker {
+    explicit: { value: string; index: number } | undefined;
+    implicit: { value: string; index: number } | undefined;
+}
+
+function updateTimezoneTracker(tracker: TimezoneTracker, value: unknown, datumIndex: number): void {
+    if (typeof value !== 'string') return;
+    if (ISO_8601_EXPLICIT_TZ.test(value)) {
+        tracker.explicit ??= { value, index: datumIndex };
+    } else {
+        tracker.implicit ??= { value, index: datumIndex };
+    }
 }
 
 /**
@@ -236,6 +266,8 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
             // Track ordering/uniqueness for this key definition
             const tracker = createKeyTracker();
+            const typeTracker: ColumnTypeTracker = { type: undefined, mixedAtIndex: undefined };
+            const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
 
             for (const scope of keyScopes ?? []) {
                 const data = sources.get(scope)?.data ?? [];
@@ -270,6 +302,9 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                         keys.push(result.value);
                         // Track ordering/uniqueness for valid keys
                         updateKeyTracker(tracker, result.value);
+                        if (updateColumnTypeTracker(typeTracker, result.value, datumIndex) === 'date') {
+                            updateTimezoneTracker(tzTracker, result.value, datumIndex);
+                        }
                         continue;
                     }
 
@@ -301,6 +336,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
             // Store the computed sort order entry for this key definition
             keySortOrders.set(keyDefIndex, trackerToSortOrderEntry(tracker));
+            this.warnMixedTimezoneColumn(keyDef.property, typeTracker.type, tzTracker);
         }
         return {
             invalidData,
@@ -364,7 +400,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
         const columns: unknown[][] = [];
         const allColumnScopes: Set<ScopeId>[] = [];
         const columnNeedValueOf: boolean[] = [];
-        const columnValueType: ColumnValueType[] = [];
+        const columnValueType: (ColumnValueType | undefined)[] = [];
         let maxDataLength = 0;
         const valueProcessors = valueDefs.map((def) => getProcessValue(def));
 
@@ -383,6 +419,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             const invalidKeys = scopeInvalidKeys.get(columnScope);
             let needsValueOf = false;
             const typeTracker: ColumnTypeTracker = { type: undefined, mixedAtIndex: undefined };
+            const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
             for (let datumIndex = 0; datumIndex < columnSource.length; datumIndex++) {
                 if (columnSource[datumIndex] == null || typeof columnSource[datumIndex] !== 'object') {
                     // Count non-object items as invalid data
@@ -401,8 +438,8 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                     this.markScopeDatumInvalid(def.scopes, columnSource, datumIndex, invalidData, invalidDataCount);
                 } else if (result.missing) {
                     this.markScopeDatumMissing(def.scopes, columnSource, datumIndex, missingData);
-                } else {
-                    updateColumnTypeTracker(typeTracker, result.value, datumIndex);
+                } else if (updateColumnTypeTracker(typeTracker, result.value, datumIndex) === 'date') {
+                    updateTimezoneTracker(tzTracker, result.value, datumIndex);
                 }
 
                 if (invalidKey) {
@@ -424,11 +461,13 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             if (typeTracker.type === 'mixed-numeric' && typeTracker.mixedAtIndex != null) {
                 this.warnMixedNumericColumn(columnScope, def.property, typeTracker.mixedAtIndex);
             }
+            this.warnMixedTimezoneColumn(def.property, typeTracker.type, tzTracker);
 
             columns.push(column);
             allColumnScopes.push(columnScopes);
             columnNeedValueOf.push(needsValueOf);
-            columnValueType.push(typeTracker.type ?? 'number');
+            // Leave unobserved columns undefined rather than guessing 'number', so type assertions don't false-positive.
+            columnValueType.push(typeTracker.type);
             maxDataLength = Math.max(maxDataLength, column.length);
         }
 
@@ -445,8 +484,17 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
     private warnMixedNumericColumn(seriesId: ScopeId, key: K, atIndex: number) {
         Logger.warnOnce(
             `Series "${seriesId}": column "${String(key)}" mixes 'number' and 'bigint' values ` +
-                `(first detected at row ${atIndex}). Each column must be uniformly typed. ` +
-                `The series renders empty; other series in this chart are unaffected.`
+                `(first detected at row ${atIndex}); the bigints are narrowed to Number and may lose precision ` +
+                `beyond ±2^53. Use one numeric type per column.`
+        );
+    }
+
+    private warnMixedTimezoneColumn(key: K, columnType: ColumnValueType | undefined, tracker: TimezoneTracker) {
+        const { explicit, implicit } = tracker;
+        // Only date-tagged columns interpret ISO strings as instants; mixed offsets in a category column are not ambiguous.
+        if (columnType !== 'date' || explicit == null || implicit == null) return;
+        Logger.warnOnce(
+            `Time axis: column "${String(key)}" contains both timezone-explicit values (e.g. "${explicit.value}", row ${explicit.index}) and timezone-implicit values (e.g. "${implicit.value}", row ${implicit.index}). Ambiguous timezone semantics may produce unexpected positions — points without an explicit offset are interpreted as local time. Use explicit offsets (Z or ±HH:MM) for cross-environment determinism.`
         );
     }
 

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -1,4 +1,5 @@
-import { Logger, first, isISO8601, isNumberObject, iterate } from 'ag-charts-core';
+import { Logger, first, isISO8601, isNumberObject, iterate, timeValueToNumber } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { ContinuousDomain } from '../../dataDomain';
 import {
@@ -21,7 +22,7 @@ import { createArray } from '../utils/helpers';
 
 /** Tracks ordering/uniqueness during key extraction */
 interface KeyExtractionTracker {
-    lastValue: number | undefined;
+    lastValue: AgNumericValue | undefined;
     sortOrder: 1 | -1 | 0; // 0 = undetermined, 1 = ascending, -1 = descending
     isUnique: boolean;
     isOrdered: boolean;
@@ -32,27 +33,41 @@ function createKeyTracker(): KeyExtractionTracker {
 }
 
 function updateKeyTracker(tracker: KeyExtractionTracker, value: unknown): void {
-    // Only track numeric values (including Date.valueOf())
-    const numericValue = typeof value === 'number' ? value : (value as Date)?.valueOf?.();
-    if (typeof numericValue !== 'number' || !Number.isFinite(numericValue)) return;
+    // Resolve to a comparable value: bigint stays exact, ISO 8601 strings parse to epoch ms, Date narrows
+    // via valueOf(). Without this, bigint/ISO keys are skipped and the series is wrongly flagged unordered.
+    let current: AgNumericValue | undefined;
+    if (typeof value === 'number') {
+        current = Number.isFinite(value) ? value : undefined;
+    } else if (typeof value === 'bigint') {
+        current = value;
+    } else if (isISO8601(value)) {
+        const epoch = timeValueToNumber(value);
+        current = Number.isFinite(epoch) ? epoch : undefined;
+    } else {
+        const viaValueOf = (value as Date)?.valueOf?.();
+        current = typeof viaValueOf === 'number' && Number.isFinite(viaValueOf) ? viaValueOf : undefined;
+    }
+    if (current === undefined) return;
 
-    if (tracker.lastValue === undefined) {
-        tracker.lastValue = numericValue;
+    const { lastValue } = tracker;
+    if (lastValue === undefined) {
+        tracker.lastValue = current;
         return;
     }
 
-    const diff = numericValue - tracker.lastValue;
-    if (diff === 0) {
+    // A column is uniformly typed here, so `===` is exact; the relational `>` for direction stays type-safe
+    // (and never throws as `bigint - number` subtraction would) if a malformed mixed column slips through.
+    if (current === lastValue) {
         tracker.isUnique = false;
     } else if (tracker.isOrdered) {
-        const direction = diff > 0 ? 1 : -1;
+        const direction = current > lastValue ? 1 : -1;
         if (tracker.sortOrder === 0) {
             tracker.sortOrder = direction;
         } else if (tracker.sortOrder !== direction) {
             tracker.isOrdered = false;
         }
     }
-    tracker.lastValue = numericValue;
+    tracker.lastValue = current;
 }
 
 function trackerToSortOrderEntry(tracker: KeyExtractionTracker): SortOrderEntry {

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -348,7 +348,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
             // Store the computed sort order entry for this key definition
             keySortOrders.set(keyDefIndex, trackerToSortOrderEntry(tracker));
-            this.warnMixedTimezoneColumn(keyDef.property, typeTracker.type, tzTracker);
+            this.warnMixedTimezoneColumn(keyDef.property, typeTracker.type, tzTracker, keyDef.timeDomain === true);
         }
         return {
             invalidData,
@@ -480,7 +480,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             if (typeTracker.mixedDateAtIndex != null) {
                 this.warnMixedDateColumn(columnScope, def.property, typeTracker.mixedDateAtIndex);
             }
-            this.warnMixedTimezoneColumn(def.property, typeTracker.type, tzTracker);
+            this.warnMixedTimezoneColumn(def.property, typeTracker.type, tzTracker, def.timeDomain === true);
 
             columns.push(column);
             allColumnScopes.push(columnScopes);
@@ -516,10 +516,16 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
         );
     }
 
-    private warnMixedTimezoneColumn(key: K, columnType: ColumnValueType | undefined, tracker: TimezoneTracker) {
+    private warnMixedTimezoneColumn(
+        key: K,
+        columnType: ColumnValueType | undefined,
+        tracker: TimezoneTracker,
+        isTimeDomain: boolean
+    ) {
         const { explicit, implicit } = tracker;
-        // Only date-tagged columns interpret ISO strings as instants; mixed offsets in a category column are not ambiguous.
-        if (columnType !== 'date' || explicit == null || implicit == null) return;
+        // Only a time-domain column interprets ISO strings as instants; on a category axis the same strings are
+        // opaque labels, so mixed offsets are not ambiguous and must not warn (value-sniffing alone tags them 'date').
+        if (!isTimeDomain || columnType !== 'date' || explicit == null || implicit == null) return;
         Logger.warnOnce(
             `Time axis: column "${String(key)}" contains both timezone-explicit values (e.g. "${explicit.value}", row ${explicit.index}) and timezone-implicit values (e.g. "${implicit.value}", row ${implicit.index}). Ambiguous timezone semantics may produce unexpected positions — points without an explicit offset are interpreted as local time. Use explicit offsets (Z or ±HH:MM) for cross-environment determinism.`
         );

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -125,7 +125,7 @@ function updateColumnTypeTracker(
         }
         tracker.type = 'date';
     } else if (isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
-        // Mixed number/bigint narrows bigints to Number (lossy beyond ±2^53); warned once at series level.
+        // Mixed number/bigint narrows bigints to Number (lossy beyond ±(2^53 - 1)); warned once at series level.
         tracker.mixedAtIndex ??= datumIndex;
         tracker.type = 'mixed-numeric';
     }
@@ -519,7 +519,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
         Logger.warnOnce(
             `Series "${seriesId}": column "${String(key)}" mixes 'number' and 'bigint' values ` +
                 `(first detected at row ${atIndex}); the bigints are narrowed to Number and may lose precision ` +
-                `beyond ±2^53. Use one numeric type per column.`
+                `beyond ±(2^53 - 1) (Number.MAX_SAFE_INTEGER). Use one numeric type per column.`
         );
     }
 

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -68,6 +68,8 @@ interface ColumnTypeTracker {
     type: ColumnValueType | undefined;
     /** Row index where `number` and `bigint` were first observed to mix; used for the one-shot warning. */
     mixedAtIndex: number | undefined;
+    /** Row index where a date column was first observed to mix with a non-date, non-numeric value. */
+    mixedDateAtIndex: number | undefined;
 }
 
 function valueColumnType(value: unknown): ColumnValueType | undefined {
@@ -100,6 +102,12 @@ function updateColumnTypeTracker(
     if (tracker.type == null || tracker.type === observed) {
         tracker.type = observed;
     } else if (isDateColumnType(tracker.type) || isDateColumnType(observed)) {
+        // A date column tolerates numeric epochs, but mixing in strings/booleans/objects is incompatible:
+        // those values cannot be placed on a time axis, so flag the column for a one-shot warning.
+        const otherType = isDateColumnType(tracker.type) ? observed : tracker.type;
+        if (!isNumericColumnType(otherType)) {
+            tracker.mixedDateAtIndex ??= datumIndex;
+        }
         tracker.type = 'date';
     } else if (isNumericColumnType(tracker.type) && isNumericColumnType(observed)) {
         // Mixed number/bigint narrows bigints to Number (lossy beyond ±2^53); warned once at series level.
@@ -266,7 +274,11 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
 
             // Track ordering/uniqueness for this key definition
             const tracker = createKeyTracker();
-            const typeTracker: ColumnTypeTracker = { type: undefined, mixedAtIndex: undefined };
+            const typeTracker: ColumnTypeTracker = {
+                type: undefined,
+                mixedAtIndex: undefined,
+                mixedDateAtIndex: undefined,
+            };
             const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
 
             for (const scope of keyScopes ?? []) {
@@ -418,7 +430,11 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             const column = new Array<unknown>();
             const invalidKeys = scopeInvalidKeys.get(columnScope);
             let needsValueOf = false;
-            const typeTracker: ColumnTypeTracker = { type: undefined, mixedAtIndex: undefined };
+            const typeTracker: ColumnTypeTracker = {
+                type: undefined,
+                mixedAtIndex: undefined,
+                mixedDateAtIndex: undefined,
+            };
             const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
             for (let datumIndex = 0; datumIndex < columnSource.length; datumIndex++) {
                 if (columnSource[datumIndex] == null || typeof columnSource[datumIndex] !== 'object') {
@@ -461,6 +477,9 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             if (typeTracker.type === 'mixed-numeric' && typeTracker.mixedAtIndex != null) {
                 this.warnMixedNumericColumn(columnScope, def.property, typeTracker.mixedAtIndex);
             }
+            if (typeTracker.mixedDateAtIndex != null) {
+                this.warnMixedDateColumn(columnScope, def.property, typeTracker.mixedDateAtIndex);
+            }
             this.warnMixedTimezoneColumn(def.property, typeTracker.type, tzTracker);
 
             columns.push(column);
@@ -486,6 +505,14 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             `Series "${seriesId}": column "${String(key)}" mixes 'number' and 'bigint' values ` +
                 `(first detected at row ${atIndex}); the bigints are narrowed to Number and may lose precision ` +
                 `beyond ±2^53. Use one numeric type per column.`
+        );
+    }
+
+    private warnMixedDateColumn(seriesId: ScopeId, key: K, atIndex: number) {
+        Logger.warnOnce(
+            `Series "${seriesId}": column "${String(key)}" mixes date/time values with non-date values ` +
+                `(first detected at row ${atIndex}). Each column must be uniformly typed; the non-date values ` +
+                `cannot be placed on a time axis and may render at invalid positions.`
         );
     }
 

--- a/packages/ag-charts-community/src/chart/data/data-model/extractor/__snapshots__/dataExtractor.test.ts.snap
+++ b/packages/ag-charts-community/src/chart/data/data-model/extractor/__snapshots__/dataExtractor.test.ts.snap
@@ -24,10 +24,10 @@ exports[`DataExtractor > empty data set processing > should generated the expect
     },
   ],
   "columnValueType": [
-    "number",
-    "number",
-    "number",
-    "number",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
   ],
   "columns": [
     [],

--- a/packages/ag-charts-community/src/chart/data/data-model/test/testUtils.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/test/testUtils.ts
@@ -1,3 +1,5 @@
+import type { AgNumericValue } from 'ag-charts-types';
+
 import {
     accumulatedValue,
     area as actualArea,
@@ -81,7 +83,7 @@ export const accumulatedPropertyValue = (property: string, groupId: string = pro
     processor: accumulatedValue(true),
 });
 
-export const sum = (groupId: string): AggregatePropertyDefinition<any, any> => ({
+export const sum = (groupId: string): AggregatePropertyDefinition<any, any, [AgNumericValue, AgNumericValue]> => ({
     id: `sum-${groupId}`,
     matchGroupIds: [groupId],
     type: 'aggregate',
@@ -101,7 +103,7 @@ export const rowCountProperty = (prop: string) => ({ ...actualRowCountProperty(p
 
 export const groupCount = () => ({ ...actualGroupCount(`groupCount`), scopes: ['test'] });
 
-export const area = (groupId: string, aggFn: AggregatePropertyDefinition<any, any>) => ({
+export const area = (groupId: string, aggFn: AggregatePropertyDefinition<any, any, any>) => ({
     ...actualArea(`area-${groupId}`, aggFn),
     scopes: ['test'],
 });

--- a/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
@@ -2,7 +2,8 @@
  * Helper functions for DataModel processing.
  * Extracted from dataModel.ts as part of Phase 2.1 refactoring.
  */
-import { isObject } from 'ag-charts-core';
+import { isFiniteNumericValue, isObject, zeroLike } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { DataChangeDescription } from '../../dataChangeDescription';
 import type { MissMap, ScopeId, ScopeProvider } from '../../dataModelTypes';
@@ -39,13 +40,26 @@ export function toKeyString(keys: any[]): string {
  * Fixes a numeric extent to ensure both values are finite numbers.
  * Returns empty array if extent is null or contains non-finite values.
  */
-export function fixNumericExtent(extent: Array<number | Date | bigint> | null): [] | [number, number] {
+export function fixNumericExtent(extent: ReadonlyArray<number | Date | bigint> | null): AgNumericValue[] {
     if (extent == null) return [];
-    // Retain exact bigint endpoints so the scale positions and labels them at full precision; Date and
-    // number values still narrow to Number. Downstream consumers branch on `typeof` at runtime.
+    // Retain exact bigint endpoints so the scale positions them at full precision; Date/number narrow to Number.
     const mapped = extent.map((v) => (typeof v === 'bigint' ? v : Number(v)));
-    const allFinite = mapped.every((v) => typeof v === 'bigint' || Number.isFinite(v));
-    return allFinite ? (mapped as unknown as [number, number]) : [];
+    return mapped.every(isFiniteNumericValue) ? mapped : [];
+}
+
+/**
+ * Extends a numeric `[min, max]` extent to include the zero baseline, so bars and areas anchor at zero.
+ * A bigint baseline is emitted as `0n` to keep both endpoints bigint; a numeric `0` would narrow them.
+ */
+export function extendDomainToZero(extent: ReadonlyArray<AgNumericValue>): AgNumericValue[] {
+    if (extent.length < 2) return [];
+    const [e0, e1] = extent;
+    if (typeof e0 !== 'bigint' && typeof e1 !== 'bigint') {
+        return Number.isFinite(e1 - e0) ? [Math.min(e0, 0), Math.max(e1, 0)] : [];
+    }
+    const lo = e0 < 0 ? e0 : zeroLike(e0);
+    const hi = e1 > 0 ? e1 : zeroLike(e1);
+    return [lo, hi];
 }
 
 /**

--- a/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
@@ -2,7 +2,7 @@
  * Helper functions for DataModel processing.
  * Extracted from dataModel.ts as part of Phase 2.1 refactoring.
  */
-import { isFiniteNumericValue, isObject, zeroLike } from 'ag-charts-core';
+import { isObject } from 'ag-charts-core';
 import type { AgNumericValue } from 'ag-charts-types';
 
 import type { DataChangeDescription } from '../../dataChangeDescription';
@@ -36,30 +36,38 @@ export function toKeyString(keys: any[]): string {
     return keys.map(keyToString).join('-');
 }
 
+/** Type guard: every entry is a bigint, so the array can be returned as an exact `bigint[]`. */
+function isBigIntArray(values: ReadonlyArray<number | Date | bigint>): values is readonly bigint[] {
+    return values.every((v) => typeof v === 'bigint');
+}
+
 /**
- * Fixes a numeric extent to ensure both values are finite numbers.
- * Returns empty array if extent is null or contains non-finite values.
+ * Fixes a numeric extent to a uniformly-typed array, or `[]` when the input is null or contains a non-finite
+ * value. The extent may be a `[min, max]` pair or the flat-mapped per-key domains a clipped range produces
+ * (e.g. OHLC's `[highMin, highMax, lowMin, lowMax]`), so every entry is preserved for the scale to span. An
+ * all-bigint extent is kept exact for full-precision positioning; otherwise Date/number entries narrow to
+ * Number. The result is never a mixed number/bigint array (a numeric column is uniformly typed by this point).
  */
-export function fixNumericExtent(extent: ReadonlyArray<number | Date | bigint> | null): AgNumericValue[] {
+export function fixNumericExtent(extent: ReadonlyArray<number | Date | bigint> | null): number[] | bigint[] {
     if (extent == null) return [];
-    // Retain exact bigint endpoints so the scale positions them at full precision; Date/number narrow to Number.
-    const mapped = extent.map((v) => (typeof v === 'bigint' ? v : Number(v)));
-    return mapped.every(isFiniteNumericValue) ? mapped : [];
+    if (isBigIntArray(extent)) return [...extent];
+    const mapped = extent.map((v) => Number(v));
+    return mapped.every(Number.isFinite) ? mapped : [];
 }
 
 /**
  * Extends a numeric `[min, max]` extent to include the zero baseline, so bars and areas anchor at zero.
- * A bigint baseline is emitted as `0n` to keep both endpoints bigint; a numeric `0` would narrow them.
+ * Both endpoints keep their type: a bigint extent emits `0n` baselines; a numeric `0` would narrow them.
  */
-export function extendDomainToZero(extent: ReadonlyArray<AgNumericValue>): AgNumericValue[] {
+export function extendDomainToZero(extent: ReadonlyArray<AgNumericValue>): [] | [number, number] | [bigint, bigint] {
     if (extent.length < 2) return [];
     const [e0, e1] = extent;
-    if (typeof e0 !== 'bigint' && typeof e1 !== 'bigint') {
-        return Number.isFinite(e1 - e0) ? [Math.min(e0, 0), Math.max(e1, 0)] : [];
+    if (typeof e0 === 'bigint' && typeof e1 === 'bigint') {
+        return [e0 < 0n ? e0 : 0n, e1 > 0n ? e1 : 0n];
     }
-    const lo = e0 < 0 ? e0 : zeroLike(e0);
-    const hi = e1 > 0 ? e1 : zeroLike(e1);
-    return [lo, hi];
+    const n0 = Number(e0);
+    const n1 = Number(e1);
+    return Number.isFinite(n1 - n0) ? [Math.min(n0, 0), Math.max(n1, 0)] : [];
 }
 
 /**

--- a/packages/ag-charts-community/src/chart/data/data-model/utils/resolvers.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/utils/resolvers.ts
@@ -1,4 +1,8 @@
+import { Logger } from 'ag-charts-core';
+
 import type {
+    ColumnValueType,
+    ColumnValueTypeMapping,
     GroupedData,
     ProcessedData,
     ProcessedDataDef,
@@ -11,6 +15,39 @@ import { COLUMN_SORT_ORDERS, DOMAIN_RANGES, KEY_SORT_ORDERS } from '../../dataMo
 import { RangeLookup } from '../../rangeLookup';
 import { type SortOrder, valuesSortOrder } from '../../sortOrder';
 import type { DataModelContext } from '../dataModelContext';
+
+const NUMERIC_COLUMN_TYPES = new Set<ColumnValueType>(['number', 'bigint', 'mixed-numeric']);
+
+// 'object' is caller-typed (the caller asserts the element type), so any runtime tag is accepted.
+function isCompatibleColumnType(expected: ColumnValueType, actual: ColumnValueType): boolean {
+    switch (expected) {
+        case 'number':
+        case 'bigint':
+        case 'mixed-numeric':
+            return NUMERIC_COLUMN_TYPES.has(actual) || actual === 'date';
+        case 'date':
+            return actual === 'date' || NUMERIC_COLUMN_TYPES.has(actual);
+        case 'string':
+            return actual === 'string';
+        case 'boolean':
+            return actual === 'boolean';
+        case 'object':
+            return true;
+    }
+}
+
+// A null actualType (e.g. all-empty column) is a no-op, not a mismatch.
+function assertColumnValueType(
+    scope: ScopeProvider,
+    searchId: string,
+    expectedType: ColumnValueType,
+    actualType: ColumnValueType | undefined
+): void {
+    if (actualType == null || isCompatibleColumnType(expectedType, actualType)) return;
+    Logger.warnOnce(
+        `column '${searchId}' for scope '${scope.id}' was resolved as '${expectedType}' but holds '${actualType}' values; check the series data types.`
+    );
+}
 
 /**
  * DataModelResolvers handles lookups and resolution of processed data.
@@ -75,17 +112,31 @@ export class DataModelResolvers<D extends object, K extends keyof D & string> {
         return this.ctx.scopeCache.get(scope.id)?.get(searchId) != null;
     }
 
-    resolveColumnById<T = any>(
+    resolveColumnById<T extends Exclude<ColumnValueType, 'object'>>(
         scope: ScopeProvider,
         searchId: string,
-        processedData: UngroupedData<any> | GroupedData<any>
-    ): T[] {
+        processedData: UngroupedData<any> | GroupedData<any>,
+        expectedType: T
+    ): ColumnValueTypeMapping[T][];
+    resolveColumnById<E = unknown>(
+        scope: ScopeProvider,
+        searchId: string,
+        processedData: UngroupedData<any> | GroupedData<any>,
+        expectedType: 'object'
+    ): E[];
+    resolveColumnById<E>(
+        scope: ScopeProvider,
+        searchId: string,
+        processedData: UngroupedData<any> | GroupedData<any>,
+        expectedType: ColumnValueType
+    ): E[] {
         const index = this.resolveProcessedDataIndexById(scope, searchId);
         const column = processedData.columns?.[index];
         if (column == null) {
             throw new Error(`AG Charts - didn't find column for [${searchId}, ${scope.id}]`);
         }
-        return column;
+        assertColumnValueType(scope, searchId, expectedType, processedData.columnValueType?.[index]);
+        return column as E[];
     }
 
     resolveColumnNeedsValueOf(

--- a/packages/ag-charts-community/src/chart/data/dataDomain.ts
+++ b/packages/ag-charts-community/src/chart/data/dataDomain.ts
@@ -1,3 +1,6 @@
+import { coerceIso8601Date } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
+
 import { type BandLike, BandedStructure, type BandedStructureConfig } from './data-model/utils/bandedStructure';
 
 export interface IDataDomain<D = any> {
@@ -19,6 +22,11 @@ export class DiscreteDomain implements IDataDomain {
     private sortOrder: SortOrder | undefined = undefined;
     private isSortedUnique: boolean = false;
 
+    constructor(
+        // When true (time keys), ISO 8601 strings coerce to Date instants rather than opaque category labels.
+        private readonly coerceDates: boolean = false
+    ) {}
+
     static is(value: unknown): value is DiscreteDomain {
         return value instanceof DiscreteDomain;
     }
@@ -37,6 +45,10 @@ export class DiscreteDomain implements IDataDomain {
     }
 
     extend(val: any) {
+        // Coerce ISO 8601 strings to Date so they bucket as instants (the column keeps the raw string for display).
+        if (this.coerceDates && typeof val === 'string') {
+            val = coerceIso8601Date(val);
+        }
         if (this.isSortedUnique && this.sortedValues) {
             // Sorted unique mode: store values directly without conversion
             // Null deduplication is handled in getDomain()
@@ -176,37 +188,39 @@ export class ContinuousDomain<T extends number | Date> implements IDataDomain<T>
         return value instanceof ContinuousDomain;
     }
 
-    static extendDomain(values: unknown[], domain: [number, number] = [Infinity, -Infinity]) {
+    static extendDomain(
+        values: unknown[],
+        domain: [AgNumericValue, AgNumericValue] = [Infinity, -Infinity]
+    ): [AgNumericValue, AgNumericValue] {
         for (const value of values) {
-            // Derived aggregation/stacked domains feed further arithmetic, so narrow bigint to Number here
-            // (unlike instance `extend`, which retains raw-column endpoints for the scale's convert()).
-            let n: number;
-            if (typeof value === 'number') {
-                n = value;
-            } else if (typeof value === 'bigint') {
-                n = Number(value);
-            } else {
+            if (typeof value !== 'number' && typeof value !== 'bigint') {
                 continue;
             }
-            if (domain[0] > n) {
-                domain[0] = n;
+            // Compare (don't narrow) to retain exact bigint endpoints; bigint-vs-Number comparison is legal (only arithmetic mixing throws).
+            if (value < domain[0]) {
+                domain[0] = value;
             }
-            if (domain[1] < n) {
-                domain[1] = n;
+            if (value > domain[1]) {
+                domain[1] = value;
             }
         }
         return domain;
     }
 
     extend(value: T | bigint) {
-        if (typeof value !== 'number' && typeof value !== 'bigint' && !(value instanceof Date)) {
+        // Coerce ISO 8601 strings to Date so the extent is computed as instants (the column keeps the raw string).
+        let v: unknown = value;
+        if (typeof v === 'string') {
+            v = coerceIso8601Date(v);
+        }
+        if (typeof v !== 'number' && typeof v !== 'bigint' && !(v instanceof Date)) {
             return;
         }
-        if (this.domain[0] > value) {
-            this.domain[0] = value;
+        if (this.domain[0] > v) {
+            this.domain[0] = v as T | bigint;
         }
-        if (this.domain[1] < value) {
-            this.domain[1] = value;
+        if (this.domain[1] < v) {
+            this.domain[1] = v as T | bigint;
         }
     }
 

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1615,7 +1615,7 @@ describe('DataModel', () => {
             expectWarningsCalls().toMatchInlineSnapshot(`
 [
   [
-    "AG Charts - Series "test": column "count" mixes 'number' and 'bigint' values (first detected at row 1). Each column must be uniformly typed. The series renders empty; other series in this chart are unaffected.",
+    "AG Charts - Series "test": column "count" mixes 'number' and 'bigint' values (first detected at row 1); the bigints are narrowed to Number and may lose precision beyond ±2^53. Use one numeric type per column.",
   ],
 ]
 `);

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -1615,7 +1615,7 @@ describe('DataModel', () => {
             expectWarningsCalls().toMatchInlineSnapshot(`
 [
   [
-    "AG Charts - Series "test": column "count" mixes 'number' and 'bigint' values (first detected at row 1); the bigints are narrowed to Number and may lose precision beyond ±2^53. Use one numeric type per column.",
+    "AG Charts - Series "test": column "count" mixes 'number' and 'bigint' values (first detected at row 1); the bigints are narrowed to Number and may lose precision beyond ±(2^53 - 1) (Number.MAX_SAFE_INTEGER). Use one numeric type per column.",
   ],
 ]
 `);

--- a/packages/ag-charts-community/src/chart/data/dataModel.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.ts
@@ -18,6 +18,8 @@ import type { DataChangeDescription, DataChangeDescriptionListener } from './dat
 import type {
     AggregatePropertyDefinition,
     BandedReducerStats,
+    ColumnValueType,
+    ColumnValueTypeMapping,
     DataGroup,
     DataModelOptions,
     GroupDatumIteratorOutput,
@@ -46,6 +48,7 @@ export * from './dataModelTypes';
 
 export {
     fixNumericExtent,
+    extendDomainToZero,
     getMissCount,
     datumKeys,
     getPathComponents,
@@ -255,12 +258,26 @@ export class DataModel<
         return this.resolvers.hasColumnById(scope, searchId);
     }
 
-    resolveColumnById<T = any>(
+    resolveColumnById<T extends Exclude<ColumnValueType, 'object'>>(
         scope: ScopeProvider,
         searchId: string,
-        processedData: UngroupedData<any> | GroupedData<any>
-    ): T[] {
-        return this.resolvers.resolveColumnById<T>(scope, searchId, processedData);
+        processedData: UngroupedData<any> | GroupedData<any>,
+        expectedType: T
+    ): ColumnValueTypeMapping[T][];
+    resolveColumnById<E = unknown>(
+        scope: ScopeProvider,
+        searchId: string,
+        processedData: UngroupedData<any> | GroupedData<any>,
+        expectedType: 'object'
+    ): E[];
+    resolveColumnById<E>(
+        scope: ScopeProvider,
+        searchId: string,
+        processedData: UngroupedData<any> | GroupedData<any>,
+        expectedType: ColumnValueType
+    ): E[] {
+        // Forward to the resolver's 'object' overload; the impl validates against the real tag.
+        return this.resolvers.resolveColumnById<E>(scope, searchId, processedData, expectedType as 'object');
     }
 
     resolveColumnNeedsValueOf(

--- a/packages/ag-charts-community/src/chart/data/dataModelTypes.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModelTypes.ts
@@ -1,3 +1,5 @@
+import type { AgNumericValue } from 'ag-charts-types';
+
 import type { BandedReducer } from './data-model/reducers/bandedReducer';
 import type { DataChangeDescription } from './dataChangeDescription';
 import type { BandedDomain, BandedDomainConfig } from './dataDomain';
@@ -20,7 +22,7 @@ export interface UngroupedDataItem<I, D, V> {
     index: I;
     keys: any[];
     values: V;
-    aggValues?: [number, number][];
+    aggValues?: [AgNumericValue, AgNumericValue][];
     datum: D;
     validScopes?: Set<string>;
 }
@@ -47,11 +49,22 @@ export const SHARED_ZERO_INDICES: readonly number[] = Object.freeze([0]);
 export type ScopeId = string;
 
 /**
- * Per-column primitive type, set once during extraction. Consumers dispatch off this tag rather than
- * re-sniffing values. `'mixed-numeric'` flags a column that contains both `number` and `bigint` values,
- * which is rejected at the series level (see {@link CommonMetadata.columnValueType}).
+ * Per-column value type, set once during extraction; an advisory tag consumers dispatch off rather than
+ * re-sniffing values. `'mixed-numeric'` is a column of both `number` and `bigint`; `'object'` is non-`Date`
+ * objects whose element type the caller supplies rather than this tag.
  */
-export type ColumnValueType = 'number' | 'bigint' | 'date' | 'string' | 'mixed-numeric';
+export type ColumnValueType = 'number' | 'bigint' | 'date' | 'string' | 'boolean' | 'mixed-numeric' | 'object';
+
+export type ColumnValueTypeMapping = {
+    number: number;
+    bigint: bigint;
+    date: Date;
+    string: string;
+    boolean: boolean;
+    'mixed-numeric': AgNumericValue;
+    // 'object' returns the caller-supplied element type; this entry only makes 'object' a valid key.
+    object: unknown;
+};
 
 export type ProcessedValue = { value: unknown; missing: boolean; valid: boolean };
 export type SortOrderEntry = {
@@ -101,17 +114,17 @@ export interface CommonMetadata<D> {
     columns: any[][];
     columnScopes: Set<ScopeId>[];
     columnNeedValueOf?: boolean[]; // true if column needs valueOf() (contains Dates/objects), false for primitives
-    columnValueType?: ColumnValueType[]; // per-column primitive type tag, set once during extraction
+    columnValueType?: (ColumnValueType | undefined)[]; // per-column primitive type tag, set once during extraction (undefined when unobserved)
     domain: {
         keys: any[][];
         values: any[][];
         groups?: any[][];
-        aggValues?: [number, number][];
+        aggValues?: [AgNumericValue, AgNumericValue][];
     };
     reduced?: {
         diff?: Record<string, ProcessedOutputDiff>;
-        smallestKeyInterval?: number;
-        largestKeyInterval?: number;
+        smallestKeyInterval?: AgNumericValue;
+        largestKeyInterval?: AgNumericValue;
         filteredValueExceedUnfiltered?: boolean;
         sortedGroupDomain?: any[][];
         animationValidation?: {
@@ -139,7 +152,7 @@ export interface CommonMetadata<D> {
 
 export interface UngroupedData<D> extends CommonMetadata<D> {
     type: 'ungrouped';
-    aggregation?: [number, number][][];
+    aggregation?: [AgNumericValue, AgNumericValue][][];
 }
 
 export interface GroupedData<D> extends CommonMetadata<D> {
@@ -275,6 +288,8 @@ export type PropertySelectors = {
 export type DatumPropertyDefinition<K> = PropertyIdentifiers & {
     type: 'key' | 'value';
     valueType: DatumPropertyType;
+    /** True for time scales, so a discrete domain coerces ISO 8601 strings to Date instants. */
+    timeDomain?: boolean;
     property: K;
     forceValue?: any;
     includeProperty?: boolean;
@@ -296,10 +311,12 @@ export type InternalDatumPropertyDefinition<K> = DatumPropertyDefinition<K> &
         missing: MissMap;
     };
 
-export type AggregatePropertyDefinition<D, K extends keyof D & string, R = [number, number], R2 = R> = Omit<
-    PropertyIdentifiers,
-    'scopes'
-> &
+export type AggregatePropertyDefinition<
+    D,
+    K extends keyof D & string,
+    R = [AgNumericValue, AgNumericValue],
+    R2 = R,
+> = Omit<PropertyIdentifiers, 'scopes'> &
     PropertySelectors & {
         type: 'aggregate';
         aggregateFunction: (values: D[K][], keys?: D[K][]) => R;

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -608,7 +608,6 @@ function buildGroupAccFn({ mode, separateNegative }: { mode: 'normal' | 'trailin
                         const isBigInt = typeof currentVal === 'bigint';
                         if (!isBigInt && !isFiniteNumber(currentVal)) continue;
 
-                        // isNegative() uses Math.sign(), which throws on bigint — compare directly.
                         const useNegative = separateNegative && (isBigInt ? currentVal < 0n : isNegative(currentVal));
                         const accValue = useNegative ? stackNegative : stackPositive;
                         if (mode === 'normal') {

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -1,12 +1,21 @@
 import {
+    Logger,
     type ScaleType,
+    absValue,
     clamp,
     isContinuous,
     isFiniteNumber,
+    isFiniteNumericValue,
+    isISO8601,
     isNegative,
+    maxValue,
     memo,
+    minValue,
+    subtractValues,
+    timeValueToNumber,
     transformIntegratedCategoryValue,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { accumulatedValue, addAccumulated, range, trailingAccumulatedValue } from './aggregateFunctions';
 import {
@@ -29,13 +38,15 @@ export const MAX_ANIMATABLE_NODES = 1000;
 
 function combineIntervalBandResults(
     bandResults: unknown[],
-    fallback: number,
-    combiner: (values: number[]) => number
-): number {
-    const validResults = bandResults.filter(
-        (result): result is number => typeof result === 'number' && Number.isFinite(result)
-    );
-    return validResults.length > 0 ? combiner(validResults) : fallback;
+    fallback: AgNumericValue,
+    combine: (a: AgNumericValue, b: AgNumericValue) => AgNumericValue
+): AgNumericValue {
+    let combined: AgNumericValue | undefined;
+    for (const result of bandResults) {
+        if (!isFiniteNumericValue(result)) continue;
+        combined = combined == null ? result : combine(combined, result);
+    }
+    return combined ?? fallback;
 }
 
 export function processedDataIsAnimatable(processedData: ProcessedData<any>) {
@@ -46,10 +57,19 @@ function basicContinuousCheckDatumValidation(value: any) {
     return value != null && isContinuous(value);
 }
 
-// Separate from basicContinuousCheckDatumValidation so a later PR can let time scales accept ISO 8601
-// strings without number/log/color scales doing the same.
-function basicTimeCheckDatumValidation(value: any) {
-    return value != null && isContinuous(value);
+const TIME_AXIS_ACCEPTED_FORMATS =
+    "Date, epoch number/bigint, or strict ISO 8601 string (e.g. '2024-01-15', '2024-01-15T10:30:00Z')";
+
+// Separate from basicContinuousCheckDatumValidation so only time scales accept ISO 8601 strings.
+function basicTimeCheckDatumValidation(value: any, _datum?: any, index?: number) {
+    if (value == null) return false;
+    if (isContinuous(value) || isISO8601(value)) return true;
+    if (typeof value === 'string') {
+        Logger.warnOnce(
+            `unsupported value [${value}] at row ${index ?? '?'} on a time axis; expected ${TIME_AXIS_ACCEPTED_FORMATS}. The value is ignored.`
+        );
+    }
+    return false;
 }
 
 function basicDiscreteCheckDatumValidation(value: any) {
@@ -86,12 +106,18 @@ function getValueType(scaleType?: ScaleType) {
             return 'category';
     }
 }
+
+function isTimeScaleType(scaleType?: ScaleType): boolean {
+    return scaleType === 'time' || scaleType === 'unit-time' || scaleType === 'ordinal-time';
+}
+
 export function keyProperty<K>(propName: K, scaleType?: ScaleType, opts: Partial<DatumPropertyDefinition<K>> = {}) {
     const allowNullKey = opts.allowNullKey ?? false;
     const result: DatumPropertyDefinition<K> = {
         property: propName,
         type: 'key',
         valueType: getValueType(scaleType),
+        timeDomain: isTimeScaleType(scaleType),
         validation: opts.validation ?? getValidationFn(scaleType, allowNullKey),
         ...opts,
     };
@@ -104,6 +130,7 @@ export function valueProperty<K>(propName: K, scaleType?: ScaleType, opts: Parti
         property: propName,
         type: 'value',
         valueType: getValueType(scaleType),
+        timeDomain: isTimeScaleType(scaleType),
         validation: opts.validation ?? getValidationFn(scaleType, allowNullKey),
         ...opts,
     };
@@ -203,23 +230,32 @@ export function groupAccumulativeValueProperty<K>(
     ];
 }
 
+// Bigint kept exact; ISO 8601 string parses to epoch ms; anything else coerces to Number (NaN/Infinity skipped).
+function finiteKey(key: unknown): AgNumericValue | undefined {
+    if (typeof key === 'bigint') return key;
+    if (isISO8601(key)) return timeValueToNumber(key);
+    const n = Number(key);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+// Subtract before narrowing: coercing each key first collapses gaps below the Number ULP at large magnitudes.
+function keyInterval(curr: AgNumericValue, prev: AgNumericValue): AgNumericValue {
+    return absValue(subtractValues(curr, prev));
+}
+
 export const SMALLEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<'smallestKeyInterval'> = {
     type: 'reducer',
     property: 'smallestKeyInterval',
     initialValue: Infinity,
     reducer() {
-        let prevX = Number.NaN;
+        let prevKey: AgNumericValue | undefined;
         return function smallestKeyIntervalReducerFn(smallestSoFar, keys) {
-            const key = keys[0];
-            const nextX = typeof key === 'number' ? key : Number(key);
-            if (!Number.isFinite(nextX)) return smallestSoFar;
-            const prevX2 = prevX;
-            prevX = nextX;
-            if (!Number.isFinite(prevX)) return smallestSoFar;
-
-            const interval = Math.abs(nextX - prevX2);
+            const key = finiteKey(keys[0]);
             const currentSmallest = smallestSoFar ?? Infinity;
-            if (interval > 0 && interval < currentSmallest) {
+            if (key == null) return currentSmallest;
+            const interval = prevKey == null ? undefined : keyInterval(key, prevKey);
+            prevKey = key;
+            if (interval != null && interval > 0 && interval < currentSmallest) {
                 return interval;
             }
             return currentSmallest;
@@ -227,7 +263,7 @@ export const SMALLEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<'smallestKey
     },
     supportsBanding: true,
     combineResults(bandResults) {
-        return combineIntervalBandResults(bandResults, Infinity, (values) => Math.min(...values));
+        return combineIntervalBandResults(bandResults, Infinity, minValue);
     },
     needsOverlap: true,
 };
@@ -237,18 +273,14 @@ export const LARGEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<'largestKeyIn
     property: 'largestKeyInterval',
     initialValue: -Infinity,
     reducer() {
-        let prevX = Number.NaN;
+        let prevKey: AgNumericValue | undefined;
         return function largestKeyIntervalReducerFn(largestSoFar, keys) {
-            const key = keys[0];
-            const nextX = typeof key === 'number' ? key : Number(key);
-            if (!Number.isFinite(nextX)) return largestSoFar;
-            const prevX2 = prevX;
-            prevX = nextX;
-            if (!Number.isFinite(prevX)) return largestSoFar;
-
-            const interval = Math.abs(nextX - prevX2);
+            const key = finiteKey(keys[0]);
             const currentLargest = largestSoFar ?? -Infinity;
-            if (interval > 0 && interval > currentLargest) {
+            if (key == null) return currentLargest;
+            const interval = prevKey == null ? undefined : keyInterval(key, prevKey);
+            prevKey = key;
+            if (interval != null && interval > 0 && interval > currentLargest) {
                 return interval;
             }
             return currentLargest;
@@ -256,7 +288,7 @@ export const LARGEST_KEY_INTERVAL: ReducerOutputPropertyDefinition<'largestKeyIn
     },
     supportsBanding: true,
     combineResults(bandResults) {
-        return combineIntervalBandResults(bandResults, -Infinity, (values) => Math.max(...values));
+        return combineIntervalBandResults(bandResults, -Infinity, maxValue);
     },
     needsOverlap: true,
 };
@@ -289,9 +321,10 @@ export const SORT_DOMAIN_GROUPS: ProcessorOutputPropertyDefinition<'sortedGroupD
 };
 
 function normaliseFnBuilder({ normaliseTo }: { normaliseTo: number }) {
-    const normalise = (val: null | number, extent: number) => {
+    const normalise = (val: AgNumericValue | null, extent: number) => {
         if (extent === 0) return 0;
-        const result = ((val ?? 0) * normaliseTo) / extent;
+        // Narrow bigint to Number: normalisation yields a fraction, and the column becomes Number after this pass.
+        const result = (Number(val ?? 0) * normaliseTo) / extent;
         if (result >= 0) {
             return Math.min(normaliseTo, result);
         }
@@ -309,7 +342,7 @@ function normaliseFnBuilder({ normaliseTo }: { normaliseTo: number }) {
                 // (relative index is offset from group start, absolute is for the entire column)
                 const datumIndex = groupIndex + relativeDatumIndex;
                 const column = columns[valueIdx];
-                const value: null | number = column[datumIndex];
+                const value: AgNumericValue | null = column[datumIndex];
                 if (value == null) {
                     column[datumIndex] = undefined;
                     continue;
@@ -331,10 +364,17 @@ function normaliseFindExtent(columns: any[][], valueIndexes: number[], dataGroup
             // Convert relative datum index to absolute column index
             // (relative index is offset from group start, absolute is for the entire column)
             const datumIndex = groupIndex + relativeDatumIndex;
-            const value: null | number | (null | number)[] = column[datumIndex];
+            const value: AgNumericValue | null | (AgNumericValue | null)[] = column[datumIndex];
             if (value == null) continue;
-            // Note - Array.isArray(new Float64Array) is false, and this type is used for stack accumulators
-            const valueExtent = typeof value === 'number' ? value : Math.max(...value.map((v) => v ?? 0));
+            // Note - Array.isArray(new Float64Array) is false, and this type is used for stack accumulators.
+            let valueExtent: number;
+            if (typeof value === 'number') {
+                valueExtent = value;
+            } else if (typeof value === 'bigint') {
+                valueExtent = Number(value);
+            } else {
+                valueExtent = Math.max(...value.map((v) => Number(v ?? 0)));
+            }
             const valIdx = valueExtent < 0 ? 0 : 1;
             if (valIdx === 0) {
                 valuesExtent[valIdx] = Math.min(valuesExtent[valIdx], valueExtent);
@@ -426,7 +466,8 @@ function buildFilterValidation([id, yKey, yFilterKey]: [id: string, yKey: string
         if (yValues.length !== yFilterValues.length) return true;
 
         for (let i = 0; i < yValues.length; i++) {
-            if (Math.abs(yFilterValues[i]) > Math.abs(yValues[i])) return true;
+            // absValue preserves bigint; Math.abs throws on bigint (ToNumber) for mixed-numeric columns.
+            if (absValue(yFilterValues[i]) > absValue(yValues[i])) return true;
         }
 
         return false;
@@ -459,8 +500,8 @@ function animationValidationProcessValue(def: DatumPropertyDefinition<unknown>, 
     let lastValue = column[0]?.valueOf();
     for (let d = 1; validation !== 0 && d < column.length; d++) {
         const keyValue = column[d]?.valueOf();
-        if (!Number.isFinite(keyValue) || lastValue > keyValue) validation &= ~ANIMATION_VALIDATION_ORDERED_KEYS;
-        if (Number.isFinite(keyValue) && lastValue === keyValue) validation &= ~ANIMATION_VALIDATION_UNIQUE_KEYS;
+        if (!isContinuous(keyValue) || lastValue > keyValue) validation &= ~ANIMATION_VALIDATION_ORDERED_KEYS;
+        if (isContinuous(keyValue) && lastValue === keyValue) validation &= ~ANIMATION_VALIDATION_UNIQUE_KEYS;
         lastValue = keyValue;
     }
 
@@ -545,9 +586,8 @@ function buildGroupAccFn({ mode, separateNegative }: { mode: 'normal' | 'trailin
                 dataGroup: DataGroup,
                 groupIndex: number
             ) {
-                // Datum scope. Seeds are number `0`; a bigint column promotes them to bigint via
-                // addAccumulated so stacked totals retain full precision (AG-16608 AC #10).
-                const acc: [number | bigint, number | bigint] = [0, 0];
+                // Number `0` seeds promote to bigint via addAccumulated so stacked totals stay exact.
+                const acc: [AgNumericValue, AgNumericValue] = [0, 0];
                 for (const valueIdx of valueIndexes) {
                     const datumIndices = dataGroup.datumIndices[valueIdx];
                     if (datumIndices == null) continue;
@@ -765,7 +805,7 @@ export function diff(
     };
 }
 
-type KeyType = string | number | boolean | null | undefined;
+type KeyType = string | number | bigint | boolean | null | undefined;
 
 export function createDatumId(key: number): number;
 export function createDatumId(key: boolean): boolean;

--- a/packages/ag-charts-community/src/chart/data/processors.ts
+++ b/packages/ag-charts-community/src/chart/data/processors.ts
@@ -496,12 +496,15 @@ function animationValidationProcessValue(def: DatumPropertyDefinition<unknown>, 
         return validation;
     }
 
-    // For continuous values, scan the column
-    let lastValue = column[0]?.valueOf();
+    // For continuous values, scan the column. finiteKey() resolves bigint (exact), ISO 8601 strings (epoch ms)
+    // and Date alike, so an ISO-string value isn't misread as unordered the way raw valueOf() + isContinuous() is.
+    let lastValue = column[0] == null ? undefined : finiteKey(column[0]);
     for (let d = 1; validation !== 0 && d < column.length; d++) {
-        const keyValue = column[d]?.valueOf();
-        if (!isContinuous(keyValue) || lastValue > keyValue) validation &= ~ANIMATION_VALIDATION_ORDERED_KEYS;
-        if (isContinuous(keyValue) && lastValue === keyValue) validation &= ~ANIMATION_VALIDATION_UNIQUE_KEYS;
+        const keyValue = column[d] == null ? undefined : finiteKey(column[d]);
+        if (keyValue === undefined || (lastValue !== undefined && lastValue > keyValue)) {
+            validation &= ~ANIMATION_VALIDATION_ORDERED_KEYS;
+        }
+        if (keyValue !== undefined && lastValue === keyValue) validation &= ~ANIMATION_VALIDATION_UNIQUE_KEYS;
         lastValue = keyValue;
     }
 

--- a/packages/ag-charts-community/src/chart/data/sortOrder.ts
+++ b/packages/ag-charts-community/src/chart/data/sortOrder.ts
@@ -6,22 +6,27 @@ export function valuesSortOrder(values: any[], needsValueOf: boolean): SortOrder
 
     let order = 0 as 1 | -1 | 0;
 
-    let v0 = values[0];
-    for (let i = 1; i < valuesLength; i++) {
-        const v1 = values[i];
-        if (v1 == null) continue;
+    let prev: number | bigint | undefined;
+    for (let i = 0; i < valuesLength; i++) {
+        const value = values[i];
+        if (value == null) continue;
 
         // Skip valueOf() call when we know the column contains only primitives
-        const primitive = needsValueOf ? v1.valueOf() : v1;
-        if (typeof primitive !== 'number') return;
+        const primitive = needsValueOf ? value.valueOf() : value;
+        if (typeof primitive !== 'number' && typeof primitive !== 'bigint') return;
 
-        const diff = Math.sign(v1 - v0) as 1 | -1 | 0;
-        if (diff !== 0) {
-            if (order !== 0 && order !== diff) return;
-            order = diff;
+        if (prev !== undefined) {
+            // Relational comparison is bigint-safe and works across number/bigint; Math.sign(v1 - v0) throws on bigint.
+            let diff: 1 | -1 | 0 = 0;
+            if (primitive > prev) diff = 1;
+            else if (primitive < prev) diff = -1;
+            if (diff !== 0) {
+                if (order !== 0 && order !== diff) return;
+                order = diff;
+            }
         }
 
-        v0 = v1;
+        prev = primitive;
     }
 
     return order === 0 ? 1 : order;

--- a/packages/ag-charts-community/src/chart/legend/legendDatum.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDatum.ts
@@ -5,6 +5,7 @@ import {
     type PluginModuleInstance,
     deriveNormalizedStops,
     formatColorBinLabel,
+    toNumber,
 } from 'ag-charts-core';
 import type {
     AgChartLegendListeners,
@@ -107,7 +108,10 @@ function deriveNamedLabels(
     const { domain, range, mode, displayDomain } = colorScale;
     if (range.length === 0) return undefined;
 
-    const [d0, d1] = displayDomain ?? [domain[0], domain.at(-1)!];
+    // Legend axis positions at finite precision; numeric labels are formatted from the exact value elsewhere.
+    const [d0, d1] = displayDomain
+        ? [toNumber(displayDomain[0]), toNumber(displayDomain[1])]
+        : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
     const labels: GradientLegendNamedLabel[] = [];
 
@@ -162,7 +166,9 @@ export function buildGradientLegendDatum(
     series: FormatterBoundSeries[]
 ): GradientLegendDatum {
     const { domain, displayDomain, mode } = colorScale;
-    const axisDomain: [number, number] = displayDomain ?? [domain[0], domain.at(-1)!];
+    const axisDomain: [number, number] = displayDomain
+        ? [toNumber(displayDomain[0]), toNumber(displayDomain[1])]
+        : [domain[0], domain.at(-1)!];
     const rawStops = deriveNormalizedStops(colorScale);
     const colorStops =
         mode === 'continuous'

--- a/packages/ag-charts-community/src/chart/series/bucketLookupFeature.ts
+++ b/packages/ag-charts-community/src/chart/series/bucketLookupFeature.ts
@@ -110,7 +110,7 @@ function resolveBucketingInputs(
     const xValues =
         domainKey === 'key'
             ? dataModel.resolveKeysById(series, 'xValue', processedData)
-            : dataModel.resolveColumnById(series, 'xValue', processedData);
+            : dataModel.resolveColumnById(series, 'xValue', processedData, 'object');
     const xNeedsValueOf =
         domainKey === 'key' ? false : dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const [d0, d1] = aggregationDomain(xAxis.scale.type, domainInput);
@@ -371,7 +371,12 @@ export class SplitBucketLookupManager<TFilter extends SplitFilter>
         const dataModel = this.splitOpts.getDataModel()!;
         const processedData = this.splitOpts.getProcessedData()!;
         const yColumnId = this.splitOpts.getYColumnId(dataModel, processedData);
-        const yEndValues = dataModel.resolveColumnById(this.splitOpts.series, yColumnId, processedData);
+        const yEndValues = dataModel.resolveColumnById(
+            this.splitOpts.series,
+            yColumnId,
+            processedData,
+            'mixed-numeric'
+        );
         const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(this.splitOpts.series, yColumnId, processedData);
 
         populateBucketSelectedFromSparseSplit(
@@ -402,7 +407,12 @@ export class SplitBucketLookupManager<TFilter extends SplitFilter>
             this.splitOpts.domainKey
         );
         const yColumnId = this.splitOpts.getYColumnId(dataModel, processedData);
-        const yEndValues = dataModel.resolveColumnById(this.splitOpts.series, yColumnId, processedData);
+        const yEndValues = dataModel.resolveColumnById(
+            this.splitOpts.series,
+            yColumnId,
+            processedData,
+            'mixed-numeric'
+        );
         const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(this.splitOpts.series, yColumnId, processedData);
         const xValuesLength = xValues.length;
         const { positiveIndexData, negativeIndexData, maxRange } = filter;

--- a/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts
@@ -3,11 +3,13 @@ import {
     type Point,
     Property,
     type Scaling,
+    addValues,
     extent,
     findMinMax,
     isFiniteNumber,
+    subtractValues,
 } from 'ag-charts-core';
-import type { Direction } from 'ag-charts-types';
+import type { AgNumericValue, Direction } from 'ag-charts-types';
 
 import { ContinuousScale } from '../../../scale/continuousScale';
 import { IrregularBandScale } from '../../../scale/irregularBandScale';
@@ -67,18 +69,24 @@ export type AbstractBarSeriesAnimationData<TTypes extends AbstractBarSeriesTypes
 >;
 
 export abstract class AbstractBarSeries<TTypes extends AbstractBarSeriesTypes> extends CartesianSeries<TTypes> {
-    protected smallestDataInterval?: number = undefined;
-    protected largestDataInterval?: number = undefined;
+    protected smallestDataInterval?: AgNumericValue = undefined;
+    protected largestDataInterval?: AgNumericValue = undefined;
 
     protected padBandExtent(keys: any[], alignStart?: boolean) {
         const ratio = typeof alignStart === 'boolean' ? 1 : 0.5;
-        const scalePadding = isFiniteNumber(this.smallestDataInterval) ? this.smallestDataInterval * ratio : 0;
-        const keysExtent = extent(keys) ?? [Number.NaN, Number.NaN];
+        // Band positioning is finite-precision, so narrow the interval here before the padding arithmetic.
+        const interval = this.smallestDataInterval == null ? Number.NaN : Number(this.smallestDataInterval);
+        const scalePadding = isFiniteNumber(interval) ? interval * ratio : 0;
+        const rawExtent = extent(keys);
+        if (rawExtent == null) return fixNumericExtent([Number.NaN, Number.NaN]);
+        // Keep endpoints exact so a bigint key axis positions at full precision; only the padding is narrowed.
+        const keysExtent: AgNumericValue[] = [rawExtent[0], rawExtent[1]];
         if (typeof alignStart === 'boolean') {
-            keysExtent[alignStart ? 0 : 1] -= (alignStart ? 1 : -1) * scalePadding;
+            const i = alignStart ? 0 : 1;
+            keysExtent[i] = subtractValues(keysExtent[i], (alignStart ? 1 : -1) * scalePadding);
         } else {
-            keysExtent[0] -= scalePadding;
-            keysExtent[1] += scalePadding;
+            keysExtent[0] = subtractValues(keysExtent[0], scalePadding);
+            keysExtent[1] = addValues(keysExtent[1], scalePadding);
         }
         return fixNumericExtent(keysExtent);
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaAggregation.ts
@@ -15,6 +15,7 @@ import {
     compactAggregationIndices,
     createAggregationIndices,
     epochColumnForTimeScale,
+    narrowBigIntColumn,
     narrowBigIntColumnRelative,
     nextPowerOf2,
     simpleMemorize2,
@@ -430,11 +431,14 @@ export function aggregateAreaDataFromDataModel(
     const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     // When existingFilters provided, bypass memoization to enable TypedArray reuse
@@ -479,11 +483,14 @@ export function aggregateAreaDataFromDataModelPartial(
     const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaAggregation.ts
@@ -5,9 +5,7 @@ import {
     AGGREGATION_INDEX_Y_MIN,
     AGGREGATION_MIN_RANGE,
     AGGREGATION_THRESHOLD,
-    type DomainWithMetadata,
     type ScaleType,
-    aggregationDomain,
     aggregationIndexForXRatio,
     aggregationRangeFittingPoints,
     aggregationXRatioForDatumIndex,
@@ -15,7 +13,7 @@ import {
     compactAggregationIndices,
     createAggregationIndices,
     epochColumnForTimeScale,
-    narrowBigIntColumn,
+    narrowAggregationX,
     narrowBigIntColumnRelative,
     nextPowerOf2,
     simpleMemorize2,
@@ -383,14 +381,13 @@ export function computeAreaAggregationPartial(
  * @internal
  */
 function aggregateAreaData(
-    scale: ScaleType,
     xValues: any[],
     yValues: any[],
-    domainInput: DomainWithMetadata<any>,
+    d0: number,
+    d1: number,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): AreaSeriesDataAggregationFilter[] | undefined {
-    const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeAreaAggregation([d0, d1], xValues, yValues, { xNeedsValueOf, yNeedsValueOf });
 }
 
@@ -436,22 +433,21 @@ export function aggregateAreaDataFromDataModel(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     // When existingFilters provided, bypass memoization to enable TypedArray reuse
     if (existingFilters) {
-        const [d0, d1] = aggregationDomain(scale, domainInput);
-        return computeAreaAggregation([d0, d1], xValues, yValues, {
+        return computeAreaAggregation(domain, xValues, yValues, {
             xNeedsValueOf,
             yNeedsValueOf,
             existingFilters,
         });
     }
 
-    return memoizedAggregateAreaData(scale, xValues, yValues, domainInput, xNeedsValueOf, yNeedsValueOf);
+    return memoizedAggregateAreaData(xValues, yValues, domain[0], domain[1], xNeedsValueOf, yNeedsValueOf);
 }
 
 /**
@@ -488,13 +484,10 @@ export function aggregateAreaDataFromDataModelPartial(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
-    const [d0, d1] = aggregationDomain(scale, domainInput);
-    return computeAreaAggregationPartial([d0, d1], xValues, yValues, {
+    return computeAreaAggregationPartial(domain, xValues, yValues, {
         xNeedsValueOf,
         yNeedsValueOf,
         targetRange,

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaAggregation.ts
@@ -14,6 +14,8 @@ import {
     aggregationXRatioForXValue,
     compactAggregationIndices,
     createAggregationIndices,
+    epochColumnForTimeScale,
+    narrowBigIntColumnRelative,
     nextPowerOf2,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -421,12 +423,19 @@ export function aggregateAreaDataFromDataModel(
     series: ScopeProvider,
     existingFilters?: AreaSeriesDataAggregationFilter[]
 ): AreaSeriesDataAggregationFilter[] | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const yValues = dataModel.resolveColumnById(series, yKey, processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawYValues = dataModel.resolveColumnById(series, yKey, processedData, 'mixed-numeric');
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     // When existingFilters provided, bypass memoization to enable TypedArray reuse
     if (existingFilters) {
@@ -463,12 +472,19 @@ export function aggregateAreaDataFromDataModelPartial(
     targetRange: number,
     existingFilters?: AreaSeriesDataAggregationFilter[]
 ): PartialAreaAggregationResult | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const yValues = dataModel.resolveColumnById(series, yKey, processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawYValues = dataModel.resolveColumnById(series, yKey, processedData, 'mixed-numeric');
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeAreaAggregationPartial([d0, d1], xValues, yValues, {

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -668,7 +668,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 if (invalidData?.[datumIndex]) continue;
 
                 const yValue = yValues[datumIndex];
-                // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+                // isContinuous accepts any bigint; Number.isFinite rejects every bigint (it never coerces them).
                 if (!isContinuous(yValue)) continue;
 
                 const xDatum = xValues[datumIndex];
@@ -738,7 +738,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             }
 
             const yValue = yValues[datumIndex];
-            // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+            // isContinuous accepts any bigint; Number.isFinite rejects every bigint (it never coerces them).
             if (!isContinuous(yValue)) {
                 return true;
             }

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -15,7 +15,10 @@ import {
     extent,
     isContinuous,
     isDefined,
+    maxValue,
     mergeDefaults,
+    minValue,
+    toNumber,
 } from 'ag-charts-core';
 import {
     type AgAreaSeriesLabelFormatterParams,
@@ -25,6 +28,7 @@ import {
     type AgAreaSeriesStylerResult,
     type AgDrawingMode,
     type AgErrorBoundSeriesTooltipRendererParams,
+    type AgNumericValue,
     type AgSeriesMarkerStyle,
 } from 'ag-charts-types';
 
@@ -42,9 +46,10 @@ import type { Text } from '../../../scene/shape/text';
 import { LogAxis } from '../../axis/logAxis';
 import { NumberAxis } from '../../axis/numberAxis';
 import type { ChartAxis } from '../../chartAxis';
+import { addAccumulated } from '../../data/aggregateFunctions';
 import type { DataController } from '../../data/dataController';
 import type { DataModel, DatumPropertyDefinition, ProcessedData } from '../../data/dataModel';
-import { fixNumericExtent } from '../../data/dataModel';
+import { extendDomainToZero, fixNumericExtent } from '../../data/dataModel';
 import type { PropertyDefinition } from '../../data/dataModelTypes';
 import {
     animationValidation,
@@ -146,8 +151,9 @@ type AreaStylerApply = MarkerStyleApply<
 >;
 
 interface StackRange {
-    leading: number;
-    trailing: number;
+    // Kept raw (possibly bigint) so a stack beyond Number.MAX_VALUE positions proportionally via yScale.convert().
+    leading: AgNumericValue;
+    trailing: AgNumericValue;
     dataValid: boolean;
     breakBefore: boolean;
 }
@@ -164,8 +170,8 @@ interface AreaSeriesCreateNodeDatumContext extends CartesianMarkerLikeContext<Ma
     readonly yKey: string;
 
     // Additional data arrays specific to area series
-    readonly yRawValues: any[];
-    readonly yCumulativeValues: any[];
+    readonly yRawValues: AgNumericValue[];
+    readonly yCumulativeValues: AgNumericValue[];
     readonly selectedValues: boolean[] | undefined;
     readonly invalidData: boolean[] | undefined;
 
@@ -197,7 +203,7 @@ interface AreaNodeDatumScratch {
     datum: any;
     xDatum: any;
     yDatum: any;
-    yCumulative: number;
+    yCumulative: AgNumericValue;
     selected: boolean | undefined;
     x: number;
     y: number;
@@ -438,10 +444,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         );
 
         if (yAxis instanceof NumberAxis && !(yAxis instanceof LogAxis)) {
-            const fixedYExtent = Number.isFinite(yExtent[1] - yExtent[0])
-                ? [Math.min(yExtent[0], 0), Math.max(yExtent[1], 0)]
-                : [];
-            return { domain: fixNumericExtent(fixedYExtent) };
+            return { domain: fixNumericExtent(extendDomainToZero(yExtent)) };
         } else {
             return { domain: fixNumericExtent(yExtent) };
         }
@@ -454,7 +457,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             'xValue',
             visibleRange
         );
-        return [Math.min(y0, 0), Math.max(y1, 0)];
+        // domainForVisibleRange may yield a bigint; minValue/maxValue avoid the Math.min/max throw, toNumber narrows once.
+        return [toNumber(minValue(y0, 0)), toNumber(maxValue(y1, 0))];
     }
 
     override getZoomRangeFittingItems(
@@ -578,7 +582,12 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         const invalidData = processedData.invalidData?.get(this.id);
 
         const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-        const yValues = dataModel.resolveColumnById(this, this.yCumulativeKey(processedData), processedData);
+        const yValues = dataModel.resolveColumnById(
+            this,
+            this.yCumulativeKey(processedData),
+            processedData,
+            'mixed-numeric'
+        );
 
         let [m0, m1] = visibleRangeIndices(1, metaIndices.length - 1, xAxis.range, (metaIndex) => {
             const startIndex = metaIndices[metaIndex];
@@ -659,7 +668,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 if (invalidData?.[datumIndex]) continue;
 
                 const yValue = yValues[datumIndex];
-                if (!Number.isFinite(yValue)) continue;
+                // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+                if (!isContinuous(yValue)) continue;
 
                 const xDatum = xValues[datumIndex];
                 bucketPoints.push({
@@ -728,7 +738,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             }
 
             const yValue = yValues[datumIndex];
-            if (!Number.isFinite(yValue)) {
+            // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+            if (!isContinuous(yValue)) {
                 return true;
             }
         }
@@ -749,7 +760,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         const xOffset = (xScale.bandwidth ?? 0) / 2;
 
         let xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-        let yValues = dataModel.resolveColumnById(this, this.yValueKey(), processedData);
+        let yValues = dataModel.resolveColumnById(this, this.yValueKey(), processedData, 'mixed-numeric');
 
         const connectMissingData = !this.isStacked() && this.properties.connectMissingData;
 
@@ -813,13 +824,15 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
 
             const leadingValue = yValues[leadingIndex];
             const trailingValue = yValues[trailingIndex];
-            const missingLeading = !Number.isFinite(leadingValue);
-            const missingTrailing = !Number.isFinite(trailingValue);
+            // addAccumulated below promotes the numeric baseline to bigint so a stack beyond Number.MAX_VALUE
+            // accumulates exactly (number + bigint would otherwise throw).
+            const missingLeading = !isContinuous(leadingValue);
+            const missingTrailing = !isContinuous(trailingValue);
             const dataValid = !missingLeading && !missingTrailing;
 
             if (dataValid) {
-                leading += leadingValue;
-                trailing += trailingValue;
+                leading = addAccumulated(leading, leadingValue);
+                trailing = addAccumulated(trailing, trailingValue);
             }
 
             if (stackIndex !== 0 && dataValid !== trackingValidData) {
@@ -981,12 +994,14 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             // Data arrays (resolved once)
             rawData: processedData.dataSources.get(this.id)?.data ?? [],
             xValues: dataModel.resolveKeysById(this, 'xValue', processedData),
-            yRawValues: dataModel.resolveColumnById(this, 'yValueRaw', processedData),
+            yRawValues: dataModel.resolveColumnById(this, 'yValueRaw', processedData, 'mixed-numeric'),
             yCumulativeValues: stacked
-                ? dataModel.resolveColumnById(this, 'yValueCumulative', processedData)
-                : dataModel.resolveColumnById(this, 'yValueRaw', processedData),
+                ? dataModel.resolveColumnById(this, 'yValueCumulative', processedData, 'mixed-numeric')
+                : dataModel.resolveColumnById(this, 'yValueRaw', processedData, 'mixed-numeric'),
             selectedValues:
-                selectedKey == null ? undefined : dataModel.resolveColumnById(this, 'selectedRaw', processedData),
+                selectedKey == null
+                    ? undefined
+                    : dataModel.resolveColumnById(this, 'selectedRaw', processedData, 'boolean'),
             invalidData: processedData.invalidData?.get(this.id),
 
             // Scales (cached)
@@ -1029,7 +1044,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
      * Uses cached context values to avoid repeated lookups.
      */
     private computeMarkerCoordinate(ctx: AreaSeriesCreateNodeDatumContext, scratch: AreaNodeDatumScratch): void {
-        let currY: number | undefined;
+        let currY: AgNumericValue | undefined;
 
         // if not normalized, the invalid data points will be processed as `undefined` in processData()
         // if normalized, the invalid data points will be processed as 0 rather than `undefined`
@@ -1065,8 +1080,9 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
 
         scratch.datum = ctx.rawData[datumIndex];
         scratch.yDatum = ctx.yRawValues[datumIndex];
-        scratch.yCumulative = +ctx.yCumulativeValues[datumIndex];
-        scratch.validPoint = Number.isFinite(scratch.yDatum) && ctx.invalidData?.[datumIndex] !== true;
+        // Keep raw (possibly bigint) so yScale.convert() positions values beyond Number.MAX_VALUE proportionally.
+        scratch.yCumulative = ctx.yCumulativeValues[datumIndex];
+        scratch.validPoint = isContinuous(scratch.yDatum) && ctx.invalidData?.[datumIndex] !== true;
 
         // Compute marker coordinates
         this.computeMarkerCoordinate(ctx, scratch);
@@ -1085,7 +1101,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 existingNode.datum = scratch.datum;
                 existingNode.datumIndex = datumIndex;
                 existingNode.midPoint = { x: scratch.x, y: scratch.y };
-                existingNode.cumulativeValue = scratch.yCumulative;
+                // Metadata only (tooltips/error-bars); position already used the exact bigint, so narrowing here is fine.
+                existingNode.cumulativeValue = Number(scratch.yCumulative);
                 existingNode.yValue = scratch.yDatum;
                 existingNode.xValue = scratch.xDatum;
                 existingNode.point = { x: scratch.x, y: scratch.y, size: ctx.markerSize };
@@ -1096,7 +1113,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                     datum: scratch.datum,
                     datumIndex,
                     midPoint: { x: scratch.x, y: scratch.y },
-                    cumulativeValue: scratch.yCumulative,
+                    cumulativeValue: Number(scratch.yCumulative),
                     yValue: scratch.yDatum,
                     xValue: scratch.xDatum,
                     yKey: ctx.yKey,
@@ -1561,7 +1578,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         const { xKey, yKey } = this.properties;
 
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData)[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData, 'mixed-numeric')[datumIndex];
         const xDomain = dataModel.getDomain(this, `xValue`, 'key', processedData).domain;
         const yDomain = dataModel.getDomain(this, this.yCumulativeKey(processedData), 'value', processedData).domain;
         const fill = this.filterItemStylerFillParams(style.fill) ?? style.fill;
@@ -1591,7 +1608,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
 
         const datum = processedData.dataSources.get(this.id)?.data?.[datumIndex];
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData)[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData, 'mixed-numeric')[datumIndex];
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         if (xValue === undefined && !allowNullKeys) return;

--- a/packages/ag-charts-community/src/chart/series/cartesian/barAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barAggregation.ts
@@ -338,11 +338,14 @@ export function aggregateBarDataFromDataModel(
     );
 
     // Split-mode aggregation keys off each value's sign, so narrow bigints absolutely (sign-preserving).
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const yStartValues =
         yNeedsValueOf || rawYStartValues == null ? rawYStartValues : narrowBigIntColumn(rawYStartValues);
     const yEndValues = yNeedsValueOf ? rawYEndValues : narrowBigIntColumn(rawYEndValues);
@@ -410,11 +413,14 @@ export function aggregateBarDataFromDataModelPartial(
     );
 
     // Split-mode aggregation keys off each value's sign, so narrow bigints absolutely (sign-preserving).
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const yStartValues =
         yNeedsValueOf || rawYStartValues == null ? rawYStartValues : narrowBigIntColumn(rawYStartValues);
     const yEndValues = yNeedsValueOf ? rawYEndValues : narrowBigIntColumn(rawYEndValues);

--- a/packages/ag-charts-community/src/chart/series/cartesian/barAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barAggregation.ts
@@ -1,13 +1,13 @@
-import type { DomainWithMetadata, ScaleType } from 'ag-charts-core';
+import type { ScaleType } from 'ag-charts-core';
 import {
     AGGREGATION_MIN_RANGE,
     AGGREGATION_THRESHOLD,
-    aggregationDomain,
     aggregationRangeFittingPoints,
     compactAggregationIndices,
     createAggregationIndices,
     epochColumnForTimeScale,
     getMidpointsForIndices,
+    narrowAggregationX,
     narrowBigIntColumn,
     nextPowerOf2,
     simpleMemorize2,
@@ -273,16 +273,15 @@ export function computeBarAggregationPartial(
  * @internal
  */
 function aggregateBarData(
-    scale: ScaleType,
     xValues: any[],
     yStartValues: any[] | undefined,
     yEndValues: any[],
-    domainInput: DomainWithMetadata<number>,
+    d0: number,
+    d1: number,
     smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): BarSeriesDataAggregationFilter[] | undefined {
-    const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeBarAggregation([d0, d1], xValues, yStartValues, yEndValues, {
         smallestKeyInterval,
         xNeedsValueOf,
@@ -343,17 +342,16 @@ export function aggregateBarDataFromDataModel(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const yStartValues =
         yNeedsValueOf || rawYStartValues == null ? rawYStartValues : narrowBigIntColumn(rawYStartValues);
     const yEndValues = yNeedsValueOf ? rawYEndValues : narrowBigIntColumn(rawYEndValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
-        const [d0, d1] = aggregationDomain(scale, domainInput);
-        return computeBarAggregation([d0, d1], xValues, yStartValues, yEndValues, {
+        return computeBarAggregation(domain, xValues, yStartValues, yEndValues, {
             smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
             xNeedsValueOf,
             yNeedsValueOf,
@@ -362,11 +360,11 @@ export function aggregateBarDataFromDataModel(
     }
 
     return memoizedAggregateBarData(
-        scale,
         xValues,
         yStartValues,
         yEndValues,
-        domainInput,
+        domain[0],
+        domain[1],
         processedData.reduced?.smallestKeyInterval,
         xNeedsValueOf,
         yNeedsValueOf
@@ -418,16 +416,15 @@ export function aggregateBarDataFromDataModelPartial(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const yStartValues =
         yNeedsValueOf || rawYStartValues == null ? rawYStartValues : narrowBigIntColumn(rawYStartValues);
     const yEndValues = yNeedsValueOf ? rawYEndValues : narrowBigIntColumn(rawYEndValues);
 
-    const [d0, d1] = aggregationDomain(scale, domainInput);
     // TODO: Use memoized version of computeBarAggregationPartial
-    return computeBarAggregationPartial([d0, d1], xValues, yStartValues, yEndValues, {
+    return computeBarAggregationPartial(domain, xValues, yStartValues, yEndValues, {
         smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
         xNeedsValueOf,
         yNeedsValueOf,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barAggregation.ts
@@ -6,10 +6,13 @@ import {
     aggregationRangeFittingPoints,
     compactAggregationIndices,
     createAggregationIndices,
+    epochColumnForTimeScale,
     getMidpointsForIndices,
+    narrowBigIntColumn,
     nextPowerOf2,
     simpleMemorize2,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { DataModel } from '../../data/dataModel';
 import type { ProcessedData, ScopeProvider } from '../../data/dataModelTypes';
@@ -72,7 +75,7 @@ export function computeBarAggregation(
     yStartValues: any[] | undefined,
     yEndValues: any[],
     options: {
-        smallestKeyInterval: number | undefined;
+        smallestKeyInterval: AgNumericValue | undefined;
         xNeedsValueOf: boolean;
         yNeedsValueOf: boolean;
         existingFilters?: BarSeriesDataAggregationFilter[];
@@ -191,7 +194,7 @@ export function computeBarAggregationPartial(
     yStartValues: any[] | undefined,
     yEndValues: any[],
     options: {
-        smallestKeyInterval: number | undefined;
+        smallestKeyInterval: AgNumericValue | undefined;
         xNeedsValueOf: boolean;
         yNeedsValueOf: boolean;
         targetRange: number;
@@ -275,7 +278,7 @@ function aggregateBarData(
     yStartValues: any[] | undefined,
     yEndValues: any[],
     domainInput: DomainWithMetadata<number>,
-    smallestKeyInterval: number | undefined,
+    smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): BarSeriesDataAggregationFilter[] | undefined {
@@ -315,22 +318,34 @@ export function aggregateBarDataFromDataModel(
     series: ScopeProvider,
     existingFilters?: BarSeriesDataAggregationFilter[]
 ): BarSeriesDataAggregationFilter[] | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
 
     const isStacked = dataModel.hasColumnById(series, 'yValue-start');
-    const yStartValues = isStacked ? dataModel.resolveColumnById(series, 'yValue-start', processedData) : undefined;
-    const yEndValues = isStacked
-        ? dataModel.resolveColumnById(series, 'yValue-end', processedData)
-        : dataModel.resolveColumnById(series, 'yValue-raw', processedData);
+    const rawYStartValues = isStacked
+        ? dataModel.resolveColumnById(series, 'yValue-start', processedData, 'mixed-numeric')
+        : undefined;
+    const rawYEndValues = isStacked
+        ? dataModel.resolveColumnById(series, 'yValue-end', processedData, 'mixed-numeric')
+        : dataModel.resolveColumnById(series, 'yValue-raw', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(
         series,
         isStacked ? 'yValue-end' : 'yValue-raw',
         processedData
     );
+
+    // Split-mode aggregation keys off each value's sign, so narrow bigints absolutely (sign-preserving).
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const yStartValues =
+        yNeedsValueOf || rawYStartValues == null ? rawYStartValues : narrowBigIntColumn(rawYStartValues);
+    const yEndValues = yNeedsValueOf ? rawYEndValues : narrowBigIntColumn(rawYEndValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
@@ -375,22 +390,34 @@ export function aggregateBarDataFromDataModelPartial(
     targetRange: number,
     existingFilters?: BarSeriesDataAggregationFilter[]
 ): PartialBarAggregationResult | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
 
     const isStacked = dataModel.hasColumnById(series, 'yValue-start');
-    const yStartValues = isStacked ? dataModel.resolveColumnById(series, 'yValue-start', processedData) : undefined;
-    const yEndValues = isStacked
-        ? dataModel.resolveColumnById(series, 'yValue-end', processedData)
-        : dataModel.resolveColumnById(series, 'yValue-raw', processedData);
+    const rawYStartValues = isStacked
+        ? dataModel.resolveColumnById(series, 'yValue-start', processedData, 'mixed-numeric')
+        : undefined;
+    const rawYEndValues = isStacked
+        ? dataModel.resolveColumnById(series, 'yValue-end', processedData, 'mixed-numeric')
+        : dataModel.resolveColumnById(series, 'yValue-raw', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(
         series,
         isStacked ? 'yValue-end' : 'yValue-raw',
         processedData
     );
+
+    // Split-mode aggregation keys off each value's sign, so narrow bigints absolutely (sign-preserving).
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const yStartValues =
+        yNeedsValueOf || rawYStartValues == null ? rawYStartValues : narrowBigIntColumn(rawYStartValues);
+    const yEndValues = yNeedsValueOf ? rawYEndValues : narrowBigIntColumn(rawYEndValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);
     // TODO: Use memoized version of computeBarAggregationPartial

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -18,8 +18,13 @@ import {
     ChartAxisDirection,
     DebugMetrics,
     areScalingEqual,
+    isContinuous,
     isFiniteNumber,
+    maxValue,
     mergeDefaults,
+    minValue,
+    toNumber,
+    zeroLike,
 } from 'ag-charts-core';
 import type {
     AgBarSeriesItemStylerParams,
@@ -28,6 +33,7 @@ import type {
     AgBarSeriesStyle,
     AgBarSeriesStylerParams,
     AgErrorBoundSeriesTooltipRendererParams,
+    AgNumericValue,
 } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../../module/moduleContext';
@@ -44,7 +50,7 @@ import { LogAxis } from '../../axis/logAxis';
 import { NumberAxis } from '../../axis/numberAxis';
 import type { ChartAxis } from '../../chartAxis';
 import type { DataController } from '../../data/dataController';
-import { DataModel, type ProcessedData, fixNumericExtent } from '../../data/dataModel';
+import { DataModel, type ProcessedData, extendDomainToZero, fixNumericExtent } from '../../data/dataModel';
 import type { GroupedData, PropertyDefinition } from '../../data/dataModelTypes';
 import {
     LARGEST_KEY_INTERVAL,
@@ -188,9 +194,10 @@ interface NodeDatumParams {
     datumIndex: number;
     x: number;
     width: number;
-    yStart: number;
-    yEnd: number;
-    yRange: number;
+    // Kept raw (possibly bigint) so yScale.convert() positions values beyond Number.MAX_VALUE proportionally.
+    yStart: AgNumericValue;
+    yEnd: AgNumericValue;
+    yRange: AgNumericValue;
     featherRatio: number;
     opacity: number;
 }
@@ -455,16 +462,14 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
                 ? dataModel.getDomain(this, 'yFilterValue-raw', 'value', processedData).domain
                 : undefined;
             if (yFilterExtent != null) {
-                yExtent = [Math.min(yExtent[0], yFilterExtent[0]), Math.max(yExtent[1], yFilterExtent[1])];
+                // minValue/maxValue (not Math.min/max, which throw on bigint) preserve exact bigint endpoints.
+                yExtent = [minValue(yExtent[0], yFilterExtent[0]), maxValue(yExtent[1], yFilterExtent[1])];
             }
         }
 
         const yAxis = this.getValueAxis();
         if (yAxis instanceof NumberAxis && !(yAxis instanceof LogAxis)) {
-            const fixedYExtent = Number.isFinite(yExtent[1] - yExtent[0])
-                ? [Math.min(0, yExtent[0]), Math.max(0, yExtent[1])]
-                : [];
-            return { domain: fixNumericExtent(fixedYExtent) };
+            return { domain: fixNumericExtent(extendDomainToZero(yExtent)) };
         } else {
             return { domain: fixNumericExtent(yExtent) };
         }
@@ -475,7 +480,8 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         if (selfDirection !== direction) return [];
         const yKey = this.yCumulativeKey(this.dataModel!);
         const [y0, y1] = this.domainForVisibleRange(ChartAxisDirection.Y, [yKey], 'xValue', visibleRange);
-        return [Math.min(y0, 0), Math.max(y1, 0)];
+        // domainForVisibleRange may yield a bigint; minValue/maxValue avoid the Math.min/max throw, toNumber narrows once.
+        return [toNumber(minValue(y0, 0)), toNumber(maxValue(y1, 0))];
     }
 
     override getZoomRangeFittingItems(
@@ -587,20 +593,24 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
 
         const { groupOffset, barOffset, barWidth } = this.getBarDimensions();
 
-        let yStartValues: number[] | undefined;
-        let yEndValues: number[] | undefined;
-        let yFilterValues: number[] | undefined;
+        let yStartValues: AgNumericValue[] | undefined;
+        let yEndValues: AgNumericValue[] | undefined;
+        let yFilterValues: AgNumericValue[] | undefined;
         if (filteredValueExceedUnfiltered) {
-            yStartValues = dataModel.resolveColumnById(this, 'yFilterValue-start', processedData);
-            yEndValues = dataModel.resolveColumnById(this, 'yFilterValue-end', processedData);
+            yStartValues = dataModel.resolveColumnById(this, 'yFilterValue-start', processedData, 'mixed-numeric');
+            yEndValues = dataModel.resolveColumnById(this, 'yFilterValue-end', processedData, 'mixed-numeric');
             yFilterValues = undefined;
         } else {
             const isCrossFilteringEnabled = dataModel.hasColumnById(this, 'yFilterValue-raw');
 
-            yStartValues = isStacked ? dataModel.resolveColumnById(this, 'yValue-start', processedData) : undefined;
-            yEndValues = isStacked ? dataModel.resolveColumnById(this, 'yValue-end', processedData) : undefined;
+            yStartValues = isStacked
+                ? dataModel.resolveColumnById(this, 'yValue-start', processedData, 'mixed-numeric')
+                : undefined;
+            yEndValues = isStacked
+                ? dataModel.resolveColumnById(this, 'yValue-end', processedData, 'mixed-numeric')
+                : undefined;
             yFilterValues = isCrossFilteringEnabled
-                ? dataModel.resolveColumnById(this, 'yFilterValue-raw', processedData)
+                ? dataModel.resolveColumnById(this, 'yFilterValue-raw', processedData, 'mixed-numeric')
                 : undefined;
         }
 
@@ -608,7 +618,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
             dataSource: rawData,
             rawData: rawData.data,
             xValues: dataModel.resolveKeysById(this, 'xValue', processedData),
-            yRawValues: dataModel.resolveColumnById(this, 'yValue-raw', processedData),
+            yRawValues: dataModel.resolveColumnById(this, 'yValue-raw', processedData, 'mixed-numeric'),
             yStartValues,
             yEndValues,
             yFilterValues,
@@ -621,7 +631,8 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
             barWidth,
             range,
             yReversed: yAxis.isReversed(),
-            bboxBottom: yScale.convert(0),
+            // 0n so a bigint y-domain takes the full-precision convert() path; a numeric 0 against it yields NaN.
+            bboxBottom: yScale.convert(0n),
             labelSpacing: label.spacing + (typeof label.padding === 'number' ? label.padding : 0),
             crisp:
                 dataAggregationFilter == null &&
@@ -662,10 +673,11 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         ctx: BarSeriesNodeDatumContext,
         nodeDatumScratch: PreparedBarNodeDatumState,
         datumIndex: number,
-        yStart: number,
-        yEnd: number
+        yStart: AgNumericValue,
+        yEnd: AgNumericValue
     ): PreparedBarNodeDatumState | undefined {
-        if (!Number.isFinite(yEnd)) {
+        // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+        if (!isContinuous(yEnd)) {
             return undefined;
         }
 
@@ -820,23 +832,24 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         const phantom = node.phantom;
         const prevY = params.yStart;
         const yValue = phantom ? prepared.yFilterValue! : (prepared.yFilterValue ?? prepared.yRawValue);
-        const cumulativeValue = phantom ? prepared.yFilterValue! : (prepared.yFilterValue ?? params.yEnd);
+        // Metadata only (tooltips/error-bars); geometry below uses the exact bigint, so narrowing here is fine.
+        const cumulativeValue = phantom ? prepared.yFilterValue! : (prepared.yFilterValue ?? Number(params.yEnd));
         const nodeLabelText = phantom ? undefined : prepared.labelText;
 
-        let currY: number;
-        if (phantom) {
-            currY = params.yEnd;
-        } else if (prepared.yFilterValue == null) {
+        // Stay in domain space (possibly bigint) so yScale.convert() positions proportionally; the cross-filter
+        // branch recombines in Number space, so a bigint baseline beyond MAX_VALUE degrades there rather than throws.
+        let currY: AgNumericValue;
+        if (phantom || prepared.yFilterValue == null) {
             currY = params.yEnd;
         } else {
-            currY = params.yStart + prepared.yFilterValue;
+            currY = Number(params.yStart) + prepared.yFilterValue;
         }
 
-        let nodeYRange: number;
-        if (phantom) {
+        let nodeYRange: AgNumericValue;
+        if (phantom || prepared.yFilterValue == null) {
             nodeYRange = params.yRange;
         } else {
-            nodeYRange = Math.max(params.yStart + (prepared.yFilterValue ?? -Infinity), params.yRange);
+            nodeYRange = Math.max(Number(params.yStart) + prepared.yFilterValue, Number(params.yRange));
         }
 
         let crossScale: number | undefined;
@@ -993,16 +1006,19 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
                 nodeDatumParamsScratch.width = width;
                 nodeDatumParamsScratch.opacity = opacity;
                 if (ctx.isStacked) {
-                    nodeDatumParamsScratch.yStart = Number(ctx.yStartValues![yMinIndex]);
-                    nodeDatumParamsScratch.yEnd = Number(ctx.yEndValues![yMaxIndex]);
+                    // Keep domain space (possibly bigint) so yScale.convert() keeps full precision; only the bucket index comes from the aggregation.
+                    nodeDatumParamsScratch.yStart = ctx.yStartValues![yMinIndex];
+                    nodeDatumParamsScratch.yEnd = ctx.yEndValues![yMaxIndex];
                     nodeDatumParamsScratch.featherRatio = 0;
                 } else {
-                    const yEndMax = Number(ctx.yRawValues[yMaxIndex]);
-                    const yEndMin = Number(ctx.yRawValues[yMinIndex]);
+                    const yEndMax = ctx.yRawValues[yMaxIndex];
+                    const yEndMin = ctx.yRawValues[yMinIndex];
 
                     nodeDatumParamsScratch.yStart = 0;
                     nodeDatumParamsScratch.yEnd = yEndMax;
-                    nodeDatumParamsScratch.featherRatio = (positive ? 1 : -1) * sign * (1 - yEndMin / yEndMax);
+                    // Narrow here: a bigint pair would otherwise divide as truncating integers.
+                    nodeDatumParamsScratch.featherRatio =
+                        (positive ? 1 : -1) * sign * (1 - toNumber(yEndMin) / toNumber(yEndMax));
                 }
                 nodeDatumParamsScratch.yRange = nodeDatumParamsScratch.yEnd;
 
@@ -1056,8 +1072,11 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
                 const yRawValue = ctx.yRawValues[datumIndex];
                 if (yRawValue == null) continue;
                 const isPositive = yRawValue >= 0 && !Object.is(yRawValue, -0);
-                const yStart = ctx.isStacked ? Number(ctx.yStartValues?.[datumIndex]) : 0;
-                const yEnd = ctx.isStacked ? Number(ctx.yEndValues?.[datumIndex]) : yRawValue;
+                // Pass raw (possibly bigint) bounds through; the baseline must match the value type (0n for
+                // bigint) or convert() yields NaN against a bigint domain.
+                const baseline = zeroLike(yRawValue);
+                const yStart = ctx.isStacked ? (ctx.yStartValues?.[datumIndex] ?? baseline) : baseline;
+                const yEnd = ctx.isStacked ? ctx.yEndValues?.[datumIndex] : yRawValue;
                 let yRange = yEnd;
                 if (ctx.isStacked) {
                     yRange = aggregation[yRangeIndex][isPositive ? 1 : 0];
@@ -1103,12 +1122,14 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
             if (yRawValue == null) continue;
 
             const x = xPosition(datumIndex);
-            const yEnd = Number(yRawValue);
+            // Raw (possibly bigint) value; Number() would collapse values beyond Number.MAX_VALUE to Infinity.
+            const yEnd = yRawValue;
 
             nodeDatumParamsScratch.datumIndex = datumIndex;
             nodeDatumParamsScratch.x = x;
             nodeDatumParamsScratch.width = width;
-            nodeDatumParamsScratch.yStart = 0;
+            // 0n baseline for a bigint value so convert() takes the bigint path; a numeric 0 against it yields NaN.
+            nodeDatumParamsScratch.yStart = zeroLike(yEnd);
             nodeDatumParamsScratch.yEnd = yEnd;
             nodeDatumParamsScratch.yRange = yEnd;
             nodeDatumParamsScratch.featherRatio = 0;
@@ -1382,7 +1403,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         const { xKey, yKey, stackGroup } = this.properties;
 
         const datum = processedData.dataSources.get(seriesId)?.data?.[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, 'yValue-raw', processedData)[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, 'yValue-raw', processedData, 'mixed-numeric')[datumIndex];
         const xDomain = dataModel.getDomain(this, 'xValue', 'key', processedData).domain;
         const yDomain = dataModel.getDomain(this, this.yCumulativeKey(dataModel), 'value', processedData).domain;
 
@@ -1610,7 +1631,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
 
         const datum = processedData.dataSources.get(this.id)?.data?.[datumIndex];
         const xValue = dataModel.resolveKeysById(this, 'xValue', processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, 'yValue-raw', processedData)[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, 'yValue-raw', processedData, 'mixed-numeric')[datumIndex];
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         if (xValue === undefined && !allowNullKeys) return; // eslint-disable-line sonarjs/different-types-comparison

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -631,7 +631,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
             barWidth,
             range,
             yReversed: yAxis.isReversed(),
-            // 0n so a bigint y-domain takes the full-precision convert() path; a numeric 0 against it yields NaN.
+            // 0n keeps a bigint y-domain on the full-precision convert() path (a numeric 0 narrows to Number).
             bboxBottom: yScale.convert(0n),
             labelSpacing: label.spacing + (typeof label.padding === 'number' ? label.padding : 0),
             crisp:
@@ -676,7 +676,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         yStart: AgNumericValue,
         yEnd: AgNumericValue
     ): PreparedBarNodeDatumState | undefined {
-        // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+        // isContinuous accepts any bigint; Number.isFinite rejects every bigint (it never coerces them).
         if (!isContinuous(yEnd)) {
             return undefined;
         }
@@ -836,8 +836,8 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         const cumulativeValue = phantom ? prepared.yFilterValue! : (prepared.yFilterValue ?? Number(params.yEnd));
         const nodeLabelText = phantom ? undefined : prepared.labelText;
 
-        // Stay in domain space (possibly bigint) so yScale.convert() positions proportionally; the cross-filter
-        // branch recombines in Number space, so a bigint baseline beyond MAX_VALUE degrades there rather than throws.
+        // Non-filtered: params.yEnd stays in domain space (possibly bigint) for a full-precision convert().
+        // Cross-filter: yFilterValue is already Number-narrowed, so yStart narrows here too and currY is Number.
         let currY: AgNumericValue;
         if (phantom || prepared.yFilterValue == null) {
             currY = params.yEnd;
@@ -1072,8 +1072,8 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
                 const yRawValue = ctx.yRawValues[datumIndex];
                 if (yRawValue == null) continue;
                 const isPositive = yRawValue >= 0 && !Object.is(yRawValue, -0);
-                // Pass raw (possibly bigint) bounds through; the baseline must match the value type (0n for
-                // bigint) or convert() yields NaN against a bigint domain.
+                // Pass raw (possibly bigint) bounds through; zeroLike() matches the baseline to the value type
+                // (0n for bigint) so it shares the value's full-precision convert() path.
                 const baseline = zeroLike(yRawValue);
                 const yStart = ctx.isStacked ? (ctx.yStartValues?.[datumIndex] ?? baseline) : baseline;
                 const yEnd = ctx.isStacked ? ctx.yEndValues?.[datumIndex] : yRawValue;
@@ -1128,7 +1128,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
             nodeDatumParamsScratch.datumIndex = datumIndex;
             nodeDatumParamsScratch.x = x;
             nodeDatumParamsScratch.width = width;
-            // 0n baseline for a bigint value so convert() takes the bigint path; a numeric 0 against it yields NaN.
+            // zeroLike() so a bigint value's baseline stays bigint and shares its full-precision convert() path.
             nodeDatumParamsScratch.yStart = zeroLike(yEnd);
             nodeDatumParamsScratch.yEnd = yEnd;
             nodeDatumParamsScratch.yRange = yEnd;

--- a/packages/ag-charts-community/src/chart/series/cartesian/barUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barUtil.ts
@@ -1,5 +1,6 @@
 import type { Scale } from 'ag-charts-core';
 import { ChartAxisDirection, isNegative } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { ApplyFn, FromToMotionPropFn, NodeUpdateState } from '../../../motion/fromToMotion';
 import { NODE_UPDATE_STATE_TO_PHASE_MAPPING } from '../../../motion/fromToMotion';
@@ -14,8 +15,8 @@ import type { ISeries, ISeriesProperties, SeriesNodeDatum } from '../seriesTypes
 export function checkCrisp(
     scale: Scale<any, any> | undefined,
     visibleRange: number[] | undefined,
-    smallestDataInterval: number | undefined,
-    largestDataInterval: number | undefined
+    smallestDataInterval: AgNumericValue | undefined,
+    largestDataInterval: AgNumericValue | undefined
 ): boolean {
     if (visibleRange != null) {
         const [visibleMin, visibleMax] = visibleRange;

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
@@ -340,8 +340,9 @@ export function aggregateBubbleDataFromDataModel(
 ): BubbleAggregation | undefined {
     const rawXValues = dataModel.resolveColumnById(series, 'xValue', processedData, 'object');
     const rawYValues = dataModel.resolveColumnById(series, 'yValue', processedData, 'mixed-numeric');
+    // Narrow the size column like x/y: the quantisation ratio mixes it with the Number-narrowed size domain.
     const sizeValues = hasSizeKey
-        ? dataModel.resolveColumnById(series, 'sizeValue', processedData, 'mixed-numeric')
+        ? narrowBigIntColumn(dataModel.resolveColumnById(series, 'sizeValue', processedData, 'mixed-numeric'))
         : undefined;
 
     const xDomain = dataModel.getDomain(series, 'xValue', 'value', processedData);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
@@ -4,6 +4,7 @@ import {
     aggregationXRatioForXValue,
     clamp,
     epochColumnForTimeScale,
+    narrowAggregationX,
     narrowBigIntColumn,
 } from 'ag-charts-core';
 
@@ -288,18 +289,17 @@ export function computeBubbleAggregation(
  * @internal
  */
 function aggregateBubbleData(
-    xScale: ScaleType,
     yScale: ScaleType,
     xValues: any[],
     yValues: any[],
     sizeValues: any[] | undefined,
-    xDomainInput: DomainWithMetadata<any>,
+    xDomain: [number, number],
     yDomainInput: DomainWithMetadata<any>,
     sizeDomain: number[],
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): BubbleAggregation | undefined {
-    const [xd0, xd1] = aggregationDomain(xScale, xDomainInput);
+    const [xd0, xd1] = xDomain;
     const [yd0, yd1] = aggregationDomain(yScale, yDomainInput);
     return computeBubbleAggregation(
         [xd0, xd1],
@@ -352,22 +352,22 @@ export function aggregateBubbleDataFromDataModel(
     const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'yValue', processedData);
 
-    // Narrow bigints absolutely to match aggregationDomain's narrowing of the domain; parse ISO time x to epoch ms first.
+    // Parse ISO time x to epoch ms first, then subtract the bigint domain-min from x and [xd0,xd1] together so a
+    // high-magnitude narrow-range x keeps full quadtree precision; non-bigint columns narrow absolutely.
     const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         xScale,
         rawXValues,
         rawXNeedsValueOf
     );
-    const xValues = narrowBigIntColumn(epochXValues);
+    const { xValues, domain: xNumericDomain } = narrowAggregationX(xScale, epochXValues, xDomain);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumn(rawYValues);
 
     return aggregateBubbleData(
-        xScale,
         yScale,
         xValues,
         yValues,
         sizeValues,
-        xDomain,
+        xNumericDomain,
         yDomain,
         sizeDomain,
         xNeedsValueOf,

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleAggregation.ts
@@ -1,5 +1,11 @@
 import type { DomainWithMetadata, ScaleType } from 'ag-charts-core';
-import { aggregationDomain, aggregationXRatioForXValue, clamp } from 'ag-charts-core';
+import {
+    aggregationDomain,
+    aggregationXRatioForXValue,
+    clamp,
+    epochColumnForTimeScale,
+    narrowBigIntColumn,
+} from 'ag-charts-core';
 
 const SIZE_QUANTIZATION = 3;
 const FILTER_DATUM_THRESHOLD = 5;
@@ -332,16 +338,27 @@ export function aggregateBubbleDataFromDataModel(
     hasSizeKey: boolean,
     series: any
 ): BubbleAggregation | undefined {
-    const xValues = dataModel.resolveColumnById(series, 'xValue', processedData);
-    const yValues = dataModel.resolveColumnById(series, 'yValue', processedData);
-    const sizeValues = hasSizeKey ? dataModel.resolveColumnById(series, 'sizeValue', processedData) : undefined;
+    const rawXValues = dataModel.resolveColumnById(series, 'xValue', processedData, 'object');
+    const rawYValues = dataModel.resolveColumnById(series, 'yValue', processedData, 'mixed-numeric');
+    const sizeValues = hasSizeKey
+        ? dataModel.resolveColumnById(series, 'sizeValue', processedData, 'mixed-numeric')
+        : undefined;
 
     const xDomain = dataModel.getDomain(series, 'xValue', 'value', processedData);
     const yDomain = dataModel.getDomain(series, 'yValue', 'value', processedData);
     const sizeDomain = hasSizeKey ? sizeScale.domain : [0, 0];
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'yValue', processedData);
+
+    // Narrow bigints absolutely to match aggregationDomain's narrowing of the domain; parse ISO time x to epoch ms first.
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        xScale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const xValues = narrowBigIntColumn(epochXValues);
+    const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumn(rawYValues);
 
     return aggregateBubbleData(
         xScale,

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -20,6 +20,7 @@ import {
     isArray,
     measureTextSegments,
     rescaleVisibleRange,
+    toNumber,
     toPlainText,
 } from 'ag-charts-core';
 import {
@@ -396,7 +397,9 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         const { size, sizeKey } = properties;
         const x = this.axes[ChartAxisDirection.X]!.scale.convert(xValue);
         const sizeValues =
-            sizeKey == null ? undefined : this.dataModel!.resolveColumnById(this, `sizeValue`, this.processedData!);
+            sizeKey == null
+                ? undefined
+                : this.dataModel!.resolveColumnById(this, `sizeValue`, this.processedData!, 'mixed-numeric');
         const sizeValue = sizeValues == null ? size : sizeScale.convert(sizeValues[index]);
         const r = 0.5 * sizeValue * pixelSize;
         return [x - r, x + r];
@@ -407,7 +410,9 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         const { size, sizeKey } = properties;
         const y = this.axes[ChartAxisDirection.Y]!.scale.convert(yValues[0]);
         const sizeValues =
-            sizeKey == null ? undefined : this.dataModel!.resolveColumnById(this, `sizeValue`, this.processedData!);
+            sizeKey == null
+                ? undefined
+                : this.dataModel!.resolveColumnById(this, `sizeValue`, this.processedData!, 'mixed-numeric');
         const sizeValue = sizeValues == null ? size : sizeScale.convert(sizeValues[index]);
         const r = 0.5 * sizeValue * pixelSize;
         return [y - r, y + r];
@@ -436,8 +441,10 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         return { domain: fixNumericExtent(extent(ext)) };
     }
 
-    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]) {
-        return this.domainForVisibleRange(ChartAxisDirection.Y, ['yValue'], 'xValue', visibleRange);
+    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]): [number, number] {
+        // domainForVisibleRange may yield a bigint; narrow once for this number-typed range contract.
+        const [y0, y1] = this.domainForVisibleRange(ChartAxisDirection.Y, ['yValue'], 'xValue', visibleRange);
+        return [toNumber(y0), toNumber(y1)];
     }
 
     override getVisibleItems(
@@ -579,7 +586,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             labelTextDomain = [];
         }
 
-        const xDataValues = dataModel.resolveColumnById(this, `xValue`, processedData);
+        const xDataValues = dataModel.resolveColumnById(this, `xValue`, processedData, 'object');
 
         return {
             // Axes (from template method parameters)
@@ -590,17 +597,17 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             rawData,
             xValues: xDataValues, // Base interface field
             xDataValues, // BubbleSeries-specific alias
-            yDataValues: dataModel.resolveColumnById(this, `yValue`, processedData),
+            yDataValues: dataModel.resolveColumnById(this, `yValue`, processedData, 'object'),
             sizeDataValues:
-                sizeKey == null ? undefined : dataModel.resolveColumnById<number>(this, `sizeValue`, processedData),
+                sizeKey == null ? undefined : dataModel.resolveColumnById(this, `sizeValue`, processedData, 'number'),
             labelDataValues:
-                labelKey == null ? undefined : dataModel.resolveColumnById(this, `labelValue`, processedData),
+                labelKey == null ? undefined : dataModel.resolveColumnById(this, `labelValue`, processedData, 'object'),
             selectedDataValues:
                 selectedKey == null
                     ? undefined
-                    : dataModel.resolveColumnById<boolean>(this, `selectedValue`, processedData),
+                    : dataModel.resolveColumnById(this, `selectedValue`, processedData, 'boolean'),
             colorDataValues:
-                colorKey == null ? undefined : dataModel.resolveColumnById<number>(this, `colorValue`, processedData),
+                colorKey == null ? undefined : dataModel.resolveColumnById(this, `colorValue`, processedData, 'number'),
 
             // Scales
             xScale,
@@ -1368,8 +1375,8 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const datum = processedData.dataSources.get(this.id)?.data?.[datumIndex];
-        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData)[datumIndex];
+        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData, 'object')[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData, 'object')[datumIndex];
 
         const allowNullKeys = this.properties.allowNullKeys ?? false;
         if (xValue === undefined && !allowNullKeys) return;
@@ -1377,7 +1384,12 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         const data: TooltipContentDataRow[] = [];
 
         if (this.isLabelEnabled() && labelKey != null) {
-            const value = dataModel.resolveColumnById<number>(this, `labelValue`, processedData)[datumIndex];
+            const value = dataModel.resolveColumnById<string | number | Date>(
+                this,
+                `labelValue`,
+                processedData,
+                'object'
+            )[datumIndex];
             const content = formatManager.format(this.callWithContext.bind(this), {
                 type: 'category',
                 value,
@@ -1414,7 +1426,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             name: string | undefined,
             property: FormatterPropertyType
         ): number | undefined => {
-            const value = dataModel.resolveColumnById<number>(this, columnId, processedData)[datumIndex];
+            const value = dataModel.resolveColumnById(this, columnId, processedData, 'number')[datumIndex];
             if (value == null) return undefined;
             const domain = dataModel.getDomain(this, columnId, 'value', processedData).domain;
             const content = formatManager.format(this.callWithContext.bind(this), {

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -1481,7 +1481,9 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
             const x1 = xValues[i];
 
             if (x1 != null && x0 != null) {
-                const interval = x1.valueOf() - x0.valueOf();
+                // Narrow via Number so a bigint valueOf() doesn't throw under Math.sign/abs/min; a time
+                // interval is always within the Number-safe range (Date spans < 2^53 ms).
+                const interval = Number(x1.valueOf()) - Number(x0.valueOf());
                 const sign = Math.sign(interval) as 1 | 0 | -1;
                 if (sign === 0) continue;
                 if (sortOrder !== undefined && sign !== sortOrder) return; // Unsorted

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -13,8 +13,11 @@ import {
     findMinIndex,
     findMinMax,
     isFiniteNumber,
+    isFiniteNumericValue,
+    maxValue,
+    minValue,
 } from 'ag-charts-core';
-import type { AgDrawingMode, AgSeriesSegmentation, SelectionState } from 'ag-charts-types';
+import type { AgDrawingMode, AgNumericValue, AgSeriesSegmentation, SelectionState } from 'ag-charts-types';
 
 import type { HighlightNodeDatum } from '../../../core/eventsHub';
 import type { AnimationValue } from '../../../motion/animation';
@@ -1208,7 +1211,7 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         crossAxisKey: string,
         visibleRange: [any, any],
         indices?: number[]
-    ): [number, number] {
+    ): [AgNumericValue, AgNumericValue] {
         const { processedData, dataModel } = this;
 
         const [r0, r1] = visibleRange;
@@ -1222,17 +1225,18 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
 
         const allAxisValues = axisKeys.map((axisKey) => this.keysOrValues(axisKey));
 
-        let axisMin = Infinity;
-        let axisMax = -Infinity;
+        let axisMin: AgNumericValue = Infinity;
+        let axisMax: AgNumericValue = -Infinity;
         for (const [i, crossAxisValue] of crossAxisValues.entries()) {
             const [x0, x1] = this.xCoordinateRange(crossAxisValue, 0, i);
             if (x1 < r0 || x0 > r1) continue;
 
             for (let j = 0; j < axisKeys.length; j++) {
                 const axisValue = allAxisValues[j][i];
-                if (typeof axisValue === 'number' && Number.isFinite(axisValue)) {
-                    axisMin = Math.min(axisMin, axisValue);
-                    axisMax = Math.max(axisMax, axisValue);
+                // isFiniteNumericValue/minValue/maxValue include bigint and stay exact; Math.min/max would throw on bigint.
+                if (isFiniteNumericValue(axisValue)) {
+                    axisMin = minValue(axisMin, axisValue);
+                    axisMax = maxValue(axisMax, axisValue);
                 }
             }
         }
@@ -1240,7 +1244,11 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         return axisMin > axisMax ? [Number.NaN, Number.NaN] : [axisMin, axisMax];
     }
 
-    protected domainForClippedRange(direction: ChartAxisDirection, axisKeys: string[], crossAxisKey: string) {
+    protected domainForClippedRange(
+        direction: ChartAxisDirection,
+        axisKeys: string[],
+        crossAxisKey: string
+    ): AgNumericValue[] {
         const { processedData, dataModel, axes } = this;
 
         const crossDirection = direction === ChartAxisDirection.X ? ChartAxisDirection.Y : ChartAxisDirection.X;
@@ -1265,16 +1273,17 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         const allAxisValues = axisKeys.map((axisKey) => this.keysOrValues(axisKey));
         const range0 = crossAxisRange[0].valueOf();
         const range1 = crossAxisRange[1].valueOf();
-        let axisMin = Infinity;
-        let axisMax = -Infinity;
+        let axisMin: AgNumericValue = Infinity;
+        let axisMax: AgNumericValue = -Infinity;
         for (const [i, crossAxisValue] of crossAxisValues.entries()) {
             const c = crossAxisValue.valueOf();
             if (c < range0 || c > range1) continue;
             for (let j = 0; j < axisKeys.length; j++) {
                 const axisValue = allAxisValues[j][i];
-                if (typeof axisValue === 'number' && Number.isFinite(axisValue)) {
-                    axisMin = Math.min(axisMin, axisValue);
-                    axisMax = Math.max(axisMax, axisValue);
+                // isFiniteNumericValue/minValue/maxValue include bigint and stay exact; Math.min/max would throw on bigint.
+                if (isFiniteNumericValue(axisValue)) {
+                    axisMin = minValue(axisMin, axisValue);
+                    axisMax = maxValue(axisMax, axisValue);
                 }
             }
         }
@@ -1369,7 +1378,9 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         if (!dataModel || !processedData) return Infinity;
 
         const crossValues = this.keysOrValues(crossAxisKey);
-        const allAxisValues = axisKeys.map((axisKey) => dataModel.resolveColumnById(this, axisKey, processedData));
+        const allAxisValues = axisKeys.map((axisKey) =>
+            dataModel.resolveColumnById(this, axisKey, processedData, 'object')
+        );
 
         const shouldFlipXY = this.shouldFlipXY();
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -5,19 +5,25 @@ import {
     type Mutable,
     type Point,
     type RequireOptional,
+    addValues,
+    createBigIntBins,
     createTicks,
     deepClone,
     findMinMax,
+    isBigInt,
     isDate,
     isNumber,
+    maxValue,
     mergeDefaults,
     tickStep,
+    toNumber,
 } from 'ag-charts-core';
 import type {
     AgHistogramSeriesBinParams,
     AgHistogramSeriesLabelFormatterParams,
     AgHistogramSeriesOptions,
     AgHistogramSeriesStyle,
+    AgNumericValue,
     SelectionState as PublicSelectionState,
 } from 'ag-charts-types';
 
@@ -31,7 +37,7 @@ import { Rect } from '../../../scene/shape/rect';
 import type { Text } from '../../../scene/shape/text';
 import type { QuadtreeNearest } from '../../../scene/util/quadtree';
 import type { ChartAxis } from '../../chartAxis';
-import { area, groupAverage, groupCount, groupSum } from '../../data/aggregateFunctions';
+import { addAccumulated, area, groupAverage, groupCount, groupSum } from '../../data/aggregateFunctions';
 import type { DataController } from '../../data/dataController';
 import type {
     AggregatePropertyDefinition,
@@ -88,18 +94,26 @@ import { addHitTestersToQuadtree, findQuadtreeMatch } from './quadtreeUtil';
 
 const defaultBinCount = 10;
 
+/** True when a value can be converted to a BigInt without throwing — a bigint, or an integral number. */
+function isBigIntConvertible(value: AgNumericValue): boolean {
+    return typeof value === 'bigint' || Number.isInteger(value);
+}
+
 type HistogramAnimationData = CartesianAnimationDataOf<HistogramSeriesTypes>;
 
+/** Bin boundaries are `bigint` for a BigInt x-column and `number` otherwise. */
+type BinDomain = [AgNumericValue, AgNumericValue];
+
 interface CalculatedBin {
-    domain: [number, number];
+    domain: BinDomain;
     /** Zero-based positional index of the bin within the series; defined for every bin, including empty ones. */
     binIndex: number;
     datum: any[];
     frequency: number;
-    /** Bar height value; area-adjusted when areaPlot is enabled. */
-    total: number;
+    /** Bar height value; area-adjusted when areaPlot is enabled. Kept exact (bigint) for a summed bigint yKey column. */
+    total: AgNumericValue;
     /** Raw aggregated yKey value, independent of areaPlot. */
-    aggregatedValue: number;
+    aggregatedValue: AgNumericValue;
 }
 
 interface HistogramSeriesNodeDataContext extends CartesianSeriesNodeDataContext<HistogramNodeDatum> {
@@ -132,8 +146,8 @@ interface HistogramSeriesNodeDatumContext extends CartesianCreateNodeDataContext
 
 class HistogramSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends CartesianSeriesNodeEvent<TEvent> {
     readonly binIndex: number;
-    readonly binRange: [number, number];
-    readonly aggregatedValue: number;
+    readonly binRange: [AgNumericValue, AgNumericValue];
+    readonly aggregatedValue: AgNumericValue;
     readonly frequency: number;
 
     constructor(
@@ -180,6 +194,26 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
 
     override get hasData(): boolean {
         return this.calculatedBins.length > 0;
+    }
+
+    private computeBins(xExtent: AgNumericValue[]): BinDomain[] {
+        const x0 = xExtent[0];
+        const x1 = xExtent[1];
+        // BigInt boundaries need both endpoints integral, else BigInt() throws — fall back to the Number path.
+        const bigIntExtent = (isBigInt(x0) || isBigInt(x1)) && isBigIntConvertible(x0) && isBigIntConvertible(x1);
+
+        if (isNumber(this.properties.binCount)) {
+            return bigIntExtent
+                ? createBigIntBins(BigInt(x0), BigInt(x1), this.properties.binCount)
+                : this.calculateNiceBins([Number(x0), Number(x1)], this.properties.binCount);
+        }
+
+        return (
+            this.properties.bins ??
+            (bigIntExtent
+                ? createBigIntBins(BigInt(x0), BigInt(x1), defaultBinCount)
+                : this.deriveBins([Number(x0), Number(x1)]))
+        );
     }
 
     // During processData phase, used to unify different ways of the user specifying
@@ -277,7 +311,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             props.push(makeAggregate('rawAgg'));
         }
 
-        let calculatedBinDomains: [number, number][] = [];
+        let calculatedBinDomains: BinDomain[] = [];
         const groupByFn: GroupByFn = (dataSet) => {
             const xExtent = fixNumericExtent(dataSet.domain.keys[0]);
             if (xExtent.length === 0) {
@@ -286,9 +320,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                 return () => [];
             }
 
-            const bins = isNumber(this.properties.binCount)
-                ? this.calculateNiceBins(xExtent, this.properties.binCount)
-                : (this.properties.bins ?? this.deriveBins(xExtent));
+            const bins = this.computeBins(xExtent);
             const binCount = bins.length;
             calculatedBinDomains = [...bins];
 
@@ -297,7 +329,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                 if (isDate(xValue)) {
                     xValue = xValue.getTime();
                 }
-                if (!isNumber(xValue)) return [];
+                if (!isNumber(xValue) && typeof xValue !== 'bigint') return [];
 
                 for (let i = 0; i < binCount; i++) {
                     const nextBin = bins[i];
@@ -335,9 +367,10 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                 const [groupAgg = [0, 0], rawAgg] = group.aggregation;
                 const datum = [...dataModel.forEachDatum(this, processedData, group, groupIndex)];
                 const frequency = this.frequency(group);
-                const total = groupAgg[0] + groupAgg[1];
+                // addAccumulated keeps bigint sums exact and tolerates a Number-seeded unused-sign accumulator.
+                const total = addAccumulated(groupAgg[0], groupAgg[1]);
                 // `aggregatedValue` ignores areaPlot's width-division (see `rawAgg` in processData).
-                const aggregatedValue = rawAgg ? rawAgg[0] + rawAgg[1] : total;
+                const aggregatedValue = rawAgg ? addAccumulated(rawAgg[0], rawAgg[1]) : total;
                 return { domain, datum, binIndex, frequency, total, aggregatedValue };
             } else {
                 return { domain, datum: [], binIndex, frequency: 0, total: 0, aggregatedValue: 0 };
@@ -377,7 +410,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         const xScale = this.axes[ChartAxisDirection.X]!.scale;
 
         const yMin = 0;
-        let yMax = -Infinity;
+        let yMax: AgNumericValue = -Infinity;
         for (const { keys, aggregation } of processedData.groups) {
             const [[negativeAgg, positiveAgg] = [0, 0]] = aggregation;
             const [xDomainMin, xDomainMax] = keys;
@@ -385,14 +418,14 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             const [x0, x1] = findMinMax([xScale.convert(xDomainMin), xScale.convert(xDomainMax)]);
 
             if (x1 >= r0 && x0 <= r1) {
-                const total = negativeAgg + positiveAgg;
-                yMax = Math.max(yMax, total);
+                // Sum exactly (operands may be bigint); toNumber narrows the number-typed return once below.
+                yMax = maxValue(yMax, addValues(negativeAgg, positiveAgg));
             }
         }
 
         if (yMin > yMax) return [Number.NaN, Number.NaN];
 
-        return [yMin, yMax];
+        return [yMin, toNumber(yMax)];
     }
 
     private frequency(group: DataGroup) {
@@ -504,7 +537,8 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             binIndex,
             binRange,
             aggregatedValue,
-            cumulativeValue: total,
+            // cumulativeValue is the plotted bar height (crosshair geometry); narrow to Number like other series.
+            cumulativeValue: Number(total),
             frequency,
             yKey,
             xKey,
@@ -550,7 +584,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         mutableNode.datum = datum;
         mutableNode.binIndex = binIndex;
         mutableNode.aggregatedValue = aggregatedValue;
-        mutableNode.cumulativeValue = total;
+        mutableNode.cumulativeValue = Number(total);
         mutableNode.frequency = frequency;
         mutableNode.binRange = binRange;
         mutableNode.x = x;
@@ -797,7 +831,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         }
         const { frequency, aggregatedValue, datum } = bin;
         const binRange = bin.domain;
-        const [rangeMin, rangeMax]: number[] = binRange;
+        const [rangeMin, rangeMax]: AgNumericValue[] = binRange;
 
         const data: TooltipContentDataRow[] = [
             {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -13,6 +13,7 @@ import {
     isBigInt,
     isDate,
     isNumber,
+    isNumericValue,
     maxValue,
     mergeDefaults,
     tickStep,
@@ -329,7 +330,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                 if (isDate(xValue)) {
                     xValue = xValue.getTime();
                 }
-                if (!isNumber(xValue) && typeof xValue !== 'bigint') return [];
+                if (!isNumericValue(xValue)) return [];
 
                 for (let i = 0; i < binCount; i++) {
                     const nextBin = bins[i];

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -500,7 +500,8 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         const { label, yKey, xKey, xName, yName } = ctx;
         const { total, datum } = bin;
 
-        if (!label.enabled || total === 0) {
+        // Number() coercion: a bigint `0n` total is an empty bin too, but `0n === 0` is false.
+        if (!label.enabled || Number(total) === 0) {
             return undefined;
         }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
@@ -6,6 +6,7 @@ import type {
     AgHistogramSeriesOptions,
     AgHistogramSeriesStyle,
     AgHistogramSeriesTooltipRendererParams,
+    AgNumericValue,
 } from 'ag-charts-types';
 
 import type { BBox } from '../../../scene/bbox';
@@ -16,8 +17,7 @@ import { CartesianSeriesProperties } from './cartesianSeries';
 import type { CartesianSeriesNodeDatum } from './cartesianSeriesTypes';
 
 export interface HistogramNodeDatum extends CartesianSeriesNodeDatum {
-    // Bins are aggregated from many datums, so they carry an explicit stable id rather than
-    // relying on the data-model `datumIndex`/`dataIdKey` matching used by 1:1 series.
+    // Bins aggregate many datums, so they carry an explicit stable id rather than the 1:1-series datumIndex match.
     readonly itemId: string;
     readonly x: number;
     readonly y: number;
@@ -29,8 +29,8 @@ export interface HistogramNodeDatum extends CartesianSeriesNodeDatum {
     readonly bottomLeftCornerRadius: boolean;
     readonly clipBBox?: BBox;
     readonly binIndex: number;
-    readonly binRange: [number, number];
-    readonly aggregatedValue: number;
+    readonly binRange: [AgNumericValue, AgNumericValue];
+    readonly aggregatedValue: AgNumericValue;
     // Plotted bar height the crosshair snaps to (area-adjusted); the raw value is `aggregatedValue`.
     readonly cumulativeValue: number;
     readonly frequency: number;

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineAggregation.ts
@@ -15,6 +15,7 @@ import {
     compactAggregationIndices,
     createAggregationIndices,
     epochColumnForTimeScale,
+    narrowBigIntColumn,
     narrowBigIntColumnRelative,
     nextPowerOf2,
     simpleMemorize2,
@@ -394,11 +395,14 @@ export function aggregateLineDataFromDataModel(
     const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
@@ -443,11 +447,14 @@ export function aggregateLineDataFromDataModelPartial(
     const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineAggregation.ts
@@ -5,9 +5,7 @@ import {
     AGGREGATION_INDEX_Y_MIN,
     AGGREGATION_MIN_RANGE,
     AGGREGATION_THRESHOLD,
-    type DomainWithMetadata,
     type ScaleType,
-    aggregationDomain,
     aggregationIndexForXRatio,
     aggregationRangeFittingPoints,
     aggregationXRatioForDatumIndex,
@@ -15,7 +13,7 @@ import {
     compactAggregationIndices,
     createAggregationIndices,
     epochColumnForTimeScale,
-    narrowBigIntColumn,
+    narrowAggregationX,
     narrowBigIntColumnRelative,
     nextPowerOf2,
     simpleMemorize2,
@@ -347,14 +345,13 @@ export function computeLineAggregationPartial(
  * @internal
  */
 function aggregateLineData(
-    scale: ScaleType,
     xValues: any[],
     yValues: any[],
-    domainInput: DomainWithMetadata<any>,
+    d0: number,
+    d1: number,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): LineSeriesDataAggregationFilter[] | undefined {
-    const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeLineAggregation([d0, d1], xValues, yValues, { xNeedsValueOf, yNeedsValueOf });
 }
 
@@ -400,22 +397,21 @@ export function aggregateLineDataFromDataModel(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
-        const [d0, d1] = aggregationDomain(scale, domainInput);
-        return computeLineAggregation([d0, d1], xValues, yValues, {
+        return computeLineAggregation(domain, xValues, yValues, {
             xNeedsValueOf,
             yNeedsValueOf,
             existingFilters,
         });
     }
 
-    return memoizedAggregateLineData(scale, xValues, yValues, domainInput, xNeedsValueOf, yNeedsValueOf);
+    return memoizedAggregateLineData(xValues, yValues, domain[0], domain[1], xNeedsValueOf, yNeedsValueOf);
 }
 
 /**
@@ -452,13 +448,10 @@ export function aggregateLineDataFromDataModelPartial(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
-    const [d0, d1] = aggregationDomain(scale, domainInput);
-    return computeLineAggregationPartial([d0, d1], xValues, yValues, {
+    return computeLineAggregationPartial(domain, xValues, yValues, {
         xNeedsValueOf,
         yNeedsValueOf,
         targetRange,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineAggregation.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineAggregation.ts
@@ -14,6 +14,8 @@ import {
     aggregationXRatioForXValue,
     compactAggregationIndices,
     createAggregationIndices,
+    epochColumnForTimeScale,
+    narrowBigIntColumnRelative,
     nextPowerOf2,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -385,12 +387,19 @@ export function aggregateLineDataFromDataModel(
     series: ScopeProvider,
     existingFilters?: LineSeriesDataAggregationFilter[]
 ): LineSeriesDataAggregationFilter[] | undefined {
-    const xValues = dataModel.resolveColumnById(series, 'xValue', processedData);
-    const yValues = dataModel.resolveColumnById(series, yKey, processedData);
+    const rawXValues = dataModel.resolveColumnById(series, 'xValue', processedData, 'object');
+    const rawYValues = dataModel.resolveColumnById(series, yKey, processedData, 'mixed-numeric');
     const domainInput = dataModel.getDomain(series, 'xValue', 'value', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
@@ -427,12 +436,19 @@ export function aggregateLineDataFromDataModelPartial(
     targetRange: number,
     existingFilters?: LineSeriesDataAggregationFilter[]
 ): PartialLineAggregationResult | undefined {
-    const xValues = dataModel.resolveColumnById(series, 'xValue', processedData);
-    const yValues = dataModel.resolveColumnById(series, yKey, processedData);
+    const rawXValues = dataModel.resolveColumnById(series, 'xValue', processedData, 'object');
+    const rawYValues = dataModel.resolveColumnById(series, yKey, processedData, 'mixed-numeric');
     const domainInput = dataModel.getDomain(series, 'xValue', 'value', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, yKey, processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const yValues = yNeedsValueOf ? rawYValues : narrowBigIntColumnRelative(rawYValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeLineAggregationPartial([d0, d1], xValues, yValues, {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -6,6 +6,7 @@ import {
     extent,
     isDefined,
     mergeDefaults,
+    toNumber,
 } from 'ag-charts-core';
 import {
     type AgDrawingMode,
@@ -33,7 +34,7 @@ import { NumberAxis } from '../../axis/numberAxis';
 import type { ChartAxis } from '../../chartAxis';
 import type { DataController } from '../../data/dataController';
 import type { DataModel, DataModelOptions, DatumPropertyDefinition, ProcessedData } from '../../data/dataModel';
-import { fixNumericExtent } from '../../data/dataModel';
+import { extendDomainToZero, fixNumericExtent } from '../../data/dataModel';
 import {
     animationValidation,
     createDatumId,
@@ -321,22 +322,21 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         );
 
         if (this.isNormalized() && yAxis instanceof NumberAxis && !(yAxis instanceof LogAxis)) {
-            const fixedYExtent = Number.isFinite(yExtent[1] - yExtent[0])
-                ? [Math.min(yExtent[0], 0), Math.max(yExtent[1], 0)]
-                : [];
-            return { domain: fixNumericExtent(fixedYExtent) };
+            return { domain: fixNumericExtent(extendDomainToZero(yExtent)) };
         } else {
             return { domain: fixNumericExtent(yExtent) };
         }
     }
 
-    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]) {
-        return this.domainForVisibleRange(
+    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]): [number, number] {
+        // domainForVisibleRange may yield a bigint; narrow once for this number-typed range contract.
+        const [y0, y1] = this.domainForVisibleRange(
             ChartAxisDirection.Y,
             [this.yCumulativeKey(this.processedData!)],
             'xValue',
             visibleRange
         );
+        return [toNumber(y0), toNumber(y1)];
     }
 
     override getZoomRangeFittingItems(
@@ -460,11 +460,16 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
             xAxis,
             yAxis,
             rawData,
-            xValues: dataModel.resolveColumnById(this, 'xValue', processedData),
-            yRawValues: dataModel.resolveColumnById(this, 'yValueRaw', processedData),
-            yCumulativeValues: dataModel.resolveColumnById(this, this.yCumulativeKey(processedData), processedData),
+            xValues: dataModel.resolveColumnById(this, 'xValue', processedData, 'object'),
+            yRawValues: dataModel.resolveColumnById(this, 'yValueRaw', processedData, 'mixed-numeric'),
+            yCumulativeValues: dataModel.resolveColumnById(
+                this,
+                this.yCumulativeKey(processedData),
+                processedData,
+                'mixed-numeric'
+            ),
             selectionValues: this.properties.selectedKey
-                ? dataModel.resolveColumnById(this, 'selectedRaw', processedData)
+                ? dataModel.resolveColumnById(this, 'selectedRaw', processedData, 'boolean')
                 : undefined,
             xScale,
             yScale,
@@ -540,7 +545,8 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 (existingNode as any).datumIndex = datumIndex;
                 (existingNode as any).point = { x: scratch.x, y: scratch.y, size: ctx.size };
                 (existingNode as any).midPoint = { x: scratch.x, y: scratch.y };
-                (existingNode as any).cumulativeValue = scratch.yCumulative;
+                // Metadata only; position already used the exact bigint, so narrowing here is fine.
+                (existingNode as any).cumulativeValue = Number(scratch.yCumulative);
                 (existingNode as any).yValue = scratch.yDatum;
                 (existingNode as any).xValue = scratch.xDatum;
                 (existingNode as any).labelText = labelText;
@@ -554,7 +560,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                     xKey: ctx.xKey,
                     point: { x: scratch.x, y: scratch.y, size: ctx.size },
                     midPoint: { x: scratch.x, y: scratch.y },
-                    cumulativeValue: scratch.yCumulative,
+                    cumulativeValue: Number(scratch.yCumulative),
                     yValue: scratch.yDatum,
                     xValue: scratch.xDatum,
                     capDefaults: ctx.capDefaults,
@@ -838,8 +844,8 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
             marker,
             hideWithSize0,
             isHighlight,
-            xColumn: dataModel.resolveColumnById<any>(this, 'xValue', processedData),
-            yColumn: dataModel.resolveColumnById<any>(this, 'yValueRaw', processedData),
+            xColumn: dataModel.resolveColumnById(this, 'xValue', processedData, 'object'),
+            yColumn: dataModel.resolveColumnById(this, 'yValueRaw', processedData, 'mixed-numeric'),
             xDomain: dataModel.getDomain(this, 'xValue', 'key', processedData).domain,
             yDomain: dataModel.getDomain(this, this.yCumulativeKey(processedData), 'value', processedData).domain,
             xKey,
@@ -981,8 +987,8 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
     ): AgLineSeriesMarkerItemStylerParams<unknown, unknown> {
         const { xKey, yKey } = this.properties;
 
-        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData)[datumIndex];
+        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData, 'object')[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData, 'mixed-numeric')[datumIndex];
         const xDomain = dataModel.getDomain(this, `xValue`, 'key', processedData).domain;
         const yDomain = dataModel.getDomain(this, this.yCumulativeKey(processedData), 'value', processedData).domain;
         const fill = this.filterItemStylerFillParams(style.fill) ?? style.fill;
@@ -1011,8 +1017,8 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const datum = processedData.dataSources.get(this.id)?.data?.[datumIndex];
-        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData)[datumIndex];
+        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData, 'object')[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValueRaw`, processedData, 'mixed-numeric')[datumIndex];
 
         if (xValue === undefined && !allowNullKeys) return;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -8,7 +8,7 @@ import {
     spanRange,
     stepPoints,
 } from 'ag-charts-core';
-import type { AgSeriesMarkerStyle } from 'ag-charts-types';
+import type { AgNumericValue, AgSeriesMarkerStyle } from 'ag-charts-types';
 
 import { type FromToFns, NODE_UPDATE_STATE_TO_PHASE_MAPPING, type NodeUpdateState } from '../../../motion/fromToMotion';
 import type { Path } from '../../../scene/shape/path';
@@ -79,8 +79,8 @@ export interface LineSeriesDatumContext extends CartesianMarkerLikeContext<LineN
     readonly yKey: string;
 
     // Additional data arrays specific to line series
-    readonly yRawValues: any[];
-    readonly yCumulativeValues: any[];
+    readonly yRawValues: AgNumericValue[];
+    readonly yCumulativeValues: AgNumericValue[];
     readonly selectionValues: ArrayLike<any> | undefined;
 
     // Pre-computed values (computed once, reused for all datums)
@@ -109,7 +109,8 @@ export interface LineNodeDatumScratch {
     datum: any;
     xDatum: any;
     yDatum: any;
-    yCumulative: number;
+    // Kept raw (possibly bigint) so yScale.convert() positions values beyond Number.MAX_VALUE proportionally.
+    yCumulative: AgNumericValue;
     selected: boolean | undefined;
     x: number;
     y: number;

--- a/packages/ag-charts-community/src/chart/series/cartesian/util.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/util.ts
@@ -6,7 +6,8 @@ import {
     isArray,
     isDate,
     isEmptyObject,
-    isNumber,
+    isISO8601,
+    isNumericValue,
     isObject,
     isString,
 } from 'ag-charts-core';
@@ -195,13 +196,13 @@ function predictGroupedCategoryAxisType(value: unknown) {
 }
 
 function predictTimeAxisType(key: string, value: unknown) {
-    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && isNumber(value))) {
+    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && (isNumericValue(value) || isISO8601(value)))) {
         return CARTESIAN_AXIS_TYPE.TIME;
     }
 }
 
 function predictOrdinalTimeAxisType(key: string, value: unknown) {
-    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && isNumber(value))) {
+    if (isDate(value) || (TIME_AXIS_KEYS.has(key) && (isNumericValue(value) || isISO8601(value)))) {
         return CARTESIAN_AXIS_TYPE.ORDINAL_TIME;
     }
 }

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -16,8 +16,7 @@ import { type SeriesNodeDatum } from './seriesTypes';
 import { findNodeDatumInArray } from './util';
 
 export interface DataModelSeriesNodeDatum extends SeriesNodeDatum {
-    // Data-model series identify nodes by their numeric `datumIndex` (and chart-level `dataIdKey`).
-    // The exception is aggregated series such as histogram, whose bins carry an explicit stable id.
+    // Optional: only aggregated series (e.g. histogram bins) set it; 1:1 series match on datumIndex instead.
     itemId?: string;
 }
 
@@ -218,7 +217,7 @@ export abstract class DataModelSeries<
         if (!dataModel || !processedData) return [];
         return this.dataModelPropertyIsKey(xKey)
             ? dataModel.resolveKeysById(this, xKey, processedData)
-            : dataModel.resolveColumnById(this, xKey, processedData);
+            : dataModel.resolveColumnById(this, xKey, processedData, 'object');
     }
 
     protected sortOrder(xKey: string): -1 | 1 | undefined {

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeries.ts
@@ -1,5 +1,15 @@
 import type { ChartAnimationPhase, DynamicContext } from 'ag-charts-core';
-import { Logger, type Point, StateMachine, arraysEqual, clamp, mergeDefaults } from 'ag-charts-core';
+import {
+    Logger,
+    type Point,
+    StateMachine,
+    arraysEqual,
+    clamp,
+    isFiniteNumericValue,
+    isNumericValue,
+    mergeDefaults,
+    toNumber,
+} from 'ag-charts-core';
 import type { AgActiveItemState, FillOptions, StrokeOptions } from 'ag-charts-types';
 
 import type { HighlightNodeDatum } from '../../../core/eventsHub';
@@ -201,9 +211,10 @@ export abstract class HierarchySeries<
             const children = childrenKey == null ? undefined : datum[childrenKey];
             const isLeaf = children == null || children.length === 0;
 
+            // Accept bigint sizes (coerced to Number) so out-of-safe-range integers still drive tile area.
             let sizeValue = sizeKey == null ? undefined : datum[sizeKey];
-            if (Number.isFinite(sizeValue)) {
-                sizeValue = Math.max(sizeValue, 0);
+            if (isFiniteNumericValue(sizeValue)) {
+                sizeValue = Math.max(toNumber(sizeValue), 0);
             } else {
                 sizeValue = isLeaf ? 1 : 0;
             }
@@ -211,8 +222,9 @@ export abstract class HierarchySeries<
             const sumSize = sizeValue;
             maxDepth = Math.max(maxDepth, depth);
 
-            const colorValue = colorKey == null ? undefined : datum[colorKey];
-            if (typeof colorValue === 'number') {
+            let colorValue = colorKey == null ? undefined : datum[colorKey];
+            if (isNumericValue(colorValue)) {
+                colorValue = toNumber(colorValue);
                 minColor = Math.min(minColor, colorValue);
                 maxColor = Math.max(maxColor, colorValue);
             }

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -20,6 +20,7 @@ import {
     mergeDefaults,
     modulus,
     normalizeAngle180,
+    toNumber,
     toPlainText,
     toRadians,
     wrapTextOrSegments,
@@ -33,6 +34,7 @@ import type {
     AgDonutSeriesOptions,
     AgDonutSeriesStyle,
     AgDrawingMode,
+    AgNumericValue,
     AgPieSeriesItemStylerParams,
     AgPieSeriesLabelFormatterParams,
     AgPieSeriesStyle,
@@ -121,8 +123,8 @@ interface PieDonutNodeDatum extends DataModelSeriesNodeDatum {
     readonly radius: number; // in the [0, 1] range
     readonly innerRadius: number;
     readonly outerRadius: number;
-    readonly angleValue: number;
-    readonly radiusValue?: number;
+    readonly angleValue: AgNumericValue;
+    readonly radiusValue?: AgNumericValue;
     readonly startAngle: number;
     readonly endAngle: number;
     readonly midAngle: number;
@@ -145,11 +147,11 @@ interface PieDonutNodeDatum extends DataModelSeriesNodeDatum {
 
 interface ProcessedDataValues {
     angleValues: number[];
-    angleRawValues: number[];
+    angleRawValues: AgNumericValue[];
     angleFilterValues: number[] | undefined;
     angleFilterRawValues: number[] | undefined;
     radiusValues: number[] | undefined;
-    radiusRawValues: number[] | undefined;
+    radiusRawValues: AgNumericValue[] | undefined;
     calloutLabelValues: string[] | undefined;
     sectorLabelValues: string[] | undefined;
     legendItemValues: string[] | undefined;
@@ -412,30 +414,31 @@ export class DonutSeries extends PolarSeries<
     }
 
     private getProcessedDataValues(dataModel: DataModel<any>, processedData: ProcessedData<any>) {
-        const angleValues = dataModel.resolveColumnById<number>(this, `angleValue`, processedData);
-        const angleRawValues = dataModel.resolveColumnById<number>(this, `angleRaw`, processedData);
+        const angleValues = dataModel.resolveColumnById(this, `angleValue`, processedData, 'number');
+        // Mixed-numeric so a bigint datum reaches the node datum and tooltip exactly.
+        const angleRawValues = dataModel.resolveColumnById(this, `angleRaw`, processedData, 'mixed-numeric');
         const angleFilterValues =
             this.properties.angleFilterKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `angleFilterValue`, processedData);
+                : dataModel.resolveColumnById(this, `angleFilterValue`, processedData, 'number');
         const angleFilterRawValues =
             this.properties.angleFilterKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `angleFilterRaw`, processedData);
+                : dataModel.resolveColumnById(this, `angleFilterRaw`, processedData, 'number');
         const radiusValues = this.properties.radiusKey
-            ? dataModel.resolveColumnById<number>(this, `radiusValue`, processedData)
+            ? dataModel.resolveColumnById(this, `radiusValue`, processedData, 'number')
             : undefined;
         const radiusRawValues = this.properties.radiusKey
-            ? dataModel.resolveColumnById<number>(this, `radiusRaw`, processedData)
+            ? dataModel.resolveColumnById(this, `radiusRaw`, processedData, 'mixed-numeric')
             : undefined;
         const calloutLabelValues = this.properties.calloutLabelKey
-            ? dataModel.resolveColumnById<string>(this, `calloutLabelValue`, processedData)
+            ? dataModel.resolveColumnById<string>(this, `calloutLabelValue`, processedData, 'object')
             : undefined;
         const sectorLabelValues = this.properties.sectorLabelKey
-            ? dataModel.resolveColumnById<string>(this, `sectorLabelValue`, processedData)
+            ? dataModel.resolveColumnById<string>(this, `sectorLabelValue`, processedData, 'object')
             : undefined;
         const legendItemValues = this.properties.legendItemKey
-            ? dataModel.resolveColumnById<string>(this, `legendItemValue`, processedData)
+            ? dataModel.resolveColumnById<string>(this, `legendItemValue`, processedData, 'object')
             : undefined;
 
         return {
@@ -491,7 +494,8 @@ export class DonutSeries extends PolarSeries<
             const currentValue = useFilterAngles ? angleFilterValues![datumIndex] : angleValues[datumIndex];
             const crossFilterScale =
                 angleFilterRawValues != null && !useFilterAngles
-                    ? Math.sqrt(angleFilterRawValues[datumIndex] / angleRawValues[datumIndex])
+                    ? // Narrow so a bigint raw angle divides as a float rather than truncating (or throwing in Math.sqrt).
+                      Math.sqrt(toNumber(angleFilterRawValues[datumIndex]) / toNumber(angleRawValues[datumIndex]))
                     : 1;
 
             const startAngle = angleScale.convert(currentStart) + toRadians(rotation);

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -17,6 +17,7 @@ import type {
     AgAutoScaledAxes,
     AgCartesianAxisPosition,
     AgContextMenuItemShowOn,
+    AgNumericValue,
     AgScrollbarPlacement,
     AgTimeInterval,
     AgTimeIntervalUnit,
@@ -420,7 +421,7 @@ export interface HighlightNodeDatum extends SeriesNodeDatum {
     readonly radiusKey?: string;
     readonly colorValue?: number;
     readonly cumulativeValue?: number;
-    readonly aggregatedValue?: number;
+    readonly aggregatedValue?: AgNumericValue;
     readonly legendItemName?: string;
 }
 

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -144,6 +144,7 @@ export { generateTicks } from './chart/axis/generateTicks';
 export { DataController } from './chart/data/dataController';
 export { DataModel, fixNumericExtent, getMissCount } from './chart/data/dataModel';
 export type {
+    ColumnValueType,
     DatumPropertyDefinition,
     GroupedData,
     ProcessedData,

--- a/packages/ag-charts-community/src/scale/abstractScale.ts
+++ b/packages/ag-charts-community/src/scale/abstractScale.ts
@@ -17,6 +17,12 @@ export abstract class AbstractScale<D, R, I = number> implements Scale<D, R, I> 
     abstract convert(value: D, options: { clamp?: boolean; alignment?: ScaleAlignment }): R;
     abstract invert(value: R, nearest?: boolean): D | undefined;
     abstract getDomainMinMax(): [D, D] | [undefined, undefined];
+    get domainMin(): D | undefined {
+        return this.getDomainMinMax()[0];
+    }
+    get domainMax(): D | undefined {
+        return this.getDomainMinMax()[1];
+    }
     ticks(
         _ticks: ScaleTickParams<I>,
         _domain?: D[],

--- a/packages/ag-charts-community/src/scale/colorScale.ts
+++ b/packages/ag-charts-community/src/scale/colorScale.ts
@@ -1,5 +1,6 @@
 import type { DomainWithMetadata, NormalizedDomain } from 'ag-charts-core';
-import { Color, Logger, clamp } from 'ag-charts-core';
+import { Color, Logger, clamp, toNumber } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { AbstractScale } from './abstractScale';
 import { Invalidating } from './invalidating';
@@ -58,7 +59,7 @@ export class ColorScale extends AbstractScale<number, string> {
      * `domain` (which carries interpolation pivots) so that colour-stop
      * positions do not distort the legend axis range.
      */
-    displayDomain?: [number, number];
+    displayDomain?: [AgNumericValue, AgNumericValue];
 
     private parsedRange = this.range.map(convertColorStringToOklcha);
 
@@ -103,8 +104,11 @@ export class ColorScale extends AbstractScale<number, string> {
         return;
     }
 
-    convert(x: number) {
+    convert(x: AgNumericValue) {
         this.refresh();
+
+        // Colour derives from the value's position in the Number domain, so finite precision suffices.
+        const xn = toNumber(x);
 
         const { domain, range, parsedRange } = this;
         const d0 = domain[0];
@@ -112,11 +116,11 @@ export class ColorScale extends AbstractScale<number, string> {
         const r0 = range[0];
         const r1 = range.at(-1)!;
 
-        if (x <= d0) {
+        if (xn <= d0) {
             return r0;
         }
 
-        if (x >= d1) {
+        if (xn >= d1) {
             return r1;
         }
 
@@ -124,19 +128,19 @@ export class ColorScale extends AbstractScale<number, string> {
         let q: number;
 
         if (domain.length === 2) {
-            const t = (x - d0) / (d1 - d0);
+            const t = (xn - d0) / (d1 - d0);
             const step = 1 / (range.length - 1);
             index = range.length <= 2 ? 0 : Math.min(Math.floor(t * (range.length - 1)), range.length - 2);
             q = (t - index * step) / step;
         } else {
             for (index = 0; index < domain.length - 2; index++) {
-                if (x < domain[index + 1]) {
+                if (xn < domain[index + 1]) {
                     break;
                 }
             }
             const a = domain[index];
             const b = domain[index + 1];
-            q = (x - a) / (b - a);
+            q = (xn - a) / (b - a);
         }
 
         if (this.mode === 'discrete') {

--- a/packages/ag-charts-community/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-community/src/scale/colorScaleUtil.ts
@@ -1,4 +1,5 @@
 import { type ColorScaleColorStop, type ColorScaleMode, computeColorBins } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { ColorScale } from './colorScale';
 
@@ -9,13 +10,13 @@ export function configureColorScale(
         domain?: [number, number];
         mode: ColorScaleMode;
     },
-    dataDomain: number[]
+    dataDomain: AgNumericValue[]
 ): void {
     if (dataDomain.length < 2) return;
     if (colorScaleProps.fills.length === 0) return;
 
-    const domainTuple: [number, number] = [dataDomain[0], dataDomain.at(-1)!];
-    const displayDomain: [number, number] = colorScaleProps.domain ?? domainTuple;
+    const domainTuple: [AgNumericValue, AgNumericValue] = [dataDomain[0], dataDomain.at(-1)!];
+    const displayDomain: [AgNumericValue, AgNumericValue] = colorScaleProps.domain ?? domainTuple;
 
     const { domain, range } = computeColorBins(colorScaleProps.fills, displayDomain, colorScaleProps.mode);
     colorScale.mode = colorScaleProps.mode;

--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -1,10 +1,15 @@
 import type { DomainWithMetadata, NormalizedDomain } from 'ag-charts-core';
 import { findMinMax } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { AbstractScale } from './abstractScale';
 import { unpackDomainMinMax } from './scaleUtil';
 
-export abstract class ContinuousScale<D extends number | Date, I = number> extends AbstractScale<D, number, I> {
+export abstract class ContinuousScale<D extends number | bigint | Date, I = number> extends AbstractScale<
+    D,
+    number,
+    I
+> {
     static is(value: unknown): value is ContinuousScale<any, any> {
         return value instanceof ContinuousScale;
     }
@@ -32,7 +37,7 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
 
     set domain(values: readonly (D | bigint)[]) {
         if (!values || values.length < 2) {
-            this._domain = values as D[];
+            this._domain = narrowStoredDomain(values);
             this.d0Big = this.d1Big = undefined;
             this.d0Cache = Number.NaN;
             this.d1Cache = Number.NaN;
@@ -43,19 +48,19 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         const d1 = values[1];
 
         if (typeof d0 === 'bigint' || typeof d1 === 'bigint') {
-            // Retain the exact bigint endpoints for the full-precision convert() ratio, but expose a
-            // Number-narrowed domain so every Math.min/max(...domain) consumer stays Number-only.
+            // Retain the exact bigint endpoints for the full-precision convert() ratio (and for the
+            // order-independent domainMin/domainMax), but expose a Number-narrowed domain array.
             this.d0Big = typeof d0 === 'bigint' ? d0 : undefined;
             this.d1Big = typeof d1 === 'bigint' ? d1 : undefined;
             this.domainNeedsValueOf = false;
             this.d0Cache = Number(d0);
             this.d1Cache = Number(d1);
-            this._domain = values.map((v) => (typeof v === 'bigint' ? Number(v) : v)) as D[];
+            this._domain = narrowStoredDomain(values);
             return;
         }
 
         this.d0Big = this.d1Big = undefined;
-        this._domain = values as D[];
+        this._domain = narrowStoredDomain(values);
 
         // Auto-detect if domain values need valueOf() and cache numeric values
         this.domainNeedsValueOf = d0 != null && typeof d0 === 'object';
@@ -63,8 +68,8 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
             this.d0Cache = (d0 as Date).valueOf();
             this.d1Cache = (d1 as Date).valueOf();
         } else {
-            this.d0Cache = d0 as unknown as number;
-            this.d1Cache = d1 as unknown as number;
+            this.d0Cache = Number(d0);
+            this.d1Cache = Number(d1);
         }
     }
 
@@ -82,14 +87,14 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         return normalizeContinuousDomains(...domains);
     }
 
-    calcBandwidth(smallestInterval = 1, minWidth: 1 | 0 = 1) {
+    calcBandwidth(smallestInterval: AgNumericValue = 1, minWidth: 1 | 0 = 1) {
         const { domain } = this;
 
         const rangeDistance = this.getPixelRange();
         if (domain.length === 0) return rangeDistance;
 
         // Use cached domain values to avoid valueOf() calls
-        const intervals = Math.abs(this.d1Cache - this.d0Cache) / smallestInterval + 1;
+        const intervals = Math.abs(this.d1Cache - this.d0Cache) / Number(smallestInterval) + 1;
 
         // The number of intervals/bands is used to determine the width of individual bands by dividing the available range.
         let bands = intervals;
@@ -104,7 +109,7 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         return rangeDistance / Math.max(1, bands);
     }
 
-    convert(value: D | number | bigint, options?: { clamp?: boolean }) {
+    convert(value: D | AgNumericValue, options?: { clamp?: boolean }) {
         const { domain } = this;
         if (!domain || domain.length < 2 || value == null) {
             return Number.NaN;
@@ -114,7 +119,7 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         const clamp = options?.clamp ?? this.defaultClamp;
 
         // Full-precision BigInt ratio for linear scales: keeps adjacent high-magnitude bigints monotonic
-        // where a float64 narrow would collapse them. Log/time scales narrow to Number below (AC #9).
+        // where a float64 narrow would collapse them. Log/time scales narrow to Number below.
         if (typeof value === 'bigint' && this.d0Big != null && this.d1Big != null && this.transform == null) {
             return convertBigInt(value, this.d0Big, this.d1Big, range, clamp);
         }
@@ -187,10 +192,30 @@ export abstract class ContinuousScale<D extends number | Date, I = number> exten
         return unpackDomainMinMax(this.domain);
     }
 
+    // Returns the exact (possibly bigint) endpoint; d0Cache/d1Cache order even when bigints narrow to equal Numbers.
+    private exactEndpoint(index: 0 | 1): D {
+        return ((index === 0 ? this.d0Big : this.d1Big) ?? this._domain[index]) as D;
+    }
+
+    override get domainMin(): D | undefined {
+        if (this._domain.length < 2) return this._domain.at(0);
+        return this.exactEndpoint(this.d0Cache <= this.d1Cache ? 0 : 1);
+    }
+
+    override get domainMax(): D | undefined {
+        if (this._domain.length < 2) return this._domain.at(0);
+        return this.exactEndpoint(this.d0Cache <= this.d1Cache ? 1 : 0);
+    }
+
     protected getPixelRange() {
         const [a, b] = this.range;
         return Math.abs(b - a);
     }
+}
+
+// Narrows bigint endpoints to Number for storage; the exact bigints are retained separately in d0Big/d1Big.
+function narrowStoredDomain<D extends number | bigint | Date>(values: readonly (D | bigint)[]): D[] {
+    return values.map((v) => (typeof v === 'bigint' ? Number(v) : v)) as D[];
 }
 
 // Integer ratio scale: 10^12 gives ~12 significant digits in [0,1] — far finer than pixel positioning
@@ -226,32 +251,27 @@ function convertBigInt(value: bigint, d0: bigint, d1: bigint, range: number[], c
     return r0 + ratio * (r1 - r0);
 }
 
-export function normalizeContinuousDomains<D extends number | Date>(
+export function normalizeContinuousDomains<D extends number | bigint | Date>(
     ...domains: DomainWithMetadata<D>[]
 ): NormalizedDomain<D> {
     let min: D | undefined;
-    let minValue = Infinity;
     let max: D | undefined;
-    let maxValue = -Infinity;
 
     for (const input of domains) {
-        const domain = input.domain;
-        for (const d of domain) {
-            const value = d.valueOf();
-            if (value < minValue) {
-                minValue = value;
+        for (const d of input.domain) {
+            // Compare relationally, not via Number(), so a bigint beyond Number.MAX_VALUE isn't collapsed to
+            // Infinity and lost. Inputs are NaN-free (producers filter non-finite extents upstream).
+            if (min === undefined || d < min) {
                 min = d;
             }
-            if (value > maxValue) {
-                maxValue = value;
+            if (max === undefined || d > max) {
                 max = d;
             }
         }
     }
 
     if (min != null && max != null) {
-        const domain = [min, max];
-        return { domain, animatable: true };
+        return { domain: [min, max], animatable: true };
     } else {
         return { domain: [], animatable: false };
     }

--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -192,19 +192,26 @@ export abstract class ContinuousScale<D extends number | bigint | Date, I = numb
         return unpackDomainMinMax(this.domain);
     }
 
-    // Returns the exact (possibly bigint) endpoint; d0Cache/d1Cache order even when bigints narrow to equal Numbers.
+    // Returns the exact (possibly bigint) endpoint stored at the given index, preferring the retained
+    // bigint over its Number-narrowed copy.
     private exactEndpoint(index: 0 | 1): D {
         return ((index === 0 ? this.d0Big : this.d1Big) ?? this._domain[index]) as D;
     }
 
+    // True when endpoint 0 is the minimum. Compares exact values so two bigints that narrow to the same
+    // Number (differ below one ULP) are still ordered correctly, whatever the stored order.
+    private startIsMin(): boolean {
+        return this.exactEndpoint(0) <= this.exactEndpoint(1);
+    }
+
     override get domainMin(): D | undefined {
         if (this._domain.length < 2) return this._domain.at(0);
-        return this.exactEndpoint(this.d0Cache <= this.d1Cache ? 0 : 1);
+        return this.exactEndpoint(this.startIsMin() ? 0 : 1);
     }
 
     override get domainMax(): D | undefined {
         if (this._domain.length < 2) return this._domain.at(0);
-        return this.exactEndpoint(this.d0Cache <= this.d1Cache ? 1 : 0);
+        return this.exactEndpoint(this.startIsMin() ? 1 : 0);
     }
 
     protected getPixelRange() {

--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -127,7 +127,7 @@ export abstract class ContinuousScale<D extends number | bigint | Date, I = numb
         // Use cached domain values to avoid valueOf() calls
         let d0: number = this.d0Cache;
         let d1: number = this.d1Cache;
-        // A bigint reaching here is on a transform (log/time) scale and narrows to Number (AC #9).
+        // A bigint reaching here has no exact bigint domain (or is on a transform scale) and narrows to Number.
         let x: number;
         if (typeof value === 'number') {
             x = value;

--- a/packages/ag-charts-community/src/scale/discreteTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/discreteTimeScale.ts
@@ -1,5 +1,5 @@
-import { ScaleAlignment, type ScaleTickParams, findMaxIndex, findMinIndex } from 'ag-charts-core';
-import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
+import { ScaleAlignment, type ScaleTickParams, findMaxIndex, findMinIndex, timeValueToNumber } from 'ag-charts-core';
+import type { AgNumericValue, AgTimeInterval, AgTimeIntervalUnit, AgTimeValue } from 'ag-charts-types';
 
 import { BandScale } from './bandScale';
 
@@ -62,8 +62,8 @@ export abstract class DiscreteTimeScale extends BandScale<Date, AgTimeInterval |
         visibleRange?: [number, number]
     ): { ticks: Date[]; count: number | undefined; firstTickIndex?: number } | undefined;
 
-    override toDomain(value: number): Date {
-        return new Date(value);
+    override toDomain(value: AgNumericValue): Date {
+        return new Date(timeValueToNumber(value));
     }
 
     protected get reversed(): boolean {
@@ -76,10 +76,10 @@ export abstract class DiscreteTimeScale extends BandScale<Date, AgTimeInterval |
         return this.bands.map((d) => d.valueOf());
     }
 
-    override convert(value: Date, options?: { clamp?: boolean; alignment?: ScaleAlignment }): number {
+    override convert(value: AgTimeValue, options?: { clamp?: boolean; alignment?: ScaleAlignment }): number {
         this.refresh();
 
-        if (!(value instanceof Date)) value = new Date(value);
+        if (!(value instanceof Date)) value = new Date(timeValueToNumber(value));
         const { domain, reversed } = this;
         const numericBands = this.numericBands;
         const bandCount = numericBands.length;

--- a/packages/ag-charts-community/src/scale/linearScale.test.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.test.ts
@@ -305,7 +305,6 @@ describe('LinearScale', () => {
 
             expect(scale.domain).toEqual([0, 100]);
             expect(scale.domain.every((v) => typeof v === 'number')).toBe(true);
-            expect(() => Math.min(...scale.domain)).not.toThrow();
         });
 
         test('clamps to the range bounds', () => {
@@ -388,22 +387,20 @@ describe('LinearScale', () => {
             const scale = new LinearScale();
             scale.range = [0, 600];
 
-            const { ticks } = scale.ticks(tickParams, [0n, 100n] as unknown as number[]);
+            const { ticks } = scale.ticks(tickParams, [0n, 100n]);
             expect(ticks).toEqual([0n, 20n, 40n, 60n, 80n, 100n]);
         });
 
         test('nices a BigInt domain outward to step multiples', () => {
             const scale = new LinearScale();
-            expect(scale.niceDomain(tickParams, [13n, 97n] as unknown as number[])).toEqual([0n, 100n]);
+            expect(scale.niceDomain(tickParams, [13n, 97n])).toEqual([0n, 100n]);
         });
 
         test('honours a custom interval when nicing a BigInt domain', () => {
             const scale = new LinearScale();
             // With interval 30 the bounds must snap to multiples of 30 (Number path), not the auto
             // bigint step that would otherwise produce [0, 100].
-            expect(scale.niceDomain({ ...tickParams, interval: 30 }, [13n, 97n] as unknown as number[])).toEqual([
-                0, 120,
-            ]);
+            expect(scale.niceDomain({ ...tickParams, interval: 30 }, [13n, 97n])).toEqual([0, 120]);
         });
 
         // AC AG-16608 #15e / #16: ticks beyond Number.MAX_SAFE_INTEGER keep exact values.
@@ -412,7 +409,7 @@ describe('LinearScale', () => {
             scale.range = [0, 600];
 
             const span = 10n ** 21n;
-            const { ticks } = scale.ticks(tickParams, [0n, span] as unknown as number[]);
+            const { ticks } = scale.ticks(tickParams, [0n, span]);
             expect(ticks).toEqual([0n, 2n * 10n ** 20n, 4n * 10n ** 20n, 6n * 10n ** 20n, 8n * 10n ** 20n, span]);
         });
 
@@ -421,7 +418,7 @@ describe('LinearScale', () => {
             scale.range = [0, 100];
 
             // A custom interval is a Number concept; the bigint domain narrows and the Number path runs.
-            const { ticks } = scale.ticks({ ...tickParams, interval: 25 }, [0n, 100n] as unknown as number[]);
+            const { ticks } = scale.ticks({ ...tickParams, interval: 25 }, [0n, 100n]);
             expect(ticks).toEqual([0, 25, 50, 75, 100]);
         });
     });

--- a/packages/ag-charts-community/src/scale/linearScale.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.ts
@@ -8,20 +8,21 @@ import {
     range,
     tickStep,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { ContinuousScale } from './continuousScale';
 
 /**
  * Maps continuous domain to a continuous range.
  */
-export class LinearScale extends ContinuousScale<number> {
+export class LinearScale extends ContinuousScale<AgNumericValue> {
     static override is(value: unknown): value is LinearScale {
         return value instanceof LinearScale;
     }
 
     protected static getTickStep(start: number, stop: number, ticks: ScaleTickParams<number>) {
         const { interval, tickCount = ContinuousScale.defaultTickCount, minTickCount, maxTickCount } = ticks;
-        return interval ?? tickStep(start, stop, tickCount, minTickCount, maxTickCount);
+        return interval == null ? tickStep(start, stop, tickCount, minTickCount, maxTickCount) : Number(interval);
     }
 
     readonly type = 'number';
@@ -36,24 +37,24 @@ export class LinearScale extends ContinuousScale<number> {
 
     override ticks(
         { interval, tickCount = ContinuousScale.defaultTickCount, minTickCount, maxTickCount }: ScaleTickParams<number>,
-        domain: number[] = this.domain,
+        domain: AgNumericValue[] = this.domain,
         visibleRange?: [number, number]
-    ): { ticks: number[]; count: number; firstTickIndex?: number } {
+    ): { ticks: AgNumericValue[]; count: number; firstTickIndex?: number } {
         if (!domain || domain.length < 2 || tickCount < 1) {
             return { ticks: [], count: 0, firstTickIndex: 0 };
         }
-        const [b0, b1] = domain as readonly (number | bigint)[];
+        const [b0, b1] = domain;
         const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
 
         // Full-precision BigInt ticks for the full (unzoomed) domain. A custom interval or zoomed
         // sub-range falls through to the Number path below — documented limitation (AG-16608 AC #17).
         const fullRange = visibleRange == null || (visibleRange[0] === 0 && visibleRange[1] === 1);
         if (isBigIntDomain && !interval && fullRange) {
-            const ticks = createBigIntTicks(b0, b1, tickCount) as unknown as number[];
+            const ticks = createBigIntTicks(b0, b1, tickCount);
             return { ticks, count: ticks.length, firstTickIndex: 0 };
         }
 
-        const numericDomain = isBigIntDomain ? domain.map(Number) : domain;
+        const numericDomain: number[] = domain.map(Number);
         if (!numericDomain.every(Number.isFinite)) {
             return { ticks: [], count: 0, firstTickIndex: 0 };
         }
@@ -61,7 +62,8 @@ export class LinearScale extends ContinuousScale<number> {
         const [d0, d1] = numericDomain;
 
         if (interval) {
-            const step = Math.abs(interval);
+            // A custom interval step is a Number concept; bigint full precision applies only to the auto-step path.
+            const step = Math.abs(Number(interval));
             if (!isDenseInterval((d1 - d0) / step, this.getPixelRange())) {
                 return range(d0, d1, step, visibleRange);
             }
@@ -70,22 +72,22 @@ export class LinearScale extends ContinuousScale<number> {
         return createTicks(d0, d1, tickCount, minTickCount, maxTickCount, visibleRange);
     }
 
-    override niceDomain(ticks: ScaleTickParams<number>, domain: number[] = this.domain) {
+    override niceDomain(ticks: ScaleTickParams<number>, domain: AgNumericValue[] = this.domain): AgNumericValue[] {
         if (domain.length < 2) return [];
 
         const { tickCount = ContinuousScale.defaultTickCount } = ticks;
 
-        const [b0, b1] = domain as readonly (number | bigint)[];
+        const [b0, b1] = domain;
         const isBigIntDomain = typeof b0 === 'bigint' && typeof b1 === 'bigint';
 
         // Bigint nicing only for the auto-step path; a custom interval is a Number concept (matches
         // ticks()), so it falls through below — else bounds would snap to an unrelated auto step.
         if (isBigIntDomain && ticks.interval == null) {
             const [n0, n1] = niceBigIntDomain(b0, b1, tickCount);
-            return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1] as unknown as number[];
+            return [ticks.nice[0] ? n0 : b0, ticks.nice[1] ? n1 : b1];
         }
 
-        const numericDomain = isBigIntDomain ? domain.map(Number) : domain;
+        const numericDomain: number[] = domain.map(Number);
         let [start, stop] = numericDomain;
 
         if (tickCount === 1) {

--- a/packages/ag-charts-community/src/scale/logScale.ts
+++ b/packages/ag-charts-community/src/scale/logScale.ts
@@ -69,6 +69,10 @@ export class LogScale extends ContinuousScale<number> {
     override niceDomain(ticks: ScaleTickParams<number>, domain: number[] = this.domain): number[] {
         if (domain.length < 2) return [];
 
+        // Log scales narrow bigint to Number (AC #9); generateTicks passes the raw dataDomain here before the
+        // scale's setter narrows it, so a bigint endpoint would otherwise throw under Math.min/Math.log.
+        domain = domain.map(Number);
+
         const { base } = this;
         const [d0, d1] = domain;
 
@@ -89,6 +93,8 @@ export class LogScale extends ContinuousScale<number> {
         if (!domain || domain.length < 2 || tickCount < 1) {
             return;
         }
+        // See niceDomain: narrow a raw bigint domain to Number before Math.min/Math.log.
+        domain = domain.map(Number);
         const base = this.base;
         const [d0, d1] = domain;
 

--- a/packages/ag-charts-community/src/scale/logScale.ts
+++ b/packages/ag-charts-community/src/scale/logScale.ts
@@ -70,7 +70,7 @@ export class LogScale extends ContinuousScale<number> {
         if (domain.length < 2) return [];
 
         // Log scales narrow bigint to Number (AC #9); generateTicks passes the raw dataDomain here before the
-        // scale's setter narrows it, so a bigint endpoint would otherwise throw under Math.min/Math.log.
+        // scale's setter narrows it, so a bigint endpoint would otherwise throw under Math.log/Math.floor.
         domain = domain.map(Number);
 
         const { base } = this;

--- a/packages/ag-charts-community/src/scale/timeScale.ts
+++ b/packages/ag-charts-community/src/scale/timeScale.ts
@@ -8,8 +8,9 @@ import {
     intervalRangeStartIndex,
     intervalStep,
     isDenseInterval,
+    timeValueToNumber,
 } from 'ag-charts-core';
-import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
+import type { AgTimeInterval, AgTimeIntervalUnit, AgTimeValue } from 'ag-charts-types';
 
 import { ContinuousScale } from './continuousScale';
 
@@ -30,8 +31,8 @@ export class TimeScale extends ContinuousScale<Date, AgTimeInterval | AgTimeInte
         return new Date(d);
     }
 
-    override convert(value: Date | number, options?: { clamp: boolean }): number {
-        return super.convert(typeof value === 'number' ? value : (value?.valueOf() ?? Number.NaN), options);
+    override convert(value: AgTimeValue, options?: { clamp: boolean }): number {
+        return super.convert(value == null ? Number.NaN : timeValueToNumber(value), options);
     }
 
     override invert(value: number): Date {

--- a/packages/ag-charts-community/src/scale/unitTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/unitTimeScale.ts
@@ -18,9 +18,10 @@ import {
     intervalRange,
     intervalRangeCount,
     intervalRangeNumeric,
+    timeValueToNumber,
     toTimeInterval,
 } from 'ag-charts-core';
-import type { AgTimeInterval, AgTimeIntervalUnit } from 'ag-charts-types';
+import type { AgTimeInterval, AgTimeIntervalUnit, AgTimeValue } from 'ag-charts-types';
 
 import { normalizeContinuousDomains } from './continuousScale';
 import { DiscreteTimeScale, type UniformityCheck } from './discreteTimeScale';
@@ -315,15 +316,11 @@ export class UnitTimeScale extends DiscreteTimeScale {
      * Optimized convert for UnitTimeScale with O(1) boundary checks.
      * Uses linear params for fast bounds checking while delegating actual
      * conversion to parent for accuracy in edge cases.
-     *
-     * Out-of-bounds values are linearly extrapolated rather than dropped, so
-     * line/area series draw a connecting segment to the axis edge (clipped by
-     * the canvas) when an explicit min/max is set — matching the `time` axis.
      */
-    override convert(value: Date, options?: { clamp?: boolean; alignment?: ScaleAlignment }): number {
+    override convert(value: AgTimeValue, options?: { clamp?: boolean; alignment?: ScaleAlignment }): number {
         this.refresh();
 
-        if (!(value instanceof Date)) value = new Date(value);
+        if (!(value instanceof Date)) value = new Date(timeValueToNumber(value));
 
         const { domain, interval } = this;
         if (domain.length < 2) return Number.NaN;
@@ -334,9 +331,7 @@ export class UnitTimeScale extends DiscreteTimeScale {
             if (boundaries != null) {
                 const t = value.valueOf();
                 if (t < boundaries.d0 || t >= boundaries.dNext) {
-                    // Extrapolate via the parent's linear-interpolation path. Undefined
-                    // when there are fewer than two bands — fall back to NaN (the
-                    // datum is dropped, as before).
+                    // Extrapolate out-of-bounds values so series connect to the axis edge rather than dropping.
                     return super.convert(value, { ...options, alignment: ScaleAlignment.Interpolate });
                 }
             }

--- a/packages/ag-charts-core/src/config/gaugePreset.ts
+++ b/packages/ag-charts-core/src/config/gaugePreset.ts
@@ -22,6 +22,7 @@ import {
     greaterThan,
     lessThan,
     number,
+    numericValue,
     optionsDefs,
     or,
     positiveNumber,
@@ -52,14 +53,14 @@ import {
 const fillsOptionsDef: OptionsDefs<FillsOptions> = {
     fills: and(
         arrayLength(2),
-        arrayOf(optionsDefs<AgGaugeColorStop>({ color: colorOrRef, stop: number }, '')),
+        arrayOf(optionsDefs<AgGaugeColorStop>({ color: colorOrRef, stop: numericValue }, '')),
         colorStopsOrderValidator
     ),
     fillMode: union('continuous', 'discrete'),
 };
 
 export const linearGaugeTargetOptionsDef: OptionsDefs<AgLinearGaugeTarget> = {
-    value: required(number),
+    value: required(numericValue),
     text: string,
     shape: or(
         union('circle', 'cross', 'diamond', 'heart', 'plus', 'pin', 'square', 'star', 'triangle', 'line'),
@@ -75,7 +76,7 @@ export const linearGaugeTargetOptionsDef: OptionsDefs<AgLinearGaugeTarget> = {
 };
 
 export const radialGaugeTargetOptionsDef: OptionsDefs<AgRadialGaugeTarget> = {
-    value: required(number),
+    value: required(numericValue),
     text: string,
     shape: or(
         union('circle', 'cross', 'diamond', 'heart', 'plus', 'pin', 'square', 'star', 'triangle', 'line'),
@@ -104,8 +105,8 @@ export const linearGaugeSeriesThemeableOptionsDef: OptionsDefs<AgLinearGaugeThem
         enabled: boolean,
         spacing: positiveNumber,
         interval: {
-            values: arrayOf(number),
-            step: number,
+            values: arrayOf(numericValue),
+            step: numericValue,
             count: number,
         },
     },
@@ -142,10 +143,10 @@ export const linearGaugeSeriesOptionsDef: OptionsDefs<AgLinearGaugePreset> = {
     ...without(commonSeriesOptionsDefs, ['listeners']),
     ...linearGaugeSeriesThemeableOptionsDef,
     type: required(constant('linear-gauge')),
-    value: required(number),
+    value: required(numericValue),
     scale: {
-        min: and(number, lessThan('max')),
-        max: and(number, greaterThan('min')),
+        min: and(numericValue, lessThan('max')),
+        max: and(numericValue, greaterThan('min')),
         label: {
             enabled: boolean,
             formatter: callback,
@@ -158,8 +159,8 @@ export const linearGaugeSeriesOptionsDef: OptionsDefs<AgLinearGaugePreset> = {
             ...fontOptionsDef,
         },
         interval: {
-            values: arrayOf(number),
-            step: number,
+            values: arrayOf(numericValue),
+            step: numericValue,
         },
         ...fillsOptionsDef,
         ...fillOptionsDef,
@@ -198,8 +199,8 @@ export const radialGaugeSeriesThemeableOptionsDef: OptionsDefs<AgRadialGaugeThem
     cornerMode: union('container', 'item'),
     cornerRadius: positiveNumber,
     scale: {
-        min: and(number, lessThan('max')),
-        max: and(number, greaterThan('min')),
+        min: and(numericValue, lessThan('max')),
+        max: and(numericValue, greaterThan('min')),
         label: {
             enabled: boolean,
             formatter: callback,
@@ -211,8 +212,8 @@ export const radialGaugeSeriesThemeableOptionsDef: OptionsDefs<AgRadialGaugeThem
             ...fontOptionsDef,
         },
         interval: {
-            values: arrayOf(number),
-            step: number,
+            values: arrayOf(numericValue),
+            step: numericValue,
         },
         ...fillsOptionsDef,
         ...fillOptionsDef,
@@ -223,8 +224,8 @@ export const radialGaugeSeriesThemeableOptionsDef: OptionsDefs<AgRadialGaugeThem
         enabled: boolean,
         spacing: positiveNumber,
         interval: {
-            values: arrayOf(number),
-            step: number,
+            values: arrayOf(numericValue),
+            step: numericValue,
             count: number,
         },
     },
@@ -259,7 +260,7 @@ export const radialGaugeSeriesOptionsDef: OptionsDefs<AgRadialGaugePreset> = {
     ...without(commonSeriesOptionsDefs, ['listeners']),
     ...radialGaugeSeriesThemeableOptionsDef,
     type: required(constant('radial-gauge')),
-    value: required(number),
+    value: required(numericValue),
     targets: arrayOfDefs(radialGaugeTargetOptionsDef, 'target options array'),
 };
 

--- a/packages/ag-charts-core/src/config/optionsDefaults.ts
+++ b/packages/ag-charts-core/src/config/optionsDefaults.ts
@@ -65,7 +65,6 @@ export const themeOperator = (value: unknown) => {
     return keys.length === 1 && keys[0].startsWith('$');
 };
 
-// Validator for public theme operators.
 export const colorRef = attachDescription(
     or(
         optionsDefs<AgColorRefMixOnto>({ ref: required(string), mix: required(ratio), onto: required(string) }),

--- a/packages/ag-charts-core/src/main.ts
+++ b/packages/ag-charts-core/src/main.ts
@@ -82,6 +82,7 @@ export * from './utils/data/json';
 export * from './utils/dom/keynavUtil';
 export * from './identity/id';
 export * from './types/idBranding';
+export * from './utils/data/iso8601';
 export * from './utils/data/iterators';
 export * from './utils/data/linkedList';
 export * from './state/memo';

--- a/packages/ag-charts-core/src/scale/colorScaleUtil.ts
+++ b/packages/ag-charts-core/src/scale/colorScaleUtil.ts
@@ -1,6 +1,6 @@
-import type { AgColorScaleColorStop } from 'ag-charts-types';
+import type { AgColorScaleColorStop, AgNumericValue } from 'ag-charts-types';
 
-import { clamp } from '../utils/data/numbers';
+import { clamp, toNumber, toNumberOrUndefined } from '../utils/data/numbers';
 
 /** Colour mode for colour scale operations. */
 export type ColorScaleMode = 'continuous' | 'discrete';
@@ -30,7 +30,7 @@ export interface ColorScaleState {
      * of `domain`, which carries interpolation pivots derived from the fill
      * stops. When omitted, defaults to `[domain[0], domain.at(-1)]`.
      */
-    displayDomain?: [number, number];
+    displayDomain?: [AgNumericValue, AgNumericValue];
 }
 
 function findNextDefinedStop(fills: Array<{ stop?: number }>, from: number): number {
@@ -56,11 +56,12 @@ export function resolveStopPositions(
             nextDefinedStopIndex = findNextDefinedStop(fills, i);
         }
 
-        const stop = fills[i]?.stop;
+        // Narrow a bigint stop to Number; mixing bigint with the Number domain below throws.
+        const stop = toNumberOrUndefined(fills[i]?.stop);
 
         if (stop == null) {
-            const stop0 = fills[previousDefinedStopIndex]?.stop;
-            const stop1 = fills[nextDefinedStopIndex]?.stop;
+            const stop0 = toNumberOrUndefined(fills[previousDefinedStopIndex]?.stop);
+            const stop1 = toNumberOrUndefined(fills[nextDefinedStopIndex]?.stop);
             const value0 = stop0 ?? d0;
             const value1 = stop1 ?? d1;
             const offset = isDiscrete && stop0 == null ? 1 : 0;
@@ -106,14 +107,16 @@ interface ColorBins {
  */
 export function computeColorBins(
     fills: ColorScaleColorStop[],
-    domain: [number, number],
+    domain: [AgNumericValue, AgNumericValue],
     mode: ColorScaleMode
 ): ColorBins {
     if (fills.length === 0) {
         return { domain: [], range: [], bins: [] };
     }
 
-    const [d0, d1] = domain;
+    // Narrow a bigint domain to Number; mixing bigint with number in the maths below throws.
+    const d0 = toNumber(domain[0]);
+    const d1 = toNumber(domain[1]);
     const isDiscrete = mode === 'discrete';
     const resolvedStops = resolveStopPositions(fills, d0, d1, isDiscrete);
     const resolvedColors = fills.map((fill) => fill.color);
@@ -167,7 +170,10 @@ export function deriveNormalizedStops(colorScale: ColorScaleState): GradientColo
     const { domain, range, mode, displayDomain } = colorScale;
     if (range.length === 0) return [];
 
-    const [d0, d1] = displayDomain ?? [domain[0], domain.at(-1)!];
+    // Narrow a bigint `displayDomain` to Number for the [0,1] fraction maths below.
+    const [d0, d1] = displayDomain
+        ? [toNumber(displayDomain[0]), toNumber(displayDomain[1])]
+        : [domain[0], domain.at(-1)!];
     const extent = d1 - d0 || 1;
 
     if (mode === 'discrete') {

--- a/packages/ag-charts-core/src/state/memento.ts
+++ b/packages/ag-charts-core/src/state/memento.ts
@@ -93,12 +93,25 @@ export class MementoCaretaker {
         if (isDate(this[key])) {
             return { __type: 'date', value: this[key].toISOString() };
         }
+        if (typeof this[key] === 'bigint') {
+            // Encode as a base-10 string; JSON numbers cannot represent bigints beyond 2^53 without precision loss.
+            return { __type: 'bigint', value: this[key].toString() };
+        }
         return value;
     }
 
     private static decodeTypes(this: any, key: any, value: any) {
-        if (isObject(this[key]) && '__type' in this[key] && this[key].__type === 'date') {
-            return new Date(this[key].value);
+        if (isObject(this[key]) && '__type' in this[key]) {
+            if (this[key].__type === 'date') {
+                return new Date(this[key].value);
+            }
+            if (this[key].__type === 'bigint') {
+                // Untrusted input: only decode a valid integer string, else leave it for guardMemento to reject.
+                const bigintValue = this[key].value;
+                if (typeof bigintValue === 'string' && /^-?\d+$/.test(bigintValue)) {
+                    return BigInt(bigintValue);
+                }
+            }
         }
         return value;
     }

--- a/packages/ag-charts-core/src/state/memento.ts
+++ b/packages/ag-charts-core/src/state/memento.ts
@@ -94,7 +94,7 @@ export class MementoCaretaker {
             return { __type: 'date', value: this[key].toISOString() };
         }
         if (typeof this[key] === 'bigint') {
-            // Encode as a base-10 string; JSON numbers cannot represent bigints beyond 2^53 without precision loss.
+            // Encode as a base-10 string; JSON numbers (doubles) lose integer precision beyond ±(2^53 - 1).
             return { __type: 'bigint', value: this[key].toString() };
         }
         return value;

--- a/packages/ag-charts-core/src/state/validation.ts
+++ b/packages/ag-charts-core/src/state/validation.ts
@@ -10,6 +10,7 @@ import {
     isDate,
     isDefined,
     isFiniteNumber,
+    isFiniteNumericValue,
     isFunction,
     isHtmlElement,
     isObject,
@@ -485,7 +486,8 @@ export const or = (...validators: Validator[]) =>
     );
 
 // Helpers
-const isComparable = (value: unknown): value is number | Date => isFiniteNumber(value) || isValidDate(value);
+const isComparable = (value: unknown): value is number | bigint | Date =>
+    isFiniteNumericValue(value) || isValidDate(value);
 const isValidDateValue = (value: unknown) =>
     isDate(value) || ((isFiniteNumber(value) || isString(value)) && isValidDate(new Date(value)));
 
@@ -497,6 +499,8 @@ export const color = attachDescription(isColor, 'a color string');
 export const date = attachDescription(isValidDateValue, 'a date');
 export const defined = attachDescription(isDefined, 'a defined value');
 export const number = attachDescription(isFiniteNumber, 'a number');
+// For fields that opt into bigint; do NOT widen the global `number` validator instead.
+export const numericValue = attachDescription(isFiniteNumericValue, 'a number or bigint');
 export const object = attachDescription(isObject, 'an object');
 export const string = attachDescription(isString, 'a string');
 

--- a/packages/ag-charts-core/src/types/scales.ts
+++ b/packages/ag-charts-core/src/types/scales.ts
@@ -68,6 +68,10 @@ export interface Scale<D, R, I = number> {
     domain: D[];
     range: R[];
     getDomainMinMax(): [D, D] | [undefined, undefined];
+    /** Domain minimum, preserving the domain value type (so a bigint domain flows through as bigint). */
+    readonly domainMin: D | undefined;
+    /** Domain maximum, preserving the domain value type (so a bigint domain flows through as bigint). */
+    readonly domainMax: D | undefined;
     normalizeDomains(...domains: DomainWithMetadata<D>[]): NormalizedDomain<D>;
     toDomain(value: number): D | undefined;
     convert(value: D, options?: { clamp?: boolean; alignment?: ScaleAlignment; alignmentExclusive?: boolean }): R;

--- a/packages/ag-charts-core/src/utils/aggregation.ts
+++ b/packages/ag-charts-core/src/utils/aggregation.ts
@@ -121,7 +121,8 @@ const offsetNumericColumnCache = new WeakMap<readonly unknown[], { offset: bigin
  * {@link narrowBigIntColumnRelative} (which subtracts the column's own minimum), the caller supplies the
  * offset so a column and its domain can be narrowed against the SAME origin — required when the narrowed
  * values are bucketed against a narrowed domain (see {@link narrowAggregationX}).
- * @returns the input `values` unchanged when the column holds no bigint and `offset` is zero.
+ * @returns a new array with bigint entries narrowed to Number (offset subtracted); cached per input array,
+ * so a repeat call with the same offset reuses the prior result.
  */
 export function narrowBigIntColumnByOffset(values: any[], offset: bigint): any[] {
     const cached = offsetNumericColumnCache.get(values);

--- a/packages/ag-charts-core/src/utils/aggregation.ts
+++ b/packages/ag-charts-core/src/utils/aggregation.ts
@@ -114,6 +114,87 @@ export function narrowBigIntColumnRelative(values: any[]): any[] {
     return converted;
 }
 
+const offsetNumericColumnCache = new WeakMap<readonly unknown[], { offset: bigint; result: any[] }>();
+
+/**
+ * Narrow a bigint column to Number after subtracting an explicit bigint `offset`. Unlike
+ * {@link narrowBigIntColumnRelative} (which subtracts the column's own minimum), the caller supplies the
+ * offset so a column and its domain can be narrowed against the SAME origin — required when the narrowed
+ * values are bucketed against a narrowed domain (see {@link narrowAggregationX}).
+ * @returns the input `values` unchanged when the column holds no bigint and `offset` is zero.
+ */
+export function narrowBigIntColumnByOffset(values: any[], offset: bigint): any[] {
+    const cached = offsetNumericColumnCache.get(values);
+    if (cached?.offset === offset) return cached.result;
+
+    const offsetNum = Number(offset);
+    const result = values.map((v) => {
+        if (typeof v === 'bigint') return Number(v - offset);
+        if (typeof v === 'number') return v - offsetNum;
+        return v;
+    });
+    offsetNumericColumnCache.set(values, { offset, result });
+    return result;
+}
+
+/**
+ * Bigint [min, max] of a number-scale aggregation X domain, or `undefined` when the domain is empty, holds a
+ * non-bigint endpoint, or the scale isn't `number` (time epochs are always within the Number-exact range).
+ * Used to subtract a common offset from the X column and its [d0, d1] so a high-magnitude narrow-range bigint
+ * domain keeps full bucketing precision instead of collapsing onto one double.
+ */
+export function bigIntAggregationExtent(
+    scale: ScaleType,
+    domainInput: DomainWithMetadata<any>
+): { min: bigint; max: bigint } | undefined {
+    if (scale !== 'number') return undefined;
+
+    const { domain, sortMetadata } = domainInput;
+    if (domain.length === 0) return undefined;
+
+    const first = domain[0];
+    const last = domain.at(-1);
+    if (sortMetadata?.sortOrder === 1) {
+        return typeof first === 'bigint' && typeof last === 'bigint' ? { min: first, max: last } : undefined;
+    }
+    if (sortMetadata?.sortOrder === -1) {
+        return typeof first === 'bigint' && typeof last === 'bigint' ? { min: last, max: first } : undefined;
+    }
+
+    // Unsorted: bigint-safe relational scan; bail to the absolute path if any endpoint isn't bigint.
+    let min: bigint | undefined;
+    let max: bigint | undefined;
+    for (const d of domain) {
+        if (typeof d !== 'bigint') return undefined;
+        if (min === undefined || d < min) min = d;
+        if (max === undefined || d > max) max = d;
+    }
+    if (min === undefined || max === undefined) return undefined;
+    return { min, max };
+}
+
+/**
+ * Narrow an aggregation X column to Number together with its [d0, d1] domain. For a bigint number-scale
+ * domain the bigint domain-min is subtracted from BOTH before crossing to Number, so a high-magnitude
+ * narrow-range column keeps full bucketing precision (mirrors the bigint scale.convert() path) rather than collapsing
+ * every value onto one double. Otherwise the column is narrowed absolutely and the domain comes from
+ * {@link aggregationDomain}.
+ */
+export function narrowAggregationX(
+    scale: ScaleType,
+    epochXValues: any[],
+    domainInput: DomainWithMetadata<any>
+): { xValues: any[]; domain: [number, number] } {
+    const extent = bigIntAggregationExtent(scale, domainInput);
+    if (extent !== undefined) {
+        return {
+            xValues: narrowBigIntColumnByOffset(epochXValues, extent.min),
+            domain: [0, Number(extent.max - extent.min)],
+        };
+    }
+    return { xValues: narrowBigIntColumn(epochXValues), domain: aggregationDomain(scale, domainInput) };
+}
+
 function estimateSmallestPixelIntervalIter(
     xValues: any[],
     d0: number,

--- a/packages/ag-charts-core/src/utils/aggregation.ts
+++ b/packages/ag-charts-core/src/utils/aggregation.ts
@@ -1,5 +1,8 @@
+import type { AgNumericValue } from 'ag-charts-types';
+
 import type { DomainWithMetadata, ScaleType } from '../types/scales';
 import { nextPowerOf2 } from './data/numberArray';
+import { timeValueToNumber } from './time/timeFormatDefaults';
 
 export const AGGREGATION_INDEX_X_MIN = 0;
 export const AGGREGATION_INDEX_X_MAX = 1;
@@ -17,6 +20,99 @@ export const AGGREGATION_INDEX_UNSET = 0xffffffff;
 const SMALLEST_INTERVAL_MIN_RECURSE = 3;
 const SMALLEST_INTERVAL_RECURSE_LIMIT = 20;
 const SMALLEST_INTERVAL_MAX_INDEX_ADJUSTMENTS = 100;
+
+// The aggregation hot path stores into Float64Arrays, so columns are narrowed/parsed once upfront, keyed
+// by source-column identity for stable memoization.
+
+const TIME_SCALE_TYPES: ReadonlySet<ScaleType> = new Set<ScaleType>(['time', 'unit-time', 'ordinal-time']);
+
+const isoEpochColumnCache = new WeakMap<readonly unknown[], unknown[]>();
+
+/**
+ * Parse an ISO-string time column to epoch ms (the bucketing maths cannot interpret a string).
+ * @returns the input `xValues` unchanged when no parsing is required; `needsValueOf` is `false` once converted.
+ */
+export function epochColumnForTimeScale(
+    scale: ScaleType,
+    xValues: any[],
+    xNeedsValueOf: boolean
+): { values: any[]; needsValueOf: boolean } {
+    const values = resolveEpochColumn(scale, xValues, xNeedsValueOf);
+    return { values, needsValueOf: values === xValues ? xNeedsValueOf : false };
+}
+
+function resolveEpochColumn(scale: ScaleType, xValues: any[], xNeedsValueOf: boolean): any[] {
+    if (xNeedsValueOf || !TIME_SCALE_TYPES.has(scale)) return xValues;
+
+    const cached = isoEpochColumnCache.get(xValues);
+    if (cached !== undefined) return cached;
+
+    const sample = xValues.find((v) => v != null);
+    const converted =
+        typeof sample === 'string' ? xValues.map((v) => (typeof v === 'string' ? timeValueToNumber(v) : v)) : xValues;
+    isoEpochColumnCache.set(xValues, converted);
+    return converted;
+}
+
+const numericColumnCache = new WeakMap<readonly unknown[], unknown[]>();
+
+/**
+ * Narrow a bigint column to Number absolutely, preserving sign and magnitude (bar's sign buckets and the
+ * bubble quadtree's domain ratios depend on it).
+ * @returns the input `values` unchanged when the column holds no bigint.
+ */
+export function narrowBigIntColumn(values: any[]): any[] {
+    const cached = numericColumnCache.get(values);
+    if (cached !== undefined) return cached;
+
+    let hasBigInt = false;
+    for (let i = 0; i < values.length; i++) {
+        if (typeof values[i] === 'bigint') {
+            hasBigInt = true;
+            break;
+        }
+    }
+    const converted = hasBigInt ? values.map((v) => (typeof v === 'bigint' ? Number(v) : v)) : values;
+    numericColumnCache.set(values, converted);
+    return converted;
+}
+
+const relativeNumericColumnCache = new WeakMap<readonly unknown[], unknown[]>();
+
+/**
+ * Narrow a bigint column to Number after subtracting its bigint minimum, so a high-magnitude narrow-range
+ * column keeps full resolution instead of collapsing onto one double. The offset destroys sign and absolute
+ * magnitude, so use ONLY for the comparison-based extrema envelope (line/area/ohlc/range); bar and bubble
+ * must use {@link narrowBigIntColumn}.
+ * @returns the input `values` unchanged when the column holds no bigint.
+ */
+export function narrowBigIntColumnRelative(values: any[]): any[] {
+    const cached = relativeNumericColumnCache.get(values);
+    if (cached !== undefined) return cached;
+
+    let minBig: bigint | undefined;
+    for (let i = 0; i < values.length; i++) {
+        const v = values[i];
+        if (typeof v === 'bigint' && (minBig === undefined || v < minBig)) {
+            minBig = v;
+        }
+    }
+
+    let converted: any[];
+    if (minBig === undefined) {
+        converted = values;
+    } else {
+        const offsetBig = minBig;
+        const offsetNum = Number(offsetBig);
+        converted = values.map((v) => {
+            if (typeof v === 'bigint') return Number(v - offsetBig);
+            if (typeof v === 'number') return v - offsetNum;
+            return v;
+        });
+    }
+    relativeNumericColumnCache.set(values, converted);
+    return converted;
+}
 
 function estimateSmallestPixelIntervalIter(
     xValues: any[],
@@ -115,7 +211,7 @@ export function aggregationRangeFittingPoints(
     xValues: any[],
     d0: number,
     d1: number,
-    opts?: { smallestKeyInterval?: number; xNeedsValueOf?: boolean }
+    opts?: { smallestKeyInterval?: AgNumericValue; xNeedsValueOf?: boolean }
 ) {
     if (Number.isFinite(d0)) {
         const smallestKeyInterval = opts?.smallestKeyInterval;
@@ -123,7 +219,7 @@ export function aggregationRangeFittingPoints(
         const smallestPixelInterval =
             smallestKeyInterval == null
                 ? estimateSmallestPixelInterval(xValues, d0, d1, xNeedsValueOf)
-                : smallestKeyInterval / (d1 - d0);
+                : Number(smallestKeyInterval) / (d1 - d0);
         return nextPowerOf2(Math.trunc(1 / smallestPixelInterval)) >> 3;
     } else {
         let power = Math.ceil(Math.log2(xValues.length)) - 1;
@@ -878,7 +974,7 @@ export function computeExtremesAggregation(
     highValues: any[],
     lowValues: any[],
     options: {
-        smallestKeyInterval: number | undefined;
+        smallestKeyInterval: AgNumericValue | undefined;
         xNeedsValueOf: boolean;
         yNeedsValueOf: boolean;
         existingFilters?: ExtremesAggregationFilter[];
@@ -963,7 +1059,7 @@ export function computeExtremesAggregationPartial(
     highValues: any[],
     lowValues: any[],
     options: {
-        smallestKeyInterval: number | undefined;
+        smallestKeyInterval: AgNumericValue | undefined;
         targetRange: number;
         xNeedsValueOf: boolean;
         yNeedsValueOf: boolean;

--- a/packages/ag-charts-core/src/utils/data/extent.ts
+++ b/packages/ag-charts-core/src/utils/data/extent.ts
@@ -1,11 +1,16 @@
+import type { AgNumericValue } from 'ag-charts-types';
+
 import type { DomainWithMetadata } from '../../types/scales';
-import { isNumber } from '../types/typeGuards';
+import { isFiniteNumericValue, isNumber, isNumericValue } from '../types/typeGuards';
 
-// bigint endpoints are retained so a bigint column's exact extent reaches the scale. Comparisons
-// against the Number Infinity seed and between bigints are legal — only +/-/* mixing throws.
-const isFiniteEndpoint = (v: number | bigint) => typeof v === 'bigint' || Number.isFinite(v);
-
-export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, number] | null {
+// Overloads keep bigint out of the result type for the common Date/number callers.
+export function extent(
+    values: readonly (number | Date | null | undefined)[],
+    sortOrder?: 1 | -1
+): [number, number] | null;
+export function extent(values: readonly (bigint | null | undefined)[], sortOrder?: 1 | -1): [bigint, bigint] | null;
+export function extent(values: readonly unknown[], sortOrder?: 1 | -1): [AgNumericValue, AgNumericValue] | null;
+export function extent(values: readonly unknown[], sortOrder?: 1 | -1): [AgNumericValue, AgNumericValue] | null {
     if (values.length === 0) {
         return null;
     }
@@ -17,17 +22,19 @@ export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, num
         const v0 = first instanceof Date ? first.getTime() : first;
         const v1 = last instanceof Date ? last.getTime() : last;
 
-        if ((typeof v0 === 'number' || typeof v0 === 'bigint') && (typeof v1 === 'number' || typeof v1 === 'bigint')) {
-            return (sortOrder === 1 ? [v0, v1] : [v1, v0]) as [number, number];
+        if (isNumericValue(v0) && isNumericValue(v1)) {
+            return sortOrder === 1 ? [v0, v1] : [v1, v0];
         }
     }
 
-    let min: number | bigint = Infinity;
-    let max: number | bigint = -Infinity;
+    // bigint endpoints are retained so a bigint column's exact extent reaches the scale. Comparisons
+    // against the Number Infinity seed and between bigints are legal — only +/-/* mixing throws.
+    let min: AgNumericValue = Infinity;
+    let max: AgNumericValue = -Infinity;
 
     for (const n of values) {
         const v = n instanceof Date ? n.getTime() : n;
-        if (typeof v !== 'number' && typeof v !== 'bigint') continue;
+        if (!isNumericValue(v)) continue;
         if (v < min) {
             min = v;
         }
@@ -36,7 +43,7 @@ export function extent(values: Array<unknown>, sortOrder?: 1 | -1): [number, num
         }
     }
 
-    return isFiniteEndpoint(min) && isFiniteEndpoint(max) ? ([min, max] as [number, number]) : null;
+    return isFiniteNumericValue(min) && isFiniteNumericValue(max) ? [min, max] : null;
 }
 
 export function normalisedExtentWithMetadata<T>(
@@ -51,10 +58,11 @@ export function normalisedExtentWithMetadata<T>(
     let clipped = false;
 
     const domainExtentNumbers = extent(d, sortOrder);
+    // `toValue` is only supplied for Date domains; a bigint number-axis domain passes through unmapped as T.
     const domainExtent =
         domainExtentNumbers && toValue
-            ? [toValue(domainExtentNumbers[0]), toValue(domainExtentNumbers[1])]
-            : (domainExtentNumbers as [T, T]);
+            ? [toValue(Number(domainExtentNumbers[0])), toValue(Number(domainExtentNumbers[1]))]
+            : (domainExtentNumbers as [T, T] | null);
 
     if (domainExtent == null) {
         let nullExtent: T[] | undefined;

--- a/packages/ag-charts-core/src/utils/data/iso8601.ts
+++ b/packages/ag-charts-core/src/utils/data/iso8601.ts
@@ -1,0 +1,30 @@
+// Runs per datum, so it must not allocate; the calendar check below rejects rollover dates the regex can't.
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}(T([01]\d|2[0-3]):[0-5]\d(:[0-5]\d(\.\d+)?)?(Z|[+-]([01]\d|2[0-3]):[0-5]\d)?)?$/;
+
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/** Reads a fixed-width run of ASCII digits as an integer without allocating. */
+function readUint(value: string, start: number, length: number): number {
+    let n = 0;
+    for (let i = 0; i < length; i++) {
+        n = n * 10 + (value.charCodeAt(start + i) - 48);
+    }
+    return n;
+}
+
+/** True only for valid ISO 8601 date / date-time strings, validated against the real calendar. */
+export function isISO8601(value: unknown): value is string {
+    if (typeof value !== 'string' || !ISO_8601.test(value)) return false;
+    const month = readUint(value, 5, 2);
+    if (month < 1 || month > 12) return false;
+    const year = readUint(value, 0, 4);
+    const day = readUint(value, 8, 2);
+    const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    const maxDay = month === 2 && isLeapYear ? 29 : DAYS_IN_MONTH[month - 1];
+    return day >= 1 && day <= maxDay;
+}
+
+/** Coerce an ISO 8601 string to a `Date` for domain construction; anything else passes through unchanged. */
+export function coerceIso8601Date(value: unknown): unknown {
+    return isISO8601(value) ? new Date(value) : value;
+}

--- a/packages/ag-charts-core/src/utils/data/numberArray.ts
+++ b/packages/ag-charts-core/src/utils/data/numberArray.ts
@@ -1,3 +1,5 @@
+import type { AgNumericValue } from 'ag-charts-types';
+
 import { clamp } from './numbers';
 
 export function clampArray(value: number, array: readonly number[]) {
@@ -5,16 +7,19 @@ export function clampArray(value: number, array: readonly number[]) {
     return clamp(min, value, max);
 }
 
-export function findMinMax(array: readonly number[]) {
+export function findMinMax(array: readonly number[]): number[];
+export function findMinMax(array: readonly AgNumericValue[]): AgNumericValue[];
+export function findMinMax(array: readonly AgNumericValue[]): AgNumericValue[] {
     if (array.length === 0) return [];
 
-    // Optimized min/max algorithm, single array pass.
-    const result = [Infinity, -Infinity];
+    // Optimized min/max algorithm, single array pass. Comparisons are bigint-safe, unlike Math.min/max.
+    let min: AgNumericValue = Infinity;
+    let max: AgNumericValue = -Infinity;
     for (const val of array) {
-        if (val < result[0]) result[0] = val;
-        if (val > result[1]) result[1] = val;
+        if (val < min) min = val;
+        if (val > max) max = val;
     }
-    return result;
+    return [min, max];
 }
 
 export function findRangeExtent(array: number[]) {

--- a/packages/ag-charts-core/src/utils/data/numbers.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.ts
@@ -1,5 +1,69 @@
+import type { AgNumericValue } from 'ag-charts-types';
+
+import * as Logger from '../../logging/logger';
+
 export function clamp(min: number, value: number, max: number) {
     return Math.min(max, Math.max(min, value));
+}
+
+/** Coerce a `number | bigint` to `number` for rendering maths; warns once when a bigint exceeds the Number range. */
+export function toNumber(value: AgNumericValue): number {
+    if (typeof value === 'number') return value;
+
+    const n = Number(value);
+    if (!Number.isFinite(n)) {
+        Logger.warnOnce(`the value ${value} exceeds the representable Number range and cannot be rendered.`);
+    }
+    return n;
+}
+
+/** Like {@link toNumber} but passes `null`/`undefined` through and stays silent on out-of-range magnitudes. */
+export function toNumberOrUndefined(value: AgNumericValue | undefined): number | undefined {
+    return value == null ? undefined : Number(value);
+}
+
+/** Both operands can combine exactly as bigints (each is already a bigint or an integral number). */
+function bothIntegral(a: AgNumericValue, b: AgNumericValue): boolean {
+    return (typeof a === 'bigint' || Number.isInteger(a)) && (typeof b === 'bigint' || Number.isInteger(b));
+}
+
+/** Adds two operands, promoting to `bigint` when both are integral so a large-magnitude result stays exact. */
+export function addValues(a: AgNumericValue, b: AgNumericValue): AgNumericValue {
+    if (typeof a === 'bigint' || typeof b === 'bigint') {
+        return bothIntegral(a, b) ? BigInt(a) + BigInt(b) : Number(a) + Number(b);
+    }
+    return a + b;
+}
+
+/** Subtracts `b` from `a`, promoting to `bigint` under the same rules as {@link addValues}. */
+export function subtractValues(a: AgNumericValue, b: AgNumericValue): AgNumericValue {
+    if (typeof a === 'bigint' || typeof b === 'bigint') {
+        return bothIntegral(a, b) ? BigInt(a) - BigInt(b) : Number(a) - Number(b);
+    }
+    return a - b;
+}
+
+/** Smaller of two operands via comparison, preserving an exact `bigint` (`Math.min` throws on bigint). */
+export function minValue(a: AgNumericValue, b: AgNumericValue): AgNumericValue {
+    if (typeof a === 'number' && typeof b === 'number') return Math.min(a, b);
+    return a < b ? a : b;
+}
+
+/** Returns the larger of two operands, preserving an exact `bigint`. Mirror of {@link minValue}. */
+export function maxValue(a: AgNumericValue, b: AgNumericValue): AgNumericValue {
+    if (typeof a === 'number' && typeof b === 'number') return Math.max(a, b);
+    return a > b ? a : b;
+}
+
+/** Returns the absolute value, preserving an exact `bigint` rather than coercing. */
+export function absValue(value: AgNumericValue): AgNumericValue {
+    if (typeof value === 'bigint') return value < 0n ? -value : value;
+    return Math.abs(value);
+}
+
+/** Returns a zero of the same kind as `value` (`0n` for a `bigint`), keeping exact bigint arithmetic. */
+export function zeroLike(value: AgNumericValue): AgNumericValue {
+    return typeof value === 'bigint' ? 0n : 0;
 }
 
 export function inRange(value: number, range: [number, number], epsilon: number = 1e-10) {
@@ -10,7 +74,8 @@ export function isNumberEqual(a: number, b: number, epsilon: number = 1e-10) {
     return a === b || Math.abs(a - b) < epsilon;
 }
 
-export function isNegative(value: number) {
+export function isNegative(value: AgNumericValue) {
+    if (typeof value === 'bigint') return value < 0n;
     return Math.sign(value) === -1 || Object.is(value, -0);
 }
 

--- a/packages/ag-charts-core/src/utils/data/numbers.ts
+++ b/packages/ag-charts-core/src/utils/data/numbers.ts
@@ -46,12 +46,17 @@ export function subtractValues(a: AgNumericValue, b: AgNumericValue): AgNumericV
 /** Smaller of two operands via comparison, preserving an exact `bigint` (`Math.min` throws on bigint). */
 export function minValue(a: AgNumericValue, b: AgNumericValue): AgNumericValue {
     if (typeof a === 'number' && typeof b === 'number') return Math.min(a, b);
+    // A NaN number operand can't be ordered against a bigint; surface it like Math.min rather than the bigint.
+    if (typeof a === 'number' && Number.isNaN(a)) return a;
+    if (typeof b === 'number' && Number.isNaN(b)) return b;
     return a < b ? a : b;
 }
 
 /** Returns the larger of two operands, preserving an exact `bigint`. Mirror of {@link minValue}. */
 export function maxValue(a: AgNumericValue, b: AgNumericValue): AgNumericValue {
     if (typeof a === 'number' && typeof b === 'number') return Math.max(a, b);
+    if (typeof a === 'number' && Number.isNaN(a)) return a;
+    if (typeof b === 'number' && Number.isNaN(b)) return b;
     return a > b ? a : b;
 }
 

--- a/packages/ag-charts-core/src/utils/data/strings.ts
+++ b/packages/ag-charts-core/src/utils/data/strings.ts
@@ -48,6 +48,9 @@ export function stringifyValue(value: unknown, maxLength = Infinity): string {
         } else if (value === -Infinity) {
             return '-Infinity';
         }
+    } else if (typeof value === 'bigint') {
+        // JSON.stringify throws on bigint, which would turn a clean validation rejection into a crash.
+        return `${value}`;
     }
     // If values is not serializable output value type instead.
     const strValue = JSON.stringify(value) ?? typeof value;

--- a/packages/ag-charts-core/src/utils/format/numberFormat.ts
+++ b/packages/ag-charts-core/src/utils/format/numberFormat.ts
@@ -1,3 +1,5 @@
+import type { AgNumericValue } from 'ag-charts-types';
+
 import { warnOnce } from '../../logging/logger';
 import { clamp } from '../data/numbers';
 import { isString } from '../types/typeGuards';
@@ -58,12 +60,10 @@ export function parseNumberFormat(format: string): FormatterOptions | undefined 
     };
 }
 
-export function createNumberFormatter(
-    format: FormatterOptions
-): (n: number | bigint, fractionDigits?: number) => string;
+export function createNumberFormatter(format: FormatterOptions): (n: AgNumericValue, fractionDigits?: number) => string;
 export function createNumberFormatter(
     format: string
-): ((n: number | bigint, fractionDigits?: number) => string) | undefined;
+): ((n: AgNumericValue, fractionDigits?: number) => string) | undefined;
 export function createNumberFormatter(format: string | FormatterOptions) {
     const options = typeof format === 'string' ? parseNumberFormat(format) : format;
     if (options == null) return;
@@ -98,7 +98,7 @@ export function createNumberFormatter(format: string | FormatterOptions) {
         padAlign ??= '=';
     }
 
-    return (n: number | bigint, fractionDigits?: number) => {
+    return (n: AgNumericValue, fractionDigits?: number) => {
         // A bigint can reach here via an `any`-typed value path; the body below uses Math/toFixed which
         // throw on bigint, so emit a locale-grouped string directly (AG-16608 AC #6/#8).
         if (typeof n === 'bigint') {

--- a/packages/ag-charts-core/src/utils/time/ticks.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.ts
@@ -223,8 +223,9 @@ export function tickFormat(
         }
     }
     const formatter = createNumberFormatter(options);
-    // A bigint tick renders full-precision rather than narrowing to Number.
-    return (n) => (typeof n === 'bigint' ? n.toLocaleString() : formatter(Number(n)));
+    // A bigint tick renders full-precision rather than narrowing to Number; pin en-US grouping to match
+    // createNumberFormatter and the rest of the chart's numeric ticks (toLocaleString() defaults to the runtime locale).
+    return (n) => (typeof n === 'bigint' ? n.toLocaleString('en-US') : formatter(Number(n)));
 }
 
 function bigIntTickStep(extent: bigint, count: number): bigint {

--- a/packages/ag-charts-core/src/utils/time/ticks.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.ts
@@ -223,9 +223,9 @@ export function tickFormat(
         }
     }
     const formatter = createNumberFormatter(options);
-    // A bigint tick renders full-precision rather than narrowing to Number; pin en-US grouping to match
-    // createNumberFormatter and the rest of the chart's numeric ticks (toLocaleString() defaults to the runtime locale).
-    return (n) => (typeof n === 'bigint' ? n.toLocaleString('en-US') : formatter(Number(n)));
+    // Route bigint through the formatter too: it applies the format's prefix/suffix and pins en-US grouping
+    // for bigint full-precision, so a bigint tick honours the user's label format rather than emitting a bare number.
+    return (n) => formatter(typeof n === 'bigint' ? n : Number(n));
 }
 
 function bigIntTickStep(extent: bigint, count: number): bigint {

--- a/packages/ag-charts-core/src/utils/time/ticks.ts
+++ b/packages/ag-charts-core/src/utils/time/ticks.ts
@@ -193,7 +193,10 @@ function decimalPlaces(decimal: string) {
     return 0;
 }
 
-export function tickFormat(ticks: any[], format?: string): ((n: number | { valueOf(): number }) => string) | undefined {
+export function tickFormat(
+    ticks: any[],
+    format?: string
+): ((n: number | bigint | { valueOf(): number }) => string) | undefined {
     const options = parseNumberFormat(format ?? ',f');
     if (options == null) return;
 
@@ -220,7 +223,8 @@ export function tickFormat(ticks: any[], format?: string): ((n: number | { value
         }
     }
     const formatter = createNumberFormatter(options);
-    return (n) => formatter(Number(n));
+    // A bigint tick renders full-precision rather than narrowing to Number.
+    return (n) => (typeof n === 'bigint' ? n.toLocaleString() : formatter(Number(n)));
 }
 
 function bigIntTickStep(extent: bigint, count: number): bigint {
@@ -291,6 +295,24 @@ export function createBigIntTicks(start: bigint, stop: bigint, count: number): b
     }
 
     return ascending ? ticks : ticks.reverse();
+}
+
+/** Contiguous, equal-width BigInt bins covering the domain (histogram bucketing); always at least one bin. */
+export function createBigIntBins(start: bigint, stop: bigint, count: number): [bigint, bigint][] {
+    const lo = start < stop ? start : stop;
+    const hi = start < stop ? stop : start;
+
+    const step = lo === hi ? 0n : bigIntTickStep(hi - lo, count);
+    if (step <= 0n) return [[lo, hi]];
+
+    const niceLo = floorToStep(lo, step);
+    const niceHi = ceilToStep(hi, step);
+
+    const bins: [bigint, bigint][] = [];
+    for (let edge = niceLo; edge < niceHi; edge += step) {
+        bins.push([edge, edge + step]);
+    }
+    return bins.length > 0 ? bins : [[niceLo, niceHi]];
 }
 
 /** Nice BigInt domain bounds — extends the endpoints outward to the surrounding step multiples. */

--- a/packages/ag-charts-core/src/utils/time/timeFormatDefaults.ts
+++ b/packages/ag-charts-core/src/utils/time/timeFormatDefaults.ts
@@ -1,10 +1,26 @@
-import type { AgTimeIntervalUnit } from 'ag-charts-types';
+import type { AgTimeIntervalUnit, AgTimeValue } from 'ag-charts-types';
 
 import { findMinMax } from '../data/numberArray';
 import { durationDay, durationHour, durationMinute, durationSecond, durationYear, intervalFloor } from './time';
 
 export function dateToNumber(value: any) {
     return value instanceof Date ? value.getTime() : value;
+}
+
+// Largest epoch (ms) a Date can represent; beyond this is an Invalid Date (NaN).
+const MAX_TIME_MS = 8.64e15;
+
+function epochInRange(epoch: number): number {
+    return Math.abs(epoch) > MAX_TIME_MS ? Number.NaN : epoch;
+}
+
+/** Coerce a time-axis value (Date, epoch number/bigint, or ISO 8601 string) to epoch ms; `NaN` if unparseable or out of Date range. */
+export function timeValueToNumber(value: AgTimeValue): number {
+    if (typeof value === 'number') return epochInRange(value);
+    if (typeof value === 'bigint') return epochInRange(Number(value));
+    if (typeof value === 'string') return Date.parse(value);
+    if (value instanceof Date) return value.getTime();
+    return value;
 }
 
 export function lowestGranularityForInterval(interval: number) {

--- a/packages/ag-charts-core/src/utils/types/typeGuards.ts
+++ b/packages/ag-charts-core/src/utils/types/typeGuards.ts
@@ -1,4 +1,4 @@
-import type { CssColor } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import type { PlainObject } from '../../types/global';
 import { parseColor } from '../dom/domUtil';
@@ -66,6 +66,20 @@ export function isNumber(value: unknown): value is number {
 
 export function isFiniteNumber(value: unknown): value is number {
     return Number.isFinite(value);
+}
+
+export function isBigInt(value: unknown): value is bigint {
+    return typeof value === 'bigint';
+}
+
+/** A `number` (including non-finite values such as `NaN`) or a `bigint`. */
+export function isNumericValue(value: unknown): value is AgNumericValue {
+    return typeof value === 'number' || typeof value === 'bigint';
+}
+
+/** A finite `number`, or a `bigint` (which is always exact and so always counts as finite here). */
+export function isFiniteNumericValue(value: unknown): value is AgNumericValue {
+    return typeof value === 'bigint' || Number.isFinite(value);
 }
 
 export function isHtmlElement(value: unknown): value is HTMLElement {

--- a/packages/ag-charts-enterprise/src/axes/angle-number/angleNumberAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/angleNumberAxis.ts
@@ -7,12 +7,13 @@ import {
     isNumberEqual,
     normalisedExtentWithMetadata,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { AngleAxisLabelDatum } from '../angle/angleAxis';
 import { AngleAxis } from '../angle/angleAxis';
 import { LinearAngleScale } from './linearAngleScale';
 
-export class AngleNumberAxis extends AngleAxis<number, LinearAngleScale, NormalisedAngleNumberAxisOptions> {
+export class AngleNumberAxis extends AngleAxis<AgNumericValue, LinearAngleScale, NormalisedAngleNumberAxisOptions> {
     static readonly className = 'AngleNumberAxis';
     static readonly type = 'angle-number' as const;
 

--- a/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
+++ b/packages/ag-charts-enterprise/src/axes/angle-number/linearAngleScale.ts
@@ -1,11 +1,12 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { type ScaleTickParams, isDenseInterval, isNumberEqual, range } from 'ag-charts-core';
+import { type ScaleTickParams, isDenseInterval, isNumberEqual, range, toNumber } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 const { LinearScale } = _ModuleSupport;
 
 export class LinearAngleScale extends LinearScale {
-    static getNiceStepAndTickCount(ticks: ScaleTickParams<number>, domain: number[]) {
-        const [start, stop] = domain;
+    static getNiceStepAndTickCount(ticks: ScaleTickParams<number>, domain: AgNumericValue[]) {
+        const [start, stop] = domain.map(toNumber);
         let step = LinearScale.getTickStep(start, stop, ticks);
         const maxTickCount = Number.isNaN(ticks.maxTickCount) ? Infinity : ticks.maxTickCount;
         const expectedTickCount = Math.abs(stop - start) / step;
@@ -19,18 +20,23 @@ export class LinearAngleScale extends LinearScale {
 
     arcLength: number = 0;
 
-    override ticks(ticks: ScaleTickParams<number>, domain: number[] = this.domain): { ticks: number[]; count: number } {
+    override ticks(
+        ticks: ScaleTickParams<number>,
+        domain: AgNumericValue[] = this.domain
+    ): { ticks: number[]; count: number } {
         const { arcLength } = this;
 
-        if (!domain || domain.length < 2 || domain.some((d) => !Number.isFinite(d)) || arcLength <= 0) {
+        // Nice-stepping is Number-only (log2/pow); a bigint domain narrows here for tick labels only.
+        const numericDomain = domain.map(toNumber);
+        if (numericDomain.length < 2 || numericDomain.some((d) => !Number.isFinite(d)) || arcLength <= 0) {
             return { ticks: [], count: 0 };
         }
 
         const { nice, interval } = ticks;
-        const [d0, d1] = domain;
+        const [d0, d1] = numericDomain;
 
         if (interval) {
-            const step = Math.abs(interval);
+            const step = Math.abs(toNumber(interval));
             const availableRange = this.getPixelRange();
             if (!isDenseInterval((d1 - d0) / step, availableRange)) {
                 const result = range(d0, d1, step);
@@ -56,13 +62,14 @@ export class LinearAngleScale extends LinearScale {
         return niceRanges.some((r) => isNumberEqual(r, sortedRange[1] - sortedRange[0]));
     }
 
-    override niceDomain(ticks: ScaleTickParams<number>, domain: number[] = this.domain): number[] {
+    override niceDomain(ticks: ScaleTickParams<number>, domain: AgNumericValue[] = this.domain): AgNumericValue[] {
         const linearNiceDomain = super.niceDomain(ticks, domain);
 
         if (!this.hasNiceRange()) return linearNiceDomain;
 
-        const reversed = linearNiceDomain[0] > linearNiceDomain[1];
-        const start = reversed ? linearNiceDomain[1] : linearNiceDomain[0];
+        const [n0, n1] = linearNiceDomain.map(toNumber);
+        const reversed = n0 > n1;
+        const start = reversed ? n1 : n0;
         const { step, count } = LinearAngleScale.getNiceStepAndTickCount(ticks, linearNiceDomain);
         const s = 1 / step; // Prevent floating point error
         const stop = step >= 1 ? Math.ceil(start / step + count) * step : Math.ceil((start + count * step) * s) / s;

--- a/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
@@ -46,7 +46,7 @@ export class RadiusNumberAxis extends RadiusAxis<
 
     protected prepareGridPathTickData(data: _ModuleSupport.TickDatum[]): _ModuleSupport.TickDatum[] {
         const { scale } = this;
-        // Narrow to Number so the sort comparator stays in Number space (bigint subtraction throws there).
+        // Narrow to Number so the comparator never mixes a bigint tick with a number tick (mixed subtraction throws).
         const domainTop = toNumber(scale.domain[1]);
         return data
             .filter(({ tick }) => toNumber(tick) !== domainTop) // Prevent outer tick being drawn behind polar line

--- a/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius-number/radiusNumberAxis.ts
@@ -6,7 +6,8 @@ import type {
     NormalisedRadiusNumberAxisOptions,
     NormalisedTextOrSegments,
 } from 'ag-charts-core';
-import { normalisedExtentWithMetadata } from 'ag-charts-core';
+import { normalisedExtentWithMetadata, toNumber } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { RadiusAxis } from '../radius/radiusAxis';
 
@@ -20,7 +21,7 @@ interface TickDatum {
 
 export class RadiusNumberAxis extends RadiusAxis<
     _ModuleSupport.LinearScale,
-    number,
+    AgNumericValue,
     NormalisedRadiusNumberAxisOptions
 > {
     static readonly className = 'RadiusNumberAxis';
@@ -45,10 +46,11 @@ export class RadiusNumberAxis extends RadiusAxis<
 
     protected prepareGridPathTickData(data: _ModuleSupport.TickDatum[]): _ModuleSupport.TickDatum[] {
         const { scale } = this;
-        const domainTop = scale.domain[1];
+        // Narrow to Number so the sort comparator stays in Number space (bigint subtraction throws there).
+        const domainTop = toNumber(scale.domain[1]);
         return data
-            .filter(({ tick }) => tick !== domainTop) // Prevent outer tick being drawn behind polar line
-            .sort((a, b) => b.tick - a.tick); // Apply grid styles starting from the largest arc
+            .filter(({ tick }) => toNumber(tick) !== domainTop) // Prevent outer tick being drawn behind polar line
+            .sort((a, b) => toNumber(b.tick) - toNumber(a.tick)); // Apply grid styles starting from the largest arc
     }
 
     protected getTickRadius(tickDatum: TickDatum): number {

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -13,8 +13,10 @@ import {
     type Point,
     PropertiesArray,
     Vec2,
+    addValues,
     isValidDate,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { TextInput } from '../text-input/textInput';
 import { AxesButtons } from './annotationAxesButtons';
@@ -647,13 +649,18 @@ export class Annotations extends AbstractModuleInstance {
         }
 
         const dateValues = dataModel.resolveKeysById<Date>({ id: 'annotations' }, 'date', processedData);
-        const volumeValues = dataModel.resolveColumnById({ id: 'annotations' }, 'volume', processedData);
+        const volumeValues = dataModel.resolveColumnById(
+            { id: 'annotations' },
+            'volume',
+            processedData,
+            'mixed-numeric'
+        );
 
-        let sum = 0;
+        let sum: AgNumericValue = 0;
         for (let datumIndex = 0; datumIndex < processedData.input.count; datumIndex++) {
             const key = dateValues[datumIndex];
             if (isValidDate(key) && key >= from && key <= to) {
-                sum += volumeValues[datumIndex];
+                sum = addValues(sum, volumeValues[datumIndex]);
             }
         }
         return sum;

--- a/packages/ag-charts-enterprise/src/features/annotations/measurer/measurerProperties.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/measurer/measurerProperties.ts
@@ -1,5 +1,6 @@
 import { type PixelSize, _ModuleSupport } from 'ag-charts-community';
 import { BaseProperties, Property, isObject } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import {
     Background,
@@ -43,7 +44,7 @@ export class MeasurerTypeProperties extends Localisable(Background(Stroke(LineSt
     @Property
     public statistics = new MeasurerStatistics();
 
-    public getVolume: (from: DataPoint['x'], to: DataPoint['x']) => number | undefined = () => undefined;
+    public getVolume: (from: DataPoint['x'], to: DataPoint['x']) => AgNumericValue | undefined = () => undefined;
 
     @Property
     text = new LineTextProperties();

--- a/packages/ag-charts-enterprise/src/features/annotations/measurer/measurerStatisticsScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/measurer/measurerStatisticsScene.ts
@@ -1,5 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import { type Bounds4, type BoxBounds, type DynamicContext, type Point, Vec4 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { type PositionedScene, layoutScenesColumn, layoutScenesRow } from '../../../utils/sceneLayout';
 import type { AnnotationContext } from '../annotationTypes';
@@ -9,7 +10,7 @@ import type { MeasurerTypeProperties, QuickDatePriceRangeProperties } from './me
 export interface Statistics {
     dateRange?: { bars: number; value: number };
     priceRange?: { percentage: number; value: number };
-    volume?: number;
+    volume?: AgNumericValue;
 }
 
 export class MeasurerStatisticsScene extends _ModuleSupport.Group {
@@ -280,10 +281,11 @@ export class MeasurerStatisticsScene extends _ModuleSupport.Group {
     }
 
     private formatVolume(
-        volume: number,
+        volume: AgNumericValue,
         localeManager?: DynamicContext<_ModuleSupport.ChartRegistry>['localeManager']
     ) {
-        const volumeString = Number.isNaN(volume) ? '' : this.volumeFormatter.format(volume);
+        const isMissing = typeof volume === 'number' && Number.isNaN(volume);
+        const volumeString = isMissing ? '' : this.volumeFormatter.format(volume);
         return localeManager?.t('measurerVolume', { value: volumeString }) ?? volumeString;
     }
 }

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBar.ts
@@ -10,6 +10,7 @@ import {
     type Scale,
     type ScaleType,
     type SeriesPluginModuleInstance,
+    findMinMax,
     isDefined,
     mergeDefaults,
 } from 'ag-charts-core';
@@ -174,7 +175,8 @@ export class ErrorBars extends AbstractModuleInstance implements SeriesPluginMod
                 const id = { x: xErrorsID, y: yErrorsID }[direction];
                 const lowerDomain = dataModel.getDomain(series, `${id}-lower`, 'value', processedData).domain;
                 const upperDomain = dataModel.getDomain(series, `${id}-upper`, 'value', processedData).domain;
-                const domain = [Math.min(...lowerDomain, ...upperDomain), Math.max(...lowerDomain, ...upperDomain)];
+                // findMinMax is bigint-safe (Math.min/max throw on bigint) and fixNumericExtent keeps exact endpoints.
+                const domain = findMinMax([...lowerDomain, ...upperDomain]);
                 return fixNumericExtent(domain);
             }
         }
@@ -256,12 +258,13 @@ export class ErrorBars extends AbstractModuleInstance implements SeriesPluginMod
         }
 
         // The datum has an error value for `key`. TempValidate this user input value:
-        if (typeof value !== 'number') {
+        if (typeof value !== 'number' && typeof value !== 'bigint') {
             Logger.warnOnce(`Found [${key}] error value of type ${typeof value}. Expected number type`);
             return;
         }
 
-        return value + offset;
+        // Narrow a bigint error value to Number for the screen-space offset (whisker positioning is pixel-space).
+        return Number(value) + offset;
     }
 
     private getDatum(nodeData: ErrorBarNodeDatum[], datumIndex: number) {

--- a/packages/ag-charts-enterprise/src/features/status-bar/statusBar.ts
+++ b/packages/ag-charts-enterprise/src/features/status-bar/statusBar.ts
@@ -6,6 +6,7 @@ import {
     ZIndexMap,
     cachedTextMeasurer,
     calcLineHeight,
+    isNumericValue,
 } from 'ag-charts-core';
 
 type NormalisedStatusBarOptions = _ModuleSupport.NormalisedStatusBarOptions;
@@ -393,8 +394,7 @@ export class StatusBar extends AbstractModuleInstance implements _ModuleSupport.
             value.setFont(opts[labelStyle]);
             value.fill = opts[labelStyle].color;
             // Intl.NumberFormat.format accepts bigint natively, so a bigint OHLC/volume renders full-precision.
-            value.text =
-                typeof datumValue === 'number' || typeof datumValue === 'bigint' ? formatter.format(datumValue) : '';
+            value.text = isNumericValue(datumValue) ? formatter.format(datumValue) : '';
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/status-bar/statusBar.ts
+++ b/packages/ag-charts-enterprise/src/features/status-bar/statusBar.ts
@@ -392,7 +392,9 @@ export class StatusBar extends AbstractModuleInstance implements _ModuleSupport.
 
             value.setFont(opts[labelStyle]);
             value.fill = opts[labelStyle].color;
-            value.text = typeof datumValue === 'number' ? formatter.format(datumValue) : '';
+            // Intl.NumberFormat.format accepts bigint natively, so a bigint OHLC/volume renders full-precision.
+            value.text =
+                typeof datumValue === 'number' || typeof datumValue === 'bigint' ? formatter.format(datumValue) : '';
         }
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.test.ts
@@ -31,6 +31,7 @@ import {
 } from 'ag-charts-community-test';
 import { ChartAxisDirection, type DeepReadonly } from 'ag-charts-core';
 import { WheelDeltaMode, dispatchEvent, wheelEvent } from 'ag-charts-test';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 
@@ -162,7 +163,7 @@ describe('Zoom', () => {
 
     describe('visibleDomain', () => {
         it('should match the zoomed domain for cartesian number axes', async () => {
-            let lastVisibleDomain: [number, number] | undefined;
+            let lastVisibleDomain: [AgNumericValue, AgNumericValue] | undefined;
             const baseOptions: AgCartesianChartOptions = {
                 data: [
                     { x: 0, y: 0 },

--- a/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
@@ -271,14 +271,12 @@ export class AxisTicks {
         const ticks: TickDatum[] = [];
         const domain = tickParams.nice ? this.scale.niceDomain(tickParams) : this.scale.domain;
         const rawTicks = this.scale.ticks(tickParams, domain)?.ticks ?? [];
-        const fractionDigits = rawTicks.reduce<number>(
-            (max, tick) => Math.max(max, countFractionDigits(Number(tick))),
-            0
-        );
+        const numericTicks = rawTicks.map(Number);
+        const fractionDigits = numericTicks.reduce<number>((max, tick) => Math.max(max, countFractionDigits(tick)), 0);
         const idGenerator = createIdsGenerator();
 
         // Formatter context only; the per-tick label below keeps the exact value.
-        const tickFormatter = this.tickFormatter(domain.map(Number), rawTicks.map(Number), false, fractionDigits);
+        const tickFormatter = this.tickFormatter(domain.map(Number), numericTicks, false, fractionDigits);
 
         for (let index = 0; index < rawTicks.length; index++) {
             const tick = rawTicks[index];

--- a/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/axisTicks.ts
@@ -271,10 +271,14 @@ export class AxisTicks {
         const ticks: TickDatum[] = [];
         const domain = tickParams.nice ? this.scale.niceDomain(tickParams) : this.scale.domain;
         const rawTicks = this.scale.ticks(tickParams, domain)?.ticks ?? [];
-        const fractionDigits = rawTicks.reduce((max, tick) => Math.max(max, countFractionDigits(tick)), 0);
+        const fractionDigits = rawTicks.reduce<number>(
+            (max, tick) => Math.max(max, countFractionDigits(Number(tick))),
+            0
+        );
         const idGenerator = createIdsGenerator();
 
-        const tickFormatter = this.tickFormatter(domain, rawTicks, false, fractionDigits);
+        // Formatter context only; the per-tick label below keeps the exact value.
+        const tickFormatter = this.tickFormatter(domain.map(Number), rawTicks.map(Number), false, fractionDigits);
 
         for (let index = 0; index < rawTicks.length; index++) {
             const tick = rawTicks[index];

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -8,7 +8,8 @@ import {
     _ModuleSupport,
 } from 'ag-charts-community';
 import type { CallbackParamRules, DeepRequired, DynamicContext, Mutable, RequireOptional } from 'ag-charts-core';
-import { ChartAxisDirection, deepClone, mergeDefaults } from 'ag-charts-core';
+import { ChartAxisDirection, deepClone, isNumericValue, mergeDefaults, toNumber } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { prepareBoxPlotFromTo, resetBoxPlotSelectionsScalingCenterFn } from './blotPlotUtil';
 import { BoxPlotNode } from './boxPlotNode';
@@ -57,11 +58,11 @@ interface BoxPlotSeriesTypes extends _ModuleSupport.AbstractBarSeriesTypes {
 /** Context object caching expensive lookups for createNodeData(). */
 interface BoxPlotSeriesNodeDatumContext extends _ModuleSupport.CartesianCreateNodeDataContext<BoxPlotNodeDatum> {
     // Box plot specific data arrays
-    readonly minValues: any[];
-    readonly q1Values: any[];
-    readonly medianValues: any[];
-    readonly q3Values: any[];
-    readonly maxValues: any[];
+    readonly minValues: AgNumericValue[];
+    readonly q1Values: AgNumericValue[];
+    readonly medianValues: AgNumericValue[];
+    readonly q3Values: AgNumericValue[];
+    readonly maxValues: AgNumericValue[];
 
     // Computed positioning (involves scale conversions - worth caching)
     readonly barWidth: number;
@@ -196,8 +197,15 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         return { domain: fixNumericExtent(yExtent) };
     }
 
-    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]) {
-        return this.domainForVisibleRange(ChartAxisDirection.Y, ['maxValue', 'minValue'], 'xValue', visibleRange);
+    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]): [number, number] {
+        // domainForVisibleRange may yield a bigint; narrow once for this number-typed range contract.
+        const [y0, y1] = this.domainForVisibleRange(
+            ChartAxisDirection.Y,
+            ['maxValue', 'minValue'],
+            'xValue',
+            visibleRange
+        );
+        return [toNumber(y0), toNumber(y1)];
     }
 
     /**
@@ -221,11 +229,11 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
             yAxis,
             rawData: processedData.dataSources.get(this.id)?.data ?? [],
             xValues: dataModel.resolveKeysById(this, 'xValue', processedData),
-            minValues: dataModel.resolveColumnById(this, 'minValue', processedData),
-            q1Values: dataModel.resolveColumnById(this, 'q1Value', processedData),
-            medianValues: dataModel.resolveColumnById(this, 'medianValue', processedData),
-            q3Values: dataModel.resolveColumnById(this, 'q3Value', processedData),
-            maxValues: dataModel.resolveColumnById(this, 'maxValue', processedData),
+            minValues: dataModel.resolveColumnById(this, 'minValue', processedData, 'mixed-numeric'),
+            q1Values: dataModel.resolveColumnById(this, 'q1Value', processedData, 'mixed-numeric'),
+            medianValues: dataModel.resolveColumnById(this, 'medianValue', processedData, 'mixed-numeric'),
+            q3Values: dataModel.resolveColumnById(this, 'q3Value', processedData, 'mixed-numeric'),
+            maxValues: dataModel.resolveColumnById(this, 'maxValue', processedData, 'mixed-numeric'),
             xScale: xAxis.scale,
             yScale: yAxis.scale,
             groupOffset,
@@ -246,7 +254,8 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
      */
     private validateBoxPlotValues(minValue: any, q1Value: any, medianValue: any, q3Value: any, maxValue: any): boolean {
         return (
-            [minValue, q1Value, medianValue, q3Value, maxValue].every((value) => typeof value === 'number') &&
+            // Accept bigint as well as number; the ordering comparisons below are valid for both (and mixed).
+            [minValue, q1Value, medianValue, q3Value, maxValue].every(isNumericValue) &&
             minValue <= q1Value &&
             q1Value <= medianValue &&
             medianValue <= q3Value &&
@@ -549,11 +558,13 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
-        const minValue = dataModel.resolveColumnById(this, `minValue`, processedData)[datumIndex];
-        const q1Value = dataModel.resolveColumnById(this, `q1Value`, processedData)[datumIndex];
-        const medianValue = dataModel.resolveColumnById(this, `medianValue`, processedData)[datumIndex];
-        const q3Value = dataModel.resolveColumnById(this, `q3Value`, processedData)[datumIndex];
-        const maxValue = dataModel.resolveColumnById(this, `maxValue`, processedData)[datumIndex];
+        const minValue = dataModel.resolveColumnById(this, `minValue`, processedData, 'mixed-numeric')[datumIndex];
+        const q1Value = dataModel.resolveColumnById(this, `q1Value`, processedData, 'mixed-numeric')[datumIndex];
+        const medianValue = dataModel.resolveColumnById(this, `medianValue`, processedData, 'mixed-numeric')[
+            datumIndex
+        ];
+        const q3Value = dataModel.resolveColumnById(this, `q3Value`, processedData, 'mixed-numeric')[datumIndex];
+        const maxValue = dataModel.resolveColumnById(this, `maxValue`, processedData, 'mixed-numeric')[datumIndex];
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         const allowNullKeys = this.properties.allowNullKeys ?? false;

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -247,12 +247,14 @@ export abstract class FlowProportionSeries<
             const fromIdValues = linksDataModel.dataModel.resolveColumnById<string | undefined>(
                 this,
                 'fromValue',
-                linksDataModel.processedData
+                linksDataModel.processedData,
+                'object'
             );
             const toIdValues = linksDataModel.dataModel.resolveColumnById<string | undefined>(
                 this,
                 'toValue',
-                linksDataModel.processedData
+                linksDataModel.processedData,
+                'object'
             );
 
             const createImplicitNode = (id: string): FlowProportionNodeDatum<TNodeDatum, TLinkDatum> => {
@@ -300,10 +302,11 @@ export abstract class FlowProportionSeries<
                 }
             }
         } else {
-            const nodeIdValues = nodesDataModel.dataModel.resolveColumnById<string>(
+            const nodeIdValues = nodesDataModel.dataModel.resolveColumnById(
                 this,
                 'idValue',
-                nodesDataModel.processedData
+                nodesDataModel.processedData,
+                'string'
             );
             const labelValues =
                 labelKey == null
@@ -311,7 +314,8 @@ export abstract class FlowProportionSeries<
                     : nodesDataModel.dataModel.resolveColumnById<string | undefined>(
                           this,
                           'labelValue',
-                          nodesDataModel.processedData
+                          nodesDataModel.processedData,
+                          'object'
                       );
 
             const nodeDataIdKey = this.data?.dataIdKey;
@@ -388,12 +392,12 @@ export abstract class FlowProportionSeries<
 
         const { sizeKey } = this.properties;
 
-        const fromIdValues = linksDataModel.resolveColumnById<string>(this, 'fromValue', linksProcessedData);
-        const toIdValues = linksDataModel.resolveColumnById<string>(this, 'toValue', linksProcessedData);
+        const fromIdValues = linksDataModel.resolveColumnById(this, 'fromValue', linksProcessedData, 'string');
+        const toIdValues = linksDataModel.resolveColumnById(this, 'toValue', linksProcessedData, 'string');
         const sizeValues =
             sizeKey == null
                 ? undefined
-                : linksDataModel.resolveColumnById<number>(this, 'sizeValue', linksProcessedData);
+                : linksDataModel.resolveColumnById(this, 'sizeValue', linksProcessedData, 'number');
 
         const nodesById = new Map<string, TNodeDatum>();
         for (const datum of this.processedNodes.values()) {

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -412,7 +412,9 @@ export abstract class FlowProportionSeries<
             for (const [index, datum] of linkData.entries()) {
                 const fromId: string = fromIdValues[index];
                 const toId: string = toIdValues[index];
-                const size: number = sizeValues == null ? 1 : sizeValues[index];
+                // Node sizes drive visual proportions/angles, so narrow a bigint sizeKey to Number here; the
+                // downstream accumulation (acc + size, totalSize +=, ratios * size) mixes it with Numbers.
+                const size: number = sizeValues == null ? 1 : Number(sizeValues[index]);
                 const fromNode = nodesById.get(fromId);
                 const toNode = nodesById.get(toId);
                 if (size <= 0 || fromNode == null || toNode == null) continue;

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -11,7 +11,8 @@ import type {
     Point,
     RequireOptional,
 } from 'ag-charts-core';
-import { ChartAxisDirection, SeriesZIndexMap } from 'ag-charts-core';
+import { ChartAxisDirection, SeriesZIndexMap, maxValue } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { BaseFunnelProperties } from './baseFunnelSeriesProperties';
 import { FunnelConnector } from './funnelConnector';
@@ -266,7 +267,9 @@ export abstract class BaseFunnelSeries<
             return { domain: this.padBandExtent(keys) };
         } else {
             const yExtent = this.domainForClippedRange(direction, ['yValue'], 'xValue');
-            const maxExtent = Math.max(...yExtent);
+            // maxValue preserves an exact bigint; Math.max throws on bigint operands.
+            let maxExtent: AgNumericValue = -Infinity;
+            for (const v of yExtent) maxExtent = maxValue(maxExtent, v);
             const fixedYExtent = [-maxExtent, maxExtent];
             return { domain: fixNumericExtent(fixedYExtent) };
         }
@@ -314,7 +317,7 @@ export abstract class BaseFunnelSeries<
         if (!isVisible) return context;
 
         const xValues = dataModel.resolveKeysById(this, 'xValue', processedData);
-        const yValues = dataModel.resolveColumnById(this, `yValue`, processedData);
+        const yValues = dataModel.resolveColumnById(this, `yValue`, processedData, 'mixed-numeric');
 
         const { groupOffset, barOffset, barWidth } = this.getBarDimensions();
 
@@ -460,7 +463,7 @@ export abstract class BaseFunnelSeries<
         datumIndex: number;
         rect: Bounds;
         barAlongX: boolean;
-        yDatum: number;
+        yDatum: AgNumericValue;
         datum: any;
         visible: boolean;
     }): FunnelNodeLabelDatum | undefined;
@@ -571,7 +574,7 @@ export abstract class BaseFunnelSeries<
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const xValue = dataModel.resolveKeysById(this, 'xValue', processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData)[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData, 'mixed-numeric')[datumIndex];
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         const allowNullKeys = this.properties.allowNullKeys ?? false;

--- a/packages/ag-charts-enterprise/src/series/funnel/funnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/funnelSeries.ts
@@ -6,6 +6,7 @@ import {
 } from 'ag-charts-community';
 import type { DynamicContext, RequireOptional } from 'ag-charts-core';
 import { ChartAxisDirection, mergeDefaults } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import {
     BaseFunnelSeries,
@@ -70,7 +71,7 @@ export class FunnelSeries extends BaseFunnelSeries<FunnelSeriesTypes> {
         datumIndex: number;
         rect: Bounds;
         barAlongX: boolean;
-        yDatum: number;
+        yDatum: AgNumericValue;
         datum: any;
         visible: boolean;
     }): FunnelNodeLabelDatum | undefined {

--- a/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
@@ -1,10 +1,11 @@
 import type { AgChartLabelFormatterParams, RichFormatter, _ModuleSupport } from 'ag-charts-community';
 import { type NormalisedTextOrSegments, isArray } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { formatWithContext } from '../../utils/formatter';
 
 interface GaugeLabelDatum {
-    value: number;
+    value: AgNumericValue;
     text?: NormalisedTextOrSegments;
     formatter?: RichFormatter<AgChartLabelFormatterParams<any>>;
 }
@@ -18,17 +19,23 @@ export const fadeInFns: _ModuleSupport.FromToFns<_ModuleSupport.Node, any, any> 
     toFn: () => ({ opacity: 1 }),
 };
 
-export function formatLabel(value: number | undefined, scale: { min: number; max: number }) {
+export function formatLabel(value: AgNumericValue | undefined, scale: { min: AgNumericValue; max: AgNumericValue }) {
     if (value == null) return '';
 
-    const { min, max } = scale;
+    // bigint is exact and integral; render full-precision and skip decimal-place estimation.
+    if (typeof value === 'bigint') {
+        return value.toLocaleString();
+    }
+
+    const min = Number(scale.min);
+    const max = Number(scale.max);
     const minLog10 = min === 0 ? 0 : Math.ceil(Math.log10(Math.abs(min)));
     const maxLog10 = max === 0 ? 0 : Math.ceil(Math.log10(Math.abs(max)));
     const dp = Math.max(2 - Math.max(minLog10, maxLog10), 0);
     return value.toFixed(dp);
 }
 
-export function getLabelText(seriesId: string, ctx: Ctx, datum: GaugeLabelDatum, valueOverride?: number) {
+export function getLabelText(seriesId: string, ctx: Ctx, datum: GaugeLabelDatum, valueOverride?: AgNumericValue) {
     if (datum.text != null) return datum.text;
 
     const value = valueOverride ?? datum.value;

--- a/packages/ag-charts-enterprise/src/series/gauge-util/segmentation.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/segmentation.ts
@@ -1,27 +1,32 @@
 import { BaseProperties, Logger, Property, type Scale } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 class GaugeSegmentationIntervalProperties extends BaseProperties {
     @Property
-    values?: number[];
+    values?: Array<AgNumericValue>;
 
     @Property
-    step?: number;
+    step?: AgNumericValue;
 
     @Property
     count?: number;
 
-    getSegments(scale: Scale<number, number>, maxTicks: number) {
+    getSegments(scale: Scale<AgNumericValue, number>, maxTicks: number) {
         const { values, step, count } = this;
-        const d0 = Math.min(...scale.domain);
-        const d1 = Math.max(...scale.domain);
+        // Keep raw endpoints exact for scale.convert(); the Number copies drive only stepping/division.
+        const d0 = scale.domainMin ?? Number.NaN;
+        const d1 = scale.domainMax ?? Number.NaN;
+        const d0n = Number(d0);
+        const d1n = Number(d1);
 
-        let ticks: number[] | undefined;
+        let ticks: Array<AgNumericValue> | undefined;
         if (values != null) {
-            const segments = values.filter((v) => v > d0 && v < d1).sort((a, b) => a - b);
+            const segments = values.filter((v) => v > d0 && v < d1).sort((a, b) => Number(a) - Number(b));
             ticks = [d0, ...segments, d1];
         } else if (step != null) {
-            const segments: number[] = [];
-            for (let i = d0; i < d1; i += step) {
+            const numericStep = Number(step);
+            const segments: AgNumericValue[] = [];
+            for (let i = d0n; i < d1n; i += numericStep) {
                 segments.push(i);
             }
             segments.push(d1);
@@ -39,7 +44,7 @@ class GaugeSegmentationIntervalProperties extends BaseProperties {
             ticks = segments == null ? undefined : [d0, ...segments, d1];
         } else {
             const segments = count + 1;
-            ticks = Array.from({ length: segments + 1 }, (_, i) => (i / segments) * (d1 - d0) + d0);
+            ticks = Array.from({ length: segments + 1 }, (_, i) => (i / segments) * (d1n - d0n) + d0n);
         }
 
         if (ticks != null && ticks.length > maxTicks) {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -361,10 +361,10 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         const xScale = xAxis.scale;
         const yScale = yAxis.scale;
 
-        const xValues = dataModel.resolveColumnById(this, `xValue`, processedData);
-        const yValues = dataModel.resolveColumnById(this, `yValue`, processedData);
+        const xValues = dataModel.resolveColumnById(this, `xValue`, processedData, 'object');
+        const yValues = dataModel.resolveColumnById(this, `yValue`, processedData, 'object');
         const colorValues = colorKey
-            ? dataModel.resolveColumnById<number>(this, `colorValue`, processedData)
+            ? dataModel.resolveColumnById(this, `colorValue`, processedData, 'number')
             : undefined;
 
         const colorDomain = colorKey ? dataModel.getDomain(this, 'colorValue', 'value', processedData).domain : [];
@@ -767,12 +767,12 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
-        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData)[datumIndex];
+        const xValue = dataModel.resolveColumnById(this, `xValue`, processedData, 'object')[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData, 'object')[datumIndex];
         const colorValue =
             colorKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `colorValue`, processedData)[datumIndex];
+                : dataModel.resolveColumnById(this, `colorValue`, processedData, 'number')[datumIndex];
 
         const allowNullKeys = this.properties.allowNullKeys ?? false;
         if (xValue === undefined && !allowNullKeys) return;

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -24,6 +24,7 @@ import {
     toRadians,
     toTextString,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { formatWithContext } from '../../utils/formatter';
 import { DatumUnion } from '../gauge-util/datumUnion';
@@ -381,7 +382,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         };
     }
 
-    labelDatum(label: LinearGaugeLabelProperties, value: number): LinearGaugeLabelDatum {
+    labelDatum(label: LinearGaugeLabelProperties, value: AgNumericValue): LinearGaugeLabelDatum {
         const {
             placement,
             avoidCollisions,
@@ -608,8 +609,9 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         const scaleStyle = scaleProps.getStyle(bar.enabled, defaultColorRange, horizontal, scale);
 
         if (segments == null && cornersOnAllItems) {
-            const segmentStart = Math.min(...scale.domain);
-            const segmentEnd = Math.max(...scale.domain);
+            // convert() maps these whole-domain endpoints to the range ends, so a Number-narrow is precision-safe.
+            const segmentStart = Number(scale.domainMin);
+            const segmentEnd = Number(scale.domainMax);
             const datum = { value, segmentStart, segmentEnd };
 
             if (bar.enabled) {
@@ -1157,7 +1159,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         return true;
     }
 
-    formatLabelText(datum?: { label: number }) {
+    formatLabelText(datum?: { label: AgNumericValue }) {
         const { labelSelection, horizontal, scale, seriesRect, gaugeRect } = this;
         const { x, y, width, height } = gaugeRect;
 
@@ -1197,8 +1199,8 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
     private animateLabelText(params: { from?: number; phase?: _ModuleSupport.AnimationPhase } = {}) {
         const { animationManager } = this.ctx;
 
-        let labelFrom = 0;
-        let labelTo = 0;
+        let labelFrom: AgNumericValue = 0;
+        let labelTo: AgNumericValue = 0;
         this.labelSelection.each((label, datum) => {
             // Reset animation
             label.opacity = 1;
@@ -1214,11 +1216,12 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         } else {
             const animationId = `${this.id}_labels`;
 
+            // The count-up tween narrows to Number; onStop re-formats from the full-precision label value.
             animationManager.animate({
                 id: animationId,
                 groupId: 'label',
-                from: { label: labelFrom },
-                to: { label: labelTo },
+                from: { label: Number(labelFrom) },
+                to: { label: Number(labelTo) },
                 phase: params.phase ?? 'update',
                 ease: easeOut,
                 onUpdate: (datum) => this.formatLabelText(datum),

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -1211,7 +1211,8 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
 
         if (this.labelsHaveExplicitText()) {
             // Ignore
-        } else if (labelFrom === labelTo) {
+        } else if (Number(labelFrom) === Number(labelTo)) {
+            // Number() compare so a value type change (`5n === 5` is false) doesn't force a no-op animation.
             this.formatLabelText({ label: labelTo });
         } else {
             const animationId = `${this.id}_labels`;

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
@@ -10,6 +10,7 @@ import type {
     AgLinearGaugeSeriesStyle,
     AgLinearGaugeTargetPlacement,
     AgLinearGaugeTooltipRendererParams,
+    AgNumericValue,
     FontStyle,
     FontWeight,
     OverflowStrategy,
@@ -77,7 +78,7 @@ export interface LinearGaugeLabelDatum extends _ModuleSupport.SeriesNodeDatum {
     avoidCollisions: boolean;
     spacing: number;
     text: NormalisedTextOrSegments | undefined;
-    value: number;
+    value: AgNumericValue;
     fill: string | undefined;
     fontStyle: FontStyle | undefined;
     fontWeight: FontWeight | undefined;
@@ -386,7 +387,8 @@ export function createLinearGradient(
     scale: _ModuleSupport.LinearScale,
     horizontal: boolean
 ): InternalAgGradientColor {
-    const colorStops = getColorStops(fills, defaultColorRange, scale.domain, fillMode);
+    // Colour-stop positions are fractional thresholds — Number is correct (no bigint precision benefit).
+    const colorStops = getColorStops(fills, defaultColorRange, scale.domain.map(Number), fillMode);
     return {
         type: 'gradient',
         gradient: 'linear',

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeUtil.ts
@@ -1,5 +1,6 @@
 import { type TextAlign, _ModuleSupport } from 'ag-charts-community';
 import { cachedTextMeasurer, isArray, measureTextSegments, toPlainText, toTextString } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { getLabelText } from '../gauge-util/label';
 import { type LabelFormatting, formatSingleLabel } from '../util/labelFormatter';
@@ -209,7 +210,7 @@ export function formatLinearGaugeLabels(
     selection: _ModuleSupport.Selection<LinearGaugeLabelDatum, _ModuleSupport.Text<LinearGaugeLabelDatum>>,
     opts: { padding: number; horizontal: boolean },
     bboxes: { seriesRect: _ModuleSupport.BBox; gaugeRect: _ModuleSupport.BBox; barRect: _ModuleSupport.BBox },
-    datumOverrides?: { label: number | undefined }
+    datumOverrides?: { label: AgNumericValue | undefined }
 ) {
     const { seriesRect, gaugeRect, barRect } = bboxes;
     const { padding, horizontal } = opts;

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -200,7 +200,12 @@ export class MapLineSeries
             ],
         });
 
-        const featureValues = dataModel.resolveColumnById<Feature | undefined>(this, `featureValue`, processedData);
+        const featureValues = dataModel.resolveColumnById<Feature | undefined>(
+            this,
+            `featureValue`,
+            processedData,
+            'object'
+        );
         this.topologyBounds = featureValues.reduce<LonLatBBox | undefined>((current, feature) => {
             const geometry = feature?.geometry;
             if (geometry == null) return current;
@@ -300,21 +305,28 @@ export class MapLineSeries
     private resolveColumn<T>(
         key: string | undefined,
         columnId: string,
-        processedData: _ModuleSupport.ProcessedData<any>
+        processedData: _ModuleSupport.ProcessedData<any>,
+        expectedType: _ModuleSupport.ColumnValueType
     ): T[] | undefined {
         if (key == null || this.dataModel == null) return undefined;
-        return this.dataModel.resolveColumnById<T>(this, columnId, processedData);
+        // expectedType is validated at runtime; the cast only selects the element-typed overload.
+        return this.dataModel.resolveColumnById<T>(this, columnId, processedData, expectedType as 'object');
     }
 
     private resolveLineDataColumns(processedData: _ModuleSupport.ProcessedData<any>) {
         const { sizeKey, colorKey, labelKey } = this.properties;
 
         return {
-            idValues: this.dataModel!.resolveColumnById<string>(this, 'idValue', processedData),
-            featureValues: this.dataModel!.resolveColumnById<Feature | undefined>(this, 'featureValue', processedData),
-            labelValues: this.resolveColumn<string>(labelKey, 'labelValue', processedData),
-            sizeValues: this.resolveColumn<number>(sizeKey, 'sizeValue', processedData),
-            colorValues: this.resolveColumn<number>(colorKey, 'colorValue', processedData),
+            idValues: this.dataModel!.resolveColumnById(this, 'idValue', processedData, 'string'),
+            featureValues: this.dataModel!.resolveColumnById<Feature | undefined>(
+                this,
+                'featureValue',
+                processedData,
+                'object'
+            ),
+            labelValues: this.resolveColumn<string>(labelKey, 'labelValue', processedData, 'object'),
+            sizeValues: this.resolveColumn<number>(sizeKey, 'sizeValue', processedData, 'number'),
+            colorValues: this.resolveColumn<number>(colorKey, 'colorValue', processedData, 'number'),
         };
     }
 
@@ -672,7 +684,7 @@ export class MapLineSeries
 
         let { stroke } = properties;
         if (datumIndex != null && this.isColorScaleValid()) {
-            const colorValues = dataModel!.resolveColumnById(this, 'colorValue', processedData!);
+            const colorValues = dataModel!.resolveColumnById(this, 'colorValue', processedData!, 'mixed-numeric');
             const colorValue = colorValues[datumIndex];
             if (colorValue != null) {
                 stroke = this.colorScale.convert(colorValue);
@@ -782,20 +794,22 @@ export class MapLineSeries
         if (!dataModel || !processedData) return;
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
-        const idValues = dataModel.resolveColumnById<string>(this, `idValue`, processedData);
+        const idValues = dataModel.resolveColumnById(this, `idValue`, processedData, 'string');
         const sizeValue =
             sizeKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `sizeValue`, processedData)[datumIndex];
+                : dataModel.resolveColumnById(this, `sizeValue`, processedData, 'number')[datumIndex];
         const colorValue =
             colorKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `colorValue`, processedData)[datumIndex];
+                : dataModel.resolveColumnById(this, `colorValue`, processedData, 'number')[datumIndex];
 
         const data: _ModuleSupport.TooltipContentDataRow[] = [];
 
         if (this.isLabelEnabled() && labelKey != null && labelKey !== idKey) {
-            const labelValue = dataModel.resolveColumnById<string>(this, `labelValue`, processedData)[datumIndex];
+            const labelValue = dataModel.resolveColumnById<string>(this, `labelValue`, processedData, 'object')[
+                datumIndex
+            ];
             const content = formatManager.format(this.callWithContext.bind(this), {
                 type: 'category',
                 value: labelValue,

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -276,9 +276,13 @@ export class MapMarkerSeries
         const featureValues =
             idKey == null
                 ? undefined
-                : dataModel.resolveColumnById<Feature | undefined>(this, `featureValue`, processedData);
-        const latValues = hasLatLon ? dataModel.resolveColumnById<number>(this, `latValue`, processedData) : undefined;
-        const lonValues = hasLatLon ? dataModel.resolveColumnById<number>(this, `lonValue`, processedData) : undefined;
+                : dataModel.resolveColumnById<Feature | undefined>(this, `featureValue`, processedData, 'object');
+        const latValues = hasLatLon
+            ? dataModel.resolveColumnById(this, `latValue`, processedData, 'number')
+            : undefined;
+        const lonValues = hasLatLon
+            ? dataModel.resolveColumnById(this, `lonValue`, processedData, 'number')
+            : undefined;
         this.topologyBounds = processedData.dataSources
             .get(this.id)
             ?.data.reduce<LonLatBBox | undefined>((current, _datum, datumIndex) => {
@@ -397,10 +401,12 @@ export class MapMarkerSeries
     private resolveColumn<T>(
         key: string | undefined,
         columnId: string,
-        processedData: _ModuleSupport.ProcessedData<any>
+        processedData: _ModuleSupport.ProcessedData<any>,
+        expectedType: _ModuleSupport.ColumnValueType
     ): T[] | undefined {
         if (key == null || this.dataModel == null) return undefined;
-        return this.dataModel.resolveColumnById<T>(this, columnId, processedData);
+        // expectedType is validated at runtime; the cast only selects the element-typed overload.
+        return this.dataModel.resolveColumnById<T>(this, columnId, processedData, expectedType as 'object');
     }
 
     private resolveDataColumns(processedData: _ModuleSupport.ProcessedData<any>) {
@@ -408,13 +414,17 @@ export class MapMarkerSeries
         const hasLatLon = latitudeKey != null && longitudeKey != null;
 
         return {
-            idValues: this.resolveColumn<string>(idKey, 'idValue', processedData),
-            featureValues: this.resolveColumn<Feature | undefined>(idKey, 'featureValue', processedData),
-            latValues: hasLatLon ? this.resolveColumn<number>(latitudeKey, 'latValue', processedData) : undefined,
-            lonValues: hasLatLon ? this.resolveColumn<number>(longitudeKey, 'lonValue', processedData) : undefined,
-            labelValues: this.resolveColumn<string>(labelKey, 'labelValue', processedData),
-            sizeValues: this.resolveColumn<number>(sizeKey, 'sizeValue', processedData),
-            colorValues: this.resolveColumn<number>(colorKey, 'colorValue', processedData),
+            idValues: this.resolveColumn<string>(idKey, 'idValue', processedData, 'string'),
+            featureValues: this.resolveColumn<Feature | undefined>(idKey, 'featureValue', processedData, 'object'),
+            latValues: hasLatLon
+                ? this.resolveColumn<number>(latitudeKey, 'latValue', processedData, 'number')
+                : undefined,
+            lonValues: hasLatLon
+                ? this.resolveColumn<number>(longitudeKey, 'lonValue', processedData, 'number')
+                : undefined,
+            labelValues: this.resolveColumn<string>(labelKey, 'labelValue', processedData, 'object'),
+            sizeValues: this.resolveColumn<number>(sizeKey, 'sizeValue', processedData, 'number'),
+            colorValues: this.resolveColumn<number>(colorKey, 'colorValue', processedData, 'number'),
         };
     }
 
@@ -939,7 +949,7 @@ export class MapMarkerSeries
 
         let { fill } = properties;
         if (datumIndex != null && this.isColorScaleValid()) {
-            const colorValues = dataModel!.resolveColumnById(this, 'colorValue', processedData!);
+            const colorValues = dataModel!.resolveColumnById(this, 'colorValue', processedData!, 'mixed-numeric');
             const colorValue = colorValues[datumIndex];
             if (colorValue != null) {
                 fill = this.colorScale.convert(colorValue);
@@ -1049,16 +1059,18 @@ export class MapMarkerSeries
         const sizeValue =
             sizeKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `sizeValue`, processedData)[datumIndex];
+                : dataModel.resolveColumnById(this, `sizeValue`, processedData, 'number')[datumIndex];
         const colorValue =
             colorKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `colorValue`, processedData)[datumIndex];
+                : dataModel.resolveColumnById(this, `colorValue`, processedData, 'number')[datumIndex];
 
         const data: _ModuleSupport.TooltipContentDataRow[] = [];
 
         if (this.isLabelEnabled() && labelKey != null && labelKey !== idKey) {
-            const labelValue = dataModel.resolveColumnById<string>(this, `labelValue`, processedData)[datumIndex];
+            const labelValue = dataModel.resolveColumnById<string>(this, `labelValue`, processedData, 'object')[
+                datumIndex
+            ];
             const content = formatManager.format(this.callWithContext.bind(this), {
                 type: 'category',
                 value: labelValue,
@@ -1118,10 +1130,10 @@ export class MapMarkerSeries
 
         let heading: string | undefined;
         if (idKey != null) {
-            heading = dataModel.resolveColumnById<string>(this, `idValue`, processedData)[datumIndex];
+            heading = dataModel.resolveColumnById(this, `idValue`, processedData, 'string')[datumIndex];
         } else if (latitudeKey != null && longitudeKey != null) {
-            const latValue = dataModel.resolveColumnById<number>(this, `latValue`, processedData)[datumIndex];
-            const lonValue = dataModel.resolveColumnById<number>(this, `lonValue`, processedData)[datumIndex];
+            const latValue = dataModel.resolveColumnById(this, `latValue`, processedData, 'number')[datumIndex];
+            const lonValue = dataModel.resolveColumnById(this, `lonValue`, processedData, 'number')[datumIndex];
             heading = `${Math.abs(latValue).toFixed(4)}\u00B0 ${latValue >= 0 ? 'N' : 'S'}, ${Math.abs(lonValue).toFixed(4)}\u00B0 ${lonValue >= 0 ? 'W' : 'E'}`;
         }
 

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -214,7 +214,12 @@ export class MapShapeSeries
             ],
         });
 
-        const featureValues = dataModel.resolveColumnById<Feature | undefined>(this, `featureValue`, processedData);
+        const featureValues = dataModel.resolveColumnById<Feature | undefined>(
+            this,
+            `featureValue`,
+            processedData,
+            'object'
+        );
         this.topologyBounds = featureValues.reduce<LonLatBBox | undefined>((current, feature) => {
             const geometry = feature?.geometry;
             if (geometry == null) return current;
@@ -368,20 +373,27 @@ export class MapShapeSeries
     private resolveColumn<T>(
         key: string | undefined,
         columnId: string,
-        processedData: _ModuleSupport.ProcessedData<any>
+        processedData: _ModuleSupport.ProcessedData<any>,
+        expectedType: _ModuleSupport.ColumnValueType
     ): T[] | undefined {
         if (key == null || this.dataModel == null) return undefined;
-        return this.dataModel.resolveColumnById<T>(this, columnId, processedData);
+        // expectedType is validated at runtime; the cast only selects the element-typed overload.
+        return this.dataModel.resolveColumnById<T>(this, columnId, processedData, expectedType as 'object');
     }
 
     private resolveShapeDataColumns(processedData: _ModuleSupport.ProcessedData<any>) {
         const { colorKey, labelKey } = this.properties;
 
         return {
-            idValues: this.dataModel!.resolveColumnById<string>(this, 'idValue', processedData),
-            featureValues: this.dataModel!.resolveColumnById<Feature | undefined>(this, 'featureValue', processedData),
-            labelValues: this.resolveColumn<string>(labelKey, 'labelValue', processedData),
-            colorValues: this.resolveColumn<number>(colorKey, 'colorValue', processedData),
+            idValues: this.dataModel!.resolveColumnById(this, 'idValue', processedData, 'string'),
+            featureValues: this.dataModel!.resolveColumnById<Feature | undefined>(
+                this,
+                'featureValue',
+                processedData,
+                'object'
+            ),
+            labelValues: this.resolveColumn<string>(labelKey, 'labelValue', processedData, 'object'),
+            colorValues: this.resolveColumn<number>(colorKey, 'colorValue', processedData, 'number'),
         };
     }
 
@@ -745,7 +757,7 @@ export class MapShapeSeries
 
         let { fill } = properties;
         if (datumIndex != null && this.isColorScaleValid()) {
-            const colorValues = dataModel!.resolveColumnById(this, 'colorValue', processedData!);
+            const colorValues = dataModel!.resolveColumnById(this, 'colorValue', processedData!, 'mixed-numeric');
             const colorValue = colorValues[datumIndex];
             if (colorValue != null) {
                 fill = this.colorScale.convert(colorValue);
@@ -835,11 +847,11 @@ export class MapShapeSeries
         if (!dataModel || !processedData) return;
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
-        const idValue = dataModel.resolveColumnById<string>(this, `idValue`, processedData)[datumIndex];
+        const idValue = dataModel.resolveColumnById(this, `idValue`, processedData, 'string')[datumIndex];
         const colorValue =
             colorKey == null
                 ? undefined
-                : dataModel.resolveColumnById<number>(this, `colorValue`, processedData)[datumIndex];
+                : dataModel.resolveColumnById(this, `colorValue`, processedData, 'number')[datumIndex];
 
         if (colorKey != null && colorValue == null) {
             return;
@@ -848,7 +860,9 @@ export class MapShapeSeries
         const data: _ModuleSupport.TooltipContentDataRow[] = [];
 
         if (this.isLabelEnabled() && labelKey != null && labelKey !== idKey) {
-            const labelValue = dataModel.resolveColumnById<string>(this, `labelValue`, processedData)[datumIndex];
+            const labelValue = dataModel.resolveColumnById<string>(this, `labelValue`, processedData, 'object')[
+                datumIndex
+            ];
             const content = formatManager.format(this.callWithContext.bind(this), {
                 type: 'category',
                 value: labelValue,

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcAggregation.ts
@@ -10,6 +10,7 @@ import {
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
     epochColumnForTimeScale,
+    narrowBigIntColumn,
     narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -69,11 +70,14 @@ export function aggregateOhlcDataFromDataModel(
         dataModel.resolveColumnNeedsValueOf(series, 'highValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'lowValue', processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
@@ -119,11 +123,14 @@ export function aggregateOhlcDataFromDataModelPartial(
         dataModel.resolveColumnNeedsValueOf(series, 'highValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'lowValue', processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcAggregation.ts
@@ -1,16 +1,10 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import type {
-    DomainWithMetadata,
-    ExtremesAggregationFilter,
-    ExtremesPartialAggregationResult,
-    ScaleType,
-} from 'ag-charts-core';
+import type { ExtremesAggregationFilter, ExtremesPartialAggregationResult, ScaleType } from 'ag-charts-core';
 import {
-    aggregationDomain,
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
     epochColumnForTimeScale,
-    narrowBigIntColumn,
+    narrowAggregationX,
     narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -29,16 +23,15 @@ export type OhlcPartialAggregationResult = ExtremesPartialAggregationResult;
 // ============================================================================
 
 function aggregateOhlcData(
-    scale: ScaleType,
     xValues: any[],
     highValues: any[],
     lowValues: any[],
-    domainInput: DomainWithMetadata<number>,
+    d0: number,
+    d1: number,
     smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): OhlcSeriesDataAggregationFilter[] | undefined {
-    const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeExtremesAggregation([d0, d1], xValues, highValues, lowValues, {
         smallestKeyInterval,
         xNeedsValueOf,
@@ -75,16 +68,15 @@ export function aggregateOhlcDataFromDataModel(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
-        const [d0, d1] = aggregationDomain(scale, domainInput);
-        return computeExtremesAggregation([d0, d1], xValues, highValues, lowValues, {
+        return computeExtremesAggregation(domain, xValues, highValues, lowValues, {
             smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
             xNeedsValueOf,
             yNeedsValueOf,
@@ -93,11 +85,11 @@ export function aggregateOhlcDataFromDataModel(
     }
 
     return memoizedAggregateOhlcData(
-        scale,
         xValues,
         highValues,
         lowValues,
-        domainInput,
+        domain[0],
+        domain[1],
         processedData.reduced?.smallestKeyInterval,
         xNeedsValueOf,
         yNeedsValueOf
@@ -128,14 +120,13 @@ export function aggregateOhlcDataFromDataModelPartial(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
-    const [d0, d1] = aggregationDomain(scale, domainInput);
-    return computeExtremesAggregationPartial([d0, d1], xValues, highValues, lowValues, {
+    return computeExtremesAggregationPartial(domain, xValues, highValues, lowValues, {
         smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
         targetRange,
         xNeedsValueOf,

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcAggregation.ts
@@ -9,8 +9,11 @@ import {
     aggregationDomain,
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
+    epochColumnForTimeScale,
+    narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 type ScopeProvider = _ModuleSupport.ScopeProvider;
 type ProcessedData = _ModuleSupport.ProcessedData<any>;
@@ -30,7 +33,7 @@ function aggregateOhlcData(
     highValues: any[],
     lowValues: any[],
     domainInput: DomainWithMetadata<number>,
-    smallestKeyInterval: number | undefined,
+    smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): OhlcSeriesDataAggregationFilter[] | undefined {
@@ -55,16 +58,24 @@ export function aggregateOhlcDataFromDataModel(
     series: ScopeProvider,
     existingFilters?: OhlcSeriesDataAggregationFilter[]
 ): OhlcSeriesDataAggregationFilter[] | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const highValues = dataModel.resolveColumnById(series, 'highValue', processedData);
-    const lowValues = dataModel.resolveColumnById(series, 'lowValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawHighValues = dataModel.resolveColumnById(series, 'highValue', processedData, 'mixed-numeric');
+    const rawLowValues = dataModel.resolveColumnById(series, 'lowValue', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf =
         dataModel.resolveColumnNeedsValueOf(series, 'highValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'lowValue', processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
+    const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
@@ -97,16 +108,24 @@ export function aggregateOhlcDataFromDataModelPartial(
     targetRange: number,
     existingFilters?: OhlcSeriesDataAggregationFilter[]
 ): OhlcPartialAggregationResult | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const highValues = dataModel.resolveColumnById(series, 'highValue', processedData);
-    const lowValues = dataModel.resolveColumnById(series, 'lowValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawHighValues = dataModel.resolveColumnById(series, 'highValue', processedData, 'mixed-numeric');
+    const rawLowValues = dataModel.resolveColumnById(series, 'lowValue', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf =
         dataModel.resolveColumnNeedsValueOf(series, 'highValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'lowValue', processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
+    const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeExtremesAggregationPartial([d0, d1], xValues, highValues, lowValues, {

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -117,7 +117,7 @@ class OhlcSeriesNodeEvent<
 interface PreparedOhlcNodeDatumState {
     datum: any;
     xValue: any;
-    // bigint-capable so yScale.convert() keeps full precision; narrowed to number for the stored datum.
+    // Kept as AgNumericValue (bigint preserved, not narrowed) so yScale.convert() positions at full precision.
     openValue: AgNumericValue;
     closeValue: AgNumericValue;
     highValue: AgNumericValue;

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -23,7 +23,9 @@ import {
     type Point,
     type Scale,
     mergeDefaults,
+    toNumber,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import {
     type OhlcSeriesDataAggregationFilter,
@@ -63,11 +65,11 @@ export interface OhlcNodeDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDa
     readonly itemId?: never;
     readonly itemType: AgOhlcSeriesItemType;
 
-    readonly openValue: number;
-    readonly closeValue: number;
-    readonly highValue?: number;
-    readonly lowValue?: number;
-    readonly aggregatedValue: number;
+    readonly openValue: AgNumericValue;
+    readonly closeValue: AgNumericValue;
+    readonly highValue?: AgNumericValue;
+    readonly lowValue?: AgNumericValue;
+    readonly aggregatedValue: AgNumericValue;
 
     readonly isRising: boolean;
 
@@ -115,10 +117,11 @@ class OhlcSeriesNodeEvent<
 interface PreparedOhlcNodeDatumState {
     datum: any;
     xValue: any;
-    openValue: number;
-    closeValue: number;
-    highValue: number;
-    lowValue: number;
+    // bigint-capable so yScale.convert() keeps full precision; narrowed to number for the stored datum.
+    openValue: AgNumericValue;
+    closeValue: AgNumericValue;
+    highValue: AgNumericValue;
+    lowValue: AgNumericValue;
     isRising: boolean;
     itemType: 'up' | 'down';
 }
@@ -133,10 +136,10 @@ interface OhlcSeriesNodeDatumContext {
     // Data arrays (resolved from dataModel - worth caching)
     readonly rawData: any[];
     readonly xValues: any[];
-    readonly openValues: any[];
-    readonly closeValues: any[];
-    readonly highValues: any[];
-    readonly lowValues: any[];
+    readonly openValues: AgNumericValue[];
+    readonly closeValues: AgNumericValue[];
+    readonly highValues: AgNumericValue[];
+    readonly lowValues: AgNumericValue[];
 
     // Scales (axis lookups - worth caching)
     readonly xScale: Scale<any, any>;
@@ -372,8 +375,15 @@ export abstract class OhlcSeriesBase<
         return { domain: fixNumericExtent(yExtent) };
     }
 
-    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]) {
-        return this.domainForVisibleRange(ChartAxisDirection.Y, ['highValue', 'lowValue'], 'xValue', visibleRange);
+    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]): [number, number] {
+        // domainForVisibleRange may yield a bigint; narrow once for this number-typed range contract.
+        const [y0, y1] = this.domainForVisibleRange(
+            ChartAxisDirection.Y,
+            ['highValue', 'lowValue'],
+            'xValue',
+            visibleRange
+        );
+        return [toNumber(y0), toNumber(y1)];
     }
 
     override getZoomRangeFittingItems(
@@ -445,10 +455,10 @@ export abstract class OhlcSeriesBase<
         return {
             rawData,
             xValues: dataModel.resolveKeysById(this, 'xValue', processedData),
-            openValues: dataModel.resolveColumnById(this, 'openValue', processedData),
-            closeValues: dataModel.resolveColumnById(this, 'closeValue', processedData),
-            highValues: dataModel.resolveColumnById(this, 'highValue', processedData),
-            lowValues: dataModel.resolveColumnById(this, 'lowValue', processedData),
+            openValues: dataModel.resolveColumnById(this, 'openValue', processedData, 'mixed-numeric'),
+            closeValues: dataModel.resolveColumnById(this, 'closeValue', processedData, 'mixed-numeric'),
+            highValues: dataModel.resolveColumnById(this, 'highValue', processedData, 'mixed-numeric'),
+            lowValues: dataModel.resolveColumnById(this, 'lowValue', processedData, 'mixed-numeric'),
             xScale,
             yScale,
             xAxis,
@@ -934,10 +944,10 @@ export abstract class OhlcSeriesBase<
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
-        const openValue = dataModel.resolveColumnById(this, `openValue`, processedData)[datumIndex];
-        const highValue = dataModel.resolveColumnById(this, `highValue`, processedData)[datumIndex];
-        const lowValue = dataModel.resolveColumnById(this, `lowValue`, processedData)[datumIndex];
-        const closeValue = dataModel.resolveColumnById(this, `closeValue`, processedData)[datumIndex];
+        const openValue = dataModel.resolveColumnById(this, `openValue`, processedData, 'mixed-numeric')[datumIndex];
+        const highValue = dataModel.resolveColumnById(this, `highValue`, processedData, 'mixed-numeric')[datumIndex];
+        const lowValue = dataModel.resolveColumnById(this, `lowValue`, processedData, 'mixed-numeric')[datumIndex];
+        const closeValue = dataModel.resolveColumnById(this, `closeValue`, processedData, 'mixed-numeric')[datumIndex];
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         const allowNullKeys = this.properties.allowNullKeys ?? false;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -670,17 +670,37 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         this.rootVertex = this.graph.addVertex('root');
 
         const idValues = dataModel.resolveKeysById(this, 'idValue', processedData);
-        const parentIdValues = dataModel.resolveColumnById(this, 'parentIdValue', processedData);
-        const imageValues = dataModel.resolveColumnById(this, 'imageValue', processedData);
-        const titleValues = dataModel.resolveColumnById(this, 'titleValue', processedData);
-        const subtitleValues = dataModel.resolveColumnById(this, 'subtitleValue', processedData);
+        const parentIdValues = dataModel.resolveColumnById<string | undefined>(
+            this,
+            'parentIdValue',
+            processedData,
+            'object'
+        );
+        const imageValues = dataModel.resolveColumnById<string | undefined>(
+            this,
+            'imageValue',
+            processedData,
+            'object'
+        );
+        const titleValues = dataModel.resolveColumnById<string | undefined>(
+            this,
+            'titleValue',
+            processedData,
+            'object'
+        );
+        const subtitleValues = dataModel.resolveColumnById<string | undefined>(
+            this,
+            'subtitleValue',
+            processedData,
+            'object'
+        );
 
         const labelsValues: (string[] | undefined)[] = [];
         for (let i = 0; i < this.properties.node.labels.length; i++) {
             // Disabled tiers have no value-property; preserve slot so tier indexing stays aligned.
             labelsValues.push(
                 this.properties.node.labels[i].enabled
-                    ? dataModel.resolveColumnById(this, `labelValue-${i}`, processedData)
+                    ? dataModel.resolveColumnById<string>(this, `labelValue-${i}`, processedData, 'object')
                     : undefined
             );
         }

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -18,9 +18,11 @@ import {
     isArray,
     measureTextSegments,
     mergeDefaults,
+    toNumber,
     toPlainText,
     toTextString,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { FunnelConnector } from '../funnel/funnelConnector';
 import { PyramidProperties } from './pyramidProperties';
@@ -50,7 +52,7 @@ type PyramidNodeLabelDatum = Readonly<Point> & {
 interface PyramidNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatum, Readonly<Point> {
     readonly index: number;
     readonly xValue: string;
-    readonly yValue: number;
+    readonly yValue: AgNumericValue;
     readonly top: number;
     readonly right: number;
     readonly bottom: number;
@@ -208,8 +210,8 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
 
         const horizontal = direction === 'horizontal';
 
-        const xValues = dataModel.resolveColumnById<string>(this, `xValue`, processedData);
-        const yValues = dataModel.resolveColumnById<number>(this, `yValue`, processedData);
+        const xValues = dataModel.resolveColumnById(this, `xValue`, processedData, 'string');
+        const yValues = dataModel.resolveColumnById(this, `yValue`, processedData, 'mixed-numeric');
 
         const xDomain = dataModel.getDomain(this, 'xValue', 'value', processedData).domain;
         const yDomain = dataModel.getDomain(this, 'yValue', 'value', processedData).domain;
@@ -241,7 +243,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
             const yValue = yValues[datumIndex];
             const enabled = visible && (legendManager?.getItemEnabled({ seriesId, itemId: datumIndex }) ?? true);
 
-            yTotal += yValue;
+            yTotal += toNumber(yValue);
 
             if (stageLabelData == null) continue;
 
@@ -331,7 +333,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
 
             const enabled = visible && (legendManager?.getItemEnabled({ seriesId, itemId: datumIndex }) ?? true);
 
-            const yEnd = yStart + yValue;
+            const yEnd = yStart + toNumber(yValue);
 
             const yMidRatio = (yStart + yEnd) / (2 * yTotal);
             const yRangeRatio = (yEnd - yStart) / yTotal;
@@ -682,8 +684,8 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
         if (!dataModel || !processedData) return;
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
-        const xValue = dataModel.resolveColumnById(this, 'xValue', processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData)[datumIndex];
+        const xValue = dataModel.resolveColumnById(this, 'xValue', processedData, 'string')[datumIndex];
+        const yValue = dataModel.resolveColumnById(this, `yValue`, processedData, 'mixed-numeric')[datumIndex];
 
         const allowNullKeys = this.properties.allowNullKeys ?? false;
         if (xValue === undefined && !allowNullKeys) return;
@@ -703,7 +705,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
             tooltip,
             {
                 symbol: this.legendItemSymbol(datumIndex),
-                data: [{ label: toPlainText(label), value: toPlainText(yValue) }],
+                data: [{ label: toPlainText(label), value: toPlainText(String(yValue)) }],
             },
             {
                 seriesId,
@@ -770,7 +772,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
         }
 
         const { showInLegend } = this.properties;
-        const stageValues = dataModel.resolveColumnById<string>(this, `xValue`, processedData);
+        const stageValues = dataModel.resolveColumnById(this, `xValue`, processedData, 'string');
 
         return (processedData.dataSources.get(this.id)?.data ?? [])
             .map((datum, datumIndex): _ModuleSupport.CategoryLegendDatum | undefined => {

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -245,7 +245,8 @@ export abstract class RadarSeries<
         }
 
         const angleValues = dataModel.resolveKeysById(this, `angleValue`, processedData);
-        const radiusValues = dataModel.resolveColumnById<number>(this, `radiusValue`, processedData);
+        // mixed-numeric so a bigint radius reaches radiusScale.convert() exactly.
+        const radiusValues = dataModel.resolveColumnById(this, `radiusValue`, processedData, 'mixed-numeric');
         const axisInnerRadius = this.getAxisInnerRadius();
 
         const radiusDomain = this.getSeriesDomain(ChartAxisDirection.Radius).domain;
@@ -555,7 +556,9 @@ export abstract class RadarSeries<
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const angleValue = dataModel.resolveKeysById(this, `angleValue`, processedData)[datumIndex];
-        const radiusValue = dataModel.resolveColumnById(this, `radiusValue`, processedData)[datumIndex];
+        const radiusValue = dataModel.resolveColumnById(this, `radiusValue`, processedData, 'mixed-numeric')[
+            datumIndex
+        ];
 
         const allowNullKeys = this.properties.allowNullKeys ?? false;
         if (angleValue === undefined && !allowNullKeys) return; // eslint-disable-line sonarjs/different-types-comparison

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -14,7 +14,10 @@ import {
     angleBetween,
     isDefined,
     isGradientFill,
+    maxValue,
+    minValue,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { RadiusCategoryAxis } from '../../axes/radius-category/radiusCategoryAxis';
 import { readDatum } from '../../utils/datum';
@@ -136,7 +139,8 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
 
         if (direction === ChartAxisDirection.Angle) {
             const xExtent = dataModel.getDomain(this, 'angleValue-end', 'value', processedData).domain;
-            const fixedXExtent = [Math.min(xExtent[0], 0), Math.max(xExtent[1], 0)];
+            // minValue/maxValue (not Math.min/max, which throw on bigint) keep an exact bigint extent.
+            const fixedXExtent = [minValue(xExtent[0], 0), maxValue(xExtent[1], 0)];
             return { domain: fixNumericExtent(fixedXExtent) };
         } else {
             return dataModel.getDomain(this, 'radiusValue', 'key', processedData);
@@ -252,9 +256,9 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
         }
 
         const radiusValues = dataModel.resolveKeysById<number>(this, 'radiusValue', processedData);
-        const angleStartValues = dataModel.resolveColumnById(this, `angleValue-start`, processedData);
-        const angleEndValues = dataModel.resolveColumnById(this, `angleValue-end`, processedData);
-        const angleRawValues = dataModel.resolveColumnById(this, `angleValue-raw`, processedData);
+        const angleStartValues = dataModel.resolveColumnById(this, `angleValue-start`, processedData, 'mixed-numeric');
+        const angleEndValues = dataModel.resolveColumnById(this, `angleValue-end`, processedData, 'mixed-numeric');
+        const angleRawValues = dataModel.resolveColumnById(this, `angleValue-raw`, processedData, 'mixed-numeric');
 
         const angleRangeIndex = dataModel.resolveProcessedDataIndexById(this, `angleValue-range`);
 
@@ -284,7 +288,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
 
         const getLabelNodeDatum = (
             datum: RadialColumnNodeDatum,
-            angleDatum: number,
+            angleDatum: AgNumericValue,
             x: number,
             y: number
         ): RadialBarLabelNodeDatum | undefined => {
@@ -561,7 +565,9 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const radiusValue = dataModel.resolveKeysById(this, `radiusValue`, processedData)[datumIndex];
-        const angleValue = dataModel.resolveColumnById(this, `angleValue-raw`, processedData)[datumIndex];
+        const angleValue = dataModel.resolveColumnById(this, `angleValue-raw`, processedData, 'mixed-numeric')[
+            datumIndex
+        ];
 
         // eslint-disable-next-line sonarjs/different-types-comparison
         if (radiusValue === undefined && !this.properties.allowNullKeys) return;

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -13,8 +13,11 @@ import {
     type Point,
     isDefined,
     isGradientFill,
+    maxValue,
+    minValue,
     normalizeAngle360,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { AngleCategoryAxis } from '../../axes/angle-category/angleCategoryAxis';
 import { type RadialSeriesStyleResult, getItemStyle, getStyle } from '../util/radialUtil';
@@ -147,9 +150,8 @@ export abstract class RadialColumnSeriesBase<
             return dataModel.getDomain(this, 'angleValue', 'key', processedData);
         } else {
             const yExtent = dataModel.getDomain(this, 'radiusValue-end', 'value', processedData).domain;
-            const fixedYExtent = Number.isFinite(yExtent[1] - yExtent[0])
-                ? [Math.min(yExtent[0], 0), Math.max(yExtent[1], 0)]
-                : [];
+            // minValue/maxValue (not Math.min/max, which throw on bigint) keep an exact bigint extent.
+            const fixedYExtent = [minValue(yExtent[0], 0), maxValue(yExtent[1], 0)];
             return { domain: fixNumericExtent(fixedYExtent) };
         }
     }
@@ -268,9 +270,14 @@ export abstract class RadialColumnSeriesBase<
         }
 
         const angleValues = dataModel.resolveKeysById(this, `angleValue`, processedData);
-        const radiusStartValues = dataModel.resolveColumnById(this, `radiusValue-start`, processedData);
-        const radiusEndValues = dataModel.resolveColumnById(this, `radiusValue-end`, processedData);
-        const radiusRawValues = dataModel.resolveColumnById(this, `radiusValue-raw`, processedData);
+        const radiusStartValues = dataModel.resolveColumnById(
+            this,
+            `radiusValue-start`,
+            processedData,
+            'mixed-numeric'
+        );
+        const radiusEndValues = dataModel.resolveColumnById(this, `radiusValue-end`, processedData, 'mixed-numeric');
+        const radiusRawValues = dataModel.resolveColumnById(this, `radiusValue-raw`, processedData, 'mixed-numeric');
 
         let groupPaddingInner = 0;
         let groupPaddingOuter = 0;
@@ -299,7 +306,7 @@ export abstract class RadialColumnSeriesBase<
 
         const getLabelNodeDatum = (
             datum: RadialColumnNodeDatum,
-            radiusDatum: number,
+            radiusDatum: AgNumericValue,
             x: number,
             y: number
         ): RadialColumnLabelNodeDatum | undefined => {
@@ -576,7 +583,9 @@ export abstract class RadialColumnSeriesBase<
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const angleValue = dataModel.resolveKeysById(this, `angleValue`, processedData)[datumIndex];
-        const radiusValue = dataModel.resolveColumnById(this, `radiusValue-raw`, processedData)[datumIndex];
+        const radiusValue = dataModel.resolveColumnById(this, `radiusValue-raw`, processedData, 'mixed-numeric')[
+            datumIndex
+        ];
 
         // eslint-disable-next-line sonarjs/different-types-comparison
         if (angleValue === undefined && !this.properties.allowNullKeys) return;

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -1349,7 +1349,8 @@ export class RadialGaugeSeries
             // Ignore
         } else if (labelTo == null || secondaryLabelTo == null) {
             this.formatLabelText();
-        } else if (labelFrom === labelTo && secondaryLabelFrom === secondaryLabelTo) {
+        } else if (Number(labelFrom) === Number(labelTo) && Number(secondaryLabelFrom) === Number(secondaryLabelTo)) {
+            // Number() compare so a value type change (`5n === 5` is false) doesn't force a no-op animation.
             this.formatLabelText({ label: labelTo, secondaryLabel: secondaryLabelTo });
         } else {
             const animationId = `${this.id}_labels`;

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -25,6 +25,7 @@ import {
     toPlainText,
     toRadians,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { LinearAngleScale } from '../../axes/angle-number/linearAngleScale';
 import { formatWithContext } from '../../utils/formatter';
@@ -564,8 +565,9 @@ export class RadialGaugeSeries
         const scaleStyle = scaleProps.getStyle(bar.enabled, defaultColorRange, scale);
 
         if (segments == null && cornersOnAllItems) {
-            const segmentStart = Math.min(...scale.domain);
-            const segmentEnd = Math.max(...scale.domain);
+            // convert() maps these whole-domain endpoints to the range ends, so a Number-narrow is precision-safe.
+            const segmentStart = Number(scale.domainMin);
+            const segmentEnd = Number(scale.domainMax);
             const datum = { value, segmentStart, segmentEnd };
             const appliedCornerRadius = Math.min(cornerRadius, (outerRadius - innerRadius) / 2);
             const angleInset = appliedCornerRadius / ((innerRadius + outerRadius) / 2);
@@ -737,7 +739,9 @@ export class RadialGaugeSeries
             const target = targets[i];
             const { value: targetValue, text, size, shape, style } = target;
 
-            if (targetValue < Math.min(...scale.domain) || targetValue > Math.max(...scale.domain)) {
+            // Exact bigint comparison: domainMin/Max flow the domain value type through unchanged.
+            const { domainMin, domainMax } = scale;
+            if (domainMin == null || domainMax == null || targetValue < domainMin || targetValue > domainMax) {
                 continue;
             }
 
@@ -1291,7 +1295,7 @@ export class RadialGaugeSeries
         return true;
     }
 
-    formatLabelText(datum?: { label: number | undefined; secondaryLabel: number | undefined }) {
+    formatLabelText(datum?: { label: AgNumericValue | undefined; secondaryLabel: AgNumericValue | undefined }) {
         const { labelSelection, radius, textAlign, verticalAlign } = this;
         const { spacing: padding, innerRadiusRatio } = this.properties;
 
@@ -1324,10 +1328,10 @@ export class RadialGaugeSeries
     private animateLabelText(params: { from?: number; phase?: _ModuleSupport.AnimationPhase } = {}) {
         const { animationManager } = this.ctx;
 
-        let labelFrom: number | undefined;
-        let labelTo: number | undefined;
-        let secondaryLabelFrom: number | undefined;
-        let secondaryLabelTo: number | undefined;
+        let labelFrom: AgNumericValue | undefined;
+        let labelTo: AgNumericValue | undefined;
+        let secondaryLabelFrom: AgNumericValue | undefined;
+        let secondaryLabelTo: AgNumericValue | undefined;
         this.labelSelection.each((label, datum) => {
             // Reset animation
             label.opacity = 1;
@@ -1350,11 +1354,12 @@ export class RadialGaugeSeries
         } else {
             const animationId = `${this.id}_labels`;
 
+            // The count-up tween narrows to Number; onStop re-formats from the full-precision label values.
             animationManager.animate({
                 id: animationId,
                 groupId: 'label',
-                from: { label: labelFrom, secondaryLabel: secondaryLabelFrom },
-                to: { label: labelTo, secondaryLabel: secondaryLabelTo },
+                from: { label: Number(labelFrom), secondaryLabel: Number(secondaryLabelFrom) },
+                to: { label: Number(labelTo), secondaryLabel: Number(secondaryLabelTo) },
                 phase: params.phase ?? 'update',
                 onUpdate: (datum) => this.formatLabelText(datum),
                 onStop: () => this.formatLabelText({ label: labelTo, secondaryLabel: secondaryLabelTo }),

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
@@ -12,6 +12,7 @@ import {
 import type {
     AgChartLabelFormatterParams,
     AgGradientColorMode,
+    AgNumericValue,
     AgRadialGaugeLabelFormatterParams,
     AgRadialGaugeMarkerShape,
     AgRadialGaugeOptions,
@@ -87,7 +88,7 @@ export type RadialGaugeLabelDatum = {
     centerX: number;
     centerY: number;
     text: string | undefined;
-    value: number;
+    value: AgNumericValue;
     fill: string | undefined;
     fontStyle: FontStyle | undefined;
     fontWeight: FontWeight | undefined;
@@ -446,7 +447,8 @@ export function createConicGradient(
     const conicAngle = normalizeAngle360((startAngle + endAngle) / 2 + Math.PI);
     const sweepAngle = normalizeAngle360Inclusive(endAngle - startAngle);
 
-    const colorStops = getColorStops(fills, defaultColorRange, domain, fillMode).map(
+    // Colour-stop positions are fractional thresholds — Number is correct (no bigint precision benefit).
+    const colorStops = getColorStops(fills, defaultColorRange, domain.map(Number), fillMode).map(
         ({ color, stop }): GradientColorStop => {
             stop = Math.min(Math.max(stop, 0), 1);
             const angle = startAngle + sweepAngle * stop;

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeUtil.ts
@@ -1,5 +1,6 @@
 import { type TextAlign, type VerticalAlign, _ModuleSupport } from 'ag-charts-community';
 import { toPlainText } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { getLabelText } from '../gauge-util/label';
 import { type LabelFormatting, formatSingleLabel, formatStackedLabels } from '../util/labelFormatter';
@@ -184,7 +185,7 @@ export function formatRadialGaugeLabels(
     selection: _ModuleSupport.Selection<RadialGaugeLabelDatum, _ModuleSupport.Text<RadialGaugeLabelDatum>>,
     opts: { padding: number; textAlign: TextAlign; verticalAlign: VerticalAlign },
     innerRadius: number,
-    datumOverrides?: { label: number | undefined; secondaryLabel: number | undefined }
+    datumOverrides?: { label: AgNumericValue | undefined; secondaryLabel: AgNumericValue | undefined }
 ) {
     const { padding, textAlign, verticalAlign } = opts;
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -27,8 +27,11 @@ import {
     type RequireOptional,
     extent,
     findMinMax,
+    isContinuous,
     mergeDefaults,
+    toNumber,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import {
     type RangeAreaSeriesDataAggregationFilter,
@@ -111,8 +114,8 @@ type StylerMarkerOptionsResult = DeepRequired<ResolvedStyleMixin>;
  */
 interface RangeAreaSeriesNodeDatumContext extends _ModuleSupport.CartesianCreateNodeDataContext<RangeAreaMarkerDatum> {
     // Data arrays (from dataModel - cache once)
-    readonly yHighValues: any[];
-    readonly yLowValues: any[];
+    readonly yHighValues: AgNumericValue[];
+    readonly yLowValues: AgNumericValue[];
 
     // Pre-computed offsets
     readonly xOffset: number;
@@ -146,8 +149,9 @@ interface RangeAreaSeriesNodeDatumContext extends _ModuleSupport.CartesianCreate
 interface RangeAreaNodeDatumScratch {
     datum: any;
     xValue: any;
-    yHighValue: number;
-    yLowValue: number;
+    // bigint-capable so yScale.convert() keeps full precision; the *Coordinate fields are pixel positions.
+    yHighValue: AgNumericValue;
+    yLowValue: AgNumericValue;
     x: number;
     yHighCoordinate: number;
     yLowCoordinate: number;
@@ -389,8 +393,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
             yAxis,
             rawData,
             xValues: dataModel.resolveKeysById(this, 'xValue', processedData),
-            yHighValues: dataModel.resolveColumnById(this, 'yHighValue', processedData),
-            yLowValues: dataModel.resolveColumnById(this, 'yLowValue', processedData),
+            yHighValues: dataModel.resolveColumnById(this, 'yHighValue', processedData, 'mixed-numeric'),
+            yLowValues: dataModel.resolveColumnById(this, 'yLowValue', processedData, 'mixed-numeric'),
             xScale,
             yScale,
             xAxisRange,
@@ -448,8 +452,15 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         }
     }
 
-    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]) {
-        return this.domainForVisibleRange(ChartAxisDirection.Y, ['yHighValue', 'yLowValue'], 'xValue', visibleRange);
+    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]): [number, number] {
+        // domainForVisibleRange may yield a bigint; narrow once for this number-typed range contract.
+        const [y0, y1] = this.domainForVisibleRange(
+            ChartAxisDirection.Y,
+            ['yHighValue', 'yLowValue'],
+            'xValue',
+            visibleRange
+        );
+        return [toNumber(y0), toNumber(y1)];
     }
 
     /**
@@ -464,8 +475,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         ctx: RangeAreaSeriesNodeDatumContext,
         scratch: RangeAreaNodeDatumScratch,
         datumIndex: number,
-        yHighValueOverride?: number,
-        yLowValueOverride?: number
+        yHighValueOverride?: AgNumericValue,
+        yLowValueOverride?: AgNumericValue
     ): void {
         scratch.xValue = ctx.xValues[datumIndex];
         if (scratch.xValue === undefined && !this.properties.allowNullKeys) return;
@@ -476,7 +487,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
 
         const currentSpanPoints = ctx.spanPoints.at(-1);
 
-        if (Number.isFinite(scratch.yHighValue) && Number.isFinite(scratch.yLowValue)) {
+        // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+        if (isContinuous(scratch.yHighValue) && isContinuous(scratch.yLowValue)) {
             scratch.inverted = scratch.yLowValue > scratch.yHighValue;
             scratch.x = ctx.xScale.convert(scratch.xValue) + ctx.xOffset;
             if (!Number.isFinite(scratch.x)) return;
@@ -530,13 +542,14 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
     }
 
     private hasInvalidDatumsInRange(
-        yHighValues: any[],
-        yLowValues: any[],
+        yHighValues: AgNumericValue[],
+        yLowValues: AgNumericValue[],
         startIndex: number,
         endIndex: number
     ): boolean {
         for (let i = startIndex; i <= endIndex; i++) {
-            if (!Number.isFinite(yHighValues[i]) || !Number.isFinite(yLowValues[i])) {
+            // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+            if (!isContinuous(yHighValues[i]) || !isContinuous(yLowValues[i])) {
                 return true;
             }
         }
@@ -552,7 +565,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         scratch: RangeAreaNodeDatumScratch,
         datumIndex: number,
         itemType: 'high' | 'low',
-        yValue: number,
+        yValue: AgNumericValue,
         y: number
     ): void {
         const { size } = ctx.item[itemType].marker;
@@ -1363,8 +1376,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
-        const yHighValue = dataModel.resolveColumnById(this, `yHighValue`, processedData)[datumIndex];
-        const yLowValue = dataModel.resolveColumnById(this, `yLowValue`, processedData)[datumIndex];
+        const yHighValue = dataModel.resolveColumnById(this, `yHighValue`, processedData, 'mixed-numeric')[datumIndex];
+        const yLowValue = dataModel.resolveColumnById(this, `yLowValue`, processedData, 'mixed-numeric')[datumIndex];
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         const allowNullKeys = this.properties.allowNullKeys ?? false;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -487,7 +487,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
 
         const currentSpanPoints = ctx.spanPoints.at(-1);
 
-        // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+        // isContinuous accepts any bigint; Number.isFinite rejects every bigint (it never coerces them).
         if (isContinuous(scratch.yHighValue) && isContinuous(scratch.yLowValue)) {
             scratch.inverted = scratch.yLowValue > scratch.yHighValue;
             scratch.x = ctx.xScale.convert(scratch.xValue) + ctx.xOffset;
@@ -548,7 +548,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
         endIndex: number
     ): boolean {
         for (let i = startIndex; i <= endIndex; i++) {
-            // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+            // isContinuous accepts any bigint; Number.isFinite rejects every bigint (it never coerces them).
             if (!isContinuous(yHighValues[i]) || !isContinuous(yLowValues[i])) {
                 return true;
             }

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeAreaAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeAreaAggregation.ts
@@ -9,8 +9,11 @@ import {
     aggregationDomain,
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
+    epochColumnForTimeScale,
+    narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 type ScopeProvider = _ModuleSupport.ScopeProvider;
 type ProcessedData = _ModuleSupport.ProcessedData<any>;
@@ -30,7 +33,7 @@ function aggregateRangeAreaData(
     highValues: any[],
     lowValues: any[],
     domainInput: DomainWithMetadata<number>,
-    smallestKeyInterval: number | undefined,
+    smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): RangeAreaSeriesDataAggregationFilter[] | undefined {
@@ -55,16 +58,24 @@ export function aggregateRangeAreaDataFromDataModel(
     series: ScopeProvider,
     existingFilters?: RangeAreaSeriesDataAggregationFilter[]
 ): RangeAreaSeriesDataAggregationFilter[] | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const highValues = dataModel.resolveColumnById(series, 'yHighValue', processedData);
-    const lowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawHighValues = dataModel.resolveColumnById(series, 'yHighValue', processedData, 'mixed-numeric');
+    const rawLowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf =
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
+    const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
@@ -97,16 +108,24 @@ export function aggregateRangeAreaDataFromDataModelPartial(
     targetRange: number,
     existingFilters?: RangeAreaSeriesDataAggregationFilter[]
 ): RangeAreaPartialAggregationResult | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const highValues = dataModel.resolveColumnById(series, 'yHighValue', processedData);
-    const lowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawHighValues = dataModel.resolveColumnById(series, 'yHighValue', processedData, 'mixed-numeric');
+    const rawLowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf =
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
+    const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeExtremesAggregationPartial([d0, d1], xValues, highValues, lowValues, {

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeAreaAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeAreaAggregation.ts
@@ -10,6 +10,7 @@ import {
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
     epochColumnForTimeScale,
+    narrowBigIntColumn,
     narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -69,11 +70,14 @@ export function aggregateRangeAreaDataFromDataModel(
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
@@ -119,11 +123,14 @@ export function aggregateRangeAreaDataFromDataModelPartial(
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeAreaAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeAreaAggregation.ts
@@ -1,16 +1,10 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import type {
-    DomainWithMetadata,
-    ExtremesAggregationFilter,
-    ExtremesPartialAggregationResult,
-    ScaleType,
-} from 'ag-charts-core';
+import type { ExtremesAggregationFilter, ExtremesPartialAggregationResult, ScaleType } from 'ag-charts-core';
 import {
-    aggregationDomain,
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
     epochColumnForTimeScale,
-    narrowBigIntColumn,
+    narrowAggregationX,
     narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -29,16 +23,15 @@ export type RangeAreaPartialAggregationResult = ExtremesPartialAggregationResult
 // ============================================================================
 
 function aggregateRangeAreaData(
-    scale: ScaleType,
     xValues: any[],
     highValues: any[],
     lowValues: any[],
-    domainInput: DomainWithMetadata<number>,
+    d0: number,
+    d1: number,
     smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): RangeAreaSeriesDataAggregationFilter[] | undefined {
-    const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeExtremesAggregation([d0, d1], xValues, highValues, lowValues, {
         smallestKeyInterval,
         xNeedsValueOf,
@@ -75,16 +68,15 @@ export function aggregateRangeAreaDataFromDataModel(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
-        const [d0, d1] = aggregationDomain(scale, domainInput);
-        return computeExtremesAggregation([d0, d1], xValues, highValues, lowValues, {
+        return computeExtremesAggregation(domain, xValues, highValues, lowValues, {
             smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
             xNeedsValueOf,
             yNeedsValueOf,
@@ -93,11 +85,11 @@ export function aggregateRangeAreaDataFromDataModel(
     }
 
     return memoizedAggregateRangeAreaData(
-        scale,
         xValues,
         highValues,
         lowValues,
-        domainInput,
+        domain[0],
+        domain[1],
         processedData.reduced?.smallestKeyInterval,
         xNeedsValueOf,
         yNeedsValueOf
@@ -128,14 +120,13 @@ export function aggregateRangeAreaDataFromDataModelPartial(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
-    const [d0, d1] = aggregationDomain(scale, domainInput);
-    return computeExtremesAggregationPartial([d0, d1], xValues, highValues, lowValues, {
+    return computeExtremesAggregationPartial(domain, xValues, highValues, lowValues, {
         smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
         targetRange,
         xNeedsValueOf,

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeAreaProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeAreaProperties.ts
@@ -14,6 +14,7 @@ import type {
 import { _ModuleSupport } from 'ag-charts-community';
 import type { InternalAgColorType, SizedPoint } from 'ag-charts-core';
 import { BaseProperties, InterpolationProperties, Property } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 export interface RangeAreaMarkerDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDatum, 'yKey' | 'yValue'> {
     readonly itemId?: never;
@@ -21,8 +22,8 @@ export interface RangeAreaMarkerDatum extends Omit<_ModuleSupport.CartesianSerie
     readonly index: number;
     readonly yLowKey: string;
     readonly yHighKey: string;
-    readonly yLowValue: number;
-    readonly yHighValue: number;
+    readonly yLowValue: AgNumericValue;
+    readonly yHighValue: AgNumericValue;
     readonly point: Readonly<SizedPoint>;
     readonly enabled: boolean;
     style?: AgSeriesMarkerStyle;

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarAggregation.ts
@@ -9,8 +9,11 @@ import {
     aggregationDomain,
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
+    epochColumnForTimeScale,
+    narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 type ScopeProvider = _ModuleSupport.ScopeProvider;
 type ProcessedData = _ModuleSupport.ProcessedData<any>;
@@ -30,7 +33,7 @@ function aggregateRangeBarData(
     highValues: any[],
     lowValues: any[],
     domainInput: DomainWithMetadata<number>,
-    smallestKeyInterval: number | undefined,
+    smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): RangeBarSeriesDataAggregationFilter[] | undefined {
@@ -55,16 +58,24 @@ export function aggregateRangeBarDataFromDataModel(
     series: ScopeProvider,
     existingFilters?: RangeBarSeriesDataAggregationFilter[]
 ): RangeBarSeriesDataAggregationFilter[] | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const highValues = dataModel.resolveColumnById(series, 'yHighValue', processedData);
-    const lowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawHighValues = dataModel.resolveColumnById(series, 'yHighValue', processedData, 'mixed-numeric');
+    const rawLowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf =
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
+    const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
@@ -97,16 +108,24 @@ export function aggregateRangeBarDataFromDataModelPartial(
     targetRange: number,
     existingFilters?: RangeBarSeriesDataAggregationFilter[]
 ): RangeBarPartialAggregationResult | undefined {
-    const xValues = dataModel.resolveKeysById(series, 'xValue', processedData);
-    const highValues = dataModel.resolveColumnById(series, 'yHighValue', processedData);
-    const lowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData);
+    const rawXValues = dataModel.resolveKeysById(series, 'xValue', processedData);
+    const rawHighValues = dataModel.resolveColumnById(series, 'yHighValue', processedData, 'mixed-numeric');
+    const rawLowValues = dataModel.resolveColumnById(series, 'yLowValue', processedData, 'mixed-numeric');
 
     const domainInput = dataModel.getDomain(series, 'xValue', 'key', processedData);
 
-    const xNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
+    const rawXNeedsValueOf = dataModel.resolveColumnNeedsValueOf(series, 'xValue', processedData);
     const yNeedsValueOf =
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
+
+    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+        scale,
+        rawXValues,
+        rawXNeedsValueOf
+    );
+    const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
+    const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeExtremesAggregationPartial([d0, d1], xValues, highValues, lowValues, {

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarAggregation.ts
@@ -10,6 +10,7 @@ import {
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
     epochColumnForTimeScale,
+    narrowBigIntColumn,
     narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -69,11 +70,14 @@ export function aggregateRangeBarDataFromDataModel(
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
@@ -119,11 +123,14 @@ export function aggregateRangeBarDataFromDataModelPartial(
         dataModel.resolveColumnNeedsValueOf(series, 'yHighValue', processedData) ??
         dataModel.resolveColumnNeedsValueOf(series, 'yLowValue', processedData);
 
-    const { values: xValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
+    const { values: epochXValues, needsValueOf: xNeedsValueOf } = epochColumnForTimeScale(
         scale,
         rawXValues,
         rawXNeedsValueOf
     );
+    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
+    // mixes a bigint with a Number and throws in the aggregation hot path.
+    const xValues = narrowBigIntColumn(epochXValues);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarAggregation.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarAggregation.ts
@@ -1,16 +1,10 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import type {
-    DomainWithMetadata,
-    ExtremesAggregationFilter,
-    ExtremesPartialAggregationResult,
-    ScaleType,
-} from 'ag-charts-core';
+import type { ExtremesAggregationFilter, ExtremesPartialAggregationResult, ScaleType } from 'ag-charts-core';
 import {
-    aggregationDomain,
     computeExtremesAggregation,
     computeExtremesAggregationPartial,
     epochColumnForTimeScale,
-    narrowBigIntColumn,
+    narrowAggregationX,
     narrowBigIntColumnRelative,
     simpleMemorize2,
 } from 'ag-charts-core';
@@ -29,16 +23,15 @@ export type RangeBarPartialAggregationResult = ExtremesPartialAggregationResult;
 // ============================================================================
 
 function aggregateRangeBarData(
-    scale: ScaleType,
     xValues: any[],
     highValues: any[],
     lowValues: any[],
-    domainInput: DomainWithMetadata<number>,
+    d0: number,
+    d1: number,
     smallestKeyInterval: AgNumericValue | undefined,
     xNeedsValueOf: boolean,
     yNeedsValueOf: boolean
 ): RangeBarSeriesDataAggregationFilter[] | undefined {
-    const [d0, d1] = aggregationDomain(scale, domainInput);
     return computeExtremesAggregation([d0, d1], xValues, highValues, lowValues, {
         smallestKeyInterval,
         xNeedsValueOf,
@@ -75,16 +68,15 @@ export function aggregateRangeBarDataFromDataModel(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
     // When existingFilters provided, bypass memoization to enable array reuse
     if (existingFilters) {
-        const [d0, d1] = aggregationDomain(scale, domainInput);
-        return computeExtremesAggregation([d0, d1], xValues, highValues, lowValues, {
+        return computeExtremesAggregation(domain, xValues, highValues, lowValues, {
             smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
             xNeedsValueOf,
             yNeedsValueOf,
@@ -93,11 +85,11 @@ export function aggregateRangeBarDataFromDataModel(
     }
 
     return memoizedAggregateRangeBarData(
-        scale,
         xValues,
         highValues,
         lowValues,
-        domainInput,
+        domain[0],
+        domain[1],
         processedData.reduced?.smallestKeyInterval,
         xNeedsValueOf,
         yNeedsValueOf
@@ -128,14 +120,13 @@ export function aggregateRangeBarDataFromDataModelPartial(
         rawXValues,
         rawXNeedsValueOf
     );
-    // Narrow bigint x absolutely to match aggregationDomain's Number-narrowed d0/d1; otherwise `xValue - d0`
-    // mixes a bigint with a Number and throws in the aggregation hot path.
-    const xValues = narrowBigIntColumn(epochXValues);
+    // Subtract the bigint domain-min from x and [d0,d1] together so a high-magnitude narrow-range x keeps full
+    // bucketing precision; falls back to an absolute narrow + aggregationDomain for non-bigint columns.
+    const { xValues, domain } = narrowAggregationX(scale, epochXValues, domainInput);
     const highValues = yNeedsValueOf ? rawHighValues : narrowBigIntColumnRelative(rawHighValues);
     const lowValues = yNeedsValueOf ? rawLowValues : narrowBigIntColumnRelative(rawLowValues);
 
-    const [d0, d1] = aggregationDomain(scale, domainInput);
-    return computeExtremesAggregationPartial([d0, d1], xValues, highValues, lowValues, {
+    return computeExtremesAggregationPartial(domain, xValues, highValues, lowValues, {
         smallestKeyInterval: processedData.reduced?.smallestKeyInterval,
         targetRange,
         xNeedsValueOf,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -24,8 +24,11 @@ import {
     type RequireOptional,
     areScalingEqual,
     findMinMax,
+    isContinuous,
     mergeDefaults,
+    toNumber,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import {
     type RangeBarSeriesDataAggregationFilter,
@@ -87,8 +90,8 @@ type RangeBarItemId = `${string}-${string}`;
  */
 interface RangeBarSeriesNodeDatumContext extends _ModuleSupport.CartesianCreateNodeDataContext<RangeBarNodeDatum> {
     // Data arrays (resolved from dataModel - worth caching)
-    readonly yLowValues: any[];
-    readonly yHighValues: any[];
+    readonly yLowValues: AgNumericValue[];
+    readonly yHighValues: AgNumericValue[];
 
     // Computed positioning (involves scale conversions - worth caching)
     readonly barWidth: number;
@@ -119,10 +122,10 @@ interface RangeBarSeriesNodeDatumContext extends _ModuleSupport.CartesianCreateN
 interface PreparedRangeBarNodeDatumState {
     datum: any;
     xValue: any;
-    yLowValue: number;
-    yHighValue: number;
-    rawLowValue: any;
-    rawHighValue: any;
+    yLowValue: AgNumericValue;
+    yHighValue: AgNumericValue;
+    rawLowValue: AgNumericValue;
+    rawHighValue: AgNumericValue;
 }
 
 /**
@@ -136,8 +139,9 @@ interface NodeDatumParams {
     groupedDataIndex: number;
     x: number;
     width: number;
-    yLow: number;
-    yHigh: number;
+    // bigint-capable so yScale.convert() keeps full precision; x/width are pixel-space.
+    yLow: AgNumericValue;
+    yHigh: AgNumericValue;
     crisp: boolean;
 }
 
@@ -152,8 +156,8 @@ interface LabelUpdateParams {
     rectY: number;
     rectWidth: number;
     rectHeight: number;
-    yLowValue: number;
-    yHighValue: number;
+    yLowValue: AgNumericValue;
+    yHighValue: AgNumericValue;
     datum: any;
 }
 
@@ -161,8 +165,8 @@ interface RangeBarNodeDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDatum
     readonly index: number;
     readonly yLowKey: string;
     readonly yHighKey: string;
-    readonly yLowValue: number;
-    readonly yHighValue: number;
+    readonly yLowValue: AgNumericValue;
+    readonly yHighValue: AgNumericValue;
     readonly width: number;
     readonly height: number;
     readonly labels: RangeBarNodeLabelDatum[];
@@ -369,8 +373,15 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         }
     }
 
-    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]) {
-        return this.domainForVisibleRange(ChartAxisDirection.Y, ['yHighValue', 'yLowValue'], 'xValue', visibleRange);
+    override getSeriesRange(_direction: ChartAxisDirection, visibleRange: [number, number]): [number, number] {
+        // domainForVisibleRange may yield a bigint; narrow once for this number-typed range contract.
+        const [y0, y1] = this.domainForVisibleRange(
+            ChartAxisDirection.Y,
+            ['yHighValue', 'yLowValue'],
+            'xValue',
+            visibleRange
+        );
+        return [toNumber(y0), toNumber(y1)];
     }
 
     /**
@@ -423,8 +434,8 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
             yAxis,
             rawData,
             xValues: dataModel.resolveKeysById(this, `xValue`, processedData),
-            yLowValues: dataModel.resolveColumnById(this, `yLowValue`, processedData),
-            yHighValues: dataModel.resolveColumnById(this, `yHighValue`, processedData),
+            yLowValues: dataModel.resolveColumnById(this, `yLowValue`, processedData, 'mixed-numeric'),
+            yHighValues: dataModel.resolveColumnById(this, `yHighValue`, processedData, 'mixed-numeric'),
             xScale,
             yScale,
             groupOffset,
@@ -465,7 +476,8 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         const rawLowValue = ctx.yLowValues[datumIndex];
         const rawHighValue = ctx.yHighValues[datumIndex];
 
-        if (!Number.isFinite(rawLowValue?.valueOf()) || !Number.isFinite(rawHighValue?.valueOf())) return undefined;
+        // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+        if (!isContinuous(rawLowValue) || !isContinuous(rawHighValue)) return undefined;
 
         const [yLowValue, yHighValue] =
             rawLowValue < rawHighValue ? [rawLowValue, rawHighValue] : [rawHighValue, rawLowValue];
@@ -745,8 +757,8 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
                 xValue: undefined,
                 yLowValue: 0,
                 yHighValue: 0,
-                rawLowValue: undefined,
-                rawHighValue: undefined,
+                rawLowValue: 0,
+                rawHighValue: 0,
             },
             labelParamsScratch: {
                 labels: [],
@@ -1227,8 +1239,8 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
 
         const datum = processedData.dataSources.get(this.id)?.data[datumIndex];
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
-        const yHighValue = dataModel.resolveColumnById(this, `yHighValue`, processedData)[datumIndex];
-        const yLowValue = dataModel.resolveColumnById(this, `yLowValue`, processedData)[datumIndex];
+        const yHighValue = dataModel.resolveColumnById(this, `yHighValue`, processedData, 'mixed-numeric')[datumIndex];
+        const yLowValue = dataModel.resolveColumnById(this, `yLowValue`, processedData, 'mixed-numeric')[datumIndex];
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
         const allowNullKeys = this.properties.allowNullKeys ?? false;

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -476,7 +476,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         const rawLowValue = ctx.yLowValues[datumIndex];
         const rawHighValue = ctx.yHighValues[datumIndex];
 
-        // isContinuous accepts bigint where Number.isFinite would drop a value beyond Number.MAX_VALUE.
+        // isContinuous accepts any bigint; Number.isFinite rejects every bigint (it never coerces them).
         if (!isContinuous(rawLowValue) || !isContinuous(rawHighValue)) return undefined;
 
         const [yLowValue, yHighValue] =

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -123,7 +123,7 @@ interface WaterfallNodeDatumParams {
     totalLabel: string | undefined;
     datum: unknown;
     xDatum: any;
-    value: number | undefined;
+    value: AgNumericValue | undefined;
     // bigint-capable so a cumulative beyond Number.MAX_VALUE survives to yScale.convert().
     cumulativeValue: AgNumericValue | undefined;
     trailingValue: AgNumericValue | undefined;
@@ -509,15 +509,17 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         rawValue?: AgNumericValue,
         cumulativeValue?: AgNumericValue,
         trailingValue?: AgNumericValue
-    ): number | undefined {
-        // Display value narrows to Number; Number()ing both operands avoids a bigint/number subtraction throw.
+    ): AgNumericValue | undefined {
+        // Preserve the original (possibly bigint) value so the label and label-formatter callback keep full
+        // precision (AC 9.2.1/9.2.2); the bar geometry uses the separately-narrowed cumulativeValue, not this.
         if (isTotal) {
-            return cumulativeValue == null ? undefined : Number(cumulativeValue);
+            return cumulativeValue;
         }
         if (isSubtotal) {
-            return Number(cumulativeValue ?? 0) - Number(trailingValue ?? 0);
+            // subtractValues stays exact for bigint cumulatives (Number()ing each first would round beyond 2^53).
+            return subtractValues(cumulativeValue ?? 0, trailingValue ?? 0);
         }
-        return rawValue == null ? undefined : Number(rawValue);
+        return rawValue;
     }
 
     /**

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -18,8 +18,12 @@ import {
     type RequireOptional,
     easeOut,
     isContinuous,
+    maxValue,
     mergeDefaults,
+    minValue,
+    subtractValues,
 } from 'ag-charts-core';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { WaterfallSeriesItem, WaterfallSeriesTotal } from './waterfallSeriesProperties';
 import { WaterfallSeriesProperties } from './waterfallSeriesProperties';
@@ -103,11 +107,11 @@ interface WaterfallSeriesNodeDatumContext extends _ModuleSupport.CartesianCreate
     readonly lineStrokeWidth: number;
     readonly yDomain: number[];
     // Data arrays
-    readonly yRawValues: (number | undefined)[];
+    readonly yRawValues: (AgNumericValue | undefined)[];
     readonly totalTypeValues: (AgWaterfallSeriesItemType | undefined)[];
-    readonly yCurrValues: number[];
-    readonly yPrevValues: number[];
-    readonly yCurrTotalValues: number[];
+    readonly yCurrValues: AgNumericValue[];
+    readonly yPrevValues: AgNumericValue[];
+    readonly yCurrTotalValues: AgNumericValue[];
     // Mutable state for connector line points (built during populateNodeData)
     pointData: WaterfallNodePointDatum[];
 }
@@ -120,8 +124,9 @@ interface WaterfallNodeDatumParams {
     datum: unknown;
     xDatum: any;
     value: number | undefined;
-    cumulativeValue: number | undefined;
-    trailingValue: number | undefined;
+    // bigint-capable so a cumulative beyond Number.MAX_VALUE survives to yScale.convert().
+    cumulativeValue: AgNumericValue | undefined;
+    trailingValue: AgNumericValue | undefined;
     datumType: AgWaterfallSeriesItemType | undefined;
 }
 
@@ -283,7 +288,8 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         } else {
             const yCurrIndex = dataModel.resolveProcessedDataIndexById(this, 'yCurrent');
             const yExtent = values[yCurrIndex];
-            const fixedYExtent = [Math.min(0, yExtent[0]), Math.max(0, yExtent[1])];
+            // minValue/maxValue (not Math.min/max, which throw on bigint) keep an exact bigint extent.
+            const fixedYExtent = [minValue(0, yExtent[0]), maxValue(0, yExtent[1])];
             return { domain: fixNumericExtent(fixedYExtent) };
         }
     }
@@ -293,7 +299,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
     }
 
     protected override populateNodeData(ctx: WaterfallSeriesNodeDatumContext): void {
-        let trailingSubtotal = 0;
+        let trailingSubtotal: AgNumericValue = 0;
 
         // Scratch object for params - reused across iterations
         const paramsScratch: WaterfallNodeDatumParams = {
@@ -418,15 +424,16 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         const yScale = yAxis.scale;
 
         const xValues = dataModel.resolveKeysById(this, `xValue`, processedData);
-        const yRawValues = dataModel.resolveColumnById(this, `yRaw`, processedData);
+        const yRawValues = dataModel.resolveColumnById(this, `yRaw`, processedData, 'mixed-numeric');
         const totalTypeValues = dataModel.resolveColumnById<AgWaterfallSeriesItemType | undefined>(
             this,
             `totalTypeValue`,
-            processedData
+            processedData,
+            'object'
         );
-        const yCurrValues = dataModel.resolveColumnById<number>(this, 'yCurrent', processedData);
-        const yPrevValues = dataModel.resolveColumnById<number>(this, 'yPrevious', processedData);
-        const yCurrTotalValues = dataModel.resolveColumnById<number>(this, 'yCurrentTotal', processedData);
+        const yCurrValues = dataModel.resolveColumnById(this, 'yCurrent', processedData, 'mixed-numeric');
+        const yPrevValues = dataModel.resolveColumnById(this, 'yPrevious', processedData, 'mixed-numeric');
+        const yCurrTotalValues = dataModel.resolveColumnById(this, 'yCurrentTotal', processedData, 'mixed-numeric');
 
         const rawData = processedData.dataSources.get(this.id)?.data ?? [];
 
@@ -481,8 +488,8 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         datumIndex: number,
         isTotal: boolean,
         isSubtotal: boolean,
-        trailingSubtotal: number
-    ): { cumulativeValue: number | undefined; trailingValue: number | undefined } {
+        trailingSubtotal: AgNumericValue
+    ): { cumulativeValue: AgNumericValue | undefined; trailingValue: AgNumericValue | undefined } {
         if (isTotal || isSubtotal) {
             return {
                 cumulativeValue: ctx.yCurrTotalValues[datumIndex],
@@ -499,17 +506,18 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
     private computeDisplayValue(
         isTotal: boolean,
         isSubtotal: boolean,
-        rawValue?: number,
-        cumulativeValue?: number,
-        trailingValue?: number
+        rawValue?: AgNumericValue,
+        cumulativeValue?: AgNumericValue,
+        trailingValue?: AgNumericValue
     ): number | undefined {
+        // Display value narrows to Number; Number()ing both operands avoids a bigint/number subtraction throw.
         if (isTotal) {
-            return cumulativeValue;
+            return cumulativeValue == null ? undefined : Number(cumulativeValue);
         }
         if (isSubtotal) {
-            return (cumulativeValue ?? 0) - (trailingValue ?? 0);
+            return Number(cumulativeValue ?? 0) - Number(trailingValue ?? 0);
         }
-        return rawValue;
+        return rawValue == null ? undefined : Number(rawValue);
     }
 
     /**
@@ -534,7 +542,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
             itemType: seriesItemType,
             datum,
             datumIndex,
-            cumulativeValue: cumulativeValue ?? 0,
+            cumulativeValue: Number(cumulativeValue ?? 0),
             xValue: xDatum,
             yValue: value,
             yKey,
@@ -590,7 +598,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         mutableNode.itemType = seriesItemType;
         mutableNode.datum = datum;
         mutableNode.datumIndex = datumIndex;
-        mutableNode.cumulativeValue = cumulativeValue ?? 0;
+        mutableNode.cumulativeValue = Number(cumulativeValue ?? 0);
         mutableNode.xValue = xDatum;
         mutableNode.yValue = value;
         mutableNode.x = rectX;
@@ -665,8 +673,8 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
     private createPointDatum(
         ctx: WaterfallSeriesNodeDatumContext,
         nodeDatum: WaterfallNodeDatum,
-        cumulativeValue: number | undefined,
-        trailingValue: number | undefined,
+        cumulativeValue: AgNumericValue | undefined,
+        trailingValue: AgNumericValue | undefined,
         isTotalOrSubtotal: boolean
     ): WaterfallNodePointDatum {
         const { yScale, barAlongX, categoryAxisReversed, lineStrokeWidth } = ctx;
@@ -999,12 +1007,13 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         if (!dataModel || !processedData || !xAxis || !yAxis) return;
 
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
-        const yValue = dataModel.resolveColumnById(this, `yRaw`, processedData)[datumIndex];
-        const yCurrTotalValues = dataModel.resolveColumnById<number>(this, 'yCurrentTotal', processedData);
+        const yValue = dataModel.resolveColumnById(this, `yRaw`, processedData, 'mixed-numeric')[datumIndex];
+        const yCurrTotalValues = dataModel.resolveColumnById(this, 'yCurrentTotal', processedData, 'mixed-numeric');
         const totalTypeValues = dataModel.resolveColumnById<AgWaterfallSeriesItemType | undefined>(
             this,
             `totalTypeValue`,
-            processedData
+            processedData,
+            'object'
         );
 
         // sonarjs/different-types-comparison: array access can return undefined if index is out of bounds
@@ -1023,14 +1032,14 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
 
         const seriesItemType = this.getSeriesItemType(isPositive, datumType);
 
-        let total: number;
+        let total: AgNumericValue;
         if (this.isTotal(datumType)) {
             total = yCurrTotalValues[datumIndex];
         } else if (this.isSubtotal(datumType)) {
             total = yCurrTotalValues[datumIndex];
             for (let previousIndex = datumIndex - 1; previousIndex >= 0; previousIndex -= 1) {
                 if (this.isSubtotal(totalTypeValues[previousIndex])) {
-                    total = total - yCurrTotalValues[previousIndex];
+                    total = subtractValues(total, yCurrTotalValues[previousIndex]);
                     break;
                 }
             }

--- a/packages/ag-charts-types/src/api/initialStateOptions.ts
+++ b/packages/ag-charts-types/src/api/initialStateOptions.ts
@@ -47,9 +47,9 @@ export interface AgInitialStateZoomOptions {
 
 export interface AgInitialStateZoomRange {
     /** The start value of the zoom range. */
-    start?: AgStateSerializableDate | AgStateSerializableBigInt | string | number | bigint;
+    start?: AgStateSerializableDate | AgStateSerializableBigInt | string | number;
     /** The end value of the zoom range. */
-    end?: AgStateSerializableDate | AgStateSerializableBigInt | string | number | bigint;
+    end?: AgStateSerializableDate | AgStateSerializableBigInt | string | number;
 }
 
 export interface AgInitialStateZoomRatio {

--- a/packages/ag-charts-types/src/api/initialStateOptions.ts
+++ b/packages/ag-charts-types/src/api/initialStateOptions.ts
@@ -4,7 +4,7 @@ import type { Ratio } from '../chart/types';
 import type { AgAutoScaledAxes } from '../chart/zoomOptions';
 import type { AgPriceVolumeChartType } from '../presets/financial/priceVolumeOptions';
 import type { AgActiveState } from './activeState';
-import type { AgStateSerializableDate } from './stateTypes';
+import type { AgStateSerializableBigInt, AgStateSerializableDate } from './stateTypes';
 
 // Theme
 export interface AgInitialStateThemeableOptions {
@@ -47,9 +47,9 @@ export interface AgInitialStateZoomOptions {
 
 export interface AgInitialStateZoomRange {
     /** The start value of the zoom range. */
-    start?: AgStateSerializableDate | string | number;
+    start?: AgStateSerializableDate | AgStateSerializableBigInt | string | number | bigint;
     /** The end value of the zoom range. */
-    end?: AgStateSerializableDate | string | number;
+    end?: AgStateSerializableDate | AgStateSerializableBigInt | string | number | bigint;
 }
 
 export interface AgInitialStateZoomRatio {

--- a/packages/ag-charts-types/src/api/stateTypes.ts
+++ b/packages/ag-charts-types/src/api/stateTypes.ts
@@ -4,3 +4,10 @@ export interface AgStateSerializableDate {
     /** The date value as an ISO 8601 string or Unix timestamp. */
     value: string | number;
 }
+
+export interface AgStateSerializableBigInt {
+    /** Type discriminator for serialisable bigint objects. */
+    __type: 'bigint';
+    /** The bigint value as a base-10 string, preserving full integer precision. */
+    value: string;
+}

--- a/packages/ag-charts-types/src/chart/annotationsOptions.ts
+++ b/packages/ag-charts-types/src/chart/annotationsOptions.ts
@@ -1,4 +1,4 @@
-import type { AgStateSerializableDate } from '../api/stateTypes';
+import type { AgStateSerializableBigInt, AgStateSerializableDate } from '../api/stateTypes';
 import type {
     FillOptions,
     LineDashOptions,
@@ -516,7 +516,7 @@ interface Extendable {
     extendEnd?: boolean;
 }
 
-export type ValueType = string | number | AgStateSerializableDate;
+export type ValueType = string | number | bigint | AgStateSerializableDate | AgStateSerializableBigInt;
 export type AgAnnotationValue = ValueType | AgGroupingValueType;
 export interface AgGroupingValueType {
     /** The value at the annotation position. */

--- a/packages/ag-charts-types/src/chart/annotationsOptions.ts
+++ b/packages/ag-charts-types/src/chart/annotationsOptions.ts
@@ -516,7 +516,7 @@ interface Extendable {
     extendEnd?: boolean;
 }
 
-export type ValueType = string | number | bigint | AgStateSerializableDate | AgStateSerializableBigInt;
+export type ValueType = string | number | AgStateSerializableDate | AgStateSerializableBigInt;
 export type AgAnnotationValue = ValueType | AgGroupingValueType;
 export interface AgGroupingValueType {
     /** The value at the annotation position. */

--- a/packages/ag-charts-types/src/chart/axisOptions.ts
+++ b/packages/ag-charts-types/src/chart/axisOptions.ts
@@ -1,5 +1,6 @@
 import type { LabelBoxOptions, TextOrSegments } from '../series/cartesian/commonOptions';
 import type { RichFormatter, Styler } from './callbackOptions';
+import type { AgNumericValue, AgTimeValue } from './dataValues';
 import type { AgCssColorOrRef } from './themeParamsOptions';
 import type {
     ContextDefault,
@@ -93,7 +94,7 @@ export interface AgBaseAxisOptions<LabelType = any, TContext = ContextDefault> {
     interval?: AgAxisBaseIntervalOptions;
 }
 
-export interface AgBaseContinuousAxisOptions<TDatum extends Date | number = number> {
+export interface AgBaseContinuousAxisOptions<TDatum extends AgTimeValue = number> {
     /** The min value for the axis domain. */
     min?: TDatum;
     /** The max value for the axis domain. */
@@ -105,7 +106,7 @@ export interface AgBaseContinuousAxisOptions<TDatum extends Date | number = numb
 }
 
 export interface AgContinuousAxisOptions<
-    TDatum extends Date | number = number,
+    TDatum extends AgTimeValue = number,
     TInterval extends AgTimeInterval | AgTimeIntervalUnit | number = number,
 > extends AgBaseContinuousAxisOptions<TDatum> {
     /** If `true`, the range will be rounded up to ensure nice equal spacing between the ticks.
@@ -189,7 +190,7 @@ export interface AgAxisLabelFormatterParams<TContext = ContextDefault> {
     /** Context for this callback. */
     readonly context?: TContext;
     /** The currently visible domain. [min, max] */
-    readonly visibleDomain?: [number, number];
+    readonly visibleDomain?: [AgNumericValue, AgNumericValue];
 }
 
 export interface AgAxisLabelStylerParams<TContext = ContextDefault> extends AgBaseAxisLabelStyleOptions {

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -27,6 +27,7 @@ import type {
     AgCrossLineThemeOptions,
 } from './crossLineOptions';
 import type { AgBaseCrosshairLabel, AgCrosshairLabel, AgCrosshairOptions } from './crosshairOptions';
+import type { AgTimeValue } from './dataValues';
 import type { AxisValue, ContextDefault, DatumDefault, Degree, PixelSize, Ratio, TextWrap } from './types';
 
 /** Configuration for axes in cartesian charts. */
@@ -283,7 +284,7 @@ export interface AgTimeAxisOptions<TContext = ContextDefault>
             >,
             'interval'
         >,
-        AgContinuousAxisOptions<Date | number, AgTimeInterval | AgTimeIntervalUnit | number> {
+        AgContinuousAxisOptions<AgTimeValue, AgTimeInterval | AgTimeIntervalUnit | number> {
     type?: 'time';
     /** Options for labels and ticks for the parent level intervals. */
     parentLevel?: AgTimeAxisParentLevel<TContext>;
@@ -301,7 +302,7 @@ export interface AgUnitTimeAxisOptions<TContext = ContextDefault>
             >,
             'interval'
         >,
-        AgBaseContinuousAxisOptions<Date | number> {
+        AgBaseContinuousAxisOptions<AgTimeValue> {
     type?: 'unit-time';
     /** Add cross-lines or regions corresponding to data values. */
     crossLines?: AgCartesianCrossLineOptions<Date | number>[];

--- a/packages/ag-charts-types/src/chart/dataValues.ts
+++ b/packages/ag-charts-types/src/chart/dataValues.ts
@@ -1,0 +1,13 @@
+/**
+ * A numeric data value. A `bigint` may be supplied for integer values outside
+ * the safe-integer range (beyond `Number.MAX_SAFE_INTEGER`).
+ */
+export type AgNumericValue = number | bigint;
+
+/**
+ * A time data value, accepted on time axes only. A `number` or `bigint` is
+ * interpreted as a Unix epoch in milliseconds; a `bigint` may be supplied for
+ * epochs outside the safe-integer range. A `string` must be a strict ISO 8601
+ * date or date-time — other string formats are rejected.
+ */
+export type AgTimeValue = Date | number | bigint | string;

--- a/packages/ag-charts-types/src/chart/dataValues.ts
+++ b/packages/ag-charts-types/src/chart/dataValues.ts
@@ -6,8 +6,9 @@ export type AgNumericValue = number | bigint;
 
 /**
  * A time data value, accepted on time axes only. A `number` or `bigint` is
- * interpreted as a Unix epoch in milliseconds; a `bigint` may be supplied for
- * epochs outside the safe-integer range. A `string` must be a strict ISO 8601
- * date or date-time — other string formats are rejected.
+ * interpreted as a Unix epoch in milliseconds; valid epochs lie within the
+ * safe-integer range, so a `bigint` is narrowed to Number without loss. A
+ * `string` must be a strict ISO 8601 date or date-time — other string formats
+ * are rejected.
  */
 export type AgTimeValue = Date | number | bigint | string;

--- a/packages/ag-charts-types/src/chart/formatterOptions.ts
+++ b/packages/ag-charts-types/src/chart/formatterOptions.ts
@@ -1,5 +1,6 @@
 import type { TextValue } from '../series/cartesian/commonOptions';
 import type { AgTimeIntervalUnit } from './axisOptions';
+import type { AgNumericValue } from './dataValues';
 import type { ContextDefault, DatumDefault, DatumKey } from './types';
 
 export type FormatterPropertyType =
@@ -73,13 +74,13 @@ interface BaseFormatterParams<TDatum, TContext, Value> {
     context?: TContext;
 }
 
-export interface NumberFormatterParams<TDatum, TContext> extends BaseFormatterParams<TDatum, TContext, number> {
+export interface NumberFormatterParams<TDatum, TContext> extends BaseFormatterParams<TDatum, TContext, AgNumericValue> {
     /** Configuration for a number-formatted value. */
     type: 'number';
     /** The recommended precision to format the value. */
     fractionDigits: number | undefined;
     /** The currently visible domain. [min, max] */
-    visibleDomain: [number, number] | undefined;
+    visibleDomain: [AgNumericValue, AgNumericValue] | undefined;
 }
 
 export type DateFormatterStyle = 'long' | 'component';

--- a/packages/ag-charts-types/src/main.ts
+++ b/packages/ag-charts-types/src/main.ts
@@ -10,6 +10,7 @@ export * from './chart/callbackOptions';
 export * from './chart/chartOptions';
 export * from './chart/chartToolbarOptions';
 export * from './chart/contextMenuOptions';
+export * from './chart/dataValues';
 export * from './chart/crossLineOptions';
 export * from './chart/crosshairOptions';
 export * from './chart/bandHighlightOptions';

--- a/packages/ag-charts-types/src/presets/gauge/commonOptions.ts
+++ b/packages/ag-charts-types/src/presets/gauge/commonOptions.ts
@@ -1,5 +1,6 @@
 import type { AgAxisLabelFormatterParams, AgBaseAxisLabelOptions } from '../../chart/axisOptions';
 import type { Formatter } from '../../chart/callbackOptions';
+import type { AgNumericValue } from '../../chart/dataValues';
 import type { AgSelectionOptions, AgSelectionStyleOptions } from '../../chart/selectionOptions';
 import type { AgCssColorOrRef } from '../../chart/themeParamsOptions';
 import type {
@@ -74,9 +75,9 @@ __VERIFY_AXIS_LABEL_OPTIONS = __AXIS_LABEL_OPTIONS;
 
 export interface AgGaugeSegmentationInterval {
     /** The segmentation interval. If the configured interval results in too many items given the chart size, it will be ignored. */
-    step?: number;
+    step?: AgNumericValue;
     /** Array of values for specified intervals along the gauge. */
-    values?: number[];
+    values?: AgNumericValue[];
     /** Number of evenly-divided segments in the gauge. */
     count?: number;
 }
@@ -98,7 +99,7 @@ export interface AgGaugeColorStop {
     /** Colour of this category. */
     color?: string;
     /** Stop value of this category. Defaults the maximum value if unset. */
-    stop?: number;
+    stop?: AgNumericValue;
 }
 
 export interface FillsOptions {

--- a/packages/ag-charts-types/src/presets/gauge/linearGaugeOptions.ts
+++ b/packages/ag-charts-types/src/presets/gauge/linearGaugeOptions.ts
@@ -1,3 +1,4 @@
+import type { AgNumericValue } from '../../chart/dataValues';
 import type { AgChartAutoSizedLabelOptions } from '../../chart/labelOptions';
 import type { AgSeriesTooltip, AgSeriesTooltipRendererParams } from '../../chart/tooltipOptions';
 import type { AgMarkerShape, ContextDefault, DatumDefault, Degree, Direction, PixelSize } from '../../chart/types';
@@ -16,9 +17,9 @@ export interface AgLinearGaugeSeriesStyle extends FillOptions, StrokeOptions, Li
 
 export interface AgLinearGaugeScaleInterval {
     /** Array of values in scale units for specified intervals along the scale. The values in this array must be compatible with the scale type. */
-    values?: number[];
+    values?: AgNumericValue[];
     /** The scale interval. Expressed in the units of the scale. If the configured interval results in too many items given the chart size, it will be ignored. */
-    step?: number;
+    step?: AgNumericValue;
 }
 
 export interface AgLinearGaugeScaleLabel<TContext = ContextDefault> extends AgGaugeScaleLabel<TContext> {
@@ -28,9 +29,9 @@ export interface AgLinearGaugeScaleLabel<TContext = ContextDefault> extends AgGa
 
 export interface AgLinearGaugeScale<TContext = ContextDefault> extends AgLinearGaugeSeriesStyle, FillsOptions {
     /** Maximum value of the scale. Any values exceeding this number will be clipped to this maximum. */
-    min?: number;
+    min?: AgNumericValue;
     /** Minimum value of the scale. Any values exceeding this number will be clipped to this minimum. */
-    max?: number;
+    max?: AgNumericValue;
     /** Configuration for the scale labels. */
     label?: AgLinearGaugeScaleLabel<TContext>;
     /** Configuration for the ticks interval. */
@@ -42,7 +43,7 @@ export interface AgLinearGaugeTooltipRendererParams extends AgSeriesTooltipRende
     ContextDefault
 > {
     /** Value of the Gauge */
-    value: number;
+    value: AgNumericValue;
 }
 
 export interface AgLinearGaugeBarStyle extends AgLinearGaugeSeriesStyle, FillsOptions {
@@ -58,7 +59,7 @@ export type AgLinearGaugeMarkerShape = AgMarkerShape | 'line';
 
 export interface AgLinearGaugeTarget extends AgLinearGaugeSeriesStyle {
     /** Value to use to position the target */
-    value: number;
+    value: AgNumericValue;
     /** Text to use for the target label. */
     text?: string;
     /** The shape to use for the markers. You can also supply a custom marker by providing a `AgMarkerShapeFn` function. */
@@ -128,7 +129,7 @@ export interface AgLinearGaugePreset<TContext = ContextDefault> extends AgLinear
     /** Configuration for the Linear Gauge. */
     type: 'linear-gauge';
     /** Value of the Linear Gauge. */
-    value: number;
+    value: AgNumericValue;
     /** Scale of the Linear Gauge. */
     scale?: AgLinearGaugeScale<TContext>;
     /** Configuration for the targets. */

--- a/packages/ag-charts-types/src/presets/gauge/radialGaugeOptions.ts
+++ b/packages/ag-charts-types/src/presets/gauge/radialGaugeOptions.ts
@@ -1,3 +1,4 @@
+import type { AgNumericValue } from '../../chart/dataValues';
 import type {
     AgChartAutoSizedLabelOptions,
     AgChartAutoSizedSecondaryLabelOptions,
@@ -17,14 +18,14 @@ import type {
 export type AgRadialGaugeTargetPlacement = 'inside' | 'outside' | 'middle';
 
 export interface AgRadialGaugeLabelFormatterParams {
-    value: number;
+    value: AgNumericValue;
 }
 
 export interface AgRadialGaugeScaleInterval {
     /** Array of values in scale units for specified intervals along the scale. The values in this array must be compatible with the scale type. */
-    values?: number[];
+    values?: AgNumericValue[];
     /** The scale interval. Expressed in the units of the scale. If the configured interval results in too many items given the chart size, it will be ignored. */
-    step?: number;
+    step?: AgNumericValue;
 }
 
 export interface AgRadialGaugeScaleLabel<TContext = ContextDefault> extends AgGaugeScaleLabel<TContext> {}
@@ -33,9 +34,9 @@ export interface AgRadialGaugeSeriesStyle extends FillOptions, StrokeOptions, Li
 
 export interface AgRadialGaugeScale<TContext = ContextDefault> extends FillsOptions, AgRadialGaugeSeriesStyle {
     /** Maximum value of the scale. Any values exceeding this number will be clipped to this maximum. */
-    min?: number;
+    min?: AgNumericValue;
     /** Minimum value of the scale. Any values exceeding this number will be clipped to this minimum. */
-    max?: number;
+    max?: AgNumericValue;
     /** Configuration for the scale labels. */
     label?: AgRadialGaugeScaleLabel<TContext>;
     /** Configuration for the ticks interval. */
@@ -47,7 +48,7 @@ export interface AgRadialGaugeTooltipRendererParams extends AgSeriesTooltipRende
     ContextDefault
 > {
     /** Value of the Gauge */
-    value: number;
+    value: AgNumericValue;
 }
 
 export interface AgRadialGaugeBarStyle extends FillsOptions, AgRadialGaugeSeriesStyle {
@@ -73,7 +74,7 @@ export interface AgRadialGaugeTargetLabelOptions extends AgChartLabelOptions<nev
 
 export interface AgRadialGaugeTarget extends AgRadialGaugeSeriesStyle {
     /** Value to use to position the target */
-    value: number;
+    value: AgNumericValue;
     /** Text to use for the target label. */
     text?: string;
     /** The shape to use for the markers. You can also supply a custom marker by providing a `AgMarkerShapeFn` function. */
@@ -153,7 +154,7 @@ export interface AgRadialGaugePreset<TContext = ContextDefault> extends AgRadial
     /** Configuration for the Radial Gauge. */
     type: 'radial-gauge';
     /** Value of the Radial Gauge. */
-    value: number;
+    value: AgNumericValue;
     /** Configuration for the targets. */
     targets?: AgRadialGaugeTarget[];
 }

--- a/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
@@ -1,4 +1,5 @@
 import type { ContextCallbackParams, Listener } from '../../chart/callbackOptions';
+import type { AgNumericValue } from '../../chart/dataValues';
 import type { AgDropShadowOptions } from '../../chart/dropShadowOptions';
 import type { AgNodeClickEvent } from '../../chart/eventOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
@@ -22,10 +23,10 @@ export interface AgHistogramSeriesBinParams<TDatum = DatumDefault> {
     readonly datum: TDatum[];
     /** Zero-based positional index of the bin within the series. Defined for every bin, including empty ones. */
     readonly binIndex: number;
-    /** The bin's start and end bounds on the x-axis. */
-    readonly binRange: [number, number];
-    /** The aggregated `yKey` value for the bin. */
-    readonly aggregatedValue: number;
+    /** The bin's start and end bounds on the x-axis. `bigint` values for a bigint `xKey` column. */
+    readonly binRange: [AgNumericValue, AgNumericValue];
+    /** The aggregated `yKey` value for the bin. A `bigint` when a bigint `yKey` column is summed (`aggregation: 'sum'`). */
+    readonly aggregatedValue: AgNumericValue;
     /** The number of source rows within the bin. */
     readonly frequency: number;
 }

--- a/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/100--stacked-area/main.ts
@@ -148,7 +148,7 @@ const options: AgCartesianChartOptions = {
         const { value, type } = params;
 
         if (type === 'number' && params.property === 'y') {
-            return `${value.toFixed(1)} Mtoe`;
+            return `${Number(value).toFixed(1)} Mtoe`;
         }
 
         if (type === 'date') {

--- a/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-negative-values/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/bubble-with-negative-values/main.ts
@@ -78,13 +78,13 @@ const options: AgCartesianChartOptions = {
     formatter: {
         x: (params) => {
             if (params.type !== 'number') return;
-            const degrees = Math.trunc(params.value);
+            const degrees = Math.trunc(Number(params.value));
             const orientation = degrees > 0 ? 'E' : degrees < 0 ? 'W' : '';
             return `${Math.abs(degrees)}° ${orientation}`;
         },
         y: (params) => {
             if (params.type !== 'number') return;
-            const degrees = Math.trunc(params.value);
+            const degrees = Math.trunc(Number(params.value));
             const orientation = degrees > 0 ? 'N' : degrees < 0 ? 'S' : '';
             return `${Math.abs(degrees)}° ${orientation}`;
         },

--- a/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/chord/main.ts
@@ -51,8 +51,9 @@ const options: AgChartOptions<DataType> = {
         const { value, type } = params;
 
         if (type === 'number') {
-            if (Math.abs(value) >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
-            return value.toLocaleString();
+            const numericValue = Number(value);
+            if (Math.abs(numericValue) >= 1e3) return `${(numericValue / 1e3).toFixed(1)}K`;
+            return numericValue.toLocaleString();
         }
     },
 };

--- a/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/horizontal-linear-gauge/main.ts
@@ -54,7 +54,7 @@ const options: AgLinearGaugeOptions = {
     tooltip: {
         enabled: true,
         renderer: (params) => {
-            const currentValue = params.value;
+            const currentValue = Number(params.value);
             const targetValue = 80;
             const performance = performanceStages[Math.floor((currentValue / 100) * performanceStages.length)];
             const gap =

--- a/packages/ag-charts-website/src/content/gallery/_examples/multiple-scatter-series/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/multiple-scatter-series/main.ts
@@ -236,7 +236,7 @@ const options: AgChartOptions = {
             if (params.type !== 'number') return;
             let fractionDigits = params.fractionDigits ?? 0;
             fractionDigits = Math.max(fractionDigits - 1, 0);
-            return `${(params.value / 1000).toFixed(fractionDigits)}K`;
+            return `${(Number(params.value) / 1000).toFixed(fractionDigits)}K`;
         },
     },
 };

--- a/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/range-bar-with-labels/main.ts
@@ -26,8 +26,8 @@ const data = getData();
 const allSalaries = data.flatMap((d) => [d.low, d.high]);
 const avgSalary = allSalaries.reduce((a, b) => a + b, 0) / allSalaries.length;
 
-const formatter = ({ value }: { value: number | Date | string | string[] }) =>
-    value.toLocaleString('en-GB', {
+const formatter = ({ value }: { value: number | bigint | Date | string | string[] }) =>
+    Number(value).toLocaleString('en-GB', {
         style: 'currency',
         currency: 'GBP',
         notation: 'compact',

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-custom-markers/main.ts
@@ -160,7 +160,7 @@ const options: AgCartesianChartOptions = {
         },
         y: (params) => {
             if (params.type !== 'number') return;
-            const value = params.value / 1000;
+            const value = Number(params.value) / 1000;
             const fractionDigits = params.source === 'tooltip' ? 1 : 0;
 
             if (value >= 100) {

--- a/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-large-data/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/scatter-with-large-data/main.ts
@@ -116,8 +116,9 @@ const options: AgChartOptions = {
     formatter: {
         y(params) {
             if (params.type !== 'number') return;
-            const pq = params.value < 0 ? 'p' : 'q';
-            return `${pq}${Math.abs(params.value).toFixed(params.fractionDigits)}`;
+            const numericValue = Number(params.value);
+            const pq = numericValue < 0 ? 'p' : 'q';
+            return `${pq}${Math.abs(numericValue).toFixed(params.fractionDigits)}`;
         },
     },
 };

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-histogram/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-histogram/main.ts
@@ -37,8 +37,8 @@ const options: AgCartesianChartOptions = {
             tooltip: {
                 renderer: (params) => {
                     const { binRange, frequency } = params;
-                    const binStart = Math.round(binRange[0]);
-                    const binEnd = Math.round(binRange[1]);
+                    const binStart = Math.round(Number(binRange[0]));
+                    const binEnd = Math.round(Number(binRange[1]));
                     const percentage = ((frequency / data.length) * 100).toFixed(1);
 
                     return {

--- a/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
+++ b/packages/ag-charts-website/src/content/gallery/_examples/simple-linear-gauge/main.ts
@@ -56,8 +56,8 @@ const options: AgLinearGaugeOptions = {
             title: 'Chemical Concentration',
             data: [
                 { label: 'Measured Value', value: `${value} mol/L` },
-                { label: 'Status', value: getStatusForValue(value) },
-                { label: 'Range', value: getRangeForValue(value) },
+                { label: 'Status', value: getStatusForValue(Number(value)) },
+                { label: 'Range', value: getRangeForValue(Number(value)) },
             ],
         }),
     },

--- a/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-utils.ts
+++ b/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-utils.ts
@@ -150,6 +150,7 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
 
     switch (node.kind) {
         case ts.SyntaxKind.AnyKeyword:
+        case ts.SyntaxKind.BigIntKeyword:
         case ts.SyntaxKind.BooleanKeyword:
         case ts.SyntaxKind.ConstructSignature:
         case ts.SyntaxKind.Identifier:


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608
https://ag-grid.atlassian.net/browse/AG-16654

**Stacked PR 1 of 3** — splits the bigint/ISO render-hardening work into reviewable slices. This is the base of the stack:

1. **core (this PR)** → `latest`
2. tests → this branch
3. docs/examples → tests branch

## Summary

Core implementation for full-precision bigint and ISO-8601 datetime values across the data model, scales, axes and every series render path.

- Flow `number | bigint` (`AgNumericValue`) and ISO datetime values through aggregation, domains, ticks and min/max paths, coercing to Number only at the final screen-space mapping so precision is preserved beyond ±2^53.
- Add `ag-charts-core` `iso8601`/numeric helpers and `ag-charts-types` `AgNumericValue`/`AgTimeValue` aliases; widen formatter, axis and aggregation option/types accordingly.
- Harden the hierarchy series (treemap + sunburst) so out-of-safe-range bigint `sizeKey`/`colorKey` values drive tile area and the colour domain, instead of collapsing to equal tiles / a single colour.
- Update the affected gallery examples for the widened `number | bigint` formatter value type, and teach the doc-reference generator about the BigInt keyword.
- Regenerate the `dataModel`/`dataExtractor` snapshots and adjust the four unit tests whose existing assertions are forced by the new column-type, scale-domain and warning behaviour.

## Review follow-ups

- Order `ContinuousScale` `domainMin`/`domainMax` by the exact (possibly bigint) endpoints rather than the Number-narrowed caches, so a descending domain whose two bigint endpoints collapse to the same double (differ below one ULP near 2^53) still returns the correct min/max. Regression test added in the tests PR (#7024).

## Test plan

- `yarn nx build:types` / `build:test` (community + enterprise) ✓
- `yarn nx lint` (community, enterprise, core, types) — 0 errors ✓
- `yarn nx test ag-charts-community` ✓ / `yarn nx test ag-charts-enterprise` ✓
- `yarn nx validate-examples ag-charts-website` ✓ (gallery fixups type-check against the widened types)

Fix #AG-16608
Fix #AG-16654