### PR TITLE
AG-17386 Update UNSUPPORTED_SERIES / UNSUPPORTED_DRAGGING

### DIFF
--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.test.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.test.ts
@@ -4578,7 +4578,8 @@ describe('DataSelection', () => {
                         expect(selectionChange.popEvents()).toEqual([]);
                     });
                 });
-                describe('mousedown and mousemove', () => {
+                // AG-17528 Selection dragging on radars is disabled for this release:
+                describe.skip('mousedown and mousemove', () => {
                     beforeEach(async () => {
                         await mouseDown(DRAG_FROM);
                         await mouseMove(DRAG_TO);

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -39,8 +39,8 @@ type SeriesType = NonNullable<AgChartOptions['series']>[number]['type'];
 function initSet(types: SeriesType[]): Set<unknown> {
     return new Set(types);
 }
-const UNSUPPORTED_SERIES = initSet(['histogram', 'waterfall', 'funnel', 'cone-funnel', 'nightingale']);
-const UNSUPPORTED_DRAGGING = initSet(['radial-column']);
+const UNSUPPORTED_SERIES = initSet(['histogram', 'waterfall', 'funnel', 'cone-funnel']);
+const UNSUPPORTED_DRAGGING = initSet(['radial-column', 'nightingale', 'radar-line', 'radar-area']);
 
 function upcastDataSelectionService(service: IDataSelectionService | undefined): DataSelectionService {
     if (service && service instanceof DataSelectionService) return service;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17386

Radial Columns, Nightingale and Radars can be combined together. Therefore we unfortunately need to disable selection dragging on all these series types.

Also keep selection-clicking on Nightingale because it's support in production.