### PR TITLE
AG-17386 Rename 'select' -> 'crossFilterSelect'

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -172,7 +172,7 @@ interface AreaSeriesCreateNodeDatumContext extends CartesianMarkerLikeContext<Ma
     // Additional data arrays specific to area series
     readonly yRawValues: AgNumericValue[];
     readonly yCumulativeValues: AgNumericValue[];
-    readonly selectedValues: boolean[] | undefined;
+    readonly crossFilterSelectedValues: boolean[] | undefined;
     readonly invalidData: boolean[] | undefined;
 
     // Aggregation
@@ -204,7 +204,7 @@ interface AreaNodeDatumScratch {
     xDatum: any;
     yDatum: any;
     yCumulative: AgNumericValue;
-    selected: boolean | undefined;
+    crossFilterSelected: boolean | undefined;
     x: number;
     y: number;
     validPoint: boolean;
@@ -998,7 +998,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             yCumulativeValues: stacked
                 ? dataModel.resolveColumnById(this, 'yValueCumulative', processedData, 'mixed-numeric')
                 : dataModel.resolveColumnById(this, 'yValueRaw', processedData, 'mixed-numeric'),
-            selectedValues:
+            crossFilterSelectedValues:
                 selectedKey == null
                     ? undefined
                     : dataModel.resolveColumnById(this, 'selectedRaw', processedData, 'boolean'),
@@ -1087,7 +1087,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         // Compute marker coordinates
         this.computeMarkerCoordinate(ctx, scratch);
 
-        scratch.selected = ctx.selectedValues?.[datumIndex];
+        scratch.crossFilterSelected = ctx.crossFilterSelectedValues?.[datumIndex];
 
         // Marker data (using ctx.nodes to match base interface)
         if (scratch.validPoint) {
@@ -1106,7 +1106,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 existingNode.yValue = scratch.yDatum;
                 existingNode.xValue = scratch.xDatum;
                 existingNode.point = { x: scratch.x, y: scratch.y, size: ctx.markerSize };
-                existingNode.selected = scratch.selected;
+                existingNode.crossFilterSelected = scratch.crossFilterSelected;
             } else {
                 ctx.nodes.push({
                     series: this,
@@ -1122,7 +1122,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                     fill: ctx.markerFill,
                     stroke: ctx.markerStroke,
                     strokeWidth: ctx.markerStrokeWidth,
-                    selected: scratch.selected,
+                    crossFilterSelected: scratch.crossFilterSelected,
                 });
             }
             ctx.nodeIndex++;
@@ -1173,7 +1173,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             xDatum: undefined,
             yDatum: undefined,
             yCumulative: 0,
-            selected: undefined,
+            crossFilterSelected: undefined,
             x: 0,
             y: 0,
             validPoint: false,
@@ -1480,7 +1480,9 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         datumSelection.each((node, datum) => {
             const state = this.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex);
             const style = datum.style ?? contextNodeData.styles[state];
-            this.applyMarkerStyle(style, node, datum.point, fillBBox, { selected: datum.selected });
+            this.applyMarkerStyle(style, node, datum.point, fillBBox, {
+                crossFilterSelected: datum.crossFilterSelected,
+            });
             const nextDrawingMode = constantDrawingMode ?? this.resolveMarkerDrawingModeForState(drawingMode, style);
             if (node.__drawingMode !== nextDrawingMode) {
                 node.drawingMode = nextDrawingMode;

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeriesOptionsDef.ts
@@ -67,5 +67,8 @@ export const areaSeriesOptionsDef: OptionsDefs<AgAreaSeriesOptions> = {
     normalizedTo: number,
 };
 
+// WARNING! This selectedKey is related to cross-filtering which is not an officially documented or supported
+// feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use with
+// extreme caution.
 // @ts-expect-error undocumented option
 areaSeriesOptionsDef.selectedKey = undocumented(string);

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeriesProperties.ts
@@ -29,6 +29,9 @@ export class AreaSeriesProperties extends CartesianSeriesProperties<AgAreaSeries
     @Property
     yName?: string;
 
+    // WARNING! This selectedKey is related to cross-filtering which is not an officially documented or supported
+    // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
+    // with extreme caution.
     @Property
     selectedKey: string | undefined;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
@@ -36,7 +36,10 @@ export interface MarkerSelectionDatum extends CartesianSeriesNodeDatum {
     readonly stroke?: string;
     readonly strokeWidth: number;
     readonly cumulativeValue: number;
-    readonly selected: boolean | undefined;
+    // WARNING! This selected-state is related to cross-filtering which is not an officially documented or supported
+    // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
+    // with extreme caution.
+    readonly crossFilterSelected: boolean | undefined;
     style?: AgSeriesMarkerStyle;
 }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -189,7 +189,10 @@ export interface BubbleScatterNodeDatum extends CartesianSeriesNodeDatum, ErrorB
     readonly count: number;
     readonly dilation: number;
     readonly area: number;
-    readonly selected: boolean | undefined;
+    // WARNING! This selected-state is related to cross-filtering which is not an officially documented or supported
+    // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
+    // with extreme caution.
+    readonly crossFilterSelected: boolean | undefined;
     style?: AgSeriesMarkerStyle;
 }
 
@@ -225,7 +228,7 @@ interface BubbleSeriesNodeDatumContext extends CartesianMarkerLikeContext<Bubble
     readonly yDataValues: any[];
     readonly sizeDataValues: number[] | undefined;
     readonly labelDataValues: any[] | undefined;
-    readonly selectedDataValues: boolean[] | undefined;
+    readonly crossFilterSelectedDataValues: boolean[] | undefined;
     readonly colorDataValues: number[] | undefined;
 
     // Additional scale (size is BubbleSeries-specific)
@@ -269,8 +272,8 @@ interface PreparedBubbleNodeDatumState {
     x: number;
     y: number;
 
-    // Selection state
-    selected: boolean | undefined;
+    // Cross-Filter (undocumented) Selection state
+    crossFilterSelected: boolean | undefined;
 
     // Label data
     nodeLabel: MeasuredLabel;
@@ -596,7 +599,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
                 sizeKey == null ? undefined : dataModel.resolveColumnById(this, `sizeValue`, processedData, 'number'),
             labelDataValues:
                 labelKey == null ? undefined : dataModel.resolveColumnById(this, `labelValue`, processedData, 'object'),
-            selectedDataValues:
+            crossFilterSelectedDataValues:
                 selectedKey == null
                     ? undefined
                     : dataModel.resolveColumnById(this, `selectedValue`, processedData, 'boolean'),
@@ -666,7 +669,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             colorValue: undefined,
             x: 0,
             y: 0,
-            selected: undefined,
+            crossFilterSelected: undefined,
             nodeLabel: { text: '', width: 0, height: 0 },
             markerSize: 0,
             count: 1,
@@ -807,7 +810,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
 
         if (!Number.isFinite(x) || !Number.isFinite(y)) return undefined;
 
-        const selected = ctx.selectedDataValues?.[datumIndex];
+        const crossFilterSelected = ctx.crossFilterSelectedDataValues?.[datumIndex];
 
         // Compute label (skip expensive formatting if labels disabled)
         let nodeLabel: MeasuredLabel;
@@ -830,7 +833,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         scratch.colorValue = colorValue;
         scratch.x = x;
         scratch.y = y;
-        scratch.selected = selected;
+        scratch.crossFilterSelected = crossFilterSelected;
         scratch.nodeLabel = nodeLabel;
         scratch.markerSize = markerSize;
 
@@ -928,7 +931,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             count: 1,
             dilation: 1,
             area: 0,
-            selected: undefined,
+            crossFilterSelected: undefined,
         };
     }
 
@@ -952,7 +955,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         mutableNode.yValue = scratch.yDatum;
         mutableNode.sizeValue = scratch.sizeValue;
         mutableNode.colorValue = scratch.colorValue;
-        mutableNode.selected = scratch.selected;
+        mutableNode.crossFilterSelected = scratch.crossFilterSelected;
         mutableNode.count = scratch.count;
         mutableNode.dilation = scratch.dilation;
         mutableNode.area = scratch.area;
@@ -1143,7 +1146,9 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
                 style.fillOpacity = clamp(fillOpacity / dilation, (fillOpacity / 0.1) * opacityScale, 1);
             }
 
