### PR TITLE
Make l10n translation review comment less verbose

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 06b051e5e1bc7da80598b1038a9a410958d3e41a
-	parent = 68a8766bc8cafb962f60be555e1e344c9654fde0
+	commit = ec7d0fe829c2f2279f0b4dc1233c3f0392b037be
+	parent = 76d13aec154fef89f1351d961eda8e50a371e883
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/scripts/l10n/review-translations.mjs
+++ b/external/ag-shared/scripts/l10n/review-translations.mjs
@@ -114,7 +114,7 @@ async function main() {
         'Review ONLY the changed lines shown in the diffs, using en-US.ts for context.',
         'Flag: mistranslations or wrong meaning; altered, missing, or mistranslated placeholders/formatters; inappropriate tone or register for product UI / screen-reader text; obviously unnatural phrasing.',
         'Do NOT flag stylistic preferences where the translation is correct, or anything outside the changed lines.',
-        'Output concise GitHub-flavoured Markdown grouped by locale, each finding as a bullet citing the key. If a locale has no issues, say so in one line. If nothing is concerning across all locales, respond with a single line stating translations look correct.',
+        'Output concise GitHub-flavoured Markdown. If nothing is concerning across all locales, respond with a single line stating translations look correct. Otherwise, add a `### <locale>` section ONLY for locales that have issues, each finding as a bullet citing the key; then end with one line listing all the locales with no issues together, e.g. "No issues found in: de-DE, fr-FR, ja-JP." Never give a clean locale its own heading.',
     ].join('\n');
 
     const userText = `## en-US.ts (source of truth, for context)\n\n\`\`\`typescript\n${enUs}\n\`\`\`\n\n## Changed translations to review\n\n${diffs}`;


### PR DESCRIPTION
Tweaks the advisory l10n translation-review output so it no longer adds a `### <locale>` heading for every locale. Now:

- If nothing is concerning, it stays a single line ("translations look correct").
- Otherwise, only locales **with** findings get a section; all clean locales are summarised together on one line (e.g. "No issues found in: de-DE, fr-FR, ja-JP").

Previously every locale — including clean ones — got its own `## <locale>` / "No issues found." block, which made the comment very long on PRs that touch all 31 locales (see ag-studio#1752).

This is a one-line change to the shared review script's system prompt; pushed to the `ag-shared` source via `subrepo push`. Companion `subrepo pull` PRs follow in ag-grid and ag-studio.