### PR TITLE
Surface staging deploy as a distinct commit status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,6 +803,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
+            statuses: write
         needs:
             [
                 detect-changes,
@@ -944,6 +945,27 @@ jobs:
                   echo "$SSH_PRIVATE_KEY" > $SSH_KEY_LOCATION
                   chmod 400 $SSH_KEY_LOCATION
                   ./tools/staging/createAndDeployDocsToTCGH.sh
+
+            - name: Publish staging deploy status check
+              # Surface the staging deploy as a distinct commit status so it's visible
+              # from the commits view (hover over the status icon) without expanding the
+              # CI report job. Only posted on `latest`, where the deploy is attempted.
+              if: always() && job.status != 'cancelled' && github.ref == 'refs/heads/latest'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  case "${{ steps.deploy_to_staging.outcome }}" in
+                    success) state="success"; description="Deployed to staging" ;;
+                    failure) state="failure"; description="Staging deploy failed" ;;
+                    *)       state="error";   description="Not deployed to staging (CI did not pass)" ;;
+                  esac
+                  gh api --method POST \
+                    -H "Accept: application/vnd.github+json" \
+                    "/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+                    -f state="${state}" \
+                    -f context="Deploy to Staging" \
+                    -f description="${description}" \
+                    -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
             - name: Tag Latest Successful Commit
               if: success() && needs.init.result == 'success' && needs.init.outputs.build_type != 'pr' && steps.lastJobStatus.outputs.workflowStatus != 'failure'


### PR DESCRIPTION
The staging deploy runs as a step inside the CI `report` job, so it is invisible from the commits view — you only see the aggregate `report` check, with no indication of whether staging was actually deployed.

This publishes a `Deploy to Staging` commit status (only on the `latest` branch, where the deploy is attempted) reflecting the deploy step outcome:

- **success** → `Deployed to staging` ✅
- **failure** → `Staging deploy failed` ❌
- **skipped** (CI didn't pass, so no deploy) → `Not deployed to staging (CI did not pass)` 🟠

The status links back to the workflow run via `target_url`, and appears in the commit's status popover on the `/commits/latest` view.

### Why a commit status rather than a separate job

A commit status surfaces in the same hover popover as job checks while only being posted on `latest`, so PRs get no extra skipped-check noise — a dedicated job would show as a grey skipped check on every PR. It also avoids untangling the deploy from the interdependent `lastJobStatus` / artifact-restore / notify steps it sits among in `report`.

Adds `statuses: write` to the `report` job permissions (required to post the status). This is a new status context, so it is not a required check on branch protection unless explicitly added.