-            this.applyMarkerStyle(style, node, datum.point, fillBBox, { selected: datum.selected });
+            this.applyMarkerStyle(style, node, datum.point, fillBBox, {
+                crossFilterSelected: datum.crossFilterSelected,
+            });
             const nextDrawingMode = constantDrawingMode ?? this.resolveMarkerDrawingModeForState(drawingMode, style);
             if (node.__drawingMode !== nextDrawingMode) {
                 node.drawingMode = nextDrawingMode;

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesOptionsDef.ts
@@ -71,5 +71,8 @@ export const bubbleSeriesOptionsDef: OptionsDefs<AgBubbleSeriesOptions> = {
     highlight: multiSeriesHighlightOptionsDef(shapeHighlightOptionsDef, shapeHighlightOptionsDef),
 };
 
+// WARNING! This selectedKey is related to cross-filtering which is not an officially documented or supported
+// feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use with
+// extreme caution.
 // @ts-expect-error undocumented option
 bubbleSeriesOptionsDef.selectedKey = undocumented(string);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesProperties.ts
@@ -61,6 +61,9 @@ export class BubbleScatterSeriesProperties extends CartesianSeriesProperties<AgB
     @Property
     colorKey?: string;
 
+    // WARNING! This selectedKey is related to cross-filtering which is not an officially documented or supported
+    // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
+    // with extreme caution.
     @Property
     selectedKey: string | undefined;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -468,7 +468,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 processedData,
                 'mixed-numeric'
             ),
