### PR TITLE
AG-15248 add type discriminant to annotation options toolbar items

### DIFF
--- a/packages/ag-charts-community/src/chart/themes/annotationOptionsDef.ts
+++ b/packages/ag-charts-community/src/chart/themes/annotationOptionsDef.ts
@@ -253,6 +253,7 @@ export const annotationOptionsDef: OptionsDefs<AgAnnotationsOptions> = {
             or(
                 optionsDefs<AgAnnotationOptionsToolbarButton>({
                     ...toolbarButtonOptionsDefs,
+                    type: union('button'),
                     value: required(
                         union(
                             'line-stroke-width',
@@ -268,6 +269,7 @@ export const annotationOptionsDef: OptionsDefs<AgAnnotationsOptions> = {
                 }),
                 optionsDefs<AgAnnotationOptionsToolbarSwitch>({
                     ...toolbarButtonOptionsDefs,
+                    type: required(union('switch')),
                     value: required(union('lock')),
                     checkedOverrides: toolbarButtonOptionsDefs,
                 })

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationOptionsToolbar.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationOptionsToolbar.ts
@@ -57,6 +57,9 @@ interface EventMap {
 
 class AnnotationOptionsButtonProperties extends ToolbarButtonProperties {
     @Property
+    type: 'button' | 'switch' = 'button';
+
+    @Property
     value!: AnnotationOptions;
 
     @Property
@@ -73,6 +76,7 @@ class AnnotationOptionsButtonProperties extends ToolbarButtonProperties {
 }
 
 interface AnnotationOptionsButtonOptions extends _ModuleSupport.ToolbarButtonOptions {
+    type: 'button' | 'switch';
     value: AnnotationOptions;
     color?: string;
     strokeWidth?: number;
@@ -465,7 +469,7 @@ export class AnnotationOptionsToolbar extends BaseProperties {
 
         for (const [index, button] of this.visibleButtons.entries()) {
             if (!button) continue;
-            if (button.value === AnnotationOptions.Lock) {
+            if (button.type === 'switch') {
                 this.toolbar.toggleSwitchCheckedByIndex(index, locked);
                 this.updateButtonByIndex(index, locked ? button.checkedOverrides.toJson() : button.toJson());
             } else {
@@ -504,6 +508,11 @@ export class AnnotationOptionsToolbar extends BaseProperties {
     private updateButtonByIndex(index: number, change: Partial<AnnotationOptionsButtonOptions>) {
         const button = this.visibleButtons.at(index);
         if (!button) return;
-        this.toolbar.updateButtonByIndex(index, { ...button.toJson(), ...change, value: change.value ?? button.value });
+        this.toolbar.updateButtonByIndex(index, {
+            ...button.toJson(),
+            ...change,
+            type: change.type ?? button.type,
+            value: change.value ?? button.value,
+        });
     }
 }

--- a/packages/ag-charts-enterprise/src/features/annotations/annotationsTheme.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotationsTheme.ts
@@ -148,6 +148,7 @@ const optionsToolbar: WithThemeParams<AgAnnotationOptionsToolbar> = {
                 value: 'settings',
             },
             {
+                type: 'switch',
                 icon: 'unlocked',
                 tooltip: 'toolbarAnnotationsLock',
                 ariaLabel: 'toolbarAnnotationsLock',

--- a/packages/ag-charts-types/src/chart/annotationsOptions.ts
+++ b/packages/ag-charts-types/src/chart/annotationsOptions.ts
@@ -562,19 +562,27 @@ export type AgAnnotationsToolbarButtonValue =
 // * Options Toolbar *
 // *******************/
 
-type AgAnnotationToolbarButton = AgAnnotationOptionsToolbarButton | AgAnnotationOptionsToolbarSwitch;
+export type AgAnnotationOptionsToolbarItem = AgAnnotationOptionsToolbarButton | AgAnnotationOptionsToolbarSwitch;
 
 export interface AgAnnotationOptionsToolbar extends Toggleable {
     /** The buttons to show in the options toolbar. */
-    buttons?: AgAnnotationToolbarButton[];
+    buttons?: AgAnnotationOptionsToolbarItem[];
 }
 
 export interface AgAnnotationOptionsToolbarButton extends ToolbarButton {
+    /**
+     * The type of toolbar item.
+     *
+     * Default: `'button'`
+     */
+    type?: 'button';
     /** The action to perform when the button is clicked. */
     value: AgAnnotationOptionsToolbarButtonValue;
 }
 
 export interface AgAnnotationOptionsToolbarSwitch extends ToolbarSwitch {
+    /** The type of toolbar item. */
+    type: 'switch';
     /** The action to perform when the switch is toggled. */
     value: AgAnnotationOptionsToolbarSwitchValue;
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-15248

The options-toolbar buttons were typed by an unexported union
`AgAnnotationToolbarButton = AgAnnotationOptionsToolbarButton | AgAnnotationOptionsToolbarSwitch`.
Two problems:

- The name was easily confused with the unrelated `AgAnnotationsToolbarButton` (plural — the main annotations toolbar).
- Neither variant carried a `type` discriminant, so the website API reference collapsed the union into an unhelpful `A | B` instead of rendering the two variants as navigable rows.

Changes:

- Rename the union to `AgAnnotationOptionsToolbarItem` and export it, aligning it with the `AgAnnotationOptionsToolbar*` family.
- Add a `type` discriminant: `type?: 'button'` (optional, defaults to `'button'`) on `AgAnnotationOptionsToolbarButton` and `type: 'switch'` (required) on `AgAnnotationOptionsToolbarSwitch`. Users only specify `type` for the non-default switch.
- Add `type` validators to the options-def `or()` branches.
- Add a `type` field (default `'button'`) to the runtime `AnnotationOptionsButtonProperties` and switch the structural switch-vs-button check in `refreshButtons` from `value === 'lock'` to `type === 'switch'`. Per-action lock handling stays keyed on `value`.
- Mark the built-in lock entry in the annotations theme as `type: 'switch'`.

The API reference now renders `AgAnnotationOptionsToolbarItem` as distinct `button` and `switch` variants, since the docs generator keys variant rendering on a string-literal `type` member (optionality is tracked separately, so an optional discriminant still qualifies).

Verified: `build:types` (types/community/enterprise), `lint`, `format`, community tests, and the annotations test suite (35/35) all pass.

Fix #AG-15248