### PR TITLE
fix(website): invalidate generate-test-files cache on example add/remove/rename

### DIFF
--- a/packages/ag-charts-website/project.json
+++ b/packages/ag-charts-website/project.json
@@ -196,7 +196,11 @@
     "generate-test-files": {
       "executor": "nx:run-commands",
       "dependsOn": ["^generate-test-files"],
-      "inputs": ["{projectRoot}/e2e/**", "!{projectRoot}/e2e/generated/**"],
+      "inputs": [
+        "{projectRoot}/e2e/**",
+        "!{projectRoot}/e2e/generated/**",
+        "{projectRoot}/src/content/**/_examples/*/main.ts"
+      ],
       "outputs": ["{projectRoot}/e2e/generated/**"],
       "cache": true,
       "options": {


### PR DESCRIPTION
## Summary

`generate-test-files` builds the E2E example specs by globbing `src/content/**/_examples/*/main.ts`, but its Nx cache `inputs` only covered `{projectRoot}/e2e/**`. Adding, removing, or renaming an example therefore did **not** change the cache key, so Nx replayed a stale cached spec set.

This broke `latest` after #7186: that PR deleted `text/_examples/inline-emoji` and renamed `inline-font-icons` → `inline-emoji-icons`, but the cached `examples-text.spec.ts` still referenced the old examples. CI then loaded `/…/text/examples/inline-emoji` (and `inline-font-icons`), which 404 → **E2E Tests (25/32)** failed. The failure reproduced deterministically across re-runs because the cache key never changed.

## Fix

Declare the example sources as inputs to `generate-test-files`:

```
"{projectRoot}/src/content/**/_examples/*/main.ts"
```

Now any example add/remove/rename invalidates the cache and the spec set regenerates. This matches the exact glob the generator (`e2e/generate-test-files.ts`) uses to enumerate examples.

## Test plan

- Verified the failing run's log: `examples-text › inline-emoji › should load …/text/examples/inline-emoji` → "Page Not Found"; router reported no static path for the deleted example.
- Confirmed `e2e/generated/**` is gitignored (generated in CI), so the stale specs came from the Nx cache, not a committed file.
- Confirmed the diagnosis is deterministic: the latest-CI re-run failed the same E2E shard again with no intervening change to `e2e/` or `_examples/`.

Fix #AG-17551