### PR TITLE
AG-16608 fix BigInt precision in crosshair, zoom and gauge callbacks

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { AgNumericValue } from 'ag-charts-types';
+
 import { LinearScale } from '../../scale/linearScale';
 import { OrdinalTimeScale } from '../../scale/ordinalTimeScale';
 import { estimateScaleTickCount } from './generateTicks';
@@ -56,7 +58,8 @@ describe('withTemporaryDomain', () => {
         scale.domain = [lo, hi];
         scale.range = [0, 1000];
 
-        withTemporaryDomain(scale, [Number(lo), Number(hi)], () => {});
+        const narrowedDomain: AgNumericValue[] = [Number(lo), Number(hi)];
+        withTemporaryDomain(scale, narrowedDomain, () => {});
 
         expect(scale.convert(lo)).toBeLessThan(scale.convert(hi));
         expect(scale.convert(lo + 1n)).not.toBe(scale.convert(lo + 2n));

--- a/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
@@ -62,6 +62,13 @@ describe('withTemporaryDomain', () => {
         withTemporaryDomain(scale, narrowedDomain, () => {});
 
         expect(scale.convert(lo)).toBeLessThan(scale.convert(hi));
-        expect(scale.convert(lo + 1n)).not.toBe(scale.convert(lo + 2n));
+
+        // Adjacent bigints ending ...995/996/997: above 2^53 these narrow onto a single float64 value, so a
+        // restore that dropped the exact endpoints collapses them onto one pixel (David's reported symptom).
+        const p5 = scale.convert(lo + 5n);
+        const p6 = scale.convert(lo + 6n);
+        const p7 = scale.convert(lo + 7n);
+        expect(p5).toBeLessThan(p6);
+        expect(p6).toBeLessThan(p7);
     });
 });

--- a/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { LinearScale } from '../../scale/linearScale';
 import { OrdinalTimeScale } from '../../scale/ordinalTimeScale';
 import { estimateScaleTickCount } from './generateTicks';
+import { withTemporaryDomain } from './generateTicksUtils';
 
 // AG-17065: for large ordinal-time domains with deep zoom, the binary search in
 // buildTickData needs to cover the full tick count range. If minTickCount is too
@@ -39,5 +41,24 @@ describe('estimateScaleTickCount', () => {
 
         const binarySearchRange = result.tickCount - result.minTickCount;
         expect(binarySearchRange).toBeGreaterThanOrEqual(result.tickCount * 0.9);
+    });
+});
+
+// AG-16608: a zoomed update runs tick generation through withTemporaryDomain. If the restore narrowed
+// the domain, the scale lost its exact bigint endpoints and adjacent high-magnitude bigints collapsed
+// onto one pixel. The restore must reinstate the exact endpoints.
+describe('withTemporaryDomain', () => {
+    it('restores exact bigint domain endpoints after temporarily narrowing for tick generation', () => {
+        const lo = 9_007_199_254_740_990n;
+        const hi = 9_007_199_254_741_000n;
+
+        const scale = new LinearScale();
+        scale.domain = [lo, hi];
+        scale.range = [0, 1000];
+
+        withTemporaryDomain(scale, [Number(lo), Number(hi)], () => {});
+
+        expect(scale.convert(lo)).toBeLessThan(scale.convert(hi));
+        expect(scale.convert(lo + 1n)).not.toBe(scale.convert(lo + 2n));
     });
 });

--- a/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
@@ -288,12 +288,12 @@ export function withTemporaryDomain<S extends Scale<D, number, TickInterval<S>>,
     temporaryDomain: D[],
     callback: () => void
 ): void {
-    const originalDomain = scale.domain;
+    const originalDomain = scale.snapshotDomain();
     try {
         scale.domain = temporaryDomain;
         callback();
     } finally {
-        scale.domain = originalDomain;
+        scale.restoreDomain(originalDomain);
     }
 }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -1103,6 +1103,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 existingNode.midPoint = { x: scratch.x, y: scratch.y };
                 // Metadata only (tooltips/error-bars); position already used the exact bigint, so narrowing here is fine.
                 existingNode.cumulativeValue = Number(scratch.yCumulative);
