### PR TITLE
AG-17459 re-render chart when external fonts finish loading

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -263,6 +263,7 @@ class AgChartsInternal {
         }
 
         chart.ctx.fontManager.updateFonts(chartOptions.googleFonts);
+        chart.ctx.fontManager.waitForFonts(chartOptions.fonts);
 
         if (data != null) {
             chart.ctx.dataService.restoreData(data);

--- a/packages/ag-charts-community/src/chart/fonts/fontManager.test.ts
+++ b/packages/ag-charts-community/src/chart/fonts/fontManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { type DynamicContext, EventEmitter } from 'ag-charts-core';
 
@@ -6,6 +6,20 @@ import type { EventsHubMap } from '../../core/eventsHub';
 import type { DOMManager } from '../../dom/domManager';
 import type { ChartRegistry } from '../../module/moduleContext';
 import { FontManager } from './fontManager';
+
+// `getDocument('fonts')` (used by waitForFonts) reads the global document's FontFaceSet, so
+// override it per-test to exercise the path without relying on the jsdom font stub.
+const realFontsDescriptor = Object.getOwnPropertyDescriptor(document, 'fonts');
+function setDocumentFonts(fonts: unknown) {
+    Object.defineProperty(document, 'fonts', { value: fonts, configurable: true });
+}
+afterEach(() => {
+    if (realFontsDescriptor) {
+        Object.defineProperty(document, 'fonts', realFontsDescriptor);
+    } else {
+        delete (document as any).fonts;
+    }
+});
 
 // Capture the ResizeObserver callback so we can simulate a font load
 let resizeObserverCallback: ResizeObserverCallback | undefined;
@@ -69,6 +83,67 @@ describe('FontManager', () => {
             [{ contentBoxSize: [{ inlineSize: 0 }] }] as unknown as ResizeObserverEntry[],
             {} as ResizeObserver
         );
+
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    function createFontManager() {
+        const eventsHub = new EventEmitter<EventsHubMap>();
+        const fontManager = new FontManager({
+            domManager: createMockDomManager(),
+            eventsHub,
+        } as unknown as DynamicContext<ChartRegistry>);
+        const handler = vi.fn();
+        eventsHub.on('font:load', handler);
+        return { fontManager, handler };
+    }
+
+    it('waitForFonts loads the exact weight-specific shorthand and emits font:load once it settles', async () => {
+        const { fontManager, handler } = createFontManager();
+        const fontSet = { check: vi.fn().mockReturnValue(false), load: vi.fn().mockResolvedValue([]) };
+        setDocumentFonts(fontSet);
+
+        fontManager.waitForFonts(new Set(['900 16px "Font Awesome 6 Free"']));
+
+        expect(fontSet.load).toHaveBeenCalledWith('900 16px "Font Awesome 6 Free"');
+        await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+    });
+
+    it('waitForFonts skips already-available fonts and does not re-render', async () => {
+        const { fontManager, handler } = createFontManager();
+        const fontSet = { check: vi.fn().mockReturnValue(true), load: vi.fn() };
+        setDocumentFonts(fontSet);
+
+        fontManager.waitForFonts(new Set(['16px Arial']));
+
+        expect(fontSet.load).not.toHaveBeenCalled();
+        await Promise.resolve();
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('waitForFonts is a no-op without a document FontFaceSet (SSR)', async () => {
+        const { fontManager, handler } = createFontManager();
+        setDocumentFonts(undefined);
+
+        expect(() => fontManager.waitForFonts(new Set(['16px Roboto']))).not.toThrow();
+        await Promise.resolve();
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('waitForFonts does not emit after the chart is destroyed', async () => {
+        const { fontManager, handler } = createFontManager();
+        let resolveLoad: () => void = () => {};
+        const loadPromise = new Promise<void>((resolve) => {
+            resolveLoad = resolve;
+        });
+        const fontSet = { check: vi.fn().mockReturnValue(false), load: vi.fn().mockReturnValue(loadPromise) };
+        setDocumentFonts(fontSet);
+
+        fontManager.waitForFonts(new Set(['16px Roboto']));
+        fontManager.destroy();
+        resolveLoad();
+        await loadPromise;
+        await Promise.resolve();
 
         expect(handler).not.toHaveBeenCalled();
     });

--- a/packages/ag-charts-community/src/chart/fonts/fontManager.ts
+++ b/packages/ag-charts-community/src/chart/fonts/fontManager.ts
@@ -1,9 +1,10 @@
-import { type DynamicContext, cachedTextMeasurer, getResizeObserver } from 'ag-charts-core';
+import { type DynamicContext, cachedTextMeasurer, getDocument, getResizeObserver } from 'ag-charts-core';
 
 import type { ChartRegistry } from '../../module/moduleContext';
 
 export class FontManager {
     private observers: Array<ResizeObserver> = [];
+    private destroyed = false;
 
     constructor(private readonly ctx: DynamicContext<ChartRegistry>) {}
 
@@ -15,7 +16,38 @@ export class FontManager {
         }
     }
 
+    // Canvas text never triggers a font download, so externally-referenced fonts (icon fonts,
+    // user `@font-face`) may be unavailable when the chart first measures and draws. Force their
+    // load via the FontFaceSet API and re-render once they settle; `check()` skips already-loaded
+    // fonts. Each spec is a weight/style shorthand (e.g. `900 16px "Font Awesome 6 Free"`) so
+    // families that ship a file per weight load the one the options reference.
+    public waitForFonts(fontSpecs?: Set<string>) {
+        if (!fontSpecs || fontSpecs.size === 0) return;
+
+        const fontSet = getDocument('fonts');
+        if (fontSet == null) return;
+
+        const pending: Array<Promise<unknown>> = [];
+        for (const spec of fontSpecs) {
+            try {
+                if (!fontSet.check(spec)) {
+                    pending.push(fontSet.load(spec));
+                }
+            } catch {
+                // `check()` throws on an invalid font shorthand; skip that spec.
+            }
+        }
+        if (pending.length === 0) return;
+
+        void Promise.allSettled(pending).then(() => {
+            if (this.destroyed) return;
+            cachedTextMeasurer.clear();
+            this.ctx.eventsHub.emit('font:load', null);
+        });
+    }
+
     public destroy() {
+        this.destroyed = true;
         for (const observer of this.observers) {
             observer.disconnect();
         }

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -3246,4 +3246,39 @@ describe('ChartOptions', () => {
             expect((processed.series![0] as any).allowNullKeys).toBeUndefined();
         });
     });
+
+    describe('font extraction', () => {
+        function extractFonts(userOptions: AgChartOptions) {
+            const chartOptions = new ChartOptions(userOptions, {} as AgChartOptions, {}, {}, {});
+            return { fonts: chartOptions.fonts, googleFonts: chartOptions.googleFonts };
+        }
+
+        it('collects weight-specific shorthands for concrete families and excludes generics', () => {
+            const { fonts } = extractFonts({
+                data: [{ x: 'a', y: 1 }],
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+                title: {
+                    text: [{ text: '★', fontFamily: 'Font Awesome 6 Free', fontWeight: 900 }],
+                },
+                subtitle: { text: 'S', fontFamily: 'CustomFont, sans-serif' },
+            } as AgChartOptions);
+
+            // Weight is part of the spec so a family that ships a separate file per weight
+            // (e.g. FontAwesome solid vs regular) loads the file the options actually reference.
+            expect(fonts).toContain('900 16px "Font Awesome 6 Free"');
+            expect(fonts).toContain('16px CustomFont');
+            expect([...fonts].some((spec) => spec.includes('sans-serif'))).toBe(false);
+        });
+
+        it('routes google fonts to the googleFonts CDN set', () => {
+            const { googleFonts } = extractFonts({
+                data: [{ x: 'a', y: 1 }],
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+                loadGoogleFonts: true,
+                title: { text: 'T', fontFamily: { googleFont: 'Pacifico' } },
+            } as AgChartOptions);
+
+            expect(googleFonts).toContain('Pacifico');
+        });
+    });
 });

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -3250,7 +3250,10 @@ describe('ChartOptions', () => {
     describe('font extraction', () => {
         function extractFonts(userOptions: AgChartOptions) {
             const chartOptions = new ChartOptions(userOptions, {} as AgChartOptions, {}, {}, {});
-            return { fonts: chartOptions.fonts, googleFonts: chartOptions.googleFonts };
+            return {
+                fonts: chartOptions.fonts ?? new Set<string>(),
+                googleFonts: chartOptions.googleFonts ?? new Set<string>(),
+            };
         }
 
         it('collects weight-specific shorthands for concrete families and excludes generics', () => {

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -3283,5 +3283,19 @@ describe('ChartOptions', () => {
 
             expect(googleFonts).toContain('Pacifico');
         });
+
+        it('carries the referenced-font set through a fast-path delta update', () => {
+            const baseOptions: AgChartOptions = {
+                data: [{ x: 'a', y: 1 }],
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+                title: { text: [{ text: '★', fontFamily: 'Font Awesome 6 Free', fontWeight: 900 }] },
+            } as AgChartOptions;
+            const base = new ChartOptions(baseOptions, {} as AgChartOptions, {}, {}, {});
+
+            // A width-only delta takes the fast path, which never re-extracts fonts.
+            const updated = new ChartOptions(base, {} as AgChartOptions, {}, {}, {}, { width: 400 });
+
+            expect(updated.fonts).toContain('900 16px "Font Awesome 6 Free"');
+        });
     });
 });

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -1,10 +1,12 @@
 import {
+    CSS_GENERIC_FAMILIES,
     ChartAxisDirection,
     type ChartModuleDefinition,
     type CloneOptions,
     Color,
     Debug,
     type DeepPartial,
+    type FontOptions,
     Logger,
     ModuleRegistry,
     ModuleType,
@@ -35,6 +37,7 @@ import {
     setDocument,
     setWindow,
     shallowClone,
+    toFontString,
     unique,
     validate,
 } from 'ag-charts-core';
@@ -68,6 +71,47 @@ import {
     setStructuralCacheEntry,
 } from './optionsStructuralCache';
 import type { SeriesGrouping } from './seriesGrouping';
+
+interface FontAccumulator {
+    /** Google font families to load from the CDN (gated by `loadGoogleFonts`). */
+    googleFonts: Set<string>;
+    /**
+     * FontFaceSet shorthands (e.g. `900 16px "Font Awesome 6 Free"`) for every concrete font
+     * referenced in options, to wait on before re-rendering. Weight/style are part of the key
+     * because a single family (e.g. FontAwesome) ships each weight as a separate font file.
+     */
+    fonts: Set<string>;
+}
+
+function newFontAccumulator(): FontAccumulator {
+    return { googleFonts: new Set(), fonts: new Set() };
+}
+
+/**
+ * Collect FontFaceSet shorthands for each concrete family in a node's `fontFamily`, carrying the
+ * node's weight/style so weight-specific font files are loaded. CSS generic keywords
+ * (`sans-serif`, etc.) are never web fonts, so there is nothing to wait for.
+ */
+function addReferencedFonts(
+    fonts: Set<string>,
+    node: { fontFamily?: unknown; fontWeight?: unknown; fontStyle?: unknown }
+) {
+    const { fontFamily, fontWeight, fontStyle } = node;
+    if (typeof fontFamily !== 'string') return;
+    for (const part of fontFamily.split(',')) {
+        const family = part.trim().replace(/(^['"])|(['"]$)/g, '');
+        if (family !== '' && !CSS_GENERIC_FAMILIES.has(family.toLowerCase())) {
+            fonts.add(
+                toFontString({
+                    fontSize: 16,
+                    fontFamily: family,
+                    fontWeight: fontWeight as FontOptions['fontWeight'],
+                    fontStyle: fontStyle as FontOptions['fontStyle'],
+                })
+            );
+        }
+    }
+}
 
 export interface ChartSpecialOverrides {
     document: Document;
@@ -157,6 +201,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     themeParameters: AgChartThemeParams = {};
     annotationThemes: any;
     googleFonts?: Set<string>;
+    fonts?: Set<string>;
     fastDelta?: DeepPartial<T>;
     chartDef?: ChartModuleDefinition<any>;
     optionsProcessingTime?: number;
@@ -226,7 +271,14 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             deltaOptions?.data !== undefined &&
             deltaOptions?.data?.length !== currentUserOptions.userOptions.data?.length;
 
-        let activeTheme, processedOptions, fastDelta, themeParameters, annotationThemes, googleFonts, optionsGraph;
+        let activeTheme,
+            processedOptions,
+            fastDelta,
+            themeParameters,
+            annotationThemes,
+            googleFonts,
+            fonts,
+            optionsGraph;
         if (
             !stripSymbols &&
             !refreshCSSVariables &&
@@ -241,7 +293,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             annotationThemes = baseChartOptions.annotationThemes;
         } else {
             ChartOptions.perfDebug(`ChartOptions.slowSetup()`);
-            ({ activeTheme, processedOptions, themeParameters, annotationThemes, googleFonts, optionsGraph } =
+            ({ activeTheme, processedOptions, themeParameters, annotationThemes, googleFonts, fonts, optionsGraph } =
                 this.slowSetup(processedOverrides, deltaOptions, stripSymbols));
         }
 
@@ -251,6 +303,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         this.themeParameters = themeParameters;
         this.annotationThemes = annotationThemes;
         this.googleFonts = googleFonts;
+        this.fonts = fonts;
         this.optionsGraph = optionsGraph;
 
         // Capture options processing time for debug stats
@@ -402,8 +455,9 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         // TODO: Chicken-or-egg, ideally should pass themeParameters in here, but this processing needs to happen
         // first. Practically, it likely doesn't matter. Either way, this should be moved to a "plugin" on the
         // graph.
-        let googleFonts = this.processFonts(activeTheme.params);
-        googleFonts = this.processFonts(options, googleFonts);
+        let fontAccumulator = this.processFonts(activeTheme.params);
+        fontAccumulator = this.processFonts(options, fontAccumulator);
+        const { googleFonts } = fontAccumulator;
 
         // Process series options _before_ passing to the OptionsGraph. This ensures the series themes are applied in
         // the correct order to the re-ordered series.
@@ -443,6 +497,8 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             googleFonts.clear();
         }
 
+        const { fonts } = fontAccumulator;
+
         ChartOptions.debug(() => ['ChartOptions.slowSetup() - processed options', deepClone(processedOptions)]);
 
         if (cacheKey !== undefined) {
@@ -455,12 +511,13 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
                 processedOptions: rest,
                 themeParameters,
                 googleFonts: googleFonts.size > 0 ? new Set(googleFonts) : undefined,
+                fonts: fonts.size > 0 ? new Set(fonts) : undefined,
                 annotationThemes,
                 chartDef: this.chartDef,
             });
         }
 
-        return { activeTheme, processedOptions, themeParameters, annotationThemes, googleFonts, optionsGraph };
+        return { activeTheme, processedOptions, themeParameters, annotationThemes, googleFonts, fonts, optionsGraph };
     }
 
     private computeStructuralCacheKeyForSlowSetup(
@@ -512,6 +569,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             themeParameters: cached.themeParameters,
             annotationThemes: cached.annotationThemes,
             googleFonts: cached.googleFonts ? new Set(cached.googleFonts) : undefined,
+            fonts: cached.fonts ? new Set(cached.fonts) : undefined,
             optionsGraph,
         };
     }
@@ -1344,36 +1402,38 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         }
     }
 
-    private static processFontOptions(this: void, node: any, _?: any, __?: any, googleFonts: Set<string> = new Set()) {
+    private static processFontOptions(this: void, node: any, acc: FontAccumulator = newFontAccumulator()) {
         if (typeof node === 'object' && 'fontFamily' in node) {
+            const { fontWeight, fontStyle } = node;
             if (Array.isArray(node.fontFamily)) {
                 const fontFamily = [];
                 for (const font of node.fontFamily) {
                     if (typeof font === 'object' && 'googleFont' in font) {
                         fontFamily.push(font.googleFont);
-                        googleFonts?.add(font.googleFont);
+                        acc.googleFonts.add(font.googleFont);
+                        addReferencedFonts(acc.fonts, { fontFamily: font.googleFont, fontWeight, fontStyle });
                     } else {
                         fontFamily.push(font);
+                        addReferencedFonts(acc.fonts, { fontFamily: font, fontWeight, fontStyle });
                     }
                 }
                 node.fontFamily = fontFamily.join(', ');
             } else if (typeof node.fontFamily === 'object' && 'googleFont' in node.fontFamily) {
                 node.fontFamily = node.fontFamily.googleFont;
-                googleFonts?.add(node.fontFamily);
+                acc.googleFonts.add(node.fontFamily);
+                addReferencedFonts(acc.fonts, { fontFamily: node.fontFamily, fontWeight, fontStyle });
+            } else if (typeof node.fontFamily === 'string') {
+                addReferencedFonts(acc.fonts, { fontFamily: node.fontFamily, fontWeight, fontStyle });
             }
         }
-        return googleFonts;
+        return acc;
     }
 
-    private processFonts(options: object, googleFonts: Set<string> = new Set()) {
-        return jsonWalk<any, any, Set<string>>(
-            options,
-            ChartOptions.processFontOptions,
-            new Set(['data', 'theme']),
-            undefined,
-            undefined,
-            googleFonts
-        );
+    private processFonts(options: object, acc: FontAccumulator = newFontAccumulator()) {
+        // `jsonWalk` threads its accumulator via a different parameter slot than this visitor
+        // expects, so close over `acc` directly to collect fonts from every nested node.
+        jsonWalk(options, (node) => ChartOptions.processFontOptions(node, acc), new Set(['data', 'theme']));
+        return acc;
     }
 
     private static removeDisabledOptionJson(this: void, optionsNode: any) {

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -291,6 +291,8 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             ({ activeTheme, processedOptions, fastDelta } = this.fastSetup(deltaOptions, baseChartOptions));
             themeParameters = baseChartOptions.themeParameters;
             annotationThemes = baseChartOptions.annotationThemes;
+            // The fast path doesn't re-extract fonts, so carry them forward to keep waiting for them.
+            fonts = baseChartOptions.fonts;
         } else {
             ChartOptions.perfDebug(`ChartOptions.slowSetup()`);
             ({ activeTheme, processedOptions, themeParameters, annotationThemes, googleFonts, fonts, optionsGraph } =

--- a/packages/ag-charts-community/src/module/optionsStructuralCache.ts
+++ b/packages/ag-charts-community/src/module/optionsStructuralCache.ts
@@ -10,6 +10,7 @@ export interface StructuralCacheEntry {
     processedOptions: unknown;
     themeParameters: AgChartThemeParams;
     googleFonts: Set<string> | undefined;
+    fonts: Set<string> | undefined;
     annotationThemes: any;
     chartDef: ChartModuleDefinition<any>;
 }

--- a/packages/ag-charts-core/src/utils/text/textUtils.ts
+++ b/packages/ag-charts-core/src/utils/text/textUtils.ts
@@ -9,7 +9,7 @@ import { isArray, isDate, isNumber } from '../types/typeGuards';
 
 // CSS generic family keywords — must remain unquoted; quoting changes their
 // meaning from keyword to literal family-name lookup.
-const CSS_GENERIC_FAMILIES = new Set([
+export const CSS_GENERIC_FAMILIES = new Set([
     'serif',
     'sans-serif',
     'monospace',

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-emoji/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-emoji/main.ts
@@ -1,7 +1,5 @@
-// Tests emoji rendered through native canvas fillText across captions, axis
-// labels, and series labels. The larger flag glyph on the axis uses
-// `verticalAlign: 'middle'` so it centres against the country-code text
-// instead of sharing its text baseline.
+// Emoji render through native canvas with no API changes. The larger axis flag uses
+// verticalAlign: 'middle' to centre against the country-code text.
 import {
     AgChartOptions,
     AgCharts,

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/main.ts
@@ -1,12 +1,5 @@
-// Tests font-icon glyphs (FontAwesome) inline with text. Two things to know:
-//   1. FontAwesome 6 Free ships solid (weight 900) and regular (weight 400)
-//      as different files in the same family. Most icons (flag, arrows, star,
-//      chart-line) live only in solid, so segments must set fontWeight: 900.
-//   2. Canvas text rendering does not trigger font downloads. We inject the
-//      FontAwesome stylesheet at runtime (so the example works identically
-//      across frameworks) and create the chart once it has loaded. The chart
-//      detects the icon fonts referenced in its options, downloads them, and
-//      re-renders automatically once they are ready.
+// FontAwesome icons inline with text. Solid icons live in the weight-900 file, so their
+// segments set fontWeight: 900. The chart loads referenced fonts and re-renders once ready.
 import {
     AgChartOptions,
     AgCharts,
@@ -110,9 +103,7 @@ const options: AgChartOptions = {
     },
 };
 
-// Inject the FontAwesome stylesheet and create the chart once its `@font-face` rules are
-// registered. The font files themselves are not downloaded yet; the chart loads them and
-// re-renders automatically.
+// Create the chart once the FontAwesome stylesheet has loaded; the chart then fetches the fonts.
 const stylesheetReady = new Promise<void>((resolve) => {
     const link = document.createElement('link');
     link.rel = 'stylesheet';

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/main.ts
@@ -2,12 +2,11 @@
 //   1. FontAwesome 6 Free ships solid (weight 900) and regular (weight 400)
 //      as different files in the same family. Most icons (flag, arrows, star,
 //      chart-line) live only in solid, so segments must set fontWeight: 900.
-//   2. Canvas text rendering does not trigger font downloads — only DOM usage
-//      does. We inject the FontAwesome stylesheet at runtime (so the example
-//      works identically across frameworks) and then force the woff2 fetch
-//      via document.fonts.load() before creating the chart. The existing
-//      `loadGoogleFonts` mechanism in AG Charts only covers Google Fonts;
-//      arbitrary CSS-loaded fonts have no built-in preload gate today.
+//   2. Canvas text rendering does not trigger font downloads. We inject the
+//      FontAwesome stylesheet at runtime (so the example works identically
+//      across frameworks) and create the chart once it has loaded. The chart
+//      detects the icon fonts referenced in its options, downloads them, and
+//      re-renders automatically once they are ready.
 import {
     AgChartOptions,
     AgCharts,
@@ -111,17 +110,17 @@ const options: AgChartOptions = {
     },
 };
 
-const fontAwesomeReady = (() => {
+// Inject the FontAwesome stylesheet and create the chart once its `@font-face` rules are
+// registered. The font files themselves are not downloaded yet; the chart loads them and
+// re-renders automatically.
+const stylesheetReady = new Promise<void>((resolve) => {
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css';
     link.crossOrigin = 'anonymous';
     link.referrerPolicy = 'no-referrer';
+    link.onload = () => resolve();
     document.head.appendChild(link);
-    return Promise.all([
-        document.fonts.load(`${SOLID_WEIGHT} 16px "${ICON_FAMILY_SOLID}"`),
-        document.fonts.load(`400 16px "${ICON_FAMILY_SOLID}"`),
-    ]);
-})();
+});
 
-fontAwesomeReady.then(() => AgCharts.create(options));
+stylesheetReady.then(() => AgCharts.create(options));

--- a/packages/ag-charts-website/src/content/docs/fonts/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/fonts/index.mdoc
@@ -141,7 +141,7 @@ Emoji render through native canvas, no API changes required.
 
 {% chartExampleRunner title="Inline Emoji" name="inline-emoji" type="generated" /%}
 
-Font icons (e.g. FontAwesome) load via a CSS `<link>` in the example's `index.html` and apply per-segment through `fontFamily` and `fontWeight`. Because canvas text rendering does not trigger font downloads, the example also awaits `document.fonts.load(...)` before creating the chart.
+Font icons (e.g. FontAwesome) load via a CSS `<link>` and apply per-segment through `fontFamily` and `fontWeight`. Canvas text rendering does not trigger font downloads, so the chart detects the fonts referenced in its options, downloads them, and re-renders automatically once they are ready.
 
 {% chartExampleRunner title="Inline Font Icons" name="inline-font-icons" type="generated" /%}
 


### PR DESCRIPTION
## Summary

Canvas text rendering never triggers a font download the way DOM text does. When a chart renders before a referenced web/icon font (FontAwesome, a user `@font-face`) has downloaded, it measures and draws with a fallback and never revisits — so an icon glyph in a title is silently dropped until the font happens to be cached on a later load.

We already solve this for Google fonts (`loadGoogleFonts`): options are scanned for referenced families, the font is loaded, and the chart re-lays-out on a `font:load` event. This generalises that re-render-on-load behaviour to **any** externally loaded font, out of the box (no new option), using the `FontFaceSet` (`document.fonts`) API.

## Changes

- **Extraction (`optionsModule.ts`)**: while walking options for Google fonts, also collect a weight/style-specific `FontFaceSet` shorthand for every concrete referenced family (e.g. `900 16px "Font Awesome 6 Free"`). Weight/style are part of the key because a family like FontAwesome ships a separate font file per weight. CSS generic keywords (`sans-serif`, etc.) are excluded via the shared `CSS_GENERIC_FAMILIES` set (now exported from `ag-charts-core`).
- **`FontManager.waitForFonts()`**: for each shorthand, `document.fonts.check()` skips already-available fonts (so system fonts cause no redundant re-render) and `document.fonts.load()` forces the download canvas wouldn't; once the loads settle it clears the text-measurer cache and emits the existing `font:load` event, which `chart.ts` already handles by re-laying-out. SSR-safe (`getDocument('fonts')` returns `undefined` with no document) and guarded against late emits after destroy.
- **Wiring**: `agCharts.ts` calls `waitForFonts(chartOptions.fonts)` alongside the existing `updateFonts(...)`; `fonts` is threaded through `ChartOptions` and the structural cache.
- **Docs/example**: the `inline-font-icons` example now creates the chart once the FontAwesome stylesheet's `@font-face` rules are registered (instead of pre-awaiting the font files), demonstrating the automatic re-render. Docs prose updated to match.

## Test plan

- New unit tests:
  - `fontManager.test.ts` — `waitForFonts` loads the exact weight-specific shorthand and emits `font:load` once loads settle; skips already-available fonts; no-op without a `FontFaceSet`; no emit after destroy.
  - `optionsModule.test.ts` — extraction collects weight-specific shorthands for nested title `text` segments and excludes generic families; Google fonts route to the CDN set.
- `yarn nx test ag-charts-community` (3656) and `yarn nx test ag-charts-enterprise` pass; `build:types` and `lint` clean.
- Manually verified in the dev server: with the pre-await removed, the FontAwesome icons in the example title/subtitle render after the chart's automatic re-render.

## Notes

- The general font path intentionally does not exclude Google families; `check()` skips them when already loaded and the Google CDN path still drives their re-render, so there is no double work or regression.

Fix #AG-17459