### PR TITLE
Skip benchmark examples whose base version lacks the feature

### DIFF
--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-volume-bigint/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-volume-bigint/main.ts
@@ -81,6 +81,9 @@ function getBenchmarkConfig(): BenchmarkConfig {
             axisType: 'number',
             dataType: 'bigint',
             version: VERSION,
+            // bigint values are a new feature; an older published base renders no valid data
+            // points, so the compare step skips this example when the base is below minVersion.
+            minVersion: '14.0.0',
         },
     };
 }

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-volume-iso-datetime/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/high-volume-iso-datetime/main.ts
@@ -102,6 +102,9 @@ function getBenchmarkConfig(): BenchmarkConfig {
             axisType: 'time',
             dataType: 'iso-8601-string',
             version: VERSION,
+            // ISO-8601 time-axis strings are a new feature; an older published base renders no
+            // valid data points, so the compare step skips this example when below minVersion.
+            minVersion: '14.0.0',
         },
     };
 }

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -471,11 +471,19 @@ fi
 base_label="${base_ref#origin/}"
 compare_label="${branch}"
 
+# In published mode the base version is the npm version we swapped in; in git-ref mode
+# leave it unset so compare-browser-results.js derives it from the base report.
+base_version_args=()
+if [[ -n "$published_version" ]]; then
+    base_version_args=(--base-version "$published_version")
+fi
+
 node "${tools_dir}/compare-browser-results.js" \
     --base "$base_results" \
     --compare "$head_results" \
     --base-label "$base_label" \
     --compare-label "$compare_label" \
+    "${base_version_args[@]}" \
     --format "$format" \
     --report-only \
     > "$output"

--- a/tools/benchmark/compare-browser-results.js
+++ b/tools/benchmark/compare-browser-results.js
@@ -35,6 +35,12 @@ const argv = yargs(hideBin(process.argv))
         default: 'compare',
         describe: 'Display name for the compare version',
     })
