### PR TITLE
Make browser-benchmark comparisons like-for-like

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -219,6 +219,15 @@ jobs:
                     yarn nx build ag-charts-website
                   fi
 
+            # Like-for-like vs a published base: serve head from its own locally-packed UMD,
+            # so head and the published base are each a packed-tarball bundle through the same
+            # pipeline. Without this, a locally-built head bundle vs a release-packed published
+            # bundle differ by a build-asymmetry offset that inflates head's apparent cost.
+            # git-ref bases are built from source here too, so no swap is needed for them.
+            - name: Pack local head bundles (npm-base parity)
+              if: matrix.role == 'head' && startsWith(needs.resolve.outputs.base, 'npm:')
+              run: ./tools/benchmark/swap-local-lib.sh dist/packages/ag-charts-website
+
             # Keep only what the benchmark pages need: the example pages
             # themselves, the dev-served library bundles, example-runner
             # boilerplate, and hashed astro assets.

--- a/tools/benchmark/compare-browser-latest.sh
+++ b/tools/benchmark/compare-browser-latest.sh
@@ -15,15 +15,23 @@
 #
 # browser-benchmark.ts always runs from the head working directory (single Playwright install).
 #
+# For npm:<version> bases, head is served from its own locally-packed UMD (swap-local-lib.sh)
+# so head and base are each a packed-tarball bundle through the same pipeline — like-for-like.
+# Without this, a locally-built head bundle vs a release-packed published bundle differ by a
+# build-asymmetry offset that inflates head's apparent cost.
+#
 # Usage:
 #   ./tools/benchmark/compare-browser-latest.sh [options] <base-ref|npm:version>
 #
 # Options:
 #   -j            Output JSON instead of table format
+#   -n <N>        Run the benchmark N times per side and aggregate (median of run medians;
+#                 cross-run variance gates noise). Default 1. Use >=3 to see past the noise floor.
 #
 # Examples:
 #   ./tools/benchmark/compare-browser-latest.sh origin/b13.2.0
 #   ./tools/benchmark/compare-browser-latest.sh npm:13.3.1
+#   ./tools/benchmark/compare-browser-latest.sh -n 3 npm:13.3.1
 #   ./tools/benchmark/compare-browser-latest.sh -j origin/latest
 #   ./tools/benchmark/compare-browser-latest.sh origin/latest -- --examples data-selection-zoom-line-area --test-cases line
 
@@ -34,11 +42,15 @@ export NX_DAEMON=false
 # --- Argument parsing ---
 
 format=table
+runs=1
 
-while getopts "j" opt; do
+while getopts "jn:" opt; do
     case $opt in
         j)
             format=json
+            ;;
+        n)
+            runs=$OPTARG
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
@@ -47,6 +59,11 @@ while getopts "j" opt; do
     esac
 done
 shift $((OPTIND - 1))
