### PR TITLE
fix(website-e2e): use workspaceRoot fileset for generate-test-files cache

### DIFF
--- a/packages/ag-charts-website/project.json
+++ b/packages/ag-charts-website/project.json
@@ -199,7 +199,7 @@
       "inputs": [
         "{projectRoot}/e2e/**",
         "!{projectRoot}/e2e/generated/**",
-        "{projectRoot}/src/content/**/_examples/*/main.ts"
+        "{workspaceRoot}/packages/ag-charts-website/src/content/**/_examples/*/main.ts"
       ],
       "outputs": ["{projectRoot}/e2e/generated/**"],
       "cache": true,


### PR DESCRIPTION
## Summary

Follow-up to #7189, which did **not** fix the red `latest`. The E2E shard `E2E Tests (25/32)` still fails on `/text/examples/inline-emoji` (404, "Page Not Found"), because the `generate-test-files` cache is still being restored stale.

**Why #7189 was a no-op:** it added `{projectRoot}/src/content/**/_examples/*/main.ts` to the target's cache inputs. But each example `main.ts` is its own **inferred nx project** (e.g. `ag-charts-website-text_inline-emoji-icons_main.ts`). A `{projectRoot}` fileset only hashes files **owned by that project**, and the example files belong to their child projects — so the glob matched nothing and the cache key never changed.

**Fix:** use a `{workspaceRoot}` fileset, which is not scoped to project ownership, so the example files are actually hashed.

## Verification (local, `NX_DAEMON=false`)

| Action | Before (`{projectRoot}`) | After (`{workspaceRoot}`) |
| --- | --- | --- |
| Re-run, no change | cache hit | cache hit |
| Modify existing example `main.ts` | cache hit ❌ | cache **miss / re-run** ✅ |
| Add new example `main.ts` | cache hit ❌ | cache **miss / re-run** ✅ |

On merge this produces a generate-test-files hash that has never been cached (it now incorporates the current `inline-emoji-icons` example set), forcing a fresh, correct test list — so it both unblocks `latest` and prevents recurrence. No clean-cache run or test-skip required.