### PR TITLE
AG-17134 Enforce charts CSP (report-only → enforce)

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
@@ -15,12 +15,13 @@ ErrorDocument 404 ${urlWithBaseUrl('/404.html')}
 # add MIME types for serving example files
 AddType text/javascript mjs ts jsx
 
-# Content-Security-Policy — report-only while validating the tightened policy.
+# Content-Security-Policy — enforced (the report-only validation window is complete).
 # Charts is served from /charts on www.ag-grid.com and inherits the grid root CSP, so
-# this block overrides it for charts pages (see getCspHtaccessBlock). The trial-form
-# origin is env-split, so the policy is generated per environment. Flip to enforce
-# once the report-only window is clean.
-${getCspHtaccessBlock({ env }, 'report-only')}
+# this block overrides it for charts pages (see getCspHtaccessBlock). In enforce mode
+# the block unsets BOTH inherited headers (the grid root policy and the legacy wildcard)
+# and sets this enforced policy. The trial-form origin is env-split, so the policy is
+# generated per environment.
+${getCspHtaccessBlock({ env }, 'enforce')}
 
 ${getRedirectRules()}
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Flips the charts CSP from **report-only to enforced**. `getCspHtaccessBlock` switches to `enforce` mode, which unsets **both** inherited headers (the grid root CSP and the legacy wildcard) and sets the tightened policy as the enforced `Content-Security-Policy` on `/charts` pages. Applies to staging + production builds.

**Deploy ordering:** charts (and studio) must be enforced in production **before** grid root is enforced — `/charts` inherits the grid root policy, so this PR going live first is required.

**Pre-deploy check:** confirm the charts prod report-only window is clean (page-load crawl + a consent-accept / pricing-form / example pass). After this is the real enforcement — any unfixed violation will now block.

Fix #AG-17134