### PR TITLE
Document item identifiers and data types

### DIFF
--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -316,7 +316,7 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
         }),
         warningMessages: [
             'AG Charts - Option `axes.y.crossLines[0][type=line].value` is required and has not been provided; expecting a number or bigint, ignoring.',
-            'AG Charts - Unknown option `axes.y.crossLines[0][type=line].range`, ignoring.',
+            'AG Charts - Unknown option `axes.y.crossLines[0][type=line].range`; Did you mean `value`? Ignoring.',
         ],
     },
     INVALID_LINE_WITHOUT_TYPE_CROSSLINE: {
@@ -337,7 +337,7 @@ const INVALID_EXAMPLES: Record<string, CartesianTestCase & { warningMessages: st
         }),
         warningMessages: [
             'AG Charts - Option `axes.y.crossLines[0][type=range].range` is required and has not been provided; expecting a number or bigint array and an array of exactly 2 items, ignoring.',
-            'AG Charts - Unknown option `axes.y.crossLines[0][type=range].value`, ignoring.',
+            'AG Charts - Unknown option `axes.y.crossLines[0][type=range].value`; Did you mean `range`? Ignoring.',
         ],
     },
 };

--- a/packages/ag-charts-core/src/state/validation.ts
+++ b/packages/ag-charts-core/src/state/validation.ts
@@ -37,6 +37,7 @@ const similarOptionsMap = [
     ['src', 'url'],
     ['width', 'thickness'],
     ['show', 'visible', 'enabled'],
+    ['value', 'range'],
 ].reduce((map, words) => {
     for (const word of words) {
         map.set(word.toLowerCase(), new Set(words.filter((w) => w !== word)));

--- a/packages/ag-charts-types/src/series/cartesian/commonOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/commonOptions.ts
@@ -295,13 +295,13 @@ export interface ImageSegment {
     type: 'image';
     /** URL of the image. */
     url: string;
-    /** Box width in pixels. Required to keep layout stable before the image decodes. */
+    /** Box width in pixels. */
     width: PixelSize;
-    /** Box height in pixels. Required to keep layout stable before the image decodes. */
+    /** Box height in pixels. */
     height: PixelSize;
     /**
-     * Textual description of the image, used for the plain-text representation surfaced to
-     * accessibility tooling and consumers that flatten labels to strings (tooltips, exports).
+     * Textual description of the image, used for
+     * accessibility and consumers that flatten labels to strings (tooltips, exports).
      * Omitting `alt` causes an image-only label to read as empty.
      */
     alt?: string;

--- a/packages/ag-charts-types/src/series/cartesian/waterfallOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/waterfallOptions.ts
@@ -16,11 +16,7 @@ import type { AgBaseCartesianSeriesAxisOptions, FillOptions, LineDashOptions, St
 export type AgWaterfallSeriesItemType = 'positive' | 'negative' | 'total' | 'subtotal';
 
 interface AgWaterfallSeriesItemIdParams {
-    /**
-     * The stable identifier of the bar, matching the `itemId` on node events and `activeItem`. For `total` and
-     * `subtotal` bars this is the `totals.itemId` if supplied, otherwise the `axisLabel`. For `positive` and
-     * `negative` bars it is the `dataIdKey` value if set, otherwise the bar's positional index.
-     */
+    /** The unique identifier of the item. */
     itemId: string | number;
 }
 
@@ -141,9 +137,7 @@ export interface WaterfallSeriesTotalMeta {
     /** The label to display at the axis position where the total value is positioned. */
     axisLabel: string;
     /**
-     * A stable identifier for this total bar, surfaced as `itemId` in node events, `activeItem` and the
-     * item callbacks. Synthetic total/subtotal bars have no entry in the data array, so this is the only
-     * way to give them a user-controlled identifier; when omitted, `itemId` falls back to the bar's `axisLabel`.
+     * A unique identifier for the `itemId` of this bar in events and callbacks. When omitted, `itemId` falls back to the bar's `axisLabel`.
      */
     itemId?: string;
 }

--- a/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
@@ -118,6 +118,8 @@ A `legendItemName` can be added to the legend initial state and series options, 
 
 The `active` state gives programmatic control over chart highlighting and tooltips, as well as saving and restoring the active state.
 
+The active item's `itemId` is derived as described in [Item Identifiers](./events/#item-identifiers).
+
 {% chartExampleRunner title="Active State" name="active-save-restore" type="generated" /%}
 
 In this example:

--- a/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
@@ -5,7 +5,7 @@ description: 'Use $framework chart time axis to display time-based data in a $fr
 
 Time axes are used to display time-based data in a chart. They can be used to show data at different levels of granularity, such as years, months, days, or even hours and minutes.
 
-Time can be provided as `number` or `Date` objects, where `number` values are interpreted as timestamps derived from Unix time. Strict [ISO 8601](#iso-8601-strings) strings are also accepted.
+Time can be provided as a `Date` object, a `number` which is interpreted as timestamps derived from Unix time or an [ISO 8601 string](#iso-8601-strings).
 
 There are three methods of displaying time along an axis.
 
@@ -16,14 +16,6 @@ There are three methods of displaying time along an axis.
 The difference between a [Unit Time Axis](#unit-time), an [Ordinal Time Axis](#ordinal-time), and a [Continuous Time Axis](#continuous-time) is demonstrated in the following example:
 
 {% chartExampleRunner title="Time Axis Types" name="time-vs-unit-time-vs-ordinal-time" type="generated" /%}
-
-## ISO 8601 Strings
-
-A time axis accepts strict ISO 8601 date and date-time strings directly, without converting them to `Date` objects first. Time-zone offsets are applied when parsing, and axis labels are rendered in the viewer's local time zone. Strings without an explicit offset are interpreted in local time; mixing explicit and implicit offsets within one column logs a console warning.
-
-{% chartExampleRunner title="ISO 8601 Strings" name="iso-8601-time-axis" type="generated" /%}
-
-Strings that are not valid ISO 8601 are skipped, and a warning naming the first such value is logged to the console. The remaining rows still render.
 
 ## Unit Time
 

--- a/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
@@ -5,7 +5,7 @@ description: 'Use $framework chart time axis to display time-based data in a $fr
 
 Time axes are used to display time-based data in a chart. They can be used to show data at different levels of granularity, such as years, months, days, or even hours and minutes.
 
-Time can be provided as a `Date` object, a `number` which is interpreted as timestamps derived from Unix time or an [ISO 8601 string](#iso-8601-strings).
+Time can be provided as a `Date` object, a `number` which is interpreted as timestamps derived from Unix time or an ISO 8601 string.
 
 There are three methods of displaying time along an axis.
 

--- a/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/chord-series/index.mdoc
@@ -81,23 +81,6 @@ The styling of all links can be customised using the `link` property.
 }
 ```
 
-## Node Identifiers
-
-Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getItemId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
-
-```js format="snippet"
-{
-    series: [
-        {
-            type: 'chord',
-            fromKey: 'from',
-            toKey: 'to',
-            getItemId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
-        },
-    ],
-}
-```
-
 ## API Reference
 
 {% tabs %}

--- a/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
@@ -145,7 +145,7 @@ Numeric values may be supplied as:
 }
 ```
 
-If a field mixes `number` and `bigint` values, AG Charts logs a warning and narrows the bigints to `number`, which may lose precision beyond ±(2⁵³ − 1). Keep to one numeric type per field.
+If a field mixes `number` and `bigint` values, AG Charts logs a warning and narrows the `bigint` values to `number`, which may lose precision beyond ±(2⁵³ − 1). Keep to one numeric type per field.
 
 Numeric values are displayed on [Number](./axes-types/#number) and [Log](./axes-types/#log) axes, and used by colour and size scales.
 

--- a/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/data-configuration/index.mdoc
@@ -103,6 +103,58 @@ However, to support scenarios where different data sources are needed, each indi
 When a series specifies its own `data` array, it overrides the root-level data option for that series only.
 Other series continue to use root-level data.
 
+## Data Types
+
+The following formats are accepted for each type of value.
+
+### Time
+
+Time values may be supplied as:
+
+- A JavaScript `Date` object.
+- A numeric Unix epoch, in milliseconds since 1 January 1970 (UTC).
+- A `bigint` Unix epoch, for values beyond the safe range of `number` (2⁵³ − 1).
+- An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date or date-time string.
+
+```js format="snippet"
+{
+    data: [
+        { time: new Date(2023, 0, 1), value: 50 }, // JavaScript Date
+        { time: 1672531200000, value: 65 }, // Unix epoch (milliseconds)
+        { time: '2023-02-01', value: 78 }, // ISO 8601 date
+        { time: '2023-02-01T14:30:00Z', value: 90 }, // ISO 8601 date-time
+    ],
+}
+```
+
+Time values are displayed on [Time Axes](./axes-types/#time).
+
+### Numbers
+
+Numeric values may be supplied as:
+
+- A `number`, for integers and decimals.
+- A `bigint`, for integers beyond the safe range of `number` (2⁵³ − 1).
+
+```js format="snippet"
+{
+    data: [
+        { id: 'a', count: 1500 }, // number
+        { id: 'b', count: 9007199254740993n }, // bigint
+    ],
+}
+```
+
+If a field mixes `number` and `bigint` values, AG Charts logs a warning and narrows the bigints to `number`, which may lose precision beyond ±(2⁵³ − 1). Keep to one numeric type per field.
+
+Numeric values are displayed on [Number](./axes-types/#number) and [Log](./axes-types/#log) axes, and used by colour and size scales.
+
+### Categories
+
+Category values may be any type. Strings are used directly; other values are converted with `toString()`.
+
+Category values are displayed on [Category Axes](./axes-types/#category).
+
 ## Field Dot Notation
 
 By default, AG Charts supports dot notation for accessing nested properties in your data.

--- a/packages/ag-charts-website/src/content/docs/events/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/events/index.mdoc
@@ -43,7 +43,7 @@ This is fired when the visibility of a series or data item is toggled. This is u
 This event contains:
 
 - The `seriesId` of the series.
-- The `itemId`, `legendItemName` or other identifiers of the changed item.
+- The `itemId` (see [Item Identifiers](#item-identifiers)), `legendItemName` or other identifiers of the changed item.
 - `visible` - the new visibility state of the series or item.
 
 {% chartExampleRunner title="Series Visibility Changed" name="series-visibility-change" type="generated" /%}
@@ -75,7 +75,7 @@ The event contains:
 - `activeItem` - the item that is now active, or `undefined` if no item is active.
 - The `activeItem` contains:
     - `type` - the type of the active item, either `'series-node'` or `'legend'`.
-    - `seriesId` and `itemId` identifying the active item.
+    - `seriesId` and `itemId` identifying the active item. See [Item Identifiers](#item-identifiers).
 - `datum` - the data from the chart data array for the active item.
 - `source` - the source of the event, either `'user-interaction'` or `'state-change'`.
 
@@ -161,7 +161,7 @@ These are fired on click or double-click of a legend item.
 These events contain:
 
 - The `seriesId` of the series associated with the legend item.
-- The `itemId`, usually the `yKey` value for cartesian series.
+- The `itemId`, usually the `yKey` value for cartesian series. See [Item Identifiers](#item-identifiers).
 
 {% chartExampleRunner title="Legend Item Click Event" name="legend-item-click-event" type="generated" /%}
 
@@ -199,6 +199,17 @@ In this example:
 - `'exact'` (default) will trigger the event if the user clicks exactly on a node.
 - `'nearest'` will trigger the event for whichever node is nearest to the click.
 - Given a number it will trigger the event when the click is made within that many pixels of a node.
+
+## Item Identifiers
+
+Many events expose an `itemId` to identify the item within its series. How it is derived depends on the item type:
+
+- **Series nodes** use a node identifier.
+    - Automatically generated from the data, and may change when the data updates.
+    - Set `dataIdKey` to use a `datum` field as a stable identifier across data updates (see [Identifying Items by Key](./transactions/#identifying-items-by-key)).
+    - Series whose nodes don't map directly to a datum - such as [Histogram](./histogram-series/) bins and [Sankey](./sankey-series/) or [Chord](./chord-series/) nodes - expose a `getItemId` callback instead.
+    - [Waterfall](./waterfall-series/) `total` and `subtotal` bars use their `totals.itemId` if set, otherwise their `totals.axisLabel`.
+- **Legend items** use the legend item's identifier. Typically the `yKey` value for most series, or the legend item's position for series with one legend item per datum, such as `pie` and `donut`.
 
 ## API Reference
 

--- a/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
@@ -58,7 +58,12 @@ In this configuration:
 - `size` formats the `sizeKey` values as a decimal number with no fractional digits.
 - `label` formats the label values removing additional information when it is a series label, otherwise returns the value as-is for the tooltip. It does this based on the `source` value.
 
-The available properties are `x`, `y`, `angle`, `radius`, `size`, `color`, `label`, `secondaryLabel`, `calloutLabel`, and `sectorLabel`. These mirror the `_Key` properties
+The available properties are `x`, `y`, `angle`, `radius`, `size`, `color`, `label`, `secondaryLabel`, `calloutLabel`, and `sectorLabel`. These mirror the `_Key` properties.
+
+{% note %}
+Each key formats its corresponding `_Key` data, not the visual element.  
+For example, `label` formats `labelKey` values on series that use it. Series labels on Line and Bar come from `yKey`, and so use the `y` key, optionally combined with `source === 'series-label'`.
+{% /note %}
 
 ## Inheritance and Precedence
 

--- a/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/histogram-series/index.mdoc
@@ -128,48 +128,6 @@ The default aggregation method is `sum`. Use the `aggregation` option to change 
 }
 ```
 
-## Bin Identifiers
-
-Each bin has a stable identifier, surfaced as the `itemId` in node events and active state. By default this identifier is generated from the bin boundaries. Use `getItemId` to map a bin to an identifier from your own domain. The returned value must be unique across the bins in the series.
-
-```js format="snippet"
-{
-    series: [
-        {
-            type: 'histogram',
-            xKey: 'age',
-            getItemId: ({ binRange }) => `${binRange[0]}-${binRange[1]}yrs`,
-        },
-    ],
-}
-```
-
-## Bin Data in Callbacks
-
-Histogram callbacks - `tooltip.renderer`, `label.formatter`, `listeners.seriesNodeClick`, `listeners.seriesNodeDoubleClick`, and context menu items - all receive the same bin data:
-
-- `datums`: the array of source data rows grouped into the bin. (`datum` is `undefined`, since a bin has no single row.)
-- `binIndex`: the zero-based position of the bin in the series, defined for empty bins too.
-- `binRange`: the bin's `[start, end]` bounds on the x-axis.
-- `aggregatedValue`: the aggregated `yKey` value for the bin.
-- `frequency`: the number of source rows in the bin.
-
-```js format="snippet"
-{
-    series: [
-        {
-            type: 'histogram',
-            xKey: 'age',
-            listeners: {
-                seriesNodeClick: ({ binRange, frequency, datums }) => {
-                    console.log(`${frequency} people aged ${binRange[0]}-${binRange[1]}`, datums);
-                },
-            },
-        },
-    ],
-}
-```
-
 ## API Reference
 
 {% tabs %}

--- a/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
@@ -111,7 +111,7 @@ By default, the Line series uses a [Category Axis](./axes-types/#category) to pl
 
 {% chartExampleRunner title="Time Data: Temperature Sensors" name="time-line" type="generated" /%}
 
-- Time can be provided as a `Date` object, a `number` which is interpreted as timestamps derived from Unix time or an [ISO 8601 string](./axes-time/#iso-8601-strings).
+- Time can be provided as a `Date` object, a `number` which is interpreted as timestamps derived from Unix time or an ISO 8601 string.
 - See [Time Axes](./axes-time) for more information about the different time axes available.
 - All time axes automatically select an appropriate label format depending on the time span of the data, making a best-effort attempt to prevent the labels from overlapping.
 

--- a/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/line-series/index.mdoc
@@ -111,7 +111,7 @@ By default, the Line series uses a [Category Axis](./axes-types/#category) to pl
 
 {% chartExampleRunner title="Time Data: Temperature Sensors" name="time-line" type="generated" /%}
 
-- Time can be provided as `number` or `Date` objects, where `number` values are interpreted as timestamps derived from Unix time.
+- Time can be provided as a `Date` object, a `number` which is interpreted as timestamps derived from Unix time or an [ISO 8601 string](./axes-time/#iso-8601-strings).
 - See [Time Axes](./axes-time) for more information about the different time axes available.
 - All time axes automatically select an appropriate label format depending on the time span of the data, making a best-effort attempt to prevent the labels from overlapping.
 

--- a/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
@@ -137,7 +137,7 @@ Use the Navigator to zoom into the middle of the data, then try the buttons:
 - '1M Centre' and '3M Centre' - Zooms to 1 or 3 months centred on the midpoint of the current window.
 - '< 1M' and '1M >' - Pan the entire window one month backward or forward.
 
-The function receives a single params object with these properties:
+The function receives a single params object which includes the following properties:
 
 - `start` and `end` - The full data domain bounds.
 - `windowStart` and `windowEnd` - The currently visible range.

--- a/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sankey-series/index.mdoc
@@ -165,23 +165,6 @@ The styling of all links can be customised using the `link` property.
 }
 ```
 
-## Node Identifiers
-
-Each node has a stable identifier, surfaced as the `itemId` in node events and active state. By default this is the node name taken from the `fromKey` and `toKey` values. Use `getItemId` to map a node to an identifier from your own domain. The returned value must be unique across nodes and links, which share one `itemId` namespace (links default to `link-<index>`).
-
-```js format="snippet"
-{
-    series: [
-        {
-            type: 'sankey',
-            fromKey: 'from',
-            toKey: 'to',
-            getItemId: ({ nodeName }) => nodeName.toLowerCase().replace(/\s+/g, '-'),
-        },
-    ],
-}
-```
-
 ## API Reference
 
 {% tabs %}

--- a/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/index.html
+++ b/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/index.html
@@ -1,0 +1,10 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <button onclick="toggleDarkMode()">Toggle Dark Mode</button>
+        <span id="status">Mode: Light — no chart.update() called</span>
+    </div>
+</div>
+<div id="charts" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem">
+    <div id="chart1"></div>
+    <div id="chart2"></div>
+</div>

--- a/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/main.ts
@@ -1,0 +1,73 @@
+// @ag-skip-fws
+import {
+    AgBarSeriesOptions,
+    AgCartesianChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
+
+const theme: AgCartesianChartOptions['theme'] = {
+    params: {
+        backgroundColor: 'var(--chart-bg)',
+        foregroundColor: 'var(--chart-fg)',
+    },
+};
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('chart1'),
+    theme,
+    title: { text: 'Monthly Revenue' },
+    data: [
+        { month: 'Jan', revenue: 120 },
+        { month: 'Feb', revenue: 150 },
+        { month: 'Mar', revenue: 180 },
+        { month: 'Apr', revenue: 140 },
+        { month: 'May', revenue: 210 },
+        { month: 'Jun', revenue: 190 },
+    ],
+    series: [
+        {
+            type: 'bar',
+            xKey: 'month',
+            yKey: 'revenue',
+            yName: 'Revenue',
+            fill: 'var(--series-fill-1)',
+        } as AgBarSeriesOptions,
+    ],
+    axes: { x: { type: 'category' }, y: { type: 'number' } },
+};
+
+AgCharts.create(options);
+
+const options2: AgCartesianChartOptions = {
+    container: document.getElementById('chart2'),
+    theme,
+    title: { text: 'Product Sales' },
+    data: [
+        { product: 'Alpha', units: 80, returns: 20 },
+        { product: 'Beta', units: 110, returns: 15 },
+        { product: 'Gamma', units: 95, returns: 30 },
+        { product: 'Delta', units: 60, returns: 10 },
+    ],
+    series: [
+        { type: 'bar', xKey: 'product', yKey: 'units', yName: 'Units Sold', fill: 'var(--series-fill-2)' },
+        { type: 'bar', xKey: 'product', yKey: 'returns', yName: 'Returns', fill: 'var(--series-fill-3)' },
+    ] as AgBarSeriesOptions[],
+    axes: { x: { type: 'category' }, y: { type: 'number' } },
+};
+
+AgCharts.create(options2);
+
+let dark = false;
+
+function toggleDarkMode() {
+    dark = !dark;
+    document.body.classList.toggle('dark', dark);
+    document.getElementById('status')!.textContent = `Mode: ${dark ? 'Dark' : 'Light'} — no chart.update() called`;
+}

--- a/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/main.ts
@@ -71,3 +71,5 @@ function toggleDarkMode() {
     document.body.classList.toggle('dark', dark);
     document.getElementById('status')!.textContent = `Mode: ${dark ? 'Dark' : 'Light'} — no chart.update() called`;
 }
+
+(window as any).toggleDarkMode = toggleDarkMode;

--- a/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/styles.css
+++ b/packages/ag-charts-website/src/content/docs/themes-test/_examples/css-variables-dark-mode/styles.css
@@ -1,0 +1,16 @@
+body {
+    --chart-bg: #ffffff;
+    --chart-fg: #333333;
+    --series-fill-1: #4f81bd;
+    --series-fill-2: #c0504d;
+    --series-fill-3: #9bbb59;
+}
+
+body.dark {
+    background: #1a1a2e;
+    --chart-bg: #1a1a2e;
+    --chart-fg: #eeeeee;
+    --series-fill-1: #5ba3f5;
+    --series-fill-2: #f5786a;
+    --series-fill-3: #6bcf7f;
+}

--- a/packages/ag-charts-website/src/content/docs/themes-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/themes-test/index.mdoc
@@ -5,3 +5,7 @@ title: 'Themes Test'
 ## CSS Variables
 
 {% chartExampleRunner title="CSS Variables" name="css-variables" type="generated" /%}
+
+## Global Dark Mode via CSS Variables
+
+{% chartExampleRunner title="Global Dark Mode via CSS Variables" name="css-variables-dark-mode" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/transactions/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/transactions/index.mdoc
@@ -145,6 +145,8 @@ When `dataIdKey` is set:
 - **Update** operations match by ID and replace the existing datum with the new object.
 - **Add** operations work the same as without `dataIdKey`.
 
+`dataIdKey` also determines the `itemId` exposed in many node events and states. See [Item Identifiers](./events/#item-identifiers) for more details.
+
 {% chartExampleRunner title="ID-Based Transaction" name="id-based-transaction" type="generated" /%}
 
 - **Add 3 Items**: Appends 3 new items to the dataset.

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -76,6 +76,7 @@ The minimum supported version of TypeScript is now 5.8.
 ### Waterfall Series
 
 - Callbacks now receive `datum: undefined` for total and subtotal bars. Use `params.itemType` to identify `'total'` and `'subtotal'` bars.
+- `label.formatter` now receives `itemType: 'subtotal'` for subtotal bars, which previously reported `'total'`.
 
 ### Histogram Series
 
@@ -89,17 +90,15 @@ All histogram callbacks (`tooltip.renderer`, `label.formatter`, `seriesNodeClick
 
 ### Numeric and Time-Axis Value Types
 
-Numeric value channels now accept `bigint`, for integers beyond `Number.MAX_SAFE_INTEGER`. Time axes also accept `bigint` epochs and ISO 8601 date strings. Two new types describe this: `AgNumericValue` (`number | bigint`) and `AgTimeValue` (`Date | number | bigint | string`).
+Numeric value channels now accept `bigint`, and time axes also accept `bigint` epochs and ISO 8601 date strings. Two new types describe this: `AgNumericValue` (`number | bigint`) and `AgTimeValue` (`Date | number | bigint | string`).
 
-Accepting these as input is backwards-compatible. Several output types — values the library passes back to your callbacks — have been widened from `number` to `AgNumericValue`:
+These output types have been widened from `number` to `AgNumericValue`:
 
 - The `value` passed to number and axis-tick formatters.
 - A continuous axis's `visibleDomain`.
 - The bin range and aggregated value passed to `histogram` tooltip and label callbacks.
 
-If a callback assigns one of these to a `number`-typed variable, or does number-only arithmetic on it, narrow it with `Number(value)`. Runtime values are unchanged: they remain `number` unless your data supplies `bigint` or ISO 8601 values.
-
-Data-space input options also accept `bigint`, so fixed bounds can match `bigint` data exactly:
+These input options now also accept `bigint`:
 
 - Continuous-axis `min`, `max`, `preferredMin`, `preferredMax` and `interval.step`.
 - Cross-line `value` and `range`.
@@ -114,7 +113,7 @@ Data-space input options also accept `bigint`, so fixed bounds can match `bigint
 
 ### Range Buttons
 
-- `AgRangesButtonValueFunction` now receives a single params object instead of positional arguments. Replace `(start, end, windowStart, windowEnd, source) => [...]` with `({ start, end, windowStart, windowEnd, source }) => [...]`.
+- AgRangesButtonValueFunction now receives all arguments within a single params object.
 
 {% /expandingSection %}
 
@@ -145,11 +144,14 @@ This release includes the following behaviour changes:
 ### Bubble Series
 
 - Out-of-domain values now clamp to `[minSize, maxSize]` instead of extrapolating beyond the bounds.
-- Setting both `minSize` and `maxSize` explicitly with `minSize > maxSize` now emits a warning and falls back to theme defaults. Use `sizeDomain: [max, min]` to reverse the size scale.
+
+### Size Scaling
+
+- Setting an explicit minimum larger than an explicit maximum now emits a warning and falls back to theme defaults on Bubble (`minSize`/`maxSize`), Map Marker (`minSize`/`maxSize`) and Map Line (`minStrokeWidth`/`maxStrokeWidth`). Use `sizeDomain: [max, min]` to reverse the size scale.
 
 ### Map Marker and Map Line Series
 
-- The default Map Marker `size` has changed from `6` to `7` to align with the other circle marker series (Bubble, Scatter, Line, Area). Charts relying on the default render markers slightly larger.
+- The default Map Marker `size` has changed from `6` to `7`.
 - Map Marker gains `minSize` and Map Line gains `minStrokeWidth` as the explicit lower bound of the size scale when `sizeKey` is set. Each defaults to `size`/`strokeWidth` respectively. When `sizeKey` is absent, `size`/`strokeWidth` remain the fixed marker size and line width.
 - Setting both bounds explicitly with the lower bound greater than the upper bound now emits a warning and falls back to theme defaults.
 
@@ -157,9 +159,17 @@ This release includes the following behaviour changes:
 
 - The default value of `scrollbar.enableSeriesAreaScrolling` has changed from `false` to `true`.
 
+### Selection
+
+- Generated selection `itemId` values (when `dataIdKey` is not set) have changed and are not stable across versions. Set `dataIdKey` if you depend on stable identifiers.
+
 ### Zoom
 
 - Setting `initialState.zoom.rangeX` or `initialState.zoom.rangeY` with string values now applies the zoom range correctly on category axes. Previously these values produced a console warning and were ignored.
+
+### Time Axis Labels
+
+- On time axes, an explicitly enabled parent label tier (`parentLevel.label`) now renders even when `label.enabled: false`.
 
 {% /expandingSection %}
 

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/total-subtotal-values/main.ts
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/_examples/total-subtotal-values/main.ts
@@ -39,9 +39,9 @@ const options: AgChartOptions = {
             yKey: 'amount',
             yName: 'Amount',
             totals: [
-                { totalType: 'subtotal', index: 4, axisLabel: 'Total Revenue' },
-                { totalType: 'subtotal', index: 9, axisLabel: 'Total Expenditure' },
-                { totalType: 'total', index: 9, axisLabel: 'Total Borrowing' },
+                { totalType: 'subtotal', index: 4, axisLabel: 'Total Revenue', itemId: 'total-revenue' },
+                { totalType: 'subtotal', index: 9, axisLabel: 'Total Expenditure', itemId: 'total-expenditure' },
+                { totalType: 'total', index: 9, axisLabel: 'Total Borrowing', itemId: 'total-borrowing' },
             ],
         },
     ],

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/index.mdoc
@@ -43,7 +43,7 @@ These values are automatically calculated based on the following criteria:
 
 Total and Subtotal values are added to the `totals` array within the `series` options object.
 
-```js format="snippet"
+```js format="snippet" printWidth=115
 {
     series: [
         {
@@ -51,9 +51,9 @@ Total and Subtotal values are added to the `totals` array within the `series` op
             xKey: 'financials',
             yKey: 'amount',
             totals: [
-                { totalType: 'subtotal', index: 4, axisLabel: 'Total Revenue' },
-                { totalType: 'subtotal', index: 9, axisLabel: 'Total Expenditure' },
-                { totalType: 'total', index: 9, axisLabel: 'Total Borrowing' },
+                { totalType: 'subtotal', index: 4, axisLabel: 'Total Revenue', itemId: 'total-revenue' },
+                { totalType: 'subtotal', index: 9, axisLabel: 'Total Expenditure', itemId: 'total-expenditure' },
+                { totalType: 'total', index: 9, axisLabel: 'Total Borrowing', itemId: 'total-borrowing' },
             ],
         },
     ],
@@ -64,7 +64,8 @@ In this configuration:
 
 - `totalType` specifies whether the value is a Total or Subtotal.
 - `index` determines the position in the data after which the Total or Subtotal will appear.
-- `axisLabel` is used to provide a unique label, used as a category on the [Category Axis](./axes-types/#category).
+- `axisLabel` is the label shown as a category on the [Category Axis](./axes-types/#category).
+- `itemId` is an optional unique [identifier](./events/#item-identifiers) for the total, surfaced in events and callbacks. Totals that share an `axisLabel` must each set a unique `itemId` to remain distinguishable.
 
 ## Customisation
 

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -15,7 +15,8 @@
                 "path": "./themes/"
             },
             {
-                "text": "Improved Data Types"
+                "text": "BigInt and ISO 8601 Support",
+                "path": "./data-configuration/#data-types"
             }
         ],
         "notesPath": "./upgrade-to-ag-charts-14"


### PR DESCRIPTION
## Summary

Documentation and options refinements grouped around two themes: how item identifiers are derived, and the data types AG Charts accepts.

**Item Identifiers**
- New **Item Identifiers** section in the events docs explaining how `itemId` is derived for series nodes (auto-generated, `dataIdKey`, `getItemId`, waterfall totals) and legend items.
- Cross-linked from api-state, transactions, events and waterfall docs.
- Removed the duplicated per-series identifier sections from the chord, sankey and histogram docs in favour of the single reference.
- Documented and exemplified waterfall `totals.itemId`, and added `['value', 'range']` to the validation similar-options map.

**Data Types**
- New **Data Types** section in the data-configuration docs covering `Date`, `number`, `bigint` (numeric and Unix epoch), ISO 8601 strings, and category values.
- Replaced the standalone "ISO 8601 Strings" section in the time-axis docs; line-series and versions notes updated to point at the new section.

**Other**
- Tightened the waterfall and image-segment type JSDocs.
- Refreshed the v14 upgrade notes (waterfall subtotal `itemType`, size scaling, selection `itemId` stability, time-axis labels).
- Added a themes-test example for global dark mode via CSS variables.

## Test plan
- [ ] `yarn nx test:e2e ag-charts-website`
- [ ] Visually verify the new data-configuration, events and themes-test examples render and the doc cross-links resolve.