### PR TITLE
AG-17584 Show PixelSize branch for Padding-typed options in API reference

### DIFF
--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
@@ -391,12 +391,10 @@ function useMemberAdditionalDetails(member: MemberNode): NodeTypes | NodeTypes[]
 
     const resolvedDetails = resolve(memberType);
 
-    // An axis-specific cross-line alias resolves to an interface with no own members whose
-    // heritage is a union type alias; expand it to its variants so the union renders.
-    const aliasedUnion = resolveAliasedUnion(
-        resolvedDetails && !Array.isArray(resolvedDetails) ? resolvedDetails : undefined,
-        reference
-    );
+    // Only expand the cross-line indirection (an empty interface extending a union alias); a direct
+    // union alias renders correctly on its own via formatUnionTypeAlias.
+    const aliasedUnion = isInterfaceNode(resolvedDetails) ? resolveAliasedUnion(resolvedDetails, reference) : undefined;
+
     if (aliasedUnion) {
         const unionTypes = aliasedUnion.unionType.type
             .flatMap((unionType) => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17584

The API reference for `Padding`-typed options (e.g. axis `label.padding`) stopped
showing that a plain `number` is accepted, displaying only the `PaddingOptions`
object branch of `Padding = PixelSize | PaddingOptions`.

A direct union type alias was being intercepted by the cross-line aliased-union
expansion (added for discriminated cross-line options) and flattened into its
interface variants, which dropped both the `type Padding = …` alias line and the
hidden `PixelSize` (number) branch. The expansion is now gated to the cross-line
indirection only (an empty interface extending a union alias), so direct union
aliases render via `formatUnionTypeAlias` as before — emitting the alias line plus
each non-hidden interface body.

Verified the cross-line options page still lists its per-axis discriminated
variants; `ag-charts-website` lint and tests pass.

Fix #AG-17584