### PR TITLE
AG-17558 report the offending property in segment formatter warnings

### DIFF
--- a/packages/ag-charts-core/src/state/validation.test.ts
+++ b/packages/ag-charts-core/src/state/validation.test.ts
@@ -1,6 +1,7 @@
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 
+import { textOrSegments } from '../config/chartDefaults';
 import { reset as resetLogger } from '../logging/logger';
 import { RegistryMode, reset as resetRegistry, setRegistryMode } from '../modules/moduleRegistry';
 import {
@@ -256,29 +257,65 @@ describe('Validation utils', () => {
     });
 
     describe('Callback Validators', () => {
-        test('callbackOf emits a single warning for invalid array returns', () => {
-            const formatterValidator = callbackOf(
-                arrayOfDefs<{ text: string }>(
-                    {
-                        text: required(string),
-                    },
-                    'text segment'
-                ),
-                'text segments'
+        const warnings = () => (console.warn as Mock).mock.calls.map((call) => String(call[0]));
+        const wrapFormatter = (
+            validator: Validator,
+            returnValue: unknown,
+            path = 'formatter',
+            description?: string
+        ) => {
+            const { cleared } = callbackOf(validator, description)(() => returnValue, {
+                options: {},
+                path,
+            }) as ValidatorResult;
+            return (cleared as (...args: any[]) => any)();
+        };
+
+        test('emits a targeted warning per invalid array element/property', () => {
+            const validator = arrayOfDefs<{ text: string }>({ text: required(string) }, 'text segment');
+            wrapFormatter(validator, [{ text: 'ok' }, { text: 123 }, 42], 'formatter', 'text segments');
+
+            const msgs = warnings();
+            expect(msgs).toHaveLength(2);
+            expect(msgs[0]).toContain('invalid property `[1].text`');
+            expect(msgs[0]).toContain('expecting a string');
+            expect(msgs[1]).toContain('invalid value `42`');
+            expect(msgs[1]).toContain('expecting text segments');
+        });
+
+        test('reports the offending sub-property for an invalid segment value', () => {
+            const result = wrapFormatter(
+                textOrSegments,
+                [{ type: 'image', url: 'https://example.com/de.png', width: 20, height: 13, verticalAlign: 't0p' }],
+                'axes[0].label.formatter'
             );
-            const formatter = (value: any) => value;
-            const context = { options: {}, path: 'formatter' };
-            const validatorResult = formatterValidator(formatter, context) as ValidatorResult;
-            const wrappedFormatter = validatorResult.cleared as (...args: any[]) => any;
 
-            wrappedFormatter([
-                { text: 'ok' },
-                { text: 123 }, // invalid
-                42, // invalid
+            const msgs = warnings();
+            expect(msgs).toHaveLength(1);
+            expect(msgs[0]).toContain('invalid property `[0].verticalAlign`');
+            expect(msgs[0]).toContain('"t0p"');
+            expect(msgs[0]).toContain("expecting a keyword such as 'baseline', 'top', 'middle' or 'bottom'");
+            // The bad property is dropped; the rest of the segment is preserved so the label still renders.
+            expect(result).toEqual([{ type: 'image', url: 'https://example.com/de.png', width: 20, height: 13 }]);
+        });
+
+        test('warns only about the invalid property and keeps valid sibling segments', () => {
+            const result = wrapFormatter(
+                textOrSegments,
+                [
+                    { type: 'text', text: 'Germany' },
+                    { type: 'image', url: 'https://example.com/de.png', width: 20, height: 13, verticalAlign: 'nope' },
+                ],
+                'axes[0].label.formatter'
+            );
+
+            const msgs = warnings();
+            expect(msgs).toHaveLength(1);
+            expect(msgs[0]).toContain('invalid property `[1].verticalAlign`');
+            expect(result).toEqual([
+                { type: 'text', text: 'Germany' },
+                { type: 'image', url: 'https://example.com/de.png', width: 20, height: 13 },
             ]);
-
-            expect(console.warn).toHaveBeenCalledTimes(1);
-            expect((console.warn as Mock).mock.calls[0][0]).toContain('returned an invalid value');
         });
     });
 

--- a/packages/ag-charts-core/src/state/validation.ts
+++ b/packages/ag-charts-core/src/state/validation.ts
@@ -718,7 +718,7 @@ export const callbackOf = (validator: Validator, description?: string) =>
                 if (result == null) return;
                 const validatorResult = validator(result, { options: result, path: '' });
                 if (typeof validatorResult === 'object') {
-                    warnCallbackErrors(validatorResult, context, validatorDescription, result);
+                    warnCallbackErrors(validatorResult, context, validatorDescription);
                     if (validatorResult.valid) {
                         return validatorResult.cleared;
                     }
@@ -748,7 +748,7 @@ export const callbackDefs = <T>(defs: OptionsDefs<T>, description = 'an object')
                 const result = safeCall(value, args, context.path);
                 if (result == null) return;
                 const validatorResult = validate(result, defs);
-                warnCallbackErrors(validatorResult, context, validatorDescription, result);
+                warnCallbackErrors(validatorResult, context, validatorDescription);
                 return validatorResult.cleared;
             },
             { [markedSymbol]: true }
@@ -764,17 +764,9 @@ export function hasRequiredInPath(errors: ValidationError[], rootPath: string) {
 function warnCallbackErrors(
     validatorResult: Pick<ValidatorResult, 'invalid'>,
     context: ValidatorContext,
-    description: string | undefined,
-    result: unknown
+    description: string | undefined
 ) {
     if (validatorResult.invalid.length === 0) return;
-
-    if (isArray(result)) {
-        const expectedDescription = description ?? validatorResult.invalid[0]?.description ?? 'a valid value';
-        return warnOnce(
-            `Callback \`${context.path}\` returned an invalid value \`${stringifyValue(result, 50)}\`; expecting ${expectedDescription}, ignoring.`
-        );
-    }
 
     for (const error of validatorResult.invalid) {
         if (error instanceof UnknownError) {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15933

When a label/caption formatter returns a rich-text/segment value with a bad sub-property — e.g. an image segment with `verticalAlign: 't0p'` — the runtime warned by dumping the whole returned array and saying only "expecting a string, a number, a date or text or image". The structured per-property error already existed but the array branch of `warnCallbackErrors` discarded it.

This drops that array short-circuit so array results use the same per-error path as objects. The warning now names the offending property, e.g.:

> Callback `axes[0].label.formatter` returned an invalid property `[0].verticalAlign`: `"t0p"`; expecting a keyword such as 'baseline', 'top', 'middle' or 'bottom', ignoring.

The valid part of the segment is still cleared and rendered (the bad property is dropped), so behaviour is unchanged aside from the message.

This is the "separate ticket for validation" called out in the AG-15933 review (raised against AG-15933 pending its own key).

Tests: rewrote the callback test that asserted the single generic dump to expect targeted per-element/property messages, and added segment cases (using the real `textOrSegments` validator) covering the `verticalAlign` typo and a valid sibling segment being preserved.

Fix #AG-15933