### PR TITLE
Clarify the simple option on mixed simple/complex union props in API reference

### DIFF
--- a/packages/ag-charts-types/src/api/initialStateOptions.ts
+++ b/packages/ag-charts-types/src/api/initialStateOptions.ts
@@ -50,9 +50,9 @@ export interface AgInitialStateZoomOptions {
 }
 
 export interface AgInitialStateZoomRange {
-    /** The start value of the zoom range. */
+    /** The start value of the zoom range. A number, or a serialised value object. */
     start?: AgStateSerializableDate | AgStateSerializableBigInt | AgStateSerializableGroupingValueType | number;
-    /** The end value of the zoom range. */
+    /** The end value of the zoom range. A number, or a serialised value object. */
     end?: AgStateSerializableDate | AgStateSerializableBigInt | AgStateSerializableGroupingValueType | number;
 }
 

--- a/packages/ag-charts-types/src/chart/annotationsOptions.ts
+++ b/packages/ag-charts-types/src/chart/annotationsOptions.ts
@@ -487,7 +487,7 @@ interface AnnotationLinePoints {
 export interface AgAnnotationPoint {
     /** The x-value of the point. */
     x: AgAnnotationValue;
-    /** The y-value of the point. */
+    /** The y-value of the point. A number, or a serialised value object. */
     y: number | AgStateSerializableBigInt;
 }
 

--- a/packages/ag-charts-types/src/chart/axisOptions.ts
+++ b/packages/ag-charts-types/src/chart/axisOptions.ts
@@ -46,9 +46,9 @@ export interface AgAxisCaptionOptions {
     fontWeight?: FontWeight;
     /** The font size in pixels to use for the title. */
     fontSize?: FontSize;
-    /** The font family to use for the title. */
+    /** The font family to use for the title. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
-    /** The colour to use for the title. */
+    /** The colour to use for the title. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     /** Spacing between the axis labels and the axis title. */
     spacing?: PixelSize;
@@ -114,7 +114,7 @@ export interface AgContinuousAxisOptions<
      * __Note:__ This does not override the `min` or `max` options.
      */
     nice?: boolean;
-    /** Configuration for the axis ticks interval. */
+    /** Configuration for the axis ticks interval. A unit keyword (or number), or an object describing the interval. */
     interval?: AgAxisContinuousIntervalOptions<TInterval>;
 }
 
@@ -170,11 +170,11 @@ export interface AgBaseAxisLabelStyleOptions extends LabelBoxOptions {
     fontWeight?: FontWeight;
     /** The font size in pixels to use for the labels. */
     fontSize?: FontSize;
-    /** The font family to use for the labels */
+    /** The font family to use for the labels. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
     /** Spacing in pixels between the axis label and the tick. */
     spacing?: PixelSize;
-    /** The colour to use for the labels */
+    /** The colour to use for the labels. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
 }
 
@@ -196,7 +196,7 @@ export interface AgAxisLabelFormatterParams<TContext = ContextDefault> {
 export interface AgAxisLabelStylerParams<TContext = ContextDefault> extends AgBaseAxisLabelStyleOptions {
     /** The label value that would be used, before applying formating. */
     readonly value: any;
-    /** The label value that would be used, after applying formating. */
+    /** The label value that would be used, after applying formatting. Plain text, or an array of segments for rich content. */
     readonly formattedValue?: TextOrSegments;
     /** Context for this callback. */
     readonly context?: TContext;
@@ -236,7 +236,7 @@ export interface AgTimeAxisFormattableLabelUnitFormat {
 export type AgTimeAxisFormattableLabelFormat = string | AgTimeAxisFormattableLabelUnitFormat;
 
 export interface AgTimeAxisFormattableLabelOptions<TContext = ContextDefault> extends AgBaseAxisLabelOptions<TContext> {
-    /** Format string used when rendering labels. */
+    /** Format string used when rendering labels. A format string, or an object specifying a format per time unit. */
     format?: AgTimeAxisFormattableLabelFormat;
 }
 

--- a/packages/ag-charts-types/src/chart/bandHighlightOptions.ts
+++ b/packages/ag-charts-types/src/chart/bandHighlightOptions.ts
@@ -14,7 +14,7 @@ export interface AgBandHighlightOptions {
     lineDash?: PixelSize[];
     /** The initial offset of the dashed line in pixels. */
     lineDashOffset?: PixelSize;
-    /** The colour to use for the fill of the band. */
+    /** The colour to use for the fill of the band. A colour string, or an object for a gradient, pattern, or image fill. */
     fill?: AgColorType;
     /** The opacity of the fill for the band. */
     fillOpacity?: Opacity;

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -308,7 +308,7 @@ export interface AgUnitTimeAxisOptions<TContext = ContextDefault>
     crossLines?: AgCartesianCrossLineOptions<AgTimeValue>[];
     /** Options for labels and ticks for the parent level intervals. */
     parentLevel?: AgTimeAxisParentLevel<TContext>;
-    /** The size of each band. */
+    /** The size of each band. A unit keyword (or number), or an object describing the interval. */
     unit?: AgTimeInterval | AgTimeIntervalUnit;
     /** Configuration for the axis ticks interval. */
     interval?: AgAxisDiscreteTimeIntervalOptions;

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -39,7 +39,7 @@ export interface AgSeriesAreaOptions {
     clip?: boolean;
     /** The corner radius of the series area. */
     cornerRadius?: number;
-    /** Configuration for the padding inside the series area. */
+    /** Configuration for the padding inside the series area. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
 }
 
@@ -55,7 +55,7 @@ export interface AgChartOverlayOptions<TContext = ContextDefault> {
      * Default: `true`
      */
     enabled?: boolean;
-    /** Text to render in the overlay. */
+    /** Text to render in the overlay. Plain text, or an array of segments for rich content. */
     text?: TextOrSegments;
     /** A function for generating HTML element or string for overlay content. */
     renderer?: Renderer<AgChartOverlayRendererParams<TContext>, HTMLElement>;
@@ -103,7 +103,7 @@ export interface AgCaptionTooltipOptions<TContext = ContextDefault> {
 export interface AgChartCaptionOptions<TContext = ContextDefault> {
     /** Whether the text should be shown. */
     enabled?: boolean;
-    /** The text to display. */
+    /** The text to display. Plain text, or an array of segments for rich content. */
     text?: TextOrSegments;
     /** Horizontal position of the text. */
     textAlign?: TextAlign;
@@ -113,9 +113,9 @@ export interface AgChartCaptionOptions<TContext = ContextDefault> {
     fontWeight?: FontWeight;
     /** The font size in pixels to use for the text. */
     fontSize?: FontSize;
-    /** The font family to use for the text. */
+    /** The font family to use for the text. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
-    /** The colour to use for the text. */
+    /** The colour to use for the text. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     /** Spacing added to help position the text. */
     spacing?: PixelSize;
@@ -249,7 +249,7 @@ export interface AgBaseThemeableChartOptions<TDatum = DatumDefault, TContext = C
      * Default: `300`
      */
     minWidth?: PixelSize;
-    /** Configuration for the padding of the chart. */
+    /** Configuration for the padding of the chart. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
     /** Configuration relating to the series area. */
     seriesArea?: AgSeriesAreaOptions;

--- a/packages/ag-charts-types/src/chart/crossLineOptions.ts
+++ b/packages/ag-charts-types/src/chart/crossLineOptions.ts
@@ -56,7 +56,7 @@ export interface AgCrossLineThemeOptions<
 export interface AgBaseCrossLineLabelOptions extends Omit<AgChartLabelStyleOptions, 'fontFamily'> {
     /** The text to show in the label. */
     text?: string;
-    /** The font family to use for the label. */
+    /** The font family to use for the label. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
 }
 

--- a/packages/ag-charts-types/src/chart/gradientLegendOptions.ts
+++ b/packages/ag-charts-types/src/chart/gradientLegendOptions.ts
@@ -12,9 +12,9 @@ export interface AgGradientLegendLabelOptions<TContext = ContextDefault> {
     fontWeight?: FontWeight;
     /** The font size in pixels to use for the labels. */
     fontSize?: FontSize;
-    /** The font family to use for the labels. */
+    /** The font family to use for the labels. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
-    /** The colour to use for the labels. */
+    /** The colour to use for the labels. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     /** Minimum gap in pixels between the axis labels before being removed to avoid collisions. */
     minSpacing?: PixelSize;
@@ -36,7 +36,7 @@ export interface AgGradientLegendScaleOptions<TContext = ContextDefault> {
 export interface AgGradientLegendOptions<TContext = ContextDefault> extends FillOptions {
     /** Whether to show the gradient legend. By default, the chart displays a gradient legend for series using a `colorKey`. */
     enabled?: boolean;
-    /** Position of the gradient legend.
+    /** Position of the gradient legend. A placement keyword, or an object for fine-grained positioning.
      *
      * Default: `'bottom'`
      */
@@ -57,7 +57,7 @@ export interface AgGradientLegendOptions<TContext = ContextDefault> extends Fill
     border?: BorderOptions;
     /** The corner radius of the legend. */
     cornerRadius?: PixelSize;
-    /** The padding between the border and legend items. */
+    /** The padding between the border and legend items. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
 }
 

--- a/packages/ag-charts-types/src/chart/legendOptions.ts
+++ b/packages/ag-charts-types/src/chart/legendOptions.ts
@@ -92,7 +92,7 @@ export interface AgChartLegendLabelFormatterParams<TContext = ContextDefault> {
 export interface AgChartLegendLabelOptions<TContext = ContextDefault> {
     /** If the label text exceeds the specified number of characters, it will be truncated and an ellipsis will be appended to indicate this. */
     maxLength?: number;
-    /** The colour of the text. */
+    /** The colour of the text. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     /** The font style to use for the legend. */
     fontStyle?: FontStyle;
@@ -100,7 +100,7 @@ export interface AgChartLegendLabelOptions<TContext = ContextDefault> {
     fontWeight?: FontWeight;
     /** The font size in pixels to use for the legend. */
     fontSize?: FontSize;
-    /** The font family to use for the legend. */
+    /** The font family to use for the legend. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
     /** Function used to render legend labels. Where `id` is a series ID, `itemId` is component ID within a series, such as a field name or an item index. */
     formatter?: Formatter<AgChartLegendLabelFormatterParams<TContext>>;
@@ -149,7 +149,7 @@ export interface AgChartLegendItemOptions<TContext = ContextDefault> {
     tooltip?: AgChartLegendItemTooltipOptions<TContext>;
     /** Used to constrain the width of legend items. */
     maxWidth?: PixelSize;
-    /** The spacing in pixels to use between legend items. */
+    /** The spacing in pixels to use between legend items. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
     /** Set to `false` to hide the legend line line representing the stroke styling of line and area series.
      *  If enabled, legend marker will be hidden if series markers are disabled. */
@@ -191,7 +191,7 @@ export interface AgChartLegendListeners<TContext = ContextDefault> {
 export interface AgChartLegendOptions<TContext = ContextDefault> extends FillOptions {
     /** Whether to show the legend. By default, the chart displays a legend when there is more than one series present. */
     enabled?: boolean;
-    /** Where the legend should be positioned in relation to the chart.
+    /** Where the legend should be positioned in relation to the chart. A placement keyword, or an object for fine-grained positioning.
      *
      * Default: `'bottom'`
      */
@@ -206,7 +206,7 @@ export interface AgChartLegendOptions<TContext = ContextDefault> extends FillOpt
     border?: BorderOptions;
     /** The corner radius of the legend. */
     cornerRadius?: PixelSize;
-    /** The padding between the border and legend items. */
+    /** The padding between the border and legend items. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
     /** The spacing in pixels to use outside the legend.
      *
@@ -246,12 +246,12 @@ export interface AgPaginationMarkerOptions {
     size?: PixelSize;
     /** If set, overrides the marker shape for the pagination buttons. If not set, the pagination buttons will default to the `'triangle'` marker shape. */
     shape?: AgMarkerShape;
-    /** The inner padding in pixels between a pagination button and the pagination label. */
+    /** The inner padding in pixels between a pagination button and the pagination label. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
 }
 
 export interface AgPaginationMarkerStyle {
-    /** The fill colour to use for the pagination button markers. */
+    /** The fill colour to use for the pagination button markers. A colour string, or an object for a gradient, pattern, or image fill. */
     fill?: AgColorType;
     /** Opacity of the pagination buttons. */
     fillOpacity?: Opacity;
@@ -264,7 +264,7 @@ export interface AgPaginationMarkerStyle {
 }
 
 export interface AgPaginationLabelOptions {
-    /** The colour of the text. */
+    /** The colour of the text. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     /** The font style to use for the pagination label. */
     fontStyle?: FontStyle;
@@ -272,7 +272,7 @@ export interface AgPaginationLabelOptions {
     fontWeight?: FontWeight;
     /** The font size in pixels to use for the pagination label. */
     fontSize?: FontSize;
-    /** The font family to use for the pagination label. */
+    /** The font family to use for the pagination label. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
 }
 

--- a/packages/ag-charts-types/src/chart/navigatorOptions.ts
+++ b/packages/ag-charts-types/src/chart/navigatorOptions.ts
@@ -57,11 +57,11 @@ export interface AgNavigatorMiniChartLabelOptions<TContext = ContextDefault> {
     fontWeight?: FontWeight;
     /** The font size in pixels to use for the labels. */
     fontSize?: FontSize;
-    /** The font family to use for the labels. */
+    /** The font family to use for the labels. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
     /** Spacing in pixels between the axis labels and the Mini Chart. */
     spacing?: PixelSize;
-    /** The colour to use for the labels. */
+    /** The colour to use for the labels. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     /** Avoid axis label collision by automatically reducing the number of labels displayed. If set to `false`, axis labels may collide. */
     avoidCollisions?: boolean;
@@ -253,7 +253,7 @@ export interface AgNavigatorMiniChartOptions<TDatum = DatumDefault, TContext = C
     series?: AgMiniChartSeriesOptions<TDatum, TContext>[];
     /** Configuration for the Mini Chart's axis labels. */
     label?: AgNavigatorMiniChartLabelOptions<TContext>;
-    /** Configuration for the padding inside the Mini Chart. */
+    /** Configuration for the padding inside the Mini Chart. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
 }
 
@@ -264,7 +264,7 @@ export interface AgNavigatorMiniChartThemeableOptions<TDatum = DatumDefault, TCo
     series?: AgMiniChartSeriesThemeableOptions<TDatum, TContext>;
     /** Configuration for the Mini Chart's axis labels. */
     label?: AgNavigatorMiniChartLabelOptions<TContext>;
-    /** Configuration for the padding inside the Mini Chart. */
+    /** Configuration for the padding inside the Mini Chart. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
 }
 

--- a/packages/ag-charts-types/src/chart/rangesOptions.ts
+++ b/packages/ag-charts-types/src/chart/rangesOptions.ts
@@ -43,6 +43,7 @@ export interface AgRangesOptions<TContext = ContextDefault> extends Toggleable, 
 
 export interface AgRangesStyles extends FillCssOptions, FontOptions, Omit<StrokeOptions, 'strokeOpacity'> {
     cornerRadius?: PixelSize;
+    /** The padding inside the range buttons. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
     textColor?: CssColor;
     active?: AgRangesStateStyles;

--- a/packages/ag-charts-types/src/chart/themeOptions.ts
+++ b/packages/ag-charts-types/src/chart/themeOptions.ts
@@ -66,7 +66,7 @@ export type AgChartThemeName =
     | 'ag-financial-dark';
 
 export interface AgPaletteColors {
-    /** The fill colour for the palette. */
+    /** The fill colour for the palette. A colour string, or a gradient object. */
     fill?: AgColorTypeStrict;
     /** The stroke colour for the palette. */
     stroke?: CssColor;
@@ -76,7 +76,7 @@ export interface AgPaletteColors {
  * Palette used by the chart instance.
  */
 export interface AgChartThemePalette {
-    /** The array of fills to be used. */
+    /** The array of fills to be used. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The array of strokes to be used. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/chart/themeParamsOptions.ts
+++ b/packages/ag-charts-types/src/chart/themeParamsOptions.ts
@@ -19,6 +19,7 @@ export interface AgColorRefMixOnto {
 export type AgCssColorOrRef = CssColor | AgColorRef | AgColorRefMixOnto;
 
 export interface AgBorderThemeParam {
+    /** Colour of the border. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     width?: PixelSize;
 }
@@ -29,110 +30,110 @@ export interface AgBorderThemeParam {
 export interface AgBaseChartThemeParams {
     /**
      * The 'brand colour' for the chart, used wherever a non-neutral colour is required. Selections, focus outlines and
-     * checkboxes use the accent colour by default.
+     * checkboxes use the accent colour by default. A colour string, or a theme-colour reference object.
      */
     accentColor?: AgCssColorOrRef;
     /**
      * Background colour of the chart. Most text, borders and backgrounds are defined as a blend between the background
-     * and foreground colors.
+     * and foreground colours. A colour string, or a theme-colour reference object.
      */
     backgroundColor?: AgCssColorOrRef;
-    /** Default colour for borders. */
+    /** Default colour for borders. A colour string, or a theme-colour reference object. */
     borderColor?: AgCssColorOrRef;
     /** Default width for borders. */
     borderWidth?: PixelSize;
     /** Default corner radius for many UI elements such as menus and dialogs.  */
     borderRadius?: PixelSize;
-    /** Background colour of standard action buttons. */
+    /** Background colour of standard action buttons. A colour string, or a theme-colour reference object. */
     buttonBackgroundColor?: AgCssColorOrRef;
-    /** Border around standard action buttons. */
+    /** Border around standard action buttons. `true` for the default border, `false` to disable, or an object to customise it. */
     buttonBorder?: boolean | AgBorderThemeParam;
     /** Corner radius for buttons. */
     buttonBorderRadius?: PixelSize;
     /** Font weight of standard action buttons. */
     buttonFontWeight?: FontWeight;
-    /** Text colour of standard action buttons. */
+    /** Text colour of standard action buttons. A colour string, or a theme-colour reference object. */
     buttonTextColor?: AgCssColorOrRef;
     /** Shadow around UI controls that have focus e.g. text inputs and buttons. The value must a valid CSS box-shadow. */
     focusShadow?: CssShadow;
     /**
      * Default colour for neutral UI elements. Most text, borders and backgrounds are defined as a blend between the
-     * background and foreground colors.
+     * background and foreground colours. A colour string, or a theme-colour reference object.
      */
     foregroundColor?: AgCssColorOrRef;
-    /** Font family used for all text. */
+    /** Font family used for all text. A single family name, or an array of names used as fallbacks. */
     fontFamily?: FontFamilyFull;
     /** Default font size used for all text. Titles and some other text are scaled to this font size. */
     fontSize?: FontSize;
     /**
-     * Background colour for text inputs.
+     * Background colour for text inputs. A colour string, or a theme-colour reference object.
      *
      * Default: `backgroundColor`
      */
     inputBackgroundColor?: AgCssColorOrRef;
-    /** Border around text inputs. */
+    /** Border around text inputs. `true` for the default border, `false` to disable, or an object to customise it. */
     inputBorder?: boolean | AgBorderThemeParam;
     /** Corner radius for inputs. */
     inputBorderRadius?: PixelSize;
     /**
-     * Colour of text within text inputs.
+     * Colour of text within text inputs. A colour string, or a theme-colour reference object.
      *
      * Default: `textColor`
      */
     inputTextColor?: AgCssColorOrRef;
-    /** Background colour for menus, e.g. right-click context menus. */
+    /** Background colour for menus, e.g. right-click context menus. A colour string, or a theme-colour reference object. */
     menuBackgroundColor?: AgCssColorOrRef;
-    /** Border around menus. */
+    /** Border around menus. `true` for the default border, `false` to disable, or an object to customise it. */
     menuBorder?: boolean | AgBorderThemeParam;
     /** Corner radius for menus. */
     menuBorderRadius?: PixelSize;
-    /** Text colour for menus. */
+    /** Text colour for menus. A colour string, or a theme-colour reference object. */
     menuTextColor?: AgCssColorOrRef;
-    /** Background colour for panels and dialogs. */
+    /** Background colour for panels and dialogs. A colour string, or a theme-colour reference object. */
     panelBackgroundColor?: AgCssColorOrRef;
-    /** Colour of text that should stand out less in panels and dialogs. */
+    /** Colour of text that should stand out less in panels and dialogs. A colour string, or a theme-colour reference object. */
     panelSubtleTextColor?: AgCssColorOrRef;
     /** Default shadow for elements that float above the chart and are intended to appear separated from it, e.g. dialogs and menus. */
     popupShadow?: CssShadow;
     /**
-     * Colour of text that should stand out less than the default.
+     * Colour of text that should stand out less than the default. A colour string, or a theme-colour reference object.
      *
      * Default: `foregroundColor + backgroundColor`
      */
     subtleTextColor?: AgCssColorOrRef;
     /**
-     * Default colour for all text.
+     * Default colour for all text. A colour string, or a theme-colour reference object.
      *
      * Default: `foregroundColor`
      */
     textColor?: AgCssColorOrRef;
-    /** Background colour for tooltips. */
+    /** Background colour for tooltips. A colour string, or a theme-colour reference object. */
     tooltipBackgroundColor?: AgCssColorOrRef;
-    /** Border around tooltips. */
+    /** Border around tooltips. `true` for the default border, `false` to disable, or an object to customise it. */
     tooltipBorder?: boolean | AgBorderThemeParam;
     /** Corner radius for tooltips. */
     tooltipBorderRadius?: PixelSize;
-    /** Text colour for tooltips. */
+    /** Text colour for tooltips. A colour string, or a theme-colour reference object. */
     tooltipTextColor?: AgCssColorOrRef;
-    /** Colour of text that should stand out less in tooltips. */
+    /** Colour of text that should stand out less in tooltips. A colour string, or a theme-colour reference object. */
     tooltipSubtleTextColor?: AgCssColorOrRef;
 }
 
 export interface AgChartThemeParams extends AgBaseChartThemeParams {
-    /** Default colour for axis lines and ticks. */
+    /** Default colour for axis lines and ticks. A colour string, or a theme-colour reference object. */
     axisLineColor?: AgCssColorOrRef;
-    /** Background colour of the chart. */
+    /** Background colour of the chart. A colour string, or a theme-colour reference object. */
     chartBackgroundColor?: AgCssColorOrRef;
     /** The outer chart padding. */
     chartPadding?: PixelSize;
     /**
-     * Background colour of tooltips, menus, dialogs, toolbars and buttons.
+     * Background colour of tooltips, menus, dialogs, toolbars and buttons. A colour string, or a theme-colour reference object.
      *
      * Default: `foregroundColor + backgroundColor`
      */
     chromeBackgroundColor?: AgCssColorOrRef;
     /**
-     * Font family used for text in tooltips, menus, dialogs, toolbars, buttons and text inputs.
+     * Font family used for text in tooltips, menus, dialogs, toolbars, buttons and text inputs. A single family name, or an array of names used as fallbacks.
      *
      * Default: `fontFamily`
      */
@@ -150,34 +151,34 @@ export interface AgChartThemeParams extends AgBaseChartThemeParams {
      */
     chromeFontWeight?: FontWeight;
     /**
-     * Default colour for text in tooltips, menus, dialogs, toolbars, buttons and text inputs.
+     * Default colour for text in tooltips, menus, dialogs, toolbars, buttons and text inputs. A colour string, or a theme-colour reference object.
      *
      * Default: `textColor`
      */
     chromeTextColor?: AgCssColorOrRef;
     /**
-     * Colour of text that should stand out less than the default in tooltips, menus, dialogs, toolbars and buttons.
+     * Colour of text that should stand out less than the default in tooltips, menus, dialogs, toolbars and buttons. A colour string, or a theme-colour reference object.
      *
      * Default: `subtleTextColor`
      */
     chromeSubtleTextColor?: AgCssColorOrRef;
     /**
-     * Background colour of crosshair labels.
+     * Background colour of crosshair labels. A colour string, or a theme-colour reference object.
      *
      * Default: `foregroundColor`
      */
     crosshairLabelBackgroundColor?: AgCssColorOrRef;
     /**
-     * Colour for text in crosshair labels.
+     * Colour for text in crosshair labels. A colour string, or a theme-colour reference object.
      *
      * Default: `backgroundColor`
      */
     crosshairLabelTextColor?: AgCssColorOrRef;
     /** Default font weight used for all text. */
     fontWeight?: FontWeight;
-    /** Default colour for grid lines. */
+    /** Default colour for grid lines. A colour string, or a theme-colour reference object. */
     gridLineColor?: AgCssColorOrRef;
-    /** Default colour for grouped-category separation lines. */
+    /** Default colour for grouped-category separation lines. A colour string, or a theme-colour reference object. */
     groupedCategoryLineColor?: AgCssColorOrRef;
 }
 

--- a/packages/ag-charts-types/src/presets/gauge/commonOptions.ts
+++ b/packages/ag-charts-types/src/presets/gauge/commonOptions.ts
@@ -53,7 +53,7 @@ export interface AgGaugeScaleLabel<TContext> {
     fontFamily?: FontFamily;
     /** Spacing in pixels between the scale label and the tick. */
     spacing?: PixelSize;
-    /** The colour to use for the labels */
+    /** The colour to use for the labels. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     /** The rotation of the scale labels in degrees. */
     rotation?: Degree;

--- a/packages/ag-charts-types/src/series/cartesian/commonOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/commonOptions.ts
@@ -45,7 +45,7 @@ export interface AxisOptions<TDatum> {
  * Represents options for filling shapes in a chart.
  */
 export interface FillOptions {
-    /** The colour for filling shapes. */
+    /** The colour for filling shapes. A colour string, or an object for a gradient, pattern, or image fill. */
     fill?: AgColorType;
     /** The opacity of the fill colour. */
     fillOpacity?: Opacity;
@@ -198,7 +198,7 @@ export interface LabelBoxOptions extends FillOptions {
     border?: BorderOptions;
     /** Apply rounded corners to the label box. */
     cornerRadius?: PixelSize;
-    /** Distance between the label text and the border. */
+    /** Distance between the label text and the border. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
 }
 
@@ -230,7 +230,7 @@ export interface FontOptions {
  * Represents styling options for text elements in a chart.
  */
 export interface TextOptions extends FontOptions {
-    /** The colour for text elements. */
+    /** The colour for text elements. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
 }
 
@@ -328,7 +328,7 @@ export interface ImageSegment {
      * Default: `'hide'`
      */
     overflowStrategy?: 'keep' | 'hide';
-    /** Padding around the image inside its reserved box. */
+    /** Padding around the image inside its reserved box. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
     /** Rounds the corners of the image and the background decoration. */
     cornerRadius?: PixelSize;

--- a/packages/ag-charts-types/src/series/cartesian/coneFunnelOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/coneFunnelOptions.ts
@@ -53,7 +53,7 @@ export interface AgConeFunnelSeriesThemeableOptions<TDatum = DatumDefault, TCont
     extends
         Omit<AgBaseCartesianThemeableOptions<TDatum, TContext>, 'showInMiniChart' | 'showInLegend' | 'selection'>,
         LineDashOptions {
-    /** The colours to cycle through for the fills of the drop-offs. */
+    /** The colours to cycle through for the fills of the drop-offs. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the drop-offs. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/cartesian/funnelOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/funnelOptions.ts
@@ -45,7 +45,7 @@ export interface AgFunnelSeriesThemeableOptions<TDatum = DatumDefault, TContext 
     extends
         Omit<AgBaseCartesianThemeableOptions<TDatum, TContext>, 'showInLegend' | 'showInMiniChart' | 'selection'>,
         LineDashOptions {
-    /** The colours to cycle through for the fills of the bars. */
+    /** The colours to cycle through for the fills of the bars. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the bars. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/polar/donutOptions.ts
+++ b/packages/ag-charts-types/src/series/polar/donutOptions.ts
@@ -125,7 +125,7 @@ export interface AgDonutSeriesThemeableOptions<TDatum = DatumDefault, TContext =
     sectorLabel?: AgDonutSeriesSectorLabelOptions<TDatum, AgDonutSeriesLabelFormatterParams<TDatum>, TContext>;
     /** Configuration for the callout lines used with the labels for the sectors. */
     calloutLine?: AgDonutSeriesCalloutOptions<TDatum, TContext>;
-    /** The colours to cycle through for the fills of the sectors. */
+    /** The colours to cycle through for the fills of the sectors. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the sectors. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/polar/pieOptions.ts
+++ b/packages/ag-charts-types/src/series/polar/pieOptions.ts
@@ -109,7 +109,7 @@ export interface AgPieSeriesThemeableOptions<TDatum = DatumDefault, TContext = C
     sectorLabel?: AgPieSeriesSectorLabelOptions<TDatum, AgPieSeriesLabelFormatterParams<TDatum>, TContext>;
     /** Configuration for the callout lines used with the labels for the sectors. */
     calloutLine?: AgPieSeriesCalloutOptions<TDatum, TContext>;
-    /** The colours to cycle through for the fills of the sectors. */
+    /** The colours to cycle through for the fills of the sectors. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the sectors. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/standalone/chordOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/chordOptions.ts
@@ -61,7 +61,7 @@ export interface AgChordSeriesThemeableOptions<TDatum = DatumDefault, TContext =
 > {
     /** Options for the label for each node. */
     label?: AgChordSeriesLabelOptions<TDatum, TContext>;
-    /** The colours to cycle through for the fills of the nodes and links. */
+    /** The colours to cycle through for the fills of the nodes and links. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the nodes and links. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/standalone/organizationOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/organizationOptions.ts
@@ -78,11 +78,13 @@ export interface AgOrganizationSeriesOptionsExpander<
 
 export interface AgOrganizationSeriesExpanderStyle extends Toggleable, FillOptions, LineDashOptions, StrokeOptions {
     cornerRadius?: PixelSize;
+    /** Padding around the expander content. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
     text?: AgOrganizationSeriesExpanderTextStyle;
 }
 
 export interface AgOrganizationSeriesExpanderTextStyle extends FontOptions {
+    /** The colour to use for the expander text. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     textAlign?: TextAlign;
 }
@@ -130,6 +132,7 @@ export interface AgOrganizationSeriesNodeStyle extends FillOptions, LineDashOpti
      * graphs.
      */
     maxWidth?: PixelSize;
+    /** Padding around the node content. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
     width?: PixelSize;
 }
@@ -190,6 +193,7 @@ export interface AgOrganizationSeriesOptionsNodeLabel<
 }
 
 export interface AgOrganizationSeriesNodeTextStyle extends FontOptions, FillCssOptions, StrokeOptions, Toggleable {
+    /** The colour to use for the node text. A colour string, or a theme-colour reference object. */
     color?: AgCssColorOrRef;
     overflowStrategy?: OverflowStrategy;
     spacing?: number;
@@ -197,7 +201,7 @@ export interface AgOrganizationSeriesNodeTextStyle extends FontOptions, FillCssO
     wrapping?: TextWrap;
     /** Corner radius of the backing box. Has no effect unless `fill` or `stroke` is set. */
     cornerRadius?: PixelSize;
-    /** Padding between the text and the backing box edge. Has no effect unless `fill` or `stroke` is set. */
+    /** Padding between the text and the backing box edge. Has no effect unless `fill` or `stroke` is set. A number applies uniform padding; an object sets each side. */
     padding?: Padding;
 }
 

--- a/packages/ag-charts-types/src/series/standalone/pyramidOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/pyramidOptions.ts
@@ -45,7 +45,7 @@ export interface AgPyramidSeriesTooltipRendererParams<TDatum = DatumDefault, TCo
 
 export interface AgPyramidSeriesThemeableOptions<TDatum = DatumDefault, TContext = ContextDefault>
     extends Omit<AgBaseSeriesThemeableOptions<TDatum, TContext>, 'selection'>, LineDashOptions {
-    /** The colours to cycle through for the fills of the stages. */
+    /** The colours to cycle through for the fills of the stages. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the stages. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/sankeyOptions.ts
@@ -61,7 +61,7 @@ export interface AgSankeySeriesThemeableOptions<TDatum = DatumDefault, TContext 
 > {
     /** Options for the label for each node. */
     label?: AgSankeySeriesLabelOptions<TDatum, TContext>;
-    /** The colours to cycle through for the fills of the nodes and links. */
+    /** The colours to cycle through for the fills of the nodes and links. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the nodes and links. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/standalone/sunburstOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/sunburstOptions.ts
@@ -62,7 +62,7 @@ export interface AgSunburstSeriesThemeableOptions<TDatum = DatumDefault, TContex
     sectorSpacing?: PixelSize;
     /** Minimum distance between text and the edges of the sectors. */
     padding?: PixelSize;
-    /** The colours to cycle through for the fills of the sectors. */
+    /** The colours to cycle through for the fills of the sectors. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the sectors. */
     strokes?: CssColor[];

--- a/packages/ag-charts-types/src/series/standalone/treemapOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/treemapOptions.ts
@@ -143,7 +143,7 @@ export interface AgTreemapSeriesThemeableOptions<TDatum = DatumDefault, TContext
     AgBaseSeriesThemeableOptions<TDatum, TContext>,
     'highlight' | 'selection' | 'showInLegend'
 > {
-    /** The colours to cycle through for the fills of the groups and tiles. */
+    /** The colours to cycle through for the fills of the groups and tiles. An array of colour strings, or fill objects for gradients, patterns, or images. */
     fills?: AgColorType[];
     /** The colours to cycle through for the strokes of the groups and tiles. */
     strokes?: CssColor[];


### PR DESCRIPTION
## Summary

Many `ag-charts-types` properties accept a union of a **simple** value and a **complex** interface/array (e.g. `fill` = a colour string *or* a gradient/pattern/image object; `padding` = a number *or* a per-side object). In the generated API reference the complex branch expands into a noisy nested tree, and the simple primitive form, which is often what users actually want, is easy to miss.

This change appends a terse, simple-form-first clause to the JSDoc of every such property so the simple option is spelled out alongside the complex one. The rendered description comes only from the consuming property's JSDoc (never the `export type` alias), so the clause is added per consumer.

~84 properties across 25 files, grouped by union type:

| Union | Clause |
|---|---|
| `AgColorType` / `[]` / `AgColorTypeStrict` | "A colour string, or an object for a gradient, pattern, or image fill." (array/strict variants worded accordingly) |
| `Padding` | "A number applies uniform padding; an object sets each side." |
| `boolean \| AgBorderThemeParam` | "`true` for the default border, `false` to disable, or an object to customise it." |
| `FontFamilyFull` | "A single family name, or an array of names used as fallbacks." |
| `TextOrSegments` | "Plain text, or an array of segments for rich content." |
| `AgCssColorOrRef` | "A colour string, or a theme-colour reference object." |
| `AgChartLegendPosition` | "A placement keyword, or an object for fine-grained positioning." |
| `AgTimeAxisFormattableLabelFormat` | "A format string, or an object specifying a format per time unit." |
| `AgTimeInterval \| AgTimeIntervalUnit` | "A unit keyword (or number), or an object describing the interval." |
| state-serializable (`number \| AgStateSerializableBigInt`, initial-state `start`/`end`) | "A number, or a serialised value object." |

Properties with no prior JSDoc gained a full one-liner. `Default:` paragraphs were preserved with the clause inserted ahead of them. Properties already naming both forms (e.g. `theme`) were left untouched. While editing affected lines, also corrected one pre-existing typo (`formating`) and two US spellings (`colors`).

## Notes / known limitations

- `FontFamilyFull` also admits a single `GoogleFontFamily` object; the clause frames the complex form only as an array of fallbacks for terseness. The google-font object still renders as its own variant.

## Test plan

- `yarn nx format` clean
- `yarn nx build:types ag-charts-types` passes (JSDoc-only edits)
- `yarn nx lint ag-charts-types` 0 errors
- Spot-check the options/api-reference rendering for a few touched props (legend `padding`, series `fill`, a `themeParamsOptions` colour, time-axis `format`) to confirm the clause appears and the simple form reads clearly above the expanded complex tree.