### PR TITLE
AG-17481 Index size-bounds warning and enforce 2-element sizeDomain

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -1275,7 +1275,21 @@ describe('BubbleSeries', () => {
             expectWarningsCalls().toMatchInlineSnapshot(`
               [
                 [
-                  "AG Charts - series[].minSize (30) cannot be greater than maxSize (5), reverting both to theme defaults.",
+                  "AG Charts - series[0].minSize (30) cannot be greater than maxSize (5), ignoring both.",
+                ],
+              ]
+            `);
+        });
+
+        it('rejects a sizeDomain that is not a 2-element array and falls back to the data domain', async () => {
+            await createBubble({ sizeDomain: [5] });
+            // The malformed sizeDomain is dropped, so the data-derived domain [0, 200] and theme
+            // defaults [7, 30] apply: s=0 -> 7, s=50 -> 12.75, s=200 -> 30 (no NaN).
+            expect(nodeSizes(chart)).toEqual([7, 12.75, 30]);
+            expectWarningsCalls().toMatchInlineSnapshot(`
+              [
+                [
+                  "AG Charts - Option \`series[0].sizeDomain\` cannot be set to \`[5]\`; expecting a number or bigint array and an array of exactly 2 items, ignoring.",
                 ],
               ]
             `);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeriesOptionsDef.ts
@@ -1,5 +1,7 @@
 import {
     type OptionsDefs,
+    and,
+    arrayLength,
     arrayOf,
     boolean,
     callbackDefs,
@@ -30,7 +32,7 @@ import type {
 
 export const bubbleSeriesThemeableOptionsDef: OptionsDefs<AgBubbleSeriesThemeableOptions> = {
     title: string,
-    sizeDomain: arrayOf(numericValue),
+    sizeDomain: and(arrayOf(numericValue), arrayLength(2, 2)),
     minSize: positiveNumber,
     maxSize: positiveNumber,
     showInMiniChart: boolean,

--- a/packages/ag-charts-community/src/chart/themes/enterpriseThemeableOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/themes/enterpriseThemeableOptionsDef.ts
@@ -1,6 +1,7 @@
 import {
     type OptionsDefs,
     and,
+    arrayLength,
     arrayOf,
     autoSizedLabelOptionsDefs,
     barHighlightOptionsDef,
@@ -326,7 +327,7 @@ export const mapLineSeriesThemeableOptionsDef: OptionsDefs<AgMapLineSeriesThemea
         ...strokeOptionsDef,
         ...lineDashOptionsDef,
     }),
-    sizeDomain: arrayOf(positiveNumericValue),
+    sizeDomain: and(arrayOf(positiveNumericValue), arrayLength(2, 2)),
     label: seriesLabelOptionsDefs,
     tooltip: tooltipOptionsDefs,
     ...commonSeriesThemeableOptionsDefs,
@@ -344,7 +345,7 @@ export const mapMarkerSeriesThemeableOptionsDef: OptionsDefs<AgMapMarkerSeriesTh
     colorScale: colorScaleOptionsDef,
     minSize: positiveNumber,
     maxSize: positiveNumber,
-    sizeDomain: arrayOf(positiveNumericValue),
+    sizeDomain: and(arrayOf(positiveNumericValue), arrayLength(2, 2)),
     label: {
         placement: union('top', 'bottom', 'left', 'right'),
         ...seriesLabelOptionsDefs,

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -682,8 +682,8 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     private processSeriesOptions(options: T) {
         const displayNullData = (options as any).displayNullData;
 
-        const processedSeries = (options.series as SeriesOptionsTypes[])?.map((series) => {
-            this.validateSizeBounds(series);
+        const processedSeries = (options.series as SeriesOptionsTypes[])?.map((series, index) => {
+            this.validateSizeBounds(series, index);
 
             const seriesDef = ModuleRegistry.getSeriesModule(series.type);
             const visibleDefined = Boolean(seriesDef?.options?.visible);
@@ -704,7 +704,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
 
     // When the user explicitly sets both size bounds inverted (min > max), warn and drop both so theme
     // defaults re-apply. A single bound is resolved at render time (min is authoritative) and is not checked here.
-    private validateSizeBounds(series: SeriesOptionsTypes) {
+    private validateSizeBounds(series: SeriesOptionsTypes, index: number) {
         const keys = SIZE_BOUND_KEYS[series.type];
         if (keys == null) return;
 
@@ -714,7 +714,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         const maxValue = seriesOptions[maxKey];
         if (isNumericValue(minValue) && isNumericValue(maxValue) && minValue > maxValue) {
             Logger.warnOnce(
-                `series[].${minKey} (${minValue}) cannot be greater than ${maxKey} (${maxValue}), reverting both to theme defaults.`
+                `series[${index}].${minKey} (${minValue}) cannot be greater than ${maxKey} (${maxValue}), ignoring both.`
             );
             delete seriesOptions[minKey];
             delete seriesOptions[maxKey];

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.test.ts
@@ -631,7 +631,7 @@ describe('MapLineSeries', () => {
             expectWarningsCalls().toMatchInlineSnapshot(`
               [
                 [
-                  "AG Charts - series[].minStrokeWidth (8) cannot be greater than maxStrokeWidth (2), reverting both to theme defaults.",
+                  "AG Charts - series[0].minStrokeWidth (8) cannot be greater than maxStrokeWidth (2), ignoring both.",
                 ],
               ]
             `);
@@ -663,6 +663,41 @@ describe('MapLineSeries', () => {
             // Zero-width domains resolve to the range midpoint (10 + 30) / 2, never NaN/Infinity.
             expect([...new Set(strokeWidths)]).toEqual([20]);
             expectWarningsCalls().toMatchInlineSnapshot(`[]`);
+        });
+
+        it('rejects a sizeDomain that is not a 2-element array and falls back to the data domain', async () => {
+            const options: AgChartOptions = {
+                ...SIMPLIFIED_EXAMPLE,
+                series: [
+                    {
+                        type: 'map-line',
+                        idKey: 'name',
+                        sizeKey: 'dailyVehicles',
+                        // Deliberately malformed: a 1-element array is not a valid sizeDomain.
+                        sizeDomain: [5],
+                        minStrokeWidth: 10,
+                        maxStrokeWidth: 30,
+                    } as never,
+                ],
+            };
+            prepareEnterpriseTestOptions(options);
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const strokeWidths: number[] = chart.series[0].contextNodeData?.nodeData.map(
+                (d: any) => d.style?.strokeWidth
+            );
+            expect(strokeWidths.length).toBeGreaterThan(0);
+            // The malformed sizeDomain is dropped, so widths resolve from the data domain within
+            // [minStrokeWidth, maxStrokeWidth] = [10, 30], never NaN.
+            expect(strokeWidths.every((width) => width >= 10 && width <= 30)).toBe(true);
+            expectWarningsCalls().toMatchInlineSnapshot(`
+              [
+                [
+                  "AG Charts - Option \`series[0].sizeDomain\` cannot be set to \`[5]\`; expecting a number or bigint greater than or equal to 0 array and an array of exactly 2 items, ignoring.",
+                ],
+              ]
+            `);
         });
     });
     describe('bigint size domain (AG-16608)', () => {

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.test.ts
@@ -742,7 +742,7 @@ describe('MapMarkerSeries', () => {
             expectWarningsCalls().toMatchInlineSnapshot(`
               [
                 [
-                  "AG Charts - series[].minSize (30) cannot be greater than maxSize (5), reverting both to theme defaults.",
+                  "AG Charts - series[1].minSize (30) cannot be greater than maxSize (5), ignoring both.",
                 ],
               ]
             `);
@@ -773,6 +773,40 @@ describe('MapMarkerSeries', () => {
             // Zero-width domains resolve to the range midpoint (10 + 30) / 2, never NaN/Infinity.
             expect([...new Set(markerSizes)]).toEqual([20]);
             expectWarningsCalls().toMatchInlineSnapshot(`[]`);
+        });
+
+        it('rejects a sizeDomain that is not a 2-element array and falls back to the data domain', async () => {
+            const options: AgChartOptions = {
+                ...SIMPLIFIED_EXAMPLE,
+                series: [
+                    { type: 'map-shape-background' },
+                    {
+                        type: 'map-marker',
+                        idKey: 'name',
+                        sizeKey: 'population',
+                        // Deliberately malformed: a 1-element array is not a valid sizeDomain.
+                        sizeDomain: [5],
+                        minSize: 10,
+                        maxSize: 30,
+                    } as never,
+                ],
+            };
+            prepareEnterpriseTestOptions(options);
+            chart = deproxy(AgCharts.create(options));
+            await waitForChartStability(chart);
+
+            const markerSizes: number[] = chart.series[1].contextNodeData?.nodeData.map((d: any) => d.point.size);
+            expect(markerSizes.length).toBeGreaterThan(0);
+            // The malformed sizeDomain is dropped, so sizes resolve from the data domain within
+            // [minSize, maxSize] = [10, 30], never NaN.
+            expect(markerSizes.every((size) => size >= 10 && size <= 30)).toBe(true);
+            expectWarningsCalls().toMatchInlineSnapshot(`
+              [
+                [
+                  "AG Charts - Option \`series[1].sizeDomain\` cannot be set to \`[5]\`; expecting a number or bigint greater than or equal to 0 array and an array of exactly 2 items, ignoring.",
+                ],
+              ]
+            `);
         });
 
         it('clamps reversed-sizeDomain out-of-domain values to minSize, not maxSize (TC2)', async () => {


### PR DESCRIPTION
## Summary

Addresses QA follow-up feedback (comment 119421) on the merged size-scaling unification PR (#7047) for Bubble, Map Marker and Map Line series.

1. **Inverted-bounds warning now identifies the series.** The `minSize > maxSize` (and `minStrokeWidth > maxStrokeWidth`) warning previously read `series[].minSize …`; it now includes the series index (`series[0].minSize …`) and the wording changed from `reverting both to theme defaults.` to `ignoring both.`. Behaviour is unchanged — both bounds are still dropped so theme defaults re-apply.
2. **`sizeDomain` must be a 2-element array.** A malformed `sizeDomain` (e.g. `[5]`) previously flowed through to the size scale, producing a `NaN` size and an empty render. The option-def validators are tightened to `and(arrayOf(...), arrayLength(2, 2))`, so a malformed value is now rejected by the existing validation layer (which emits an indexed warning and drops the value) and the series falls back to the data-derived domain, rendering at default sizes.

The third item raised in the comment — distinguishing user `theme.overrides` from default theme values for the inverted-bounds warning — is intentionally **not** included. Default theme values already never trigger the warning (the check runs on raw user series options before theme merge); warning on `theme.overrides` was flagged as optional/complicated and is left as a possible follow-up.

## Changes

- `optionsModule.ts` — thread the series index into `validateSizeBounds` and update the warning text.
- `bubbleSeriesOptionsDef.ts`, `enterpriseThemeableOptionsDef.ts` — tighten `sizeDomain` validators to require exactly two elements.

## Test plan

- Updated the three existing inverted-bounds snapshots to the new indexed/`ignoring both.` text.
- Added a malformed-`sizeDomain` test per series asserting the warning and non-`NaN` rendering at the data domain.
- `yarn nx format`, `build:types`, `lint` (community + enterprise) — clean.
- Full suites: community 3638 passed, enterprise 2378 passed.

Fix #AG-17481