### PR TITLE
AG-16032 Align ordinal-time day labels with day boundaries

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/generateTicks.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.ts
@@ -337,7 +337,8 @@ function calculateRawTicks<TScale extends Scale<TDatum, number, TickInterval<TSc
                     niceDomain.length > 0 &&
                     tickParams.interval == null &&
                     (UnitTimeScale.is(scale) ||
-                        (generatePrimaryTicks && (TimeScale.is(scale) || OrdinalTimeScale.is(scale))))
+                        OrdinalTimeScale.is(scale) ||
+                        (generatePrimaryTicks && TimeScale.is(scale)))
                 ) {
                     const dates = niceDomain as (Date | number)[];
                     const start = Math.min(dates[0].valueOf(), dates.at(-1)!.valueOf());
@@ -361,6 +362,26 @@ function calculateRawTicks<TScale extends Scale<TDatum, number, TickInterval<TSc
                     intervalMilliseconds(minTimeInterval) >= intervalMilliseconds(timeInterval)
                 ) {
                     timeInterval = minTimeInterval;
+                }
+
+                if (OrdinalTimeScale.is(scale) && !generatePrimaryTicks && timeInterval != null) {
+                    const dayMs = intervalMilliseconds('day');
+                    const weekMs = 7 * dayMs;
+                    // Boundary-aligned interval ticks only help intraday data viewed at a day-level tick
+                    // interval (day up to a few days): there a day label must land on the first bar of its
+                    // day rather than a mid-day bar. Outside that window keep the legacy evenly-spaced
+                    // default ticks:
+                    //  - sub-day intervals (zoomed in) preserve the finer-grained time-of-day labels;
+                    //  - week-and-coarser intervals (zoomed out) keep even spacing, where a few hours'
+                    //    misalignment of a weekly/monthly label is invisible anyway;
+                    //  - daily-and-coarser data has ~one datum per label, so alignment is moot.
+                    const intervalMs = intervalMilliseconds(timeInterval);
+                    const dataIsIntraday =
+                        minimumTimeGranularity != null && intervalMilliseconds(minimumTimeGranularity) < dayMs;
+                    const intervalIsDayLevel = intervalMs >= dayMs && intervalMs < weekMs;
+                    if (!(dataIsIntraday && intervalIsDayLevel)) {
+                        timeInterval = undefined;
+                    }
                 }
 
                 const intervalTicks = timeInterval

--- a/packages/ag-charts-enterprise/src/axes/ordinal/ordinalTimeAxis.test.ts
+++ b/packages/ag-charts-enterprise/src/axes/ordinal/ordinalTimeAxis.test.ts
@@ -764,6 +764,75 @@ describe('Ordinal Time Axis Examples', () => {
         expect(imageData).toMatchImageSnapshot(IMAGE_SNAPSHOT_DEFAULTS);
     });
 
+    it('aligns base-tier labels to parent-level boundaries without parentLevel enabled', async () => {
+        // Continuous hourly data across ~2 weeks, so genuine midnight datums exist.
+        const data = Array.from({ length: 14 * 24 }, (_, i) => ({
+            date: new Date(2025, 8, 2, i),
+            value: 100 + Math.sin(i / 12) * 10,
+        }));
+
+        chart = await createEnterpriseChart<AgCartesianChartOptions>({
+            data,
+            series: [{ type: 'line', xKey: 'date', yKey: 'value', marker: { enabled: false } }],
+            axes: {
+                y: { type: 'number', position: 'left' },
+                x: { type: 'ordinal-time', position: 'bottom' },
+            },
+        });
+
+        const axis = (chart.axes as _ModuleSupport.ChartAxis[]).find((a) => a.type === 'ordinal-time')!;
+        const labelledTicks = (axis as any).tickLayout.ticks.filter((t: any) => t.tickLabel);
+
+        expect(labelledTicks.length).toBeGreaterThan(0);
+        for (const { tick } of labelledTicks) {
+            const date = tick as Date;
+            expect([date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds()]).toEqual([
+                0, 0, 0, 0,
+            ]);
+        }
+    });
+
+    it('aligns labels to the first datum at/after each day boundary (gapped market-hours data)', async () => {
+        // Weekday market hours only (09:00-16:00), so most days have no midnight datum.
+        const data: { date: Date; value: number }[] = [];
+        const start = new Date(2025, 0, 6); // Monday
+        for (let day = 0; day < 14; day++) {
+            const d = new Date(start.getFullYear(), start.getMonth(), start.getDate() + day);
+            if (d.getDay() === 0 || d.getDay() === 6) continue;
+            for (let h = 9; h <= 16; h++) {
+                data.push({ date: new Date(d.getFullYear(), d.getMonth(), d.getDate(), h), value: 100 + h });
+            }
+        }
+
+        chart = await createEnterpriseChart<AgCartesianChartOptions>({
+            data,
+            series: [{ type: 'line', xKey: 'date', yKey: 'value', marker: { enabled: false } }],
+            axes: {
+                y: { type: 'number', position: 'left' },
+                x: { type: 'ordinal-time', position: 'bottom' },
+            },
+        });
+
+        const axis = (chart.axes as _ModuleSupport.ChartAxis[]).find((a) => a.type === 'ordinal-time')!;
+        const sortedTimes = data.map((d) => d.date.getTime()).sort((a, b) => a - b);
+        const labelledTicks = (axis as any).tickLayout.ticks.filter((t: any) => t.tickLabel);
+
+        expect(labelledTicks.length).toBeGreaterThan(1);
+        for (const { tick } of labelledTicks) {
+            const current = tick as Date;
+            const index = sortedTimes.indexOf(current.getTime());
+            expect(index).toBeGreaterThanOrEqual(0);
+            if (index > 0) {
+                const previous = new Date(sortedTimes[index - 1]);
+                const sameDay =
+                    previous.getFullYear() === current.getFullYear() &&
+                    previous.getMonth() === current.getMonth() &&
+                    previous.getDate() === current.getDate();
+                expect(sameDay).toBe(false);
+            }
+        }
+    });
+
     // AG-17065: deeply zoomed large ordinal-time dataset must not hang in tick generation.
     // Jest's default timeout catches a regression — the fix ensures the overlap loop exits
     // in O(log n) iterations instead of ~1000 linear iterations.


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-16032

Ordinal-time axis day labels now land on the bar at the day boundary (the first datum at/after midnight) by default, without enabling `parentLevel`. Previously labels were evenly sampled and could sit on a mid-day bar (e.g. "Sep 8" not lining up with the 00:00 candle).

Implementation: in `calculateRawTicks()`, ordinal-time now infers a tick interval, and a gate boundary-aligns labels only when the data is intraday **and** the inferred interval is day-level (>= 1 day and < 1 week). Sub-day intervals (zoomed in), week-and-coarser intervals (zoomed out), and daily-or-coarser data keep the legacy even-sampling — so finer time-of-day labels and existing wide-view spacing are preserved.

Behaviour change: default ordinal-time day labelling shifts for wide intraday views (no opt-out) — worth a release note.

Test plan:
- Two behavioural tests added: continuous hourly data -> every labelled tick is at local midnight; gapped market-hours data -> each labelled tick is the first datum of its day.
- Full enterprise suite green (2457 passed), zero snapshot churn; community axis tests green.

Fix #AG-16032