### PR TITLE
Use code-block links for itemId refs; tidy histogram upgrade note

### DIFF
--- a/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
@@ -118,7 +118,7 @@ A `legendItemName` can be added to the legend initial state and series options, 
 
 The `active` state gives programmatic control over chart highlighting and tooltips, as well as saving and restoring the active state.
 
-The active item's `itemId` is derived as described in [Item Identifiers](./events/#item-identifiers).
+The active item's [`itemId`](./events/#item-identifiers) is derived as described in the Item Identifiers section.
 
 {% chartExampleRunner title="Active State" name="active-save-restore" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/events/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/events/index.mdoc
@@ -43,7 +43,7 @@ This is fired when the visibility of a series or data item is toggled. This is u
 This event contains:
 
 - The `seriesId` of the series.
-- The `itemId` (see [Item Identifiers](#item-identifiers)), `legendItemName` or other identifiers of the changed item.
+- The [`itemId`](#item-identifiers), `legendItemName` or other identifiers of the changed item.
 - `visible` - the new visibility state of the series or item.
 
 {% chartExampleRunner title="Series Visibility Changed" name="series-visibility-change" type="generated" /%}
@@ -75,7 +75,7 @@ The event contains:
 - `activeItem` - the item that is now active, or `undefined` if no item is active.
 - The `activeItem` contains:
     - `type` - the type of the active item, either `'series-node'` or `'legend'`.
-    - `seriesId` and `itemId` identifying the active item. See [Item Identifiers](#item-identifiers).
+    - `seriesId` and [`itemId`](#item-identifiers) identifying the active item.
 - `datum` - the data from the chart data array for the active item.
 - `source` - the source of the event, either `'user-interaction'` or `'state-change'`.
 
@@ -161,7 +161,7 @@ These are fired on click or double-click of a legend item.
 These events contain:
 
 - The `seriesId` of the series associated with the legend item.
-- The `itemId`, usually the `yKey` value for cartesian series. See [Item Identifiers](#item-identifiers).
+- The [`itemId`](#item-identifiers), usually the `yKey` value for cartesian series.
 
 {% chartExampleRunner title="Legend Item Click Event" name="legend-item-click-event" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -80,13 +80,10 @@ The minimum supported version of TypeScript is now 5.8.
 
 ### Histogram Series
 
-All histogram callbacks (`tooltip.renderer`, `label.formatter`, `seriesNodeClick`, `seriesNodeDoubleClick`, and context menu callbacks) now receive a consistent set of params: `datums` is `TDatum[]` (the raw source rows in the bin), with `binIndex`, `aggregatedValue`, `frequency`, and `binRange` as top-level fields. `datum` is `undefined`, since a bin has no single source row.
+All histogram callbacks (`tooltip.renderer`, `label.formatter`, `seriesNodeClick`, `seriesNodeDoubleClick`, and context menu callbacks) are affected:
 
-- In `tooltip.renderer`, the bin rows move from `datum` (which was `AgHistogramBinDatum`) to `datums`.
-- In `seriesNodeClick`, `seriesNodeDoubleClick`, and context menu callbacks, the bin rows are exposed as `datums` (the raw source objects), replacing the extracted column values previously on `datum`.
-- `xRange` is removed from `tooltip.renderer` params. Use `binRange` instead.
-- The bin-object `domain` field is removed from `tooltip.renderer` params.
-- `binIndex`, `aggregatedValue`, `frequency`, and `binRange` are added as top-level params to all histogram callbacks.
+- `datum` is now `undefined`, since a bin has no single source row. The bin source rows are exposed as `datums: TDatum[]`.
+- In `tooltip.renderer`, `xRange` and `domain` are no longer provided. Use `binRange` and `datums` instead.
 
 ### Numeric and Time-Axis Value Types
 

--- a/packages/ag-charts-website/src/content/docs/waterfall-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/waterfall-series/index.mdoc
@@ -65,7 +65,7 @@ In this configuration:
 - `totalType` specifies whether the value is a Total or Subtotal.
 - `index` determines the position in the data after which the Total or Subtotal will appear.
 - `axisLabel` is the label shown as a category on the [Category Axis](./axes-types/#category).
-- `itemId` is an optional unique [identifier](./events/#item-identifiers) for the total, surfaced in events and callbacks. Totals that share an `axisLabel` must each set a unique `itemId` to remain distinguishable.
+- [`itemId`](./events/#item-identifiers) is an optional unique identifier for the total, surfaced in events and callbacks. Totals that share an `axisLabel` must each set a unique `itemId` to remain distinguishable.
 
 ## Customisation
 


### PR DESCRIPTION
Use the new code-block-link mechanism (added in #7113) for `itemId` references in the docs.

## Summary

- **itemId code-links** — wrap the inline `itemId` code directly in the Item Identifiers link instead of trailing "see Item Identifiers" links alongside it. Updated in:
  - `events/index.mdoc` (×3: seriesVisibilityChange, activeChange, legendItemClick)
  - `api-state/index.mdoc` (`#active`)
  - `waterfall-series/index.mdoc`
- **Histogram upgrade note** — tighten the prose of the v14 histogram-callback migration note in `upgrade-to-ag-charts-14/index.mdoc`.

All `#item-identifiers` / `./events/#item-identifiers` anchors resolve against the existing Item Identifiers section in `events/index.mdoc`.

## Test plan

- Docs-only change; verify the `itemId` links render as code-block links and navigate to the Item Identifiers section (e.g. `/charts/react/api-state/#active`).