### PR TITLE
AG-17134 Port charts production CSP report-only fixes to latest

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -80,6 +80,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.google.com', // reCAPTCHA (license-pricing trial form)
             'https://www.gstatic.com', // reCAPTCHA
             'https://www.youtube.com', // YouTube iframe JS API (loads into the page)
+            'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
+            'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
             UNSAFE_INLINE,
             UNSAFE_EVAL,
         ],
@@ -106,6 +108,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://js.zi-scripts.com', // ZoomInfo
             'https://*.zoominfo.com', // ZoomInfo
             'https://www.google.com', // reCAPTCHA (api2/clr XHR)
+            'https://cdn.cookielaw.org', // OneTrust config/JSON/asset XHR (GTM-injected, prod-only)
+            'https://*.onetrust.com', // OneTrust geolocation + consent-receipt endpoints
             trialFormOrigin, // trial-licence form fetch POST
         ],
         'frame-src': [

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -74,6 +74,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             AG_GRID_HOSTS,
             'https://plausible.io',
             'https://www.googletagmanager.com',
+            'https://www.google-analytics.com', // Universal Analytics analytics.js (GTM-injected after cookie consent)
             'https://cdn.jsdelivr.net',
             'https://js.zi-scripts.com', // ZoomInfo tag (injected via GTM)
             'https://*.zoominfo.com', // ZoomInfo FormComplete (trial form)

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -100,7 +100,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://plausible.io',
             'https://*.algolia.net', // Algolia DocSearch
             'https://*.algolianet.com', // Algolia DocSearch
-            'https://www.google-analytics.com',
+            'https://*.google-analytics.com', // GA4 incl. regional collect endpoints (region1/2.google-analytics.com)
             'https://*.analytics.google.com',
             'https://stats.g.doubleclick.net',
             'https://www.googletagmanager.com',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Forward-ports the AG-17134 CSP report-only fixes that were made on `b13.3.1` and validated on charts production. Cherry-picks (cspRules.ts only):

- #7018 — OneTrust cookie-consent (`cdn.cookielaw.org` script-src + connect-src, `*.onetrust.com` connect-src) + ZoomInfo `blob:` script
- #7021 — GA4 regional collect endpoints (`www.google-analytics.com` → `*.google-analytics.com`)
- #7028 — GA `analytics.js` in script-src (post-consent)

All GTM-injected, production-only tags. Report-only — no enforced behaviour change.

