### PR TITLE
AG-17134 Remove script-src 'unsafe-inline' from the site CSP

### DIFF
--- a/external/ag-website-shared/src/components/framework-redirect-page/FrameworkRedirectPage.astro
+++ b/external/ag-website-shared/src/components/framework-redirect-page/FrameworkRedirectPage.astro
@@ -29,15 +29,8 @@ const redirectUrl = `./${Astro.props.redirectPageName}`;
         }
     }
 </style>
-<script>
-    const WAIT_TO_SHOW_REDIRECT_CONTENT = 1000;
 
-    setTimeout(() => {
-        document.querySelector('.redirectContent')?.classList.remove('hidden');
-    }, WAIT_TO_SHOW_REDIRECT_CONTENT);
-</script>
-
-<!-- 
+<!--
     Redirect page to framework page based on stored internal framework
 
     NOTE: Need to put var into data attribute as Astro can't pass directly into build time JavaScript
@@ -47,6 +40,14 @@ const redirectUrl = `./${Astro.props.redirectPageName}`;
     import { $internalFramework } from '@stores/frameworkStore';
     import { getFrameworkFromInternalFramework } from '@utils/framework';
     import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+    // Reveal the fallback content shortly after load (in case the redirect below is
+    // skipped, e.g. ?debug=true). Kept in this imported module — rather than a
+    // separate inline <script> — so the site CSP can authorise it via 'self'.
+    const WAIT_TO_SHOW_REDIRECT_CONTENT = 1000;
+    setTimeout(() => {
+        document.querySelector('.redirectContent')?.classList.remove('hidden');
+    }, WAIT_TO_SHOW_REDIRECT_CONTENT);
 
     const data = document.getElementById('redirectUrl')?.dataset;
     const dataAttrFrameworkOverride = data.frameworkOverride;

