### PR TITLE
ci(jira-agent): route held codex-review iterate through agent-run

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -227,11 +227,17 @@ jobs:
     # resume route → a forced workflow_dispatch stage. `!cancelled()` lets the
     # gate evaluate even when preflight is skipped (the forced-dispatch path).
     agent-run:
-        needs: preflight
+        # Both gates feed this one job: `preflight` for the resume routes +
+        # ci-failure-iterate, and `ci-success-handler` for the codex-review
+        # hold (green PR, open P0/P1 findings → pr-iterate). On any given
+        # event only one of the two needed jobs runs and the other is skipped
+        # (empty outputs); `!cancelled()` lets the `if` evaluate regardless.
+        needs: [preflight, ci-success-handler]
         if: |
             !cancelled() &&
             (needs.preflight.outputs.stage != '' ||
              needs.preflight.outputs.ci_failure_eligible == 'true' ||
+             needs.ci-success-handler.outputs.dispatch_pr_iterate == 'true' ||
              (github.event_name == 'workflow_dispatch' && inputs.stage != 'resume'))
         runs-on: ubuntu-latest
         timeout-minutes: 60
@@ -267,10 +273,11 @@ jobs:
 
             - uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/jira-pipeline
               with:
-                  # ci-failure-iterate wins when the failure preflight is eligible;
-                  # otherwise the resume route, or a forced workflow_dispatch stage.
-                  stage: ${{ needs.preflight.outputs.ci_failure_eligible == 'true' && 'ci-failure-iterate' || needs.preflight.outputs.stage || inputs.stage }}
-                  issue_key: ${{ needs.preflight.outputs.issue_key || env.ISSUE_KEY }}
+                  # Stage precedence: ci-failure-iterate (failure preflight eligible)
+                  # → pr-iterate (green CI held on open P0/P1 Codex findings)
+                  # → the resume route → a forced workflow_dispatch stage.
+                  stage: ${{ needs.preflight.outputs.ci_failure_eligible == 'true' && 'ci-failure-iterate' || needs.ci-success-handler.outputs.dispatch_pr_iterate == 'true' && 'pr-iterate' || needs.preflight.outputs.stage || inputs.stage }}
+                  issue_key: ${{ needs.preflight.outputs.issue_key || needs.ci-success-handler.outputs.issue_key || env.ISSUE_KEY }}
                   ci_failure_run_url: ${{ needs.preflight.outputs.ci_failure_run_url }}
                   recycle_from: ${{ needs.preflight.outputs.prior_pr_outcome }}
                   jira_agent_app_id: ${{ vars.JIRA_AGENT_APP_ID }}
@@ -305,6 +312,11 @@ jobs:
             handled: ${{ steps.handler.outputs.handled }}
             issue_key: ${{ steps.handler.outputs.issue_key }}
             pr_number: ${{ steps.handler.outputs.pr_number }}
+            # 'true' when a green PR still has open P0/P1 Codex findings: the
+            # handler HELD the Needs-Review promotion and asks for a pr-iterate
+            # to address them. Routed into agent-run below (the success-side
+            # analog of ci-failure-iterate) — no self-dispatch needed.
+            dispatch_pr_iterate: ${{ steps.handler.outputs.dispatch_pr_iterate }}
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
## What

Route the held codex-review iterate through the existing `agent-run` job instead of stranding it.

When `ci-success-handler` finds a green agent PR that still carries open **P0/P1 Codex findings**, it *holds* the Needs-Review promotion and emits `dispatch_pr_iterate=true`, expecting a follow-on `pr-iterate` to address them. Nothing in the stub consumed that output, so those tickets parked at `draft-pr-open` / In Progress indefinitely (observed on **AG-17548** — green PR #7069 with one open `[P1]` finding, never promoted).

## How

Wire it into the **existing** `agent-run` job rather than a separate self-dispatching job — the success-side analog of how `ci-failure-iterate` already routes on the failure side:

- `agent-run` now `needs: [preflight, ci-success-handler]`
- its `if:` and `stage` expression resolve `stage=pr-iterate` when `dispatch_pr_iterate == 'true'`
- `ci-success-handler` surfaces `dispatch_pr_iterate` as a job output (the shared `jira-ci-success-handler` action already emits it as a step output)

On any given trigger only one of the two needed jobs runs; the other is skipped with empty outputs, and the existing `!cancelled()` guard lets the `if` evaluate either way. No new workflow invocation, no `actions: write`, no extra checkout/token/setup. No collision with `pr-plnkr` — it gates on `handled == 'true'`, and a held promotion leaves `handled == 'false'`, so exactly one of the two fires per green run.

## Notes

- Known timing caveat (unchanged): `ci-success-handler` fires on main-CI completion while the Codex review runs in parallel; a finding posted seconds later can be missed. The robust fix (a second findings-check preflight on the Codex-review workflow's own `workflow_run·success`) is orthogonal and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
