### PR TITLE
fix(website-e2e): invalidate generate-test-files cache on example changes

### DIFF
--- a/packages/ag-charts-website/project.json
+++ b/packages/ag-charts-website/project.json
@@ -196,7 +196,11 @@
     "generate-test-files": {
       "executor": "nx:run-commands",
       "dependsOn": ["^generate-test-files"],
-      "inputs": ["{projectRoot}/e2e/**", "!{projectRoot}/e2e/generated/**"],
+      "inputs": [
+        "{projectRoot}/e2e/**",
+        "!{projectRoot}/e2e/generated/**",
+        "{projectRoot}/src/content/**/_examples/*/main.ts"
+      ],
       "outputs": ["{projectRoot}/e2e/generated/**"],
       "cache": true,
       "options": {


### PR DESCRIPTION
## Summary

CI on `latest` went red after PR #7186 renamed the `inline-emoji` text example to `inline-emoji-icons`. The E2E shard `E2E Tests (25/32)` failed because the generated test list still referenced `/text/examples/inline-emoji`, which 404s ("Page Not Found") against the freshly built site.

**Root cause:** the `generate-test-files` nx target discovers examples at generation time via `glob('src/content/**/_examples/*/main.ts')`, but its cache `inputs` only covered `{projectRoot}/e2e/**`. Adding, removing or renaming an example does not touch `e2e/**`, so the target's cache key never changed and nx restored a **stale** generated test list. The website build itself uses current source, so the test list and the served pages drifted out of sync.

This also explains why re-running the failed job did not help: at the merge commit the `e2e/**` inputs are unchanged, so nx restores the same stale cache every time.

## Fix

Add `{projectRoot}/src/content/**/_examples/*/main.ts` to the `generate-test-files` cache inputs, so the test list is regenerated whenever the set of examples changes.

## Verification

- Ran the generator against current `latest` source — it now emits only `inline-emoji-icons`, no standalone `inline-emoji`.
- The separate `Website Build` failure in the same run was a flaky thumbnail-generation timeout (`simple-scatter`) and passed on re-run; not addressed here.