### PR TITLE
Memoise font-family quoting in toFontString

### DIFF
--- a/packages/ag-charts-core/src/utils/text/textUtils.test.ts
+++ b/packages/ag-charts-core/src/utils/text/textUtils.test.ts
@@ -42,6 +42,13 @@ describe('toFontString', () => {
                 '14px "Font Awesome 6 Free", sans-serif'
             );
         });
+
+        it('returns identical results on repeated calls (memoised quoting)', () => {
+            expect(toFontString({ ...baseFont, fontFamily: 'Helvetica Neue' })).toBe('14px "Helvetica Neue"');
+            expect(toFontString({ ...baseFont, fontFamily: 'Helvetica Neue' })).toBe('14px "Helvetica Neue"');
+            // A different family must not be served the cached entry of another.
+            expect(toFontString({ ...baseFont, fontFamily: 'Arial' })).toBe('14px Arial');
+        });
     });
 
     describe('weight and style', () => {

--- a/packages/ag-charts-core/src/utils/text/textUtils.ts
+++ b/packages/ag-charts-core/src/utils/text/textUtils.ts
@@ -25,11 +25,19 @@ export const CSS_GENERIC_FAMILIES = new Set([
     'fangsong',
 ]);
 
+// toFontString runs per text render/measure with a handful of distinct font families, so the
+// split/regex quoting is memoised by input. Soft-capped to bound pathological distinct-family
+// workloads; on overflow the whole cache is cleared (steady-state hit rate stays ~100%).
+const quotedFontFamilyCache = new Map<string, string>();
+const MAX_QUOTED_FONT_FAMILY_ENTRIES = 256;
+
 // Quote multi-word / digit-containing family names so canvas font shorthand
 // parses correctly; preserve already-quoted tokens and CSS generic keywords.
 function quoteFontFamily(fontFamily: string | undefined): string {
     if (!fontFamily) return '';
-    return fontFamily
+    const cached = quotedFontFamilyCache.get(fontFamily);
+    if (cached !== undefined) return cached;
+    const quoted = fontFamily
         .split(',')
         .map((part) => {
             const trimmed = part.trim();
@@ -40,6 +48,9 @@ function quoteFontFamily(fontFamily: string | undefined): string {
             return trimmed;
         })
         .join(', ');
+    if (quotedFontFamilyCache.size >= MAX_QUOTED_FONT_FAMILY_ENTRIES) quotedFontFamilyCache.clear();
+    quotedFontFamilyCache.set(fontFamily, quoted);
+    return quoted;
 }
 
 export function toFontString({ fontSize, fontStyle, fontWeight, fontFamily }: FontOptions) {


### PR DESCRIPTION
## Summary

`toFontString` runs on every text render/measure (axis labels, legends, tooltips, datum labels). Since 13.3.1 it quotes the font family — `split(',')` + per-token `trim`/regex/`join` — on every call, where 13.3.1 used a direct concat. Charts use only a handful of distinct font families, so this repeats identical string work thousands of times per render.

This memoises the quoting by its string input (a `Map<string,string>`), so after the first call each family resolves with a lookup. Soft-capped with clear-on-overflow to bound pathological distinct-family workloads, mirroring `markerPathCache`.

Found while attributing the post-13.3.1 high-frequency update-path regression: `quoteFontFamily` is a genuinely-new per-render cost (absent in 13.3.1). The win is small in isolation but cross-cutting — it benefits every text-rendering chart.

## Test plan

- `textUtils.test.ts`: existing quoting cases all pass; added an idempotency test (repeated calls return identical results; distinct families don't collide in the cache).
- `ag-charts-community` full suite: 3687 pass, image snapshots byte-identical (font strings unchanged → no visual regression).
- `ag-charts-core` build:types + lint clean.

## Note

The output is byte-for-byte identical to before — this is a pure memoisation of a deterministic function, not a behaviour change.