### PR TITLE
AG-17347 Reorder scrollbar scrolling controls and tidy upgrade guide

### DIFF
--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-scrolling/index.html
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-scrolling/index.html
@@ -1,11 +1,11 @@
 <div class="example-controls">
     <div class="controls-row">
-        <label>Series Area Scrolling:</label>
-        <button onclick="setSeriesAreaScrolling(true)">Enable</button>
-        <button class="gap-right" onclick="setSeriesAreaScrolling(false)">Disable</button>
         <label>Axis Scrolling:</label>
         <button onclick="setAxisScrolling(true)">Enable</button>
         <button onclick="setAxisScrolling(false)">Disable</button>
+        <label>Series Area Scrolling:</label>
+        <button onclick="setSeriesAreaScrolling(true)">Enable</button>
+        <button class="gap-right" onclick="setSeriesAreaScrolling(false)">Disable</button>
     </div>
 </div>
 <div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/scrollbar/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/index.mdoc
@@ -134,14 +134,14 @@ The Scrollbar track mirrors native scrollbar behaviour:
 
 Scrolling over the Scrollbar track always pans the viewport. Scrolling over the series area also pans the chart by default.
 
-Set `enableSeriesAreaScrolling` to `false` to disable series-area scrolling, and `enableAxisScrolling` to `true` to extend scrolling to the axis areas.
+Set `enableAxisScrolling` to `true` to extend scrolling to the axis areas, and set `enableSeriesAreaScrolling` to `false` to disable series area scrolling.  
 
 {% chartExampleRunner title="Scrollbar Scrolling" name="scrollbar-scrolling" type="generated" /%}
 
 In this example:
 
-- `enableSeriesAreaScrolling` controls whether scrolling within the series area pans the chart. It is enabled by default.
-- `enableAxisScrolling` enables scrolling over the axis to pan in that axis direction.
+- `enableAxisScrolling` controls whether scrolling over the axis pans in that direction.
+- `enableSeriesAreaScrolling` controls whether scrolling within the series area pans the chart.
 - If [Zoom](./zoom) is also enabled, its scroll interactions take precedence.
 
 ## Visibility

--- a/packages/ag-charts-website/src/content/docs/scrollbar/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/index.mdoc
@@ -134,7 +134,7 @@ The Scrollbar track mirrors native scrollbar behaviour:
 
 Scrolling over the Scrollbar track always pans the viewport. Scrolling over the series area also pans the chart by default.
 
-Set `enableAxisScrolling` to `true` to extend scrolling to the axis areas, and set `enableSeriesAreaScrolling` to `false` to disable series area scrolling.  
+Set `enableAxisScrolling` to `true` to extend scrolling to the axis areas, and set `enableSeriesAreaScrolling` to `false` to disable series area scrolling.
 
 {% chartExampleRunner title="Scrollbar Scrolling" name="scrollbar-scrolling" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
@@ -12,7 +12,7 @@ In the above example:
 - Hovering a bar segment in one series will dim the other series.
 - Hovering a legend item will dim the other series.
 
-Highlighting is enabled by default. Use `highlight.enabled` to configure it globally, or `series[].highlight.enabled` to override it per series
+Highlighting is enabled by default. Use `highlight.enabled` to configure it globally, or `series[].highlight.enabled` to override it per series.
 
 ## Bring to Front
 

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -113,7 +113,7 @@ This release includes the following behaviour changes:
 ### Theme Defaults
 
 - The default `fontFamily` has changed to the IBM Plex Sans stack (`"IBM Plex Sans", -apple-system, "system-ui", ...`) to align with AG Grid v14. Charts that relied on the previous system font may render with a different typeface.
-- The default `focusShadow` has changed to a 50% opacity accent colour .
+- The default `focusShadow` has changed to a 50% opacity accent colour.
 
 ### Tooltips
 

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -112,8 +112,8 @@ This release includes the following behaviour changes:
 
 ### Theme Defaults
 
-- The default `fontFamily` has been updated to the IBM Plex Sans stack (`"IBM Plex Sans", -apple-system, "system-ui", ...`) to align with AG Grid v14. Charts that relied on the previous system font may render with a different typeface.
-- The default `focusShadow` has been updated to a 50% opacity accent colour to match AG Grid v14.
+- The default `fontFamily` has changed to the IBM Plex Sans stack (`"IBM Plex Sans", -apple-system, "system-ui", ...`) to align with AG Grid v14. Charts that relied on the previous system font may render with a different typeface.
+- The default `focusShadow` has changed to a 50% opacity accent colour .
 
 ### Tooltips
 
@@ -127,7 +127,7 @@ This release includes the following behaviour changes:
 
 ### Scrollbar
 
-- The default value of `scrollbar.enableSeriesAreaScrolling` has changed from `false` to `true`. Charts with `scrollbar.enabled: true` and no explicit `enableSeriesAreaScrolling` setting will now pan on wheel-scroll over the series area. Set `scrollbar.enableSeriesAreaScrolling: false` to restore the previous behaviour.
+- The default value of `scrollbar.enableSeriesAreaScrolling` has changed from `false` to `true`.
 
 ### Zoom
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17347

- Reorder scrollbar-scrolling example controls so Axis Scrolling appears before Series Area Scrolling, matching the logical axis-first presentation.
- Update the corresponding prose in the Scrollbar docs to reflect the same order.
- Simplify two entries in the Upgrade to AG Charts 14 guide: shorten the `focusShadow` entry and condense the `enableSeriesAreaScrolling` entry to a single line.

Fix #AG-17347