### PR TITLE
AG-17148 update pricing link for charts page

### DIFF
--- a/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
+++ b/external/ag-website-shared/src/content/license-features/chartsFeaturesMatrix.json
@@ -658,7 +658,7 @@
             {
                 "label": {
                     "name": "Enterprise Support",
-                    "link": "https://www.ag-grid.com/react-data-grid/community-vs-enterprise/"
+                    "link": "https://www.ag-grid.com/charts/react/community-vs-enterprise/"
                 },
                 "community": {
                     "value": false,
@@ -676,7 +676,7 @@
             {
                 "label": {
                     "name": "Perpetual License",
-                    "link": "https://www.ag-grid.com/react-data-grid/community-vs-enterprise/"
+                    "link": "https://www.ag-grid.com/charts/react/community-vs-enterprise/"
                 },
                 "community": {
                     "value": false,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17148

Update the **Enterprise Support** and **Perpetual License** links on the charts features matrix to point at the charts community-vs-enterprise page instead of the grid one.

Ported from ag-grid/ag-grid#13959 (release-branch equivalent of #13981).