### PR TITLE
AG-17524 Don't raise highlight-disabled map series datum on hover

### DIFF
--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.test.ts
@@ -104,6 +104,32 @@ describe('MapShapeSeries', () => {
         });
     });
 
+    describe('Bring to front on highlight', () => {
+        it('does not raise the hovered datum when highlight is disabled', async () => {
+            const options: AgChartOptions = {
+                ...SIMPLIFIED_EXAMPLE,
+                series: [{ type: 'map-shape', idKey: 'name', highlight: { enabled: false } }],
+            };
+            prepareEnterpriseTestOptions(options);
+
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const seriesImpl = chart.series[0] as MapShapeSeries;
+            const node = seriesImpl['contextNodeData']?.nodeData[2];
+
+            (chart as Chart).ctx.highlightManager.updateHighlight(chart.id, node);
+            // Re-run the render that populates the highlight overlay. A highlight-disabled series must
+            // leave the overlay empty so the hovered datum is never raised above overlapping series,
+            // regardless of any unrelated update that re-renders it while highlighted.
+            seriesImpl.update();
+            await waitForChartStability(chart);
+
+            const raisedNodes = Array.from(seriesImpl.highlightNodeGroup.children());
+            expect(raisedNodes).toHaveLength(0);
+        });
+    });
+
     describe('Heatmap', () => {
         it('should render a simple chart', async () => {
             const options: AgChartOptions = { ...HEATMAP_EXAMPLE };

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.test.ts
@@ -105,10 +105,25 @@ describe('MapShapeSeries', () => {
     });
 
     describe('Bring to front on highlight', () => {
-        it('does not raise the hovered datum when highlight is disabled', async () => {
+        const hoverFirstShape = async (series: any) => {
+            const [datum] = series.contextNodeData?.nodeData ?? [];
+            expect(datum).toBeDefined();
+            const midPoint = series.datumMidPoint(datum);
+            const { x, y } = _ModuleSupport.Transformable.toCanvasPoint(series.contentGroup, midPoint.x, midPoint.y);
+            await hoverAction(x, y)(chart);
+            await waitForChartStability(chart);
+        };
+
+        // Hovering raises the shape into the highlight overlay so it draws above overlapping series; a
+        // highlight-disabled series must leave the overlay empty. The enabled case (raises) guards the
+        // disabled case (does not) from passing vacuously.
+        it.each([
+            { enabled: true, raisedShapes: 1 },
+            { enabled: false, raisedShapes: 0 },
+        ])('raises the hovered shape only when highlight.enabled is $enabled', async ({ enabled, raisedShapes }) => {
             const options: AgChartOptions = {
                 ...SIMPLIFIED_EXAMPLE,
-                series: [{ type: 'map-shape', idKey: 'name', highlight: { enabled: false } }],
+                series: [{ type: 'map-shape', idKey: 'name', highlight: { enabled } }],
             };
             prepareEnterpriseTestOptions(options);
 
@@ -116,17 +131,15 @@ describe('MapShapeSeries', () => {
             await waitForChartStability(chart);
 
             const seriesImpl = chart.series[0] as MapShapeSeries;
-            const node = seriesImpl['contextNodeData']?.nodeData[2];
+            await hoverFirstShape(seriesImpl);
 
-            (chart as Chart).ctx.highlightManager.updateHighlight(chart.id, node);
-            // Re-run the render that populates the highlight overlay. A highlight-disabled series must
-            // leave the overlay empty so the hovered datum is never raised above overlapping series,
-            // regardless of any unrelated update that re-renders it while highlighted.
+            // The hover-update optimisation skips re-rendering a highlight-disabled series, so drive the
+            // render directly to populate the overlay — the overlay must stay empty regardless of what
+            // re-renders the series while it holds the active highlight.
             seriesImpl.update();
             await waitForChartStability(chart);
 
-            const raisedNodes = Array.from(seriesImpl.highlightNodeGroup.children());
-            expect(raisedNodes).toHaveLength(0);
+            expect(Array.from(seriesImpl.highlightNodeGroup.children())).toHaveLength(raisedShapes);
         });
     });
 

--- a/packages/ag-charts-enterprise/src/series/map-util/topologySeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-util/topologySeries.ts
@@ -43,6 +43,10 @@ export abstract class TopologySeries<
     }
 
     protected getHighlightedDatum(): TDatum | undefined {
+        // Mirror `isSeriesHighlighted`: with highlight disabled there is no highlighted datum, so the
+        // highlight overlay stays empty and the hovered datum is not raised above overlapping series.
+        if (!this.properties.highlight.enabled) return undefined;
+
         let highlightedDatum: TDatum | undefined = this.ctx.highlightManager?.getActiveHighlight() as any;
         const { legendItemName } = this.properties;
         const matchingLegendItemName =


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17524

A `map-shape` with `highlight: { enabled: false }` inconsistently raised the hovered shape above overlapping `map-line` series — not on the first hover, but after a tube line had been hovered.

`TopologySeries.getHighlightedDatum()` returned the active datum regardless of `highlight.enabled`, so the highlight overlay (which renders above other series) raised the hovered shape even with highlighting disabled. Cartesian series gate this on `isSeriesHighlighted()`, which is `false` when highlight is disabled. A v13.2 hover-update optimisation only refreshed the overlay after an unrelated highlight-enabled series was hovered, hence the inconsistency.

Gate `getHighlightedDatum()` on `highlight.enabled` so a highlight-disabled map series behaves like every other series: the hovered datum is never raised. Highlight-enabled behaviour is unchanged.

Test plan:
- New regression test in `mapShapeSeries.test.ts` (fails without the fix).
- map-shape/line/marker suites pass, including highlight-enabled snapshots.
- Browser-verified on the `map-shapes-lines` gallery example: the borough is consistently not raised across all hover sequences; the highlight-enabled tube line still raises on hover.

Fix #AG-17524