### PR TITLE
AG-17564 fix waterfall totalValue for subtotals after the first

### DIFF
--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -260,6 +260,32 @@ describe('WaterfallSeries', () => {
             expect(seriesNodeClick.mock.calls[0][0].totalValue).toBe(SUBTOTAL_VALUE);
             expect(seriesNodeClick.mock.calls[1][0].totalValue).toBeUndefined();
         });
+
+        it('computes each subtotal totalValue relative to the previous subtotal, not the absolute total', async () => {
+            // Two subtotals: 1st after A,B (segment 150, absolute 150 — coincide); 2nd after C,D
+            // (absolute cumulative 200, segment since the 1st subtotal 50). totalValue must be the
+            // segment the bar represents (50), matching the rendered value, not the absolute total (200).
+            const options = totalValueOptions({
+                totals: [
+                    { totalType: 'subtotal', index: 1, axisLabel: 'Sub 1' },
+                    { totalType: 'subtotal', index: 3, axisLabel: 'Sub 2' },
+                ],
+            });
+            prepareEnterpriseTestOptions(options as any);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const subtotals = seriesOf(chart)
+                .getNodeData()
+                .filter((n: any) => n.itemType === 'subtotal');
+
+            expect(subtotals).toHaveLength(2);
+            expect(subtotals[0].totalValue).toBe(150);
+            expect(subtotals[0].totalValue).toBe(subtotals[0].yValue);
+            expect(subtotals[1].totalValue).toBe(50);
+            expect(subtotals[1].totalValue).toBe(subtotals[1].yValue);
+            expect(subtotals[1].totalValue).not.toBe(200);
+        });
     });
 
     it(`should render a waterfall chart as expected`, async () => {

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -566,7 +566,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
             datum,
             datumIndex,
             cumulativeValue: Number(cumulativeValue ?? 0),
-            totalValue: this.getTotalValue(seriesItemType, cumulativeValue),
+            totalValue: this.getTotalValue(seriesItemType, value),
             xValue: xDatum,
             yValue: value,
             yKey,
@@ -621,7 +621,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         mutableNode.datum = datum;
         mutableNode.datumIndex = datumIndex;
         mutableNode.cumulativeValue = Number(cumulativeValue ?? 0);
-        mutableNode.totalValue = this.getTotalValue(seriesItemType, cumulativeValue);
+        mutableNode.totalValue = this.getTotalValue(seriesItemType, value);
         mutableNode.xValue = xDatum;
         mutableNode.yValue = value;
         mutableNode.x = rectX;
@@ -792,10 +792,10 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
 
     private getTotalValue(
         itemType: AgWaterfallSeriesItemType,
-        cumulativeValue: AgNumericValue | undefined
+        value: AgNumericValue | undefined
     ): AgNumericValue | undefined {
-        if (cumulativeValue == null) return undefined;
-        return this.isTotal(itemType) || this.isSubtotal(itemType) ? cumulativeValue : undefined;
+        if (value == null) return undefined;
+        return this.isTotal(itemType) || this.isSubtotal(itemType) ? value : undefined;
     }
 
     protected override nodeFactory() {


### PR DESCRIPTION
## Summary

Follow-up to #7103. QA found that the `totalValue` param exposed to Waterfall callbacks/events was wrong for any `subtotal` after the first: it reported the absolute grand running total instead of the segment the bar actually represents.

- **Reproducer:** 2nd `subtotal` bar — rendered label/`value` `-686` (correct), but `totalValue` reported `-133` (the absolute cumulative) instead of `-686`.
- **Root cause:** `totalValue` was sourced from the raw `cumulativeValue` (`ctx.yCurrTotalValues[i]`, the absolute running total across all bars). For the **first** subtotal this coincidentally equals the displayed segment value because the trailing baseline is `0`, which is why the original single-subtotal test passed vacuously. Every later subtotal diverges.
- **Fix:** base `totalValue` on the already-computed display `value`, which resolves the segment relative to the previous total/subtotal. For `total` items this is the absolute cumulative; for `subtotal` items the segment delta; `undefined` for `positive`/`negative`. Every consumer (label formatter, tooltip renderer, item styler, node-click events) reads `nodeDatum.totalValue`, so the two datum-construction sites are the single fix point.

## Test plan

- Added a regression test with **two** subtotals separated by data (the original fixture had only one, so `value === totalValue` everywhere and the bug was invisible). It asserts the 2nd subtotal's `totalValue` equals its segment (`50`, matching the rendered value) rather than the absolute cumulative (`200`). Confirmed failing before the fix, passing after.
- `yarn nx test ag-charts-enterprise` waterfall + callbacks suites (200 tests) pass; no snapshot changes.
- `yarn nx format`, `build:types`, `lint` all green.

Fix #AG-17564