+                existingNode.cumulativeValueExact = scratch.yCumulative;
                 existingNode.yValue = scratch.yDatum;
                 existingNode.xValue = scratch.xDatum;
                 existingNode.point = { x: scratch.x, y: scratch.y, size: ctx.markerSize };
@@ -1114,6 +1115,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                     datumIndex,
                     midPoint: { x: scratch.x, y: scratch.y },
                     cumulativeValue: Number(scratch.yCumulative),
+                    cumulativeValueExact: scratch.yCumulative,
                     yValue: scratch.yDatum,
                     xValue: scratch.xDatum,
                     yKey: ctx.yKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -2969,4 +2969,31 @@ describe('BarSeries', () => {
             expectWarningsCalls().toEqual([]);
         });
     });
+
+    // AG-16608: the crosshair label reads `cumulativeValueExact` to keep full bigint precision; the
+    // narrowed `cumulativeValue` is float64-rounded and used only for geometry/error-bar maths.
+    describe('bigint cumulativeValueExact', () => {
+        it('should retain the exact bigint plotted value alongside the narrowed cumulativeValue', async () => {
+            const options: AgChartOptions = {
+                data: [
+                    { x: 'A', y: BIG },
+                    { x: 'B', y: BIG + 2n },
+                ],
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+            };
+            prepareTestOptions(options);
+
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const series = deproxy(chart).series[0] as any;
+            const nodeData = series.contextNodeData?.nodeData;
+
+            expect(nodeData).toHaveLength(2);
+            expect(nodeData[0].cumulativeValueExact).toBe(BIG);
+            // Geometry value narrows to float64, losing the final digit.
+            expect(nodeData[0].cumulativeValue).toBe(Number(BIG));
+            expect(BigInt(nodeData[0].cumulativeValue)).not.toBe(BIG);
+        });
+    });
 });

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -834,6 +834,8 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         const yValue = phantom ? prepared.yFilterValue! : (prepared.yFilterValue ?? prepared.yRawValue);
         // Metadata only (tooltips/error-bars); geometry below uses the exact bigint, so narrowing here is fine.
         const cumulativeValue = phantom ? prepared.yFilterValue! : (prepared.yFilterValue ?? Number(params.yEnd));
+        // Full-precision plotted value for display surfaces (crosshair); cross-filtered values are already narrowed.
+        const cumulativeValueExact = phantom ? prepared.yFilterValue! : (prepared.yFilterValue ?? params.yEnd);
         const nodeLabelText = phantom ? undefined : prepared.labelText;
 
         // Non-filtered: params.yEnd stays in domain space (possibly bigint) for a full-precision convert().
@@ -882,6 +884,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         mutableNode.datum = prepared.datum;
         mutableNode.datumIndex = params.datumIndex;
         mutableNode.cumulativeValue = cumulativeValue;
+        mutableNode.cumulativeValueExact = cumulativeValueExact;
         mutableNode.xValue = prepared.xValue;
         mutableNode.yValue = yValue;
         mutableNode.x = barRectX;

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -549,6 +549,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             aggregatedValue,
             // cumulativeValue is the plotted bar height (crosshair geometry); narrow to Number like other series.
             cumulativeValue: Number(total),
+            cumulativeValueExact: total,
             frequency,
             yKey,
             xKey,
@@ -596,6 +597,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         mutableNode.binIndex = binIndex;
         mutableNode.aggregatedValue = aggregatedValue;
         mutableNode.cumulativeValue = Number(total);
+        mutableNode.cumulativeValueExact = total;
         mutableNode.frequency = frequency;
         mutableNode.binRange = binRange;
         mutableNode.x = x;

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -547,6 +547,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 (existingNode as any).midPoint = { x: scratch.x, y: scratch.y };
                 // Metadata only; position already used the exact bigint, so narrowing here is fine.
                 (existingNode as any).cumulativeValue = Number(scratch.yCumulative);
