### PR TITLE
Fix release-review install: use default token for packages:read

### DIFF
--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -107,8 +107,10 @@ jobs:
             - name: Install @ag-grid/dev-prompts
               uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
               with:
+                  # Default github.token carries packages:read (workflow permissions
+                  # block); the repo-scoped app token does not. Matches jira-agent-
+                  # pipeline.yml / pr-review.yml.
                   channel: ${{ env.DEV_PROMPTS_CHANNEL }}
-                  github-token: ${{ steps.prompts-token.outputs.token }}
 
             - name: Run documentation review
               uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/release-review
@@ -152,8 +154,10 @@ jobs:
             - name: Install @ag-grid/dev-prompts
               uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
               with:
+                  # Default github.token carries packages:read (workflow permissions
+                  # block); the repo-scoped app token does not. Matches jira-agent-
+                  # pipeline.yml / pr-review.yml.
                   channel: ${{ env.DEV_PROMPTS_CHANNEL }}
-                  github-token: ${{ steps.prompts-token.outputs.token }}
 
             - name: Run options review
               uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/release-review


### PR DESCRIPTION
## What

The `Install @ag-grid/dev-prompts` step in `release-review.yml` was passed the repo-scoped app token (minted for `ag-dev-prompts`), which lacks `packages:read`. The npm install of `@ag-grid/dev-prompts` from GitHub Packages failed with exit 1, so the review step was skipped and both jobs went red before doing any work.

Drop the `github-token` override on both install steps so they fall back to `github.token`, which carries `packages:read` from the workflow `permissions` block — matching the proven pattern in `jira-agent-pipeline.yml` and `pr-review.yml`. The app token remains in use for `setup-nx` (unchanged).

## Verification (dispatched from this branch, `current_branch=origin/latest`)

- **Options review** ([run 27704384349](https://github.com/ag-grid/ag-charts/actions/runs/27704384349)): install ✅, review ✅ — produced report + posted Slack summary (b13.3.1 → latest, MEDIUM risk). Job goes red **only** at the Slack *file* upload (`files.getUploadURLExternal: missing_scope`).
- **Docs review** ([run 27705241899](https://github.com/ag-grid/ag-charts/actions/runs/27705241899)): install ✅, branch resolution ✅; agent ran but produced no report (1 permission denial, 20 turns).

## Known follow-ups (both in ag-dev-prompts, not this repo)

1. **Slack `files:write` scope** missing on the bot app behind `SLACK_BOT_OAUTH_TOKEN` — blocks the full-report file upload (summary text posts fine; report is preserved as a run artifact regardless).
2. **Docs review agent** writes no report under the headless harness — needs investigation in the shared `release-review` action / `release-docs-review` skill (likely allowed-tools / report-path).