### PR TITLE
Free disk space in setup-nx and retire macOS support

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -61,13 +61,7 @@ runs:
           shell: bash
           run: |
               if [ -z "${NX_PARALLEL}" ]; then
-                # Get CPU count in a cross-platform way
-                if command -v nproc >/dev/null 2>&1; then
-                  CPUS=$(nproc)
-                else
-                  # macOS fallback
-                  CPUS=$(sysctl -n hw.logicalcpu)
-                fi
+                CPUS=$(nproc)
                 echo "NX_PARALLEL=${CPUS}" >> $GITHUB_ENV
                 echo "Setting NX_PARALLEL to ${CPUS}"
               else
@@ -196,12 +190,6 @@ runs:
           if: inputs.cache_mode == 'rw' && inputs.nx_restore != 'false'
           with:
               branch_type: ${{ steps.nx_config.outputs.type }}
-
-        - name: MacOS Setup
-          if: inputs.os == 'macos'
-          shell: bash
-          run: |
-              brew install fontconfig libpng jpeg giflib librsvg
 
         - name: yarn install
           if: inputs.yarn_postinstall == 'true'

--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -44,6 +44,12 @@ outputs:
 runs:
     using: 'composite'
     steps:
+        - name: Free disk space
+          if: runner.os == 'Linux'
+          shell: bash
+          run: |
+              sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+
         - name: Dump GitHub context
           env:
               GITHUB_CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION
Two related changes to the `setup-nx` composite action.

### 1. Free disk space (avoid runner ENOSPC)
Adds a `Free disk space` step at the start of the action, removing large preinstalled toolchains (dotnet, android, ghc, boost, hosted tool cache) before the disk-heavy `node_modules`/Nx cache restore and `yarn install`. Mirrors a fix being applied across ag-studio and ag-grid to prevent intermittent `No space left on device` failures on standard `ubuntu-24.04` runners.

### 2. Retire macOS support
The self-hosted macOS benchmark runner — the only macOS use-case — no longer exists; all jobs now run on `ubuntu-24.04`. This removes:
- The `MacOS Setup` brew step. It was already dead code: it gated on `inputs.os == 'macos'`, but `os` is not a declared input and no caller passes it.
- The `sysctl` macOS CPU-count fallback in `Set Nx parallelization`, simplified to `nproc` since runners are always Linux.

### Note
The `Free disk space` step keeps an `if: runner.os == 'Linux'` guard for consistency with the ag-studio/ag-grid PRs and as harmless defence-in-depth, even though runners are now Linux-only.