+                (existingNode as any).cumulativeValueExact = scratch.yCumulative;
                 (existingNode as any).yValue = scratch.yDatum;
                 (existingNode as any).xValue = scratch.xDatum;
                 (existingNode as any).labelText = labelText;
@@ -561,6 +562,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                     point: { x: scratch.x, y: scratch.y, size: ctx.size },
                     midPoint: { x: scratch.x, y: scratch.y },
                     cumulativeValue: Number(scratch.yCumulative),
+                    cumulativeValueExact: scratch.yCumulative,
                     yValue: scratch.yDatum,
                     xValue: scratch.xDatum,
                     capDefaults: ctx.capDefaults,

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -189,6 +189,12 @@ export interface SeriesNodeDatum {
     readonly datums?: unknown[];
     /** Waterfall series only: the computed cumulative value for `total`/`subtotal` bars. */
     readonly totalValue?: AgNumericValue;
+    /**
+     * Full-precision counterpart of {@link ErrorBoundSeriesNodeDatum.cumulativeValue}, which narrows to
+     * Number for geometry/arithmetic. Display surfaces (e.g. the crosshair label) read this so a bigint
+     * value keeps full precision rather than the float64-rounded `cumulativeValue`.
+     */
+    readonly cumulativeValueExact?: AgNumericValue;
     readonly datumIndex: DatumIndex;
     readonly point?: Readonly<Point> & SizedPoint;
     readonly missing?: boolean;

--- a/packages/ag-charts-community/src/scale/abstractScale.ts
+++ b/packages/ag-charts-community/src/scale/abstractScale.ts
@@ -17,6 +17,12 @@ export abstract class AbstractScale<D, R, I = number> implements Scale<D, R, I> 
     abstract convert(value: D, options: { clamp?: boolean; alignment?: ScaleAlignment }): R;
     abstract invert(value: R, nearest?: boolean): D | undefined;
     abstract getDomainMinMax(): [D, D] | [undefined, undefined];
+    snapshotDomain(): D[] {
+        return this.domain;
+    }
+    restoreDomain(snapshot: D[]): void {
+        this.domain = snapshot;
+    }
     get domainMin(): D | undefined {
         return this.getDomainMinMax()[0];
     }

--- a/packages/ag-charts-community/src/scale/continuousScale.ts
+++ b/packages/ag-charts-community/src/scale/continuousScale.ts
@@ -217,6 +217,14 @@ export abstract class ContinuousScale<D extends number | bigint | Date, I = numb
         return unpackDomainMinMax(this.domain);
     }
 
+    override snapshotDomain(): D[] {
+        const snapshot = this._domain.slice();
+        // d0Big/d1Big are only set when the domain was supplied as bigint, so D admits bigint here.
+        if (this.d0Big != null) snapshot[0] = this.d0Big as D;
+        if (this.d1Big != null) snapshot[1] = this.d1Big as D;
+        return snapshot;
+    }
+
     // Returns the exact (possibly bigint) endpoint stored at the given index, preferring the retained
     // bigint over its Number-narrowed copy.
     private exactEndpoint(index: 0 | 1): D {

--- a/packages/ag-charts-community/src/scale/linearScale.test.ts
+++ b/packages/ag-charts-community/src/scale/linearScale.test.ts
@@ -382,6 +382,28 @@ describe('LinearScale', () => {
                 previous = position;
             }
         });