+    .option('base-version', {
+        type: 'string',
+        describe:
+            'Semantic version of the base library (e.g. 13.3.1). Used to exclude examples whose ' +
+            'minVersion is newer than the base. Falls back to the version recorded in the base report.',
+    })
     .option('format', {
         type: 'string',
         choices: ['table', 'json'],
@@ -114,6 +120,55 @@ function coefficientOfVariation(values) {
 // changes within the noise floor should not be treated as real regressions.
 const NOISY_CV_THRESHOLD = 0.1;
 
+// --- Version gating ---
+
+/** Parse a semver string into release parts plus a prerelease flag; null when unparseable. */
+function parseSemver(version) {
+    if (typeof version !== 'string') return null;
+    const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(version.trim());
+    if (!match) return null;
+    return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]), prerelease: match[4] ?? null };
+}
+
+/** Compare release parts only (prerelease ignored): negative if a < b. */
+function compareRelease(a, b) {
+    return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+/**
+ * Whether an example gated at `minVersion` should be excluded against `baseVersion`.
+ *
+ * Fails open: an unparseable base version, or a prerelease/dev build (assumed to be a
+ * `latest`-equivalent reference that already carries the feature), is never excluded —
+ * only a released base strictly older than minVersion is.
+ */
+function baseBelowMinVersion(baseVersion, minVersion) {
+    const min = parseSemver(minVersion);
+    if (!min) return false;
+    const base = parseSemver(baseVersion);
+    if (!base || base.prerelease) return false;
+    return compareRelease(base, min) < 0;
+}
+
+/** First library version recorded across a report's successful examples; null if none. */
+function reportVersion(report) {
+    for (const example of Object.values(report?.examples || {})) {
+        const version = example?.data?.version;
+        if (typeof version === 'string' && version) return version;
+    }
+    return null;
+}
+
+/** Map of exampleName -> declared minVersion, gathered from example metadata. */
+function collectMinVersions(report) {
+    const minVersions = new Map();
+    for (const [exampleName, example] of Object.entries(report?.examples || {})) {
+        const minVersion = example?.data?.metadata?.minVersion;
+        if (typeof minVersion === 'string' && minVersion) minVersions.set(exampleName, minVersion);
+    }
+    return minVersions;
+}
+
 // --- Extract results from report ---
 
 function extractResults(report) {
@@ -157,12 +212,26 @@ const compare = extractResults(compareReport);
 const baseKeys = new Set(base.results.keys());
 const compareKeys = new Set(compare.results.keys());
 
+// Effective base version: explicit flag wins, else the version recorded in the report
+// (the published library version in npm-base mode, or the ref's version in git-base mode).
+const baseVersion = argv['base-version'] || reportVersion(baseReport);
+
+// minVersion is declared on the head examples; only keys present in both reports are
+// gated, so the compare report is always authoritative.
+const minVersions = collectMinVersions(compareReport);
+
 // Matched results
 const matched = [];
+const skippedBelowMinVersion = [];
 for (const key of baseKeys) {
     if (compareKeys.has(key)) {
         const b = base.results.get(key);
         const c = compare.results.get(key);
+        const minVersion = minVersions.get(b.exampleName);
+        if (minVersion && baseBelowMinVersion(baseVersion, minVersion)) {
+            skippedBelowMinVersion.push({ test: b.displayName, minVersion, baseVersion: baseVersion ?? null });
+            continue;
+        }
         // Median is robust to outlier iterations (GC pauses, CI noise spikes);
         // it falls back to the average when raw timings are unavailable.
         const pctTimeChange =
@@ -270,6 +339,12 @@ if (argv.format === 'table') {
         console.log(`\nErrors (${errors.length}):`);
         errors.forEach((err) => console.log(`  ! ${err}`));
     }
+    if (skippedBelowMinVersion.length > 0) {
+        console.log(`\nSkipped — base below min version (${skippedBelowMinVersion.length}):`);
+        skippedBelowMinVersion.forEach((s) =>
+            console.log(`  ⤬ ${s.test} (needs ≥ ${s.minVersion}, base is ${s.baseVersion ?? 'unknown'})`)
+        );
+    }
 
     // Summary line
     const improvements = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange < 0).length;
@@ -285,6 +360,7 @@ if (argv.format === 'table') {
                 added,
                 removed,
                 errors,
+                skippedBelowMinVersion,
             },
             null,
             2

--- a/tools/benchmark/format-browser-slack-message.js
+++ b/tools/benchmark/format-browser-slack-message.js
@@ -37,6 +37,7 @@ const {
     added = [],
     removed = [],
     errors = [],
+    skippedBelowMinVersion = [],
 } = JSON.parse(fs.readFileSync(argv.input, 'utf8'));
 
 // --- Build Slack message ---
@@ -84,6 +85,7 @@ const notes = [];
 if (added.length > 0) notes.push(`${added.length} added`);
 if (removed.length > 0) notes.push(`${removed.length} removed`);
 if (errors.length > 0) notes.push(`${errors.length} errors`);
+if (skippedBelowMinVersion.length > 0) notes.push(`${skippedBelowMinVersion.length} skipped (base below min version)`);
 if (notes.length > 0) {
     blocks.push({ type: 'divider' });
     blocks.push({


### PR DESCRIPTION
## Summary

The nightly browser benchmark compares the head example set against an older published base library. Examples exercising **new** features (bigint data values, ISO-8601 strings on a time axis) render no valid data points on a base that lacks the feature, so the base is meaninglessly fast — producing bogus regressions (e.g. +280%) that inflate the nightly counts.

This adds a per-example **`minVersion`** marker so the compare step excludes such cases against a base below that version, rather than reporting them as regressions.

## Changes

- **Examples** — stamp `minVersion: '14.0.0'` in the `metadata` of `high-volume-bigint` and `high-volume-iso-datetime` (flows into the report JSON; no harness/type changes).
- **`compare-browser-results.js`** — new `--base-version` flag, semver gating helpers, and a `skippedBelowMinVersion` bucket. Gated cases are diverted out of `matched`, so they no longer affect the rankings, the notable-regressions list, or the improved/regressed summary. Surfaced in both table and JSON output.
- **`compare-browser-latest.sh`** — passes `--base-version <npm version>` in published-npm mode; git-ref mode derives the version from the base report.
- **`format-browser-slack-message.js`** — adds a "N skipped (base below min version)" note so excluded cases are visible.

## Fail-open semantics

Only a **released** base strictly older than `minVersion` is excluded. A prerelease/dev base, an unparseable ref (e.g. `origin/b13.2.0`), or a missing version is treated as the `latest` reference and **not** excluded — so real comparisons are never silently hidden.

## Test plan

Verified against the real Jun-16 CI reports (`benchmark-results` artifact):

- base `13.3.1` (released, < min) → 4 new-feature cases skipped, ranked 116 → 112; counts and notable list exclude them.
- base `14.0.0` (== min) and `14.1.0` (> min) → not skipped (116).
- base `13.3.0-beta.x` (prerelease) → fail-open, not skipped.
- base `origin/b13.2.0` (unparseable) → fail-open, not skipped.
- no `--base-version` → version derived from base report (`13.3.1`) → 4 skipped.

`prettier --check` and `bash -n` pass on the changed files.