### PR TITLE
AG-17459 Inject example link elements into the document head

### DIFF
--- a/packages/ag-charts-website/src/components/docs/constants.ts
+++ b/packages/ag-charts-website/src/components/docs/constants.ts
@@ -10,4 +10,5 @@ export const LICENSE_INSTALL_REDIRECT_PAGE = 'license-install';
 export const FILES_TO_HIDE: Record<string, InternalFramework[] | boolean> = {
     'index.html': ['reactFunctional', 'reactFunctionalTs', 'vue3', 'angular'],
     'ag-example-styles.css': true,
+    'head.html': true,
 };

--- a/packages/ag-charts-website/src/components/example-runner/components/CodeViewer.tsx
+++ b/packages/ag-charts-website/src/components/example-runner/components/CodeViewer.tsx
@@ -39,6 +39,10 @@ export function stripOutExampleGeneratorCode(files: FileContents) {
     if (files['index.html']) {
         files['index.html'] = files['index.html']?.replace(e2eStyleRegex, '').trim();
     }
+
+    // `head.html` is a synthetic fragment injected into the document `<head>`, not a project
+    // file — the rendered host page already includes its contents, so exports must not carry it.
+    delete files['head.html'];
 }
 
 /**

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/index.html
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/index.html
@@ -1,1 +1,7 @@
 <div id="myChart"></div>
+<link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+/>

--- a/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/main.ts
+++ b/packages/ag-charts-website/src/content/docs/fonts/_examples/inline-font-icons/main.ts
@@ -103,15 +103,4 @@ const options: AgChartOptions = {
     },
 };
 
-// Create the chart once the FontAwesome stylesheet has loaded; the chart then fetches the fonts.
-const stylesheetReady = new Promise<void>((resolve) => {
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css';
-    link.crossOrigin = 'anonymous';
-    link.referrerPolicy = 'no-referrer';
-    link.onload = () => resolve();
-    document.head.appendChild(link);
-});
-
-stylesheetReady.then(() => AgCharts.create(options));
+AgCharts.create(options);

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/examplesGenerator.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/examplesGenerator.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { ANGULAR_GENERATED_MAIN_FILE_NAME, SOURCE_ENTRY_FILE_NAME } from './constants';
 import { transformPlainEntryFile } from './transformPlainEntryFile';
 import chartVanillaSrcParser from './transformation-scripts/chart-vanilla-src-parser';
+import { extractHeadLinks } from './transformation-scripts/extract-head-elements';
 import type { GeneratedContents, InternalFramework } from './types';
 import {
     getEntryFileName,
@@ -130,6 +131,11 @@ export const getGeneratedContents = async (params: GeneratedContentParams): Prom
         }
     }
 
+    // Extract any `<link>` elements so they can be injected into the document `<head>` instead
+    // of the body, which would otherwise leak them into the generated framework components.
+    const { head: headHtml, body: indexHtmlBody } = extractHeadLinks(indexHtml);
+    indexHtml = indexHtmlBody;
+
     let skipContainerCheck = false;
     if (entryFile.includes('@ag-skip-container-check')) {
         entryFile = entryFile.replace(/^\s*\/\/ @ag-skip-container-check\s*\n*$/g, '');
@@ -238,6 +244,10 @@ export const getGeneratedContents = async (params: GeneratedContentParams): Prom
         // The NPM package `serialize-javascript` can deal with trivial cases, but non-trivial cases
         // such as a callback that uses another function declared in the example are not handled well.
         files['_options.json'] = JSON.stringify(jsonOptions);
+    }
+
+    if (headHtml) {
+        files['head.html'] = headHtml;
     }
 
     const result: GeneratedContents = {

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/extract-head-elements.test.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/extract-head-elements.test.ts
@@ -1,0 +1,50 @@
+import { extractHeadLinks } from './extract-head-elements';
+
+describe('extractHeadLinks', () => {
+    it('extracts a single link element and removes it from the body', () => {
+        const html = `<link rel="stylesheet" href="https://example.com/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<div id="myChart"></div>`;
+
+        const { head, body } = extractHeadLinks(html);
+
+        expect(head).toContain('rel="stylesheet"');
+        expect(head).toContain('href="https://example.com/all.min.css"');
+        expect(head).toContain('crossorigin="anonymous"');
+        expect(head).toContain('referrerpolicy="no-referrer"');
+        expect(body).not.toContain('<link');
+        expect(body).toContain('<div id="myChart"></div>');
+    });
+
+    it('extracts multiple link elements', () => {
+        const html = `<link rel="stylesheet" href="a.css" />
+<link rel="stylesheet" href="b.css" />
+<div id="myChart"></div>`;
+
+        const { head, body } = extractHeadLinks(html);
+
+        expect(head).toContain('href="a.css"');
+        expect(head).toContain('href="b.css"');
+        expect(body).not.toContain('<link');
+    });
+
+    it('returns an empty head and the unchanged body when there are no link elements', () => {
+        const html = `<div id="myChart"></div>`;
+
+        const { head, body } = extractHeadLinks(html);
+
+        expect(head).toBe('');
+        expect(body).toBe(html);
+    });
+
+    it('preserves other body content such as example controls', () => {
+        const html = `<link rel="stylesheet" href="a.css" />
+<div id="controls"><button id="toggle">Toggle</button></div>
+<div id="myChart"></div>`;
+
+        const { body } = extractHeadLinks(html);
+
+        expect(body).toContain('<div id="controls">');
+        expect(body).toContain('<button id="toggle">Toggle</button>');
+        expect(body).toContain('<div id="myChart"></div>');
+    });
+});

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/extract-head-elements.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/extract-head-elements.ts
@@ -1,0 +1,27 @@
+import * as cheerio from 'cheerio';
+
+/**
+ * Splits an example `index.html` into its `<link>` elements (which belong in the document
+ * `<head>`) and the remaining body content.
+ *
+ * `<link>` elements left in the body are parsed into the framework component templates,
+ * where they are invalid and break rendering. Extracting them lets the generator inject them
+ * into the document `<head>` instead, uniformly across all frameworks.
+ */
+export function extractHeadLinks(html: string): { head: string; body: string } {
+    const domTree = cheerio.load(html, null, false);
+    const links = domTree('link');
+
+    if (links.length === 0) {
+        return { head: '', body: html };
+    }
+
+    const head = links
+        .toArray()
+        .map((elem) => domTree.html(elem))
+        .join('\n');
+
+    links.remove();
+
+    return { head, body: domTree.html() ?? '' };
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17459

Adding a `<link>` element to an example's `index.html` previously leaked it into the generated React/Angular/Vue component templates, breaking them — the generator parses the whole `index.html` body into the component template.

This extracts `<link>` elements from the example `index.html` and injects them into the document `<head>` uniformly across all frameworks, via the existing (but previously unused) `head.html`/`headFragment` mechanism in `FrameworkTemplate.astro`.

### Summary
- New `extractHeadLinks` helper splits `<link>` elements out of the body (returns the body byte-identical when there are no links).
- `examplesGenerator` feeds the link-stripped body to the parser and framework generators, and emits the extracted links as a synthetic `head.html` file.
- `head.html` is hidden from the docs/gallery code viewer (`FILES_TO_HIDE`) and stripped from Plunker/CodeSandbox exports (their host `index.html` already inlines the rendered `<head>`).
- The `inline-font-icons` example moves its Font Awesome stylesheet from JS-based DOM injection into `index.html`, which is now framework-portable.

### Test plan
- Unit tests for `extractHeadLinks` (single/multiple links, no links, control markup preserved).
- `yarn nx format`, `yarn nx lint ag-charts-website`, plugin `tsc --noEmit` all green.
- Manual: switch the `fonts/inline-font-icons` example across React/Angular/Vue/TS/JS — icons render, the `<link>` is absent from generated components and present in the page `<head>`, no `head.html` tab in the viewer.

Fix #AG-17459