### PR TITLE
Benchmark PRs against their merge-base, not the live base tip

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -77,6 +77,7 @@ jobs:
         outputs:
             branch: ${{ steps.get-branch.outputs.branch }}
             base: ${{ steps.get-branch.outputs.base }}
+            base-label: ${{ steps.get-branch.outputs.base-label }}
             shards: ${{ steps.shards.outputs.shards }}
             build-matrix: ${{ steps.build-matrix.outputs.build-matrix }}
             comment-id: ${{ steps.notify-start.outputs.result }}
@@ -103,9 +104,17 @@ jobs:
             - id: 'get-branch'
               run: |
                   if [[ "${{ github.event_name }}" == "issue_comment" ]] ; then
-                    # For PR comments, get the branch from the PR
-                    echo "branch=$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')" >> $GITHUB_OUTPUT
-                    echo "base=$(gh pr view $PR_NO --repo $REPO --json baseRefName --jq '.baseRefName')" >> $GITHUB_OUTPUT
+                    # For PR comments, benchmark the PR head against the branch's
+                    # MERGE-BASE (the commit it forked from), not the live base-branch
+                    # tip. Comparing against the tip charges the PR for optimisations
+                    # merged into the base after the fork point, manufacturing
+                    # regressions; the merge-base isolates the PR's own diff.
+                    head_ref=$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+                    base_ref=$(gh pr view $PR_NO --repo $REPO --json baseRefName --jq '.baseRefName')
+                    merge_base=$(gh api "repos/$REPO/compare/$base_ref...$head_ref" --jq '.merge_base_commit.sha')
+                    echo "branch=${head_ref}" >> $GITHUB_OUTPUT
+                    echo "base=${merge_base}" >> $GITHUB_OUTPUT
+                    echo "base-label=merge-base ${merge_base:0:10} (${base_ref})" >> $GITHUB_OUTPUT
                   elif [[ "${{ github.event_name }}" == "schedule" ]] ; then
                     # Scheduled runs compare against the most recently published npm
                     # version: the head example set runs against the published UMD
@@ -113,10 +122,12 @@ jobs:
                     published=$(npm view ag-charts-community version)
                     echo "branch=latest" >> $GITHUB_OUTPUT
                     echo "base=npm:${published}" >> $GITHUB_OUTPUT
+                    echo "base-label=npm:${published}" >> $GITHUB_OUTPUT
                   else
                     # For manual workflow dispatch, use the current branch
                     echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
                     echo "base=${{ inputs.compare-base }}" >> $GITHUB_OUTPUT
+                    echo "base-label=${{ inputs.compare-base }}" >> $GITHUB_OUTPUT
                   fi
               env:
                   REPO: ${{ github.repository }}
@@ -354,7 +365,7 @@ jobs:
                   node ./tools/benchmark/compare-browser-results.js \
                       --base reports/browser-benchmarks/base.json \
                       --compare reports/browser-benchmarks/head.json \
-                      --base-label "${{ needs.resolve.outputs.base }}" \
+                      --base-label "${{ needs.resolve.outputs.base-label }}" \
                       --compare-label "${{ needs.resolve.outputs.branch }}" \
                       --format table \
                       --report-only \
@@ -362,7 +373,7 @@ jobs:
                   node ./tools/benchmark/compare-browser-results.js \
                       --base reports/browser-benchmarks/base.json \
                       --compare reports/browser-benchmarks/head.json \
-                      --base-label "${{ needs.resolve.outputs.base }}" \
+                      --base-label "${{ needs.resolve.outputs.base-label }}" \
                       --compare-label "${{ needs.resolve.outputs.branch }}" \
                       --format json \
                       --report-only \


### PR DESCRIPTION
## Summary

The `/benchmarks` PR command currently benchmarks the PR head against the **current tip** of the base branch (`latest`). When a performance optimisation merges into the base branch *after* a PR has forked, that PR is charged for *lacking* the optimisation — producing regressions in the benchmark report that have nothing to do with the PR's own diff.

This was observed on #7140: five data-model column-extraction optimisations from #7152 merged into `latest` ~1h before that PR's benchmark run, and showed up as a spurious ~+12% regression cluster across the high-frequency / initial-load series. Rebuilding the same PR head against its **merge-base** instead collapsed those deltas to ~0%.

## Change

For `issue_comment` (`/benchmarks`) runs, resolve the base ref to the **merge-base** of the PR head and its base branch — obtained via the compare API (`merge_base_commit.sha`) — rather than the live base-branch tip. This isolates the PR's own changes, which is what a PR benchmark should measure.

- New `base-label` resolve output keeps the result comment readable (`merge-base <sha> (latest)`).
- `schedule` (compares against published npm) and `workflow_dispatch` (explicit `compare-base`) modes are unchanged — they keep their existing base and label.

## Notes / trade-off

The example set is still defined by the head ref, so examples added in the PR simply have no baseline at the merge-base (handled as before). Nightly regression tracking against published npm is unaffected.

## Test plan

- [x] `benchmark.yml` parses as valid YAML.
- [ ] Trigger `/benchmarks` on a test PR and confirm the report header reads `merge-base <sha> (latest)` and the base site builds from the merge-base SHA.