### PR TITLE
fix(examples-generator): detect chart.updateDelta as chart API usage

### DIFF
--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -85,8 +85,8 @@ This release includes the following breaking changes:
 
 - Several numeric output types are widened from number to the new `AgNumericValue (number | bigint)` alias; time axes use the companion `AgTimeValue (Date | number | bigint | string)`.
     - the value in a number formatter
-      ▎ - visibleDomain in an axis label.formatter
-      ▎ - binRange and aggregatedValue in histogram tooltip/label callbacks
+    - visibleDomain in an axis label.formatter
+    - binRange and aggregatedValue in histogram tooltip/label callbacks
 - Initial zoom state (zoom.rangeX/Y.start/end) now also accepts a serialised-bigint form for full-precision restore.
 
 ### Theme Params

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/parser-utils.ts
@@ -347,7 +347,10 @@ export function getTypes(node: ts.Node) {
     return typesToInclude;
 }
 
-const CHART_API_EXPRESSIONS = [/AgCharts\.(?!create|createFinancialChart|createGauge)/, /chart\.(?!update)/];
+// `chart.update(...)` is handled via declarative state binding in the framework variants, so it is
+// excluded here. The `\b` ensures only `chart.update` itself is excluded — `chart.updateDelta(...)`
+// and other instance methods are still detected as chart-API usage and wired to a component ref.
+const CHART_API_EXPRESSIONS = [/AgCharts\.(?!create|createFinancialChart|createGauge)/, /chart\.(?!update\b)/];
 export function usesChartApi(node: ts.Node) {
     if (ts.isCallExpression(node)) {
         const nodeText = node.getText();

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/usesChartApi.test.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/usesChartApi.test.ts
@@ -1,0 +1,28 @@
+import { parseFile, usesChartApi } from './parser-utils';
+
+describe('usesChartApi', () => {
+    const detect = (src: string) => usesChartApi(parseFile(src));
+
+    it('detects imperative chart instance methods', () => {
+        expect(detect('function f() { chart.download(); }')).toBe(true);
+        expect(detect('function f() { chart.getImageDataURL(); }')).toBe(true);
+    });
+
+    it('detects updateDelta as chart API usage', () => {
+        // Regression: `updateDelta` shares the `update` prefix and was previously
+        // excluded by the `chart.update` declarative-binding carve-out.
+        expect(detect('function f() { chart.updateDelta({}); }')).toBe(true);
+    });
+
+    it('excludes the declarative chart.update call', () => {
+        expect(detect('function f() { chart.update(options); }')).toBe(false);
+    });
+
+    it('detects non-create AgCharts static API usage', () => {
+        expect(detect('function f() { AgCharts.download(chart); }')).toBe(true);
+    });
+
+    it('ignores AgCharts factory calls', () => {
+        expect(detect('const chart = AgCharts.create(options);')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem

The example generator gates its chart-instance ref-wiring (React `useRef`, Angular `@ViewChild`, Vue template ref) on a `usesChartApi` flag, detected via:

```js
const CHART_API_EXPRESSIONS = [/AgCharts\.(?!create|...)/, /chart\.(?!update)/];
```

The `(?!update)` negative lookahead exists to exclude the *declarative* `chart.update(options)` call (frameworks handle that via state binding). But the lookahead also matches the `update` prefix of `updateDelta`, so `chart.updateDelta(...)` was wrongly classified as *not* chart-API usage. With `usesChartApi = false`, the Angular/React/Vue transforms skip the ref wiring entirely and leave a dangling `chart` reference — so a button handler calling `chart.updateDelta({})` throws `ReferenceError: chart is not defined` in the framework variants.

This surfaced on #7170 (async-data Reload button); the `loading` example has the same latent issue but its button is never clicked by the E2E suite.

## Fix

Tighten the lookahead to `/chart\.(?!update\b)/` so only `chart.update` itself is excluded. `chart.updateDelta(...)` (and any other instance method) is now detected and wired to a component ref, generating e.g. `this.agCharts.chart!.updateDelta({})` (Angular) / `chartRef.current.updateDelta({})` (React) — the same path `chart.download()` and `chart.update()` already use.

## Tests

Added `usesChartApi.test.ts` covering: imperative instance methods, `updateDelta` (regression), the `chart.update` exclusion, non-create static API, and `AgCharts.create` factory exclusion. All pass.

## Notes

- No committed generated files change (framework variants are generated at build/test time).
- Once merged, the `.controls-row` workaround applied to the async-data example in #7170 is no longer strictly required for correctness, though it remains harmless and consistent with sibling examples.