-            selectionValues: this.properties.selectedKey
+            crossFilterSelectionValues: this.properties.selectedKey
                 ? dataModel.resolveColumnById(this, 'selectedRaw', processedData, 'boolean')
                 : undefined,
             xScale,
@@ -508,7 +508,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         scratch.xDatum = ctx.xValues[datumIndex];
         scratch.yDatum = ctx.yRawValues[datumIndex];
         scratch.yCumulative = ctx.yCumulativeValues[datumIndex];
-        scratch.selected = ctx.selectionValues?.[datumIndex];
+        scratch.crossFilterSelected = ctx.crossFilterSelectionValues?.[datumIndex];
 
         scratch.x = ctx.xScale.convert(scratch.xDatum) + ctx.xOffset;
         scratch.y = ctx.yScale.convert(scratch.yCumulative) + ctx.yOffset;
@@ -550,7 +550,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 (existingNode as any).yValue = scratch.yDatum;
                 (existingNode as any).xValue = scratch.xDatum;
                 (existingNode as any).labelText = labelText;
-                (existingNode as any).selected = scratch.selected;
+                (existingNode as any).crossFilterSelected = scratch.crossFilterSelected;
             } else {
                 ctx.nodes.push({
                     series: this,
@@ -565,7 +565,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                     xValue: scratch.xDatum,
                     capDefaults: ctx.capDefaults,
                     labelText,
-                    selected: scratch.selected,
+                    crossFilterSelected: scratch.crossFilterSelected,
                 });
             }
             ctx.nodeIndex++;
@@ -615,7 +615,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
             xDatum: undefined,
             yDatum: undefined,
             yCumulative: 0,
-            selected: undefined,
+            crossFilterSelected: undefined,
             x: 0,
             y: 0,
         };
@@ -889,7 +889,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 contextNodeData.styles[thisSeries.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex)];
             thisSeries.applyMarkerStyle(style, node, datum.point, fillBBox, {
                 applyPosition,
-                selected: datum.selected,
+                crossFilterSelected: datum.crossFilterSelected,
             });
             const nextDrawingMode =
                 constantDrawingMode ?? thisSeries.resolveMarkerDrawingModeForState(drawingMode, style);

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeriesOptionsDef.ts
@@ -71,6 +71,9 @@ export const lineSeriesOptionsDef: OptionsDefs<AgLineSeriesOptions> = {
     errorBar: errorBarOptionsDefs,
 };
 
