### PR TITLE
Temporarily skip flaky Google Fonts E2E test

### DIFF
--- a/packages/ag-charts-website/e2e/fonts.spec.ts
+++ b/packages/ag-charts-website/e2e/fonts.spec.ts
@@ -10,7 +10,11 @@ test.describe('fonts', () => {
 
     for (const { framework, url } of testUrls) {
         test.describe(`for ${framework}`, () => {
-            test('google fonts', async ({ page }) => {
+            // Skipped: consistently flaky in CI. The example renders fonts via `loadGoogleFonts: true`,
+            // so the page waits on the live Google Fonts CDN; when the CDN is slow/unreachable from the
+            // runners the `networkidle` wait never settles and the test times out. Re-enable once the
+            // example no longer depends on a live external CDN at test time.
+            test.skip('google fonts', async ({ page }) => {
                 // Pre-warm the browser's font cache before navigating to the example.
                 // This ensures fonts are already loaded when the chart renders, eliminating
                 // the race between font download and initial chart render.


### PR DESCRIPTION
Temporarily skips the `fonts › google fonts` E2E test (`packages/ag-charts-website/e2e/fonts.spec.ts`) to unblock CI on `latest`.

**Why:** The test has been failing consistently since ~13:37 today, timing out after 30s at `util.ts:235` (`page.waitForLoadState('networkidle')`). The example renders fonts via `loadGoogleFonts: true`, so the page fetches webfonts from the live Google Fonts CDN at runtime; when the CDN is slow/unreachable from the runners the `networkidle` wait never settles. Playwright retried 2× and failed all attempts. This is an external-network flake, not a code regression — the test, example, and font-loading code were unchanged before the last green run, and the only commits in the failure window were `gha/snapshots-*` merges.

**Change:** `test(...)` → `test.skip(...)` with an inline comment explaining the cause and the re-enable condition. The test body is left intact so it stays visible in reports and is easy to restore.

**Follow-up:** This removes real coverage of `loadGoogleFonts` and should be re-enabled once the example no longer depends on a live external CDN at test time (e.g. self-host/stub the fonts). Recommend filing a ticket to track re-enablement.