### PR TITLE
perf(data-model): skip redundant column rescans in extraction/updates

### DIFF
--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -124,6 +124,15 @@ function updateColumnTypeTracker(
     value: unknown,
     datumIndex: number
 ): ColumnValueType | undefined {
+    // Hot-loop fast path: for the primitive types whose `typeof` maps 1:1 to a column type
+    // (number/bigint/boolean), a value of the column's already-settled type cannot change it or
+    // introduce a string — skip the full classify and merge. `string` (→ string|date via isISO8601)
+    // and `object` (→ date|number|object) are not 1:1, so they fall through to the slow path.
+    const settled = tracker.type;
+    if ((settled === 'number' || settled === 'bigint' || settled === 'boolean') && typeof value === settled) {
+        return settled;
+    }
+
     const observed = valueColumnType(value);
     if (observed == null) return undefined;
 

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -5,6 +5,7 @@ import {
     isISO8601,
     isNumberObject,
     iterate,
+    seedEpochColumnIdentity,
     timeValueToNumber,
 } from 'ag-charts-core';
 import type { AgNumericValue } from 'ag-charts-types';
@@ -93,6 +94,9 @@ interface ColumnTypeTracker {
     mixedAtIndex: number | undefined;
     /** Row index where a date column was first observed to mix with a non-date, non-numeric value. */
     mixedDateAtIndex: number | undefined;
+    /** Whether any column value was a string. A string-free column needs no epoch-ms parse, so its
+     *  epoch cache can be seeded as identity to spare downstream consumers a redundant string scan. */
+    sawString: boolean;
 }
 
 function valueColumnType(value: unknown): ColumnValueType | undefined {
@@ -121,6 +125,12 @@ function updateColumnTypeTracker(
 ): ColumnValueType | undefined {
     const observed = valueColumnType(value);
     if (observed == null) return undefined;
+
+    // A string is tagged 'string' (non-ISO) or 'date' (ISO); Date objects are also 'date', so only the
+    // date case needs a typeof to disambiguate. Gating on `observed` keeps the numeric path scan-free.
+    if (observed === 'string' || (observed === 'date' && typeof value === 'string')) {
+        tracker.sawString = true;
+    }
 
     if (tracker.type == null || tracker.type === observed) {
         tracker.type = observed;
@@ -344,6 +354,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                 type: undefined,
                 mixedAtIndex: undefined,
                 mixedDateAtIndex: undefined,
+                sawString: false,
             };
             const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
 
@@ -416,6 +427,13 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             keySortOrders.set(keyDefIndex, trackerToSortOrderEntry(tracker));
             this.warnMixedTimezoneColumn(keyDef.property, typeTracker.type, tzTracker, keyDef.timeDomain === true);
             keyHasIsoStrings.push(typeTracker.type === 'date' && sawIsoStrings(tzTracker));
+            // A string-free key column needs no epoch-ms parse: seed each scope's array as its own
+            // identity so downstream consumers skip the redundant string scan (see extractValues).
+            if (!typeTracker.sawString) {
+                for (const keys of keyDefKeys.values()) {
+                    seedEpochColumnIdentity(keys);
+                }
+            }
         }
         return {
             invalidData,
@@ -503,6 +521,7 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                 type: undefined,
                 mixedAtIndex: undefined,
                 mixedDateAtIndex: undefined,
+                sawString: false,
             };
             const tzTracker: TimezoneTracker = { explicit: undefined, implicit: undefined };
             for (let datumIndex = 0; datumIndex < columnSource.length; datumIndex++) {
@@ -557,6 +576,12 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             // Leave unobserved columns undefined rather than guessing 'number', so type assertions don't false-positive.
             columnValueType.push(typeTracker.type);
             columnHasIsoStrings.push(typeTracker.type === 'date' && sawIsoStrings(tzTracker));
+            // A string-free column is its own epoch representation: seed the cache so the domain and
+            // aggregation paths skip the per-call string scan (ISO-string columns are seeded lazily
+            // when extendDomainFromEpochColumn parses them below).
+            if (!typeTracker.sawString) {
+                seedEpochColumnIdentity(column);
+            }
             maxDataLength = Math.max(maxDataLength, column.length);
         }
 

--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -6,6 +6,7 @@ import {
     isNumberObject,
     iterate,
     seedEpochColumnIdentity,
+    seedNumericColumnIdentity,
     timeValueToNumber,
 } from 'ag-charts-core';
 import type { AgNumericValue } from 'ag-charts-types';
@@ -581,6 +582,11 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
             // when extendDomainFromEpochColumn parses them below).
             if (!typeTracker.sawString) {
                 seedEpochColumnIdentity(column);
+            }
+            // A pure (non-bigint) numeric column is its own narrowed representation: seed the
+            // bigint-narrowing caches so the aggregation path skips its per-call bigint scan.
+            if (typeTracker.type === 'number') {
+                seedNumericColumnIdentity(column);
             }
             maxDataLength = Math.max(maxDataLength, column.length);
         }

--- a/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
@@ -674,32 +674,34 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
         extractValue: (cached: InsertionCacheValue | undefined, destIndex: number) => T,
         onRemove?: (removedValues: T[]) => void
     ): void {
-        // The array mutates in place, but only a materialised epoch column (ISO strings parsed to
-        // epoch ms) goes stale. A string-free column caches as its own identity, and a column's
-        // value type is fixed at extraction, so that identity result stays valid across the
-        // mutation; invalidating it would force an O(n) rescan of the whole column on next access.
+        // The array mutates in place, so any epoch column derived from it may go stale. A materialised
+        // epoch column (ISO strings parsed to epoch ms) is always stale after a write. A string-free
+        // column is cached as its own identity and only goes stale if this delta writes a string into
+        // it — `ensureEpochColumn`'s lazy parse never re-runs on an identity hit, so an unparsed string
+        // would otherwise survive. Tracking strings in the delta keeps the common all-numeric/Date
+        // streaming case scan-free while staying correct when the value kind changes.
         const epochColumn = getEpochColumn(target);
-        if (epochColumn !== undefined && epochColumn !== target) {
-            invalidateEpochColumn(target);
-        }
-        changeDesc.applyToArray(
-            target,
-            (destIndex) => {
-                const cached = insertionCache?.get(destIndex);
-                return extractValue(cached, destIndex);
-            },
-            onRemove
-        );
+        const identityEpochColumn = epochColumn !== undefined && epochColumn === target;
+        let deltaWroteString = false;
+        const writeValue = (cached: InsertionCacheValue | undefined, destIndex: number): T => {
+            const value = extractValue(cached, destIndex);
+            if (identityEpochColumn && typeof value === 'string') {
+                deltaWroteString = true;
+            }
+            return value;
+        };
 
-        const updatedIndices = changeDesc.getUpdatedIndices();
-        if (updatedIndices.length === 0) return;
+        changeDesc.applyToArray(target, (destIndex) => writeValue(insertionCache?.get(destIndex), destIndex), onRemove);
 
-        for (const destIndex of updatedIndices) {
+        for (const destIndex of changeDesc.getUpdatedIndices()) {
             if (destIndex < 0 || destIndex >= target.length) {
                 continue;
             }
-            const cached = insertionCache?.get(destIndex);
-            target[destIndex] = extractValue(cached, destIndex);
+            target[destIndex] = writeValue(insertionCache?.get(destIndex), destIndex);
+        }
+
+        if (epochColumn !== undefined && (!identityEpochColumn || deltaWroteString)) {
+            invalidateEpochColumn(target);
         }
     }
 

--- a/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/incremental/incrementalProcessor.ts
@@ -1,4 +1,4 @@
-import { first, invalidateEpochColumn } from 'ag-charts-core';
+import { first, getEpochColumn, invalidateEpochColumn } from 'ag-charts-core';
 
 import {
     DataChangeDescription,
@@ -674,8 +674,14 @@ export class IncrementalProcessor<D extends object, K extends keyof D & string> 
         extractValue: (cached: InsertionCacheValue | undefined, destIndex: number) => T,
         onRemove?: (removedValues: T[]) => void
     ): void {
-        // The array mutates in place, so any parse-once epoch column derived from it is now stale.
-        invalidateEpochColumn(target);
+        // The array mutates in place, but only a materialised epoch column (ISO strings parsed to
+        // epoch ms) goes stale. A string-free column caches as its own identity, and a column's
+        // value type is fixed at extraction, so that identity result stays valid across the
+        // mutation; invalidating it would force an O(n) rescan of the whole column on next access.
+        const epochColumn = getEpochColumn(target);
+        if (epochColumn !== undefined && epochColumn !== target) {
+            invalidateEpochColumn(target);
+        }
         changeDesc.applyToArray(
             target,
             (destIndex) => {

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -3162,6 +3162,30 @@ describe('DataModel', () => {
             expect(epochs.at(-1)).toBe(Date.parse('2024-01-15T12:00:00Z'));
         });
 
+        it('reparses a string-free time key column when an incremental insert introduces an ISO string', () => {
+            // A string-free numeric-epoch column is seeded as its own epoch identity at extraction. An
+            // incremental insert that writes an ISO string into it must drop that identity, otherwise
+            // ensureEpochColumn's lazy parse never re-runs on the identity hit and the raw string leaks
+            // into the continuous key domain.
+            const model = timeKeyModel();
+            const initialData: Array<{ x: number | string; y: number }> = [
+                { x: Date.parse('2024-01-15T09:00:00Z'), y: 1 },
+                { x: Date.parse('2024-01-15T10:00:00Z'), y: 2 },
+            ];
+            const dataSet = new DataSet(initialData);
+            const sources = basicDataSet(initialData).set(ISO_SCOPE, dataSet);
+
+            const processed = model.processData(sources)!;
+            const keys = processed.keys[0].get(ISO_SCOPE)!;
+            expect(getEpochColumn(keys)).toBe(keys);
+
+            dataSet.addTransaction({ append: [{ x: '2024-01-15T12:00:00Z', y: 3 }] });
+            const reprocessed = model.reprocessData(processed, undefined, undefined);
+
+            const epochs = reprocessed.domain.keys[0].map((d: unknown) => (d instanceof Date ? d.getTime() : d));
+            expect(epochs.at(-1)).toBe(Date.parse('2024-01-15T12:00:00Z'));
+        });
+
         it('keeps ISO-shaped strings as labels in a category-axis domain (AG-16654 guard)', () => {
             const model = new DataModel<any, any, false>({
                 props: [scoped(keyProperty('x')), scoped(valueProperty('y', 'number'))],

--- a/packages/ag-charts-community/src/chart/data/dataModel.test.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.test.ts
@@ -131,7 +131,9 @@ describe('DataModel', () => {
                     const result = dataModel.processData(data)!;
 
                     expect(getEpochColumn(result.columns[0])).toEqual(isoDates.map((d) => Date.parse(d)));
-                    expect(getEpochColumn(result.columns[1])).toBeUndefined();
+                    // The string-free numeric column is its own epoch representation: extraction seeds it
+                    // as identity so downstream consumers skip the redundant string scan.
+                    expect(getEpochColumn(result.columns[1])).toBe(result.columns[1]);
                 });
             });
 

--- a/packages/ag-charts-core/src/utils/aggregation.ts
+++ b/packages/ag-charts-core/src/utils/aggregation.ts
@@ -99,6 +99,25 @@ export function narrowBigIntColumnRelative(values: any[]): any[] {
     return converted;
 }
 
+/**
+ * Register a column known to hold no bigint as its own narrowed representation, so a later
+ * {@link narrowBigIntColumn} or {@link narrowBigIntColumnRelative} returns on the cache hit instead
+ * of repeating the O(n) bigint scan. Extraction's type-tracking pass already knows when a column is
+ * pure (non-bigint) numeric, whose absolute and relative narrowings are both the column itself.
+ * Mirrors the epoch-column identity seeding in {@link seedEpochColumnIdentity}.
+ *
+ * The offset-narrowing cache is intentionally not seeded: it subtracts a caller-supplied offset, so
+ * its result is not the identity even for a bigint-free column.
+ */
+export function seedNumericColumnIdentity(values: unknown[]): void {
+    if (!numericColumnCache.has(values)) {
+        numericColumnCache.set(values, values);
+    }
+    if (!relativeNumericColumnCache.has(values)) {
+        relativeNumericColumnCache.set(values, values);
+    }
+}
+
 const offsetNumericColumnCache = new WeakMap<readonly unknown[], { offset: bigint; result: any[] }>();
 
 /**

--- a/packages/ag-charts-core/src/utils/data/epochColumns.ts
+++ b/packages/ag-charts-core/src/utils/data/epochColumns.ts
@@ -28,6 +28,18 @@ export function ensureEpochColumn(values: unknown[]): unknown[] {
     return converted;
 }
 
+/**
+ * Register a string-free column as its own epoch representation. Extraction's type-tracking pass
+ * already knows whether a column holds any string, so seeding the cache here lets a later
+ * {@link ensureEpochColumn} return on the cache hit instead of repeating the O(n) string scan.
+ * No-op when an epoch column is already cached (e.g. a parsed ISO column must not be overwritten).
+ */
+export function seedEpochColumnIdentity(values: unknown[]): void {
+    if (!epochColumnCache.has(values)) {
+        epochColumnCache.set(values, values);
+    }
+}
+
 /** Cached epoch column for `values`, or `undefined` when none has been materialised. */
 export function getEpochColumn(values: unknown[]): unknown[] | undefined {
     return epochColumnCache.get(values);

--- a/tools/benchmark/profile-benchmark.ts
+++ b/tools/benchmark/profile-benchmark.ts
@@ -52,24 +52,30 @@ async function main() {
     const url = `${argv['base-url']}/vanilla/benchmarks/examples/${argv.example}?benchmark=true${testCasesQuery}`;
 
     const browser = await chromium.launch();
-    const context = await browser.newContext({ viewport: { width: 800, height: 600 }, deviceScaleFactor: 2 });
-    const page = await context.newPage();
-    const cdp = await context.newCDPSession(page);
-    await cdp.send('Profiler.enable');
-    await cdp.send('Profiler.setSamplingInterval', { interval: argv['sampling-interval-us'] });
-    await cdp.send('Profiler.start');
+    let profile;
+    let benchmarkError;
+    let results;
+    try {
+        const context = await browser.newContext({ viewport: { width: 800, height: 600 }, deviceScaleFactor: 2 });
+        const page = await context.newPage();
+        const cdp = await context.newCDPSession(page);
+        await cdp.send('Profiler.enable');
+        await cdp.send('Profiler.setSamplingInterval', { interval: argv['sampling-interval-us'] });
+        await cdp.send('Profiler.start');
 
-    console.log(`Navigating to ${url}`);
-    await page.goto(url, { waitUntil: 'load', timeout: 60_000 });
-    await page.waitForFunction(() => (window as any).__benchmarkComplete === true, undefined, {
-        timeout: argv.timeout,
-        polling: 1_000,
-    });
+        console.log(`Navigating to ${url}`);
+        await page.goto(url, { waitUntil: 'load', timeout: 60_000 });
+        await page.waitForFunction(() => (window as any).__benchmarkComplete === true, undefined, {
+            timeout: argv.timeout,
+            polling: 1_000,
+        });
 
-    const { profile } = await cdp.send('Profiler.stop');
-    const benchmarkError = await page.evaluate(() => (window as any).__benchmarkError);
-    const results = await page.evaluate(() => (window as any).__benchmarkResults);
-    await browser.close();
+        ({ profile } = await cdp.send('Profiler.stop'));
+        benchmarkError = await page.evaluate(() => (window as any).__benchmarkError);
+        results = await page.evaluate(() => (window as any).__benchmarkResults);
+    } finally {
+        await browser.close();
+    }
 
     if (benchmarkError) {
         console.error(`Benchmark reported an error: ${benchmarkError}`);

--- a/tools/benchmark/profile-benchmark.ts
+++ b/tools/benchmark/profile-benchmark.ts
@@ -1,0 +1,90 @@
+// Captures a V8 CPU profile (.cpuprofile) of a benchmark example running in headless
+// Chromium. Requires the website dev server to be running (see run-browser-benchmarks.sh
+// for the env vars, or the benchmark-profile skill for the full workflow).
+//
+// Usage:
+//   npx tsx tools/benchmark/profile-benchmark.ts --example high-volume-iso-datetime \
+//       --test-cases initial-load --output reports/iso-initial.cpuprofile
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from 'playwright';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+async function main() {
+    const argv = await yargs(hideBin(process.argv))
+        .option('base-url', {
+            type: 'string',
+            default: 'http://localhost:4601/charts',
+            describe: 'Base URL of the dev server',
+        })
+        .option('example', {
+            type: 'string',
+            demandOption: true,
+            describe: 'Benchmark example name (directory under benchmarks/_examples)',
+        })
+        .option('test-cases', {
+            type: 'string',
+            default: '',
+            describe: 'Comma-separated test-case IDs from the example getBenchmarkConfig() (default: all)',
+        })
+        .option('output', {
+            type: 'string',
+            default: '',
+            describe: 'Output .cpuprofile path (default: reports/<example>.cpuprofile)',
+        })
+        .option('sampling-interval-us', {
+            type: 'number',
+            default: 100,
+            describe: 'Profiler sampling interval in microseconds',
+        })
+        .option('timeout', {
+            type: 'number',
+            default: 300_000,
+            describe: 'Benchmark completion timeout in milliseconds',
+        })
+        .strict()
+        .help()
+        .parse();
+
+    const out = argv.output || `reports/${argv.example}.cpuprofile`;
+    const testCasesQuery = argv['test-cases'] ? `&testCases=${encodeURIComponent(argv['test-cases'])}` : '';
+    const url = `${argv['base-url']}/vanilla/benchmarks/examples/${argv.example}?benchmark=true${testCasesQuery}`;
+
+    const browser = await chromium.launch();
+    const context = await browser.newContext({ viewport: { width: 800, height: 600 }, deviceScaleFactor: 2 });
+    const page = await context.newPage();
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('Profiler.enable');
+    await cdp.send('Profiler.setSamplingInterval', { interval: argv['sampling-interval-us'] });
+    await cdp.send('Profiler.start');
+
+    console.log(`Navigating to ${url}`);
+    await page.goto(url, { waitUntil: 'load', timeout: 60_000 });
+    await page.waitForFunction(() => (window as any).__benchmarkComplete === true, undefined, {
+        timeout: argv.timeout,
+        polling: 1_000,
+    });
+
+    const { profile } = await cdp.send('Profiler.stop');
+    const benchmarkError = await page.evaluate(() => (window as any).__benchmarkError);
+    const results = await page.evaluate(() => (window as any).__benchmarkResults);
+    await browser.close();
+
+    if (benchmarkError) {
+        console.error(`Benchmark reported an error: ${benchmarkError}`);
+        process.exit(1);
+    }
+
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    fs.writeFileSync(out, JSON.stringify(profile));
+    console.log(`Profile written to ${out}`);
+    for (const r of results?.results ?? []) {
+        console.log(`  ${r.testCase}: avg ${r.averageTime.toFixed(1)}ms over ${r.sampleCount} samples`);
+    }
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Pre-release performance work on the data-model column-extraction path, targeting regressions introduced by the new per-datum extraction machinery (column type-tracking, continuous/time validation, bigint narrowing) added since 13.3.1.

Changes:
- **Avoid full epoch-column rescan on incremental updates** — incremental processor carries forward epoch column state instead of rescanning every column on each update.
- **Seed epoch cache at extraction** — populates the epoch cache during `extractValues` so subsequent column scans are skipped.
- **Seed numeric column cache as identity** for pure-`number` columns at extraction (`seedNumericColumnIdentity`), skipping the O(n) bigint-narrowing scan per full extraction. Identity-only, not the offset cache.
- **Settled-type fast-path** in `updateColumnTypeTracker` for `number`/`bigint`/`boolean` (typeof maps 1:1), skipping the `valueColumnType` call; `string`/`object` keep the full path.
- **Correctness: invalidate identity epoch cache when an incremental insert introduces a string** — a string-free time column seeded as its own epoch identity must drop that identity when an `applyTransaction` insert writes an ISO string into it, or `ensureEpochColumn`'s lazy parse leaves the raw string in the continuous key domain. Tracks strings in the delta so the all-numeric/Date streaming case stays scan-free. (addresses PR review)
- **Benchmark tooling**: CPU-profile capture for benchmark examples (`profile-benchmark.ts`), with Chromium closed in a `finally` on failure.

## Why

`updateDelta({data})` recreates the DataSet and re-extracts all points each update, so the new machinery's per-datum cost dominates full re-extraction. These changes remove redundant column rescans without changing extraction semantics.

## Cross-release benchmark validation

HEAD vs the latest patch of each published minor line (curated 8-example set). `before` = published npm bundle (minified UMD), `after` = HEAD (local build); negative % = HEAD faster. HEAD's local build carries a ~3–4% parse penalty vs minified published bundles, measured via the Initial-Load/Chart-Create control:

| base | median Δ | chart-create offset | datum-highlight | reading |
|---|---|---|---|---|
| npm:13.3.1 | +4.3% | +4.0% | **−20.9%** | at parity (median ≈ offset); real highlight win |
| npm:13.2.1 | +8.5% | +11.9% | −29.1% | faster than raw (offset > median) |
| npm:13.1.0 | +0.9% | +2.9% | −29.6% | at parity; highlight win |
| npm:13.0.1 | +3.1% | +2.8% | −23.2% | at parity; highlight win |
| npm:12.3.1 | −2.2% | +14.6% | −69.6% | faster |
| npm:12.2.0 | −8.7% | +4.9% | −72.7% | faster |
| npm:12.1.2 | −14.8% | −42.2% | −83.6% | much faster |
| npm:12.0.2 | −23.1% | −40.4% | −94.5% | much faster |

- Decisively faster than every 12.x line; **at algorithmic parity with recent 13.x** once the unminified-build offset is removed, with a real ~20–30% win on the extraction/highlight path.
- Flagged "regressions" are Initial-Load/Chart-Create cases dominated by minified-vs-unminified bundle parse cost, not algorithmic regressions.
- `high-freq-line` update residual is now within offset+noise (+6.9%, flagged noisy; was +18% pre-branch). The deferred diff-aware `updateDelta` is the only remaining lever (post-release follow-up).

## Test plan

- `nx test ag-charts-community -- dataModel incrementalProcessor` (204 pass, incl. the new epoch-cache invalidation regression test; example-data tests must run through nx, not raw vitest).
- Browser benchmark compare + CPU profile diff vs npm:13.3.1 and the per-minor sweep above.