+
+        // AG-16608: tick generation narrows the domain via withTemporaryDomain; the snapshot/restore pair
+        // must reinstate the exact bigint endpoints so a zoomed convert() keeps adjacent bigints distinct.
+        test('preserves exact bigint endpoints across a snapshotDomain/restoreDomain round-trip', () => {
+            const lo = 9_007_199_254_740_990n; // straddles Number.MAX_SAFE_INTEGER (2^53 - 1)
+            const hi = 9_007_199_254_741_000n;
+
+            const scale = new LinearScale();
+            scale.domain = [lo, hi];
+            scale.range = [0, 1000];
+
+            const snapshot = scale.snapshotDomain();
+            scale.domain = [Number(lo), Number(hi)]; // mimic the narrowed domain used during tick generation
+            scale.restoreDomain(snapshot);
+
+            let previous = -Infinity;
+            for (let v = lo; v <= hi; v++) {
+                const position = scale.convert(v);
+                expect(position).toBeGreaterThan(previous);
+                previous = position;
+            }
+        });
     });
 
     describe('convertClamped', () => {

--- a/packages/ag-charts-core/src/types/scales.ts
+++ b/packages/ag-charts-core/src/types/scales.ts
@@ -72,6 +72,12 @@ export interface Scale<D, R, I = number> {
     readonly domainMin: D | undefined;
     /** Domain maximum, preserving the domain value type (so a bigint domain flows through as bigint). */
     readonly domainMax: D | undefined;
+    /**
+     * Capture the domain for an exact round-trip restore via {@link restoreDomain}. A continuous scale
+     * preserves its exact bigint endpoints here; the narrowed `domain` getter would discard them.
+     */
+    snapshotDomain(): D[];
+    restoreDomain(snapshot: D[]): void;
     normalizeDomains(...domains: DomainWithMetadata<D>[]): NormalizedDomain<D>;
     toDomain(value: number): D | undefined;
     convert(value: D, options?: { clamp?: boolean; alignment?: ScaleAlignment; alignmentExclusive?: boolean }): R;

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -406,7 +406,7 @@ export class Crosshair
         activeHighlight: Exclude<_ModuleSupport.HighlightChangeEvent['currentHighlight'], undefined>
     ): { [key: string]: { position: number; value: any } } {
         const { axisCtx } = this;
-        const { series, xKey = '', aggregatedValue, cumulativeValue, midPoint } = activeHighlight;
+        const { series, xKey = '', aggregatedValue, cumulativeValue, cumulativeValueExact, midPoint } = activeHighlight;
         const datum = readDatum(activeHighlight);
         const seriesKeyProperties = series.getKeyProperties(axisCtx.direction);
 
@@ -416,9 +416,11 @@ export class Crosshair
         const isYKey = seriesKeyProperties.includes('yKey') && matchingAxisId;
         const isXKey = seriesKeyProperties.includes('xKey') && matchingAxisId;
 
-        // Histogram exposes a raw, area-independent `aggregatedValue` for callbacks rather than the
-        // plotted height, so prefer `cumulativeValue` (the drawn value) when present.
-        const datumValue = cumulativeValue ?? aggregatedValue;
+        // `cumulativeValueExact` keeps full precision for a bigint plotted value (the narrowed
+        // `cumulativeValue` would float64-round it). Histogram exposes a raw, area-independent
+        // `aggregatedValue` for callbacks rather than the plotted height, so prefer the plotted value
+        // (`cumulativeValueExact`/`cumulativeValue`) when present.
+        const datumValue = cumulativeValueExact ?? cumulativeValue ?? aggregatedValue;
         if (isYKey && datumValue !== undefined) {
             const position = axisCtx.scale.convert(datumValue) + halfBandwidth;
             const isInRange = this.isInRange(position);

--- a/packages/ag-charts-enterprise/src/series/gauge-util/gaugeTooltip.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/gaugeTooltip.ts
@@ -1,13 +1,14 @@
 import { _ModuleSupport } from 'ag-charts-community';
+import type { AgNumericValue } from 'ag-charts-types';
 
-type GauageTooltipInfo = { value: number | undefined; text: string | undefined; fallbackLabel: string };
+type GauageTooltipInfo = { value: AgNumericValue | undefined; text: string | undefined; fallbackLabel: string };
 
 interface GaugeSeriesLike {
     properties: {
-        value: number;
+        value: AgNumericValue;
         label: { text?: string };
         scale: { min: number; max: number };
-        targets: { text?: string; value?: number }[];
+        targets: { text?: string; value?: AgNumericValue }[];
     };
     ctx: { localeManager: _ModuleSupport.LocaleManager };
 }

--- a/packages/ag-charts-enterprise/src/series/gauge-util/gaugeTooltip.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/gaugeTooltip.ts
@@ -7,7 +7,7 @@ interface GaugeSeriesLike {
     properties: {
         value: AgNumericValue;
         label: { text?: string };
-        scale: { min: number; max: number };
+        scale: { min: AgNumericValue; max: AgNumericValue };
         targets: { text?: string; value?: AgNumericValue }[];
     };
     ctx: { localeManager: _ModuleSupport.LocaleManager };

--- a/packages/ag-charts-enterprise/src/series/gauge-util/label.test.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/label.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgNumericValue } from 'ag-charts-types';
+
+import { getLabelText } from './label';
+
+describe('gauge getLabelText', () => {
+    const ctx = { chartService: {} };
+
+    // AG-16608: the count-up animation override is Number-narrowed (a bigint can't be precisely tweened).
+    // The user formatter must still receive the raw bigint so callbacks preserve the value type.
+    it('passes the raw bigint to the formatter even when the animation override narrows it', () => {
+        const value = 9_007_199_254_740_993n; // Number.MAX_SAFE_INTEGER + 2
+        let received: AgNumericValue | undefined;
+        const datum = {
+            value,
+            formatter: (params: any) => {
+                received = params.value;
+                return String(params.value);
+            },
+        };
+
+        // The fourth argument mimics the narrowed count-up tween value passed during animation.
+        const text = getLabelText('gauge-id', ctx, datum, Number(value));
+
+        expect(typeof received).toBe('bigint');
+        expect(received).toBe(value);
+        expect(text).toBe('9007199254740993');
+    });
+
+    it('uses the Number animation override for a non-bigint value so the count-up still animates', () => {
+        let received: AgNumericValue | undefined;
+        const datum = {
+            value: 100,
+            formatter: (params: any) => {
+                received = params.value;
+                return String(params.value);
+            },
+        };
+
+        getLabelText('gauge-id', ctx, datum, 42);
+
+        expect(received).toBe(42);
+    });
+});

--- a/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/label.ts
@@ -38,7 +38,9 @@ export function formatLabel(value: AgNumericValue | undefined, scale: { min: AgN
 export function getLabelText(seriesId: string, ctx: Ctx, datum: GaugeLabelDatum, valueOverride?: AgNumericValue) {
     if (datum.text != null) return datum.text;
 
-    const value = valueOverride ?? datum.value;
+    // A bigint can't be precisely tweened, so the animation count-up override is Number-narrowed. Keep the
+    // raw bigint for the formatter so callbacks preserve the value type; Number values still use the tween.
+    const value = typeof datum.value === 'bigint' ? datum.value : (valueOverride ?? datum.value);
     let labelFormat: NormalisedTextOrSegments | undefined;
     if (datum?.formatter != null) {
         labelFormat = formatWithContext(ctx, datum.formatter, { seriesId, datum: undefined, value });

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.test.ts
@@ -13,6 +13,7 @@ import {
     spyOnAnimationManager,
     waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 
@@ -309,6 +310,33 @@ describe('LinearGaugeSeries', () => {
                 segmentation: { enabled: true, interval: { values: [5_000_000_000_000_000n] } },
             });
             expect(valuesCaption).toContain(BIG_VALUE.toLocaleString());
+        });
+
+        it('should pass full-precision bigint tick values to the scale label formatter', async () => {
+            const seenValues: AgNumericValue[] = [];
+            const options: AgLinearGaugeOptions = {
+                type: 'linear-gauge',
+                value: BIG_VALUE,
+                scale: {
+                    min: 9_007_199_254_740_000n,
+                    max: 9_007_199_254_741_000n,
+                    label: {
+                        formatter: ({ value }) => {
+                            seenValues.push(value);
+                            return `${value}`;
+                        },
+                    },
+                },
+            };
+            prepareEnterpriseTestOptions(options);
+            chart = deproxy(AgCharts.createGauge(options));
+            await waitForChartStability(chart);
+
+            expect(seenValues.length).toBeGreaterThan(0);
+            expect(seenValues.every((value) => typeof value === 'bigint')).toBe(true);
+            expect(
+                seenValues.some((value) => typeof value === 'bigint' && value > BigInt(Number.MAX_SAFE_INTEGER))
+            ).toBe(true);
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -247,7 +247,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         this.animationState.transition('updateData');
     }
 
-    public formatLabel(value: number) {
+    public formatLabel(value: AgNumericValue) {
         return formatLabel(value, this.properties.scale);
     }
 

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -439,13 +439,16 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
         const measurer = cachedTextMeasurer(label);
         const ticks =
             scaleProps.interval.values ??
-            scale.ticks({
-                nice: [false, false],
-                interval: scaleProps.interval.step,
-                minTickCount: 0,
-                maxTickCount: 6,
-                tickCount: 5,
-            })?.ticks ??
+            scale.ticks(
+                {
+                    nice: [false, false],
+                    interval: scaleProps.interval.step,
+                    minTickCount: 0,
+                    maxTickCount: 6,
+                    tickCount: 5,
+                },
+                [scaleProps.min, scaleProps.max]
+            )?.ticks ??
             [];
         const linesOrTicks =
             lines ?? ticks?.map((tick) => getLabelText(this.id, this.ctx, this.labelDatum(label, tick)) ?? '');
@@ -461,16 +464,16 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
     }
 
     private tickFormatter(
-        domain: number[],
-        ticks: number[]
-    ): (value: number, index: number) => NormalisedTextOrSegments {
+        domain: AgNumericValue[],
+        ticks: AgNumericValue[]
+    ): (value: AgNumericValue, index: number) => NormalisedTextOrSegments {
         const { format, formatter } = this.properties.scale.label;
-        let tickFormatter: ((value: number) => NormalisedTextOrSegments) | undefined;
+        let tickFormatter: ((value: AgNumericValue) => NormalisedTextOrSegments) | undefined;
         if (format != null) {
             tickFormatter = tickFormat(ticks, typeof format === 'string' ? format : undefined);
         }
 
-        return (value: number, index: number): NormalisedTextOrSegments => {
+        return (value: AgNumericValue, index: number): NormalisedTextOrSegments => {
             let r: NormalisedTextOrSegments | undefined = undefined;
             if (formatter) {
                 r ??= formatWithContext(this.ctx, formatter, {
@@ -562,8 +565,8 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
             label: scaleLabel,
             parallel: horizontal,
             interval: scaleProps.interval,
-            tickFormatter: (domain: number[], ticks: number[]) => this.tickFormatter(domain, ticks),
-            domain: scale.domain,
+            tickFormatter: (domain: AgNumericValue[], ticks: AgNumericValue[]) => this.tickFormatter(domain, ticks),
+            domain: [scaleProps.min, scaleProps.max],
             range: this.range,
             reverse: false,
             primaryTickCount: undefined,

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
@@ -245,10 +245,10 @@ class LinearGaugeScaleLabelProperties extends SeriesLabelProperties {
 
 class LinearGaugeScaleProperties extends BaseProperties {
     @Property
-    min: number = 0;
+    min: AgNumericValue = 0;
 
     @Property
-    max: number = 1;
+    max: AgNumericValue = 1;
 
     @Property
     fills = new PropertiesArray<_ModuleSupport.StopProperties>(_ModuleSupport.StopProperties);

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeriesProperties.ts
@@ -335,7 +335,7 @@ export class LinearGaugeLabelProperties extends AutoSizedLabel<unknown> {
 
 export class LinearGaugeSeriesProperties extends SeriesProperties<AgLinearGaugeOptions> {
     @Property
-    value: number = 0;
+    value: AgNumericValue = 0;
 
     @Property
     readonly segmentation = new GaugeSegmentationProperties();

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.test.ts
@@ -12,6 +12,7 @@ import {
     spyOnAnimationManager,
     waitForChartStability,
 } from 'ag-charts-community-test';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 
@@ -254,6 +255,33 @@ describe('RadialGaugeSeries', () => {
                 },
             });
             expect(caption).toContain(BIG_VALUE.toLocaleString());
+        });
+
+        it('should pass full-precision bigint tick values to the scale label formatter', async () => {
+            const seenValues: AgNumericValue[] = [];
+            const options: AgRadialGaugeOptions = {
+                type: 'radial-gauge',
+                value: BIG_VALUE,
+                scale: {
+                    min: 9_007_199_254_740_000n,
+                    max: 9_007_199_254_741_000n,
+                    label: {
+                        formatter: ({ value }) => {
+                            seenValues.push(value);
+                            return `${value}`;
+                        },
+                    },
+                },
+            };
+            prepareEnterpriseTestOptions(options);
+            chart = deproxy(AgCharts.createGauge(options));
+            await waitForChartStability(chart);
+
+            expect(seenValues.length).toBeGreaterThan(0);
+            expect(seenValues.every((value) => typeof value === 'bigint')).toBe(true);
+            expect(
+                seenValues.some((value) => typeof value === 'bigint' && value > BigInt(Number.MAX_SAFE_INTEGER))
+            ).toBe(true);
         });
     });
 

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -16,6 +16,7 @@ import {
     type NormalisedTextOrSegments,
     type Point,
     StateMachine,
+    createBigIntTicks,
     isBetweenAngles,
     isNumberEqual,
     mergeDefaults,
@@ -115,7 +116,7 @@ interface RadialGaugeNeedleDatum {
 
 interface RadialGaugeTickDatum {
     index: number;
-    value: number;
+    value: AgNumericValue;
     text: NormalisedTextOrSegments;
 }
 
@@ -341,13 +342,20 @@ export class RadialGaugeSeries
         const tickCount = Math.max(minTickCount, Math.min(maxTickCount, preferredTickCount));
         const ticks =
             interval.values ??
-            scale.ticks({
-                nice: [false, false],
-                interval: interval.step,
-                minTickCount,
-                maxTickCount,
-                tickCount,
-            })?.ticks ??
+            // LinearAngleScale.ticks narrows to Number for its angular nice-stepping; for a bigint scale
+            // domain generate full-precision bigint ticks directly so scale-label callbacks receive bigint.
+            (typeof min === 'bigint' && typeof max === 'bigint' && interval.step == null
+                ? createBigIntTicks(min, max, tickCount)
+                : scale.ticks(
+                      {
+                          nice: [false, false],
+                          interval: interval.step,
+                          minTickCount,
+                          maxTickCount,
+                          tickCount,
+                      },
+                      [min, max]
+                  )?.ticks) ??
             [];
         const tickFormatter = tickFormat(ticks, typeof label.format === 'string' ? label.format : undefined);
 
@@ -360,7 +368,7 @@ export class RadialGaugeSeries
                     type: 'number',
                     value,
                     index,
-                    domain: scale.domain,
+                    domain: [min, max],
                     boundSeries: undefined!,
                 });
             }
@@ -1325,7 +1333,7 @@ export class RadialGaugeSeries
         }
     }
 
-    private animateLabelText(params: { from?: number; phase?: _ModuleSupport.AnimationPhase } = {}) {
+    private animateLabelText(params: { from?: AgNumericValue; phase?: _ModuleSupport.AnimationPhase } = {}) {
         const { animationManager } = this.ctx;
 
         let labelFrom: AgNumericValue | undefined;

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -280,7 +280,7 @@ export class RadialGaugeSeries
         this.animationState.transition('updateData');
     }
 
-    private formatLabel(value: number) {
+    private formatLabel(value: AgNumericValue) {
         const { min, max } = this.properties.scale;
         return formatLabel(value, { min, max });
     }

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
@@ -255,10 +255,10 @@ class RadialGaugeScaleLabelProperties extends SeriesLabelProperties {}
 
 class RadialGaugeScaleProperties extends BaseProperties {
     @Property
-    min: number = 0;
+    min: AgNumericValue = 0;
 
     @Property
-    max: number = 1;
+    max: AgNumericValue = 1;
 
     @Property
     fills = new PropertiesArray<_ModuleSupport.StopProperties>(_ModuleSupport.StopProperties);

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeriesProperties.ts
@@ -375,7 +375,7 @@ class RadialGaugeSecondaryLabelProperties extends AutoSizedSecondaryLabel<AgRadi
 
 export class RadialGaugeSeriesProperties extends SeriesProperties<AgRadialGaugeOptions> {
     @Property
-    value!: number;
+    value!: AgNumericValue;
 
     @Property
     startAngle: number = 0;

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -566,6 +566,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
             datum,
             datumIndex,
             cumulativeValue: Number(cumulativeValue ?? 0),
+            cumulativeValueExact: cumulativeValue ?? 0,
             totalValue: this.getTotalValue(seriesItemType, value),
             xValue: xDatum,
             yValue: value,
@@ -621,6 +622,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         mutableNode.datum = datum;
         mutableNode.datumIndex = datumIndex;
         mutableNode.cumulativeValue = Number(cumulativeValue ?? 0);
+        mutableNode.cumulativeValueExact = cumulativeValue ?? 0;
         mutableNode.totalValue = this.getTotalValue(seriesItemType, value);
         mutableNode.xValue = xDatum;
         mutableNode.yValue = value;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16608

Addresses the in-scope QA findings from David's review of BigInt support ([comment 119950](https://ag-grid.atlassian.net/browse/AG-16608?focusedCommentId=119950)).

### Changes

- **Crosshair (F1)** — the snap label read the float64-narrowed `cumulativeValue`, so it showed `…992` while the tooltip showed `…993`. Added a full-precision `cumulativeValueExact` field on the node datum, populated it across all five cartesian series that feed the crosshair (bar, line, area, histogram, waterfall), and made the crosshair prefer it. The narrowed `cumulativeValue` is retained for geometry/error-bar maths.
- **Zoom (F2)** — `withTemporaryDomain` (tick generation) snapshotted the narrowed `domain` getter and restored it, clearing the scale's exact bigint endpoints; a zoomed `convert()` then fell back to float64 and collapsed adjacent high-magnitude bigints onto one pixel. Added `snapshotDomain()`/`restoreDomain()` to the `Scale` contract so the exact endpoints survive the round-trip (default behaviour unchanged for non-continuous scales).
- **Gauges (F3)** — three gauge surfaces narrowed bigint to `number`: the `value`/tooltip helpers were typed `number` (contradicting the public `AgNumericValue` contract); the label count-up animation fed the Number-narrowed tween to the user formatter; and the **scale tick-label** callback (`scale.label.formatter` — the surface David's repro inspects) received a Number-narrowed tick. Widened the internal value/tooltip types and kept the raw bigint for label callbacks during animation, and widened the gauge scale `min`/`max` to `AgNumericValue` so a bigint scale domain produces full-precision bigint ticks (linear gauge via the shared tick generator; radial gauge via `createBigIntTicks`, since its `LinearAngleScale` narrows to Number in its angular nice-stepping).

### Tests

Regression tests added: scale snapshot/restore round-trip; bar `cumulativeValueExact`; gauge `getLabelText` bigint preservation; and `scale.label.formatter` receiving bigint for both linear and radial gauges. The `withTemporaryDomain` test now compares adjacent high-magnitude bigints (David's `…995/996/997`) so it fails when the exact endpoints are dropped, rather than a pair that stays float64-representable. Type-check and lint pass on all changed files.

### Out of scope (David's split — follow-ups)

Zoom range state as bigint, zoom save/restore drift, and annotation positioning between bigint bands remain as separate follow-ups.

Fix #AG-16608
