### PR TITLE
AG-17492 rename getDataId callback to getItemId, key cache by bin position

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
@@ -176,7 +176,7 @@ describe('HistogramSeries', () => {
         });
     });
 
-    describe('getDataId', () => {
+    describe('getItemId', () => {
         const nodeDataOf = (c: any) => (deproxy(c).series[0] as any).getNodeData() as any[];
         const itemIdsOf = (c: any) => nodeDataOf(c).map((n) => n.itemId);
 
@@ -224,13 +224,13 @@ describe('HistogramSeries', () => {
             expect(itemIdsOf(chart)).toEqual(['bin:-10,-5', 'bin:-5,0.5']);
         });
 
-        it('uses the getDataId callback to override the id', async () => {
-            const getDataId = vi.fn((p: { binIndex: number }) => `b${p.binIndex}`);
-            chart = createBinnedChart({ getDataId });
+        it('uses the getItemId callback to override the id', async () => {
+            const getItemId = vi.fn((p: { binIndex: number }) => `b${p.binIndex}`);
+            chart = createBinnedChart({ getItemId });
             await waitForChartStability(chart);
 
             expect(itemIdsOf(chart)).toEqual(['b0', 'b1']);
-            expect(getDataId).toHaveBeenCalledWith(
+            expect(getItemId).toHaveBeenCalledWith(
                 expect.objectContaining({
                     binIndex: 0,
                     binRange: [0, 10],
@@ -243,8 +243,8 @@ describe('HistogramSeries', () => {
 
         it('passes the chart context to the callback', async () => {
             const context = { tenant: 'acme' };
-            const getDataId = vi.fn((p: { context?: any }) => `${p.context?.tenant}`);
-            chart = createBinnedChart({ context, getDataId });
+            const getItemId = vi.fn((p: { context?: any }) => `${p.context?.tenant}`);
+            chart = createBinnedChart({ context, getItemId });
             await waitForChartStability(chart);
 
             expect(itemIdsOf(chart)).toEqual(['acme', 'acme']);
@@ -277,10 +277,10 @@ describe('HistogramSeries', () => {
         });
 
         it('falls back to the default id when the callback throws', async () => {
-            const getDataId = () => {
+            const getItemId = () => {
                 throw new Error('boom');
             };
-            chart = createBinnedChart({ getDataId });
+            chart = createBinnedChart({ getItemId });
             await waitForChartStability(chart);
 
             expect(itemIdsOf(chart)).toEqual(['bin:0,10', 'bin:10,20']);
@@ -391,14 +391,14 @@ describe('HistogramSeries', () => {
             expect(firstBin.aggregatedValue).toBe(6);
         });
 
-        const clickFirstBin = async (c: any) => {
+        const firstBinCanvasPoint = (c: any) => {
             const series = deproxy(c).series[0] as any;
             const node = series.getNodeData()[0];
-            const { x, y } = Transformable.toCanvasPoint(
-                series.contentGroup,
-                node.x + node.width / 2,
-                node.y + node.height / 2
-            );
+            return Transformable.toCanvasPoint(series.contentGroup, node.x + node.width / 2, node.y + node.height / 2);
+        };
+
+        const clickFirstBin = async (c: any) => {
+            const { x, y } = firstBinCanvasPoint(c);
             await clickAction(x, y)(c);
             await waitForChartStability(c);
         };
@@ -434,13 +434,7 @@ describe('HistogramSeries', () => {
             chart = createChart({ listeners: { seriesNodeDoubleClick } });
             await waitForChartStability(chart);
 
-            const series = deproxy(chart).series[0] as any;
-            const node = series.getNodeData()[0];
-            const { x, y } = Transformable.toCanvasPoint(
-                series.contentGroup,
-                node.x + node.width / 2,
-                node.y + node.height / 2
-            );
+            const { x, y } = firstBinCanvasPoint(chart);
             await doubleClickAction(x, y)(chart);
             await waitForChartStability(chart);
 
@@ -455,13 +449,7 @@ describe('HistogramSeries', () => {
             chart = createChart({ tooltip: { renderer } });
             await waitForChartStability(chart);
 
-            const series = deproxy(chart).series[0] as any;
-            const node = series.getNodeData()[0];
-            const { x, y } = Transformable.toCanvasPoint(
-                series.contentGroup,
-                node.x + node.width / 2,
-                node.y + node.height / 2
-            );
+            const { x, y } = firstBinCanvasPoint(chart);
             await hoverAction(x, y)(chart);
             await waitForChartStability(chart);
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -492,8 +492,11 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         const { xKey, yKey } = ctx;
         const { domain: binRange, datum, binIndex, frequency, total, aggregatedValue } = bin;
         const [binStart, binEnd] = binRange;
-        const { getDataId } = this.properties;
-        const customId = getDataId == null ? undefined : this.cachedCallWithContext(getDataId, this.binParams(bin));
+        const { getItemId } = this.properties;
+        const customId =
+            getItemId == null
+                ? undefined
+                : this.cachedCallWithContext(getItemId, this.binParams(bin), `${this.id}:${binStart},${binEnd}`);
         const itemId = customId ?? `bin:${binStart},${binEnd}`;
 
         return {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesOptionsDef.ts
@@ -49,5 +49,5 @@ export const histogramSeriesOptionsDef: OptionsDefs<AgHistogramSeriesOptions> = 
     yKeyAxis: string,
     xName: string,
     yName: string,
-    getDataId: callbackOf(string),
+    getItemId: callbackOf(string),
 };

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
@@ -1,7 +1,7 @@
 import type { InternalAgColorType, NormalisedTextOrSegments, RequireOptional } from 'ag-charts-core';
 import { Property } from 'ag-charts-core';
 import type {
-    AgHistogramSeriesGetDataIdParams,
+    AgHistogramSeriesGetItemIdParams,
     AgHistogramSeriesLabelFormatterParams,
     AgHistogramSeriesOptions,
     AgHistogramSeriesStyle,
@@ -95,7 +95,7 @@ export class HistogramSeriesProperties extends CartesianSeriesProperties<AgHisto
     binCount?: number;
 
     @Property
-    getDataId?: (params: AgHistogramSeriesGetDataIdParams) => string = undefined;
+    getItemId?: (params: AgHistogramSeriesGetItemIdParams) => string = undefined;
 
     @Property
     readonly shadow = new DropShadow();

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1574,8 +1574,12 @@ export abstract class Series<
         }
     }
 
-    public cachedCallWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> | undefined {
-        return this.ctx.callbackCache.call([this.properties, this.ctx.chartService], fn, params);
+    public cachedCallWithContext<F extends Callback>(
+        fn: F,
+        params: CallbackParam<F>,
+        cacheKey?: string
+    ): ReturnType<F> | undefined {
+        return this.ctx.callbackCache.call([this.properties, this.ctx.chartService], fn, params, cacheKey);
     }
 
     public callWithContext<F extends Callback>(fn: F, params: CallbackParam<F>): ReturnType<F> {

--- a/packages/ag-charts-core/src/state/callbackCache.ts
+++ b/packages/ag-charts-core/src/state/callbackCache.ts
@@ -41,12 +41,18 @@ export function callWithContext<F extends Callback>(
 export class CallbackCache {
     private cache: WeakMap<Function, Map<string, any>> = new WeakMap();
 
-    call<F extends Callback>(callers: Caller | Caller[], fn: F, params: CallbackParam<F>): ReturnType<F> | undefined {
+    call<F extends Callback>(
+        callers: Caller | Caller[],
+        fn: F,
+        params: CallbackParam<F>,
+        cacheKey?: string
+    ): ReturnType<F> | undefined {
         let serialisedParams: string;
         let paramCache = this.cache.get(fn);
 
         try {
-            serialisedParams = JSON.stringify(params);
+            // An explicit key avoids stringifying params that carry bulk data (e.g. a row array).
+            serialisedParams = cacheKey ?? JSON.stringify(params);
         } catch {
             // Unable to serialise params!
             // No caching possible.

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeries.test.ts
@@ -111,7 +111,7 @@ describe('ChordSeries', () => {
         });
     });
 
-    describe('getDataId', () => {
+    describe('getItemId', () => {
         const DATA = [
             { from: 'A', to: 'B', size: 5 },
             { from: 'B', to: 'C', size: 5 },
@@ -135,11 +135,11 @@ describe('ChordSeries', () => {
             expect(getNodeItemIds(chart)).toEqual(['A', 'B', 'C']);
         });
 
-        it('uses the getDataId callback to override the node itemId', async () => {
-            const getDataId = vi.fn((p: { nodeName: string }) => `node:${p.nodeName}`);
+        it('uses the getItemId callback to override the node itemId', async () => {
+            const getItemId = vi.fn((p: { nodeName: string }) => `node:${p.nodeName}`);
             const options: AgChartOptions = {
                 data: DATA,
-                series: [{ type: 'chord', fromKey: 'from', toKey: 'to', sizeKey: 'size', getDataId }],
+                series: [{ type: 'chord', fromKey: 'from', toKey: 'to', sizeKey: 'size', getItemId }],
             };
             prepareEnterpriseTestOptions(options as any);
 
@@ -147,15 +147,15 @@ describe('ChordSeries', () => {
             await waitForChartStability(chart);
 
             expect(getNodeItemIds(chart)).toEqual(['node:A', 'node:B', 'node:C']);
-            expect(getDataId).toHaveBeenCalledWith(expect.objectContaining({ nodeName: 'A' }));
+            expect(getItemId).toHaveBeenCalledWith(expect.objectContaining({ nodeName: 'A' }));
         });
 
         it('passes the chart context to the callback', async () => {
             const context = { tenant: 'acme' };
-            const getDataId = vi.fn((p: { nodeName: string; context?: any }) => `${p.context?.tenant}:${p.nodeName}`);
+            const getItemId = vi.fn((p: { nodeName: string; context?: any }) => `${p.context?.tenant}:${p.nodeName}`);
             const options: AgChartOptions = {
                 data: DATA,
-                series: [{ type: 'chord', fromKey: 'from', toKey: 'to', sizeKey: 'size', context, getDataId }],
+                series: [{ type: 'chord', fromKey: 'from', toKey: 'to', sizeKey: 'size', context, getItemId }],
             };
             prepareEnterpriseTestOptions(options as any);
 

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeriesOptionsDef.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeriesOptionsDef.ts
@@ -22,7 +22,7 @@ export const chordSeriesOptionsDef: OptionsDefs<AgChordSeriesOptions> = {
     toKey: required(string),
     sizeKey: string,
     sizeName: string,
-    getDataId: callbackOf(string),
+    getItemId: callbackOf(string),
 };
 
 // @ts-expect-error undocumented option

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeriesProperties.ts
@@ -1,5 +1,5 @@
 import {
-    type AgChordSeriesGetDataIdParams,
+    type AgChordSeriesGetItemIdParams,
     type AgChordSeriesLabelFormatterParams,
     type AgChordSeriesLinkItemStylerParams,
     type AgChordSeriesLinkStyle,
@@ -145,7 +145,7 @@ export class ChordSeriesProperties extends SeriesProperties<AgChordSeriesOptions
     nodes: any[] | undefined = undefined;
 
     @Property
-    getDataId?: (params: AgChordSeriesGetDataIdParams) => string = undefined;
+    getItemId?: (params: AgChordSeriesGetItemIdParams) => string = undefined;
 
     @Property
     readonly fillGradientDefaults = new FillGradientDefaults();

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionProperties.ts
@@ -1,6 +1,6 @@
 import type {
     AgChordSeriesTooltipRendererParams,
-    AgSankeySeriesGetDataIdParams,
+    AgSankeySeriesGetItemIdParams,
     AgSankeySeriesTooltipRendererParams,
     _ModuleSupport,
 } from 'ag-charts-community';
@@ -23,5 +23,5 @@ export interface FlowProportionSeriesProperties<
     tooltip: _ModuleSupport.SeriesTooltip<
         AgChordSeriesTooltipRendererParams<any> & AgSankeySeriesTooltipRendererParams<any>
     >;
-    getDataId?: (params: AgSankeySeriesGetDataIdParams<any, any>) => string;
+    getItemId?: (params: AgSankeySeriesGetItemIdParams<any, any>) => string;
 }

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -345,9 +345,9 @@ export abstract class FlowProportionSeries<
         this.processedNodes = processedNodes;
     }
 
-    private callGetDataId(params: { nodeName: string; index: number; datum: unknown }): string | undefined {
-        const { getDataId } = this.properties;
-        return getDataId == null ? undefined : this.cachedCallWithContext(getDataId, params);
+    private callGetItemId(params: { nodeName: string; index: number; datum: unknown }): string | undefined {
+        const { getItemId } = this.properties;
+        return getItemId == null ? undefined : this.cachedCallWithContext(getItemId, params);
     }
 
     override findNodeDatum(itemId: AgActiveItemState['itemId']): TDatum<TNodeDatum, TLinkDatum> | undefined {
@@ -876,7 +876,7 @@ export abstract class FlowProportionSeries<
         const { nodeName } = info;
         const nodeIdValue = this.readDataIdKey(datum, info);
         const offset = toFlowNodeOffset(datumIndex);
-        const computedId = this.callGetDataId({ nodeName, index: offset, datum });
+        const computedId = this.callGetItemId({ nodeName, index: offset, datum });
         return computedId ?? (nodeIdValue == null ? nodeName : String(nodeIdValue));
     }
 

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.test.ts
@@ -303,7 +303,7 @@ describe('SankeySeries', () => {
         });
     });
 
-    describe('getDataId', () => {
+    describe('getItemId', () => {
         const DATA = [
             { from: 'A', to: 'B', size: 5 },
             { from: 'B', to: 'C', size: 5 },
@@ -327,11 +327,11 @@ describe('SankeySeries', () => {
             expect(getNodeItemIds(chart)).toEqual(['A', 'B', 'C']);
         });
 
-        it('uses the getDataId callback to override the node itemId', async () => {
-            const getDataId = vi.fn((p: { nodeName: string }) => `node:${p.nodeName}`);
+        it('uses the getItemId callback to override the node itemId', async () => {
+            const getItemId = vi.fn((p: { nodeName: string }) => `node:${p.nodeName}`);
             const options: AgStandaloneChartOptions = {
                 data: DATA,
-                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size', getDataId }],
+                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size', getItemId }],
             };
             prepareEnterpriseTestOptions(options as any);
 
@@ -339,15 +339,15 @@ describe('SankeySeries', () => {
             await waitForChartStability(chart);
 
             expect(getNodeItemIds(chart)).toEqual(['node:A', 'node:B', 'node:C']);
-            expect(getDataId).toHaveBeenCalledWith(expect.objectContaining({ nodeName: 'A' }));
+            expect(getItemId).toHaveBeenCalledWith(expect.objectContaining({ nodeName: 'A' }));
         });
 
         it('passes the chart context to the callback', async () => {
             const context = { tenant: 'acme' };
-            const getDataId = vi.fn((p: { nodeName: string; context?: any }) => `${p.context?.tenant}:${p.nodeName}`);
+            const getItemId = vi.fn((p: { nodeName: string; context?: any }) => `${p.context?.tenant}:${p.nodeName}`);
             const options: AgStandaloneChartOptions = {
                 data: DATA,
-                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size', context, getDataId }],
+                series: [{ type: 'sankey', fromKey: 'from', toKey: 'to', sizeKey: 'size', context, getItemId }],
             };
             prepareEnterpriseTestOptions(options as any);
 

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesOptionsDef.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesOptionsDef.ts
@@ -24,7 +24,7 @@ export const sankeySeriesOptionsDef: OptionsDefs<AgSankeySeriesOptions> = {
     toKey: required(string),
     sizeKey: string,
     sizeName: string,
-    getDataId: callbackOf(string),
+    getItemId: callbackOf(string),
 };
 
 // @ts-expect-error undocumented option

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeriesProperties.ts
@@ -1,5 +1,5 @@
 import {
-    type AgSankeySeriesGetDataIdParams,
+    type AgSankeySeriesGetItemIdParams,
     type AgSankeySeriesLabelFormatterParams,
     type AgSankeySeriesLinkItemStylerParams,
     type AgSankeySeriesLinkOptions,
@@ -159,7 +159,7 @@ export class SankeySeriesProperties extends SeriesProperties<AgSankeySeriesOptio
     sizeName: string | undefined = undefined;
 
     @Property
-    getDataId?: (params: AgSankeySeriesGetDataIdParams) => string = undefined;
+    getItemId?: (params: AgSankeySeriesGetItemIdParams) => string = undefined;
 
     @Property
     readonly fillGradientDefaults = new FillGradientDefaults();

--- a/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
@@ -15,7 +15,7 @@ import type { AgBaseCartesianSeriesAxisOptions, FillOptions, LineDashOptions, St
 
 /**
  * The standard set of bin data exposed to every histogram callback (tooltip, label formatter,
- * node click/double-click, context menu and `getDataId`).
+ * node click/double-click, context menu and `getItemId`).
  */
 export interface AgHistogramSeriesBinParams<TDatum = DatumDefault> {
     /** The raw source rows grouped into the bin. */
@@ -48,7 +48,7 @@ export interface AgHistogramSeriesLabelFormatterParams<TDatum = DatumDefault>
     readonly value: any;
 }
 
-export interface AgHistogramSeriesGetDataIdParams<TDatum = DatumDefault, TContext = ContextDefault>
+export interface AgHistogramSeriesGetItemIdParams<TDatum = DatumDefault, TContext = ContextDefault>
     extends ContextCallbackParams<TContext>, AgHistogramSeriesBinParams<TDatum> {}
 
 export interface AgHistogramSeriesStyle extends FillOptions, StrokeOptions, LineDashOptions {
@@ -132,5 +132,5 @@ export interface AgHistogramSeriesOptions<TDatum = DatumDefault, TContext = Cont
      *
      * If not supplied, an identifier is generated from the bin boundaries.
      */
-    getDataId?: (params: AgHistogramSeriesGetDataIdParams<TDatum, TContext>) => string;
+    getItemId?: (params: AgHistogramSeriesGetItemIdParams<TDatum, TContext>) => string;
 }

--- a/packages/ag-charts-types/src/series/standalone/chordOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/chordOptions.ts
@@ -21,10 +21,10 @@ export interface AgChordSeriesOptions<TDatum = DatumDefault, TContext = ContextD
      *
      * If not supplied, the node name is used as its identifier.
      */
-    getDataId?: (params: AgChordSeriesGetDataIdParams<TDatum, TContext>) => string;
+    getItemId?: (params: AgChordSeriesGetItemIdParams<TDatum, TContext>) => string;
 }
 
-export interface AgChordSeriesGetDataIdParams<
+export interface AgChordSeriesGetItemIdParams<
     TDatum = DatumDefault,
     TContext = ContextDefault,
 > extends ContextCallbackParams<TContext> {

--- a/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
@@ -21,10 +21,10 @@ export interface AgSankeySeriesOptions<TDatum = DatumDefault, TContext = Context
      *
      * If not supplied, the node name is used as its identifier.
      */
-    getDataId?: (params: AgSankeySeriesGetDataIdParams<TDatum, TContext>) => string;
+    getItemId?: (params: AgSankeySeriesGetItemIdParams<TDatum, TContext>) => string;
 }
 
-export interface AgSankeySeriesGetDataIdParams<
+export interface AgSankeySeriesGetItemIdParams<
     TDatum = DatumDefault,
     TContext = ContextDefault,
 > extends ContextCallbackParams<TContext> {

--- a/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
@@ -83,7 +83,7 @@ The styling of all links can be customised using the `link` property.
 
 ## Node Identifiers
 
-Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
+Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getItemId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
 
 ```js format="snippet"
 {
@@ -92,7 +92,7 @@ Each node has a stable identifier, surfaced as the `itemId` in node events and a
             type: 'chord',
             fromKey: 'from',
             toKey: 'to',
-            getDataId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
+            getItemId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
         },
     ],
 }

--- a/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
@@ -130,7 +130,7 @@ The default aggregation method is `sum`. Use the `aggregation` option to change 
 
 ## Bin Identifiers
 
-Each bin has a stable identifier, surfaced as the `itemId` in node events and active state. By default this identifier is generated from the bin boundaries. Use `getDataId` to map a bin to an identifier from your own domain. The returned value must be unique across the bins in the series.
+Each bin has a stable identifier, surfaced as the `itemId` in node events and active state. By default this identifier is generated from the bin boundaries. Use `getItemId` to map a bin to an identifier from your own domain. The returned value must be unique across the bins in the series.
 
 ```js format="snippet"
 {
@@ -138,7 +138,7 @@ Each bin has a stable identifier, surfaced as the `itemId` in node events and ac
         {
             type: 'histogram',
             xKey: 'age',
-            getDataId: ({ binRange }) => `${binRange[0]}-${binRange[1]}yrs`,
+            getItemId: ({ binRange }) => `${binRange[0]}-${binRange[1]}yrs`,
         },
     ],
 }

--- a/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
@@ -167,7 +167,7 @@ The styling of all links can be customised using the `link` property.
 
 ## Node Identifiers
 
-Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getDataId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
+Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getItemId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
 
 ```js format="snippet"
 {
@@ -176,7 +176,7 @@ Each node has a stable identifier, surfaced as the `itemId` in node events and a
             type: 'sankey',
             fromKey: 'from',
             toKey: 'to',
-            getDataId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
+            getItemId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
         },
     ],
 }


### PR DESCRIPTION
## Summary

Fast-follow to AG-17492 (#7011, merged). Two related changes to the bin/node identifier callback:

1. **Rename `getDataId` → `getItemId`** across the public types, option defs, properties, and docs for histogram, sankey and chord. The callback's return value *is* the node/bin `itemId`, so the new name describes it accurately. Applied before release to avoid a later breaking change.
2. **Key the histogram `getItemId` cache by bin position.** Previously the callback was memoised via `JSON.stringify(binParams)`, which serialised the full bin row array (`datum: TDatum[]`) per bin on every node-data rebuild — a regression flagged in the #7011 review. It now uses a cheap, series-scoped key (`${series.id}:${binStart},${binEnd}`) while still passing the rich params to the callback. `CallbackCache.call` / `Series.cachedCallWithContext` gained an optional `cacheKey` argument; existing positional callers are unaffected.

Also extracts a shared `firstBinCanvasPoint` helper in the histogram tests (de-duplicates three identical canvas-point computations).

## Why the cheap key is safe

- The callback cache is cleared on every `FULL` update / data change, so a per-bin `[start,end]` key cannot go stale across data changes.
- The key is namespaced with the series `id` because `CallbackCache` is shared chart-wide — this also closes a latent cross-series collision the pre-PR key had.
- Only histogram passes a bulk row array; sankey/chord/flow-proportion pass a single node `datum`, so they remain cache-keyless (cheap to stringify).

## Verification

- `build:types`, `lint` (0 errors) for core, community, enterprise
- Tests: histogram (66), sankey (39), chord (19), organization (96) — all pass

## Follow-ups (deferred from the #7011 review, not in this PR)

- Context-menu `datum` type for histogram (`getItems`/`action` receive `TDatum[]` at runtime, typed `TDatum`) — needs a histogram-specific params type rather than widening the generic chart-level type.
- Confirm the AG-17492 migration-guide entry is covered by the release-content process.