+// WARNING! This selectedKey is related to cross-filtering which is not an officially documented or supported
+// feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use with
+// extreme caution.
 // @ts-expect-error undocumented option
 lineSeriesOptionsDef.selectedKey = undocumented(string);
 // @ts-expect-error undocumented option

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeriesProperties.ts
@@ -27,6 +27,9 @@ export class LineSeriesProperties extends CartesianSeriesProperties<AgLineSeries
     @Property
     yName?: string;
 
+    // WARNING! This selectedKey is related to cross-filtering which is not an officially documented or supported
+    // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
+    // with extreme caution.
     @Property
     selectedKey: string | undefined;
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -55,7 +55,10 @@ export interface LineNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSerie
     readonly yValue: NonNullable<CartesianSeriesNodeDatum['yValue']>;
     readonly point: NonNullable<CartesianSeriesNodeDatum['point']>;
     readonly labelText?: NormalisedTextOrSegments;
-    readonly selected: boolean | undefined;
+    // WARNING! This selected-state is related to cross-filtering which is not an officially documented or supported
+    // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
+    // with extreme caution.
+    readonly crossFilterSelected: boolean | undefined;
     style?: AgSeriesMarkerStyle;
 }
 
@@ -81,7 +84,7 @@ export interface LineSeriesDatumContext extends CartesianMarkerLikeContext<LineN
     // Additional data arrays specific to line series
     readonly yRawValues: AgNumericValue[];
     readonly yCumulativeValues: AgNumericValue[];
-    readonly selectionValues: ArrayLike<any> | undefined;
+    readonly crossFilterSelectionValues: ArrayLike<any> | undefined;
 
     // Pre-computed values (computed once, reused for all datums)
     readonly size: number;
@@ -111,7 +114,7 @@ export interface LineNodeDatumScratch {
     yDatum: any;
     // Kept raw (possibly bigint) so yScale.convert() positions values beyond Number.MAX_VALUE proportionally.
     yCumulative: AgNumericValue;
-    selected: boolean | undefined;
+    crossFilterSelected: boolean | undefined;
     x: number;
     y: number;
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeriesOptionsDef.ts
@@ -63,5 +63,8 @@ export const scatterSeriesOptionsDef: OptionsDefs<AgScatterSeriesOptions> = {
     highlight: multiSeriesHighlightOptionsDef(shapeHighlightOptionsDef, shapeHighlightOptionsDef),
 };
 
+// WARNING! This selectedKey is related to cross-filtering which is not an officially documented or supported
+// feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use with
+// extreme caution.
 // @ts-expect-error undocumented option
 scatterSeriesOptionsDef.selectedKey = undocumented(string);

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1454,7 +1454,7 @@ export abstract class Series<
         markerNode: Marker,
         point: { x: number; y: number; size?: number; focusSize?: number } | undefined,
         fillBBox?: ShapeFillBBox,
-        { applyPosition = true, selected = true } = {}
+        { applyPosition = true, crossFilterSelected = true } = {}
     ) {
         const { shape, size = 0 } = style;
         const visible = this.visible && size > 0 && point && !Number.isNaN(point.x) && !Number.isNaN(point.y);
@@ -1462,7 +1462,7 @@ export abstract class Series<
         markerNode.setStyleProperties(style, fillBBox);
         markerNode.setVisibilityAndPosition(!!visible, shape!, size, applyPosition ? point : undefined);
 
-        if (!selected) {
+        if (!crossFilterSelected) {
             markerNode.fillOpacity *= CROSS_FILTER_MARKER_FILL_OPACITY_FACTOR;
             markerNode.strokeOpacity *= CROSS_FILTER_MARKER_STROKE_OPACITY_FACTOR;
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17386

In the past, this cross-filtering internals has confused coding agents into thinking that it's related to data-selection, which it isn't.

This sign-posting to hopefully help to avoid this confusion.

The `selectedKey` cannot be renamed because it's a (undocumented) key that is read from the user option; renaming this will certainly break things.