### PR TITLE
docs: fix verified release-review documentation inaccuracies

### DIFF
--- a/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-time/index.mdoc
@@ -42,7 +42,7 @@ The Unit Time Axis does not aggregate data, so you should ensure that each serie
 The Unit Time Axis assumes that data is provided with one item per unit, and will infer a `unit` based on the data.
 
 For some scenarios - such as datasets with missing data points - it may be necessary to specify the `unit` explicitly.
-To explicitly set the `unit`, provide an `AgTimeInterval` string or `AgTimeIntervalUnit` object.
+To explicitly set the `unit`, provide an `AgTimeIntervalUnit` string or `AgTimeInterval` object.
 
 ```js format="snippet"
 {

--- a/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
@@ -15,7 +15,7 @@ These properties provide enough context and information to tailor the formatting
 
 These include:
 
-- `type` - whether the value is coming from a category, number, or date domain. This should not be confused with the JavaScript type of the value - use `typeof params.value` to determine that.
+- `type` - whether the value is coming from a category, number, or date domain.
 - `value` - the raw value to be formatted.
 - `source` - the chart element, such as `axis-label` or `tooltip`.
 - `property` - the data visualisation property, such as `x`, `y`, `size`. These mirror the `_Key` properties.

--- a/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/formatters/index.mdoc
@@ -15,7 +15,7 @@ These properties provide enough context and information to tailor the formatting
 
 These include:
 
-- `type` - whether the value is coming from a category, number, or date domain. This should not be confused with the `type` of the value - use `typeOf` to determine that.
+- `type` - whether the value is coming from a category, number, or date domain. This should not be confused with the JavaScript type of the value - use `typeof params.value` to determine that.
 - `value` - the raw value to be formatted.
 - `source` - the chart element, such as `axis-label` or `tooltip`.
 - `property` - the data visualisation property, such as `x`, `y`, `size`. These mirror the `_Key` properties.
@@ -148,7 +148,7 @@ Where:
 - `fill` - Can be any character.
 - `align`:
     - `>` - Forces the field to be right-aligned within the available space (default).
-    - `<>` - Forces the field to be left-aligned within the available space.
+    - `<` - Forces the field to be left-aligned within the available space.
     - `^` - Forces the field to be centred within the available space.
     - `=` - Like >, but with any sign and symbol to the left of any padding.
 - `sign`:

--- a/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/range-controls/index.mdoc
@@ -161,7 +161,7 @@ When buttons specify ranges that exceed the data bounds, they are disabled by de
 
 In this example:
 
-- The data only spans 3 months, so the '6 Months', 'YTD', and '1 Year' buttons are disabled by default.
+- The data only spans 3 months, so the '6M', 'YTD', and '1Y' buttons are disabled by default.
 - The 'All' button is always enabled.
 - Individual buttons can use the `enabled` property within their definition to force enable or disable states.
 
@@ -225,7 +225,7 @@ In this example:
 - Default - Purple fill. The idle state for buttons that are not active, hovered, or disabled.
 - Active - Green fill. Click a button to see this state.
 - Hover - Orange fill. Hover over a button to see this state.
-- Disabled - Light grey fill with muted text. The '1 Year' button shows this state as the data only spans 6 months.
+- Disabled - Light grey fill with muted text. The '1Y' button shows this state as the data only spans 6 months.
 - Button and dropdown styling inherit from the top level options, but can be overridden with the `button` and `dropdown` objects.
 
 ## API Reference

--- a/packages/ag-charts-website/src/content/docs/stylers-test/_examples/item-styler-test/main.ts
+++ b/packages/ag-charts-website/src/content/docs/stylers-test/_examples/item-styler-test/main.ts
@@ -67,6 +67,8 @@ const mapMarkerTopology = getMapMarkerTopology();
 const validHighlightStates = [
     'highlighted-item',
     'unhighlighted-item',
+    'highlighted-branch',
+    'unhighlighted-branch',
     'highlighted-series',
     'unhighlighted-series',
     'none',

--- a/packages/ag-charts-website/src/content/docs/treemap-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/treemap-series/index.mdoc
@@ -114,7 +114,7 @@ It's possible to override the default colours, or the colours on a group or tile
     series: [
         {
             type: 'treemap',
-            labelKey: 'name',
+            labelKey: 'title',
             sizeKey: 'total',
             sizeName: 'Total',
             fills: ['#E64A19', '#F57C00', '#FFA000', '#FBC02D', '#AFB42B', '#689F38', '#388E3C', '#00796B', '#0097A7', '#0288D1'],


### PR DESCRIPTION
## Summary

Fixes for the b13.3.1 → latest **release documentation review** ([run 27753203356](https://github.com/ag-grid/ag-charts/actions/runs/27753203356)).

Every finding was put through an **adversarial verification pass** — one skeptic agent per finding, prompted to *refute* the finding against live source/types/git history before any change was trusted. This materially changed the outcome: **all three "Critical" blockers were false alarms**, and 2 of the other findings were stale/non-existent.

Only the **6 findings that survived verification** are changed here.

## ✅ Applied (verified against source)

| Page | Fix | Evidence |
|------|-----|----------|
| `formatters` | `typeOf` → `typeof params.value` (no such property exists on any `*FormatterParams`) | `ag-charts-types/.../formatterOptions.ts:54-108` |
| `formatters` | left-align token `` `<>` `` → `` `<` `` | `ag-charts-core/.../numberFormat.ts:23,306` (align is a single-char class) |
| `axes-time` | swapped descriptors: `AgTimeIntervalUnit` is the **string**, `AgTimeInterval` is the **object** | `ag-charts-types/.../axisOptions.ts:256,258` |
| `treemap-series` | Other Colours snippet `labelKey: 'name'` → `'title'` | example `other-colors/main.ts:27` + `data.ts` (only `title` keys) |
| `range-controls` | prose labels `'6 Months'`/`'1 Year'` → `'6M'`/`'1Y'` (×2) | locale `en-US.ts:233,241`; examples use default buttons |
| `stylers-test` harness | add `highlighted-branch`/`unhighlighted-branch` to `validHighlightStates` | states emitted by `hierarchySeries.ts:502`; harness gate omitted them → false "Invalid" |

**Note on the `stylers-test` fix:** the branch states were added **only** to `validHighlightStates` (the validity gate). They were deliberately *not* added to `unseenStates`/`allValidHighlightStates`, which track the states a chart is *expected* to emit for the "Complete ✓" progress — adding branch states there would make every non-hierarchy chart permanently "Partial".

## ❌ Refuted by verification — intentionally NOT changed

These were reported (3 as **Critical**) but verification found the docs **correct** or the issue **non-existent**:

- **`upgrade-to-ag-charts-14` — `separationLinesColor` "not removed" (Critical):** it *was* renamed → `groupedCategoryLineColor` this release (commit `30b064bb5b`, AG-17494). The report conflated the old and new names. Doc is correct.
- **`upgrade-to-ag-charts-14` — `fontFamily` "didn't change" (Critical):** it *did* change to the IBM Plex Sans stack this release (same commit). Doc is correct.
- **`upgrade-to-ag-charts-14` — `focusShadow` "didn't change" (Critical):** it *did* change to a 50%-opacity accent colour this release (same commit). Doc is correct.
- **`treemap-series-test` wrong title (High):** already fixed in `0eb71587af`; title is `'Treemap Series Test'`.
- **`fonts-test` missing frontmatter (Medium):** page no longer exists (renamed to `text`/`text-test`).

The headline takeaway: the report's "dominant blocker" (the upgrade guide) was a verification artefact — the tool appears to have diffed against the wrong base and inverted the rename. The upgrade guide is accurate as written.

## Verification

- `yarn nx format:mdoc ag-charts-website` — ✓ all formatted
- `yarn nx format` — ✓ (no changes flagged on touched files)
- Changes are documentation prose + one string-array entry; type-safe by construction.

---
For @alantreadway and David to review.