+
+if ! [[ "$runs" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Invalid -n (runs) value: '$runs' — must be a positive integer" >&2
+    exit 1
+fi
 
 base_ref=${1:?Usage: compare-browser-latest.sh [-j] <base-ref|npm:version> [-- <browser-benchmark.ts args>]}
 shift
@@ -253,6 +270,33 @@ run_benchmarks() {
     log "Results written to ${output}"
 }
 
+# Run the benchmark `runs` times against one served site, writing <prefix>-run-<i>.json.
+# Produced paths are returned in the global RUN_FILES array (bash 3.2 has no namerefs,
+# so the caller copies RUN_FILES into its own array after each call).
+RUN_FILES=()
+run_benchmarks_n() {
+    local base_url=$1
+    local prefix=$2
+
+    RUN_FILES=()
+    local i out
+    for ((i = 1; i <= runs; i++)); do
+        out="${prefix}-run-${i}.json"
+        if (( runs > 1 )); then
+            log "Run ${i}/${runs}..."
+        fi
+        run_benchmarks "$base_url" "$out" || {
+            if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
+                return 1
+            fi
+        }
+        [[ -f "$out" ]] && RUN_FILES+=("$out")
+    done
+}
+
+head_run_files=()
+base_run_files=()
+
 # ===========================
 # Main
 # ===========================
@@ -294,15 +338,29 @@ PUBLIC_SITE_URL="http://localhost:${HEAD_PORT}" PUBLIC_HTTPS_SERVER=false \
     exit 1
 }
 
+# npm-base mode: serve head from its own locally-packed UMD so head and the published
+# base are each a packed-tarball bundle (like-for-like). git-ref bases are built from
+# source by the same local pipeline, so no swap is needed — they are already like-for-like.
+if [[ -n "$published_version" ]]; then
+    log "Packing local head bundles for like-for-like comparison..."
+    "${tools_dir}/swap-local-lib.sh" "${root}/dist/packages/ag-charts-website" || {
+        logError "Failed to pack local head bundles"
+        exit 1
+    }
+fi
+
 start_static_server "${root}/dist/packages/ag-charts-website" head "$HEAD_PORT"
 HEAD_SERVER_PID=$_STATIC_SERVER_PID
 HEAD_URL=$_STATIC_SERVER_URL
-run_benchmarks "$HEAD_URL" "$head_results" || {
+run_benchmarks_n "$HEAD_URL" "${reports_dir}/head" || {
     if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
         logError "Head benchmarks failed"
         exit 1
     fi
 }
+head_run_files=("${RUN_FILES[@]+"${RUN_FILES[@]}"}")
+# Keep head.json (= first run) for consumers that read the single-run path.
+[[ ${#head_run_files[@]} -gt 0 ]] && cp "${head_run_files[0]}" "$head_results"
 
 log "Stopping head static server..."
 stop_static_server "$HEAD_SERVER_PID"
@@ -340,12 +398,14 @@ if [[ -n "$published_version" ]]; then
         BASE_SERVER_PID=$_STATIC_SERVER_PID
         BASE_URL=$_STATIC_SERVER_URL
 
-        run_benchmarks "$BASE_URL" "$base_results" || {
+        run_benchmarks_n "$BASE_URL" "${reports_dir}/base" || {
             if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
                 logError "Base benchmarks failed"
                 exit 1
             fi
         }
+        base_run_files=("${RUN_FILES[@]+"${RUN_FILES[@]}"}")
+        [[ ${#base_run_files[@]} -gt 0 ]] && cp "${base_run_files[0]}" "$base_results"
 
         log "Stopping base static server..."
         stop_static_server "$BASE_SERVER_PID"
@@ -420,12 +480,14 @@ if [[ -d "${worktree_dir}" ]]; then
             BASE_SERVER_PID=$_STATIC_SERVER_PID
             BASE_URL=$_STATIC_SERVER_URL
 
-            run_benchmarks "$BASE_URL" "$base_results" || {
+            run_benchmarks_n "$BASE_URL" "${reports_dir}/base" || {
                 if [[ "${AG_BENCHMARK_SOFT_FAIL:-}" != "true" ]]; then
                     logError "Base benchmarks failed"
                     exit 1
                 fi
             }
+            base_run_files=("${RUN_FILES[@]+"${RUN_FILES[@]}"}")
+            [[ ${#base_run_files[@]} -gt 0 ]] && cp "${base_run_files[0]}" "$base_results"
 
             log "Stopping base static server..."
             stop_static_server "$BASE_SERVER_PID"
@@ -478,12 +540,21 @@ if [[ -n "$published_version" ]]; then
     base_version_args=(--base-version "$published_version")
 fi
 
+# Pass every per-run file so the reporter aggregates across runs. Fall back to the
+# single-run paths when run files are unavailable (e.g. soft-fail partial results).
+base_file_args=()
+for f in "${base_run_files[@]+"${base_run_files[@]}"}"; do base_file_args+=(--base "$f"); done
+[[ ${#base_file_args[@]} -eq 0 ]] && base_file_args=(--base "$base_results")
+compare_file_args=()
+for f in "${head_run_files[@]+"${head_run_files[@]}"}"; do compare_file_args+=(--compare "$f"); done
+[[ ${#compare_file_args[@]} -eq 0 ]] && compare_file_args=(--compare "$head_results")
+
 node "${tools_dir}/compare-browser-results.js" \
-    --base "$base_results" \
-    --compare "$head_results" \
+    "${base_file_args[@]}" \
+    "${compare_file_args[@]}" \
     --base-label "$base_label" \
     --compare-label "$compare_label" \
-    "${base_version_args[@]}" \
+    "${base_version_args[@]+"${base_version_args[@]}"}" \
     --format "$format" \
     --report-only \
     > "$output"

--- a/tools/benchmark/compare-browser-results.js
+++ b/tools/benchmark/compare-browser-results.js
@@ -236,6 +236,9 @@ function extractResults(reports) {
         const intraRunCvMax = Math.max(0, ...runs.map((r) => r.intraRunCv ?? 0));
         const crossRunCv = coefficientOfVariation(runMedians); // null for a single run
         const first = runs[0];
+        // Noise measure: with multiple runs the median already absorbs intra-run sample jitter
+        // (structurally high for micro-benchmarks), so run-to-run (cross-run) CV is what matters.
+        // Fall back to intra-run CV only for single-run inputs.
         merged.set(key, {
             exampleName: first.exampleName,
             displayName: first.displayName,
@@ -244,7 +247,7 @@ function extractResults(reports) {
             sampleCount: first.sampleCount,
             runCount: runs.length,
             crossRunCv,
-            cv: Math.max(intraRunCvMax, crossRunCv ?? 0),
+            cv: crossRunCv ?? intraRunCvMax,
         });
     }
 

--- a/tools/benchmark/compare-browser-results.js
+++ b/tools/benchmark/compare-browser-results.js
@@ -17,13 +17,27 @@ const { formatPercentageChange } = require('./format-utils');
 const argv = yargs(hideBin(process.argv))
     .option('base', {
         type: 'string',
+        array: true,
         demandOption: true,
-        describe: 'Path to the base (baseline) browser benchmark JSON report',
+        describe:
+            'Path(s) to base (baseline) browser benchmark JSON report(s). Pass multiple to ' +
+            'aggregate independent runs (median across runs; cross-run variance flags noisy results).',
     })
     .option('compare', {
         type: 'string',
+        array: true,
         demandOption: true,
-        describe: 'Path to the compare (head) browser benchmark JSON report',
+        describe: 'Path(s) to compare (head) browser benchmark JSON report(s). Multiple = independent runs.',
+    })
+    .option('min-pct', {
+        type: 'number',
+        default: 10,
+        describe: 'Minimum % regression to flag as notable.',
+    })
+    .option('min-abs-ms', {
+        type: 'number',
+        default: 2,
+        describe: 'Minimum absolute ms regression to flag as notable (guards micro-timing quantisation).',
     })
     .option('base-label', {
         type: 'string',
@@ -169,9 +183,10 @@ function collectMinVersions(report) {
     return minVersions;
 }
 
-// --- Extract results from report ---
+// --- Extract results from report(s) ---
 
-function extractResults(report) {
+/** Per-run extraction: one report -> Map(key -> single-run metrics). */
+function extractRun(report) {
     const results = new Map();
     const errors = [];
 
@@ -187,11 +202,9 @@ function extractResults(report) {
                 exampleName,
                 testCase: result.testCase,
                 params: result.params || {},
-                averageTime: result.averageTime,
                 medianTime: median(result.timings) ?? result.averageTime,
-                cv: coefficientOfVariation(result.timings),
+                intraRunCv: coefficientOfVariation(result.timings),
                 minTime: result.minTime,
-                maxTime: result.maxTime,
                 sampleCount: result.sampleCount,
                 displayName: displayName(exampleName, result),
             });
@@ -201,24 +214,63 @@ function extractResults(report) {
     return { results, errors };
 }
 
+/**
+ * Aggregate N independent runs into one metrics map per key.
+ *
+ * The representative time is the median of each run's median, which is robust to a single
+ * slow run. Cross-run CV (variance of the per-run medians) captures run-to-run noise that
+ * intra-run sample CV cannot — separate page loads drift even when a single session is stable.
+ */
+function extractResults(reports) {
+    const perRun = reports.map(extractRun);
+    const errors = perRun.flatMap((r) => r.errors);
+
+    const keys = new Set();
+    for (const { results } of perRun) for (const k of results.keys()) keys.add(k);
+
+    const merged = new Map();
+    for (const key of keys) {
+        const runs = perRun.map(({ results }) => results.get(key)).filter(Boolean);
+        if (runs.length === 0) continue;
+        const runMedians = runs.map((r) => r.medianTime);
+        const intraRunCvMax = Math.max(0, ...runs.map((r) => r.intraRunCv ?? 0));
+        const crossRunCv = coefficientOfVariation(runMedians); // null for a single run
+        const first = runs[0];
+        merged.set(key, {
+            exampleName: first.exampleName,
+            displayName: first.displayName,
+            medianTime: median(runMedians),
+            minTime: Math.min(...runs.map((r) => r.minTime ?? Infinity)),
+            sampleCount: first.sampleCount,
+            runCount: runs.length,
+            crossRunCv,
+            cv: Math.max(intraRunCvMax, crossRunCv ?? 0),
+        });
+    }
+
+    return { results: merged, errors };
+}
+
 // --- Compare ---
 
-const baseReport = loadReport(argv.base);
-const compareReport = loadReport(argv.compare);
+const baseReports = argv.base.map(loadReport);
+const compareReports = argv.compare.map(loadReport);
 
-const base = extractResults(baseReport);
-const compare = extractResults(compareReport);
+const base = extractResults(baseReports);
+const compare = extractResults(compareReports);
+
+const runCount = Math.min(baseReports.length, compareReports.length);
 
 const baseKeys = new Set(base.results.keys());
 const compareKeys = new Set(compare.results.keys());
 
 // Effective base version: explicit flag wins, else the version recorded in the report
 // (the published library version in npm-base mode, or the ref's version in git-base mode).
-const baseVersion = argv['base-version'] || reportVersion(baseReport);
+const baseVersion = argv['base-version'] || reportVersion(baseReports[0]);
 
 // minVersion is declared on the head examples; only keys present in both reports are
 // gated, so the compare report is always authoritative.
-const minVersions = collectMinVersions(compareReport);
+const minVersions = collectMinVersions(compareReports[0]);
 
 // Matched results
 const matched = [];
@@ -237,12 +289,17 @@ for (const key of baseKeys) {
         const pctTimeChange =
             b.medianTime === 0 ? null : Math.round(((c.medianTime - b.medianTime) / b.medianTime) * 1000) / 10;
         const noisy = (b.cv ?? 0) > NOISY_CV_THRESHOLD || (c.cv ?? 0) > NOISY_CV_THRESHOLD;
+        // Run-to-run noise band: the worse side's cross-run CV, as a percentage. A change must
+        // clear NOISE_BAND_FACTOR x this to be signal rather than measurement drift.
+        const crossRunCvPct = Math.max(b.crossRunCv ?? 0, c.crossRunCv ?? 0) * 100;
 
         matched.push({
             test: b.displayName,
             pctTimeChange,
             absDeltaMs: c.medianTime - b.medianTime,
             noisy,
+            crossRunCvPct: crossRunCvPct || null,
+            runCount: Math.min(b.runCount ?? 1, c.runCount ?? 1),
             beforeMs: timeFormat(b.medianTime),
             afterMs: timeFormat(c.medianTime),
             beforeMinMs: timeFormat(b.minTime),
@@ -281,9 +338,23 @@ for (const err of compare.errors) {
 // Rank by time change
 const rankedByTime = matched.toSorted((a, b) => (a.pctTimeChange ?? -Infinity) - (b.pctTimeChange ?? -Infinity));
 
-// Notable regressions: >10% AND >=2ms absolute — relative deltas on
-// micro-timings reflect timer quantisation rather than real regressions.
-const notable = rankedByTime.filter((r) => r.pctTimeChange !== null && r.pctTimeChange > 10 && r.absDeltaMs >= 2);
+// Notable regressions must clear every noise filter:
+//  - relative floor (default >10%): a meaningful proportional slowdown;
+//  - absolute floor (default >=2ms): guards against timer quantisation on micro-timings;
+//  - not noisy: intra- or cross-run CV within the acceptable band;
+//  - above the run-to-run noise band: when multiple runs were aggregated, the change must
+//    exceed NOISE_BAND_FACTOR x the measured cross-run CV, so drift never reads as a regression.
+const MIN_PCT = argv['min-pct'];
+const MIN_ABS_MS = argv['min-abs-ms'];
+const NOISE_BAND_FACTOR = 2;
+function isNotableRegression(r) {
+    if (r.pctTimeChange === null || r.pctTimeChange <= MIN_PCT) return false;
+    if (r.absDeltaMs < MIN_ABS_MS) return false;
+    if (r.noisy) return false;
+    if (r.crossRunCvPct != null && r.pctTimeChange <= NOISE_BAND_FACTOR * r.crossRunCvPct) return false;
+    return true;
+}
+const notable = rankedByTime.filter(isNotableRegression);
 
 // --- Output ---
 
@@ -292,12 +363,15 @@ const compareLabel = argv['compare-label'];
 
 if (argv.format === 'table') {
     console.log(`Comparing ${baseLabel} (baseline) vs. ${compareLabel}`);
+    if (runCount > 1) {
+        console.log(`Aggregated across ${runCount} runs per side (median of run medians; cross-run CV gates noise).`);
+    }
 
     if (notable.length > 0) {
         if (!argv['report-only']) {
             process.exitCode = 1;
         }
-        console.log('\nNotable Regressions (>10%)');
+        console.log(`\nNotable Regressions (>${MIN_PCT}%, >=${MIN_ABS_MS}ms, denoised)`);
         console.table(
             notable.map((r) => ({
                 test: r.test,
@@ -356,6 +430,9 @@ if (argv.format === 'table') {
             {
                 base: baseLabel,
                 compare: compareLabel,
+                runCount,
+                thresholds: { minPct: MIN_PCT, minAbsMs: MIN_ABS_MS, noiseBandFactor: NOISE_BAND_FACTOR },
+                notable: notable.map((r) => r.test),
                 rankedByTime,
                 added,
                 removed,

--- a/tools/benchmark/swap-local-lib.sh
+++ b/tools/benchmark/swap-local-lib.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Replace the dev-served library bundles in a built website dist with the UMD
+# bundles produced by packing the LOCAL workspace packages (head).
+#
+# This is the head-side mirror of swap-published-lib.sh: that script installs the
+# *published* tarball's UMD for the base, this one installs the *locally-packed*
+# tarball's UMD for head. Running both means head and base are each served from a
+# `<pkg>.tgz` produced by the same pack pipeline — eliminating the build-asymmetry
+# that otherwise inflates head's apparent cost (a locally `nx build`-served bundle
+# vs a release-packed published bundle are not like-for-like).
+#
+# Usage:
+#   ./tools/benchmark/swap-local-lib.sh <site-dist-dir>
+#
+# Example:
+#   ./tools/benchmark/swap-local-lib.sh dist/packages/ag-charts-website
+
+set -euo pipefail
+
+site_dir=${1:?Usage: swap-local-lib.sh <site-dist-dir>}
+
+if [[ ! -d "${site_dir}/dev" ]]; then
+    echo "ERROR: ${site_dir}/dev not found — is this a built website dist?" >&2
+    exit 1
+fi
+
+root=$(git rev-parse --show-toplevel)
+export NX_DAEMON=false
+
+for pkg in ag-charts-community ag-charts-enterprise ag-charts-locale; do
+    echo "[swap-local-lib] Packing local ${pkg} (production)..." >&2
+    # Pack the publishable artifact; production config matches the published bundle
+    # (sourcemaps off, debug asserts dropped) so head and base differ only in source.
+    npx nx pack "${pkg}" --configuration production >&2
+
+    tgz="${root}/dist/packages/${pkg}.tgz"
+    if [[ ! -f "${tgz}" ]]; then
+        echo "ERROR: expected packed tarball not found at ${tgz}" >&2
+        exit 1
+    fi
+
+    extract_dir="$(mktemp -d)/${pkg}"
+    mkdir -p "${extract_dir}"
+    tar -xzf "${tgz}" -C "${extract_dir}"
+
+    if [[ ! -f "${extract_dir}/package/dist/umd/${pkg}.js" ]]; then
+        echo "ERROR: local ${pkg} tarball has no dist/umd/${pkg}.js" >&2
+        exit 1
+    fi
+
+    dest="${site_dir}/dev/${pkg}/dist/umd"
+    rm -rf "${dest}"
+    mkdir -p "${dest}"
+    cp "${extract_dir}/package/dist/umd/"* "${dest}/"
+    rm -rf "$(dirname "${extract_dir}")"
+    echo "[swap-local-lib] Installed locally-packed ${pkg} into ${dest}" >&2
+done
+
+echo "[swap-local-lib] Done: ${site_dir} now serves locally-packed head bundles" >&2


### PR DESCRIPTION
## Summary

The `npm:<version>` browser-benchmark comparison was not apples-to-apples, which manufactured phantom regressions in the overnight report.

**Root cause:** head was served from a local `nx build` bundle while the base was the release-packed *published* tarball. Both are unminified UMD, but the published artifact is production-built (sourcemaps off, debug asserts dropped), so head read a few percent slower purely from the build pipeline. Combined with a measured 5–14% single-run noise floor, sub-15% deltas were unreliable.

Worked example — `high-perf-line` Initial Load, the same head build measured every way:
| Method | Result |
|---|---|
| npm 1-run (asymmetric) | **+14% / +112ms** (reported as a major regression) |
| symmetric pack-and-swap, 2 runs | +7.7%, +10.5% (one freak-fast base run) |
| symmetric pack-and-swap, **5 runs** | **−2.2%, not notable** (converged — not a regression) |

## Changes

- **`swap-local-lib.sh` (new):** production-packs the local head packages and installs their UMD into the site, mirroring `swap-published-lib.sh` for the base. Both sides become a packed-tarball bundle through the same pipeline → like-for-like.
- **`compare-browser-latest.sh`:** swap the local pack into head for `npm:` bases; add `-n N` to run N times per side; fix an unbound-variable crash in the reporter invocation. Kept bash 3.2 compatible (no namerefs).
- **`compare-browser-results.js`:** accept multiple report files per side, aggregate across runs (median of run medians), compute cross-run CV, and gate notable regressions on `>min-pct` AND `>=min-abs-ms` AND not noisy AND above 2× cross-run CV. Backward compatible with a single file.
- **`benchmark.yml`:** pack local head bundles for `npm:` bases in the build job, so the overnight and release-cut runs are like-for-like.

## Test plan

- Reporter verified on real reports: single-file path unchanged; multi-file aggregates and the cross-run-CV gate demotes a noisy regression out of `notable`.
- `swap-local-lib.sh` produces a production UMD tarball (sourcemap-stripped) and installs it.
- End-to-end `compare-browser-latest.sh -j -n 5 npm:13.3.1 -- --examples high-perf-line` runs head-swap + 5 runs/side and reports the converged, denoised result.
- Scripts syntax-checked under bash 3.2 (macOS `/bin/bash`); CI runs bash 5.