### PR TITLE
AG-17134 Allow GA analytics.js in charts script-src (post-consent)

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -74,6 +74,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             AG_GRID_HOSTS,
             'https://plausible.io',
             'https://www.googletagmanager.com',
+            'https://www.google-analytics.com', // Universal Analytics analytics.js (GTM-injected after cookie consent)
             'https://cdn.jsdelivr.net',
             'https://js.zi-scripts.com', // ZoomInfo tag (injected via GTM)
             'https://*.zoominfo.com', // ZoomInfo FormComplete (trial form)


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

After accepting cookies in the OneTrust banner, GTM injects Universal Analytics, which loads `https://www.google-analytics.com/analytics.js` as a **script**. Our `script-src` did not list that host (only `connect-src` had the `*.google-analytics.com` wildcard, for the collect XHRs), so it reported a `script-src` violation.

Add `https://www.google-analytics.com` to `script-src`. Consent-gated + GTM-injected → production-only, so staging never surfaced it.

Report-only — no enforced behaviour change.