### PR TITLE
docs: add Colours page and refresh themes, text and v14 upgrade notes

### DIFF
--- a/packages/ag-charts-website/src/content/docs-nav/nav.json
+++ b/packages/ag-charts-website/src/content/docs-nav/nav.json
@@ -338,6 +338,11 @@
                         },
                         {
                             "type": "item",
+                            "title": "Colours",
+                            "path": "colours"
+                        },
+                        {
+                            "type": "item",
                             "title": "Fills & Borders",
                             "path": "fills-borders"
                         },

--- a/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
@@ -41,6 +41,24 @@ bounds have been established.
 `source` distinguishes user-initiated fetches from programmatic ones, which is useful for avoiding re-fetch loops where
 a fetch triggers a chart update that triggers another fetch.
 
+When the [Navigator](./navigator/) mini chart is enabled, it issues its own `getData` call with `source: 'mini-chart'`
+to load a full-range overview, independent of the main chart's windowed fetches. Return coarse, full-range data for
+this source and detailed windowed data otherwise:
+
+```js format="snippet"
+{
+    dataSource: {
+        getData: ({ windowStart, windowEnd, source }) => {
+            return source === 'mini-chart' ? FakeServer.get({}) : FakeServer.get({ windowStart, windowEnd });
+        },
+    },
+    navigator: {
+        enabled: true,
+        miniChart: {},
+    },
+}
+```
+
 This pattern supports both progressive detail loading by returning finer data
 as the window narrows, as well as server-side paging where only the visible range is fetched from the server on each
 zoom or scroll.

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-formats/index.html
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-formats/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-formats/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-formats/main.ts
@@ -1,0 +1,36 @@
+import { AgChartOptions, AgCharts, LegendModule, ModuleRegistry, PieSeriesModule } from 'ag-charts-community';
+
+ModuleRegistry.registerModules([PieSeriesModule, LegendModule]);
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Colour Formats',
+    },
+    data: [
+        { format: '#4878d0', value: 30 },
+        { format: 'rgb(238, 133, 75)', value: 25 },
+        { format: 'hsl(145, 63%, 42%)', value: 25 },
+        { format: 'mediumpurple', value: 20 },
+    ],
+    series: [
+        {
+            type: 'pie',
+            angleKey: 'value',
+            legendItemKey: 'format',
+            // Each slice is filled with the colour named by its legend label.
+            fills: [
+                '#4878d0', // hex
+                'rgb(238, 133, 75)', // rgb
+                'hsl(145, 63%, 42%)', // hsl
+                'mediumpurple', // named colour
+            ],
+            strokeWidth: 0,
+        },
+    ],
+    legend: {
+        position: 'right',
+    },
+};
+
+AgCharts.create(options);

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/index.html
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/index.html
@@ -1,0 +1,26 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <div class="gap-right">
+            <label for="accent-select">accentColor:</label>
+            <select id="accent-select" onchange="changeAccent(event)">
+                <option value="#2f6df0">Blue</option>
+                <option value="#d1495b">Red</option>
+                <option value="#21b372">Green</option>
+                <option value="#8a4fff">Purple</option>
+            </select>
+        </div>
+        <div class="gap-right">
+            <label for="bg-select">backgroundColor:</label>
+            <select id="bg-select" onchange="changeBackground(event)">
+                <option value="#ffffff">White</option>
+                <option value="#10131a">Midnight</option>
+                <option value="#fff1e5">Paper</option>
+            </select>
+        </div>
+        <div>
+            <label for="mix-range">mix: <span id="mix-value">0.85</span></label>
+            <input id="mix-range" type="range" min="0" max="1" step="0.05" value="0.85" oninput="changeMix(event)" />
+        </div>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
@@ -1,0 +1,75 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
+
+let accentColor = '#2f6df0';
+let backgroundColor = '#ffffff';
+let mix = 0.85;
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Monthly Revenue',
+    },
+    data: [
+        { month: 'Jan', revenue: 120 },
+        { month: 'Feb', revenue: 150 },
+        { month: 'Mar', revenue: 180 },
+        { month: 'Apr', revenue: 140 },
+        { month: 'May', revenue: 210 },
+        { month: 'Jun', revenue: 190 },
+    ],
+    series: [
+        {
+            type: 'bar',
+            xKey: 'month',
+            yKey: 'revenue',
+            yName: 'Revenue',
+            // A reference resolves on a series fill as well as on theme parameters.
+            fill: { ref: 'accentColor' } as any,
+        },
+    ],
+    axes: {
+        x: { type: 'category', position: 'bottom' },
+        y: { type: 'number', position: 'left' },
+    },
+};
+
+const chart = AgCharts.create(options);
+updateTheme();
+
+function updateTheme() {
+    options.theme = {
+        params: {
+            accentColor,
+            backgroundColor,
+            // Text and axes are derived from the accent and background colours.
+            foregroundColor: { ref: 'accentColor', mix, onto: 'backgroundColor' },
+        },
+    };
+    chart.update(options);
+}
+
+function changeAccent(event: Event) {
+    accentColor = (event.target as HTMLSelectElement).value;
+    updateTheme();
+}
+
+function changeBackground(event: Event) {
+    backgroundColor = (event.target as HTMLSelectElement).value;
+    updateTheme();
+}
+
+function changeMix(event: Event) {
+    mix = Number((event.target as HTMLInputElement).value);
+    document.getElementById('mix-value')!.textContent = mix.toFixed(2);
+    updateTheme();
+}

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
@@ -16,6 +16,14 @@ let mix = 0.85;
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
+    theme: {
+        params: {
+            accentColor,
+            backgroundColor,
+            // Text and axes are derived from the accent and background colours.
+            foregroundColor: { ref: 'accentColor', mix, onto: 'backgroundColor' },
+        },
+    },
     title: {
         text: 'Monthly Revenue',
     },
