### PR TITLE
AG-17134 Backport: remove unsafe-eval from the charts main-site CSP

### DIFF
--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -17,6 +17,7 @@ import agSourcemapCors from '../../external/ag-website-shared/plugins/agSourcema
 import { SITEMAP_CACHE_DIR } from '../../external/ag-website-shared/src/constants';
 import agAutoRedirect from './plugins/agAutoRedirect';
 import agCssAsString from './plugins/agCssAsString';
+import agDevCsp from './plugins/agDevCsp';
 import agHotModuleReload from './plugins/agHotModuleReload';
 import agHtaccessGen from './plugins/agHtaccessGen';
 import agRedirectsChecker from './plugins/agRedirectsChecker';
@@ -82,6 +83,7 @@ const plugins = [
     agCssAsString(),
     agHotModuleReload(),
     agAutoRedirect(['/javascript', '/react', '/vue', '/angular', '/gallery']),
+    agDevCsp(),
 ];
 if (NODE_ENV !== 'test') {
     plugins.push(mkcert()); // mkcert is not necessary for tests
@@ -136,15 +138,8 @@ export default defineConfig({
             },
             allowedHosts: [new URL(PUBLIC_SITE_URL).hostname],
             headers: {
-                'Content-Security-Policy': [
-                    "default-src 'self'",
-                    "script-src 'self' https://*.ag-grid.com https://localhost:4600 https://localhost:4601 https://www.googletagmanager.com https://cdn.jsdelivr.net 'unsafe-inline' 'unsafe-eval'",
-                    "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'",
-                    "font-src 'self' https://fonts.gstatic.com data:",
-                    "img-src 'self' data: blob: https:",
-                    "connect-src 'self' https:",
-                    "worker-src 'self' blob:",
-                ].join('; '),
+                // Content-Security-Policy is served per request by agDevCsp so
+                // example paths can get a different policy from ordinary pages.
                 'X-Content-Type-Options': 'nosniff',
             },
         },

--- a/packages/ag-charts-website/plugins/agDevCsp.ts
+++ b/packages/ag-charts-website/plugins/agDevCsp.ts
@@ -1,0 +1,30 @@
+import type { Plugin, ViteDevServer } from 'vite';
+
+import { getCspValue } from '../src/utils/htaccess/cspRules';
+
+const SITE_CSP = getCspValue({ env: 'dev', scope: 'site' });
+const EXAMPLES_CSP = getCspValue({ env: 'dev', scope: 'examples' });
+
+// Mirrors EXAMPLES_PATH_CONDITION in cspRules.ts: match the /examples/ or
+// /archive/ segment anywhere (charts serves example-runner documents under both
+// /gallery/examples/... and /<framework>/<page>/examples/..., under the /charts base).
+const EXAMPLES_PATH = /\/(examples|archive)\//;
+
+/**
+ * Vite plugin serving the dev server's Content-Security-Policy header with the
+ * same path-scoped split as the generated .htaccess: ordinary pages get the
+ * 'site' policy (no 'unsafe-eval'), example-runner documents get the relaxed
+ * 'examples' policy. Keeps local development honest about main-page eval use.
+ */
+export default function agDevCsp(): Plugin {
+    return {
+        name: 'ag-dev-csp',
+        configureServer(server: ViteDevServer) {
+            server.middlewares.use((req, res, next) => {
+                const csp = EXAMPLES_PATH.test(req.url ?? '') ? EXAMPLES_CSP : SITE_CSP;
+                res.setHeader('Content-Security-Policy', csp);
+                next();
+            });
+        },
+    };
+}

--- a/packages/ag-charts-website/scripts/csp/generate-csp.ts
+++ b/packages/ag-charts-website/scripts/csp/generate-csp.ts
@@ -2,8 +2,8 @@
 /* eslint-disable no-console */
 import { writeFileSync } from 'fs';
 
-import type { CspEnv, CspMode } from '../../src/utils/htaccess/cspRules';
-import { getCspHeaderName, getCspHtaccessBlock, getCspValue } from '../../src/utils/htaccess/cspRules';
+import type { CspEnv, CspMode, CspScope } from '../../src/utils/htaccess/cspRules';
+import { getCspHeaderName, getCspValue, getScopedCspHtaccessBlock } from '../../src/utils/htaccess/cspRules';
 
 /**
  * Generate the AG Charts Content-Security-Policy for a given environment.
@@ -13,6 +13,7 @@ import { getCspHeaderName, getCspHtaccessBlock, getCspValue } from '../../src/ut
  *       [--env=staging|production|dev]
  *       [--mode=report-only|enforce]
  *       [--format=htaccess|header|value]
+ *       [--scope=site|examples]    (header/value formats only; htaccess emits both)
  *       [--out=<file>]
  *
  * The policy itself lives in src/utils/htaccess/cspRules.ts (single source of
@@ -24,6 +25,7 @@ type Format = 'htaccess' | 'header' | 'value';
 const ENVS: CspEnv[] = ['dev', 'staging', 'production'];
 const MODES: CspMode[] = ['report-only', 'enforce'];
 const FORMATS: Format[] = ['htaccess', 'header', 'value'];
+const SCOPES: CspScope[] = ['site', 'examples'];
 
 function assertOneOf<T extends string>(value: string | undefined, allowed: T[], flag: string): T {
     if (value === undefined || !allowed.includes(value as T)) {
@@ -32,10 +34,11 @@ function assertOneOf<T extends string>(value: string | undefined, allowed: T[], 
     return value as T;
 }
 
-function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format; out?: string } {
+function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format; scope: CspScope; out?: string } {
     let env: CspEnv = 'staging';
     let mode: CspMode = 'report-only';
     let format: Format = 'htaccess';
+    let scope: CspScope = 'site';
     let out: string | undefined;
 
     for (let i = 0, len = argv.length; i < len; ++i) {
@@ -48,6 +51,8 @@ function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format
             mode = assertOneOf(value, MODES, '--mode');
         } else if (key === '--format') {
             format = assertOneOf(value, FORMATS, '--format');
+        } else if (key === '--scope') {
+            scope = assertOneOf(value, SCOPES, '--scope');
         } else if (key === '--out') {
             out = value;
         } else {
@@ -55,22 +60,24 @@ function parseArgs(argv: string[]): { env: CspEnv; mode: CspMode; format: Format
         }
     }
 
-    return { env, mode, format, out };
+    return { env, mode, format, scope, out };
 }
 
-function render(format: Format, env: CspEnv, mode: CspMode): string {
+function render(format: Format, env: CspEnv, mode: CspMode, scope: CspScope): string {
     if (format === 'value') {
-        return getCspValue({ env });
+        return getCspValue({ env, scope });
     }
     if (format === 'header') {
-        return `${getCspHeaderName(mode)}: ${getCspValue({ env })}`;
+        return `${getCspHeaderName(mode)}: ${getCspValue({ env, scope })}`;
     }
-    return getCspHtaccessBlock({ env }, mode);
+    // The htaccess format emits the full path-scoped block (site policy plus the
+    // <If> override for example/archive paths) — what ships in the generated file.
+    return getScopedCspHtaccessBlock({ env }, mode);
 }
 
 function main(): void {
-    const { env, mode, format, out } = parseArgs(process.argv.slice(2));
-    const output = render(format, env, mode);
+    const { env, mode, format, scope, out } = parseArgs(process.argv.slice(2));
+    const output = render(format, env, mode, scope);
 
     if (out) {
         writeFileSync(out, `${output}\n`);

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
@@ -1,0 +1,83 @@
+import { getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
+
+describe('cspRules', () => {
+    describe('scope', () => {
+        it("site scope omits 'unsafe-eval' from script-src", () => {
+            expect(getCspDirectives({ env: 'production', scope: 'site' })['script-src']).not.toContain("'unsafe-eval'");
+        });
+
+        it("examples scope includes 'unsafe-eval' in script-src", () => {
+            expect(getCspDirectives({ env: 'production', scope: 'examples' })['script-src']).toContain("'unsafe-eval'");
+        });
+
+        it('defaults to site scope', () => {
+            expect(getCspDirectives({ env: 'production' })).toEqual(
+                getCspDirectives({ env: 'production', scope: 'site' })
+            );
+        });
+
+        it("scopes differ only by script-src 'unsafe-eval'", () => {
+            const site = getCspDirectives({ env: 'production', scope: 'site' });
+            const examples = getCspDirectives({ env: 'production', scope: 'examples' });
+            const names = Object.keys(site);
+            expect(Object.keys(examples)).toEqual(names);
+            for (let i = 0, len = names.length; i < len; ++i) {
+                const name = names[i];
+                if (name === 'script-src') {
+                    expect(examples[name]).toEqual([...site[name], "'unsafe-eval'"]);
+                } else {
+                    expect(examples[name]).toEqual(site[name]);
+                }
+            }
+        });
+
+        it("both scopes include 'wasm-unsafe-eval' for browser-side Shiki highlighting", () => {
+            expect(getCspDirectives({ env: 'production', scope: 'site' })['script-src']).toContain(
+                "'wasm-unsafe-eval'"
+            );
+            expect(getCspDirectives({ env: 'production', scope: 'examples' })['script-src']).toContain(
+                "'wasm-unsafe-eval'"
+            );
+        });
+
+        it("both scopes keep 'unsafe-inline' in script-src and style-src", () => {
+            const site = getCspDirectives({ env: 'production', scope: 'site' });
+            expect(site['script-src']).toContain("'unsafe-inline'");
+            expect(site['style-src']).toContain("'unsafe-inline'");
+        });
+
+        it('connect-src allows data: so sized SVG/data-URI images can be fetched for resize injection', () => {
+            expect(getCspDirectives({ env: 'production', scope: 'site' })['connect-src']).toContain('data:');
+        });
+
+        it('style-src and font-src allow cdnjs for the font-icons docs example', () => {
+            const site = getCspDirectives({ env: 'production', scope: 'site' });
+            expect(site['style-src']).toContain('https://cdnjs.cloudflare.com');
+            expect(site['font-src']).toContain('https://cdnjs.cloudflare.com');
+        });
+    });
+
+    describe('getScopedCspHtaccessBlock', () => {
+        it('enforce mode unsets and re-sets the enforced header inside the <If> override', () => {
+            const block = getScopedCspHtaccessBlock({ env: 'production' }, 'enforce');
+            const ifBlock = block.slice(block.indexOf('<If'));
+            expect(ifBlock).toContain('Header always unset Content-Security-Policy\n');
+            expect(ifBlock).toContain('Header always set Content-Security-Policy "');
+            expect(ifBlock).toContain("'unsafe-eval'");
+        });
+
+        it('matches the /examples/ and /archive/ segment anywhere (charts nests examples under framework/gallery paths)', () => {
+            expect(getScopedCspHtaccessBlock({ env: 'production' }, 'enforce')).toContain(
+                '<If "%{REQUEST_URI} =~ m#/(examples|archive)/#">'
+            );
+        });
+
+        it('report-only mode never unsets the enforced header', () => {
+            const block = getScopedCspHtaccessBlock({ env: 'production' }, 'report-only');
+            const lines = block.split('\n');
+            expect(lines.find((l) => l.trim() === 'Header always unset Content-Security-Policy')).toBeUndefined();
+            expect(block).not.toContain('Header always set Content-Security-Policy "');
+            expect(block).toContain('Header always set Content-Security-Policy-Report-Only "');
+        });
+    });
+});

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -18,8 +18,17 @@
 export type CspEnv = 'dev' | 'staging' | 'production';
 export type CspMode = 'report-only' | 'enforce';
 
+/**
+ * 'site' is the default policy for ordinary pages. 'examples' additionally
+ * allows 'unsafe-eval' and applies only to the example-runner documents — see
+ * EXAMPLES_PATH_CONDITION.
+ */
+export type CspScope = 'site' | 'examples';
+
 export interface CspOptions {
     env: CspEnv;
+    /** Which policy variant to build. Defaults to 'site'. */
+    scope?: CspScope;
     /** Override the trial-licence form origin. Defaults to the per-env value. */
     trialFormOrigin?: string;
 }
@@ -30,9 +39,24 @@ export type CspDirectives = Record<string, string[]>;
 const SELF = "'self'";
 const NONE = "'none'";
 const UNSAFE_INLINE = "'unsafe-inline'";
-// Required by the Angular example-runner (JIT compilation) and the charts
-// example/theme tooling. Removing it is tracked separately.
+// Permits WebAssembly compilation without permitting JS eval() — narrower than
+// 'unsafe-eval'. Needed on every page: docs snippets are highlighted in the
+// browser by Shiki, whose oniguruma engine instantiates a WASM module
+// (see CodeShiki.tsx). Browsers that predate this token fall back to requiring
+// 'unsafe-eval' for WASM.
+const WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
+// Allowed only in the 'examples' scope: the example-runner documents load modules
+// with legacy SystemJS (fetches source over XHR and evals it) and the Angular
+// examples compile templates in the browser (JIT). The chart library itself does
+// not need it (see AG-11258), so ordinary pages no longer carry it.
 const UNSAFE_EVAL = "'unsafe-eval'";
+
+// Apache <If> expression matching the URL paths that get the 'examples' scope.
+// Charts serves example-runner documents at both /gallery/examples/<name>/... and
+// /<framework>/<page>/examples/<name>/..., and the whole site sits under /charts in
+// production, so '/examples/' is not a leading prefix — match the segment anywhere.
+// '/archive/' covers archived doc versions (which ship the same runner).
+export const EXAMPLES_PATH_CONDITION = '%{REQUEST_URI} =~ m#/(examples|archive)/#';
 
 // 'self' resolves to www.ag-grid.com on production (charts lives under /charts) and
 // charts-staging.ag-grid.com on staging, so cross-subdomain references to the
@@ -64,6 +88,7 @@ const DEV_CONNECT_SRC = ['https://localhost:4600', 'https://localhost:4601', 'ws
 
 export function getCspDirectives(options: CspOptions): CspDirectives {
     const { env } = options;
+    const scope = options.scope ?? 'site';
     const trialFormOrigin = options.trialFormOrigin ?? TRIAL_FORM_ORIGIN[env];
     const salesforceFormOrigin = SALESFORCE_FORM_ORIGIN[env];
 
@@ -84,10 +109,26 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
             'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
             UNSAFE_INLINE,
-            UNSAFE_EVAL,
+            WASM_UNSAFE_EVAL,
         ],
-        'style-src': [SELF, 'https://fonts.googleapis.com', 'https://cdn.jsdelivr.net', UNSAFE_INLINE],
-        'font-src': [SELF, 'https://fonts.gstatic.com', 'https://cdn.jsdelivr.net', 'data:'],
+        // 'unsafe-inline' stays: the charts theming/legacy styles inject <style>
+        // elements at runtime and static hosting rules out per-request nonces.
+        // cdnjs.cloudflare.com: the font-icons docs example loads the Font Awesome stylesheet
+        // (and its woff2 fonts) from there at runtime.
+        'style-src': [
+            SELF,
+            'https://fonts.googleapis.com',
+            'https://cdn.jsdelivr.net',
+            'https://cdnjs.cloudflare.com',
+            UNSAFE_INLINE,
+        ],
+        'font-src': [
+            SELF,
+            'https://fonts.gstatic.com',
+            'https://cdn.jsdelivr.net',
+            'https://cdnjs.cloudflare.com',
+            'data:',
+        ],
         // Relaxed to https:. Images/media are open-ended (blog/showcase images, chart
         // example assets) and a weak XSS vector — the strict script/connect/frame-src
         // below carry the protection.
@@ -97,6 +138,7 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         // a decision (broaden vs allowlist) before flipping to enforce.
         'connect-src': [
             SELF,
+            'data:', // sized SVG/data-URI images are fetched for resize injection (see imageLoader.ts)
             AG_GRID_HOSTS,
             'https://plausible.io',
             'https://*.algolia.net', // Algolia DocSearch
@@ -132,6 +174,10 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         ],
         'frame-ancestors': [SELF, AG_GRID_HOSTS], // allow *.ag-grid.com (e.g. blog) to embed examples
     };
+
+    if (scope === 'examples') {
+        directives['script-src'].push(UNSAFE_EVAL);
+    }
 
     if (env === 'dev') {
         directives['script-src'].push(...DEV_SCRIPT_SRC);
@@ -181,4 +227,28 @@ export function getCspHtaccessBlock(options: CspOptions, mode: CspMode): string 
     lines.push('Header always unset Content-Security-Policy-Report-Only');
     lines.push(getCspHtaccessLine(options, mode));
     return lines.join('\n');
+}
+
+/**
+ * Build the full `.htaccess` CSP block with the path-scoped policy split: the
+ * 'site' policy (no 'unsafe-eval') for ordinary pages, replaced by the
+ * 'examples' policy for the paths matched by EXAMPLES_PATH_CONDITION.
+ *
+ * A second CSP policy can only tighten (browsers enforce the intersection), so
+ * the relaxation must unset and re-set the header rather than add another one.
+ */
+export function getScopedCspHtaccessBlock(options: Omit<CspOptions, 'scope'>, mode: CspMode): string {
+    const headerName = getCspHeaderName(mode);
+    return [
+        getCspHtaccessBlock({ ...options, scope: 'site' }, mode),
+        '',
+        "# Example-runner documents and archived doc versions additionally need 'unsafe-eval'",
+        '# (SystemJS eval-loads modules; the Angular JIT compiler also compiles in the browser).',
+        '# <If> sections merge after all other configuration, so this unset+set replaces the',
+        '# header set above for matching requests.',
+        `<If "${EXAMPLES_PATH_CONDITION}">`,
+        `    Header always unset ${headerName}`,
+        `    ${getCspHtaccessLine({ ...options, scope: 'examples' }, mode)}`,
+        '</If>',
+    ].join('\n');
 }

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
@@ -1,0 +1,72 @@
+import { PRODUCTION_CSP_PHASE, getHtaccessContent } from './htaccessRules';
+
+describe('htaccessRules CSP (AG-17134)', () => {
+    const production = getHtaccessContent({ env: 'production' });
+    const staging = getHtaccessContent({ env: 'staging' });
+
+    const ifOpen = '<If "%{REQUEST_URI} =~ m#/(examples|archive)/#">';
+    const unconditionalLines = (content: string) => content.split('\n').filter((l) => !l.startsWith(' '));
+    const extractIfBlock = (content: string) => {
+        const start = content.indexOf(ifOpen);
+        const end = content.indexOf('</If>', start);
+        expect(start).toBeGreaterThan(-1);
+        expect(end).toBeGreaterThan(start);
+        return content.slice(start, end);
+    };
+
+    it('emits a CSP header in both environments', () => {
+        expect(production).toContain('Content-Security-Policy');
+        expect(staging).toContain('Content-Security-Policy');
+    });
+
+    it('staging: unconditional enforced policy has no unsafe-eval but keeps unsafe-inline', () => {
+        const setLine = unconditionalLines(staging).find((l) =>
+            l.startsWith('Header always set Content-Security-Policy "')
+        );
+        expect(setLine).toBeDefined();
+        expect(setLine).not.toContain("'unsafe-eval'");
+        expect(setLine).toContain("'unsafe-inline'");
+    });
+
+    it('staging: <If> override re-sets the enforced policy with unsafe-eval for example/archive paths', () => {
+        const ifBlock = extractIfBlock(staging);
+        expect(ifBlock).toContain('Header always unset Content-Security-Policy\n');
+        expect(ifBlock).toContain("'unsafe-eval'");
+    });
+
+    it('staging: site-wide set precedes the <If> override', () => {
+        expect(staging.indexOf('Header always set Content-Security-Policy "')).toBeLessThan(staging.indexOf(ifOpen));
+    });
+
+    if (PRODUCTION_CSP_PHASE === 'report-only') {
+        it('production (report-only window): keeps enforcing the previous policy with unsafe-eval', () => {
+            const enforced = unconditionalLines(production).find((l) =>
+                l.startsWith('Header always set Content-Security-Policy "')
+            );
+            expect(enforced).toBeDefined();
+            expect(enforced).toContain("'unsafe-eval'");
+        });
+
+        it('production (report-only window): reports on the tightened site policy without unsafe-eval', () => {
+            const reportOnly = unconditionalLines(production).find((l) =>
+                l.startsWith('Header always set Content-Security-Policy-Report-Only "')
+            );
+            expect(reportOnly).toBeDefined();
+            expect(reportOnly).not.toContain("'unsafe-eval'");
+        });
+
+        it('production (report-only window): the <If> override only swaps the report-only header', () => {
+            const ifBlock = extractIfBlock(production);
+            expect(ifBlock).toContain('Header always unset Content-Security-Policy-Report-Only\n');
+            expect(ifBlock).not.toContain('Header always set Content-Security-Policy "');
+        });
+    } else {
+        it('production (enforced): unconditional enforced policy has no unsafe-eval', () => {
+            const enforced = unconditionalLines(production).find((l) =>
+                l.startsWith('Header always set Content-Security-Policy "')
+            );
+            expect(enforced).toBeDefined();
+            expect(enforced).not.toContain("'unsafe-eval'");
+        });
+    }
+});

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
@@ -3,10 +3,17 @@ import type { AstroUserConfig } from 'astro';
 import { SITE_BASE_URL } from '../../constants';
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
-import { getCspHtaccessBlock } from './cspRules';
+import { getCspHtaccessBlock, getScopedCspHtaccessBlock } from './cspRules';
 import { SITE_301_REDIRECTS, type SimpleRedirectRule } from './redirects';
 
 export type HtaccessEnv = Extract<CspEnv, 'staging' | 'production'>;
+
+// Rollout state for removing 'unsafe-eval' from the production main-site CSP.
+// While 'report-only', production keeps enforcing the previous policy (which
+// allows 'unsafe-eval' everywhere) and reports violations of the tightened
+// path-scoped split. Flip to 'enforce' once the report-only window is clean.
+// Staging always enforces the split.
+export const PRODUCTION_CSP_PHASE: 'report-only' | 'enforce' = 'report-only';
 
 export function getHtaccessContent(options: { env: HtaccessEnv }) {
     const { env } = options;
@@ -16,18 +23,30 @@ ErrorDocument 404 ${urlWithBaseUrl('/404.html')}
 # add MIME types for serving example files
 AddType text/javascript mjs ts jsx
 
-# Content-Security-Policy — enforced (the report-only validation window is complete).
-# Charts is served from /charts on www.ag-grid.com and inherits the grid root CSP, so
-# this block overrides it for charts pages (see getCspHtaccessBlock). In enforce mode
-# the block unsets BOTH inherited headers (the grid root policy and the legacy wildcard)
-# and sets this enforced policy. The trial-form origin is env-split, so the policy is
-# generated per environment.
-${getCspHtaccessBlock({ env }, 'enforce')}
+# Content-Security-Policy — path-scoped. Charts is served from /charts on www.ag-grid.com
+# and inherits the grid root CSP, so this block overrides it for charts pages (see
+# getCspHtaccessBlock). Ordinary pages get the tightened policy (no 'unsafe-eval'); the
+# <If> override re-allows it for example-runner documents. The trial-form origin is
+# env-split, so the policy is generated per environment.
+${getCspContent(env)}
 
 ${getRedirectRules()}
 
 Options -Indexes
 `;
+}
+
+function getCspContent(env: HtaccessEnv): string {
+    // Staging enforces the split immediately. Production keeps enforcing the previous
+    // policy (which allows 'unsafe-eval' on every page) and reports the tightened split
+    // via Report-Only until the validation window is clean. The Report-Only <If> override
+    // matters: without it, every example-runner page would report eval violations.
+    if (env === 'staging' || PRODUCTION_CSP_PHASE === 'enforce') {
+        return getScopedCspHtaccessBlock({ env }, 'enforce');
+    }
+    return `${getCspHtaccessBlock({ env, scope: 'examples' }, 'enforce')}
+
+${getScopedCspHtaccessBlock({ env }, 'report-only')}`;
 }
 
 export function getRedirectRules() {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

Backport of #7077 to the `b13.3.1` release branch (cherry-pick of `a321c51a36`).

Splits the charts site CSP into a `site` scope (no `'unsafe-eval'`) and an `examples` scope (keeps `'unsafe-eval'`), re-set for example-runner / archived-doc paths via an Apache `<If>` override (base-agnostic match so it works under the `/charts` prefix and nested gallery/example paths). Adds `'wasm-unsafe-eval'` to the shared `script-src` for browser-side Shiki highlighting. Staging enforces the split; production stays on the previous policy and reports the split via Report-Only, gated by `PRODUCTION_CSP_PHASE` (`'report-only'`). Mirrors the split on the dev server via the `agDevCsp` vite plugin.

The one cherry-pick conflict (`htaccessRules.ts` CSP block) was resolved in favour of the new phased `getCspContent(env)` path-scoped emission.

CSP unit tests pass (18).
