### PR TITLE
perf(data-model): skip type-tracker call for settled-primitive columns

### DIFF
--- a/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/extraction/dataExtractor.ts
@@ -119,17 +119,18 @@ function valueColumnType(value: unknown): ColumnValueType | undefined {
     }
 }
 
+// Only number/bigint/boolean map 1:1 from typeof to column type; string and object are ambiguous and must reclassify.
+function settledPrimitiveUnchanged(settled: ColumnValueType | undefined, value: unknown): boolean {
+    return (settled === 'number' || settled === 'bigint' || settled === 'boolean') && typeof value === settled;
+}
+
 function updateColumnTypeTracker(
     tracker: ColumnTypeTracker,
     value: unknown,
     datumIndex: number
 ): ColumnValueType | undefined {
-    // Hot-loop fast path: for the primitive types whose `typeof` maps 1:1 to a column type
-    // (number/bigint/boolean), a value of the column's already-settled type cannot change it or
-    // introduce a string — skip the full classify and merge. `string` (→ string|date via isISO8601)
-    // and `object` (→ date|number|object) are not 1:1, so they fall through to the slow path.
     const settled = tracker.type;
-    if ((settled === 'number' || settled === 'bigint' || settled === 'boolean') && typeof value === settled) {
+    if (settledPrimitiveUnchanged(settled, value)) {
         return settled;
     }
 
@@ -401,7 +402,10 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                         keys.push(result.value);
                         // Track ordering/uniqueness for valid keys
                         updateKeyTracker(tracker, result.value);
-                        if (updateColumnTypeTracker(typeTracker, result.value, datumIndex) === 'date') {
+                        if (
+                            !settledPrimitiveUnchanged(typeTracker.type, result.value) &&
+                            updateColumnTypeTracker(typeTracker, result.value, datumIndex) === 'date'
+                        ) {
                             updateTimezoneTracker(tzTracker, result.value, datumIndex);
                         }
                         continue;
@@ -552,7 +556,10 @@ export class DataExtractor<D extends object, K extends keyof D & string> {
                     this.markScopeDatumInvalid(def.scopes, columnSource, datumIndex, invalidData, invalidDataCount);
                 } else if (result.missing) {
                     this.markScopeDatumMissing(def.scopes, columnSource, datumIndex, missingData);
-                } else if (updateColumnTypeTracker(typeTracker, result.value, datumIndex) === 'date') {
+                } else if (
+                    !settledPrimitiveUnchanged(typeTracker.type, result.value) &&
+                    updateColumnTypeTracker(typeTracker, result.value, datumIndex) === 'date'
+                ) {
                     updateTimezoneTracker(tzTracker, result.value, datumIndex);
                 }
 


### PR DESCRIPTION
## Summary

The per-column type tracking added for bigint/ISO support (post-13.3.1, AG-16608/AG-16654) calls `updateColumnTypeTracker` for **every valid datum** in the key and value extraction loops. Profiling shows V8 does **not** inline that function — its classify-and-merge slow path is too large — so each datum pays a real call even though the common case (a column already settled to `number`/`bigint`/`boolean` with a matching value) short-circuits in the first few lines.

This lifts that fast-path condition into a tiny `settledPrimitiveUnchanged()` predicate and checks it **inline at both loop sites**, skipping the call (and the dead timezone-tracking branch) entirely for settled-primitive data — the overwhelmingly common case.

Behaviour is provably unchanged: the predicate is exactly the condition the function's own fast path already used.

## Why

Part of investigating the cumulative extraction-path regression vs 13.3.1. The type-tracking machinery accounts for ~87% of the *extraction* self-time growth; `updateColumnTypeTracker` alone shows as a distinct ~80ms frame (axes-1M-time initial-load) purely from per-datum call overhead.

## Measured impact

Profiling axes-1M-time initial-load: the `updateColumnTypeTracker` frame **disappears** (~80ms self-time eliminated; replaced by a ~46ms predicate).

Benchmark harness, optimised-HEAD vs the same npm:13.3.1 baseline, on extraction-bound tests:

| test | before | after |
|---|---|---|
| multi-series / Legend Toggle ×10 | +13.6% | **+8.9%** |
| multi-series / Initial Load | +9.1% | **+6.9%** |
| high-freq-line / Initial Load | +10.7% | **+8.6%** |
| high-freq-line / Append Batch | +9.6% | **+5.3%** |

~2–5pp recovered per extraction-bound bench (≈20–45% of each gap). This is a **partial** win — type-tracking is only ~25% of the overall regression; the remainder is in the aggregation/render paths and is out of scope here.

## Test plan

- [x] `yarn nx build:types ag-charts-community`
- [x] `yarn nx lint ag-charts-community`
- [x] `yarn nx test ag-charts-community` data-model suites — 278/278 pass
- [ ] CI `/benchmarks` run to confirm at scale