### PR TITLE
AG-17546 Add datums array to chart-level callback params

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -902,6 +902,11 @@ describe('Chart', () => {
             expect(nodeClick).toHaveBeenCalledWith(expect.objectContaining({ type: 'seriesNodeClick' }));
             expect(seriesNodeClick).toHaveBeenCalledWith(expect.objectContaining({ type: 'seriesNodeClick' }));
 
+            // A 1:1 series exposes the single row as `datum` and leaves `datums` undefined.
+            const barClickEvent = nodeClick.mock.calls[0][0];
+            expect(barClickEvent.datum).toEqual({ xValue: 'category', yValue: 1 });
+            expect(barClickEvent.datums).toBeUndefined();
+
             await doubleClickAction(200, 200)(agChartInstance);
 
             expect(nodeDoubleClick).toHaveBeenCalledTimes(1);

--- a/packages/ag-charts-community/src/chart/interaction/activeManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/activeManager.ts
@@ -71,7 +71,7 @@ export class ActiveManager implements MementoOriginator<AgActiveState> {
         // External (API) dispatch:
         if (frozenChanged || !objectsEqual(oldItemState, newItemState)) {
             const { frozen, activeItem } = this.createMementoWithItem(newItemState);
-            const { datum, itemType } = nodeDatum ?? {};
+            const { datum, datums, itemType } = nodeDatum ?? {};
 
             this.ctx.fireEvent({
                 type: 'activeChange',
@@ -81,6 +81,7 @@ export class ActiveManager implements MementoOriginator<AgActiveState> {
                 datum,
                 // Series-specific metadata is only attached when present, so events for series that
                 // don't set it (most series) keep their original shape.
+                ...(datums === undefined ? {} : { datums }),
                 ...(itemType === undefined ? {} : { itemType }),
                 dataIdKey: nodeDatum?.series.data?.dataIdKey,
                 preventDefault: () => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
@@ -244,7 +244,7 @@ describe('HistogramSeries', () => {
                     binRange: [0, 10],
                     aggregatedValue: 2,
                     frequency: 2,
-                    datum: [{ x: 1 }, { x: 5 }],
+                    datums: [{ x: 1 }, { x: 5 }],
                 })
             );
         });
@@ -336,10 +336,11 @@ describe('HistogramSeries', () => {
             ]);
             expect(nodes.map((n) => n.frequency)).toEqual([3, 0, 0, 1]);
 
-            // AC1: datum is the bin's full source rows, not extracted values; row order within a bin
-            // isn't guaranteed, so compare order-independently.
-            expect(nodes[0].datum).toHaveLength(3);
-            expect(nodes[0].datum).toEqual(
+            // AC1: datums is the bin's full source rows, not extracted values; row order within a bin
+            // isn't guaranteed, so compare order-independently. datum is undefined (a bin has no single row).
+            expect(nodes[0].datum).toBeUndefined();
+            expect(nodes[0].datums).toHaveLength(3);
+            expect(nodes[0].datums).toEqual(
                 expect.arrayContaining([
                     { x: 2, y: 1, label: 'a' },
                     { x: 5, y: 2, label: 'b' },
@@ -347,13 +348,10 @@ describe('HistogramSeries', () => {
                 ])
             );
 
-            // datums mirrors the bin's source rows so global callbacks have a correctly-typed array.
-            expect(nodes[0].datums).toBe(nodes[0].datum);
-
             // TC1: an empty bin is still a positioned bin.
             expect(nodes[2].binIndex).toBe(2);
             expect(nodes[2].binRange).toEqual([20, 30]);
-            expect(nodes[2].datum).toEqual([]);
+            expect(nodes[2].datum).toBeUndefined();
             expect(nodes[2].datums).toEqual([]);
             expect(nodes[2].frequency).toBe(0);
             expect(nodes[2].aggregatedValue).toBe(0);
@@ -463,16 +461,16 @@ describe('HistogramSeries', () => {
                 aggregatedValue: 3,
                 frequency: 3,
             });
-            expect(event.datum).toHaveLength(3);
-            expect(event.datum).toEqual(
+            // datums exposes every bin row; datum is undefined for a bin (no single row).
+            expect(event.datum).toBeUndefined();
+            expect(event.datums).toHaveLength(3);
+            expect(event.datums).toEqual(
                 expect.arrayContaining([
                     { x: 2, y: 1, label: 'a' },
                     { x: 5, y: 2, label: 'b' },
                     { x: 8, y: 3, label: 'c' },
                 ])
             );
-            // datums exposes the same bin rows under a correctly-typed array; datum is unchanged.
-            expect(event.datums).toEqual(event.datum);
         });
 
         it('fires seriesNodeDoubleClick with the bin params', async () => {
@@ -502,8 +500,9 @@ describe('HistogramSeries', () => {
             expect(renderer).toHaveBeenCalledTimes(1);
             const params = renderer.mock.calls[0][0];
             expect(params).toMatchObject({ binIndex: 0, binRange: [0, 10], aggregatedValue: 3, frequency: 3 });
-            expect(params.datum).toHaveLength(3);
-            expect(params.datum).toEqual(
+            expect(params.datum).toBeUndefined();
+            expect(params.datums).toHaveLength(3);
+            expect(params.datums).toEqual(
                 expect.arrayContaining([
                     { x: 2, y: 1, label: 'a' },
                     { x: 5, y: 2, label: 'b' },

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.test.ts
@@ -347,10 +347,14 @@ describe('HistogramSeries', () => {
                 ])
             );
 
+            // datums mirrors the bin's source rows so global callbacks have a correctly-typed array.
+            expect(nodes[0].datums).toBe(nodes[0].datum);
+
             // TC1: an empty bin is still a positioned bin.
             expect(nodes[2].binIndex).toBe(2);
             expect(nodes[2].binRange).toEqual([20, 30]);
             expect(nodes[2].datum).toEqual([]);
+            expect(nodes[2].datums).toEqual([]);
             expect(nodes[2].frequency).toBe(0);
             expect(nodes[2].aggregatedValue).toBe(0);
         });
@@ -467,6 +471,8 @@ describe('HistogramSeries', () => {
                     { x: 8, y: 3, label: 'c' },
                 ])
             );
+            // datums exposes the same bin rows under a correctly-typed array; datum is unchanged.
+            expect(event.datums).toEqual(event.datum);
         });
 
         it('fires seriesNodeDoubleClick with the bin params', async () => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -484,7 +484,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
     /** The standardised bin metadata passed to every histogram callback. */
     private binParams(bin: CalculatedBin): AgHistogramSeriesBinParams<any> {
         const { datum, binIndex, domain: binRange, aggregatedValue, frequency } = bin;
-        return { datum, binIndex, binRange, aggregatedValue, frequency };
+        return { datum: undefined, datums: datum, binIndex, binRange, aggregatedValue, frequency };
     }
 
     /**
@@ -539,7 +539,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             series: this,
             itemId,
             datumIndex: binIndex,
-            datum,
+            datum: undefined,
             datums: datum,
             binIndex,
             binRange,
@@ -588,7 +588,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
 
         // Update properties
         mutableNode.datumIndex = binIndex;
-        mutableNode.datum = datum;
+        mutableNode.datum = undefined;
         mutableNode.datums = datum;
         mutableNode.binIndex = binIndex;
         mutableNode.aggregatedValue = aggregatedValue;
@@ -774,7 +774,8 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         const { xKey, yKey, xName, yName } = this.properties;
         opts.labelSelection.each((text, datum) => {
             const params: AgHistogramSeriesLabelFormatterParams = {
-                datum: datum.datum as any[],
+                datum: undefined,
+                datums: datum.datums as any[],
                 binIndex: datum.binIndex,
                 binRange: datum.binRange,
                 aggregatedValue: datum.aggregatedValue,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -540,6 +540,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             itemId,
             datumIndex: binIndex,
             datum,
+            datums: datum,
             binIndex,
             binRange,
             aggregatedValue,
@@ -588,6 +589,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         // Update properties
         mutableNode.datumIndex = binIndex;
         mutableNode.datum = datum;
+        mutableNode.datums = datum;
         mutableNode.binIndex = binIndex;
         mutableNode.aggregatedValue = aggregatedValue;
         mutableNode.cumulativeValue = Number(total);

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -159,7 +159,7 @@ export type INodeEventConstructor<
 > = new <T extends TEvent>(
     type: T,
     event: Event,
-    { datum }: TDatum,
+    nodeDatum: TDatum,
     series: TSeries,
     selectionState: PublicSelectionState | undefined
 ) => INodeEvent<T>;
@@ -172,6 +172,7 @@ export class SeriesNodeEvent<
     TEvent extends string = SeriesNodeEventTypes,
 > implements INodeEvent<TEvent> {
     readonly datum: unknown;
+    readonly datums?: unknown[];
     readonly seriesId: string;
     readonly itemId: string | number;
     readonly dataIdKey: string | undefined;
@@ -186,6 +187,7 @@ export class SeriesNodeEvent<
         selectionState: PublicSelectionState | undefined
     ) {
         this.datum = nodeDatum.datum;
+        this.datums = nodeDatum.datums;
         this.seriesId = series.id;
         this.dataIdKey = series.data?.dataIdKey;
         this.itemId = getItemId(nodeDatum, this.dataIdKey);

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -90,6 +90,7 @@ export interface INodeEvent<TEvent extends string = SeriesNodeEventTypes> extend
     // Note: this is typically a MouseEvent, but it can be a TouchEvent or KeyboardEvent too.
     readonly event: Event;
     readonly datum: unknown;
+    readonly datums?: unknown[];
     readonly seriesId: string;
     readonly itemId: string | number;
     readonly dataIdKey: string | undefined;
@@ -184,6 +185,7 @@ export interface SeriesNodeDatum {
     readonly itemId?: ItemId;
     readonly itemType?: ItemType;
     readonly datum: unknown;
+    readonly datums?: unknown[];
     readonly datumIndex: DatumIndex;
     readonly point?: Readonly<Point> & SizedPoint;
     readonly missing?: boolean;

--- a/packages/ag-charts-enterprise/src/__snapshots__/callbacks.test.ts.snap
+++ b/packages/ag-charts-enterprise/src/__snapshots__/callbacks.test.ts.snap
@@ -2699,7 +2699,8 @@ exports[`AG-15850 labels > histogram > formatter 1`] = `
         1,
         1.5,
       ],
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 1,
         },
@@ -2721,7 +2722,8 @@ exports[`AG-15850 labels > histogram > formatter 1`] = `
         2,
         2.5,
       ],
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 2,
         },
@@ -2743,7 +2745,8 @@ exports[`AG-15850 labels > histogram > formatter 1`] = `
         3,
         3.5,
       ],
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 3,
         },
@@ -2765,7 +2768,8 @@ exports[`AG-15850 labels > histogram > formatter 1`] = `
         4,
         4.5,
       ],
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 4,
         },
@@ -2800,7 +2804,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [],
+      "datum": undefined,
+      "datums": [],
       "enabled": true,
       "fill": undefined,
       "fillOpacity": undefined,
@@ -2837,7 +2842,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 1,
         },
@@ -2878,7 +2884,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [],
+      "datum": undefined,
+      "datums": [],
       "enabled": true,
       "fill": undefined,
       "fillOpacity": undefined,
@@ -2915,7 +2922,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 2,
         },
@@ -2956,7 +2964,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [],
+      "datum": undefined,
+      "datums": [],
       "enabled": true,
       "fill": undefined,
       "fillOpacity": undefined,
@@ -2993,7 +3002,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 3,
         },
@@ -3034,7 +3044,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [],
+      "datum": undefined,
+      "datums": [],
       "enabled": true,
       "fill": undefined,
       "fillOpacity": undefined,
@@ -3071,7 +3082,8 @@ exports[`AG-15850 labels > histogram > itemStyler 1`] = `
       },
       "color": "white",
       "cornerRadius": 4,
-      "datum": [
+      "datum": undefined,
+      "datums": [
         {
           "myValue": 4,
         },

--- a/packages/ag-charts-enterprise/src/callbacks.test.ts
+++ b/packages/ag-charts-enterprise/src/callbacks.test.ts
@@ -1333,8 +1333,9 @@ describe('AG-15850 activeChange', () => {
     let mockActiveChange: ReturnType<typeof newFreezableMock<D, C, M>>;
     let version: string | undefined = undefined;
 
+    // datums (histogram-only) is omitted like itemType: both are attached to the event only when present.
     type ExpectedAgActiveChangeEventProperties = RequireOptional<
-        DeepReadonly<Omit<AgActiveChangeEvent<unknown, unknown>, 'preventDefault' | 'context' | 'itemType'>>
+        DeepReadonly<Omit<AgActiveChangeEvent<unknown, unknown>, 'preventDefault' | 'context' | 'itemType' | 'datums'>>
     >;
     function expectAgActiveChangeEvent(props: ExpectedAgActiveChangeEventProperties) {
         const { activeItem, dataIdKey, datum, frozen, source, type, ..._rest } = props;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it, test } from 'vitest';
+import { afterEach, describe, expect, it, test, vi } from 'vitest';
 
 import type { AgChartOptions, AgContextMenuItem } from 'ag-charts-community';
-import { AgCharts } from 'ag-charts-community';
+import { AgCharts, _ModuleSupport } from 'ag-charts-community';
 import {
     clickAction,
     computeLegendBBox,
@@ -159,6 +159,65 @@ describe('Context Menu', () => {
             await waitForChartStability(chart);
 
             expect(highlightManager.getActiveHighlight()).toBeUndefined();
+        });
+    });
+
+    describe('series-node getItems datums (AG-17546)', () => {
+        const HISTOGRAM_OPTIONS: AgChartOptions = {
+            data: [{ x: 2 }, { x: 5 }, { x: 8 }, { x: 35 }],
+            series: [
+                {
+                    type: 'histogram',
+                    xKey: 'x',
+                    bins: [
+                        [0, 10],
+                        [10, 20],
+                        [20, 30],
+                        [30, 40],
+                    ],
+                },
+            ],
+            contextMenu: { enabled: true },
+        };
+
+        const nodeCanvasPoint = (datumIndex: number) => {
+            const series = deproxy(chart).series[0] as any;
+            const node = series.getNodeData()[datumIndex];
+            return _ModuleSupport.Transformable.toCanvasPoint(
+                series.contentGroup,
+                node.x + node.width / 2,
+                node.y + node.height / 2
+            );
+        };
+
+        it('passes the bin source rows to getItems as datums', async () => {
+            const getItems = vi.fn((_params: any) => []);
+            await prepareChart({ enabled: true, getItems }, HISTOGRAM_OPTIONS);
+
+            const { x, y } = nodeCanvasPoint(0);
+            await contextMenuAction(x, y)(chart);
+            await waitForChartStability(chart);
+
+            expect(getItems).toHaveBeenCalledTimes(1);
+            const params = getItems.mock.calls[0][0];
+            // datums exposes every row grouped into the bin; datum is unchanged (also the bin array).
+            expect(params.datums).toHaveLength(3);
+            expect(params.datums).toEqual(expect.arrayContaining([{ x: 2 }, { x: 5 }, { x: 8 }]));
+            expect(params.datum).toEqual(params.datums);
+        });
+
+        it('leaves datums undefined for a 1:1 series node', async () => {
+            const getItems = vi.fn((_params: any) => []);
+            await prepareChart({ enabled: true, getItems });
+
+            const { x, y } = nodeCanvasPoint(3);
+            await contextMenuAction(x, y)(chart);
+            await waitForChartStability(chart);
+
+            expect(getItems).toHaveBeenCalledTimes(1);
+            const params = getItems.mock.calls[0][0];
+            expect(params.datum).toEqual({ x: 3, y: 75 });
+            expect(params.datums).toBeUndefined();
         });
     });
 

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
@@ -200,10 +200,10 @@ describe('Context Menu', () => {
 
             expect(getItems).toHaveBeenCalledTimes(1);
             const params = getItems.mock.calls[0][0];
-            // datums exposes every row grouped into the bin; datum is unchanged (also the bin array).
+            // datums exposes every row grouped into the bin; datum is undefined for a bin.
             expect(params.datums).toHaveLength(3);
             expect(params.datums).toEqual(expect.arrayContaining([{ x: 2 }, { x: 5 }, { x: 8 }]));
-            expect(params.datum).toEqual(params.datums);
+            expect(params.datum).toBeUndefined();
         });
 
         it('leaves datums undefined for a 1:1 series node', async () => {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -163,8 +163,8 @@ export class ContextMenu extends AbstractModuleInstance {
 
                 // Histogram bins carry standardised bin metadata; binIndex is always set for histogram nodes.
                 if (this.pickedNode.binIndex !== undefined) {
-                    const { binIndex, binRange, aggregatedValue, frequency } = this.pickedNode;
-                    Object.assign(params, { binIndex, binRange, aggregatedValue, frequency });
+                    const { datums, binIndex, binRange, aggregatedValue, frequency } = this.pickedNode;
+                    Object.assign(params, { datums, binIndex, binRange, aggregatedValue, frequency });
                 }
                 return params;
             }

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -315,8 +315,11 @@ export class Crosshair
         if (!options?.enabled) return;
 
         const { crosshairGroup, axisCtx } = this;
-        const { datum, series } = event.currentHighlight ?? {};
-        const hasCrosshair = datum && (series?.axes.x?.id === axisCtx.axisId || series?.axes.y?.id === axisCtx.axisId);
+        const { datum, datums, series } = event.currentHighlight ?? {};
+        // Bins (histogram) expose their rows on `datums`, with `datum` left undefined.
+        const hasCrosshair =
+            (datum != null || datums != null) &&
+            (series?.axes.x?.id === axisCtx.axisId || series?.axes.y?.id === axisCtx.axisId);
 
         this.activeHighlight = hasCrosshair ? event.currentHighlight : undefined;
         this.activeHighlightInViewport = event.highlightInViewport;

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -30,6 +30,8 @@ export interface AgNodeClickEvent<TEvent extends string, TDatum, TContext = Cont
     dataIdKey?: DatumKey<TDatum>;
     /** Datum from the chart or series data array. */
     datum: TDatum;
+    /** Every datum grouped into the bin for histogram series; `undefined` for all other series. */
+    datums?: TDatum[];
     /** Waterfall series only: the type of bar - `positive`, `negative`, `total` or `subtotal`. */
     itemType?: AgItemType;
     /** The current selection state of this datum. Set to `undefined` if the selection module is not enabled. */
@@ -80,6 +82,8 @@ export interface AgActiveChangeEvent<TDatum, TContext> extends AgActiveState, Ag
     context?: TContext;
     /** Datum from the chart or series data array. */
     datum?: TDatum;
+    /** Every datum grouped into the bin for histogram series; `undefined` for all other series. */
+    datums?: TDatum[];
     /** The active item's type, for series that distinguish item types (e.g. waterfall, OHLC, candlestick, range area); `undefined` otherwise. */
     itemType?: AgItemType;
     /** The data ID key, if set on chart options. When present, `activeItem.itemId` is a stable identifier. */

--- a/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
@@ -19,8 +19,10 @@ import type { AgBaseCartesianSeriesAxisOptions, FillOptions, LineDashOptions, St
  * node click/double-click, context menu and `getItemId`).
  */
 export interface AgHistogramSeriesBinParams<TDatum = DatumDefault> {
-    /** The raw source rows grouped into the bin. */
-    readonly datum: TDatum[];
+    /** Always `undefined` for a bin, which aggregates many rows; use `datums` for the source rows. */
+    readonly datum: undefined;
+    /** Every source row grouped into the bin. */
+    readonly datums: TDatum[];
     /** Zero-based positional index of the bin within the series. Defined for every bin, including empty ones. */
     readonly binIndex: number;
     /** The bin's start and end bounds on the x-axis. `bigint` values for a bigint `xKey` column. */
@@ -33,7 +35,7 @@ export interface AgHistogramSeriesBinParams<TDatum = DatumDefault> {
 
 export interface AgHistogramSeriesTooltipRendererParams<TDatum = DatumDefault, TContext = ContextDefault>
     extends
-        Omit<AgCartesianSeriesTooltipRendererParams<TDatum[], TContext>, 'xKey' | 'yKey' | 'datum'>,
+        Omit<AgCartesianSeriesTooltipRendererParams<TDatum, TContext>, 'xKey' | 'yKey' | 'datum'>,
         AgHistogramSeriesBinParams<TDatum>,
         FillOptions,
         StrokeOptions {
@@ -62,7 +64,7 @@ export interface AgHistogramSeriesThemeableOptions<TDatum = DatumDefault, TConte
     /** Configuration for the shadow used behind the chart series. */
     shadow?: AgDropShadowOptions;
     /** Configuration for the labels shown on bars. */
-    label?: AgChartLabelOptions<TDatum[], AgHistogramSeriesLabelFormatterParams<TDatum>, TContext>;
+    label?: AgChartLabelOptions<undefined, AgHistogramSeriesLabelFormatterParams<TDatum>, TContext>;
     /** Series-specific tooltip configuration. */
     tooltip?: AgSeriesTooltip<AgHistogramSeriesTooltipRendererParams<TDatum, TContext>>;
     /** Configuration for highlighting when a series or legend item is hovered over. */
@@ -101,11 +103,13 @@ export interface AgHistogramSeriesOptionsNames {
 
 /** Node click/double-click event fired for a histogram bin. */
 export interface AgHistogramSeriesNodeClickEvent<TDatum = DatumDefault, TContext = ContextDefault>
-    extends Omit<AgNodeClickEvent<'seriesNodeClick', TDatum, TContext>, 'datum'>, AgHistogramSeriesBinParams<TDatum> {}
+    extends
+        Omit<AgNodeClickEvent<'seriesNodeClick', TDatum, TContext>, 'datum' | 'datums'>,
+        AgHistogramSeriesBinParams<TDatum> {}
 
 export interface AgHistogramSeriesNodeDoubleClickEvent<TDatum = DatumDefault, TContext = ContextDefault>
     extends
-        Omit<AgNodeClickEvent<'seriesNodeDoubleClick', TDatum, TContext>, 'datum'>,
+        Omit<AgNodeClickEvent<'seriesNodeDoubleClick', TDatum, TContext>, 'datum' | 'datums'>,
         AgHistogramSeriesBinParams<TDatum> {}
 
 export interface AgHistogramSeriesListeners<TDatum = DatumDefault, TContext = ContextDefault> {

--- a/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
@@ -148,7 +148,7 @@ Each bin has a stable identifier, surfaced as the `itemId` in node events and ac
 
 Histogram callbacks - `tooltip.renderer`, `label.formatter`, `listeners.seriesNodeClick`, `listeners.seriesNodeDoubleClick`, and context menu items - all receive the same bin data:
 
-- `datum`: the array of source data rows grouped into the bin.
+- `datums`: the array of source data rows grouped into the bin. (`datum` is `undefined`, since a bin has no single row.)
 - `binIndex`: the zero-based position of the bin in the series, defined for empty bins too.
 - `binRange`: the bin's `[start, end]` bounds on the x-axis.
 - `aggregatedValue`: the aggregated `yKey` value for the bin.
@@ -161,8 +161,8 @@ Histogram callbacks - `tooltip.renderer`, `label.formatter`, `listeners.seriesNo
             type: 'histogram',
             xKey: 'age',
             listeners: {
-                seriesNodeClick: ({ binRange, frequency, datum }) => {
-                    console.log(`${frequency} people aged ${binRange[0]}-${binRange[1]}`, datum);
+                seriesNodeClick: ({ binRange, frequency, datums }) => {
+                    console.log(`${frequency} people aged ${binRange[0]}-${binRange[1]}`, datums);
                 },
             },
         },

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -79,10 +79,10 @@ The minimum supported version of TypeScript is now 5.8.
 
 ### Histogram Series
 
-All histogram callbacks (`tooltip.renderer`, `label.formatter`, `seriesNodeClick`, `seriesNodeDoubleClick`, and context menu callbacks) now receive a consistent set of params: `datum` is `TDatum[]` (the raw source rows in the bin), with `binIndex`, `aggregatedValue`, `frequency`, and `binRange` as top-level fields.
+All histogram callbacks (`tooltip.renderer`, `label.formatter`, `seriesNodeClick`, `seriesNodeDoubleClick`, and context menu callbacks) now receive a consistent set of params: `datums` is `TDatum[]` (the raw source rows in the bin), with `binIndex`, `aggregatedValue`, `frequency`, and `binRange` as top-level fields. `datum` is `undefined`, since a bin has no single source row.
 
-- In `tooltip.renderer`, `datum` is changed from `AgHistogramBinDatum` to `TDatum[]`.
-- In `seriesNodeClick`, `seriesNodeDoubleClick`, and context menu callbacks, `datum` is changed from extracted column values to the raw source objects.
+- In `tooltip.renderer`, the bin rows move from `datum` (which was `AgHistogramBinDatum`) to `datums`.
+- In `seriesNodeClick`, `seriesNodeDoubleClick`, and context menu callbacks, the bin rows are exposed as `datums` (the raw source objects), replacing the extracted column values previously on `datum`.
 - `xRange` is removed from `tooltip.renderer` params. Use `binRange` instead.
 - The bin-object `domain` field is removed from `tooltip.renderer` params.
 - `binIndex`, `aggregatedValue`, `frequency`, and `binRange` are added as top-level params to all histogram callbacks.


### PR DESCRIPTION
## Summary

Standardises the data exposed to callbacks across all series so that **arrays of rows always live on `datums`** and **`datum` is always the single-row contract**:

- `datums?: TDatum[]` is added to the chart-level callbacks that hand a node datum to a series-agnostic callback (node-click events, context menu, `activeChange`). Populated for a histogram bin; `undefined` for every other series.
- For the histogram, the bin's source rows move to `datums`, and `datum` becomes `undefined` (a bin aggregates many rows, so it has no single row). This replaces the unreleased AG-17492 shape where histogram callbacks exposed the rows as `datum: TDatum[]`.

This removes the redundancy where a histogram callback would otherwise expose the same array under both `datum` and `datums`.

## Why

Histogram is a non-1:1 series: a bin aggregates many rows. AG-17492 (unreleased — not in `b13.3.x`) had overloaded `datum` to be the bin's row array, breaking the universal `datum: TDatum` contract and leaving series-agnostic callbacks (context menu, `activeChange`) typed as a single `TDatum` while delivering an array at runtime. The new `datums` property is the single, correctly-typed home for bin rows; `datum` stays the single-row contract everywhere.

## Changes

**Public API (`ag-charts-types`)**
- `AgNodeClickEvent` and `AgActiveChangeEvent`: add `datums?: TDatum[]`.
- `AgHistogramSeriesBinParams`: rename `datum: TDatum[]` → `datums: TDatum[]`, and declare `datum: undefined`. This flows to the histogram tooltip, label formatter, `getItemId`, and node-click event types. The histogram label option generic becomes `undefined` so the label formatter/styler `datum` is honestly `undefined`.

**Runtime (`ag-charts-community`)**
- `seriesTypes.ts`: optional `datums` carrier on `SeriesNodeDatum` and `INodeEvent`.
- `series.ts`: `SeriesNodeEvent` copies `datums` from the node datum.
- `histogramSeries.ts`: populates `datums` (the bin rows) and sets `datum: undefined` on the node datum, `binParams`, and label params.
- `activeManager.ts`: forwards `datums` on `activeChange`, omitted when absent (mirroring `itemType`).

**Runtime (`ag-charts-enterprise`)**
- `contextMenu.ts`: forwards `datums` in the histogram bin-metadata block.
- `crosshair.ts`: the "has a datum to show a crosshair for" guard now also recognises a bin (data on `datums`), so histogram crosshairs still render now that bin `datum` is `undefined`.

**Scope excluded:** `AgSelectionItem` (histogram omits `selection`); value formatters (they receive data values, not node datums).

## Test plan

- `histogramSeries.test.ts` — node/`seriesNodeClick`/tooltip/`getItemId` expose `datums`; `datum` is `undefined`.
- `chart.test.ts` — a 1:1 (bar) node-click keeps `datum` as the single row and leaves `datums` undefined.
- `contextMenu.test.ts` — histogram `getItems` receives the bin rows as `datums`; `datum` is `undefined`; a 1:1 series node keeps `datum` and leaves `datums` undefined.
- `crosshair.test.ts` — histogram crosshair still renders (image snapshots).
- `callbacks.test.ts` — histogram label formatter/itemStyler snapshots updated to `datum: undefined` + `datums`.
- Docs updated: `histogram-series` page and the v14 upgrade guide.
- `build:types`, `lint`, full `ag-charts-community` (3646) and `ag-charts-enterprise` (2387) suites pass.

Fix #AG-17546