@@ -44,14 +52,13 @@ const options: AgCartesianChartOptions = {
 };
 
 const chart = AgCharts.create(options);
-updateTheme();
 
+/** inScope */
 function updateTheme() {
     options.theme = {
         params: {
             accentColor,
             backgroundColor,
-            // Text and axes are derived from the accent and background colours.
             foregroundColor: { ref: 'accentColor', mix, onto: 'backgroundColor' },
         },
     };

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/index.html
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/index.html
@@ -1,0 +1,6 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <button onclick="togglePalette()">Toggle palette</button>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/main.ts
@@ -1,0 +1,71 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
+
+const dawn = {
+    '--chart-bg': '#fffdf7',
+    '--chart-fg': '#3a2e2e',
+    '--series-online': '#e07a5f',
+    '--series-retail': '#3d405b',
+};
+
+const dusk = {
+    '--chart-bg': '#161b22',
+    '--chart-fg': '#e6edf3',
+    '--series-online': '#58a6ff',
+    '--series-retail': '#ff7b72',
+};
+
+function applyPalette(palette: Record<string, string>) {
+    for (const [name, value] of Object.entries(palette)) {
+        document.documentElement.style.setProperty(name, value);
+    }
+}
+
+applyPalette(dawn);
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    theme: {
+        params: {
+            backgroundColor: 'var(--chart-bg)',
+            foregroundColor: 'var(--chart-fg)',
+        },
+    },
+    title: {
+        text: 'Monthly Revenue',
+    },
+    data: [
+        { month: 'Jan', online: 120, retail: 90 },
+        { month: 'Feb', online: 150, retail: 100 },
+        { month: 'Mar', online: 180, retail: 130 },
+        { month: 'Apr', online: 140, retail: 120 },
+        { month: 'May', online: 210, retail: 160 },
+        { month: 'Jun', online: 190, retail: 150 },
+    ],
+    series: [
+        { type: 'bar', xKey: 'month', yKey: 'online', yName: 'Online', fill: 'var(--series-online)' },
+        { type: 'bar', xKey: 'month', yKey: 'retail', yName: 'Retail', fill: 'var(--series-retail)' },
+    ],
+    axes: {
+        x: { type: 'category', position: 'bottom' },
+        y: { type: 'number', position: 'left' },
+    },
+};
+
+AgCharts.create(options);
+
+let dark = false;
+
+function togglePalette() {
+    dark = !dark;
+    applyPalette(dark ? dusk : dawn);
+}

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/main.ts
@@ -11,17 +11,17 @@ import {
 ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
 
 const dawn = {
-    '--chart-bg': '#fffdf7',
-    '--chart-fg': '#3a2e2e',
-    '--series-online': '#e07a5f',
-    '--series-retail': '#3d405b',
+    '--demo-bg': '#fffdf7',
+    '--demo-fg': '#3a2e2e',
+    '--demo-online': '#e07a5f',
+    '--demo-retail': '#3d405b',
 };
 
 const dusk = {
-    '--chart-bg': '#161b22',
-    '--chart-fg': '#e6edf3',
-    '--series-online': '#58a6ff',
-    '--series-retail': '#ff7b72',
+    '--demo-bg': '#161b22',
+    '--demo-fg': '#e6edf3',
+    '--demo-online': '#58a6ff',
+    '--demo-retail': '#ff7b72',
 };
 
 function applyPalette(palette: Record<string, string>) {
@@ -30,14 +30,12 @@ function applyPalette(palette: Record<string, string>) {
     }
 }
 
-applyPalette(dawn);
-
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
     theme: {
         params: {
-            backgroundColor: 'var(--chart-bg)',
-            foregroundColor: 'var(--chart-fg)',
+            backgroundColor: 'var(--demo-bg)',
+            foregroundColor: 'var(--demo-fg)',
         },
     },
     title: {
@@ -52,8 +50,8 @@ const options: AgCartesianChartOptions = {
         { month: 'Jun', online: 190, retail: 150 },
     ],
     series: [
-        { type: 'bar', xKey: 'month', yKey: 'online', yName: 'Online', fill: 'var(--series-online)' },
-        { type: 'bar', xKey: 'month', yKey: 'retail', yName: 'Retail', fill: 'var(--series-retail)' },
+        { type: 'bar', xKey: 'month', yKey: 'online', yName: 'Online', fill: 'var(--demo-online)' },
+        { type: 'bar', xKey: 'month', yKey: 'retail', yName: 'Retail', fill: 'var(--demo-retail)' },
     ],
     axes: {
         x: { type: 'category', position: 'bottom' },

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/styles.css
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/css-variables/styles.css
@@ -1,0 +1,6 @@
+:root {
+    --demo-bg: #fffdf7;
+    --demo-fg: #3a2e2e;
+    --demo-online: #e07a5f;
+    --demo-retail: #3d405b;
+}

--- a/packages/ag-charts-website/src/content/docs/colours/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/colours/index.mdoc
@@ -1,0 +1,79 @@
+---
+title: 'Colours'
+description: 'Every colour value form accepted by $framework Charts in one place: CSS colour strings, CSS variables, and theme parameter references, plus gradient, pattern and image fills.'
+---
+
+AG Charts accepts standard CSS colour strings, CSS variables, and theme parameter references anywhere a colour is set. Richer gradient, pattern and image fills are available on `fill` properties.
+
+## Colour Formats
+
+Any colour string accepted by CSS can be used wherever a colour is set — series fills, strokes, text colours, and theme parameters.
+
+{% chartExampleRunner title="Colour Formats" name="colour-formats" type="generated" /%}
+
+| Format       | Example                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------- |
+| Hex          | `'#4878d0'`, `'#48d'`, `'#4878d0cc'` (with alpha)                                                       |
+| rgb / rgba   | `'rgb(72, 120, 208)'`, `'rgba(72, 120, 208, 0.8)'`                                                      |
+| hsl / hsla   | `'hsl(145, 63%, 42%)'`, `'hsl(145 63% 42% / 0.8)'`                                                      |
+| Named colour | `'mediumpurple'` (any [CSS named colour](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color)) |
+
+## CSS Variables
+
+Use a CSS custom property such as `var(--brand-primary)` anywhere a colour is accepted.
+
+{% chartExampleRunner title="CSS Variables" name="css-variables" type="generated" /%}
+
+```js format="snippet"
+{
+    theme: {
+        params: {
+            backgroundColor: 'var(--chart-bg)',
+            foregroundColor: 'var(--chart-fg)',
+        },
+    },
+    series: [
+        { type: 'bar', xKey: 'month', yKey: 'online', fill: 'var(--series-online)' },
+        { type: 'bar', xKey: 'month', yKey: 'retail', fill: 'var(--series-retail)' },
+    ],
+}
+```
+
+- **Toggle palette** changes the variables only; the series, background, axes and text all follow.
+- The chart re-renders automatically when a variable changes — no `chart.update()` needed.
+
+{% note %}
+The `--ag-charts-*` namespace is reserved for internal use.
+{% /note %}
+
+## Theme Parameter References
+
+A colour can reference a [theme parameter](./themes/#parameters) instead of a literal value, keeping related colours in sync. A reference can be used anywhere a colour is accepted — including a series `fill` — but can only point _to_ a theme parameter.
+
+{% chartExampleRunner title="Theme Parameter References" name="colour-references" type="generated" /%}
+
+```js format="snippet"
+{
+    theme: {
+        params: {
+            accentColor: '#2f6df0',
+            backgroundColor: '#ffffff',
+            foregroundColor: { ref: 'accentColor', mix: 0.85, onto: 'backgroundColor' },
+            axisColor: { ref: 'accentColor', mix: 0.5 },
+        },
+    },
+    series: [{ type: 'bar', xKey: 'month', yKey: 'revenue', fill: { ref: 'accentColor' } }],
+}
+```
+
+The reference forms are:
+
+- `{ ref: 'accentColor' }` — resolve to another theme parameter.
+- `{ ref: 'accentColor', mix: 0.5 }` — mix the referenced parameter towards transparency.
+- `{ ref: 'accentColor', mix: 0.85, onto: 'backgroundColor' }` — blend one parameter onto another.
+
+See [Themes](./themes/#colour-references) for more details.
+
+## Gradient, Pattern & Image Fills
+
+`fill` properties also accept gradient, pattern, and image fills — on series, markers, [legend](./legend/) backgrounds, and label boxes. See [Series Fills](./fills/) for the full reference. A `stroke` accepts a colour string only.

--- a/packages/ag-charts-website/src/content/docs/colours/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/colours/index.mdoc
@@ -28,13 +28,13 @@ Use a CSS custom property such as `var(--brand-primary)` anywhere a colour is ac
 {
     theme: {
         params: {
-            backgroundColor: 'var(--chart-bg)',
-            foregroundColor: 'var(--chart-fg)',
+            backgroundColor: 'var(--demo-bg)',
+            foregroundColor: 'var(--demo-fg)',
         },
     },
     series: [
-        { type: 'bar', xKey: 'month', yKey: 'online', fill: 'var(--series-online)' },
-        { type: 'bar', xKey: 'month', yKey: 'retail', fill: 'var(--series-retail)' },
+        { type: 'bar', xKey: 'month', yKey: 'online', fill: 'var(--demo-online)' },
+        { type: 'bar', xKey: 'month', yKey: 'retail', fill: 'var(--demo-retail)' },
     ],
 }
 ```

--- a/packages/ag-charts-website/src/content/docs/fills/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/fills/index.mdoc
@@ -10,7 +10,7 @@ Series and Markers can have solid, gradient and pattern fills, allowing for uniq
 
 Supported Fill Types are:
 
-- **Solid Fill**: A single CSS colour (provided as a `#rgb` hex code, `rgb()` or `rgba()` values, or [a CSS colour name](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color) such as 'black').
+- **Solid Fill**: A single colour. See [Colours](./colours/) for the accepted colour formats, CSS variables, and theme references.
 
 - **Gradient Fill**: A transition between multiple colours.
 

--- a/packages/ag-charts-website/src/content/docs/text/_examples/inline-images/main.ts
+++ b/packages/ag-charts-website/src/content/docs/text/_examples/inline-images/main.ts
@@ -17,6 +17,8 @@ import { TData, getData } from './data';
 
 ModuleRegistry.registerModules([AnimationModule, BarSeriesModule, CategoryAxisModule, LegendModule, NumberAxisModule]);
 
+const flagsUrl = '${baseWWWUrl}/example-assets/flags/';
+
 const arrowUp =
     'data:image/svg+xml;utf8,' +
     encodeURIComponent(
@@ -35,7 +37,7 @@ const options: AgChartOptions = {
             { text: 'Top Markets ' },
             {
                 type: 'image',
-                url: '${baseWWWUrl}/example-assets/flags/us.png',
+                url: flagsUrl + 'us.png',
                 width: 24,
                 height: 18,
                 verticalAlign: 'middle',
@@ -79,7 +81,7 @@ const options: AgChartOptions = {
                 formatter: ({ value }) => [
                     {
                         type: 'image',
-                        url: '${baseWWWUrl}/example-assets/flags/' + `${value}.png`,
+                        url: flagsUrl + `${value}.png`,
                         width: 20,
                         height: 15,
                         verticalAlign: 'middle',

--- a/packages/ag-charts-website/src/content/docs/text/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/text/index.mdoc
@@ -138,7 +138,7 @@ Three approaches add imagery to any label that accepts text segments — axis la
 Provide any image URL through the `url` property:
 
 ```js
-const url = 'https://example.com/flag.png';
+const flagsUrl = '${baseWWWUrl}/example-assets/flags/';
 ```
 
 ```js format="snippet"
@@ -150,7 +150,7 @@ const url = 'https://example.com/flag.png';
                 formatter: ({ value }) => [
                     {
                         type: 'image',
-                        url,
+                        url: flagsUrl + `${value}.png`,
                         width: 20,
                         height: 15,
                         verticalAlign: 'middle',

--- a/packages/ag-charts-website/src/content/docs/text/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/text/index.mdoc
@@ -135,6 +135,12 @@ Three approaches add imagery to any label that accepts text segments — axis la
 
 {% chartExampleRunner title="Inline Images" name="inline-images" type="generated" /%}
 
+Provide any image URL through the `url` property:
+
+```js
+const url = 'https://example.com/flag.png';
+```
+
 ```js format="snippet"
 {
     axes: {
@@ -144,7 +150,7 @@ Three approaches add imagery to any label that accepts text segments — axis la
                 formatter: ({ value }) => [
                     {
                         type: 'image',
-                        url: '${baseWWWUrl}/example-assets/flags/' + `${value}.png`,
+                        url,
                         width: 20,
                         height: 15,
                         verticalAlign: 'middle',

--- a/packages/ag-charts-website/src/content/docs/text/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/text/index.mdoc
@@ -1,19 +1,50 @@
 ---
 title: 'Text'
+description: 'Style the text in a $framework chart: fonts and Google Fonts, multiple font styles within a single element, and inline images, emoji and icons.'
 ---
 
-Font options include font family, size, weight, and style.
+This section describes how to style the text used throughout a chart, including titles, labels and other elements. It covers font options, applying multiple font styles and inline images within a single text element.
 
-## Font Options
+## Fonts
 
-Each chart element has font options, including `fontFamily`, `fontSize` and `fontWeight`.
-See [API Options](/options/) for more details.
+Each chart element has font options, including `fontFamily`, `fontSize` and `fontWeight`. The font options for the whole chart can be set once using [theme parameters](./themes/#parameters).
+
+### Font Families
+
+Font families can accept the following value types:
+
+| Syntax                            | Description                                                                                                                                                                                                                                    |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `string`                          | A CSS font-family value, such as `'Arial, sans-serif'`.                                                                                                                                                                                        |
+| `{ googleFont: 'IBM Plex Sans' }` | A Google font. You must load the font or ask the chart to load it for you, see [Google Fonts](#google-fonts) below.                                                                                                                            |
+| `['Arial', 'sans-serif']`         | An array of fonts. Each item can be a string font name or a `{ googleFont: "..." }` object. The browser will attempt to use the first font and fall back to later fonts if the first one fails to load or is not available on the host system. |
+
+### Google Fonts
+
+To prevent potential licensing and privacy implications, the chart will not load Google fonts unless requested to.
+
+If you want to use Google fonts, you should either:
+
+- Set the chart's `loadGoogleFonts` option to `true` and use the `{ googleFont: "..." }` object for the chart to load the font from Google's CDN.
+- Load the font yourself using a `@font-face` rule in your application's CSS.
+
+If the font has not been loaded through either of the above methods, the theme will fall back to the most appropriate font available on the system.
+
+{% chartExampleRunner title="Google Fonts" name="google-fonts" type="generated" /%}
+
+In the above example:
+
+<!-- cspell:ignore Pacifico Orbitron -->
+
+- The `loadGoogleFonts` option is set to `true` to automatically load Google fonts.
+- The title uses the Google font `Pacifico`.
+- The subtitle uses the Google font `DM Serif Text` with a fallback to `monospace`.
+- The left axis uses the local system font `Helvetica` with a fallback to `Arial` then `sans-serif`.
+- The bottom axis uses the Google font `Orbitron`.
 
 ## Multi-Style Text Elements
 
-The chart title, subtitle and footnote support multiple font styles within the one element.
-
-This is done by passing an array of `TextSegment` objects, where each object contains a `text` property and associated font style overrides.
+The chart title, subtitle and footnote support multiple font styles within one element.
 
 {% chartExampleRunner title="Multi-Style Text" name="text-segments" type="generated" /%}
 
@@ -41,14 +72,12 @@ This is done by passing an array of `TextSegment` objects, where each object con
 
 In the above example:
 
-- The `title`, `subtitle` and `footnote` use text segments to vary font options within the text.
-- The top level font options within each element are used for all text segments, unless overridden.
+- Pass an array of `TextSegment` objects, each with a `text` property and font style overrides.
+- The top-level font options on each element apply to all segments, unless a segment overrides them.
 
 ### Label Formatters with Multi-Style Text
 
-Series labels and axes labels also support multiple font styles when using formatters.
-
-Instead of returning a string, formatters can return an array of `TextSegment` objects, where each segment contains a `text` property and associated font style overrides.
+Series and axis label formatters also support multiple font styles.
 
 {% chartExampleRunner title="Multi-Style Label Formatters" name="label-formatters" type="generated" /%}
 
@@ -70,7 +99,7 @@ Instead of returning a string, formatters can return an array of `TextSegment` o
 
 In the above example:
 
-- The label formatter returns an array of `TextSegment` objects instead of a string.
+- The formatter returns an array of `TextSegment` objects instead of a string.
 - The first segment shows the value in large, bold, white text.
 - The second segment displays "units" in smaller, semi-transparent text.
 - Each text segment can have independent font styling (size, weight, color, style, family).
@@ -78,7 +107,7 @@ In the above example:
 
 ### Aligning Segments Vertically
 
-When a segment uses a larger `fontSize` than the rest of the line — a flag emoji next to a country code, an icon glyph next to text — the segments share a baseline by default, which can leave the larger glyph riding high. Set `verticalAlign` on the segment to centre it against the line instead.
+Segments share a baseline by default, so a larger glyph — a flag emoji, an icon — can ride high above the line. Set `verticalAlign: 'middle'` to centre it instead.
 
 ```js format="snippet"
 {
@@ -96,11 +125,13 @@ When a segment uses a larger `fontSize` than the rest of the line — a flag emo
 }
 ```
 
-`verticalAlign` accepts `'baseline'` (default), `'top'`, `'middle'`, or `'bottom'`. The setting applies per-segment, so a single line can mix baseline-aligned text with centred emoji or icon glyphs.
+`verticalAlign` applies per segment, so a single line can mix baseline-aligned text with centred emoji or icon glyphs.
 
-## Inline Images
+## Images
 
-Place images alongside text in any label that accepts text segments — axis labels, series labels, captions, and navigator labels. An image segment uses `type: 'image'` and requires `width` and `height` so layout space is reserved before the image finishes loading.
+Three approaches add imagery to any label that accepts text segments — axis labels, series labels, captions, and navigator labels: inline images, emoji, and font icons.
+
+### Inline Images
 
 {% chartExampleRunner title="Inline Images" name="inline-images" type="generated" /%}
 
@@ -126,58 +157,28 @@ Place images alongside text in any label that accepts text segments — axis lab
 }
 ```
 
-An image segment supports:
+An image segment uses `type: 'image'` and supports:
 
+- `width` and `height` — required, so layout space is reserved before the image finishes loading.
 - `verticalAlign` — alignment against the line. Inline images default to `'baseline'`; block images (`block: true`) default to `'middle'`.
-- `padding`, `cornerRadius`, `backgroundFill` — decoration drawn around the image, with the `backgroundFill` also acting as the placeholder while the image loads or if loading fails.
-- `overflowStrategy: 'hide' | 'keep'` — drop priority when a label exceeds its allotted box. `'hide'` images are dropped before text is truncated. `'keep'` images take priority over text: trailing text segments are dropped to fit the image, and the image itself is only dropped when it cannot fit the label box on its own.
-- `block: true` — starts a block row anchored to the left of the label, with subsequent segments wrapping into a column to its right. A block row begins at the start of the label or after a `\n` line break in the preceding text segment. Multiple block rows stack vertically.
+- `padding`, `cornerRadius`, `backgroundFill` — decoration around the image. `backgroundFill` also shows as a placeholder while the image loads or if it fails.
+- `overflowStrategy` — drop priority when a label overflows its box. `'hide'` images are dropped before text is truncated; `'keep'` images take priority, dropping trailing text first and only dropping the image if it cannot fit on its own.
+- `block: true` — starts a block row anchored to the left of the label, with following segments wrapping into a column to its right. Block rows begin at the start of the label or after a `\n`, and stack vertically.
 
 {% chartExampleRunner title="Block-leading Image" name="inline-images-treemap" type="generated" /%}
 
-## Inline Emoji and Icons
+### Emoji
 
 Emoji render through native canvas, no API changes required.
 
 {% chartExampleRunner title="Inline Emoji" name="inline-emoji" type="generated" /%}
 
-Font icons (e.g. FontAwesome) load via a CSS `<link>` and apply per-segment through `fontFamily` and `fontWeight`. Canvas text rendering does not trigger font downloads, so the chart detects the fonts referenced in its options, downloads them, and re-renders automatically once they are ready.
+### Font Icons
+
+Font icons (e.g. FontAwesome) apply per segment through `fontFamily` and `fontWeight`, loaded via a CSS `<link>`. The chart downloads any referenced fonts and re-renders once they are ready.
 
 {% chartExampleRunner title="Inline Font Icons" name="inline-font-icons" type="generated" /%}
 
-## Font Theme Parameters
+## API Reference
 
-The font options for the whole chart can be set once, by using [theme parameters](./themes/#parameters).
-
-## Extended Syntax for Font Families
-
-Font families can accept the following value types:
-
-| Syntax                            | Description                                                                                                                                                                                                                                    |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `string`                          | A CSS font-family value, such as `'Arial, sans-serif'`.                                                                                                                                                                                        |
-| `{ googleFont: 'IBM Plex Sans' }` | A Google font. You must load the font or ask the chart to load it for you, see [Loading Google Fonts](#loading-google-fonts) below.                                                                                                            |
-| `['Arial', 'sans-serif']`         | An array of fonts. Each item can be a string font name or a `{ googleFont: "..." }` object. The browser will attempt to use the first font and fall back to later fonts if the first one fails to load or is not available on the host system. |
-
-## Loading Google Fonts
-
-To prevent potential licensing and privacy implications, the chart will not load Google fonts unless requested to.
-
-If you want to use Google fonts, you should either:
-
-- Set the chart's `loadGoogleFonts` option to `true` and use the `{ googleFont: "..." }` object for the chart to load the font from Google's CDN.
-- Load the font yourself using a `@font-face` rule in your application's CSS.
-
-If the font has not been loaded through either of the above methods, the theme will fall back to the most appropriate font available on the system.
-
-{% chartExampleRunner title="Google Fonts" name="google-fonts" type="generated" /%}
-
-In the above example:
-
-<!-- cspell:ignore Pacifico Orbitron -->
-
-- The `loadGoogleFonts` option is set to `true` to automatically load Google fonts.
-- The title uses the Google font `Pacifico`.
-- The subtitle uses the Google font `DM Serif Text` with a fallback to `monospace`.
-- The left axis uses the local system font `Helvetica` with a fallback to `Arial` then `sans-serif`.
-- The bottom axis uses the Google font `Orbitron`.
+See [API Options](/options/) for the full list of font options on each chart element.

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/index.html
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/index.html
@@ -1,0 +1,21 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <div class="gap-right">
+            <label for="color-select">color:</label>
+            <select id="color-select" onchange="changeColor(event)">
+                <option value="accentColor">{ ref: 'accentColor' }</option>
+                <option value="#d1495b">#d1495b</option>
+                <option value="#21b372">#21b372</option>
+            </select>
+        </div>
+        <div class="gap-right">
+            <label for="width-range">width: <span id="width-value">2</span></label>
+            <input id="width-range" type="range" min="0" max="8" step="1" value="2" oninput="changeWidth(event)" />
+        </div>
+        <div>
+            <label for="radius-range">radius: <span id="radius-value">8</span></label>
+            <input id="radius-range" type="range" min="0" max="20" step="1" value="8" oninput="changeRadius(event)" />
+        </div>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/index.html
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/index.html
@@ -3,7 +3,7 @@
         <div class="gap-right">
             <label for="color-select">color:</label>
             <select id="color-select" onchange="changeColor(event)">
-                <option value="accentColor">{ ref: 'accentColor' }</option>
+                <option value="accentColor">accentColor (ref)</option>
                 <option value="#d1495b">#d1495b</option>
                 <option value="#21b372">#21b372</option>
             </select>

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/main.ts
@@ -2,20 +2,13 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     CategoryAxisModule,
-    ChartToolbarModule,
     LineSeriesModule,
     ModuleRegistry,
     NumberAxisModule,
     ZoomModule,
 } from 'ag-charts-enterprise';
 
-ModuleRegistry.registerModules([
-    LineSeriesModule,
-    CategoryAxisModule,
-    NumberAxisModule,
-    ZoomModule,
-    ChartToolbarModule,
-]);
+ModuleRegistry.registerModules([LineSeriesModule, CategoryAxisModule, NumberAxisModule, ZoomModule]);
 
 let width = 2;
 let radius = 8;

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/main.ts
@@ -1,0 +1,77 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    CategoryAxisModule,
+    ChartToolbarModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+    ZoomModule,
+} from 'ag-charts-enterprise';
+
+ModuleRegistry.registerModules([
+    LineSeriesModule,
+    CategoryAxisModule,
+    NumberAxisModule,
+    ZoomModule,
+    ChartToolbarModule,
+]);
+
+let width = 2;
+let radius = 8;
+let color = 'accentColor';
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Adjust the border on the zoom buttons',
+    },
+    data: [
+        { month: 'Jan', revenue: 120 },
+        { month: 'Feb', revenue: 150 },
+        { month: 'Mar', revenue: 180 },
+        { month: 'Apr', revenue: 140 },
+        { month: 'May', revenue: 210 },
+        { month: 'Jun', revenue: 190 },
+    ],
+    series: [{ type: 'line', xKey: 'month', yKey: 'revenue', yName: 'Revenue' }],
+    axes: {
+        x: { type: 'category' },
+        y: { type: 'number' },
+    },
+    zoom: {
+        enabled: true,
+        buttons: { visible: 'always' },
+    },
+};
+
+const chart = AgCharts.create(options);
+updateBorder();
+
+function updateBorder() {
+    options.theme = {
+        params: {
+            accentColor: '#2f6df0',
+            buttonBorder: { width, color: color === 'accentColor' ? { ref: 'accentColor' } : color },
+            buttonBorderRadius: radius,
+        },
+    };
+    chart.update(options);
+}
+
+function changeWidth(event: Event) {
+    width = Number((event.target as HTMLInputElement).value);
+    document.getElementById('width-value')!.textContent = String(width);
+    updateBorder();
+}
+
+function changeRadius(event: Event) {
+    radius = Number((event.target as HTMLInputElement).value);
+    document.getElementById('radius-value')!.textContent = String(radius);
+    updateBorder();
+}
+
+function changeColor(event: Event) {
+    color = (event.target as HTMLSelectElement).value;
+    updateBorder();
+}

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/main.ts
@@ -16,6 +16,13 @@ let color = 'accentColor';
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
+    theme: {
+        params: {
+            accentColor: '#2f6df0',
+            buttonBorder: { width, color: color === 'accentColor' ? { ref: 'accentColor' } : color },
+            buttonBorderRadius: radius,
+        },
+    },
     title: {
         text: 'Adjust the border on the zoom buttons',
     },
@@ -39,8 +46,8 @@ const options: AgCartesianChartOptions = {
 };
 
 const chart = AgCharts.create(options);
-updateBorder();
 
+/** inScope */
 function updateBorder() {
     options.theme = {
         params: {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/index.html
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/index.html
@@ -1,0 +1,26 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <div class="gap-right">
+            <label for="ref-select">ref:</label>
+            <select id="ref-select" onchange="changeRef(event)">
+                <option value="accentColor">accentColor</option>
+                <option value="foregroundColor">foregroundColor</option>
+                <option value="backgroundColor">backgroundColor</option>
+            </select>
+        </div>
+        <div class="gap-right">
+            <label for="onto-select">onto:</label>
+            <select id="onto-select" onchange="changeOnto(event)">
+                <option value="none">none</option>
+                <option value="backgroundColor">backgroundColor</option>
+                <option value="foregroundColor">foregroundColor</option>
+                <option value="accentColor">accentColor</option>
+            </select>
+        </div>
+        <div>
+            <label for="mix-range">mix: <span id="mix-value">0.35</span></label>
+            <input id="mix-range" type="range" min="0" max="1" step="0.05" value="0.35" oninput="changeMix(event)" />
+        </div>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
@@ -16,6 +16,15 @@ let mix = 0.35;
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
+    theme: {
+        params: {
+            accentColor: '#2f6df0',
+            backgroundColor: '#ffffff',
+            foregroundColor: '#1b2a4a',
+            // Only the text colour is derived from the controls below.
+            textColor: { ref, mix } as any,
+        },
+    },
     title: {
         text: 'Quarterly Revenue',
     },
@@ -38,8 +47,8 @@ const options: AgCartesianChartOptions = {
 };
 
 const chart = AgCharts.create(options);
-updateTextColor();
 
+/** inScope */
 function updateTextColor() {
     const textColor = onto === 'none' ? { ref, mix } : { ref, mix, onto };
     options.theme = {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
@@ -10,7 +10,7 @@ import {
 
 ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
 
-let ref = 'accentColor';
+let colorRef = 'accentColor';
 let onto = 'none';
 let mix = 0.35;
 
@@ -22,7 +22,7 @@ const options: AgCartesianChartOptions = {
             backgroundColor: '#ffffff',
             foregroundColor: '#1b2a4a',
             // Only the text colour is derived from the controls below.
-            textColor: { ref, mix } as any,
+            textColor: { ref: colorRef, mix } as any,
         },
     },
     title: {
@@ -50,7 +50,7 @@ const chart = AgCharts.create(options);
 
 /** inScope */
 function updateTextColor() {
-    const textColor = onto === 'none' ? { ref, mix } : { ref, mix, onto };
+    const textColor = onto === 'none' ? { ref: colorRef, mix } : { ref: colorRef, mix, onto };
     options.theme = {
         params: {
             accentColor: '#2f6df0',
@@ -64,7 +64,7 @@ function updateTextColor() {
 }
 
 function changeRef(event: Event) {
-    ref = (event.target as HTMLSelectElement).value;
+    colorRef = (event.target as HTMLSelectElement).value;
     updateTextColor();
 }
 

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
@@ -1,0 +1,71 @@
+import {
+    AgCartesianChartOptions,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
+
+let ref = 'accentColor';
+let onto = 'none';
+let mix = 0.35;
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    title: {
+        text: 'Quarterly Revenue',
+    },
+    subtitle: {
+        text: 'Text colour derived from a parameter reference',
+    },
+    data: [
+        { month: 'Jan', revenue: 120 },
+        { month: 'Feb', revenue: 150 },
+        { month: 'Mar', revenue: 180 },
+        { month: 'Apr', revenue: 140 },
+        { month: 'May', revenue: 210 },
+        { month: 'Jun', revenue: 190 },
+    ],
+    series: [{ type: 'bar', xKey: 'month', yKey: 'revenue', yName: 'Revenue', fill: '#c9d6e8' }],
+    axes: {
+        x: { type: 'category', position: 'bottom', title: { text: 'Month' } },
+        y: { type: 'number', position: 'left', title: { text: 'Revenue ($000s)' } },
+    },
+};
+
+const chart = AgCharts.create(options);
+updateTextColor();
+
+function updateTextColor() {
+    const textColor = onto === 'none' ? { ref, mix } : { ref, mix, onto };
+    options.theme = {
+        params: {
+            accentColor: '#2f6df0',
+            backgroundColor: '#ffffff',
+            foregroundColor: '#1b2a4a',
+            // Only the text colour is derived from the controls below.
+            textColor: textColor as any,
+        },
+    };
+    chart.update(options);
+}
+
+function changeRef(event: Event) {
+    ref = (event.target as HTMLSelectElement).value;
+    updateTextColor();
+}
+
+function changeOnto(event: Event) {
+    onto = (event.target as HTMLSelectElement).value;
+    updateTextColor();
+}
+
+function changeMix(event: Event) {
+    mix = Number((event.target as HTMLInputElement).value);
+    document.getElementById('mix-value')!.textContent = mix.toFixed(2);
+    updateTextColor();
+}

--- a/packages/ag-charts-website/src/content/docs/themes/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/themes/index.mdoc
@@ -53,7 +53,7 @@ A custom theme is an object with the following optional properties:
 
 See the [Themes API page](/themes-api/) for the complete options structure.
 
-### Palette
+## Palette
 
 A palette is the array of colours used for the data, for example the bars in a bar series chart.
 
@@ -70,7 +70,7 @@ const myTheme = {
 };
 ```
 
-### Parameters
+## Parameters
 
 The `params` object is used to set styles across the whole chart in one place.
 
@@ -104,7 +104,53 @@ In the above example:
 - All text elements are set to the same font family.
 - All text, except the titles and footer, are set to the same font size.
 
-### Overrides
+### Colour References
+
+Any colour parameter can reference another instead of a fixed value, keeping related colours in sync. See [Colours](./colours/) for all accepted colour value forms.
+
+{% chartExampleRunner title="Colour References" name="theme-colour-references" type="generated" /%}
+
+The chart `textColor` is derived from the controls. With `onto` set to `none`, `mix` fades the referenced colour towards transparency.
+
+```js format="snippet"
+const myTheme = {
+    params: {
+        accentColor: '#0d7680',
+        subtleTextColor: { ref: 'textColor', mix: 0.6 },
+        tooltipBackgroundColor: { ref: 'accentColor', mix: 0.1, onto: 'backgroundColor' },
+    },
+};
+```
+
+- `{ ref: 'accentColor' }` - use another parameter's value.
+- `{ ref: 'accentColor', mix: 0.5 }` - that colour at `50%` opacity.
+- `{ ref: 'accentColor', mix: 0.1, onto: 'backgroundColor' }` - blend `ref` onto `onto`, weighted by `mix`.
+
+### Borders
+
+Border parameters use a consistent `{ width, color }` shape across every element.
+
+{% chartExampleRunner title="Borders" name="theme-borders" type="generated" /%}
+
+The controls style `buttonBorder`, shown on the zoom buttons.
+
+```js format="snippet"
+const myTheme = {
+    params: {
+        borderColor: '#cccccc',
+        borderWidth: 1,
+        borderRadius: 4,
+        buttonBorder: { width: 2, color: { ref: 'accentColor' } },
+        buttonBorderRadius: 8,
+    },
+};
+```
+
+- `borderColor`, `borderWidth`, `borderRadius` - global defaults for bordered elements (buttons, inputs, menus, tooltips).
+- `<element>Border` - `boolean` to toggle, or `{ width, color }` to override. `color` accepts a [colour reference](#colour-references).
+- `<element>BorderRadius` - corner radius, inheriting from `borderRadius`.
+
+## Overrides
 
 The `overrides` object is similar in its structure to the chart's options and is used as follows:
 
@@ -146,7 +192,7 @@ In the above example:
 - The font size of the title is increased.
 - The `bar` series has specific label and stroke options set.
 
-### Advanced Custom Theme
+## Advanced Custom Theme
 
 {% chartExampleRunner title="Advanced Themes" name="advanced-theme" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -164,6 +164,10 @@ This release includes the following behaviour changes:
 
 - Generated selection `itemId` values (when `dataIdKey` is not set) have changed and are not stable across versions. Set `dataIdKey` if you depend on stable identifiers.
 
+### Sunburst and Treemap Series
+
+- The default `itemId` on Sunburst and Treemap series has changed from a string to a number. Update any code that compares or stores the `itemId` as a string.
+
 ### Zoom
 
 - Setting `initialState.zoom.rangeX` or `initialState.zoom.rangeY` with string values now applies the zoom range correctly on category axes. Previously these values produced a console warning and were ignored.

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -8,11 +8,12 @@
                 "path": "./async-data/"
             },
             {
-                "text": "Image in Label"
+                "text": "Inline Images",
+                "path": "./text/#images"
             },
             {
-                "text": "Improved Colour Options",
-                "path": "./themes/"
+                "text": "CSS Variables, Colour Mixing & HSL",
+                "path": "./colours/"
             },
             {
                 "text": "BigInt and ISO 8601 Support",


### PR DESCRIPTION
## Summary

Documentation updates for AG Charts 14, covering colours, themes, and the Text page.

- **New Colours page** (`docs/colours/`) with examples for colour formats, colour references, and CSS variables; added to the docs nav under Layout & Styling.
- **Themes page** extended with colour-reference and border examples.
- **Text page** restructured: leads with a Fonts section (font families + Google Fonts), groups inline images, emoji and font icons under a single **Images** section, adds an intro and API Reference section, and tightens prose to match sibling pages.
- **Versions / upgrade notes**: the v14 "Inline Images" highlight now links to the new `text/#images` section, and the Sunburst/Treemap `itemId` type change is documented in the v14 upgrade notes.

## Test plan

- [ ] `yarn nx generate-examples ag-charts-website` and `yarn nx validate-examples` pass for the new/updated examples.
- [ ] Pages render correctly across frameworks in the dev server (Colours, Themes, Text).
- [ ] Right-hand contents nav and the v14 highlight link resolve on the Text page.