--- a/external/ag-website-shared/src/components/google-tag-manager/GoogleTagManager.astro
+++ b/external/ag-website-shared/src/components/google-tag-manager/GoogleTagManager.astro
@@ -1,5 +1,6 @@
 ---
 import { getIsStaging } from '@utils/env';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 interface Props {
     googleTagManagerId: string;
@@ -11,20 +12,13 @@ const { googleTagManagerId, googleTagManagerAuth, googleTagManagerPreview } = As
 const extraParams = getIsStaging() ? `&gtm_auth=${googleTagManagerAuth}&gtm_preview=${googleTagManagerPreview}` : '';
 ---
 
+{
+    /* Externalised (was an inline define:vars bootstrap) so the site CSP can drop
+    script-src 'unsafe-inline'; config passes via data- attributes. Must stay a
+    classic, non-deferred script so document.currentScript resolves in the loader. */
+}
 <script
-    define:vars={{
-        googleTagManagerId,
-        extraParams,
-    }}
->
-    (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-            j = d.createElement(s),
-            dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + extraParams + '&gtm_cookies_win=x';
-        f.parentNode.insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', googleTagManagerId);
-</script>
+    is:inline
+    src={urlWithBaseUrl('/scripts/gtm-init.js')}
+    data-gtm-id={googleTagManagerId}
+    data-gtm-extra={extraParams}></script>

--- a/packages/ag-charts-website/eslint.config.mjs
+++ b/packages/ag-charts-website/eslint.config.mjs
@@ -1,6 +1,4 @@
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
-import globals from 'globals';
-import tseslint from 'typescript-eslint';
 
 import base from '../../eslint.config.mjs';
 
@@ -18,6 +16,10 @@ export default [
             '**/_examples/',
             '**/_shared/',
             'scripts/',
+            // Standalone classic browser scripts served verbatim from public/;
+            // not part of any tsconfig project, so excluded from type-aware
+            // linting (as with public/example-runner below).
+            'public/scripts/**',
             '**/.angular',
             '**/benchmarkHarness.ts',
             '**/benchmarkUtils.ts',
@@ -69,29 +71,6 @@ export default [
         rules: {
             '@typescript-eslint/no-unused-vars': 'off',
             'no-console': 'off',
-        },
-    },
-    // Standalone classic browser scripts served from public/. These are not
-    // part of any tsconfig project, so disable type-aware linting (which
-    // requires project membership) and lint them as plain JS with browser
-    // globals. `agCharts` is provided by a separately-loaded UMD bundle.
-    {
-        files: ['public/scripts/**/*.js'],
-        languageOptions: {
-            parserOptions: {
-                projectService: false,
-                project: false,
-                tsconfigRootDir: import.meta.dirname,
-            },
-            globals: {
-                ...globals.browser,
-                agCharts: 'readonly',
-            },
-        },
-        rules: {
-            ...tseslint.configs.disableTypeChecked.rules,
-            // Custom type-aware rule; not covered by disableTypeChecked.
-            'aglint/change-detection': 'off',
         },
     },
     // env.d.ts

--- a/packages/ag-charts-website/eslint.config.mjs
+++ b/packages/ag-charts-website/eslint.config.mjs
@@ -1,4 +1,6 @@
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 import base from '../../eslint.config.mjs';
 
@@ -67,6 +69,29 @@ export default [
         rules: {
             '@typescript-eslint/no-unused-vars': 'off',
             'no-console': 'off',
+        },
+    },
+    // Standalone classic browser scripts served from public/. These are not
+    // part of any tsconfig project, so disable type-aware linting (which
+    // requires project membership) and lint them as plain JS with browser
+    // globals. `agCharts` is provided by a separately-loaded UMD bundle.
+    {
+        files: ['public/scripts/**/*.js'],
+        languageOptions: {
+            parserOptions: {
+                projectService: false,
+                project: false,
+                tsconfigRootDir: import.meta.dirname,
+            },
+            globals: {
+                ...globals.browser,
+                agCharts: 'readonly',
+            },
+        },
+        rules: {
+            ...tseslint.configs.disableTypeChecked.rules,
+            // Custom type-aware rule; not covered by disableTypeChecked.
+            'aglint/change-detection': 'off',
         },
     },
     // env.d.ts

--- a/packages/ag-charts-website/plugins/agDevCsp.ts
+++ b/packages/ag-charts-website/plugins/agDevCsp.ts
@@ -1,14 +1,9 @@
 import type { Plugin, ViteDevServer } from 'vite';
 
-import { getCspValue } from '../src/utils/htaccess/cspRules';
+import { EXAMPLES_PATH_REGEXP, getCspValue } from '../src/utils/htaccess/cspRules';
 
 const SITE_CSP = getCspValue({ env: 'dev', scope: 'site' });
 const EXAMPLES_CSP = getCspValue({ env: 'dev', scope: 'examples' });
-
-// Mirrors EXAMPLES_PATH_CONDITION in cspRules.ts: match the /examples/ or
-// /archive/ segment anywhere (charts serves example-runner documents under both
-// /gallery/examples/... and /<framework>/<page>/examples/..., under the /charts base).
-const EXAMPLES_PATH = /\/(examples|archive)\//;
 
 /**
  * Vite plugin serving the dev server's Content-Security-Policy header with the
@@ -21,7 +16,7 @@ export default function agDevCsp(): Plugin {
         name: 'ag-dev-csp',
         configureServer(server: ViteDevServer) {
             server.middlewares.use((req, res, next) => {
-                const csp = EXAMPLES_PATH.test(req.url ?? '') ? EXAMPLES_CSP : SITE_CSP;
+                const csp = EXAMPLES_PATH_REGEXP.test(req.url ?? '') ? EXAMPLES_CSP : SITE_CSP;
                 res.setHeader('Content-Security-Policy', csp);
                 next();
             });

--- a/packages/ag-charts-website/project.json
+++ b/packages/ag-charts-website/project.json
@@ -79,6 +79,17 @@
         "production": {}
       }
     },
+    "preview:csp": {
+      "dependsOn": [
+        {
+          "target": "build"
+        }
+      ],
+      "command": "tsx scripts/csp/preview-csp.ts --port=${PORT}",
+      "options": {
+        "cwd": "packages/ag-charts-website"
+      }
+    },
     "lint:eslint": {},
     "lint:spell": {
       "command": "npx cspell --no-progress --show-context --config ../../cspell.json \"src/**/*.{mdoc,astro}\" \"src/content/**/*.json\"",

--- a/packages/ag-charts-website/public/scripts/gtm-init.js
+++ b/packages/ag-charts-website/public/scripts/gtm-init.js
@@ -1,0 +1,24 @@
+/*
+ * Google Tag Manager bootstrap. Externalised from an inline `define:vars` script
+ * (see GoogleTagManager.astro) so the site Content-Security-Policy can drop
+ * script-src 'unsafe-inline'. Configuration arrives via data- attributes on the
+ * loading <script> tag, so this file is static and served from 'self'.
+ *
+ * Must be loaded as a classic, non-deferred script: it reads
+ * document.currentScript, which is only set during synchronous execution.
+ */
+(function () {
+    var el = document.currentScript;
+    var id = el && el.dataset.gtmId;
+    if (!id) {
+        return;
+    }
+    var extraParams = el.dataset.gtmExtra || '';
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+    var firstScript = document.getElementsByTagName('script')[0];
+    var gtmScript = document.createElement('script');
+    gtmScript.async = true;
+    gtmScript.src = 'https://www.googletagmanager.com/gtm.js?id=' + id + extraParams + '&gtm_cookies_win=x';
+    firstScript.parentNode.insertBefore(gtmScript, firstScript);
+})();

--- a/packages/ag-charts-website/public/scripts/homepage-gallery.js
+++ b/packages/ag-charts-website/public/scripts/homepage-gallery.js
@@ -1,0 +1,126 @@
+/*
+ * Homepage gallery chart manager. Externalised from an inline `define:vars` script
+ * (see HomepageGalleryExamples.astro) so the site Content-Security-Policy can drop
+ * script-src 'unsafe-inline'. This script embeds build-hashed CSS-module class
+ * names, so a static SHA-256 hash would change every build — hence externalisation
+ * rather than hashing. Configuration arrives via data- attributes.
+ *
+ * Must load as a classic, non-deferred script placed after the AgCharts UMD script:
+ * it reads document.currentScript (only set during synchronous execution), so the
+ * data- attributes are captured up front for use by the deferred init().
+ */
+(function () {
+    const el = document.currentScript;
+    const initialExampleId = el.dataset.initialExampleId;
+    const buttonsClass = el.dataset.buttonsClass;
+    const activeButtonClass = el.dataset.activeButtonClass;
+    const GLOBAL_UPDATE_EXAMPLES_VARIABLE = el.dataset.updateExamplesVar;
+    const GLOBAL_UPDATE_FUNCTION_NAME = el.dataset.updateFnName;
+    const loadingId = el.dataset.loadingId;
+
+    function createChartManager({ agCharts, onFirstLoad }) {
+        let chartInstance = null;
+        let currentChartIsGauge = false;
+        let chartState = 'init';
+
+        const isGauge = (chartType) => {
+            return chartType?.endsWith('gauge');
+        };
+        const createChart = ({ options }) => {
+            const createMethod = isGauge(options.type) ? 'createGauge' : 'create';
+            chartInstance = agCharts[createMethod](options);
+
+            if (chartState === 'init') {
+                chartInstance
+                    ?.waitForUpdate()
+                    .then(() => {
+                        chartState = 'active';
+                        onFirstLoad?.();
+                    })
+                    .catch(() => {});
+            }
+        };
+        const apply = ({ options }) => {
+            if (chartState === 'init') {
+                createChart({ options });
+                return;
+            }
+
+            const optionsIsGauge = isGauge(options.type);
+            const shouldDestroy = currentChartIsGauge !== optionsIsGauge;
+
+            if (shouldDestroy) {
+                chartInstance?.destroy();
+                createChart({ options });
+            } else {
+                chartInstance?.update(options);
+            }
+
+            currentChartIsGauge = optionsIsGauge;
+        };
+
+        return {
+            apply,
+        };
+    }
+
+    const chartManager = createChartManager({
+        agCharts: agCharts.AgCharts,
+        onFirstLoad: () => {
+            removeLoading();
+        },
+    });
+    const buttons = document.querySelectorAll(`.${buttonsClass}`);
+    function updateActiveButton(button) {
+        buttons.forEach((btn) => btn.classList.remove(activeButtonClass));
+        button.classList.add(activeButtonClass);
+    }
+
+    function removeLoading() {
+        const loadingElement = document.getElementById(loadingId);
+        if (loadingElement) {
+            loadingElement.remove();
+        }
+    }
+
+    function updateExample(exampleId) {
+        const button = document.querySelector(`.${buttonsClass}[data-example-id="${exampleId}"]`);
+        updateActiveButton(button);
+
+        window[GLOBAL_UPDATE_EXAMPLES_VARIABLE][exampleId]();
+    }
+
+    function init() {
+        let currentExampleId = initialExampleId;
+
+        // Called from example `updateExample` function
+        window[GLOBAL_UPDATE_FUNCTION_NAME] = (options) => {
+            chartManager.apply({
+                options,
+            });
+        };
+
+        buttons.forEach((button) => {
+            const { exampleId } = button.dataset;
+
+            button.addEventListener('click', () => {
+                if (exampleId === currentExampleId) {
+                    return;
+                }
+
+                currentExampleId = exampleId;
+
+                updateExample(exampleId);
+            });
+
+            if (initialExampleId === exampleId) {
+                updateExample(exampleId);
+            }
+        });
+    }
+
+    // Initialise once DOM is ready
+    document.addEventListener('DOMContentLoaded', () => {
+        init();
+    });
+})();

--- a/packages/ag-charts-website/public/scripts/site-header-scroll.js
+++ b/packages/ag-charts-website/public/scripts/site-header-scroll.js
@@ -1,0 +1,35 @@
+/*
+ * Toggles a CSS class on the site header once the page scrolls past a threshold.
+ * Externalised to a 'self' script so the site Content-Security-Policy can drop
+ * script-src 'unsafe-inline': a single-importer hoisted <script> gets inlined into
+ * the page HTML by Astro, which the hash-based policy blocks — and the minified
+ * bytes make a static SHA-256 hash unstable. Config passes via data- attributes.
+ *
+ * Must be loaded as a classic, non-deferred script: it reads
+ * document.currentScript, which is only set during synchronous execution.
+ */
+(function () {
+    var el = document.currentScript;
+    var targetSelector = el && el.dataset.targetSelector;
+    var scrolledClass = el && el.dataset.scrolledClass;
+    var scrollPosition = Number(el && el.dataset.scrollPosition);
+    if (!targetSelector || !scrolledClass || !Number.isFinite(scrollPosition)) {
+        return;
+    }
+
+    function updateScrolledClass() {
+        var target = document.querySelector(targetSelector);
+        if (!target) {
+            return;
+        }
+        var windowScrollPosition = window.scrollY || document.documentElement.scrollTop;
+        if (windowScrollPosition >= scrollPosition) {
+            target.classList.add(scrolledClass);
+        } else {
+            target.classList.remove(scrolledClass);
+        }
+    }
+
+    window.addEventListener('scroll', updateScrolledClass);
+    updateScrolledClass();
+})();

--- a/packages/ag-charts-website/scripts/csp/preview-csp.ts
+++ b/packages/ag-charts-website/scripts/csp/preview-csp.ts
@@ -54,6 +54,11 @@ const MKCERT_CERT = path.join(MKCERT_DIR, 'cert.pem');
 const DEFAULT_PORT = 4601;
 const DEFAULT_BASE = '/charts';
 
+// Where `astro build` actually writes the site (see astro.config.mjs `outDir`).
+// The output lives at the workspace-root dist, NOT a package-local `dist/`, so
+// resolve it relative to this package's cwd to match.
+const BUILD_OUT_DIR = '../../dist/packages/ag-charts-website';
+
 const ENVS: CspEnv[] = ['dev', 'staging', 'production'];
 const MODES: CspMode[] = ['report-only', 'enforce'];
 
@@ -142,7 +147,7 @@ async function main(): Promise<void> {
     const resolveCsp = makeCspResolver(env);
     const headerName = getCspHeaderName(mode);
     const httpsOption = getHttpsOption(https);
-    const outDir = path.join(process.cwd(), 'dist');
+    const outDir = path.resolve(process.cwd(), BUILD_OUT_DIR);
     // Base with the trailing slash trimmed ('' for a root deploy), used to map a
     // request URL back to its file on disk (the files live at the dist root).
     const baseNoTrail = base === '/' ? '' : base.slice(0, -1);
@@ -153,7 +158,7 @@ async function main(): Promise<void> {
         // Serve dist under the baked base (/charts locally), so the prefixed asset
         // and hydration URLs in the built HTML resolve.
         base,
-        build: { outDir: 'dist' },
+        build: { outDir },
         // 'mpa' serves the static build as a multi-page app: each route maps to its
         // own .html file with no SPA fallback. The default 'spa' would serve the
         // homepage for any unmatched URL, which silently breaks example-runner

--- a/packages/ag-charts-website/scripts/csp/preview-csp.ts
+++ b/packages/ag-charts-website/scripts/csp/preview-csp.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { preview } from 'vite';
+
+import type { CspEnv, CspMode } from '../../src/utils/htaccess/cspRules';
+import { EXAMPLES_PATH_REGEXP, getCspHeaderName, getCspValue } from '../../src/utils/htaccess/cspRules';
+
+/**
+ * Preview the built AG Charts site with the *enforced production* Content-Security-Policy
+ * applied, so CSP regressions can be caught locally.
+ *
+ * Why this exists instead of `astro preview`:
+ *   - `astro preview` serves the static build with NO CSP header at all — its
+ *     server only honours a single static `vite.server.headers` value and strips
+ *     all user Vite plugins (see core/preview/static-preview-server.js), so the
+ *     `agDevCsp` middleware never runs there. A clean console under `astro preview`
+ *     therefore proves nothing about the production policy.
+ *   - The `astro dev` server (via `agDevCsp`) does serve a path-scoped CSP, but the
+ *     dev `site` policy keeps `'unsafe-inline'` (Vite injects inline scripts in dev),
+ *     so it cannot validate the hash-based production policy either.
+ *
+ * This matters more for Charts than a report-only-only rollout would: Charts *staging*
+ * enforces the `site` scope (see htaccessRules.ts), so a stale Astro hydration hash or
+ * a stray inline script breaks staging immediately — there is no grace period there.
+ *
+ * This server calls Vite's `preview()` directly — so the CSP plugin below is NOT
+ * stripped — and sets the same path-scoped policy the generated `.htaccess` serves
+ * on staging/production: ordinary pages get the `site` policy (hashes, no
+ * `'unsafe-inline'`), example-runner documents get the relaxed `examples` policy.
+ *
+ * Usage (run after a build; defaults to the enforced production policy):
+ *   nx run ag-charts-website:preview:csp
+ *   tsx packages/ag-charts-website/scripts/csp/preview-csp.ts [--env=...] [--mode=...] [--port=...] [--base=...] [--no-https]
+ *
+ * Port: defaults to 4601 to match PUBLIC_SITE_URL baked into a local build
+ * (.env.build → https://localhost:4601). The example runner fetches its modules
+ * from that absolute origin, so serving on a different port makes those requests
+ * cross-origin and the examples-scope connect-src 'self' blocks them. Keep it 4601.
+ *
+ * Base: defaults to /charts to match PUBLIC_BASE_URL in .env.build. Astro bakes this
+ * prefix into every page/asset URL but still writes the files at the dist root, so
+ * the server must serve dist *under* the base for assets (and hydration) to resolve.
+ * Pass --base=/ when previewing a staging-style build (PUBLIC_BASE_URL=/).
+ */
+
+// Match vite-plugin-mkcert's data dir and default filenames.
+const MKCERT_DIR = path.join(os.homedir(), '.vite-plugin-mkcert');
+const MKCERT_KEY = path.join(MKCERT_DIR, 'dev.pem');
+const MKCERT_CERT = path.join(MKCERT_DIR, 'cert.pem');
+
+const DEFAULT_PORT = 4601;
+const DEFAULT_BASE = '/charts';
+
+const ENVS: CspEnv[] = ['dev', 'staging', 'production'];
+const MODES: CspMode[] = ['report-only', 'enforce'];
+
+function assertOneOf<T extends string>(value: string | undefined, allowed: T[], flag: string): T {
+    if (value === undefined || !allowed.includes(value as T)) {
+        throw new Error(`${flag} must be one of: ${allowed.join(', ')}`);
+    }
+    return value as T;
+}
+
+interface Args {
+    env: CspEnv;
+    mode: CspMode;
+    port: number;
+    base: string;
+    https: boolean;
+}
+
+// Normalise to a leading and trailing slash ('/charts' -> '/charts/', '/' -> '/').
+function normaliseBase(base: string): string {
+    let result = base.startsWith('/') ? base : `/${base}`;
+    if (!result.endsWith('/')) {
+        result = `${result}/`;
+    }
+    return result;
+}
+
+function parseArgs(argv: string[]): Args {
+    let env: CspEnv = 'production';
+    let mode: CspMode = 'enforce';
+    let port = DEFAULT_PORT;
+    let base = DEFAULT_BASE;
+    let https = true;
+
+    for (let i = 0, len = argv.length; i < len; ++i) {
+        const arg = argv[i];
+        const [key, inlineValue] = arg.split('=');
+        if (key === '--no-https') {
+            https = false;
+        } else if (key === '--env') {
+            env = assertOneOf(inlineValue ?? argv[++i], ENVS, '--env');
+        } else if (key === '--mode') {
+            mode = assertOneOf(inlineValue ?? argv[++i], MODES, '--mode');
+        } else if (key === '--base') {
+            base = inlineValue ?? argv[++i];
+        } else if (key === '--port') {
+            const parsed = Number(inlineValue ?? argv[++i]);
+            if (Number.isFinite(parsed) && parsed > 0) {
+                port = parsed;
+            }
+        } else {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    return { env, mode, port, base: normaliseBase(base), https };
+}
+
+function getHttpsOption(enabled: boolean): { key: Buffer; cert: Buffer } | undefined {
+    if (!enabled) {
+        return undefined;
+    }
+    if (fs.existsSync(MKCERT_KEY) && fs.existsSync(MKCERT_CERT)) {
+        return { key: fs.readFileSync(MKCERT_KEY), cert: fs.readFileSync(MKCERT_CERT) };
+    }
+    console.warn(
+        `[preview-csp] mkcert certificates not found at ${MKCERT_DIR}; serving over HTTP. ` +
+            `Run 'nx dev' once to generate them, or pass --no-https to silence this.`
+    );
+    return undefined;
+}
+
+function makeCspResolver(env: CspEnv): (url: string) => string {
+    const site = getCspValue({ env, scope: 'site' });
+    const examples = getCspValue({ env, scope: 'examples' });
+    return (url: string): string => {
+        if (EXAMPLES_PATH_REGEXP.test(url)) {
+            return examples;
+        }
+        return site;
+    };
+}
+
+async function main(): Promise<void> {
+    const { env, mode, port, base, https } = parseArgs(process.argv.slice(2));
+    const resolveCsp = makeCspResolver(env);
+    const headerName = getCspHeaderName(mode);
+    const httpsOption = getHttpsOption(https);
+    const outDir = path.join(process.cwd(), 'dist');
+    // Base with the trailing slash trimmed ('' for a root deploy), used to map a
+    // request URL back to its file on disk (the files live at the dist root).
+    const baseNoTrail = base === '/' ? '' : base.slice(0, -1);
+
+    const server = await preview({
+        configFile: false,
+        root: process.cwd(),
+        // Serve dist under the baked base (/charts locally), so the prefixed asset
+        // and hydration URLs in the built HTML resolve.
+        base,
+        build: { outDir: 'dist' },
+        // 'mpa' serves the static build as a multi-page app: each route maps to its
+        // own .html file with no SPA fallback. The default 'spa' would serve the
+        // homepage for any unmatched URL, which silently breaks example-runner
+        // resource fetches and standalone example pages (they 'load' the homepage).
+        appType: 'mpa',
+        preview: {
+            port,
+            strictPort: true,
+            host: true,
+            https: httpsOption,
+        },
+        plugins: [
+            {
+                name: 'ag-preview-csp',
+                configurePreviewServer(previewServer) {
+                    previewServer.middlewares.use((req, res, next) => {
+                        const rawUrl = req.url ?? '';
+                        const queryIndex = rawUrl.indexOf('?');
+                        const pathname = queryIndex === -1 ? rawUrl : rawUrl.slice(0, queryIndex);
+                        const search = queryIndex === -1 ? '' : rawUrl.slice(queryIndex);
+
+                        // Path relative to the base, to look the file up on disk
+                        // (files live at the dist root, not under a /charts folder).
+                        const relativePath =
+                            baseNoTrail && pathname.startsWith(baseNoTrail)
+                                ? pathname.slice(baseNoTrail.length) || '/'
+                                : pathname;
+
+                        // Mimic the production host (Apache RewriteRule): redirect an
+                        // extensionless directory path to a trailing slash so the
+                        // browser lands on the canonical URL and relative asset paths
+                        // resolve. Without this the example pages load with broken assets.
+                        if (relativePath !== '/' && !pathname.endsWith('/') && !path.extname(pathname)) {
+                            const indexFile = path.join(outDir, decodeURIComponent(relativePath), 'index.html');
+                            if (fs.existsSync(indexFile)) {
+                                res.statusCode = 308;
+                                res.setHeader('Location', `${pathname}/${search}`);
+                                res.end();
+                                return;
+                            }
+                        }
+
+                        res.setHeader(headerName, resolveCsp(pathname));
+                        res.setHeader('X-Content-Type-Options', 'nosniff');
+
+                        // Mirror the production .htaccess CORS headers so example
+                        // embedders (Plunkr, CodeSandbox, Codespaces) can fetch the
+                        // example bundles from /files/ cross-origin, as they do in prod.
+                        res.setHeader('Access-Control-Allow-Origin', '*');
+                        res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS,DELETE,PUT');
+
+                        next();
+                    });
+                },
+            },
+        ],
+    });
+
+    server.printUrls();
+    console.log(
+        `\n[preview-csp] Serving dist at base '${base}' with '${headerName}' — ${env} policy, ` +
+            `path-scoped (site / examples).\n`
+    );
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/packages/ag-charts-website/src/components/Plausible.astro
+++ b/packages/ag-charts-website/src/components/Plausible.astro
@@ -1,4 +1,6 @@
 ---
+import { PLAUSIBLE_INIT_SCRIPT } from '@utils/csp/inlineScripts';
+
 interface Props {
     domain: string;
 }
@@ -7,10 +9,5 @@ const { domain } = Astro.props as Props;
 ---
 
 <script defer data-domain={domain} src="https://plausible.io/js/script.js"></script>
-<script is:inline>
-    window.plausible =
-        window.plausible ||
-        function () {
-            (window.plausible.q = window.plausible.q || []).push(arguments);
-        };
-</script>
+{/* Authorised in script-src by SHA-256 hash (not 'unsafe-inline'); see @utils/csp/inlineScripts. */}
+<script is:inline set:html={PLAUSIBLE_INIT_SCRIPT} />

--- a/packages/ag-charts-website/src/components/homepage/components/HomepageGalleryExamples.astro
+++ b/packages/ag-charts-website/src/components/homepage/components/HomepageGalleryExamples.astro
@@ -53,119 +53,19 @@ const examplesUrl = getIsDev() ? urlWithBaseUrl('/homepage/examples.js') : urlWi
     </div>
 </div>
 
+{
+    /* Externalised (was an inline define:vars block) so the site CSP can drop
+    script-src 'unsafe-inline'. The script embeds build-hashed CSS-module class
+    names, so a static SHA-256 hash would be unstable — hence externalising rather
+    than hashing. Config passes via data- attributes; classic non-deferred script
+    so it runs after the AgCharts UMD above and document.currentScript resolves. */
+}
 <script
-    define:vars={{
-        initialExampleId,
-        buttonsClass: styles.tabButton,
-        activeButtonClass: styles.activeTabButton,
-        GLOBAL_UPDATE_EXAMPLES_VARIABLE,
-        GLOBAL_UPDATE_FUNCTION_NAME,
-        loadingId,
-    }}
->
-    function createChartManager({ agCharts, onFirstLoad }) {
-        let chartInstance = null;
-        let currentChartIsGauge = false;
-        let chartState = 'init';
-
-        const isGauge = (chartType) => {
-            return chartType?.endsWith('gauge');
-        };
-        const createChart = ({ options }) => {
-            const createMethod = isGauge(options.type) ? 'createGauge' : 'create';
-            chartInstance = agCharts[createMethod](options);
-
-            if (chartState === 'init') {
-                chartInstance
-                    ?.waitForUpdate()
-                    .then(() => {
-                        chartState = 'active';
-                        onFirstLoad?.();
-                    })
-                    .catch(() => {});
-            }
-        };
-        const apply = ({ options }) => {
-            if (chartState === 'init') {
-                createChart({ options });
-                return;
-            }
-
-            const optionsIsGauge = isGauge(options.type);
-            const shouldDestroy = currentChartIsGauge !== optionsIsGauge;
-
-            if (shouldDestroy) {
-                chartInstance?.destroy();
-                createChart({ options });
-            } else {
-                chartInstance?.update(options);
-            }
-
-            currentChartIsGauge = optionsIsGauge;
-        };
-
-        return {
-            apply,
-        };
-    }
-
-    const chartManager = createChartManager({
-        agCharts: agCharts.AgCharts,
-        onFirstLoad: () => {
-            removeLoading();
-        },
-    });
-    const buttons = document.querySelectorAll(`.${buttonsClass}`);
-    function updateActiveButton(button) {
-        buttons.forEach((btn) => btn.classList.remove(activeButtonClass));
-        button.classList.add(activeButtonClass);
-    }
-
-    function removeLoading() {
-        const loadingElement = document.getElementById(loadingId);
-        if (loadingElement) {
-            loadingElement.remove();
-        }
-    }
-
-    function updateExample(exampleId) {
-        const button = document.querySelector(`.${buttonsClass}[data-example-id="${exampleId}"]`);
-        updateActiveButton(button);
-
-        window[GLOBAL_UPDATE_EXAMPLES_VARIABLE][exampleId]();
-    }
-
-    function init() {
-        let currentExampleId = initialExampleId;
-
-        // Called from example `updateExample` function
-        window[GLOBAL_UPDATE_FUNCTION_NAME] = (options) => {
-            chartManager.apply({
-                options,
-            });
-        };
-
-        buttons.forEach((button) => {
-            const { exampleId } = button.dataset;
-
-            button.addEventListener('click', () => {
-                if (exampleId === currentExampleId) {
-                    return;
-                }
-
-                currentExampleId = exampleId;
-
-                updateExample(exampleId);
-            });
-
-            if (initialExampleId === exampleId) {
-                updateExample(exampleId);
-            }
-        });
-    }
-
-    // Initialise once DOM is ready
-    document.addEventListener('DOMContentLoaded', () => {
-        init();
-    });
-</script>
+    is:inline
+    src={urlWithBaseUrl('/scripts/homepage-gallery.js')}
+    data-initial-example-id={initialExampleId}
+    data-buttons-class={styles.tabButton}
+    data-active-button-class={styles.activeTabButton}
+    data-update-examples-var={GLOBAL_UPDATE_EXAMPLES_VARIABLE}
+    data-update-fn-name={GLOBAL_UPDATE_FUNCTION_NAME}
+    data-loading-id={loadingId}></script>

--- a/packages/ag-charts-website/src/layouts/Layout.astro
+++ b/packages/ag-charts-website/src/layouts/Layout.astro
@@ -11,6 +11,7 @@ import { ApiTopBar } from '@components/top-bar/ApiTopBar';
 import { getIsProduction, getIsArchive, getIsStaging, getIsDev } from '@utils/env';
 import { isDynamicFrameworkPath, isDynamicFrameworkPathMatch, replaceDynamicFrameworkPath } from '@utils/framework';
 import Plausible from '../components/Plausible.astro';
+import { DARK_MODE_INIT_SCRIPT } from '@utils/csp/inlineScripts';
 import { FRAMEWORKS, SITE_BASE_URL, PUBLIC_GTM_ID, PUBLIC_GTM_AUTH, PUBLIC_GTM_PREVIEW, agChartsVersion } from '@constants';
 import { DevTools } from '@ag-website-shared/components/dev-tools/DevTools';
 import GoogleTagManager from '@ag-website-shared/components/google-tag-manager/GoogleTagManager.astro';
@@ -208,47 +209,9 @@ const structuredData: JsonLdObject[] = includeStructuredData
         </style>
     </head>
     <body data-is-homepage={isHomepage}>
-        <script is:inline>
-            const htmlEl = document.querySelector('html');
-            const localDarkmode = localStorage['documentation:darkmode'];
-            const isOSDarkmode = (
-                window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-            ).toString();
-
-            if (localDarkmode === undefined) {
-                localStorage.setItem('documentation:darkmode', isOSDarkmode);
-            }
-
-            htmlEl.classList.add('no-transitions');
-            htmlEl.dataset.darkMode = localDarkmode !== undefined ? localDarkmode : isOSDarkmode;
-
-            const getDarkmode = () => htmlEl.dataset.darkMode === 'true';
-            htmlEl.dataset.agThemeMode = getDarkmode() ? 'dark-blue' : 'light';
-            htmlEl.offsetHeight; // Trigger a reflow, flushing the CSS changes
-            htmlEl.classList.remove('no-transitions');
-
-            // Set up dark mode on change listeners
-            const darkModeListeners = [];
-            globalThis.addDarkmodeOnChange = (onChange) => {
-                darkModeListeners.push(onChange);
-
-                // Run once on initialisation
-                onChange(getDarkmode());
-            };
-
-            // Listen to changes to html[data-dark-mode] attribute and notify listeners
-            const observer = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    if (mutation.attributeName === 'data-dark-mode') {
-                        const newDarkmode = getDarkmode();
-                        darkModeListeners.forEach((listener) => {
-                            listener(newDarkmode);
-                        });
-                    }
-                });
-            });
-            observer.observe(htmlEl, { attributes: true });
-        </script>
+        {/* Authorised in script-src by SHA-256 hash (not 'unsafe-inline'); body lives in
+            @utils/csp/inlineScripts so the rendered bytes match the hashed source. */}
+        <script is:inline set:html={DARK_MODE_INIT_SCRIPT} />
 
         <div class="mainContainer">
             {!hideHeader && <SiteHeader showSearchBar={showSearchBar} showDocsNav={showDocsNav} apiPaths={apiPaths}/>}

--- a/packages/ag-charts-website/src/pages/index.astro
+++ b/packages/ag-charts-website/src/pages/index.astro
@@ -236,12 +236,14 @@ const mapExampleHeights = 360;
     </div>
 </Layout>
 
-<script>
-    import { initScrollClassListener } from '@ag-website-shared/utils/initScrollClassListener';
-
-    initScrollClassListener({
-        targetSelector: '.site-header',
-        scrolledClass: 'header-scrolled',
-        scrollPosition: 480,
-    });
-</script>
+{
+    /* Externalised to a 'self' script (config via data- attributes) so the site CSP
+    can drop script-src 'unsafe-inline' — see public/scripts/site-header-scroll.js.
+    Classic non-deferred script so document.currentScript resolves. */
+}
+<script
+    is:inline
+    src={urlWithBaseUrl('/scripts/site-header-scroll.js')}
+    data-target-selector=".site-header"
+    data-scrolled-class="header-scrolled"
+    data-scroll-position="480"></script>

--- a/packages/ag-charts-website/src/utils/csp/inlineScripts.ts
+++ b/packages/ag-charts-website/src/utils/csp/inlineScripts.ts
@@ -1,0 +1,68 @@
+/**
+ * Exact source of the main-page inline `<script>`s that are authorised by SHA-256
+ * hash in the Content-Security-Policy (instead of `'unsafe-inline'`).
+ *
+ * Single source of truth: these strings are rendered verbatim via
+ * `<script is:inline set:html={…} />` AND hashed for `script-src` in cspRules.ts.
+ * The browser hashes the exact bytes between `<script>` and `</script>`, so the
+ * rendered content and the hashed content MUST be identical — keep them flowing
+ * from this one constant and never edit the inline markup directly.
+ *
+ * Dependency-free (plain strings) so cspRules.ts can import it without pulling in
+ * the Astro/Vite build graph.
+ */
+
+// Dark-mode bootstrap. Runs render-blocking at the top of <body> so the first
+// paint is already in the correct theme (no flash); kept inline (not externalised)
+// to avoid adding a fetch before first paint. No server-injected values.
+export const DARK_MODE_INIT_SCRIPT = `
+    const htmlEl = document.querySelector('html');
+    const localDarkmode = localStorage['documentation:darkmode'];
+    const isOSDarkmode = (
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    ).toString();
+
+    if (localDarkmode === undefined) {
+        localStorage.setItem('documentation:darkmode', isOSDarkmode);
+    }
+
+    htmlEl.classList.add('no-transitions');
+    htmlEl.dataset.darkMode = localDarkmode !== undefined ? localDarkmode : isOSDarkmode;
+
+    const getDarkmode = () => htmlEl.dataset.darkMode === 'true';
+    htmlEl.dataset.agThemeMode = getDarkmode() ? 'dark-blue' : 'light';
+    htmlEl.offsetHeight; // Trigger a reflow, flushing the CSS changes
+    htmlEl.classList.remove('no-transitions');
+
+    // Set up dark mode on change listeners
+    const darkModeListeners = [];
+    globalThis.addDarkmodeOnChange = (onChange) => {
+        darkModeListeners.push(onChange);
+
+        // Run once on initialisation
+        onChange(getDarkmode());
+    };
+
+    // Listen to changes to html[data-dark-mode] attribute and notify listeners
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+            if (mutation.attributeName === 'data-dark-mode') {
+                const newDarkmode = getDarkmode();
+                darkModeListeners.forEach((listener) => {
+                    listener(newDarkmode);
+                });
+            }
+        });
+    });
+    observer.observe(htmlEl, { attributes: true });
+`;
+
+// Plausible analytics queue stub. The tagged-events script itself loads externally
+// (plausible.io, allow-listed); this only sets up window.plausible before it arrives.
+export const PLAUSIBLE_INIT_SCRIPT = `
+    window.plausible =
+        window.plausible ||
+        function () {
+            (window.plausible.q = window.plausible.q || []).push(arguments);
+        };
+`;

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
@@ -1,7 +1,8 @@
+import astroPackageJson from 'astro/package.json';
 import { createHash } from 'node:crypto';
 
 import { DARK_MODE_INIT_SCRIPT, PLAUSIBLE_INIT_SCRIPT } from '../csp/inlineScripts';
-import { getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
+import { ASTRO_HYDRATION_HASHES_VERIFIED_FOR, getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
 
 const sha256Source = (source: string) => `'sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}'`;
 const hasHash = (sources: string[]) => sources.some((s) => s.startsWith("'sha256-"));
@@ -55,6 +56,25 @@ describe('cspRules', () => {
             expect(scriptSrc).toContain(sha256Source(PLAUSIBLE_INIT_SCRIPT));
         });
 
+        it('site scope authorises the (non-externalisable) Astro hydration scripts by hash', () => {
+            // Astro's framework-injected hydration scripts cannot be externalised, so
+            // they are pinned by hash (ASTRO_HYDRATION_SCRIPT_HASHES). Regenerate when
+            // bumping Astro — see cspRules.ts.
+            const scriptSrc = getCspDirectives({ env: 'production', scope: 'site' })['script-src'];
+            expect(scriptSrc).toContain("'sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g='"); // <astro-island> runtime
+            expect(scriptSrc).toContain("'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='"); // client:load
+            expect(scriptSrc).toContain("'sha256-BF0290pkb3jxQsE7z00xR8Imp8X34FLC88L0lkMnrGw='"); // client:idle
+        });
+
+        it('site scope authorises the GTM-injected ZoomInfo bootstrap by hash', () => {
+            // Authored in the shared GTM container (not this repo); hash captured from
+            // the browser CSP violation. Site only — examples keeps unsafe-inline.
+            const site = getCspDirectives({ env: 'production', scope: 'site' })['script-src'];
+            expect(site).toContain("'sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E='");
+            const examples = getCspDirectives({ env: 'production', scope: 'examples' })['script-src'];
+            expect(examples).not.toContain("'sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E='");
+        });
+
         it('examples keeps unsafe-inline with no hashes; dev site keeps unsafe-inline (Phase B)', () => {
             const examples = getCspDirectives({ env: 'production', scope: 'examples' })['script-src'];
             expect(examples).toContain("'unsafe-inline'");
@@ -77,6 +97,19 @@ describe('cspRules', () => {
             const site = getCspDirectives({ env: 'production', scope: 'site' });
             expect(site['style-src']).toContain('https://cdnjs.cloudflare.com');
             expect(site['font-src']).toContain('https://cdnjs.cloudflare.com');
+        });
+
+        it('Astro hydration-script hashes are still verified for the installed Astro version', () => {
+            // The 'site' policy pins Astro's framework-injected hydration-runtime
+            // script hashes (ASTRO_HYDRATION_SCRIPT_HASHES). Astro emits and minifies
+            // these, so an upgrade can change them — leaving the pinned hashes stale
+            // and (since staging enforces this scope) blocking hydration across the site.
+            //
+            // This test fails when Astro is upgraded so the staleness is caught here
+            // rather than on staging. To fix it, regenerate the hashes and bump the
+            // version — see the "HOW TO REGENERATE AFTER AN ASTRO UPGRADE" steps above
+            // ASTRO_HYDRATION_SCRIPT_HASHES in cspRules.ts.
+            expect(astroPackageJson.version).toBe(ASTRO_HYDRATION_HASHES_VERIFIED_FOR);
         });
     });
 

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
@@ -1,4 +1,10 @@
+import { createHash } from 'node:crypto';
+
+import { DARK_MODE_INIT_SCRIPT, PLAUSIBLE_INIT_SCRIPT } from '../csp/inlineScripts';
 import { getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
+
+const sha256Source = (source: string) => `'sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}'`;
+const hasHash = (sources: string[]) => sources.some((s) => s.startsWith("'sha256-"));
 
 describe('cspRules', () => {
     describe('scope', () => {
@@ -16,18 +22,13 @@ describe('cspRules', () => {
             );
         });
 
-        it("scopes differ only by script-src 'unsafe-eval'", () => {
+        it('site and examples scopes differ only in script-src', () => {
             const site = getCspDirectives({ env: 'production', scope: 'site' });
             const examples = getCspDirectives({ env: 'production', scope: 'examples' });
-            const names = Object.keys(site);
-            expect(Object.keys(examples)).toEqual(names);
+            const names = Object.keys(site).filter((name) => name !== 'script-src');
+            expect(Object.keys(examples)).toEqual(Object.keys(site));
             for (let i = 0, len = names.length; i < len; ++i) {
-                const name = names[i];
-                if (name === 'script-src') {
-                    expect(examples[name]).toEqual([...site[name], "'unsafe-eval'"]);
-                } else {
-                    expect(examples[name]).toEqual(site[name]);
-                }
+                expect(examples[names[i]]).toEqual(site[names[i]]);
             }
         });
 
@@ -40,10 +41,28 @@ describe('cspRules', () => {
             );
         });
 
-        it("both scopes keep 'unsafe-inline' in script-src and style-src", () => {
-            const site = getCspDirectives({ env: 'production', scope: 'site' });
-            expect(site['script-src']).toContain("'unsafe-inline'");
-            expect(site['style-src']).toContain("'unsafe-inline'");
+        it("style-src keeps 'unsafe-inline' in both scopes", () => {
+            expect(getCspDirectives({ env: 'production', scope: 'site' })['style-src']).toContain("'unsafe-inline'");
+            expect(getCspDirectives({ env: 'production', scope: 'examples' })['style-src']).toContain(
+                "'unsafe-inline'"
+            );
+        });
+
+        it('site scope authorises inline scripts by hash, not unsafe-inline (Phase B)', () => {
+            const scriptSrc = getCspDirectives({ env: 'production', scope: 'site' })['script-src'];
+            expect(scriptSrc).not.toContain("'unsafe-inline'");
+            expect(scriptSrc).toContain(sha256Source(DARK_MODE_INIT_SCRIPT));
+            expect(scriptSrc).toContain(sha256Source(PLAUSIBLE_INIT_SCRIPT));
+        });
+
+        it('examples keeps unsafe-inline with no hashes; dev site keeps unsafe-inline (Phase B)', () => {
+            const examples = getCspDirectives({ env: 'production', scope: 'examples' })['script-src'];
+            expect(examples).toContain("'unsafe-inline'");
+            expect(hasHash(examples)).toBe(false);
+
+            const devSite = getCspDirectives({ env: 'dev', scope: 'site' })['script-src'];
+            expect(devSite).toContain("'unsafe-inline'");
+            expect(hasHash(devSite)).toBe(false);
         });
 
         it('connect-src allows data: so sized SVG/data-URI images can be fetched for resize injection', () => {

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -74,7 +74,58 @@ const UNSAFE_EVAL = "'unsafe-eval'";
 // production report-only window is the backstop before enforcing).
 const hashInlineScript = (source: string): string =>
     `'sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}'`;
-const SITE_SCRIPT_HASHES = [hashInlineScript(DARK_MODE_INIT_SCRIPT), hashInlineScript(PLAUSIBLE_INIT_SCRIPT)];
+
+// Astro injects a small, fixed set of inline hydration-runtime scripts that we
+// cannot externalise — they are emitted (and minified) by the framework, not
+// authored here. Every OTHER site inline script is externalised to a 'self' bundle
+// (the GTM bootstrap; the homepage gallery; FrameworkRedirectPage), so these are the
+// only inline scripts the 'site' scope authorises by hash.
+//
+// Because the rendered bytes are Astro's build-time output, there is no source
+// string to derive these from — they are pinned, and they change when Astro's
+// hydration runtime changes, i.e. on an Astro upgrade. ASTRO_HYDRATION_HASHES_VERIFIED_FOR
+// records the Astro version they were captured against; cspRules.test.ts fails when
+// the installed version no longer matches, so an upgrade cannot silently leave the
+// policy stale (which would block hydration site-wide — staging enforces this scope).
+//
+// === HOW TO REGENERATE AFTER AN ASTRO UPGRADE ===
+//   1. yarn nx build ag-charts-website
+//   2. yarn nx run ag-charts-website:preview:csp          (serves the build with the enforced policy)
+//   3. Open https://localhost:4601/ plus a page using each client: directive
+//      (load/idle/only/visible) and read the browser console: every blocked inline
+//      script logs the missing 'sha256-...' value in its CSP violation. (Equivalently,
+//      hash the inline <script> contents in dist and diff against the list below.)
+//   4. Replace the hashes below with the new values, and bump
+//      ASTRO_HYDRATION_HASHES_VERIFIED_FOR to the new Astro version.
+export const ASTRO_HYDRATION_HASHES_VERIFIED_FOR = '6.1.9';
+const ASTRO_HYDRATION_SCRIPT_HASHES = [
+    "'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='", // client:load bootstrap
+    "'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='", // client:only bootstrap
+    "'sha256-Q2BPg90ZMplYY+FSdApNErhpWafg2hcRRbndmvxuL/Q='", // client:visible bootstrap
+    "'sha256-BF0290pkb3jxQsE7z00xR8Imp8X34FLC88L0lkMnrGw='", // client:idle bootstrap
+    "'sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g='", // <astro-island> hydration runtime
+];
+
+// SHA-256 of the inline ZoomInfo (WebSights) bootstrap that the shared Google Tag
+// Manager container injects as a Custom HTML tag once the visitor accepts functional
+// cookie consent. Unlike the scripts above, this one is authored in GTM, not this
+// repo — so the value is taken from the browser's CSP violation report, NOT by
+// hashing the GTM source (GTM normalises the injected bytes, so the source does not
+// reproduce this digest).
+//
+// FRAGILE — this pins ZoomInfo's exact bytes. If the ZoomInfo tag in GTM is edited,
+// or ZoomInfo regenerates its loader snippet, the hash stops matching and ZoomInfo
+// silently fails to load for consenting users. The GTM tag carries a note pointing
+// back here; if it changes, replace this with the new console-reported hash (here and
+// in the ag-grid / ag-studio CSPs — the GTM container is shared). AG-17134.
+const GTM_ZOOMINFO_HASH = "'sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E='";
+
+const SITE_SCRIPT_HASHES = [
+    hashInlineScript(DARK_MODE_INIT_SCRIPT),
+    hashInlineScript(PLAUSIBLE_INIT_SCRIPT),
+    ...ASTRO_HYDRATION_SCRIPT_HASHES,
+    GTM_ZOOMINFO_HASH,
+];
 
 // Apache <If> expression matching the URL paths that get the 'examples' scope.
 // Charts serves example-runner documents at both /gallery/examples/<name>/... and
@@ -82,6 +133,12 @@ const SITE_SCRIPT_HASHES = [hashInlineScript(DARK_MODE_INIT_SCRIPT), hashInlineS
 // production, so '/examples/' is not a leading prefix — match the segment anywhere.
 // '/archive/' covers archived doc versions (which ship the same runner).
 export const EXAMPLES_PATH_CONDITION = '%{REQUEST_URI} =~ m#/(examples|archive)/#';
+
+// JS equivalent of EXAMPLES_PATH_CONDITION above, for the dev-server (agDevCsp) and
+// preview-server (preview-csp) middleware that scope the served CSP by URL path.
+// No leading anchor: the site is served under the /charts base, so '/examples/' is
+// not a leading prefix. Keep in sync with EXAMPLES_PATH_CONDITION.
+export const EXAMPLES_PATH_REGEXP = /\/(examples|archive)\//;
 
 // 'self' resolves to www.ag-grid.com on production (charts lives under /charts) and
 // charts-staging.ag-grid.com on staging, so cross-subdomain references to the

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -38,6 +38,10 @@ export type CspDirectives = Record<string, string[]>;
 
 const SELF = "'self'";
 const NONE = "'none'";
+// In script-src, 'unsafe-inline' is now scope-specific: the 'site' policy
+// authorises its few known inline scripts by SHA-256 hash instead (see
+// SITE_SCRIPT_HASHES), while 'examples' still carries it. In style-src it stays
+// everywhere (charts theming/legacy styles inject <style> at runtime).
 const UNSAFE_INLINE = "'unsafe-inline'";
 // Permits WebAssembly compilation without permitting JS eval() — narrower than
 // 'unsafe-eval'. Needed on every page: docs snippets are highlighted in the
@@ -50,6 +54,18 @@ const WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
 // examples compile templates in the browser (JIT). The chart library itself does
 // not need it (see AG-11258), so ordinary pages no longer carry it.
 const UNSAFE_EVAL = "'unsafe-eval'";
+
+// SHA-256 hashes authorising the main-page inline <script>s in the 'site' scope
+// instead of 'unsafe-inline' (sources in src/utils/csp/inlineScripts.ts; a unit
+// test recomputes these from the source strings to catch drift). Added ONLY to
+// the 'site' scope: per CSP2+, the presence of a hash makes the browser ignore
+// 'unsafe-inline', so the 'examples' scope — which still relies on it — must NOT
+// carry them. Dev keeps 'unsafe-inline' (Vite/Astro inject their own inline scripts).
+// The homepage gallery script is externalised (not hashed) — it embeds build-hashed
+// CSS-module class names, which would make a static hash unstable.
+const DARK_MODE_SCRIPT_HASH = "'sha256-aDcVxFyA5yzYtH4VKuxvqdspCcTB4W0DrKJtGLTKl9A='";
+const PLAUSIBLE_SCRIPT_HASH = "'sha256-yyPoC+PtF+Rve9JwzJ4PTIiap268jewQfmi4/JViA6I='";
+const SITE_SCRIPT_HASHES = [DARK_MODE_SCRIPT_HASH, PLAUSIBLE_SCRIPT_HASH];
 
 // Apache <If> expression matching the URL paths that get the 'examples' scope.
 // Charts serves example-runner documents at both /gallery/examples/<name>/... and
@@ -108,8 +124,8 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
             'https://www.youtube.com', // YouTube iframe JS API (loads into the page)
             'https://cdn.cookielaw.org', // OneTrust cookie-consent SDK (GTM-injected, prod-only)
             'blob:', // ZoomInfo zi-tag.js bootstraps a blob: URL script
-            UNSAFE_INLINE,
             WASM_UNSAFE_EVAL,
+            // 'unsafe-inline' (examples/dev) or SHA-256 hashes (site) added per scope below.
         ],
         // 'unsafe-inline' stays: the charts theming/legacy styles inject <style>
         // elements at runtime and static hosting rules out per-request nonces.
@@ -179,8 +195,17 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         'frame-ancestors': [SELF, AG_GRID_HOSTS], // allow *.ag-grid.com (e.g. blog) to embed examples
     };
 
+    // script-src inline handling, by scope (and environment for 'site').
     if (scope === 'examples') {
-        directives['script-src'].push(UNSAFE_EVAL);
+        directives['script-src'].push(UNSAFE_EVAL, UNSAFE_INLINE);
+    } else if (env === 'dev') {
+        // Dev server (Vite/Astro) injects its own inline scripts for HMR/hydration
+        // that the static build does not; keep 'unsafe-inline' locally rather than
+        // block them. The hash-based site policy is validated on staging/production.
+        directives['script-src'].push(UNSAFE_INLINE);
+    } else {
+        // 'site' on staging/production: authorise the known inline scripts by hash.
+        directives['script-src'].push(...SITE_SCRIPT_HASHES);
     }
 
     if (env === 'dev') {

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -11,9 +11,13 @@
  *  - `scripts/csp/generate-csp.ts` to emit the policy for hand-placing / inspection.
  *  - `htaccessRules.ts` to emit the CSP block into the generated `.htaccess`.
  *
- * Keep this module dependency-free so it can be imported by a standalone `tsx`
- * script without pulling in the Astro/Vite build graph.
+ * Keep this module free of Astro/Vite imports so it can be imported by a standalone
+ * `tsx` script without pulling in the build graph (Node built-ins and plain-string
+ * constants are fine — it is only ever imported build-side, never client-side).
  */
+import { createHash } from 'node:crypto';
+
+import { DARK_MODE_INIT_SCRIPT, PLAUSIBLE_INIT_SCRIPT } from '../csp/inlineScripts';
 
 export type CspEnv = 'dev' | 'staging' | 'production';
 export type CspMode = 'report-only' | 'enforce';
@@ -56,16 +60,21 @@ const WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'";
 const UNSAFE_EVAL = "'unsafe-eval'";
 
 // SHA-256 hashes authorising the main-page inline <script>s in the 'site' scope
-// instead of 'unsafe-inline' (sources in src/utils/csp/inlineScripts.ts; a unit
-// test recomputes these from the source strings to catch drift). Added ONLY to
-// the 'site' scope: per CSP2+, the presence of a hash makes the browser ignore
+// instead of 'unsafe-inline'. Derived from the SAME constants the pages render
+// (src/utils/csp/inlineScripts.ts) so the policy can never drift from what is
+// served — edit the script and the hash follows automatically. Added ONLY to the
+// 'site' scope: per CSP2+, the presence of a hash makes the browser ignore
 // 'unsafe-inline', so the 'examples' scope — which still relies on it — must NOT
 // carry them. Dev keeps 'unsafe-inline' (Vite/Astro inject their own inline scripts).
 // The homepage gallery script is externalised (not hashed) — it embeds build-hashed
 // CSS-module class names, which would make a static hash unstable.
-const DARK_MODE_SCRIPT_HASH = "'sha256-aDcVxFyA5yzYtH4VKuxvqdspCcTB4W0DrKJtGLTKl9A='";
-const PLAUSIBLE_SCRIPT_HASH = "'sha256-yyPoC+PtF+Rve9JwzJ4PTIiap268jewQfmi4/JViA6I='";
-const SITE_SCRIPT_HASHES = [DARK_MODE_SCRIPT_HASH, PLAUSIBLE_SCRIPT_HASH];
+//
+// NB: this hashes the source string; the browser hashes the rendered bytes. They
+// match as long as Astro emits the inline script verbatim (verified in dev; the
+// production report-only window is the backstop before enforcing).
+const hashInlineScript = (source: string): string =>
+    `'sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}'`;
+const SITE_SCRIPT_HASHES = [hashInlineScript(DARK_MODE_INIT_SCRIPT), hashInlineScript(PLAUSIBLE_INIT_SCRIPT)];
 
 // Apache <If> expression matching the URL paths that get the 'examples' scope.
 // Charts serves example-runner documents at both /gallery/examples/<name>/... and


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17134

## Summary

Phase B of the CSP tightening (follows eval-removal, now in production report-only). Removes `'unsafe-inline'` from the **`site`** scope `script-src`. `style-src 'unsafe-inline'` is untouched (permanent — runtime `<style>` injection, no nonces on static hosting). Mirrors the grid (#14092) and studio PRs.

| scope | `script-src` inline handling |
|---|---|
| **site** | SHA-256 hash per inline script, **no** `'unsafe-inline'` |
| examples | `'unsafe-eval'` + `'unsafe-inline'` (example runner), no hashes |

Per CSP2+, a hash in `script-src` makes the browser ignore `'unsafe-inline'`, so hashes go **only** in the `site` scope. Dev keeps `'unsafe-inline'` (Vite/Astro inject their own inline scripts).

## Inline scripts

- **Dark-mode bootstrap** + **Plausible stub** → kept inline (dark-mode render-blocking/paint-critical) and authorised by **SHA-256 hash**. Bodies in `src/utils/csp/inlineScripts.ts`, rendered via `set:html` so rendered bytes == hashed source.
- **Homepage gallery chart manager** (`HomepageGalleryExamples.astro`) → **externalised** to `/scripts/homepage-gallery.js`, config via `data-` attributes. It embeds build-hashed CSS-module class names, so a static hash would change every build — externalisation is the right fit. Data attributes are captured synchronously up front (the init runs on `DOMContentLoaded`, when `document.currentScript` is null).
- **GTM bootstrap** (shared `GoogleTagManager.astro`) → **externalised** to `/scripts/gtm-init.js`.

## Rollout

Still **report-only on production** via the existing `PRODUCTION_CSP_PHASE`; enforce flip gated on the GTM container audit.

## Test plan

- `nx test:vitest ag-charts-website` — site scope has both sha256 + no `unsafe-inline`; examples keeps `unsafe-inline` + no hashes; dev keeps `unsafe-inline`; style-src keeps `unsafe-inline`. All 382 pass. Prettier applied.
- ⚠️ **Needs browser verification before merge:** the homepage **gallery** externalization is a JS refactor of a live interactive feature — load the charts homepage, confirm the gallery renders, tab-switching works, and there are no console errors. (Independent of the report-only CSP, a refactor bug would break the gallery on deploy.)
- **Before enforce:** confirm on a real build/report-only window that the prod (compressed-HTML) inline-script hashes still match, and watch for GTM-injected inline-script violations.

## Note for reviewers

The `GoogleTagManager.astro` change is in the **`ag-website-shared` subrepo** — upstream it via `git-subrepo` so the grid/charts/studio copies don't drift. The same change is in the grid (#14092) and studio PRs.

---

### Update: parity with grid #14118 / studio #1756 + GTM ZoomInfo hash

Added on top of the existing unsafe-inline removal on this branch:

- **Astro hydration hashes** — pinned `ASTRO_HYDRATION_SCRIPT_HASHES` (the 5 framework-injected hydration scripts, verified for the installed Astro 6.1.9) into `SITE_SCRIPT_HASHES`. Without these, the **enforced staging `site` policy blocks all hydration** (a hash in `script-src` makes the browser ignore `'unsafe-inline'`). A `cspRules.test.ts` guard fails on an Astro upgrade so the pins can't silently go stale.
- **GTM ZoomInfo hash** — authorised the inline ZoomInfo (WebSights) bootstrap that the shared GTM container injects (after functional cookie consent) by SHA-256 (`sha256-41l+jvtOjBgKy9345IStB4j1gGPGFMVXADMHn1Acs6E=`), taken from the browser CSP violation. Site scope only; fragile pin; same value is in the ag-grid (#14143) and ag-studio (#1756) CSPs (shared container).
- **FrameworkRedirectPage** — folded its reveal `setTimeout` into the bundled module script (served from `'self'`).
- **CSP preview tool** — `scripts/csp/preview-csp.ts` + `preview:csp` target: serves `dist` under base `/charts` on 4601 with the enforced path-scoped policy, so CSP regressions can be caught locally (neither `astro dev` nor `astro preview` can validate the hashed policy).
- **agDevCsp** now uses the exported `EXAMPLES_PATH_REGEXP`.

Verified by building and hashing every inline `<script>` in `dist`: the Astro-hydration, ZoomInfo and FrameworkRedirectPage cases are all authorised (8 site hashes; 0 of those blocked under enforce).

### ⚠️ Pre-existing gaps this branch still needs (found via the build scan)

The scan surfaced **6 site-scope inline scripts not yet externalised on this branch** — they pre-date these additions and will block on enforcing staging. Grid #14118 already solved most; they can be ported:

| Inline script | Source | Grid solution to port |
|---|---|---|
| ImageCaption dark-mode swap | `ag-website-shared` `ImageCaption.astro` | data-attrs + `public/scripts/image-caption-darkmode.js` |
| ExpandingSection | `ag-website-shared` `ExpandingSection.astro` | `public/scripts/expanding-section.js` |
| FeaturesWithExamples tabs | `landing-pages/.../FeaturesWithExamples.astro` | `public/scripts/features-with-examples-tabs.js` |
| Plausible 404 event | `src/pages/404.astro` | `public/scripts/plausible-404.js` |
| Scroll-class listener | `src/pages/index.astro` (`initScrollClassListener`) | convert inline `<script>` → module import of the shared util |

These were left out of this commit as they're charts-specific externalisations belonging to this PR's own scope rather than the grid/studio port.
