### PR TITLE
AG-17592 Thread colour-ref fill/stroke types across all packages

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -89,7 +89,6 @@ export abstract class AgCharts {
             if (licenseManager?.isDisplayWatermark()) {
                 enterpriseRegistry.injectWatermark?.(chart.chart!.ctx.domManager, licenseManager.getWatermarkMessage());
             }
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- TS2589 without it: O cannot be inferred through AgChartInstanceProxy
             return chart as unknown as AgChartInstance<O>;
         });
     }

--- a/packages/ag-charts-community/src/chart/labelUtil.ts
+++ b/packages/ag-charts-community/src/chart/labelUtil.ts
@@ -1,4 +1,12 @@
-import type { Callback, CallbackParam, DynamicContext, IsAny, NormalisedTextOrSegments, Point } from 'ag-charts-core';
+import type {
+    Callback,
+    CallbackParam,
+    DynamicContext,
+    IsAny,
+    NormalisedColorType,
+    NormalisedTextOrSegments,
+    Point,
+} from 'ag-charts-core';
 import { type NormalisedChartLabelStyleOptions, mergeDefaults } from 'ag-charts-core';
 import type {
     AgChartLabelStylerParams,
@@ -73,7 +81,7 @@ export function getLabelStyles<TParams>(
 
         const styleParams: NormalisedCallbackParams<
             AgChartLabelStylerParams<unknown, unknown>,
-            { color?: CssColor; fontSize: number }
+            { color?: CssColor; fontSize: number; fill?: NormalisedColorType }
         > = {
             border: label.border,
             color: label.color,
@@ -94,12 +102,11 @@ export function getLabelStyles<TParams>(
             selectionState: series.getSelectionStateString(nodeDatum?.datumIndex),
             candidateState: series.getCandidateStateString(nodeDatum?.datumIndex),
         };
-        const stylerResult =
-            series.ctx.optionsGraphService.resolvePartial(
-                labelPath,
-                series.cachedCallWithContext(label.itemStyler, { ...params, ...styleParams }),
-                { pick: false }
-            ) ?? {};
+        const stylerResult = (series.ctx.optionsGraphService.resolvePartial(
+            labelPath,
+            series.cachedCallWithContext(label.itemStyler, { ...params, ...styleParams }),
+            { pick: false }
+        ) ?? {}) as NormalisedChartLabelStyleOptions;
 
         return mergeDefaults(stylerResult, styleParams);
     }

--- a/packages/ag-charts-community/src/chart/legend/legendSymbol.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendSymbol.ts
@@ -1,5 +1,5 @@
 import type { InternalAgColorType } from 'ag-charts-core';
-import type { AgColorType, AgSeriesMarkerStyle } from 'ag-charts-types';
+import type { AgSeriesMarkerStyle } from 'ag-charts-types';
 
 import { Group } from '../../scene/group';
 import { Line } from '../../scene/shape/line';
@@ -7,7 +7,7 @@ import { Marker } from '../marker/marker';
 
 export interface LegendMarker extends Omit<AgSeriesMarkerStyle, 'stroke'> {
     fill?: InternalAgColorType;
-    stroke?: AgColorType;
+    stroke?: InternalAgColorType;
     enabled?: boolean;
 }
 

--- a/packages/ag-charts-community/src/chart/mapping/themes.test.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.test.ts
@@ -1,7 +1,6 @@
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import type { InternalAgColorType } from 'ag-charts-core';
 import type {
     AgBarSeriesOptions,
     AgChartInstance,
@@ -9,6 +8,8 @@ import type {
     AgChartTheme,
     AgChartThemeName,
     AgChartThemePalette,
+    AgColorType,
+    AgCssColorOrRef,
 } from 'ag-charts-types';
 
 import { AgCharts } from '../../api/agCharts';
@@ -39,7 +40,7 @@ describe('themes.ts', () => {
         const getActualPalette = (chart: AgChartInstance) => {
             let result = undefined;
             for (const series of deproxy(chart).chartOptions.processedOptions.series ?? []) {
-                result ??= { fills: [] as InternalAgColorType[], strokes: [] as string[] };
+                result ??= { fills: [] as AgColorType[], strokes: [] as AgCssColorOrRef[] };
 
                 expect(series.type).toEqual('bar');
                 const barseries = series as AgBarSeriesOptions;

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -1,8 +1,11 @@
 import type {
-    CallbackParamRules,
     DomainWithMetadata,
     DynamicContext,
     InternalAgColorType,
+    NormalisedAreaSeriesMarkerItemStylerParams,
+    NormalisedAreaSeriesStylerResult,
+    NormalisedColorType,
+    NormalisedSeriesMarkerStyle,
     Point,
     RequireOptional,
 } from 'ag-charts-core';
@@ -22,14 +25,12 @@ import {
 } from 'ag-charts-core';
 import {
     type AgAreaSeriesLabelFormatterParams,
-    type AgAreaSeriesMarkerItemStylerParams,
     type AgAreaSeriesOptions,
     type AgAreaSeriesStylerParams,
-    type AgAreaSeriesStylerResult,
     type AgDrawingMode,
     type AgErrorBoundSeriesTooltipRendererParams,
     type AgNumericValue,
-    type AgSeriesMarkerStyle,
+    type NormalisedCallbackParams,
 } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../../module/moduleContext';
@@ -135,7 +136,7 @@ type AreaNoStylerCompute = MarkerStyleCompute<
     AreaSeries,
     AreaNoStylerPassCtx,
     MarkerSelectionDatum,
-    AgSeriesMarkerStyle
+    NormalisedSeriesMarkerStyle
 >;
 type AreaStylerCompute = MarkerStyleCompute<
     AreaSeries,
@@ -1432,7 +1433,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
 
         if (itemStyler == null) {
             // No itemStyler: style is a pure function of (highlightState, selectionState).
-            this.runMarkerStylePass<AreaNoStylerPassCtx, MarkerSelectionDatum, AgSeriesMarkerStyle, AreaSeries>(
+            this.runMarkerStylePass<AreaNoStylerPassCtx, MarkerSelectionDatum, NormalisedSeriesMarkerStyle, AreaSeries>(
                 datumSelection,
                 isHighlight,
                 { marker, hideWithSize0, isHighlight },
@@ -1547,8 +1548,11 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         const selectionState = toSelectionString(selectionStateEnum);
         const candidateState = toSelectionString(candidateStateEnum);
 
-        type MarkerRules = { marker: RequireOptional<AgSeriesMarkerStyle> };
-        type ResultRules = CallbackParamRules<AgAreaSeriesStylerParams<unknown, unknown> & MarkerRules>;
+        type MarkerRules = { marker: RequireOptional<NormalisedSeriesMarkerStyle> };
+        type ResultRules = NormalisedCallbackParams<
+            AgAreaSeriesStylerParams<unknown, unknown> & MarkerRules,
+            { fill?: NormalisedColorType }
+        >;
         return {
             marker: {
                 fill: marker.fill,
@@ -1581,8 +1585,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         dataModel: NonNullable<typeof this.dataModel>,
         processedData: NonNullable<typeof this.processedData>,
         datumIndex: number,
-        style: Required<AgSeriesMarkerStyle>
-    ): AgAreaSeriesMarkerItemStylerParams<unknown, unknown> {
+        style: Required<NormalisedSeriesMarkerStyle>
+    ): NormalisedAreaSeriesMarkerItemStylerParams<unknown, unknown> {
         const { xKey, yKey } = this.properties;
 
         const xValue = dataModel.resolveKeysById(this, `xValue`, processedData)[datumIndex];
@@ -1597,7 +1601,10 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             yValue,
             ...style,
             fill,
-        } satisfies CallbackParamRules<AgAreaSeriesMarkerItemStylerParams<unknown, unknown>>;
+        } satisfies NormalisedCallbackParams<
+            NormalisedAreaSeriesMarkerItemStylerParams<unknown, unknown>,
+            { fill: NormalisedColorType }
+        >;
     }
 
     private makeLabelFormatterParams(): AgAreaSeriesLabelFormatterParams {
@@ -1624,13 +1631,13 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         const stylerStyle = this.getStyle(undefined);
         const params = this.makeItemStylerParams(dataModel, processedData, datumIndex, stylerStyle.marker);
 
-        const format = this.getMarkerStyle<AgAreaSeriesMarkerItemStylerParams<unknown, unknown>>(
+        const format = this.getMarkerStyle<NormalisedAreaSeriesMarkerItemStylerParams<unknown, unknown>>(
             this.properties.marker,
             { datumIndex, datum },
             params,
             { isHighlight: false },
             stylerStyle.marker
-        ) as RequireOptional<AgSeriesMarkerStyle>;
+        ) as RequireOptional<NormalisedSeriesMarkerStyle>;
 
         return this.formatTooltipWithContext(
             tooltip,
@@ -1831,13 +1838,13 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
         return new Marker<MarkerSelectionDatum>();
     }
 
-    public getStyle(
-        highlightState: HighlightState | undefined
-    ): Required<AgAreaSeriesStylerResult> & { marker: Required<AgSeriesMarkerStyle> & { enabled: boolean } } {
+    public getStyle(highlightState: HighlightState | undefined): Required<NormalisedAreaSeriesStylerResult> & {
+        marker: Required<NormalisedSeriesMarkerStyle> & { enabled: boolean };
+    } {
         const { styler, marker, fill, fillOpacity, lineDash, lineDashOffset, stroke, strokeOpacity, strokeWidth } =
             this.properties;
         const { size, shape, fill: markerFill = 'transparent', fillOpacity: markerFillOpacity } = marker;
-        let stylerResult: AgAreaSeriesStylerResult & { marker?: { enabled?: boolean } } = {};
+        let stylerResult: NormalisedAreaSeriesStylerResult & { marker?: { enabled?: boolean } } = {};
         if (styler) {
             const selectionState: SelectionState | undefined = this.getDataSelectionState(undefined);
             const candidateState: SelectionState | undefined = this.getDataCandidacyState(undefined);
@@ -1847,7 +1854,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 ['series', `${this.declarationOrder}`],
                 cbResult,
                 { pick: false }
-            );
+            ) as NormalisedAreaSeriesStylerResult;
             stylerResult = resolved ?? {};
         }
         stylerResult.marker ??= {};
@@ -1870,8 +1877,8 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 stroke: stylerResult.marker.stroke ?? marker.stroke ?? stroke,
                 strokeOpacity: stylerResult.marker.strokeOpacity ?? marker.strokeOpacity ?? strokeOpacity,
                 strokeWidth: stylerResult.marker.strokeWidth ?? marker.strokeWidth ?? strokeWidth,
-            } satisfies RequireOptional<AgSeriesMarkerStyle> & { enabled: boolean },
-        } satisfies RequireOptional<AgAreaSeriesStylerResult> & { marker: { enabled: boolean } };
+            } satisfies RequireOptional<NormalisedSeriesMarkerStyle> & { enabled: boolean },
+        } satisfies RequireOptional<NormalisedAreaSeriesStylerResult> & { marker: { enabled: boolean } };
     }
 
     public getFormattedMarkerStyle(datum: MarkerSelectionDatum) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -1412,7 +1412,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             datum.datumIndex,
             stylerStyle.marker
         );
-        datum.style = series.getMarkerStyle(
+        datum.style = series.getMarkerStyle<NormalisedAreaSeriesMarkerItemStylerParams<unknown, unknown>>(
             ctx.marker,
             datum,
             params,
@@ -1890,7 +1890,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
             stylerStyle.marker
         );
 
-        return this.getMarkerStyle(
+        return this.getMarkerStyle<NormalisedAreaSeriesMarkerItemStylerParams<unknown, unknown>>(
             this.properties.marker,
             datum,
             params,

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaUtil.ts
@@ -1,6 +1,11 @@
-import type { InternalAgColorType, NormalisedTextOrSegments, Point, SizedPoint } from 'ag-charts-core';
+import type {
+    InternalAgColorType,
+    NormalisedSeriesMarkerStyle,
+    NormalisedTextOrSegments,
+    Point,
+    SizedPoint,
+} from 'ag-charts-core';
 import { SpanJoin, isScaleValid, spanRange } from 'ag-charts-core';
-import type { AgSeriesMarkerStyle } from 'ag-charts-types';
 
 import type { NodeUpdateState } from '../../../motion/fromToMotion';
 import type { Path } from '../../../scene/shape/path';
@@ -40,7 +45,7 @@ export interface MarkerSelectionDatum extends CartesianSeriesNodeDatum {
     // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
     // with extreme caution.
     readonly crossFilterSelected: boolean | undefined;
-    style?: AgSeriesMarkerStyle;
+    style?: NormalisedSeriesMarkerStyle;
 }
 
 export interface LabelSelectionDatum extends Readonly<Point>, SeriesNodeDatum {
@@ -56,7 +61,7 @@ export interface AreaSeriesNodeDataContext extends CartesianSeriesNodeDataContex
     strokeData: AreaStrokePathDatum;
     stackVisible: boolean;
     crossFiltering: boolean;
-    styles: SeriesNodeStyleContext<AgSeriesMarkerStyle>;
+    styles: SeriesNodeStyleContext<NormalisedSeriesMarkerStyle>;
     segments?: Segment[];
 }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -3,6 +3,7 @@ import type {
     DomainWithMetadata,
     DynamicContext,
     Mutable,
+    NormalisedBarSeriesStyle,
     NormalisedTextOrSegments,
     Point,
     RequireOptional,
@@ -30,7 +31,6 @@ import type {
     AgBarSeriesItemStylerParams,
     AgBarSeriesLabelFormatterParams,
     AgBarSeriesOptions,
-    AgBarSeriesStyle,
     AgBarSeriesStylerParams,
     AgErrorBoundSeriesTooltipRendererParams,
     AgNumericValue,
@@ -218,12 +218,12 @@ interface BarNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDat
     readonly clipBBox: BBox | undefined;
     readonly crisp: boolean;
     readonly label?: BarNodeLabelDatum;
-    style?: Required<AgBarSeriesStyle>;
+    style?: Required<NormalisedBarSeriesStyle>;
 }
 
 interface BarSeriesNodeDataContext extends AbstractBarSeriesNodeDataContext<BarNodeDatum> {
     phantomNodeData: BarNodeDatum[];
-    styles: SeriesNodeStyleContext<AgBarSeriesStyle>;
+    styles: SeriesNodeStyleContext<NormalisedBarSeriesStyle>;
     segments?: Segment[];
 }
 
@@ -1403,7 +1403,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         datumIndex: number,
         xValue: string,
         isHighlight: boolean,
-        style: Required<AgBarSeriesStyle>
+        style: Required<NormalisedBarSeriesStyle>
     ): AgBarSeriesItemStylerParams<unknown, unknown> {
         const { id: seriesId } = this;
         const { xKey, yKey, stackGroup } = this.properties;
@@ -1439,7 +1439,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         highlightState: HighlightState | undefined,
         selectionState: SelectionState | undefined,
         candidateState: SelectionState | undefined
-    ): Required<AgBarSeriesStyle> & { opacity: number } {
+    ): Required<NormalisedBarSeriesStyle> & { opacity: number } {
         const {
             cornerRadius,
             fill,
@@ -1451,15 +1451,14 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
             strokeWidth,
             styler,
         } = this.properties;
-        let stylerResult: AgBarSeriesStyle = {};
+        let stylerResult: NormalisedBarSeriesStyle = {};
         if (!ignoreStylerCallback && styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
-            stylerResult =
-                this.ctx.optionsGraphService.resolvePartial(
-                    ['series', `${this.declarationOrder}`],
-                    this.cachedCallWithContext(styler, stylerParams) ?? {},
-                    { pick: false }
-                ) ?? {};
+            stylerResult = (this.ctx.optionsGraphService.resolvePartial(
+                ['series', `${this.declarationOrder}`],
+                this.cachedCallWithContext(styler, stylerParams) ?? {},
+                { pick: false }
+            ) ?? {}) as NormalisedBarSeriesStyle;
         }
         return {
             cornerRadius: stylerResult.cornerRadius ?? cornerRadius,
@@ -1480,7 +1479,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         highlightState: HighlightState | undefined,
         selectionState: SelectionState | undefined,
         candidateState: SelectionState | undefined
-    ): Required<AgBarSeriesStyle> {
+    ): Required<NormalisedBarSeriesStyle> {
         const { properties, dataModel, processedData } = this;
         const { itemStyler, simpleItemStyler } = properties;
 
@@ -1496,7 +1495,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
                 selectionStyle,
                 highlightStyle,
                 this.getStyle(false, highlightState, selectionState, candidateState)
-            ) as Required<AgBarSeriesStyle>;
+            ) as Required<NormalisedBarSeriesStyle>;
         }
 
         let style = mergeDefaults(

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -1,4 +1,4 @@
-import type { DynamicContext } from 'ag-charts-core';
+import type { DynamicContext, NormalisedSeriesMarkerStyle } from 'ag-charts-core';
 import {
     type CallbackParamRules,
     ChartAxisDirection,
@@ -35,7 +35,6 @@ import {
     type AgScatterSeriesItemStylerParams,
     type AgScatterSeriesStylerParams,
     type AgScatterSeriesStylerResult,
-    type AgSeriesMarkerStyle,
     type FillOptions,
     type FormatterPropertyType,
     type LineDashOptions,
@@ -139,13 +138,13 @@ type BubbleNoStylerCompute = MarkerStyleCompute<
     BubbleSeries,
     BubbleNoStylerPassCtx,
     BubbleScatterNodeDatum,
-    AgSeriesMarkerStyle
+    NormalisedSeriesMarkerStyle
 >;
 type BubbleNoStylerApply = MarkerStyleApply<
     BubbleSeries,
     BubbleNoStylerPassCtx,
     BubbleScatterNodeDatum,
-    AgSeriesMarkerStyle
+    NormalisedSeriesMarkerStyle
 >;
 type BubbleStylerCompute = MarkerStyleCompute<
     BubbleSeries,
@@ -193,14 +192,14 @@ export interface BubbleScatterNodeDatum extends CartesianSeriesNodeDatum, ErrorB
     // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
     // with extreme caution.
     readonly crossFilterSelected: boolean | undefined;
-    style?: AgSeriesMarkerStyle;
+    style?: NormalisedSeriesMarkerStyle;
 }
 
 interface BubbleSeriesNodeDataContext extends CartesianSeriesNodeDataContext<
     BubbleScatterNodeDatum,
     BubbleScatterNodeDatum
 > {
-    styles: SeriesNodeStyleContext<AgSeriesMarkerStyle>;
+    styles: SeriesNodeStyleContext<NormalisedSeriesMarkerStyle>;
 }
 
 /**
@@ -1075,7 +1074,12 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         if (marker.itemStyler == null && !colorScaleValid) {
             // No itemStyler / colour-scale: only datum.point.size varies per datum, so cache a
             // per-state template and splice the size in at apply time.
-            this.runMarkerStylePass<BubbleNoStylerPassCtx, BubbleScatterNodeDatum, AgSeriesMarkerStyle, BubbleSeries>(
+            this.runMarkerStylePass<
+                BubbleNoStylerPassCtx,
+                BubbleScatterNodeDatum,
+                NormalisedSeriesMarkerStyle,
+                BubbleSeries
+            >(
                 datumSelection,
                 isHighlight,
                 { marker, params, isHighlight },
@@ -1516,7 +1520,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         );
     }
 
-    private legendItemSymbol(styleOverride?: Partial<AgSeriesMarkerStyle>): LegendSymbolOptions {
+    private legendItemSymbol(styleOverride?: Partial<NormalisedSeriesMarkerStyle>): LegendSymbolOptions {
         const style = this.getStyle(undefined);
         const marker = this.getMarkerStyle<AgBubbleSeriesOptionsKeys>(
             this.properties.marker,
@@ -1527,7 +1531,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
                 checkForHighlight: false,
                 resolveMarkerSubPath: [],
             },
-            style satisfies RequireOptional<AgSeriesMarkerStyle>
+            style satisfies RequireOptional<NormalisedSeriesMarkerStyle>
         );
         return {
             marker: styleOverride ? { ...marker, ...styleOverride } : marker,
@@ -1612,7 +1616,9 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         return new Marker<BubbleScatterNodeDatum>();
     }
 
-    public getStyle(highlightState: HighlightState | undefined): Required<AgSeriesMarkerStyle> & { maxSize: number } {
+    public getStyle(
+        highlightState: HighlightState | undefined
+    ): Required<NormalisedSeriesMarkerStyle> & { maxSize: number } {
         const { properties } = this;
         const { marker } = properties;
 
@@ -1632,6 +1638,8 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
 
         const floorOverride = this.getSizeFloorOverride(stylerResult);
 
+        // resolvePartial has already resolved any colour refs in stylerResult, and the marker
+        // properties hold resolved colours, so the merged style is a NormalisedSeriesMarkerStyle.
         return {
             fill: stylerResult.fill ?? properties.fill!,
             fillOpacity: stylerResult.fillOpacity ?? properties.fillOpacity,
@@ -1643,7 +1651,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             stroke: stylerResult.stroke ?? properties.stroke!,
             strokeOpacity: stylerResult.strokeOpacity ?? properties.strokeOpacity,
             strokeWidth: stylerResult.strokeWidth ?? properties.strokeWidth,
-        };
+        } as Required<NormalisedSeriesMarkerStyle> & { maxSize: number };
     }
 
     // Bubble and scatter share the `marker.size` backing field but expose it under different styler keys:

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -1,4 +1,4 @@
-import type { ChartAnimationPhase, Scaling } from 'ag-charts-core';
+import type { ChartAnimationPhase, NormalisedSeriesSegmentation, Scaling } from 'ag-charts-core';
 import {
     ChartAxisDirection,
     Debug,
@@ -17,7 +17,7 @@ import {
     maxValue,
     minValue,
 } from 'ag-charts-core';
-import type { AgDrawingMode, AgNumericValue, AgSeriesSegmentation, SelectionState } from 'ag-charts-types';
+import type { AgDrawingMode, AgNumericValue, SelectionState } from 'ag-charts-types';
 
 import type { HighlightNodeDatum } from '../../../core/eventsHub';
 import type { AnimationValue } from '../../../motion/animation';
@@ -160,7 +160,7 @@ export abstract class CartesianSeriesProperties<T extends object>
     pickOutsideVisibleMinorAxis = false;
 
     @Property
-    segmentation: AgSeriesSegmentation = new Segmentation();
+    segmentation: NormalisedSeriesSegmentation = new Segmentation();
 }
 
 export const RENDER_TO_OFFSCREEN_CANVAS_THRESHOLD = 100;

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts
@@ -1,5 +1,4 @@
-import type { ChartAxisDirection, Scale, Scaling } from 'ag-charts-core';
-import type { AgSeriesSegmentation } from 'ag-charts-types';
+import type { ChartAxisDirection, NormalisedSeriesSegmentation, Scale, Scaling } from 'ag-charts-core';
 
 import type { BBox } from '../../../scene/bbox';
 import type { Node, NodeWithOpacity } from '../../../scene/node';
@@ -125,7 +124,7 @@ export interface CartesianSeriesPropertiesBase<T extends object> extends SeriesP
     yKeyAxis: string;
     legendItemName?: string;
     pickOutsideVisibleMinorAxis: boolean;
-    segmentation: AgSeriesSegmentation;
+    segmentation: NormalisedSeriesSegmentation;
 }
 
 // ============================================================================

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -1,4 +1,4 @@
-import type { CallbackParamRules, DynamicContext } from 'ag-charts-core';
+import type { CallbackParamRules, DynamicContext, NormalisedHistogramSeriesStyle } from 'ag-charts-core';
 import {
     ChartAxisDirection,
     type DomainWithMetadata,
@@ -25,7 +25,6 @@ import type {
     AgHistogramSeriesItemStylerParams,
     AgHistogramSeriesLabelFormatterParams,
     AgHistogramSeriesOptions,
-    AgHistogramSeriesStyle,
     AgHistogramSeriesStylerParams,
     AgNumericValue,
     SelectionState as PublicSelectionState,
@@ -122,7 +121,7 @@ interface CalculatedBin {
 }
 
 interface HistogramSeriesNodeDataContext extends CartesianSeriesNodeDataContext<HistogramNodeDatum> {
-    styles: SeriesNodeStyleContext<AgHistogramSeriesStyle>;
+    styles: SeriesNodeStyleContext<NormalisedHistogramSeriesStyle>;
 }
 
 /**
@@ -703,7 +702,9 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
 
     // The theme resolves fill/stroke before any styler runs, so the style fields exposed to styler
     // callbacks are always present even though they are statically optional on the properties.
-    private resolvedStyle(style: RequireOptional<AgHistogramSeriesStyle>): Required<AgHistogramSeriesStyle> {
+    private resolvedStyle(
+        style: RequireOptional<NormalisedHistogramSeriesStyle>
+    ): Required<NormalisedHistogramSeriesStyle> {
         const { fill, fillOpacity, stroke, strokeWidth, strokeOpacity, lineDash, lineDashOffset, cornerRadius } = style;
         return {
             fill,
@@ -714,7 +715,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
             lineDash,
             lineDashOffset,
             cornerRadius,
-        } as Required<AgHistogramSeriesStyle>;
+        } as Required<NormalisedHistogramSeriesStyle>;
     }
 
     private makeStylerParams(
@@ -737,7 +738,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
     private makeItemStylerParams(
         bin: CalculatedBin,
         isHighlight: boolean,
-        style: RequireOptional<AgHistogramSeriesStyle>
+        style: RequireOptional<NormalisedHistogramSeriesStyle>
     ): AgHistogramSeriesItemStylerParams<unknown, unknown> {
         const { id: seriesId } = this;
         const { xKey, yKey } = this.properties;
@@ -760,19 +761,18 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         isHighlight: boolean,
         datumIndex: number | undefined,
         highlightState: HighlightState | undefined
-    ): RequireOptional<AgHistogramSeriesStyle> {
+    ): RequireOptional<NormalisedHistogramSeriesStyle> {
         const { properties } = this;
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex, highlightState);
 
-        let base: RequireOptional<AgHistogramSeriesStyle> = properties.getStyle();
+        let base: RequireOptional<NormalisedHistogramSeriesStyle> = properties.getStyle();
         const { styler } = properties;
         if (!ignoreStylerCallback && styler != null) {
-            const stylerResult =
-                this.ctx.optionsGraphService.resolvePartial(
-                    ['series', `${this.declarationOrder}`],
-                    this.cachedCallWithContext(styler, this.makeStylerParams(highlightState)) ?? {},
-                    { pick: false }
-                ) ?? {};
+            const stylerResult = (this.ctx.optionsGraphService.resolvePartial(
+                ['series', `${this.declarationOrder}`],
+                this.cachedCallWithContext(styler, this.makeStylerParams(highlightState)) ?? {},
+                { pick: false }
+            ) ?? {}) as RequireOptional<NormalisedHistogramSeriesStyle>;
             base = mergeDefaults(stylerResult, base);
         }
 
@@ -783,7 +783,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
         datumIndex: number | undefined,
         isHighlight: boolean,
         highlightState?: HighlightState
-    ): RequireOptional<AgHistogramSeriesStyle> {
+    ): RequireOptional<NormalisedHistogramSeriesStyle> {
         let style = this.getStyle(datumIndex === undefined, isHighlight, datumIndex, highlightState);
 
         const { itemStyler } = this.properties;
@@ -799,7 +799,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
                         )
                 );
                 if (overrides) {
-                    style = mergeDefaults(overrides, style);
+                    style = mergeDefaults(overrides as RequireOptional<NormalisedHistogramSeriesStyle>, style);
                 }
             }
         }

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeriesProperties.ts
@@ -1,4 +1,9 @@
-import type { InternalAgColorType, NormalisedTextOrSegments, RequireOptional } from 'ag-charts-core';
+import type {
+    InternalAgColorType,
+    NormalisedHistogramSeriesStyle,
+    NormalisedTextOrSegments,
+    RequireOptional,
+} from 'ag-charts-core';
 import { Property } from 'ag-charts-core';
 import type {
     AgHistogramSeriesGetItemIdParams,
@@ -45,7 +50,7 @@ export interface HistogramNodeDatum extends CartesianSeriesNodeDatum {
     // Required for types
     readonly crisp: boolean;
     readonly opacity?: number;
-    style?: RequireOptional<AgHistogramSeriesStyle>;
+    style?: RequireOptional<NormalisedHistogramSeriesStyle>;
 }
 
 export class HistogramSeriesProperties extends CartesianSeriesProperties<AgHistogramSeriesOptions> {
@@ -115,7 +120,7 @@ export class HistogramSeriesProperties extends CartesianSeriesProperties<AgHisto
     @Property
     readonly tooltip = makeSeriesTooltip<AgHistogramSeriesTooltipRendererParams>();
 
-    getStyle(): RequireOptional<AgHistogramSeriesStyle> & { opacity: number } {
+    getStyle(): RequireOptional<NormalisedHistogramSeriesStyle> & { opacity: number } {
         const { fill, fillOpacity, stroke, strokeWidth, strokeOpacity, lineDash, lineDashOffset, cornerRadius } = this;
         return {
             fill,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -1,4 +1,11 @@
-import type { CallbackParamRules, DomainWithMetadata, DynamicContext, RequireOptional } from 'ag-charts-core';
+import type {
+    CallbackParamRules,
+    DomainWithMetadata,
+    DynamicContext,
+    NormalisedLineSeriesStylerResult,
+    NormalisedSeriesMarkerStyle,
+    RequireOptional,
+} from 'ag-charts-core';
 import {
     AGGREGATION_INDEX_Y_MAX,
     ChartAxisDirection,
@@ -15,8 +22,6 @@ import {
     type AgLineSeriesMarkerItemStylerParams,
     type AgLineSeriesOptions,
     type AgLineSeriesStylerParams,
-    type AgLineSeriesStylerResult,
-    type AgSeriesMarkerStyle,
 } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../../module/moduleContext';
@@ -133,7 +138,12 @@ interface LineStylerPassCtx extends LineNoStylerPassCtx {
     yKey: string;
 }
 
-type LineNoStylerCompute = MarkerStyleCompute<LineSeries, LineNoStylerPassCtx, LineNodeDatum, AgSeriesMarkerStyle>;
+type LineNoStylerCompute = MarkerStyleCompute<
+    LineSeries,
+    LineNoStylerPassCtx,
+    LineNodeDatum,
+    NormalisedSeriesMarkerStyle
+>;
 type LineStylerCompute = MarkerStyleCompute<
     LineSeries,
     LineStylerPassCtx,
@@ -829,7 +839,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
 
         if (itemStyler == null) {
             // No itemStyler: style is a pure function of (highlightState, selectionState).
-            this.runMarkerStylePass<LineNoStylerPassCtx, LineNodeDatum, AgSeriesMarkerStyle, LineSeries>(
+            this.runMarkerStylePass<LineNoStylerPassCtx, LineNodeDatum, NormalisedSeriesMarkerStyle, LineSeries>(
                 datumSelection,
                 isHighlight,
                 { marker, hideWithSize0, isHighlight },
@@ -957,7 +967,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         const selectionState = toSelectionString(selectionStateEnum);
         const candidateState = toSelectionString(candidateStateEnum);
 
-        type MarkerRules = { marker: RequireOptional<AgSeriesMarkerStyle> };
+        type MarkerRules = { marker: RequireOptional<NormalisedSeriesMarkerStyle> };
         type ResultRules = CallbackParamRules<AgLineSeriesStylerParams<unknown, unknown> & MarkerRules>;
         return {
             marker: {
@@ -989,7 +999,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
         dataModel: NonNullable<typeof this.dataModel>,
         processedData: NonNullable<typeof this.processedData>,
         datumIndex: number,
-        style: Required<AgSeriesMarkerStyle>
+        style: Required<NormalisedSeriesMarkerStyle>
     ): AgLineSeriesMarkerItemStylerParams<unknown, unknown> {
         const { xKey, yKey } = this.properties;
 
@@ -1037,7 +1047,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
             params,
             { isHighlight: false },
             stylerStyle.marker
-        ) as RequireOptional<AgSeriesMarkerStyle>;
+        ) as RequireOptional<NormalisedSeriesMarkerStyle>;
 
         return this.formatTooltipWithContext(
             tooltip,
@@ -1088,7 +1098,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 strokeWidth: marker.strokeWidth,
                 lineDash: marker.lineDash,
                 lineDashOffset: marker.lineDashOffset,
-            } satisfies RequireOptional<AgSeriesMarkerStyle>
+            } satisfies RequireOptional<NormalisedSeriesMarkerStyle>
         );
 
         return {
@@ -1286,20 +1296,21 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
 
     public getStyle(
         highlightState: HighlightState | undefined
-    ): Required<AgLineSeriesStylerResult> & { marker: Required<AgSeriesMarkerStyle> } {
+    ): Required<NormalisedLineSeriesStylerResult> & { marker: Required<NormalisedSeriesMarkerStyle> } {
         const { styler, marker, lineDash, lineDashOffset, stroke, strokeOpacity, strokeWidth } = this.properties;
         const { size, shape, fill = 'transparent', fillOpacity } = marker;
-        let stylerResult: AgLineSeriesStylerResult = {};
+        let stylerResult: NormalisedLineSeriesStylerResult = {};
         if (styler) {
             const selectionState: SelectionState | undefined = this.getDataSelectionState(undefined);
             const candidateState: SelectionState | undefined = this.getDataCandidacyState(undefined);
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
             const cbResult = this.cachedCallWithContext(styler, stylerParams) ?? {};
+            // resolvePartial has already resolved any colour refs returned by the styler.
             const resolved = this.ctx.optionsGraphService.resolvePartial(
                 ['series', `${this.declarationOrder}`],
                 cbResult,
                 { pick: false }
-            );
+            ) as NormalisedLineSeriesStylerResult | undefined;
             stylerResult = resolved ?? {};
         }
         stylerResult.marker ??= {};
@@ -1319,8 +1330,8 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 stroke: stylerResult.marker.stroke ?? marker.stroke ?? stroke,
                 strokeOpacity: stylerResult.marker.strokeOpacity ?? marker.strokeOpacity ?? strokeOpacity,
                 strokeWidth: stylerResult.marker.strokeWidth ?? marker.strokeWidth ?? strokeWidth,
-            } satisfies RequireOptional<AgSeriesMarkerStyle>,
-        } satisfies RequireOptional<AgLineSeriesStylerResult>;
+            } satisfies RequireOptional<NormalisedSeriesMarkerStyle>,
+        } satisfies RequireOptional<NormalisedLineSeriesStylerResult>;
     }
 
     public getFormattedMarkerStyle(datum: LineNodeDatum) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineUtil.ts
@@ -1,4 +1,10 @@
-import type { InterpolationProperties, NormalisedTextOrSegments, Point, Span } from 'ag-charts-core';
+import type {
+    InterpolationProperties,
+    NormalisedSeriesMarkerStyle,
+    NormalisedTextOrSegments,
+    Point,
+    Span,
+} from 'ag-charts-core';
 import {
     SpanJoin,
     areScalingEqual,
@@ -8,7 +14,7 @@ import {
     spanRange,
     stepPoints,
 } from 'ag-charts-core';
-import type { AgNumericValue, AgSeriesMarkerStyle } from 'ag-charts-types';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { type FromToFns, NODE_UPDATE_STATE_TO_PHASE_MAPPING, type NodeUpdateState } from '../../../motion/fromToMotion';
 import type { Path } from '../../../scene/shape/path';
@@ -59,13 +65,13 @@ export interface LineNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSerie
     // feature. It has nothing to do with the official data selection API in the options contract. Do not use, or use
     // with extreme caution.
     readonly crossFilterSelected: boolean | undefined;
-    style?: AgSeriesMarkerStyle;
+    style?: NormalisedSeriesMarkerStyle;
 }
 
 export interface LineSeriesNodeDataContext extends CartesianSeriesNodeDataContext<LineNodeDatum> {
     strokeData: LineStrokePathDatum;
     crossFiltering: boolean;
-    styles: SeriesNodeStyleContext<AgSeriesMarkerStyle>;
+    styles: SeriesNodeStyleContext<NormalisedSeriesMarkerStyle>;
     segments?: Segment[];
 }
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/markerUtil.ts
@@ -1,6 +1,6 @@
-import type { Point, Scale, SizedPoint } from 'ag-charts-core';
+import type { NormalisedSeriesMarkerStyle, Point, Scale, SizedPoint } from 'ag-charts-core';
 import { ChartAxisDirection, clamp, findRangeExtent, inverseEaseOut } from 'ag-charts-core';
-import type { AgDrawingMode, AgMarkerShape, AgSeriesMarkerStyle } from 'ag-charts-types';
+import type { AgDrawingMode, AgMarkerShape } from 'ag-charts-types';
 
 import { QUICK_TRANSITION } from '../../../motion/animation';
 import type { ExtraOpts, NodeUpdateState } from '../../../motion/fromToMotion';
@@ -208,7 +208,7 @@ export function cartesianMarkerDrawMode(
 }
 
 type SeriesStyler<TStylerParams, TStylerResult> = (params: TStylerParams) => TStylerResult;
-type DefaultOverrideStyle = AgSeriesMarkerStyle & { size: number };
+type DefaultOverrideStyle = NormalisedSeriesMarkerStyle & { size: number };
 
 interface MarkerSeriesStylerProps<TStylerParams, TStylerResult> {
     properties: {
@@ -220,8 +220,8 @@ interface MarkerSeriesStylerProps<TStylerParams, TStylerResult> {
         params?: TParams,
         opts?: { highlightState?: HighlightState },
         defaultOverrideStyle?: DefaultOverrideStyle,
-        inheritedStyle?: AgSeriesMarkerStyle
-    ): AgSeriesMarkerStyle & { size: number };
+        inheritedStyle?: NormalisedSeriesMarkerStyle
+    ): NormalisedSeriesMarkerStyle & { size: number };
 }
 
 type LineProperties = {
@@ -234,7 +234,7 @@ export function getMarkerStyles<TStylerParams, TStylerResult, TItemStylerParams>
     series: MarkerSeriesStylerProps<TStylerParams, TStylerResult>,
     line: LineProperties,
     marker: SeriesMarker<TItemStylerParams>,
-    inheritedStyle?: AgSeriesMarkerStyle
+    inheritedStyle?: NormalisedSeriesMarkerStyle
 ) {
     inheritedStyle ??= {
         stroke: line.stroke,
@@ -254,6 +254,6 @@ export function getMarkerStyles<TStylerParams, TStylerResult, TItemStylerParams>
             );
             return styles;
         },
-        {} as Record<HighlightState, AgSeriesMarkerStyle>
+        {} as Record<HighlightState, NormalisedSeriesMarkerStyle>
     );
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/util.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/util.ts
@@ -2,6 +2,8 @@ import {
     CARTESIAN_AXIS_TYPE,
     CARTESIAN_POSITION,
     ChartAxisDirection,
+    type NormalisedSeriesSegmentation,
+    type NormalisedSeriesShapeSegmentOptions,
     type Size,
     isArray,
     isDate,
@@ -11,13 +13,7 @@ import {
     isObject,
     isString,
 } from 'ag-charts-core';
-import type {
-    AgCartesianSeriesOptions,
-    AgSeriesSegmentation,
-    AgSeriesShapeSegmentOptions,
-    DatumDefault,
-    SeriesPredictAxis,
-} from 'ag-charts-types';
+import type { AgCartesianSeriesOptions, DatumDefault, SeriesPredictAxis } from 'ag-charts-types';
 
 import { BBox } from '../../../scene/bbox';
 import type { ChartAxis } from '../../chartAxis';
@@ -27,7 +23,7 @@ function isAxisReversed(axis: ChartAxis) {
 }
 
 export function calculateSegments(
-    segmentation: AgSeriesSegmentation,
+    segmentation: NormalisedSeriesSegmentation,
     xAxis: ChartAxis,
     yAxis: ChartAxis,
     seriesRect: BBox,
@@ -66,8 +62,8 @@ export function calculateSegments(
         return isXDirection ? seriesRect.width + horizontalMargin : seriesRect.height + verticalMargin;
     };
 
-    const getSegments = (segments: AgSeriesShapeSegmentOptions[]) => {
-        const result: AgSeriesShapeSegmentOptions[] = [];
+    const getSegments = (segments: NormalisedSeriesShapeSegmentOptions[]) => {
+        const result: NormalisedSeriesShapeSegmentOptions[] = [];
 
         let previousDefinedStopIndex = -1;
         for (let i = 0; i < segments.length; i++) {

--- a/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/hierarchy/hierarchySeriesProperties.ts
@@ -1,5 +1,4 @@
-import { Property } from 'ag-charts-core';
-import type { AgColorType } from 'ag-charts-types';
+import { type NormalisedColorType, Property } from 'ag-charts-core';
 
 import { ColorScaleProperties } from '../../../scene/gradient/stops';
 import { DEFAULT_FILLS, DEFAULT_STROKES } from '../../themes/defaultColors';
@@ -47,7 +46,7 @@ export abstract class HierarchySeriesProperties<T extends object> extends Series
     colorName?: string;
 
     @Property
-    fills: AgColorType[] = Object.values(DEFAULT_FILLS);
+    fills: NormalisedColorType[] = Object.values(DEFAULT_FILLS);
 
     @Property
     strokes: string[] = Object.values(DEFAULT_STROKES);

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -1,6 +1,11 @@
-import type { DynamicContext, NormalisedTextOrSegments } from 'ag-charts-core';
+import type {
+    DynamicContext,
+    NormalisedColorType,
+    NormalisedDonutSeriesStyle,
+    NormalisedPieSeriesStyle,
+    NormalisedTextOrSegments,
+} from 'ag-charts-core';
 import {
-    type CallbackParamRules,
     ChartAxisDirection,
     ChartUpdateType,
     DebugMetrics,
@@ -32,12 +37,11 @@ import type {
     AgDonutSeriesItemStylerParams,
     AgDonutSeriesLabelFormatterParams,
     AgDonutSeriesOptions,
-    AgDonutSeriesStyle,
     AgDrawingMode,
     AgNumericValue,
     AgPieSeriesItemStylerParams,
     AgPieSeriesLabelFormatterParams,
-    AgPieSeriesStyle,
+    NormalisedCallbackParams,
     SelectionState,
 } from 'ag-charts-types';
 
@@ -169,7 +173,7 @@ enum DonutNodeTag {
 
 interface PieDonutSeriesLabelFormatterParams
     extends AgDonutSeriesLabelFormatterParams, AgPieSeriesLabelFormatterParams {}
-interface PieDonutSeriesStyle extends AgDonutSeriesStyle, AgPieSeriesStyle {}
+interface PieDonutSeriesStyle extends NormalisedDonutSeriesStyle, NormalisedPieSeriesStyle {}
 
 export class DonutSeries extends PolarSeries<
     PieDonutNodeDatum,
@@ -758,7 +762,7 @@ export class DonutSeries extends PolarSeries<
                         ['series', `${this.declarationOrder}`],
                         this.callWithContext(itemStyler, params),
                         { proxyPaths: { fill: ['fills', `${datumIndex}`], stroke: ['strokes', `${datumIndex}`] } }
-                    );
+                    ) as NormalisedDonutSeriesStyle;
                 }
             );
         }
@@ -780,7 +784,7 @@ export class DonutSeries extends PolarSeries<
         datum: unknown,
         datumIndex: number,
         isHighlight: boolean,
-        style: Required<AgPieSeriesStyle>
+        style: Required<NormalisedPieSeriesStyle>
     ) {
         const { angleKey, radiusKey, calloutLabelKey, sectorLabelKey, legendItemKey } = this.properties;
 
@@ -803,8 +807,9 @@ export class DonutSeries extends PolarSeries<
             selectionState: this.getSelectionStateString(datumIndex),
             candidateState: this.getCandidateStateString(datumIndex),
             seriesId: this.id,
-        } satisfies CallbackParamRules<
-            AgDonutSeriesItemStylerParams<unknown, unknown> | AgPieSeriesItemStylerParams<unknown, unknown>
+        } satisfies NormalisedCallbackParams<
+            AgDonutSeriesItemStylerParams<unknown, unknown> | AgPieSeriesItemStylerParams<unknown, unknown>,
+            { fill?: NormalisedColorType; stroke?: NormalisedColorType }
         >;
     }
 

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -11,7 +11,6 @@ import {
     DebugMetrics,
     type Has,
     type InternalAgColorType,
-    type InternalAgGradientColor,
     Logger,
     type Point,
     PolarZIndexMap,
@@ -1775,7 +1774,7 @@ export class DonutSeries extends PolarSeries<
         let { fill } = sectorFormat;
         const { stroke } = sectorFormat;
         if (isGradientFill(fill)) {
-            fill = { ...fill, gradient: 'linear', rotation: 0, reverse: false } as InternalAgGradientColor;
+            fill = { ...fill, gradient: 'linear', rotation: 0, reverse: false };
         }
 
         return {

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeriesProperties.ts
@@ -1,4 +1,4 @@
-import type { InternalAgColorType } from 'ag-charts-core';
+import type { InternalAgColorType, NormalisedDonutSeriesTooltipRendererParams } from 'ag-charts-core';
 import { BaseProperties, PropertiesArray, Property } from 'ag-charts-core';
 import type {
     AgDonutCalloutLineItemStylerParams,
@@ -7,7 +7,6 @@ import type {
     AgDonutSeriesLabelFormatterParams,
     AgDonutSeriesOptions,
     AgDonutSeriesStyle,
-    AgDonutSeriesTooltipRendererParams,
     Styler,
 } from 'ag-charts-types';
 
@@ -195,5 +194,5 @@ export class DonutSeriesProperties extends SeriesProperties<AgDonutSeriesOptions
     readonly calloutLine = new DonutSeriesCalloutLine();
 
     @Property
-    readonly tooltip = makeSeriesTooltip<AgDonutSeriesTooltipRendererParams<any>>();
+    readonly tooltip = makeSeriesTooltip<NormalisedDonutSeriesTooltipRendererParams<any>>();
 }

--- a/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
@@ -1,4 +1,4 @@
-import type { BoxBounds, InternalAgColorType, Point } from 'ag-charts-core';
+import type { BoxBounds, NormalisedColorType, Point } from 'ag-charts-core';
 import { boxContains, isBetweenAngles, toRadians } from 'ag-charts-core';
 import type { AgSelectionContainment } from 'ag-charts-types';
 
@@ -19,7 +19,7 @@ type AnimatableSectorDatum = {
     startAngle: number;
     endAngle: number;
     sectorFormat: {
-        fill?: InternalAgColorType;
+        fill?: NormalisedColorType;
         stroke?: string;
     };
 };

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -3,6 +3,8 @@ import type {
     ChartAnimationPhase,
     DomainWithMetadata,
     DynamicContext,
+    NormalisedColorType,
+    NormalisedSeriesMarkerStyle,
     NormalisedTextOrSegments,
     PlacedLabel,
     PointLabelDatum,
@@ -37,11 +39,9 @@ import {
 import type {
     AgActiveItemState,
     AgChartLabelFormatterParams,
-    AgColorType,
     AgDrawingMode,
     AgInitialStateLegendOptions,
     AgNumericValue,
-    AgSeriesMarkerStyle,
     AgSeriesTooltipRendererParams,
     AgSeriesVisibilityChange,
     FormatterParams,
@@ -991,12 +991,15 @@ export abstract class Series<
         return this.properties.selection.getStyle(staged);
     }
 
-    protected resolveMarkerDrawingModeForState(drawingMode: AgDrawingMode, style?: AgSeriesMarkerStyle): AgDrawingMode {
+    protected resolveMarkerDrawingModeForState(
+        drawingMode: AgDrawingMode,
+        style?: NormalisedSeriesMarkerStyle
+    ): AgDrawingMode {
         return resolveMarkerDrawingMode(drawingMode, style);
     }
 
     protected abstract hasItemStylers(): boolean;
-    public filterItemStylerFillParams(fill: AgColorType | undefined): InternalAgColorType | undefined {
+    public filterItemStylerFillParams(fill: NormalisedColorType | undefined): NormalisedColorType | undefined {
         if (isGradientFill(fill)) {
             return without(fill, ['bounds', 'colorSpace', 'gradient', 'reverse']);
         } else if (isPatternFill(fill)) {
@@ -1413,8 +1416,10 @@ export abstract class Series<
             resolveStyler?: boolean;
             hideWithSize0?: boolean;
         },
-        defaultOverrideStyle: AgSeriesMarkerStyle & { size: number } = { size: point?.size ?? marker.size ?? 0 },
-        inheritedStyle?: AgSeriesMarkerStyle
+        defaultOverrideStyle: NormalisedSeriesMarkerStyle & { size: number } = {
+            size: point?.size ?? marker.size ?? 0,
+        },
+        inheritedStyle?: NormalisedSeriesMarkerStyle
     ) {
         const { itemStyler } = marker;
         const {
@@ -1430,7 +1435,7 @@ export abstract class Series<
         const candidateState: SelectionState | undefined = this.getDataCandidacyState(datumIndex);
 
         if (hideWithSize0 && isUnselected(stagedSelectionState(selectionState, candidateState))) {
-            return { size: 0 } satisfies AgSeriesMarkerStyle;
+            return { size: 0 } satisfies NormalisedSeriesMarkerStyle;
         }
 
         // Lazy resolvePath — only the resolveStyler/itemStyler branches consume it.
@@ -1449,10 +1454,10 @@ export abstract class Series<
             }
         }
 
-        const highlightStyle: AgSeriesMarkerStyle | undefined = checkForHighlight
+        const highlightStyle: NormalisedSeriesMarkerStyle | undefined = checkForHighlight
             ? this.getHighlightStyle(isHighlight, datumIndex, highlightState)
             : undefined;
-        const selectionStyle: AgSeriesMarkerStyle | undefined =
+        const selectionStyle: NormalisedSeriesMarkerStyle | undefined =
             checkForHighlight && this.isSelectionEnabled()
                 ? this.getSelectionStyle(datumIndex, selectionState, candidateState)
                 : undefined;
@@ -1487,7 +1492,10 @@ export abstract class Series<
                 candidateState: candidateStateString,
                 datum,
             });
-            const resolved = this.ctx.optionsGraphService.resolvePartial(getResolvePath(), style);
+            const resolved = this.ctx.optionsGraphService.resolvePartial(
+                getResolvePath(),
+                style
+            ) as NormalisedSeriesMarkerStyle;
 
             markerStyle = mergeMarkerStylesPair(resolved, markerStyle);
         }
@@ -1496,7 +1504,7 @@ export abstract class Series<
     }
 
     protected applyMarkerStyle(
-        style: AgSeriesMarkerStyle,
+        style: NormalisedSeriesMarkerStyle,
         markerNode: Marker,
         point: { x: number; y: number; size?: number; focusSize?: number } | undefined,
         fillBBox: ShapeFillBBox | undefined,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -17,7 +17,6 @@ import {
     CleanupRegistry,
     type DistantObject,
     EventEmitter,
-    type InternalAgColorType,
     LRUCache,
     Logger,
     type Point,

--- a/packages/ag-charts-community/src/chart/series/seriesMarker.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesMarker.ts
@@ -1,4 +1,9 @@
-import type { InternalAgColorType, RequireOptional } from 'ag-charts-core';
+import type {
+    InternalAgColorType,
+    NormalisedSeriesMarkerStyle,
+    NormalisedSeriesMarkerStylerParams,
+    RequireOptional,
+} from 'ag-charts-core';
 import {
     ChangeDetectableProperties,
     Property,
@@ -52,11 +57,11 @@ export class SeriesMarker<TParams = never> extends ChangeDetectableProperties {
     @Property
     @SceneObjectChangeDetection({ equals: TRIPLE_EQ })
     itemStyler?: Styler<
-        AgSeriesMarkerStylerParams<unknown, unknown> & RequireOptional<Omit<TParams, 'context'>>,
+        NormalisedSeriesMarkerStylerParams<unknown, unknown> & RequireOptional<Omit<TParams, 'context'>>,
         AgSeriesMarkerStyle
     >;
 
-    private _cachedStyle?: AgSeriesMarkerStyle;
+    private _cachedStyle?: NormalisedSeriesMarkerStyle;
 
     override onChangeDetection(property: string): void {
         // Invalidate the snapshot on any decorated property change.
@@ -64,7 +69,7 @@ export class SeriesMarker<TParams = never> extends ChangeDetectableProperties {
         super.onChangeDetection(property);
     }
 
-    getStyle(): AgSeriesMarkerStyle {
+    getStyle(): NormalisedSeriesMarkerStyle {
         // Returning the shared snapshot is safe: callers spread / read but never mutate it.
         if (this._cachedStyle !== undefined) {
             return this._cachedStyle;
@@ -80,7 +85,7 @@ export class SeriesMarker<TParams = never> extends ChangeDetectableProperties {
             strokeOpacity,
             lineDash,
             lineDashOffset,
-        } satisfies RequireOptional<AgSeriesMarkerStyle>;
+        } satisfies RequireOptional<NormalisedSeriesMarkerStyle>;
         this._cachedStyle = style;
         return style;
     }
@@ -91,15 +96,15 @@ export class SeriesMarker<TParams = never> extends ChangeDetectableProperties {
 }
 
 /** Highlight/selection styles carry an extra `opacity` field via HighlightOptions's StyleMixins. */
-export type MergeMarkerStyleSource = AgSeriesMarkerStyle & { opacity?: number };
-type MergeMarkerStyleResult = AgSeriesMarkerStyle & { size: number; opacity?: number };
+export type MergeMarkerStyleSource = NormalisedSeriesMarkerStyle & { opacity?: number };
+type MergeMarkerStyleResult = NormalisedSeriesMarkerStyle & { size: number; opacity?: number };
 
 /** Specialised mergeDefaults: left-most non-undefined wins, no recursion (no source holds plain objects). */
 export function mergeMarkerStyles(
     selectionStyle: MergeMarkerStyleSource | undefined,
     highlightStyle: MergeMarkerStyleSource | undefined,
-    defaultOverride: AgSeriesMarkerStyle & { size: number },
-    markerStyle: AgSeriesMarkerStyle,
+    defaultOverride: NormalisedSeriesMarkerStyle & { size: number },
+    markerStyle: NormalisedSeriesMarkerStyle,
     inheritedStyle: MergeMarkerStyleSource | undefined
 ): MergeMarkerStyleResult {
     return {

--- a/packages/ag-charts-community/src/chart/series/seriesMarker.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesMarker.ts
@@ -12,7 +12,7 @@ import {
     TRIPLE_EQ,
     objectsEqual,
 } from 'ag-charts-core';
-import type { AgMarkerShape, AgSeriesMarkerStyle, AgSeriesMarkerStylerParams, Styler } from 'ag-charts-types';
+import type { AgMarkerShape, AgSeriesMarkerStyle, Styler } from 'ag-charts-types';
 
 export class SeriesMarker<TParams = never> extends ChangeDetectableProperties {
     @Property

--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -2,6 +2,9 @@ import type {
     AreExact,
     ColorSpace,
     InternalAgColorType,
+    NormalisedColorType,
+    NormalisedGradientColorStop,
+    NormalisedSeriesSegmentation,
     RequiredInternalAgGradientColor,
     RequiredInternalAgImageFill,
     RequiredInternalAgPatternColor,
@@ -9,14 +12,12 @@ import type {
 import { BaseProperties, PropertiesArray, Property, mergeDefaults } from 'ag-charts-core';
 import type {
     AgColorRepeat,
-    AgColorType,
     AgGradientColorBounds,
     AgGradientColorStop,
     AgGradientType,
     AgImageFillFit,
     AgPatternName,
     AgSelectionContainment,
-    AgSeriesSegmentation,
     AgSeriesShapeSegmentOptions,
     CssColor,
     InteractionRange,
@@ -78,7 +79,7 @@ export function getSelectionStyleOptionKeys(selectionState: SelectionState): Sel
 }
 
 type StyleMixins = {
-    fill: AgColorType;
+    fill: NormalisedColorType;
     fillOpacity: number;
     stroke: string;
     strokeWidth: number;
@@ -250,7 +251,7 @@ export class SegmentOptions extends BaseProperties implements AgSeriesShapeSegme
     lineDashOffset: number = 0;
 }
 
-export class Segmentation implements AgSeriesSegmentation {
+export class Segmentation implements NormalisedSeriesSegmentation {
     @Property
     enabled?: boolean;
 
@@ -269,7 +270,7 @@ export class FillGradientDefaults
     type: 'gradient' = 'gradient' as const;
 
     @Property
-    colorStops: AgGradientColorStop[] = [];
+    colorStops: NormalisedGradientColorStop[] = [];
 
     @Property
     bounds: AgGradientColorBounds = 'item';

--- a/packages/ag-charts-community/src/chart/series/shapeUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/shapeUtil.ts
@@ -1,5 +1,6 @@
 import {
     type InternalAgColorType,
+    type NormalisedColorType,
     type RequiredInternalAgColorType,
     type RequiredInternalAgGradientColor,
     type RequiredInternalAgImageFill,
@@ -109,19 +110,19 @@ export function getShapeFill(
     return fill;
 }
 
-export function getShapeStyle<T extends { fill?: InternalAgColorType }>(
+export function getShapeStyle<T extends { fill?: NormalisedColorType }>(
     style: T,
     defaultGradient: RequiredInternalAgGradientColor,
     defaultPattern: RequiredInternalAgPatternColor,
     defaultImage: RequiredInternalAgImageFill
 ): T;
-export function getShapeStyle<T extends { fill?: InternalAgColorType }>(
+export function getShapeStyle<T extends { fill?: NormalisedColorType }>(
     style: T | undefined,
     defaultGradient: RequiredInternalAgGradientColor,
     defaultPattern: RequiredInternalAgPatternColor,
     defaultImage: RequiredInternalAgImageFill
 ): T | undefined;
-export function getShapeStyle<T extends { fill?: InternalAgColorType }>(
+export function getShapeStyle<T extends { fill?: NormalisedColorType }>(
     style: T | undefined,
     defaultGradient: RequiredInternalAgGradientColor,
     defaultPattern: RequiredInternalAgPatternColor,

--- a/packages/ag-charts-community/src/scene/gradient/stops.ts
+++ b/packages/ag-charts-community/src/scene/gradient/stops.ts
@@ -2,16 +2,16 @@ import {
     BaseProperties,
     type ColorScaleMode,
     type GradientColorStop,
+    type NormalisedGradientColorStop,
     PropertiesArray,
     Property,
     discreteColorStops,
     resolveStopPositions,
 } from 'ag-charts-core';
-import type { AgGradientColorStop } from 'ag-charts-types';
 
 import { ColorScale } from '../../scale/colorScale';
 
-export class StopProperties extends BaseProperties implements AgGradientColorStop {
+export class StopProperties extends BaseProperties implements NormalisedGradientColorStop {
     @Property
     stop?: number;
 
@@ -50,12 +50,14 @@ function getDefaultColorStops(defaultColorStops: string[], fillMode: ColorScaleM
 }
 
 export function getColorStops(
-    baseFills: Array<AgGradientColorStop | string>,
+    baseFills: Array<NormalisedGradientColorStop | string>,
     defaultColorStops: string[],
     domain: number[],
     fillMode: ColorScaleMode = 'continuous'
 ): GradientColorStop[] {
-    const fills = baseFills.map<AgGradientColorStop>((fill) => (typeof fill === 'string' ? { color: fill } : fill));
+    const fills = baseFills.map<NormalisedGradientColorStop>((fill) =>
+        typeof fill === 'string' ? { color: fill } : fill
+    );
     if (fills.length === 0) {
         return getDefaultColorStops(defaultColorStops, fillMode);
     }

--- a/packages/ag-charts-community/src/scene/shape/segmentedPath.ts
+++ b/packages/ag-charts-community/src/scene/shape/segmentedPath.ts
@@ -1,5 +1,10 @@
-import { SceneRefChangeDetection, getPath2D } from 'ag-charts-core';
-import type { FillOptions, LineDashOptions, StrokeOptions } from 'ag-charts-types';
+import {
+    type NormalisedFillOptions,
+    type NormalisedStrokeOptions,
+    SceneRefChangeDetection,
+    getPath2D,
+} from 'ag-charts-core';
+import type { LineDashOptions } from 'ag-charts-types';
 
 import { Path } from './path';
 
@@ -10,7 +15,7 @@ export interface ClipRect {
     y1: number;
 }
 
-export interface Segment extends StrokeOptions, FillOptions, LineDashOptions {
+export interface Segment extends NormalisedStrokeOptions, NormalisedFillOptions, LineDashOptions {
     clipRect: ClipRect;
 }
 

--- a/packages/ag-charts-community/src/scene/shape/svgUtils.ts
+++ b/packages/ag-charts-community/src/scene/shape/svgUtils.ts
@@ -1,5 +1,5 @@
-import type { FontOptions } from 'ag-charts-core';
-import type { LineDashOptions, StrokeOptions } from 'ag-charts-types';
+import type { FontOptions, NormalisedStrokeOptions } from 'ag-charts-core';
+import type { LineDashOptions } from 'ag-charts-types';
 
 export function setSvgFontAttributes(element: SVGElement, options: FontOptions) {
     const { fontStyle, fontWeight, fontSize, fontFamily } = options;
@@ -9,7 +9,7 @@ export function setSvgFontAttributes(element: SVGElement, options: FontOptions) 
     if (fontFamily) element.setAttribute('font-family', fontFamily);
 }
 
-export function setSvgStrokeAttributes(element: SVGElement, options: StrokeOptions) {
+export function setSvgStrokeAttributes(element: SVGElement, options: NormalisedStrokeOptions) {
     const { stroke, strokeWidth, strokeOpacity } = options;
     if (stroke) element.setAttribute('stroke', stroke);
     if (strokeWidth != null) element.setAttribute('stroke-width', String(strokeWidth));

--- a/packages/ag-charts-core/src/config/optionsDefaults.ts
+++ b/packages/ag-charts-core/src/config/optionsDefaults.ts
@@ -5,15 +5,11 @@ import type {
     AgColorScaleColorStop,
     AgColorType,
     AgCssColorOrRef,
-    AgGradientColorBounds,
     AgGradientColorStop,
     AgGradientColorStrict,
-    AgGradientType,
     AgHighlightStyleOptions,
-    AgImageFill,
     AgLineHighlightStyleOptions,
     AgNumericValue,
-    AgPatternColor,
     AgSelectionContainment,
     AgSelectionStyleOptions,
     AgSeriesLineSegmentOptions,
@@ -56,7 +52,11 @@ import {
     undocumented,
     union,
 } from '../state/validation';
-import type { NormalisedGradientColor } from '../types/normalised-options/normalisedCommonOptions';
+import type {
+    InternalAgGradientColor,
+    InternalAgImageFill,
+    InternalAgPatternColor,
+} from '../types/normalised-options/normalisedCommonOptions';
 import { isObject } from '../utils/types/typeGuards';
 
 // Validator for internal theme operators.
@@ -181,41 +181,6 @@ export const gradientStrict = optionsDefs<AgGradientColorStrict>(
     gradientStrictDefs,
     'a gradient object with colour stops'
 );
-
-export interface InternalAgGradientColor extends NormalisedGradientColor {
-    /** Format of the gradient */
-    gradient?: AgGradientType;
-    /** The domain of the colour gradient, defaults to item. */
-    bounds?: AgGradientColorBounds;
-    /** Reverse the order of colour stops. */
-    reverse?: boolean;
-    /** Colour space to use when interpolating colours in the gradient. */
-    colorSpace?: ColorSpace;
-}
-
-export type ColorSpace = 'rgb' | 'oklch';
-
-export interface InternalAgPatternColor extends AgPatternColor {
-    /** Padding for the shape in the pattern unit. */
-    padding?: number;
-}
-export interface InternalAgImageFill extends AgImageFill {}
-
-export type RequiredInternalAgImageFill = Required<Omit<InternalAgImageFill, 'url' | 'width' | 'height'>> &
-    Pick<Partial<InternalAgImageFill>, 'url'> &
-    Pick<InternalAgImageFill, 'width' | 'height'>;
-
-export type RequiredInternalAgPatternColor = Required<Omit<InternalAgPatternColor, 'path'>> &
-    Pick<InternalAgPatternColor, 'path'>;
-
-export type RequiredInternalAgGradientColor = Required<InternalAgGradientColor>;
-
-export type InternalAgColorType = CssColor | InternalAgGradientColor | InternalAgPatternColor | InternalAgImageFill;
-export type RequiredInternalAgColorType =
-    | CssColor
-    | RequiredInternalAgGradientColor
-    | RequiredInternalAgPatternColor
-    | (RequiredInternalAgImageFill & Pick<InternalAgImageFill, 'url'>);
 
 export const strokeOptionsDef: OptionsDefs<StrokeOptions> = {
     stroke: colorOrRef,

--- a/packages/ag-charts-core/src/config/optionsDefaults.ts
+++ b/packages/ag-charts-core/src/config/optionsDefaults.ts
@@ -5,7 +5,6 @@ import type {
     AgColorScaleColorStop,
     AgColorType,
     AgCssColorOrRef,
-    AgGradientColor,
     AgGradientColorBounds,
     AgGradientColorStop,
     AgGradientColorStrict,
@@ -57,6 +56,7 @@ import {
     undocumented,
     union,
 } from '../state/validation';
+import type { NormalisedGradientColor } from '../types/normalised-options/normalisedCommonOptions';
 import { isObject } from '../utils/types/typeGuards';
 
 // Validator for internal theme operators.
@@ -182,7 +182,7 @@ export const gradientStrict = optionsDefs<AgGradientColorStrict>(
     'a gradient object with colour stops'
 );
 
-export interface InternalAgGradientColor extends AgGradientColor {
+export interface InternalAgGradientColor extends NormalisedGradientColor {
     /** Format of the gradient */
     gradient?: AgGradientType;
     /** The domain of the colour gradient, defaults to item. */

--- a/packages/ag-charts-core/src/config/themeUtil.ts
+++ b/packages/ag-charts-core/src/config/themeUtil.ts
@@ -10,14 +10,14 @@ import type {
     WithThemeParams,
 } from 'ag-charts-types';
 
+import type {
+    RequiredInternalAgGradientColor,
+    RequiredInternalAgImageFill,
+    RequiredInternalAgPatternColor,
+} from '../types/normalised-options/normalisedCommonOptions';
 import { CARTESIAN_AXIS_TYPE, CARTESIAN_POSITION } from '../types/themeConstants';
 import { mapValues } from '../utils/data/object';
 import { Color } from '../utils/format/color';
-import {
-    type RequiredInternalAgGradientColor,
-    type RequiredInternalAgImageFill,
-    type RequiredInternalAgPatternColor,
-} from './optionsDefaults';
 
 type CartesianAxis = Exclude<AgCartesianChartOptions['axes'], undefined>[0];
 

--- a/packages/ag-charts-core/src/main.ts
+++ b/packages/ag-charts-core/src/main.ts
@@ -1,10 +1,15 @@
 // Types
 export * from './types/global';
 export * from './types/normalised-options/normalise';
+export * from './types/normalised-options/normalisedAreaSeries';
 export * from './types/normalised-options/normalisedAxisOptions';
+export * from './types/normalised-options/normalisedCartesianSeries';
 export * from './types/normalised-options/normalisedCommonOptions';
 export * from './types/normalised-options/normalisedChartCaptionOptions';
+export * from './types/normalised-options/normalisedDonutSeries';
 export * from './types/normalised-options/normalisedGradientLegendOptions';
+export * from './types/normalised-options/normalisedPieSeries';
+export * from './types/normalised-options/normalisedSeriesMarkerOptions';
 export * from './types/normalised-options/normalisedLabelOptions';
 export * from './types/normalised-options/normalisedLegendOptions';
 export * from './types/normalised-options/normalisedSelectionOptions';

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedAreaSeries.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedAreaSeries.ts
@@ -1,0 +1,17 @@
+import type { NormalisedSeriesMarkerStyle } from 'ag-charts-core';
+import type { AgAreaSeriesMarkerItemStylerParams, AgAreaSeriesStylerResult } from 'ag-charts-types';
+
+import type { Normalised } from './normalise';
+import type { FillStrokeMorph, NormalisedColorType } from './normalisedCommonOptions';
+
+export type NormalisedAreaSeriesMarkerItemStylerParams<TDatum, TContext> = Normalised<
+    AgAreaSeriesMarkerItemStylerParams<TDatum, TContext>,
+    never,
+    { fill?: NormalisedColorType }
+>;
+
+export type NormalisedAreaSeriesStylerResult = Normalised<
+    AgAreaSeriesStylerResult,
+    never,
+    FillStrokeMorph & { marker?: NormalisedSeriesMarkerStyle }
+>;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedAreaSeries.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedAreaSeries.ts
@@ -1,8 +1,8 @@
-import type { NormalisedSeriesMarkerStyle } from 'ag-charts-core';
 import type { AgAreaSeriesMarkerItemStylerParams, AgAreaSeriesStylerResult } from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
 import type { FillStrokeMorph, NormalisedColorType } from './normalisedCommonOptions';
+import type { NormalisedSeriesMarkerStyle } from './normalisedSeriesMarkerOptions';
 
 export type NormalisedAreaSeriesMarkerItemStylerParams<TDatum, TContext> = Normalised<
     AgAreaSeriesMarkerItemStylerParams<TDatum, TContext>,

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedAxisOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedAxisOptions.ts
@@ -42,6 +42,7 @@ import type {
 } from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
+import type { NormalisedColorType } from './normalisedCommonOptions';
 
 // --- Label normalised shapes ---
 //
@@ -74,54 +75,54 @@ type AxisLabelRequiredKeys =
  * the user-facing types where it's actually defined (per invariant I2 — only the
  * formattable subtypes carry it).
  */
-type FontFamilyMorph = { color?: CssColor; fontFamily: string };
+type AxisMorphs = { color?: CssColor; fill?: NormalisedColorType; fontFamily: string };
 
 export type NormalisedBaseAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgBaseAxisLabelOptions<TContext>,
     AxisLabelRequiredKeys,
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 export type NormalisedNumericAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgNumericAxisFormattableLabelOptions<TContext>,
     AxisLabelRequiredKeys,
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 export type NormalisedBaseCartesianAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgBaseCartesianAxisLabelOptions<TContext>,
     AxisLabelRequiredKeys,
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 export type NormalisedCartesianAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgCartesianAxisLabelOptions<TContext>,
     AxisLabelRequiredKeys,
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 export type NormalisedCartesianTimeAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgCartesianTimeAxisLabelOptions<TContext>,
     AxisLabelRequiredKeys,
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 export type NormalisedGroupedCategoryAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgGroupedCategoryAxisLabelOptions<TContext>,
     AxisLabelRequiredKeys,
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 export type NormalisedAngleAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgAngleAxisLabelOptions<TContext>,
     AxisLabelRequiredKeys | 'orientation',
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 export type NormalisedAngleAxisFormattableLabelOptions<TContext = ContextDefault> = Normalised<
     AgAngleAxisFormattableLabelOptions<TContext>,
     AxisLabelRequiredKeys | 'orientation',
-    FontFamilyMorph
+    AxisMorphs
 >;
 
 // --- Line / tick / gridLine normalised shapes ---

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedAxisOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedAxisOptions.ts
@@ -396,7 +396,10 @@ export type NormalisedSparklineCrosshairLabelOptions<TContext = ContextDefault> 
     'enabled' | 'xOffset' | 'yOffset'
 >;
 
-type CrosshairLabelMorph<TFormat, TContext> = { label: NormalisedCrosshairLabelOptions<TFormat, TContext> };
+type CrosshairLabelMorph<TFormat, TContext> = {
+    label: NormalisedCrosshairLabelOptions<TFormat, TContext>;
+    stroke?: CssColor;
+};
 
 export type NormalisedCrosshairOptions<TFormat = string, TContext = ContextDefault> = Normalised<
     AgCrosshairOptions<NormalisedCrosshairLabelOptions<TFormat, TContext>>,
@@ -406,7 +409,8 @@ export type NormalisedCrosshairOptions<TFormat = string, TContext = ContextDefau
 
 export type NormalisedBandHighlightOptions = Normalised<
     AgBandHighlightOptions,
-    'enabled' | 'stroke' | 'strokeWidth' | 'strokeOpacity' | 'lineDash' | 'lineDashOffset' | 'fill' | 'fillOpacity'
+    'enabled' | 'stroke' | 'strokeWidth' | 'strokeOpacity' | 'lineDash' | 'lineDashOffset' | 'fill' | 'fillOpacity',
+    { stroke?: CssColor; fill?: NormalisedColorType }
 >;
 
 // --- Cross-lines normalised shapes ---

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedAxisOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedAxisOptions.ts
@@ -42,7 +42,7 @@ import type {
 } from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
-import type { NormalisedColorType } from './normalisedCommonOptions';
+import type { NormalisedBorderOptions, NormalisedColorType } from './normalisedCommonOptions';
 
 // --- Label normalised shapes ---
 //
@@ -75,7 +75,12 @@ type AxisLabelRequiredKeys =
  * the user-facing types where it's actually defined (per invariant I2 — only the
  * formattable subtypes carry it).
  */
-type AxisMorphs = { color?: CssColor; fill?: NormalisedColorType; fontFamily: string };
+type AxisMorphs = {
+    color?: CssColor;
+    fill?: NormalisedColorType;
+    border: NormalisedBorderOptions;
+    fontFamily: string;
+};
 
 export type NormalisedBaseAxisLabelOptions<TContext = ContextDefault> = Normalised<
     AgBaseAxisLabelOptions<TContext>,

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedCartesianSeries.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedCartesianSeries.ts
@@ -21,8 +21,8 @@ export type NormalisedLineSeriesStylerResult = Normalised<
     { stroke?: CssColor; marker?: NormalisedSeriesMarkerStyle }
 >;
 
-export type NormalisedSeriesSegmentation<SegmentOptions = NormalisedSeriesShapeSegmentOptions> = Normalised<
-    AgSeriesSegmentation<SegmentOptions>,
+export type NormalisedSeriesSegmentation = Normalised<
+    AgSeriesSegmentation,
     never,
     { segments: NormalisedSeriesShapeSegmentOptions[] }
 >;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedCartesianSeries.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedCartesianSeries.ts
@@ -1,0 +1,12 @@
+import type { FillStrokeMorph } from 'ag-charts-core';
+import type { AgSeriesSegmentation, AgSeriesShapeSegmentOptions } from 'ag-charts-types';
+
+import type { Normalised } from './normalise';
+
+export type NormalisedSeriesSegmentation<SegmentOptions = NormalisedSeriesShapeSegmentOptions> = Normalised<
+    AgSeriesSegmentation<SegmentOptions>,
+    never,
+    { segments: NormalisedSeriesShapeSegmentOptions[] }
+>;
+
+export type NormalisedSeriesShapeSegmentOptions = Normalised<AgSeriesShapeSegmentOptions, never, FillStrokeMorph>;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedCartesianSeries.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedCartesianSeries.ts
@@ -1,7 +1,25 @@
-import type { FillStrokeMorph } from 'ag-charts-core';
-import type { AgSeriesSegmentation, AgSeriesShapeSegmentOptions } from 'ag-charts-types';
+import type {
+    AgBarSeriesStyle,
+    AgHistogramSeriesStyle,
+    AgLineSeriesStylerResult,
+    AgSeriesSegmentation,
+    AgSeriesShapeSegmentOptions,
+    CssColor,
+} from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
+import type { FillStrokeMorph } from './normalisedCommonOptions';
+import type { NormalisedSeriesMarkerStyle } from './normalisedSeriesMarkerOptions';
+
+export type NormalisedBarSeriesStyle = Normalised<AgBarSeriesStyle, never, FillStrokeMorph>;
+
+export type NormalisedHistogramSeriesStyle = Normalised<AgHistogramSeriesStyle, never, FillStrokeMorph>;
+
+export type NormalisedLineSeriesStylerResult = Normalised<
+    AgLineSeriesStylerResult,
+    never,
+    { stroke?: CssColor; marker?: NormalisedSeriesMarkerStyle }
+>;
 
 export type NormalisedSeriesSegmentation<SegmentOptions = NormalisedSeriesShapeSegmentOptions> = Normalised<
     AgSeriesSegmentation<SegmentOptions>,

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedCommonOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedCommonOptions.ts
@@ -1,6 +1,10 @@
 import type {
     AgGradientColor,
+    AgGradientColorBounds,
     AgGradientColorStop,
+    AgGradientType,
+    AgImageFill,
+    AgPatternColor,
     BorderOptions,
     CssColor,
     FillOptions,
@@ -12,11 +16,6 @@ import type {
     TextValue,
 } from 'ag-charts-types';
 
-import type {
-    InternalAgGradientColor,
-    InternalAgImageFill,
-    InternalAgPatternColor,
-} from '../../config/optionsDefaults';
 import type { Normalised } from './normalise';
 
 export type NormalisedPaddingOptions = Normalised<PaddingOptions, 'top' | 'right' | 'bottom' | 'left'>;
@@ -26,18 +25,57 @@ export type NormalisedTextSegment = Normalised<TextSegment, never, { color?: Css
 export type NormalisedContentSegment = NormalisedTextSegment | ImageSegment;
 export type NormalisedTextOrSegments = TextValue | NormalisedContentSegment[];
 
-export type NormalisedColorType = CssColor | InternalAgGradientColor | InternalAgPatternColor | InternalAgImageFill;
-
-export type NormalisedFillOptions = Normalised<FillOptions, never, { fill?: NormalisedColorType }>;
-export type NormalisedStrokeOptions = Normalised<StrokeOptions, never, { stroke?: CssColor }>;
-
-export type NormalisedBorderOptions = Normalised<BorderOptions, never, { stroke?: CssColor }>;
+export type ColorSpace = 'rgb' | 'oklch';
 
 export type NormalisedGradientColorStop = Normalised<AgGradientColorStop, never, { color?: CssColor }>;
 export type NormalisedGradientColor = Normalised<
     AgGradientColor,
     never,
     { colorStops?: NormalisedGradientColorStop[] }
+>;
+
+export interface InternalAgGradientColor extends NormalisedGradientColor {
+    /** Format of the gradient */
+    gradient?: AgGradientType;
+    /** The domain of the colour gradient, defaults to item. */
+    bounds?: AgGradientColorBounds;
+    /** Reverse the order of colour stops. */
+    reverse?: boolean;
+    /** Colour space to use when interpolating colours in the gradient. */
+    colorSpace?: ColorSpace;
+}
+
+export interface InternalAgPatternColor extends AgPatternColor {
+    /** Padding for the shape in the pattern unit. */
+    padding?: number;
+}
+export interface InternalAgImageFill extends AgImageFill {}
+
+export type RequiredInternalAgImageFill = Required<Omit<InternalAgImageFill, 'url' | 'width' | 'height'>> &
+    Pick<Partial<InternalAgImageFill>, 'url'> &
+    Pick<InternalAgImageFill, 'width' | 'height'>;
+
+export type RequiredInternalAgPatternColor = Required<Omit<InternalAgPatternColor, 'path'>> &
+    Pick<InternalAgPatternColor, 'path'>;
+
+export type RequiredInternalAgGradientColor = Required<InternalAgGradientColor>;
+
+export type InternalAgColorType = CssColor | InternalAgGradientColor | InternalAgPatternColor | InternalAgImageFill;
+export type RequiredInternalAgColorType =
+    | CssColor
+    | RequiredInternalAgGradientColor
+    | RequiredInternalAgPatternColor
+    | (RequiredInternalAgImageFill & Pick<InternalAgImageFill, 'url'>);
+
+export type NormalisedColorType = CssColor | InternalAgGradientColor | InternalAgPatternColor | InternalAgImageFill;
+
+export type NormalisedFillOptions = Normalised<FillOptions, never, { fill?: NormalisedColorType }>;
+export type NormalisedStrokeOptions = Normalised<StrokeOptions, never, { stroke?: CssColor }>;
+
+export type NormalisedBorderOptions = Normalised<
+    BorderOptions,
+    'enabled' | 'strokeWidth' | 'strokeOpacity',
+    { stroke?: CssColor }
 >;
 
 export type FillStrokeMorph = { fill?: NormalisedColorType; stroke?: CssColor };

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedCommonOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedCommonOptions.ts
@@ -1,13 +1,43 @@
-import type { CssColor, ImageSegment, PaddingOptions, TextOptions, TextSegment, TextValue } from 'ag-charts-types';
+import type {
+    AgGradientColor,
+    AgGradientColorStop,
+    BorderOptions,
+    CssColor,
+    FillOptions,
+    ImageSegment,
+    PaddingOptions,
+    StrokeOptions,
+    TextOptions,
+    TextSegment,
+    TextValue,
+} from 'ag-charts-types';
 
+import type {
+    InternalAgGradientColor,
+    InternalAgImageFill,
+    InternalAgPatternColor,
+} from '../../config/optionsDefaults';
 import type { Normalised } from './normalise';
 
 export type NormalisedPaddingOptions = Normalised<PaddingOptions, 'top' | 'right' | 'bottom' | 'left'>;
 
 export type NormalisedTextOptions = Normalised<TextOptions, never, { color?: CssColor }>;
-
 export type NormalisedTextSegment = Normalised<TextSegment, never, { color?: CssColor }>;
-
 export type NormalisedContentSegment = NormalisedTextSegment | ImageSegment;
-
 export type NormalisedTextOrSegments = TextValue | NormalisedContentSegment[];
+
+export type NormalisedColorType = CssColor | InternalAgGradientColor | InternalAgPatternColor | InternalAgImageFill;
+
+export type NormalisedFillOptions = Normalised<FillOptions, never, { fill?: NormalisedColorType }>;
+export type NormalisedStrokeOptions = Normalised<StrokeOptions, never, { stroke?: CssColor }>;
+
+export type NormalisedBorderOptions = Normalised<BorderOptions, never, { stroke?: CssColor }>;
+
+export type NormalisedGradientColorStop = Normalised<AgGradientColorStop, never, { color?: CssColor }>;
+export type NormalisedGradientColor = Normalised<
+    AgGradientColor,
+    never,
+    { colorStops?: NormalisedGradientColorStop[] }
+>;
+
+export type FillStrokeMorph = { fill?: NormalisedColorType; stroke?: CssColor };

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedDonutSeries.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedDonutSeries.ts
@@ -1,0 +1,12 @@
+import type { AgDonutSeriesStyle, AgDonutSeriesTooltipRendererParams } from 'ag-charts-types';
+
+import type { Normalised } from './normalise';
+import type { FillStrokeMorph } from './normalisedCommonOptions';
+
+export type NormalisedDonutSeriesStyle = Normalised<AgDonutSeriesStyle, never, FillStrokeMorph>;
+
+export type NormalisedDonutSeriesTooltipRendererParams<T> = Normalised<
+    AgDonutSeriesTooltipRendererParams<T>,
+    never,
+    FillStrokeMorph
+>;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedLabelOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedLabelOptions.ts
@@ -1,5 +1,10 @@
 import type { AgChartLabelStyleOptions, CssColor } from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
+import type { NormalisedBorderOptions, NormalisedColorType } from './normalisedCommonOptions';
 
-export type NormalisedChartLabelStyleOptions = Normalised<AgChartLabelStyleOptions, never, { color?: CssColor }>;
+export type NormalisedChartLabelStyleOptions = Normalised<
+    AgChartLabelStyleOptions,
+    never,
+    { color?: CssColor; fill?: NormalisedColorType; border?: NormalisedBorderOptions }
+>;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedLabelOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedLabelOptions.ts
@@ -1,10 +1,12 @@
-import type { AgChartLabelStyleOptions, CssColor } from 'ag-charts-types';
+import type { AgChartLabelStyleOptions, BorderOptions, CssColor } from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
-import type { NormalisedBorderOptions, NormalisedColorType } from './normalisedCommonOptions';
+import type { NormalisedColorType } from './normalisedCommonOptions';
 
+// Unlike the strict `NormalisedBorderOptions` (used by the legend), a label border leaves
+// `strokeWidth`/`strokeOpacity` optional — they have no theme default on label styles.
 export type NormalisedChartLabelStyleOptions = Normalised<
     AgChartLabelStyleOptions,
     never,
-    { color?: CssColor; fill?: NormalisedColorType; border?: NormalisedBorderOptions }
+    { color?: CssColor; fill?: NormalisedColorType; border?: Normalised<BorderOptions, never, { stroke?: CssColor }> }
 >;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedLegendOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedLegendOptions.ts
@@ -8,16 +8,13 @@ import type {
     AgPaginationLabelOptions,
     AgPaginationMarkerOptions,
     AgPaginationMarkerStyle,
-    BorderOptions,
     CssColor,
 } from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
-import type { NormalisedPaddingOptions } from './normalisedCommonOptions';
+import type { NormalisedBorderOptions, NormalisedColorType, NormalisedPaddingOptions } from './normalisedCommonOptions';
 
 // --- Leaf normalised types ---
-
-export type NormalisedBorderOptions = Normalised<BorderOptions, 'enabled' | 'stroke' | 'strokeWidth' | 'strokeOpacity'>;
 
 export type NormalisedLegendMarkerOptions = Normalised<
     AgChartLegendMarkerOptions,
@@ -96,6 +93,7 @@ export type NormalisedLegendOptions = Normalised<
     | 'fillOpacity',
     {
         border: NormalisedBorderOptions;
+        fill: NormalisedColorType;
         item: NormalisedLegendItemOptions;
         pagination: NormalisedLegendPaginationOptions;
     }

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedLegendOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedLegendOptions.ts
@@ -33,7 +33,7 @@ export type NormalisedLegendLabelOptions = Normalised<
 export type NormalisedPaginationMarkerStyle = Normalised<
     AgPaginationMarkerStyle,
     'fill' | 'strokeWidth' | 'strokeOpacity',
-    { fill: string }
+    { fill: string; stroke?: CssColor }
 >;
 
 export type NormalisedPaginationMarkerOptions = Normalised<

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedPieSeries.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedPieSeries.ts
@@ -1,0 +1,6 @@
+import type { AgPieSeriesStyle } from 'ag-charts-types';
+
+import type { Normalised } from './normalise';
+import type { FillStrokeMorph } from './normalisedCommonOptions';
+
+export type NormalisedPieSeriesStyle = Normalised<AgPieSeriesStyle, never, FillStrokeMorph>;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedSeriesMarkerOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedSeriesMarkerOptions.ts
@@ -1,0 +1,12 @@
+import type { AgSeriesMarkerStyle, AgSeriesMarkerStylerParams } from 'ag-charts-types';
+
+import type { Normalised } from './normalise';
+import type { FillStrokeMorph, NormalisedColorType } from './normalisedCommonOptions';
+
+export type NormalisedSeriesMarkerStyle = Normalised<AgSeriesMarkerStyle, never, { fill?: NormalisedColorType }>;
+
+export type NormalisedSeriesMarkerStylerParams<TDatum, TContext> = Normalised<
+    AgSeriesMarkerStylerParams<TDatum, TContext>,
+    never,
+    FillStrokeMorph
+>;

--- a/packages/ag-charts-core/src/types/normalised-options/normalisedSeriesMarkerOptions.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/normalisedSeriesMarkerOptions.ts
@@ -1,9 +1,9 @@
 import type { AgSeriesMarkerStyle, AgSeriesMarkerStylerParams } from 'ag-charts-types';
 
 import type { Normalised } from './normalise';
-import type { FillStrokeMorph, NormalisedColorType } from './normalisedCommonOptions';
+import type { FillStrokeMorph } from './normalisedCommonOptions';
 
-export type NormalisedSeriesMarkerStyle = Normalised<AgSeriesMarkerStyle, never, { fill?: NormalisedColorType }>;
+export type NormalisedSeriesMarkerStyle = Normalised<AgSeriesMarkerStyle, never, FillStrokeMorph>;
 
 export type NormalisedSeriesMarkerStylerParams<TDatum, TContext> = Normalised<
     AgSeriesMarkerStylerParams<TDatum, TContext>,

--- a/packages/ag-charts-core/src/utils/geometry/fill.ts
+++ b/packages/ag-charts-core/src/utils/geometry/fill.ts
@@ -1,6 +1,9 @@
 import type { AgImageFill, AgPatternColor } from 'ag-charts-types';
 
-import type { InternalAgColorType, InternalAgGradientColor } from '../../config/optionsDefaults';
+import type {
+    InternalAgColorType,
+    InternalAgGradientColor,
+} from '../../types/normalised-options/normalisedCommonOptions';
 import { isArray, isObject } from '../types/typeGuards';
 
 export function isGradientFill(fill: any): fill is InternalAgGradientColor {

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/capScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/capScene.ts
@@ -1,11 +1,10 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import { Vec2 } from 'ag-charts-core';
-import type { CssColor, StrokeOptions } from 'ag-charts-types';
+import { type NormalisedStrokeOptions, Vec2 } from 'ag-charts-core';
 
 export abstract class CapScene extends _ModuleSupport.Group {
     abstract type: string;
 
-    abstract update(options: { x: number; y: number; angle: number } & StrokeOptions): void;
+    abstract update(options: { x: number; y: number; angle: number } & NormalisedStrokeOptions): void;
 }
 
 export class ArrowCapScene extends CapScene {
@@ -19,7 +18,7 @@ export class ArrowCapScene extends CapScene {
         this.append([this.path]);
     }
 
-    update(options: { x: number; y: number; angle: number } & StrokeOptions) {
+    update(options: { x: number; y: number; angle: number } & NormalisedStrokeOptions) {
         const { path } = this;
         const { x, y, angle, ...rest } = options;
 
@@ -30,8 +29,7 @@ export class ArrowCapScene extends CapScene {
         const leftEnd = Vec2.rotate(Vec2.from(0, armLength), angle + offsetAngle, origin);
         const rightEnd = Vec2.rotate(Vec2.from(armLength, 0), angle - offsetAngle, origin);
 
-        // Stroke refs are resolved before reaching the scene node.
-        path.setProperties(rest as StrokeOptions & { stroke?: CssColor });
+        path.setProperties(rest);
         path.fillOpacity = 0;
 
         path.path.clear();

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/capScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/capScene.ts
@@ -1,6 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
 import { Vec2 } from 'ag-charts-core';
-import type { StrokeOptions } from 'ag-charts-types';
+import type { CssColor, StrokeOptions } from 'ag-charts-types';
 
 export abstract class CapScene extends _ModuleSupport.Group {
     abstract type: string;
@@ -30,7 +30,8 @@ export class ArrowCapScene extends CapScene {
         const leftEnd = Vec2.rotate(Vec2.from(0, armLength), angle + offsetAngle, origin);
         const rightEnd = Vec2.rotate(Vec2.from(armLength, 0), angle - offsetAngle, origin);
 
-        path.setProperties(rest);
+        // Stroke refs are resolved before reaching the scene node.
+        path.setProperties(rest as StrokeOptions & { stroke?: CssColor });
         path.fillOpacity = 0;
 
         path.path.clear();

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/startEndScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/startEndScene.ts
@@ -1,4 +1,5 @@
 import type { AgAnnotationHandleStyles, _ModuleSupport } from 'ag-charts-community';
+import type { FillStrokeMorph, Normalised } from 'ag-charts-core';
 import { type Bounds4, type BoxBounds, type Point, Vec2, Vec4, entries } from 'ag-charts-core';
 
 import type { AnnotationContext } from '../annotationTypes';
@@ -9,6 +10,8 @@ import { DivariantHandle } from './handle';
 import { LinearScene } from './linearScene';
 
 export type StartEndHandle = 'start' | 'end';
+
+type NormalisedAnnotationHandleStyles = Normalised<AgAnnotationHandleStyles, never, FillStrokeMorph>;
 
 export abstract class StartEndScene<Datum extends StartEndProperties> extends LinearScene<Datum> {
     override activeHandle?: StartEndHandle;
@@ -112,12 +115,13 @@ export abstract class StartEndScene<Datum extends StartEndProperties> extends Li
     }
 
     protected updateHandles(datum: Datum, coords: Bounds4, bbox?: _ModuleSupport.BBox) {
+        // Colour refs in the handle styles are resolved at runtime before reaching the scene node.
         this.start.update({
-            ...this.getHandleStyles(datum, 'start'),
+            ...(this.getHandleStyles(datum, 'start') as NormalisedAnnotationHandleStyles),
             ...this.getHandleCoords(datum, coords, 'start'),
         });
         this.end.update({
-            ...this.getHandleStyles(datum, 'end'),
+            ...(this.getHandleStyles(datum, 'end') as NormalisedAnnotationHandleStyles),
             ...this.getHandleCoords(datum, coords, 'end', bbox),
         });
 

--- a/packages/ag-charts-enterprise/src/features/annotations/scenes/withBackgroundScene.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/scenes/withBackgroundScene.ts
@@ -1,5 +1,5 @@
 import type { _ModuleSupport } from 'ag-charts-community';
-import { type Bounds4, type Point, Vec4 } from 'ag-charts-core';
+import { type Bounds4, type NormalisedFillOptions, type Point, Vec4 } from 'ag-charts-core';
 import type { FillOptions } from 'ag-charts-types';
 
 import type { AnnotationContext } from '../annotationTypes';
@@ -37,7 +37,8 @@ export class WithBackgroundScene {
         background.path.closePath();
         background.checkPathDirty();
 
-        const backgroundStyles = this.getBackgroundStyles?.(datum) ?? datum.background;
+        // Colour refs are resolved during theme-merge, so the fill is a concrete colour by render time.
+        const backgroundStyles = (this.getBackgroundStyles?.(datum) ?? datum.background) as NormalisedFillOptions;
         background.fill = backgroundStyles.fill;
         background.fillOpacity = backgroundStyles.fillOpacity ?? 1;
     }

--- a/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
+++ b/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
@@ -3,12 +3,10 @@ import {
     AbstractModuleInstance,
     ChartAxisDirection,
     ChartUpdateType,
-    type InternalAgColorType,
     type NormalisedBandHighlightOptions,
     ZIndexMap,
     createId,
 } from 'ag-charts-core';
-import type { CssColor } from 'ag-charts-types';
 
 const {
     Range,
@@ -161,18 +159,12 @@ export class BandHighlight extends AbstractModuleInstance {
 
         const { stroke, strokeWidth, strokeOpacity, lineDash, fill, fillOpacity, lineDashOffset } = options;
 
-        // Colour refs are resolved during theme-merge, so stroke/fill are concrete by render.
-        node.stroke = stroke as CssColor;
+        node.stroke = stroke;
         node.strokeWidth = strokeWidth;
         node.strokeOpacity = strokeOpacity;
         node.lineDash = lineDash;
         node.lineDashOffset = lineDashOffset;
-        node.fill = getShapeFill(
-            fill as InternalAgColorType,
-            this.fillGradientDefaults,
-            this.fillPatternDefaults,
-            this.fillImageDefaults
-        );
+        node.fill = getShapeFill(fill, this.fillGradientDefaults, this.fillPatternDefaults, this.fillImageDefaults);
         node.fillOpacity = fillOpacity;
         node.startLine = true;
         node.endLine = true;

--- a/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
+++ b/packages/ag-charts-enterprise/src/features/band-highlight/bandHighlight.ts
@@ -3,10 +3,12 @@ import {
     AbstractModuleInstance,
     ChartAxisDirection,
     ChartUpdateType,
+    type InternalAgColorType,
     type NormalisedBandHighlightOptions,
     ZIndexMap,
     createId,
 } from 'ag-charts-core';
+import type { CssColor } from 'ag-charts-types';
 
 const {
     Range,
@@ -159,12 +161,18 @@ export class BandHighlight extends AbstractModuleInstance {
 
         const { stroke, strokeWidth, strokeOpacity, lineDash, fill, fillOpacity, lineDashOffset } = options;
 
-        node.stroke = stroke;
+        // Colour refs are resolved during theme-merge, so stroke/fill are concrete by render.
+        node.stroke = stroke as CssColor;
         node.strokeWidth = strokeWidth;
         node.strokeOpacity = strokeOpacity;
         node.lineDash = lineDash;
         node.lineDashOffset = lineDashOffset;
-        node.fill = getShapeFill(fill, this.fillGradientDefaults, this.fillPatternDefaults, this.fillImageDefaults);
+        node.fill = getShapeFill(
+            fill as InternalAgColorType,
+            this.fillGradientDefaults,
+            this.fillPatternDefaults,
+            this.fillImageDefaults
+        );
         node.fillOpacity = fillOpacity;
         node.startLine = true;
         node.endLine = true;

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -17,6 +17,7 @@ import {
     createId,
     toPlainText,
 } from 'ag-charts-core';
+import type { CssColor } from 'ag-charts-types';
 
 import { readDatum } from '../../utils/datum';
 import { CrosshairLabel } from './crosshairLabel';
@@ -242,7 +243,8 @@ export class Crosshair
         const isVertical = this.isVertical();
 
         lineGroupSelection.each((line) => {
-            line.stroke = stroke;
+            // Colour refs are resolved during theme-merge, so this is a concrete CSS colour by render.
+            line.stroke = stroke as CssColor;
             line.strokeWidth = strokeWidth;
             line.strokeOpacity = strokeOpacity;
             line.lineDash = lineDash;

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -17,7 +17,6 @@ import {
     createId,
     toPlainText,
 } from 'ag-charts-core';
-import type { CssColor } from 'ag-charts-types';
 
 import { readDatum } from '../../utils/datum';
 import { CrosshairLabel } from './crosshairLabel';
@@ -243,8 +242,7 @@ export class Crosshair
         const isVertical = this.isVertical();
 
         lineGroupSelection.each((line) => {
-            // Colour refs are resolved during theme-merge, so this is a concrete CSS colour by render.
-            line.stroke = stroke as CssColor;
+            line.stroke = stroke;
             line.strokeWidth = strokeWidth;
             line.strokeOpacity = strokeOpacity;
             line.lineDash = lineDash;

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -1,6 +1,6 @@
 import type { AgErrorBarOptions, AgErrorBarThemeableOptions } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import type { PickNodeDatumResult, RequireOptional } from 'ag-charts-core';
+import type { Normalised, PickNodeDatumResult, RequireOptional } from 'ag-charts-core';
 import {
     type NearestResult,
     mergeDefaults,
@@ -12,6 +12,7 @@ import type {
     AgBarSeriesItemStylerParams,
     AgLineSeriesMarkerItemStylerParams,
     AgScatterSeriesItemStylerParams,
+    CssColor,
     HighlightState,
     SelectionState,
 } from 'ag-charts-types';
@@ -21,6 +22,8 @@ const { BBox } = _ModuleSupport;
 export type ErrorBarNodeDatum = _ModuleSupport.CartesianSeriesNodeDatum &
     _ModuleSupport.ErrorBoundSeriesNodeDatum & { yKey: string };
 export type ErrorBarStylingOptions = Omit<AgErrorBarThemeableOptions, 'cap'>;
+// Resolved render-time shape: refs are resolved to concrete colours during theme-merge before reaching scene nodes.
+type NormalisedErrorBarStylingOptions = Normalised<ErrorBarStylingOptions, never, { stroke?: CssColor }>;
 
 type ErrorBarKey = 'xLowerKey' | 'xUpperKey' | 'yLowerKey' | 'yUpperKey';
 type IgnoredSeriesKey = 'context' | 'size' | 'shape' | 'fill' | 'fillOpacity' | 'labelKey' | 'colorKey';
@@ -160,7 +163,7 @@ export class ErrorBarNode extends _ModuleSupport.Group<ErrorBarNodeDatum> {
         return { whiskerStyle, capsStyle };
     }
 
-    private applyStyling(target: _ModuleSupport.Path, source?: ErrorBarStylingOptions) {
+    private applyStyling(target: _ModuleSupport.Path, source?: NormalisedErrorBarStylingOptions) {
         // Style can be any object, including user data (e.g. formatter
         // result). So filter out anything that isn't styling options:
         partialAssign(
@@ -193,7 +196,8 @@ export class ErrorBarNode extends _ModuleSupport.Group<ErrorBarNodeDatum> {
         const { xBar, yBar, capDefaults } = this.datum;
 
         const whisker = this.whiskerPath;
-        this.applyStyling(whisker, whiskerStyle);
+        // Refs resolved at runtime before render.
+        this.applyStyling(whisker, whiskerStyle as NormalisedErrorBarStylingOptions);
         whisker.path.clear(true);
         if (yBar !== undefined) {
             whisker.path.moveTo(yBar.lowerPoint.x, yBar.lowerPoint.y);
@@ -210,7 +214,8 @@ export class ErrorBarNode extends _ModuleSupport.Group<ErrorBarNodeDatum> {
         this.capLength = this.calculateCapLength(capsStyle ?? {}, capDefaults);
         const capOffset = this.capLength / 2;
         const caps = this.capsPath;
-        this.applyStyling(caps, capsStyle);
+        // Refs resolved at runtime before render.
+        this.applyStyling(caps, capsStyle as NormalisedErrorBarStylingOptions);
         caps.path.clear(true);
         if (yBar !== undefined) {
             caps.path.moveTo(yBar.lowerPoint.x - capOffset, yBar.lowerPoint.y);

--- a/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
+++ b/packages/ag-charts-enterprise/src/features/error-bar/errorBarNode.ts
@@ -24,6 +24,15 @@ export type ErrorBarNodeDatum = _ModuleSupport.CartesianSeriesNodeDatum &
 export type ErrorBarStylingOptions = Omit<AgErrorBarThemeableOptions, 'cap'>;
 // Resolved render-time shape: refs are resolved to concrete colours during theme-merge before reaching scene nodes.
 type NormalisedErrorBarStylingOptions = Normalised<ErrorBarStylingOptions, never, { stroke?: CssColor }>;
+type NormalisedErrorBarCapStyle = Normalised<
+    NonNullable<AgErrorBarThemeableOptions['cap']>,
+    never,
+    { stroke?: CssColor }
+>;
+type NormalisedErrorBarStyles = {
+    whiskerStyle: NormalisedErrorBarStylingOptions;
+    capsStyle: NormalisedErrorBarCapStyle | undefined;
+};
 
 type ErrorBarKey = 'xLowerKey' | 'xUpperKey' | 'yLowerKey' | 'yUpperKey';
 type IgnoredSeriesKey = 'context' | 'size' | 'shape' | 'fill' | 'fillOpacity' | 'labelKey' | 'colorKey';
@@ -147,7 +156,7 @@ export class ErrorBarNode extends _ModuleSupport.Group<ErrorBarNodeDatum> {
         highlightState: HighlightState,
         selectionState: SelectionState | undefined,
         candidateState: SelectionState | undefined
-    ) {
+    ): NormalisedErrorBarStyles {
         let { cap: capsStyle, ...whiskerStyle } = style;
 
         const params = this.getItemStylerParams(options, style, highlightState, selectionState, candidateState);
@@ -160,7 +169,8 @@ export class ErrorBarNode extends _ModuleSupport.Group<ErrorBarNodeDatum> {
             capsStyle = mergeDefaults(result?.cap, result, capsStyle);
         }
 
-        return { whiskerStyle, capsStyle };
+        // Colour refs are resolved at runtime before render, so the styles are concrete here.
+        return { whiskerStyle, capsStyle } as NormalisedErrorBarStyles;
     }
 
     private applyStyling(target: _ModuleSupport.Path, source?: NormalisedErrorBarStylingOptions) {
@@ -196,8 +206,7 @@ export class ErrorBarNode extends _ModuleSupport.Group<ErrorBarNodeDatum> {
         const { xBar, yBar, capDefaults } = this.datum;
 
         const whisker = this.whiskerPath;
-        // Refs resolved at runtime before render.
-        this.applyStyling(whisker, whiskerStyle as NormalisedErrorBarStylingOptions);
+        this.applyStyling(whisker, whiskerStyle);
         whisker.path.clear(true);
         if (yBar !== undefined) {
             whisker.path.moveTo(yBar.lowerPoint.x, yBar.lowerPoint.y);
@@ -214,8 +223,7 @@ export class ErrorBarNode extends _ModuleSupport.Group<ErrorBarNodeDatum> {
         this.capLength = this.calculateCapLength(capsStyle ?? {}, capDefaults);
         const capOffset = this.capLength / 2;
         const caps = this.capsPath;
-        // Refs resolved at runtime before render.
-        this.applyStyling(caps, capsStyle as NormalisedErrorBarStylingOptions);
+        this.applyStyling(caps, capsStyle);
         caps.path.clear(true);
         if (yBar !== undefined) {
             caps.path.moveTo(yBar.lowerPoint.x - capOffset, yBar.lowerPoint.y);

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -17,6 +17,7 @@ import {
     isTimeIntervalUnit,
     isValidDate,
 } from 'ag-charts-core';
+import type { CssColor } from 'ag-charts-types';
 
 const { userInteraction, LayoutElement, Toolbar } = _ModuleSupport;
 
@@ -344,7 +345,8 @@ export class Ranges extends AbstractModuleInstance {
         return {
             fill: this.getComponentFill(stateStyles.fill, stateStyles.fillOpacity),
             fillOpacity: stateStyles.fillOpacity,
-            stroke: stateStyles.stroke,
+            // Colour refs are resolved during theme-merge, so this is a concrete CSS colour by render.
+            stroke: stateStyles.stroke as CssColor,
             textColor: stateStyles.textColor,
         };
     }

--- a/packages/ag-charts-enterprise/src/features/scrollbar/scrollbar.ts
+++ b/packages/ag-charts-enterprise/src/features/scrollbar/scrollbar.ts
@@ -4,6 +4,8 @@ import {
     ChartAxisDirection,
     ChartUpdateType,
     type DynamicContext,
+    type FillStrokeMorph,
+    type Normalised,
     UNIT_MAX,
     UNIT_MIN,
     ZIndexMap,
@@ -11,6 +13,7 @@ import {
     definedZoomState,
     isNumberEqual,
 } from 'ag-charts-core';
+import type { AgScrollbarThumbStyle, AgScrollbarTrackStyle } from 'ag-charts-types';
 
 import { ZoomScrollPanner } from '../zoom-interaction/zoomScrollPanner';
 import { ScrollbarDOMProxy } from './scrollbarDOMProxy';
@@ -18,6 +21,13 @@ import { ScrollbarDOMProxy } from './scrollbarDOMProxy';
 const { BBox, Group, Rect, LayoutElement, InteractionState } = _ModuleSupport;
 
 type ScrollbarOrientation = 'horizontal' | 'vertical';
+
+type NormalisedScrollbarTrackStyle = Normalised<AgScrollbarTrackStyle, never, FillStrokeMorph>;
+type NormalisedScrollbarThumbStyle = Normalised<
+    AgScrollbarThumbStyle,
+    never,
+    FillStrokeMorph & { hoverStyle?: FillStrokeMorph }
+>;
 
 interface ScrollbarOrientationState {
     orientation: ScrollbarOrientation;
@@ -241,18 +251,22 @@ export class Scrollbar extends AbstractModuleInstance {
     }
 
     private updateStyles({ track, thumb, properties, hovered }: ScrollbarOrientationState) {
-        track.setStyleProperties(properties.track);
+        // Colour refs are resolved during theme-merge before reaching the scene, so fill/stroke are concrete here.
+        const trackStyle = properties.track as NormalisedScrollbarTrackStyle;
+        const thumbStyle = properties.thumb as NormalisedScrollbarThumbStyle;
+
+        track.setStyleProperties(trackStyle);
         track.cornerRadius = properties.track.cornerRadius;
         track.opacity = properties.track.opacity;
 
-        thumb.setStyleProperties(properties.thumb);
+        thumb.setStyleProperties(thumbStyle);
         thumb.cornerRadius = properties.thumb.cornerRadius;
         thumb.opacity = properties.thumb.opacity;
 
-        const hoverStyle = properties.thumb.hoverStyle;
+        const hoverStyle = thumbStyle.hoverStyle;
 
-        thumb.fill = hovered ? (hoverStyle?.fill ?? properties.thumb.fill) : properties.thumb.fill;
-        thumb.stroke = hovered ? (hoverStyle?.stroke ?? properties.thumb.stroke) : properties.thumb.stroke;
+        thumb.fill = hovered ? (hoverStyle?.fill ?? thumbStyle.fill) : thumbStyle.fill;
+        thumb.stroke = hovered ? (hoverStyle?.stroke ?? thumbStyle.stroke) : thumbStyle.stroke;
     }
 
     private updateTrack(state: ScrollbarOrientationState, bounds: _ModuleSupport.BBox) {

--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegend.ts
@@ -8,6 +8,7 @@ import {
     createId,
     expandLegendPosition,
 } from 'ag-charts-core';
+import type { CssColor } from 'ag-charts-types';
 
 import { AxisTicks } from './axisTicks';
 
@@ -331,7 +332,9 @@ export class GradientLegend extends AbstractModuleInstance {
 
     private getContainerStyles() {
         const opts = this.opts;
-        const { enabled: borderEnabled, stroke, strokeOpacity, strokeWidth } = opts.border;
+        const { enabled: borderEnabled, strokeOpacity, strokeWidth } = opts.border;
+        // Colour refs are resolved during theme-merge, so the value is a concrete colour by render.
+        const stroke = opts.border.stroke as CssColor | undefined;
         const cornerRadius = opts.cornerRadius;
         const fill = opts.fill as string | undefined;
         const fillOpacity = opts.fillOpacity;

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -4,10 +4,19 @@ import {
     type AgBoxPlotSeriesOptions,
     type AgBoxPlotSeriesStyle,
     type AgBoxPlotSeriesStylerParams,
+    type AgBoxPlotWhiskerOptions,
     type SelectionState,
     _ModuleSupport,
 } from 'ag-charts-community';
-import type { CallbackParamRules, DeepRequired, DynamicContext, Mutable, RequireOptional } from 'ag-charts-core';
+import type {
+    CallbackParamRules,
+    DeepRequired,
+    DynamicContext,
+    FillStrokeMorph,
+    Mutable,
+    Normalised,
+    RequireOptional,
+} from 'ag-charts-core';
 import { ChartAxisDirection, deepClone, isNumericValue, mergeDefaults, toNumber } from 'ag-charts-core';
 import type { AgNumericValue } from 'ag-charts-types';
 
@@ -36,8 +45,25 @@ const {
     upsertNodeDatum,
 } = _ModuleSupport;
 
+/** Whisker style after theme-merge: colour refs are resolved before reaching this point. */
+type NormalisedBoxPlotWhiskerOptions = Normalised<AgBoxPlotWhiskerOptions, never, FillStrokeMorph>;
+
+/** Box plot style after theme-merge: fill/stroke (and nested whisker stroke) are resolved colours. */
+type NormalisedBoxPlotSeriesStyle = Normalised<
+    AgBoxPlotSeriesStyle,
+    never,
+    FillStrokeMorph & { whisker?: NormalisedBoxPlotWhiskerOptions }
+>;
+
+/** Highlight style after theme-merge, retaining the additional `opacity` field. */
+type NormalisedBoxPlotHighlightStyleOptions = Normalised<
+    AgBoxPlotHighlightStyleOptions,
+    never,
+    FillStrokeMorph & { whisker?: NormalisedBoxPlotWhiskerOptions }
+>;
+
 interface BoxPlotSeriesNodeDataContext extends _ModuleSupport.AbstractBarSeriesNodeDataContext<BoxPlotNodeDatum> {
-    styles: _ModuleSupport.SeriesNodeStyleContext<AgBoxPlotSeriesStyle>;
+    styles: _ModuleSupport.SeriesNodeStyleContext<NormalisedBoxPlotSeriesStyle>;
 }
 
 /**
@@ -391,7 +417,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
             visible: this.visible,
             // Set by assembleResult()
             groupScale: undefined,
-            styles: undefined as unknown as _ModuleSupport.SeriesNodeStyleContext<AgBoxPlotSeriesStyle>,
+            styles: undefined as unknown as _ModuleSupport.SeriesNodeStyleContext<NormalisedBoxPlotSeriesStyle>,
             segments: undefined,
         };
     }
@@ -759,7 +785,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         highlightState: _ModuleSupport.HighlightState | undefined,
         selectionState: _ModuleSupport.SelectionState | undefined,
         candidateState: _ModuleSupport.SelectionState | undefined
-    ): Required<AgBoxPlotSeriesStyle> & { opacity: number } {
+    ): Required<NormalisedBoxPlotSeriesStyle> & { opacity: number } {
         const {
             cap,
             cornerRadius,
@@ -773,15 +799,16 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
             styler,
             whisker,
         } = this.properties;
-        let stylerResult: AgBoxPlotSeriesStyle = {};
+        let stylerResult: NormalisedBoxPlotSeriesStyle = {};
         if (!ignoreStylerCallback && styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
             stylerResult =
-                this.ctx.optionsGraphService.resolvePartial(
+                // resolvePartial resolves colour refs, so the result is a normalised style.
+                (this.ctx.optionsGraphService.resolvePartial(
                     ['series', `${this.declarationOrder}`],
                     this.cachedCallWithContext(styler, stylerParams) ?? {},
                     { pick: false }
-                ) ?? {};
+                ) as NormalisedBoxPlotSeriesStyle) ?? {};
         }
         return {
             cornerRadius: stylerResult.cornerRadius ?? cornerRadius,
@@ -810,7 +837,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         highlightState: _ModuleSupport.HighlightState | undefined,
         selectionState: _ModuleSupport.SelectionState | undefined,
         candidateState: _ModuleSupport.SelectionState | undefined
-    ): Required<AgBoxPlotSeriesStyle> {
+    ): Required<NormalisedBoxPlotSeriesStyle> {
         const { properties } = this;
         const { itemStyler } = properties;
 
@@ -852,7 +879,11 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         return style;
     }
 
-    private makeItemStylerParams(datumIndex: number, isHighlight: boolean, style: Required<AgBoxPlotSeriesStyle>) {
+    private makeItemStylerParams(
+        datumIndex: number,
+        isHighlight: boolean,
+        style: Required<NormalisedBoxPlotSeriesStyle>
+    ) {
         const { id: seriesId } = this;
         const { xKey, minKey, q1Key, medianKey, q3Key, maxKey } = this.properties;
 
@@ -892,7 +923,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
 
         if (itemStyler == null) {
             // No itemStyler: style is a pure function of (highlightState, selectionState).
-            const styleByState = new Map<string, Required<AgBoxPlotSeriesStyle>>();
+            const styleByState = new Map<string, Required<NormalisedBoxPlotSeriesStyle>>();
             const thisSeries = this;
 
             datumSelection.each(function updateDatumSelectionStyles(_, nodeDatum) {
@@ -955,10 +986,11 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         const wickStrokeAlignment = properties.whisker.strokeWidth ?? properties.strokeWidth;
 
         datumSelection.each((boxPlotNode, nodeDatum) => {
+            // Colour refs are resolved at theme-merge, so the style is normalised by render.
             const style = (nodeDatum.style ??
                 contextNodeData.styles[
                     this.getHighlightState(highlightedDatum, isHighlight, nodeDatum.datumIndex)
-                ]) as DeepRequired<AgBoxPlotHighlightStyleOptions>;
+                ]) as DeepRequired<NormalisedBoxPlotHighlightStyleOptions>;
             boxPlotNode.setFillProperties(style.fill, fillBBox);
 
             const nodeOpacity = style.opacity ?? 1;

--- a/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/candlestick/candlestickSeries.ts
@@ -1,9 +1,24 @@
 import { type AgCandlestickSeriesOptions, _ModuleSupport } from 'ag-charts-community';
-import { type InternalAgGradientColor, isGradientFill, isImageFill, isPatternFill } from 'ag-charts-core';
+import {
+    type FillStrokeMorph,
+    type InternalAgGradientColor,
+    type Normalised,
+    isGradientFill,
+    isImageFill,
+    isPatternFill,
+} from 'ag-charts-core';
+import type { CssColor } from 'ag-charts-types';
 
 import { type OhlcNodeDatum, OhlcSeriesBase, type OhlcSeriesBaseTypes } from '../ohlc/ohlcSeriesBase';
 import { CandlestickNode } from './candlestickNode';
 import { CandlestickSeriesProperties } from './candlestickSeriesProperties';
+
+/** Post-resolution style: colour refs are resolved to concrete colours before reaching the scene node. */
+type NormalisedCandlestickStyle = Normalised<
+    NonNullable<OhlcNodeDatum['style']>,
+    never,
+    FillStrokeMorph & { wick: Normalised<NonNullable<OhlcNodeDatum['style']>['wick'], never, { stroke?: CssColor }> }
+>;
 
 /**
  * Consolidated type interface for CandlestickSeries.
@@ -59,7 +74,8 @@ export class CandlestickSeries extends OhlcSeriesBase<CandlestickSeriesTypes> {
             const { centerX, width, y, height, yOpen, yClose, crisp } = datum;
             const baseStyle = datum.isRising ? up : down;
             const highlightState = series.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex);
-            const style = datum.style ?? contextNodeData.styles[datum.itemType][highlightState];
+            const style = (datum.style ??
+                contextNodeData.styles[datum.itemType][highlightState]) as NormalisedCandlestickStyle;
 
             node.setStaticProperties(centerX, width, y, height, yOpen, yClose, crisp);
 

--- a/packages/ag-charts-enterprise/src/series/chord/chordSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/chord/chordSeries.ts
@@ -2,7 +2,9 @@ import { _ModuleSupport } from 'ag-charts-community';
 import {
     type CallbackParamRules,
     type DynamicContext,
+    type FillStrokeMorph,
     Logger,
+    type Normalised,
     type RequireOptional,
     angleBetween,
     cachedTextMeasurer,
@@ -32,6 +34,8 @@ import { ChordLink, bezierControlPoints } from './chordLink';
 import { ChordSeriesProperties } from './chordSeriesProperties';
 
 const { SeriesNodePickMode, createDatumId, Sector, getShapeStyle, getLabelStyles, BBox } = _ModuleSupport;
+
+type NormalisedChordSeriesNodeStyle = Normalised<AgChordSeriesNodeStyle, never, FillStrokeMorph>;
 
 interface ChordNodeDatum extends FlowProportionNodeDatum<ChordNodeDatum, ChordLinkDatum> {
     centerX: number;
@@ -454,7 +458,7 @@ export class ChordSeries extends FlowProportionSeries<
     private makeItemStylerParams(
         { datum, datumIndex, size = 0, label }: Partial<ChordNodeDatum>,
         isHighlight: boolean,
-        style: Required<AgChordSeriesNodeStyle>
+        style: Required<NormalisedChordSeriesNodeStyle>
     ) {
         const { id: seriesId } = this;
         const { fromKey, toKey, sizeKey } = this.properties;

--- a/packages/ag-charts-enterprise/src/series/cone-funnel/coneFunnelProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/cone-funnel/coneFunnelProperties.ts
@@ -1,11 +1,11 @@
 import type {
-    AgColorType,
     AgConeFunnelSeriesLabelFormatterParams,
     AgConeFunnelSeriesOptions,
     AgConeFunnelSeriesStyle,
     AgConeFunnelSeriesTooltipRendererParams,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
+import type { InternalAgColorType } from 'ag-charts-core';
 import { Property } from 'ag-charts-core';
 
 import type { BaseFunnelProperties } from '../funnel/baseFunnelSeriesProperties';
@@ -35,7 +35,7 @@ export class ConeFunnelProperties
     valueKey!: string;
 
     @Property
-    fills: AgColorType[] = [];
+    fills: InternalAgColorType[] = [];
 
     @Property
     fillOpacity: number = 1;

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -11,7 +11,9 @@ import type {
     ChartAxisDirection,
     DistantObject,
     DomainWithMetadata,
+    FillStrokeMorph,
     InternalAgColorType,
+    Normalised,
     Point,
 } from 'ag-charts-core';
 
@@ -47,6 +49,9 @@ const {
 type NodeStyle = Pick<FillOptions & StrokeOptions & LineDashOptions, 'fill' | 'stroke'> &
     Omit<Required<FillOptions & StrokeOptions & LineDashOptions>, 'fill' | 'stroke'>;
 
+// Fill/stroke colour refs are resolved to concrete colours before reaching scene nodes and legend markers.
+type NormalisedNodeStyle = Normalised<NodeStyle, never, FillStrokeMorph>;
+
 export interface FlowProportionLinkDatum<
     TNodeDatum extends FlowProportionNodeDatum<TNodeDatum, TLinkDatum>,
     TLinkDatum extends FlowProportionLinkDatum<TNodeDatum, TLinkDatum>,
@@ -58,7 +63,7 @@ export interface FlowProportionLinkDatum<
     fromNode: TNodeDatum;
     toNode: TNodeDatum;
     size: number;
-    style: NodeStyle;
+    style: NormalisedNodeStyle;
 }
 
 export interface FlowProportionNodeDatum<
@@ -74,7 +79,7 @@ export interface FlowProportionNodeDatum<
     id: string;
     size: number;
     label: string | undefined;
-    style: NodeStyle;
+    style: NormalisedNodeStyle;
 }
 
 export interface FlowProportionSeriesContext<
@@ -362,14 +367,14 @@ export abstract class FlowProportionSeries<
         nodeDatum: Partial<TNodeDatum>,
         fromNodeDatumIndex: FlowNodeDatumIndex,
         isHighlight: boolean
-    ): Required<NodeStyle>;
+    ): Required<NormalisedNodeStyle>;
 
     protected abstract getLinkStyle(
         datum: TLinkDatum['datum'],
         datumIndex: FlowLinkDatumIndex,
         fromNodeDatumIndex: FlowNodeDatumIndex,
         isHighlight: boolean
-    ): Required<NodeStyle>;
+    ): Required<NormalisedNodeStyle>;
 
     protected getNodeGraph(
         createNode: (node: FlowProportionNodeDatum<TNodeDatum, TLinkDatum>) => TNodeDatum,
@@ -815,7 +820,7 @@ export abstract class FlowProportionSeries<
         const datum = this.readUserDatum(datumIndex);
         const size = seriesDatum.size;
 
-        let format: Required<NodeStyle>;
+        let format: Required<NormalisedNodeStyle>;
         if (seriesDatum.type === FlowProportionDatumType.Link) {
             format = this.getLinkStyle(datum, seriesDatum.datumIndex, nodeIndex, false);
         } else {

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -7,6 +7,8 @@ import {
 import type {
     DomainWithMetadata,
     DynamicContext,
+    FillStrokeMorph,
+    Normalised,
     NormalisedTextOrSegments,
     Point,
     RequireOptional,
@@ -47,6 +49,8 @@ export type Bounds = {
     width: number;
     height: number;
 };
+
+type NormalisedFunnelSeriesStyle = Normalised<AgFunnelSeriesStyle, never, FillStrokeMorph>;
 
 export type FunnelNodeLabelDatum = Readonly<Point> & {
     datumIndex: number;
@@ -506,8 +510,11 @@ export abstract class BaseFunnelSeries<
         const fillBBox = this.getShapeFillBBox();
 
         opts.connectorSelection.each((connector, datum) => {
+            // Colour refs are resolved during theme-merge, so the style is already normalised by render.
             const { fill, fillOpacity, stroke, strokeOpacity, strokeWidth, lineDash, lineDashOffset } =
-                this.connectorStyle(datum.datumIndex);
+                this.connectorStyle(datum.datumIndex) as RequireOptional<NormalisedFunnelSeriesStyle> & {
+                    opacity: number;
+                };
 
             connector.setProperties(resetConnectorSelectionsFn(connector, datum));
 
@@ -644,8 +651,9 @@ export abstract class BaseFunnelSeries<
     }
 
     private legendItemSymbol(datumIndex: number): _ModuleSupport.LegendSymbolOptions {
+        // Colour refs are resolved during theme-merge, so the style is already normalised by render.
         const { strokeWidth, fillOpacity, strokeOpacity, lineDash, lineDashOffset, fill, stroke } =
-            this.properties.getStyle(datumIndex);
+            this.properties.getStyle(datumIndex) as Required<NormalisedFunnelSeriesStyle> & { opacity: number };
 
         return {
             marker: {

--- a/packages/ag-charts-enterprise/src/series/funnel/funnelProperties.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/funnelProperties.ts
@@ -1,5 +1,4 @@
 import type {
-    AgColorType,
     AgFunnelSeriesItemStylerParams,
     AgFunnelSeriesLabelFormatterParams,
     AgFunnelSeriesOptions,
@@ -72,7 +71,7 @@ export class FunnelProperties
     valueKey!: string;
 
     @Property
-    fills: AgColorType[] = [];
+    fills: InternalAgColorType[] = [];
 
     @Property
     fillOpacity: number = 1;

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -15,9 +15,11 @@ import {
     ChartAxisDirection,
     type DomainWithMetadata,
     type DynamicContext,
+    type FillStrokeMorph,
     type InternalAgColorType,
     Logger,
     type Mutable,
+    type Normalised,
     type NormalisedTextOrSegments,
     type Point,
     type SizedPoint,
@@ -52,13 +54,15 @@ const {
     upsertNodeDatum,
 } = _ModuleSupport;
 
+type NormalisedHeatmapSeriesStyle = Normalised<AgHeatmapSeriesStyle, never, FillStrokeMorph>;
+
 interface HeatmapNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum {
     readonly point: Readonly<SizedPoint>;
     midPoint: Readonly<Point>;
     readonly width: number;
     readonly height: number;
     readonly colorValue: any;
-    style: AgHeatmapSeriesStyle;
+    style: NormalisedHeatmapSeriesStyle;
 }
 
 interface HeatmapLabelDatum extends Point {
@@ -75,11 +79,11 @@ interface HeatmapLabelDatum extends Point {
     color: string | undefined;
     textAlign: TextAlign;
     textBaseline: VerticalAlign;
-    style: AgHeatmapSeriesStyle;
+    style: NormalisedHeatmapSeriesStyle;
 }
 
-type ItemStyle = Pick<AgHeatmapSeriesStyle, 'fill'> &
-    Required<Omit<AgHeatmapSeriesStyle, 'fill'>> & { opacity: number };
+type ItemStyle = Pick<NormalisedHeatmapSeriesStyle, 'fill'> &
+    Required<Omit<NormalisedHeatmapSeriesStyle, 'fill'>> & { opacity: number };
 
 /** Context object caching expensive lookups for createNodeData(). */
 interface HeatmapSeriesNodeDatumContext extends _ModuleSupport.CartesianCreateNodeDataContext<HeatmapNodeDatum> {
@@ -622,7 +626,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         { datumIndex, datum, colorValue }: Partial<HeatmapNodeDatum>,
         isHighlight: boolean,
         highlightState?: _ModuleSupport.HighlightState
-    ) {
+    ): NormalisedHeatmapSeriesStyle {
         const { properties } = this;
         const { itemStyler, stroke, strokeWidth, strokeOpacity, colorKey } = properties;
         const { missingDataFill } = properties.colorScale;
@@ -637,6 +641,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         } else {
             fill = 'transparent';
         }
+        // Colour refs are resolved during theme-merge before reaching scene nodes.
         const style = mergeDefaults(selectionStyle, highlightStyle, {
             fill,
             fillOpacity: 1,
@@ -644,7 +649,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
             strokeWidth,
             strokeOpacity,
             opacity: 1,
-        });
+        }) as Required<NormalisedHeatmapSeriesStyle>;
 
         let overrides;
         if (itemStyler != null && datumIndex != null) {
@@ -661,7 +666,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         datum: unknown,
         datumIndex: number,
         isHighlight: boolean,
-        style: Required<AgHeatmapSeriesStyle>
+        style: Required<NormalisedHeatmapSeriesStyle>
     ) {
         const { id: seriesId, properties } = this;
         const { xKey, yKey, colorKey } = properties;

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -11,6 +11,8 @@ import {
 import {
     type ChartAnimationPhase,
     type DynamicContext,
+    type FillStrokeMorph,
+    type Normalised,
     type NormalisedTextOrSegments,
     type Point,
     StateMachine,
@@ -24,7 +26,7 @@ import {
     toRadians,
     toTextString,
 } from 'ag-charts-core';
-import type { AgNumericValue } from 'ag-charts-types';
+import type { AgLinearGaugeSeriesStyle, AgNumericValue } from 'ag-charts-types';
 
 import { formatWithContext } from '../../utils/formatter';
 import { DatumUnion } from '../gauge-util/datumUnion';
@@ -66,6 +68,8 @@ const {
 } = _ModuleSupport;
 
 type SeriesNodeDatum = _ModuleSupport.SeriesNodeDatum;
+
+type NormalisedLinearGaugeSeriesStyle = Normalised<AgLinearGaugeSeriesStyle, never, FillStrokeMorph>;
 
 interface TargetLabel {
     enabled: boolean;
@@ -898,7 +902,8 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
             const { topLeftCornerRadius, topRightCornerRadius, bottomRightCornerRadius, bottomLeftCornerRadius } =
                 datum;
 
-            rect.setStyleProperties(datum.style, fillBBox);
+            // Colour refs are resolved during theme-merge, so the style is already normalised by render.
+            rect.setStyleProperties(datum.style as NormalisedLinearGaugeSeriesStyle, fillBBox);
             rect.topLeftCornerRadius = topLeftCornerRadius;
             rect.topRightCornerRadius = topRightCornerRadius;
             rect.bottomRightCornerRadius = bottomRightCornerRadius;
@@ -963,7 +968,8 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
             const { topLeftCornerRadius, topRightCornerRadius, bottomRightCornerRadius, bottomLeftCornerRadius } =
                 datum;
 
-            rect.setStyleProperties(datum.style, fillBBox);
+            // Colour refs are resolved during theme-merge, so the style is already normalised by render.
+            rect.setStyleProperties(datum.style as NormalisedLinearGaugeSeriesStyle, fillBBox);
 
             rect.setProperties(resetLinearGaugeSeriesResetRectFunction(rect, datum));
             rect.topLeftCornerRadius = topLeftCornerRadius;

--- a/packages/ag-charts-enterprise/src/series/map-line-background/mapLineBackgroundSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line-background/mapLineBackgroundSeries.ts
@@ -1,5 +1,5 @@
-import { type AgMapLineBackgroundOptions, _ModuleSupport } from 'ag-charts-community';
-import type { DynamicContext, FeatureCollection } from 'ag-charts-core';
+import { type AgMapLineBackgroundOptions, type AgMapLineSeriesStyle, _ModuleSupport } from 'ag-charts-community';
+import type { DynamicContext, FeatureCollection, FillStrokeMorph, Normalised } from 'ag-charts-core';
 import { Logger } from 'ag-charts-core';
 
 import { GeoGeometry, GeoGeometryRenderMode } from '../map-util/geoGeometry';
@@ -14,6 +14,8 @@ import {
 } from './mapLineBackgroundSeriesProperties';
 
 const { createDatumId, Group, Selection, PointerEvents } = _ModuleSupport;
+
+type NormalisedMapLineSeriesStyle = Normalised<AgMapLineSeriesStyle, never, FillStrokeMorph>;
 
 interface MapLineNodeDataContext extends _ModuleSupport.DataModelSeriesNodeDataContext<MapLineBackgroundNodeDatum> {}
 
@@ -199,7 +201,8 @@ export class MapLineBackgroundSeries
             geoGeometry.visible = true;
             geoGeometry.projectedGeometry = projectedGeometry;
 
-            geoGeometry.setProperties(datum.style);
+            // Colour refs are resolved during theme-merge; the resolved style holds concrete colours by render.
+            geoGeometry.setProperties(datum.style as NormalisedMapLineSeriesStyle);
         });
     }
 

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -4,7 +4,9 @@ import type {
     DynamicContext,
     Feature,
     FeatureCollection,
+    FillStrokeMorph,
     Geometry,
+    Normalised,
     PlacedLabel,
 } from 'ag-charts-core';
 import {
@@ -61,6 +63,8 @@ interface LineDataValues {
     readonly sizeValue: number | undefined;
     readonly labelValue: string | undefined;
 }
+
+type NormalisedMapLineSeriesStyle = Normalised<AgMapLineSeriesStyle, never, FillStrokeMorph>;
 
 export class MapLineSeries
     extends TopologySeries<
@@ -486,7 +490,7 @@ export class MapLineSeries
     protected getItemStyle(
         { datumIndex = 0, datum, colorValue, sizeValue }: Partial<MapLineNodeDatum>,
         isHighlight: boolean
-    ): Required<AgMapLineSeriesStyle> {
+    ): Required<NormalisedMapLineSeriesStyle> {
         const { properties, colorScale, sizeScale } = this;
         const { colorKey, colorScale: colorScaleProps, itemStyler } = properties;
         const { missingDataFill } = colorScaleProps;
@@ -503,7 +507,12 @@ export class MapLineSeries
 
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
-        const style = mergeDefaults(selectionStyle, highlightStyle, baseStyle);
+        // Colour refs in `baseStyle` are resolved before this point, so the merged style is concrete.
+        const style = mergeDefaults(
+            selectionStyle,
+            highlightStyle,
+            baseStyle
+        ) as Required<NormalisedMapLineSeriesStyle>;
 
         if (sizeValue != null) {
             style.strokeWidth = sizeScale.convertClamped(sizeValue);
@@ -524,7 +533,7 @@ export class MapLineSeries
         datum: unknown,
         datumIndex: number,
         isHighlight: boolean,
-        style: Required<AgMapLineSeriesStyle>
+        style: Required<NormalisedMapLineSeriesStyle>
     ) {
         const { id: seriesId } = this;
         const { sizeKey, idKey, labelKey, colorKey } = this.properties;
@@ -579,7 +588,8 @@ export class MapLineSeries
             geoGeometry.visible = true;
             geoGeometry.projectedGeometry = projectedGeometry;
 
-            geoGeometry.setProperties(style);
+            // Colour refs are resolved during theme-merge, so the style is concrete by render.
+            geoGeometry.setProperties(style as NormalisedMapLineSeriesStyle);
             geoGeometry.drawingMode = drawingMode;
         });
     }

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -5,9 +5,11 @@ import {
     type DynamicContext,
     type Feature,
     type FeatureCollection,
+    type FillStrokeMorph,
     type Geometry,
     type ITextMeasurer,
     Logger,
+    type Normalised,
     type PlacedLabel,
     type Point,
     type SizedPoint,
@@ -57,6 +59,8 @@ const {
     Marker,
     getLabelStyles,
 } = _ModuleSupport;
+
+type NormalisedMapMarkerSeriesStyle = Normalised<AgMapMarkerSeriesStyle, never, FillStrokeMorph>;
 
 interface MapMarkerNodeDataContext extends _ModuleSupport.DataModelSeriesNodeDataContext<
     MapMarkerNodeDatum,
@@ -786,7 +790,7 @@ export class MapMarkerSeries
     protected getMarkerItemStyle(
         { datumIndex, datum, colorValue, sizeValue }: Partial<MapMarkerNodeDatum>,
         isHighlight: boolean
-    ): Required<AgMapMarkerSeriesStyle> {
+    ): Required<NormalisedMapMarkerSeriesStyle> {
         const { properties, colorScale, sizeScale } = this;
         const { colorKey, colorScale: colorScaleProps, itemStyler } = properties;
         const { missingDataFill } = colorScaleProps;
@@ -825,14 +829,15 @@ export class MapMarkerSeries
                 style = mergeDefaults(overrides, baseStyle);
             }
         }
-        return style;
+        // fill/stroke refs are resolved during theme-merge before reaching here.
+        return style as Required<NormalisedMapMarkerSeriesStyle>;
     }
 
     private makeItemStylerParams(
         datum: unknown,
         datumIndex: number,
         isHighlight: boolean,
-        style: Required<AgMapMarkerSeriesStyle>
+        style: Required<NormalisedMapMarkerSeriesStyle>
     ) {
         const { id: seriesId } = this;
         const { sizeKey, idKey, labelKey, colorKey, latitudeKey, longitudeKey } = this.properties;

--- a/packages/ag-charts-enterprise/src/series/map-shape-background/mapShapeBackgroundSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape-background/mapShapeBackgroundSeries.ts
@@ -1,5 +1,9 @@
-import { type AgMapShapeBackgroundOptions, _ModuleSupport } from 'ag-charts-community';
-import type { DynamicContext, FeatureCollection } from 'ag-charts-core';
+import {
+    type AgMapShapeBackgroundOptions,
+    type AgMapShapeBackgroundThemeableOptions,
+    _ModuleSupport,
+} from 'ag-charts-community';
+import type { DynamicContext, FeatureCollection, FillStrokeMorph, Normalised } from 'ag-charts-core';
 import { Logger } from 'ag-charts-core';
 
 import { GeoGeometry, GeoGeometryRenderMode } from '../map-util/geoGeometry';
@@ -14,6 +18,8 @@ import {
 } from './mapShapeBackgroundSeriesProperties';
 
 const { createDatumId, Selection, Group, PointerEvents } = _ModuleSupport;
+
+type NormalisedMapShapeBackgroundStyle = Normalised<AgMapShapeBackgroundThemeableOptions, never, FillStrokeMorph>;
 
 interface MapShapeBackgroundNodeDataContext extends _ModuleSupport.DataModelSeriesNodeDataContext<MapShapeBackgroundNodeDatum> {}
 
@@ -196,7 +202,8 @@ export class MapShapeBackgroundSeries
             }
             geoGeometry.visible = true;
             geoGeometry.projectedGeometry = projectedGeometry;
-            geoGeometry.setProperties(datum.style);
+            // Colour refs are resolved during theme-merge, so the style is concrete by render.
+            geoGeometry.setProperties(datum.style as NormalisedMapShapeBackgroundStyle);
         });
     }
 

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -4,8 +4,10 @@ import type {
     DynamicContext,
     Feature,
     FeatureCollection,
+    FillStrokeMorph,
     Geometry,
     ITextMeasurer,
+    Normalised,
     NormalisedTextOrSegments,
     Point,
     Position,
@@ -72,6 +74,8 @@ interface ShapeDataValues {
     readonly colorValue: number | undefined;
     readonly labelValue: string | undefined;
 }
+
+type NormalisedMapShapeSeriesStyle = Normalised<AgMapShapeSeriesStyle, never, FillStrokeMorph>;
 
 const fixedScale = _ModuleSupport.MercatorScale.fixedScale();
 
@@ -556,12 +560,13 @@ export class MapShapeSeries
     protected getItemStyle(
         { datumIndex, datum, colorValue }: Partial<MapShapeNodeDatum>,
         isHighlight: boolean
-    ): Required<AgMapShapeSeriesStyle> {
+    ): Required<NormalisedMapShapeSeriesStyle> {
         const { properties, colorScale } = this;
         const { colorKey, colorScale: colorScaleProps, itemStyler } = properties;
         const { missingDataFill } = colorScaleProps;
 
-        const baseStyle = properties.getStyle();
+        // Colour refs are resolved during theme-merge before getStyle() returns.
+        const baseStyle = properties.getStyle() as Required<NormalisedMapShapeSeriesStyle> & { opacity: number };
 
         if (colorValue != null) {
             const fillOverride = this.isColorScaleValid()
@@ -602,7 +607,7 @@ export class MapShapeSeries
         datum: unknown,
         datumIndex: number,
         isHighlight: boolean,
-        style: Required<AgMapShapeSeriesStyle>
+        style: Required<NormalisedMapShapeSeriesStyle>
     ) {
         const { id: seriesId } = this;
         const { idKey, labelKey, colorKey } = this.properties;
@@ -659,7 +664,8 @@ export class MapShapeSeries
             geoGeometry.visible = true;
             geoGeometry.projectedGeometry = projectedGeometry;
 
-            geoGeometry.setStyleProperties(nodeDatum.style, fillBBox);
+            // Style is resolved by getItemStyle; colour refs are gone by render.
+            geoGeometry.setStyleProperties(nodeDatum.style as NormalisedMapShapeSeriesStyle, fillBBox);
 
             geoGeometry.drawingMode = drawingMode;
 

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeries.ts
@@ -1,8 +1,12 @@
 import { type AgOhlcSeriesOptions, _ModuleSupport } from 'ag-charts-community';
+import type { FillStrokeMorph, Normalised } from 'ag-charts-core';
 
 import { OhlcNode } from './ohlcNode';
 import { type OhlcNodeDatum, OhlcSeriesBase, type OhlcSeriesBaseTypes } from './ohlcSeriesBase';
 import { OhlcSeriesProperties } from './ohlcSeriesProperties';
+
+/** Post-resolution style: colour refs are resolved to concrete colours before reaching the scene node. */
+type NormalisedOhlcStyle = Normalised<NonNullable<OhlcNodeDatum['style']>, never, FillStrokeMorph>;
 
 /**
  * Consolidated type interface for OhlcSeries.
@@ -58,11 +62,10 @@ export class OhlcSeries extends OhlcSeriesBase<OhlcSeriesTypes> {
 
             node.setStaticProperties(centerX, width, y, height, yOpen, yClose, crisp);
 
-            const style =
-                datum.style ??
+            const style = (datum.style ??
                 contextNodeData.styles[datum.itemType][
                     series.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex)
-                ];
+                ]) as NormalisedOhlcStyle;
 
             node.setStyleProperties(style);
 

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -18,14 +18,17 @@ import {
     ChartAxisDirection,
     DebugMetrics,
     type DynamicContext,
+    type FillStrokeMorph,
     Logger,
     type Mutable,
+    type Normalised,
+    type NormalisedColorType,
     type Point,
     type Scale,
     mergeDefaults,
     toNumber,
 } from 'ag-charts-core';
-import type { AgNumericValue } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import {
     type OhlcSeriesDataAggregationFilter,
@@ -61,6 +64,9 @@ const {
 
 interface OhlcCandleStickSeriesStyle extends AgCandlestickSeriesItemOptions, AgOhlcSeriesItemOptions {}
 
+/** Post-resolution style: colour refs are resolved to concrete colours before reaching the scene node. */
+type NormalisedOhlcCandleStickSeriesStyle = Normalised<OhlcCandleStickSeriesStyle, never, FillStrokeMorph>;
+
 export interface OhlcNodeDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDatum, 'yKey' | 'yValue'> {
     readonly itemId?: never;
     readonly itemType: AgOhlcSeriesItemType;
@@ -82,7 +88,7 @@ export interface OhlcNodeDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDa
 
     readonly crisp: boolean;
 
-    style?: Required<OhlcCandleStickSeriesStyle>;
+    style?: Required<NormalisedOhlcCandleStickSeriesStyle>;
 }
 
 class OhlcSeriesNodeEvent<
@@ -179,7 +185,7 @@ interface OhlcSeriesNodeDatumContext {
 }
 
 interface OhlcSeriesBaseNodeDataContext extends _ModuleSupport.AbstractBarSeriesNodeDataContext<OhlcNodeDatum> {
-    styles: Record<'up' | 'down', _ModuleSupport.SeriesNodeStyleContext<OhlcCandleStickSeriesStyle>>;
+    styles: Record<'up' | 'down', _ModuleSupport.SeriesNodeStyleContext<NormalisedOhlcCandleStickSeriesStyle>>;
 }
 
 /**
@@ -858,7 +864,12 @@ export abstract class OhlcSeriesBase<
             this.getHighlightStyle(isHighlight, datumIndex, highlightState);
         const selectionStyle: (FillOptions & StrokeOptions & LineDashOptions & { opacity?: number }) | undefined =
             this.getSelectionStyle(datumIndex);
-        const baseStyle = mergeDefaults(selectionStyle, highlightStyle, properties.getStyle(itemType));
+        // Colour refs are resolved during theme-merge before reaching getStyle().
+        const baseStyle = mergeDefaults(
+            selectionStyle,
+            highlightStyle,
+            properties.getStyle(itemType)
+        ) as Required<NormalisedOhlcCandleStickSeriesStyle> & { opacity: number };
 
         let style = baseStyle;
 
@@ -887,9 +898,7 @@ export abstract class OhlcSeriesBase<
         itemType: 'up' | 'down',
         datumIndex: number,
         isHighlight: boolean,
-        style:
-            | (Required<AgOhlcSeriesItemOptions> & { opacity: number })
-            | (Required<AgCandlestickSeriesItemOptions> & { opacity: number })
+        style: Required<NormalisedOhlcCandleStickSeriesStyle> & { opacity: number }
     ) {
         const { id: seriesId, properties, processedData } = this;
         const { xKey, openKey, closeKey, highKey, lowKey } = properties;
@@ -960,10 +969,11 @@ export abstract class OhlcSeriesBase<
 
         const format = this.getItemStyle(datumIndex, false);
 
+        // Colour refs on item.fill/stroke are resolved to concrete colours before this point.
         const marker = {
-            fill: item.fill ?? item.stroke,
+            fill: (item.fill ?? item.stroke) as NormalisedColorType,
             fillOpacity: item.fillOpacity ?? item.strokeOpacity ?? 1,
-            stroke: item.stroke,
+            stroke: item.stroke as CssColor,
             strokeWidth: item.strokeWidth ?? 1,
             strokeOpacity: item.strokeOpacity ?? 1,
             lineDash: item.lineDash ?? [0],

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -9,6 +9,7 @@ import {
     type AgOrganizationSeriesNodeStyle,
     type AgOrganizationSeriesNodeTextStyle,
     type AgOrganizationSeriesNodeTextStylerParams,
+    type CssColor,
     type PaddingOptions,
     type RichFormatter,
     type Styler,
@@ -20,6 +21,8 @@ import {
     ChartAxisDirection,
     type DeepRequired,
     type DynamicContext,
+    type Normalised,
+    type NormalisedColorType,
     type NormalisedTextOrSegments,
     type Point,
     Vertex,
@@ -910,8 +913,10 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         return style;
     }
 
-    private getNodeDefaultStyle(): DeepRequired<
-        Omit<AgOrganizationSeriesNodeStyle, 'padding'> & { padding: PaddingOptions }
+    private getNodeDefaultStyle(): Normalised<
+        DeepRequired<Omit<AgOrganizationSeriesNodeStyle, 'padding'> & { padding: PaddingOptions }>,
+        never,
+        { fill: NormalisedColorType; stroke: CssColor }
     > {
         const {
             cornerRadius,

--- a/packages/ag-charts-enterprise/src/series/organization/organizationTypes.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationTypes.ts
@@ -1,6 +1,10 @@
-import type { DeepRequired, Normalised, NormalisedPaddingOptions, NormalisedTextOrSegments } from 'ag-charts-core';
 import type {
-    AgColorType,
+    Normalised,
+    NormalisedColorType,
+    NormalisedPaddingOptions,
+    NormalisedTextOrSegments,
+} from 'ag-charts-core';
+import type {
     AgOrganizationSeriesExpanderStyle,
     AgOrganizationSeriesExpanderTextStyle,
     AgOrganizationSeriesNodeStyle,
@@ -99,12 +103,12 @@ export type NormalisedOrganizationNodeStyle = Normalised<
     | 'lineDashOffset'
     | 'maxHeight'
     | 'maxWidth'
-    | 'stroke'
     | 'strokeOpacity'
     | 'strokeWidth'
     | 'width',
     {
-        fill: DeepRequired<AgColorType>;
+        fill: NormalisedColorType;
+        stroke: CssColor;
         expander: NormalisedOrganizationSeriesExpanderStyle;
         image: NormalisedOrganizationSeriesOptionsNodeImage;
         labels: NormalisedOrganizationNodeTextStyle[];

--- a/packages/ag-charts-enterprise/src/series/organization/organizationUtils.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationUtils.ts
@@ -6,10 +6,10 @@ import {
     type TextAlign,
     _ModuleSupport,
 } from 'ag-charts-community';
-import type { FontOptions } from 'ag-charts-core';
+import type { FontOptions, NormalisedColorType } from 'ag-charts-core';
 
 export function applyFillStyles(node: _ModuleSupport.Shape, styles: FillOptions) {
-    node.fill = styles.fill;
+    node.fill = styles.fill as NormalisedColorType; // refs resolved at runtime before reaching the node
     node.fillOpacity = styles.fillOpacity ?? 1;
 }
 
@@ -19,7 +19,7 @@ export function applyStrokeStyles(
 ) {
     node.lineDash = styles.lineDash;
     node.lineDashOffset = styles.lineDashOffset ?? 0;
-    node.stroke = styles.stroke;
+    node.stroke = styles.stroke as CssColor; // refs resolved at runtime before reaching the node
     node.strokeOpacity = styles.strokeOpacity ?? 1;
     node.strokeWidth = styles.strokeWidth ?? 0;
 }

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -10,6 +10,9 @@ import {
     type ChartAnimationPhase,
     type DomainWithMetadata,
     type DynamicContext,
+    type FillStrokeMorph,
+    type Normalised,
+    type NormalisedColorType,
     type NormalisedTextOrSegments,
     type Point,
     StateMachine,
@@ -51,6 +54,8 @@ type PyramidNodeLabelDatum = Readonly<Point> & {
 
 type PyramidStageValue = string | number | { toString(): string };
 
+type NormalisedPyramidSeriesStyle = Normalised<AgPyramidSeriesStyle, never, FillStrokeMorph>;
+
 interface PyramidNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatum, Readonly<Point> {
     readonly index: number;
     readonly xValue: PyramidStageValue;
@@ -60,7 +65,7 @@ interface PyramidNodeDatum extends _ModuleSupport.DataModelSeriesNodeDatum, Read
     readonly bottom: number;
     readonly left: number;
     readonly label: PyramidNodeLabelDatum | undefined;
-    style: AgPyramidSeriesStyle;
+    style: NormalisedPyramidSeriesStyle;
 }
 
 interface PyramidNodeDataContext extends _ModuleSupport.DataModelSeriesNodeDataContext<
@@ -509,14 +514,14 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
     protected getItemStyle(
         { datumIndex, datum }: Partial<PyramidNodeDatum>,
         isHighlight: boolean
-    ): Required<AgPyramidSeriesStyle> {
+    ): Required<NormalisedPyramidSeriesStyle> {
         const { properties } = this;
         const { itemStyler } = properties;
 
         const highlightStyle = this.getHighlightStyle(isHighlight, datumIndex);
         const selectionStyle = this.getSelectionStyle(datumIndex);
         const baseStyle = mergeDefaults(selectionStyle, highlightStyle, properties.getStyle(datumIndex));
-        let style = baseStyle;
+        let style = baseStyle as Required<NormalisedPyramidSeriesStyle>; // refs resolved at runtime
 
         if (itemStyler != null && datumIndex != null) {
             const overrides = this.cachedDatumCallback(
@@ -539,7 +544,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
         datum: unknown,
         datumIndex: number,
         isHighlight: boolean,
-        style: Required<AgPyramidSeriesStyle>
+        style: Required<NormalisedPyramidSeriesStyle>
     ) {
         const { id: seriesId, properties } = this;
         const { stageKey, valueKey } = properties;
@@ -749,7 +754,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
 
     private legendItemSymbol(datumIndex: number) {
         const { fills, strokes, strokeWidth, fillOpacity, strokeOpacity, lineDash, lineDashOffset } = this.properties;
-        const fill = fills[datumIndex] ?? 'black';
+        const fill = (fills[datumIndex] ?? 'black') as NormalisedColorType; // refs resolved at runtime
         const stroke = strokes[datumIndex] ?? 'black';
         return {
             marker: {

--- a/packages/ag-charts-enterprise/src/series/radar-area/radarAreaSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar-area/radarAreaSeries.ts
@@ -5,7 +5,7 @@ import {
     type AgSeriesMarkerStyle,
     _ModuleSupport,
 } from 'ag-charts-community';
-import type { CallbackParamRules, DynamicContext, RequireOptional } from 'ag-charts-core';
+import type { CallbackParamRules, DynamicContext, NormalisedColorType, RequireOptional } from 'ag-charts-core';
 import { ChartAxisDirection } from 'ag-charts-core';
 
 import { type RadarPathPoint, RadarSeries, type ResolvedRadarStyle } from '../radar/radarSeries';
@@ -122,7 +122,7 @@ export class RadarAreaSeries extends RadarSeries<S, O, P> {
 
             areaNode.setStyleProperties(
                 {
-                    fill: stylerStyle.fill,
+                    fill: stylerStyle.fill as NormalisedColorType, // colour refs resolved at runtime
                     stroke: undefined,
                     fillOpacity: stylerStyle.fillOpacity,
                     lineDash: stylerStyle.lineDash,

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -5,6 +5,7 @@ import {
     type AgRadarSeriesStyle,
     type AgSeriesMarkerStyle,
     type ContextDefault,
+    type CssColor,
     type DatumDefault,
     type SelectionState,
     _ModuleSupport,
@@ -14,6 +15,7 @@ import {
     ChartAxisDirection,
     type DomainWithMetadata,
     type DynamicContext,
+    type NormalisedSeriesMarkerStyle,
     type Point,
     type RequireOptional,
     extent,
@@ -60,7 +62,7 @@ export interface RadarPathPoint {
 }
 
 interface RadarSeriesNodeDataContext extends _ModuleSupport.SeriesNodeDataContext<RadarNodeDatum> {
-    styles: _ModuleSupport.SeriesNodeStyleContext<AgSeriesMarkerStyle>;
+    styles: _ModuleSupport.SeriesNodeStyleContext<NormalisedSeriesMarkerStyle>;
 }
 
 /** Per-pass context for the radar marker-style passes (shared by no-itemStyler and itemStyler paths). */
@@ -89,7 +91,10 @@ type RadarStylerApply = _ModuleSupport.MarkerStyleApply<
     ResolvedRadarStyle<any>
 >;
 
-type StylerResult<TStyle extends AgRadarSeriesStyle> = TStyle & { marker?: { enabled?: boolean } };
+type StylerResult<TStyle extends AgRadarSeriesStyle> = Omit<TStyle, 'stroke' | 'marker'> & {
+    stroke?: CssColor;
+    marker?: NormalisedSeriesMarkerStyle & { enabled?: boolean };
+};
 
 type BaseRadarSeries = RadarSeries<
     AgRadarSeriesStyle,
@@ -101,9 +106,9 @@ type BaseRadarSeries = RadarSeries<
 >;
 
 export type ResolvedRadarStyle<TStyle extends AgRadarSeriesStyle> = {
-    [K in keyof TStyle]-?: Exclude<TStyle[K], undefined>;
+    [K in keyof TStyle]-?: K extends 'stroke' ? CssColor : Exclude<TStyle[K], undefined>;
 } & {
-    marker: Required<AgSeriesMarkerStyle> & { enabled: boolean };
+    marker: Required<NormalisedSeriesMarkerStyle> & { enabled: boolean };
 };
 
 class RadarSeriesNodeEvent<
@@ -520,8 +525,9 @@ export abstract class RadarSeries<
         drawingMode = this.getDrawingMode(isHighlight, drawingMode);
 
         selection.each((node, datum) => {
+            // datum.style is populated from resolved (ref-free) marker styles by the style passes.
             const style =
-                datum.style ??
+                (datum.style as NormalisedSeriesMarkerStyle | undefined) ??
                 contextNodeData.styles[this.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex)];
             this.applyMarkerStyle(style, node, datum.point, fillBBox, { hideWithSize0 });
 

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -9,6 +9,8 @@ import {
     ChartAxisDirection,
     type DomainWithMetadata,
     type DynamicContext,
+    type FillStrokeMorph,
+    type Normalised,
     type NormalisedTextOrSegments,
     type Point,
     angleBetween,
@@ -18,7 +20,7 @@ import {
     minValue,
     zeroLike,
 } from 'ag-charts-core';
-import type { AgNumericValue } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import { RadiusCategoryAxis } from '../../axes/radius-category/radiusCategoryAxis';
 import { readDatum } from '../../utils/datum';
@@ -49,6 +51,8 @@ const {
     updateLabelNode,
     getItemStyles,
 } = _ModuleSupport;
+
+type NormalisedRadialSeriesStyle = Normalised<AgRadialSeriesStyle, never, FillStrokeMorph>;
 
 class RadialBarSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
@@ -484,7 +488,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
                 const fillParams: _ModuleSupport.GradientParams | undefined =
                     isGradientFill(fill) && fill.bounds !== 'item' ? { centerX: 0, centerY: 0 } : undefined;
 
-                node.setStyleProperties(style, fillBBox, fillParams);
+                node.setStyleProperties(style as NormalisedRadialSeriesStyle, fillBBox, fillParams);
 
                 node.lineJoin = 'round';
                 node.inset = node.stroke == null ? 0 : node.strokeWidth / 2;
@@ -644,7 +648,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
 
         const markerStyle = {
             fill: fill ?? 'rgba(0, 0, 0, 0)',
-            stroke: stroke ?? 'rgba(0, 0, 0, 0)',
+            stroke: (stroke ?? 'rgba(0, 0, 0, 0)') as CssColor, // resolved at runtime
             fillOpacity,
             strokeOpacity,
             strokeWidth,

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -9,6 +9,8 @@ import {
     ChartAxisDirection,
     type DomainWithMetadata,
     type DynamicContext,
+    type FillStrokeMorph,
+    type Normalised,
     type NormalisedTextOrSegments,
     type Point,
     isDefined,
@@ -18,7 +20,7 @@ import {
     normalizeAngle360,
     zeroLike,
 } from 'ag-charts-core';
-import type { AgNumericValue } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import { AngleCategoryAxis } from '../../axes/angle-category/angleCategoryAxis';
 import { type RadialSeriesStyleResult, getItemStyle, getStyle } from '../util/radialUtil';
@@ -45,6 +47,8 @@ const {
     updateLabelNode,
     getItemStyles,
 } = _ModuleSupport;
+
+type NormalisedRadialSeriesStyle = Normalised<AgRadialSeriesStyle, never, FillStrokeMorph>;
 
 class RadialColumnSeriesNodeEvent<
     TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
@@ -529,7 +533,7 @@ export abstract class RadialColumnSeriesBase<
 
                 this.updateItemPath(node, nodeDatum, isHighlight);
 
-                node.setStyleProperties(style, fillBBox, fillParams);
+                node.setStyleProperties(style as NormalisedRadialSeriesStyle, fillBBox, fillParams);
 
                 node.cornerRadius = style.cornerRadius ?? 0;
                 node.lineJoin = 'round';
@@ -664,7 +668,7 @@ export abstract class RadialColumnSeriesBase<
 
         const markerStyle = {
             fill: fill ?? 'rgba(0, 0, 0, 0)',
-            stroke: stroke ?? 'rgba(0, 0, 0, 0)',
+            stroke: (stroke as CssColor) ?? 'rgba(0, 0, 0, 0)', // resolved at runtime
             fillOpacity,
             strokeOpacity,
             strokeWidth,

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -668,7 +668,7 @@ export abstract class RadialColumnSeriesBase<
 
         const markerStyle = {
             fill: fill ?? 'rgba(0, 0, 0, 0)',
-            stroke: (stroke as CssColor) ?? 'rgba(0, 0, 0, 0)', // resolved at runtime
+            stroke: (stroke ?? 'rgba(0, 0, 0, 0)') as CssColor, // resolved at runtime
             fillOpacity,
             strokeOpacity,
             strokeWidth,

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -10,6 +10,7 @@ import {
     type VerticalAlign,
     _ModuleSupport,
 } from 'ag-charts-community';
+import type { FillStrokeMorph, Normalised } from 'ag-charts-core';
 import {
     type ChartAnimationPhase,
     type DynamicContext,
@@ -26,7 +27,7 @@ import {
     toPlainText,
     toRadians,
 } from 'ag-charts-core';
-import type { AgNumericValue } from 'ag-charts-types';
+import type { AgNumericValue, AgRadialGaugeSeriesStyle } from 'ag-charts-types';
 
 import { LinearAngleScale } from '../../axes/angle-number/linearAngleScale';
 import { formatWithContext } from '../../utils/formatter';
@@ -71,6 +72,8 @@ const {
 } = _ModuleSupport;
 
 type SeriesNodeDatum = _ModuleSupport.SeriesNodeDatum;
+
+type NormalisedRadialGaugeSeriesStyle = Normalised<AgRadialGaugeSeriesStyle, never, FillStrokeMorph>;
 
 interface TargetLabel {
     enabled: boolean;
@@ -901,7 +904,7 @@ export class RadialGaugeSeries
                 ? _ModuleSupport.PointerEvents.All
                 : _ModuleSupport.PointerEvents.None;
 
-            sector.setStyleProperties(datum.style, fillBBox);
+            sector.setStyleProperties(datum.style as NormalisedRadialGaugeSeriesStyle, fillBBox);
 
             sector.startOuterCornerRadius = startCornerRadius;
             sector.startInnerCornerRadius = startCornerRadius;
@@ -959,7 +962,7 @@ export class RadialGaugeSeries
             sector.innerRadius = innerRadius;
             sector.outerRadius = outerRadius;
 
-            sector.setStyleProperties(datum.style, fillBBox);
+            sector.setStyleProperties(datum.style as NormalisedRadialGaugeSeriesStyle, fillBBox);
 
             sector.startOuterCornerRadius = startCornerRadius;
             sector.startInnerCornerRadius = startCornerRadius;
@@ -1052,7 +1055,7 @@ export class RadialGaugeSeries
         targetSelection.each((target, datum) => {
             const { centerX, centerY, angle, radius, shape, size, rotation } = datum;
 
-            target.setStyleProperties(datum.style);
+            target.setStyleProperties(datum.style as NormalisedRadialGaugeSeriesStyle);
 
             target.size = size;
             target.shape = shape === 'line' ? lineMarker : shape;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -23,6 +23,9 @@ import {
     type DeepRequired,
     type DomainWithMetadata,
     type DynamicContext,
+    type Normalised,
+    type NormalisedColorType,
+    type NormalisedSeriesMarkerStyle,
     type Point,
     type RequireOptional,
     extent,
@@ -31,7 +34,7 @@ import {
     mergeDefaults,
     toNumber,
 } from 'ag-charts-core';
-import type { AgNumericValue } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import {
     type RangeAreaSeriesDataAggregationFilter,
@@ -104,8 +107,25 @@ type ResolvedStyleMixin = {
         high?: ResolvedLineStyleMixin;
     };
 };
-type PartialStylerResult = AgRangeAreaSeriesStyle & { opacity?: number };
-type StylerResult = DeepRequired<PartialStylerResult, 'fill'> & { topLevel: Required<AgRangeAreaSeriesLineStyle> };
+/** Range-area line style after theme-merge: colour refs are resolved before reaching this point. */
+type NormalisedRangeAreaSeriesLineStyle = Normalised<
+    AgRangeAreaSeriesLineStyle,
+    never,
+    { stroke?: CssColor; marker?: NormalisedSeriesMarkerStyle }
+>;
+/** Range-area style after theme-merge: fill (and nested item styles) are resolved colours. */
+type NormalisedRangeAreaSeriesStyle = Normalised<
+    AgRangeAreaSeriesStyle,
+    never,
+    {
+        fill?: NormalisedColorType;
+        item?: { low?: NormalisedRangeAreaSeriesLineStyle; high?: NormalisedRangeAreaSeriesLineStyle };
+    }
+>;
+type PartialStylerResult = NormalisedRangeAreaSeriesStyle & { opacity?: number };
+type StylerResult = DeepRequired<PartialStylerResult, 'fill'> & {
+    topLevel: Required<NormalisedRangeAreaSeriesLineStyle>;
+};
 type StylerMarkerOptionsResult = DeepRequired<ResolvedStyleMixin>;
 
 /**
@@ -1174,7 +1194,8 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
                 contextNodeData.styles[itemType][
                     this.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex)
                 ];
-            this.applyMarkerStyle(style, node, datum.point, fillBBox, { hideWithSize0 });
+            // Style colours are resolved at runtime before reaching the scene node.
+            this.applyMarkerStyle(style as NormalisedSeriesMarkerStyle, node, datum.point, fillBBox, { hideWithSize0 });
             node.drawingMode = drawingMode;
         });
 
@@ -1248,15 +1269,15 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
 
         const selectionState: _ModuleSupport.SelectionState | undefined = this.getDataSelectionState(undefined);
         const candidateState: _ModuleSupport.SelectionState | undefined = this.getDataCandidacyState(undefined);
-        let stylerResult: AgRangeAreaSeriesStyle & ResolvedStyleMixin = {};
+        let stylerResult: NormalisedRangeAreaSeriesStyle & ResolvedStyleMixin = {};
         if (styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
             stylerResult =
-                this.ctx.optionsGraphService.resolvePartial(
+                (this.ctx.optionsGraphService.resolvePartial(
                     ['series', `${this.declarationOrder}`],
                     this.cachedCallWithContext(styler, stylerParams) ?? {},
                     { pick: false }
-                ) ?? {};
+                ) as NormalisedRangeAreaSeriesStyle & ResolvedStyleMixin) ?? {};
         }
 
         const markerOpts: StylerMarkerOptionsResult = {

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeAreaIntersection.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeAreaIntersection.ts
@@ -1,5 +1,5 @@
-import { type FillOptions, _ModuleSupport } from 'ag-charts-community';
-import { type Point, type Size, spanRange } from 'ag-charts-core';
+import { _ModuleSupport } from 'ag-charts-community';
+import { type NormalisedFillOptions, type Point, type Size, spanRange } from 'ag-charts-core';
 
 function getYValueAtX({ span }: _ModuleSupport.LinePathSpan, x: number): number {
     switch (span.type) {
@@ -117,7 +117,7 @@ export function calculateIntersectionSegments(
     seriesRect: _ModuleSupport.BBox,
     chartSize: Size,
     startsInverted: boolean,
-    style: FillOptions = {}
+    style: NormalisedFillOptions = {}
 ) {
     const horizontalMargin = Math.max(seriesRect.x, chartSize.width - (seriesRect.x + seriesRect.width));
     const verticalMargin = Math.max(seriesRect.y, chartSize.height - (seriesRect.y + seriesRect.height));

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -18,7 +18,9 @@ import {
     DebugMetrics,
     type DomainWithMetadata,
     type DynamicContext,
+    type FillStrokeMorph,
     type Mutable,
+    type Normalised,
     type NormalisedTextOrSegments,
     type Point,
     type RequireOptional,
@@ -81,6 +83,8 @@ interface RangeBarNodeLabelDatum extends Readonly<Point> {
 }
 
 type RangeBarItemId = `${string}-${string}`;
+
+type NormalisedRangeBarSeriesStyle = Normalised<AgRangeBarSeriesStyle, never, FillStrokeMorph>;
 
 /**
  * Shared context for creating/updating RangeBarNodeDatum instances.
@@ -175,7 +179,7 @@ interface RangeBarNodeDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDatum
     // Required for types
     readonly clipBBox?: _ModuleSupport.BBox;
     readonly opacity?: number;
-    style?: Required<AgRangeBarSeriesStyle>;
+    style?: Required<NormalisedRangeBarSeriesStyle>;
 }
 
 type RangeBarAnimationData = _ModuleSupport.AbstractBarSeriesAnimationData<RangeBarSeriesTypes>;
@@ -206,7 +210,7 @@ interface RangeBarSeriesNodeDataContext extends _ModuleSupport.AbstractBarSeries
     RangeBarNodeLabelDatum
 > {
     itemId: RangeBarItemId;
-    styles: _ModuleSupport.SeriesNodeStyleContext<AgRangeBarSeriesStyle>;
+    styles: _ModuleSupport.SeriesNodeStyleContext<NormalisedRangeBarSeriesStyle>;
 }
 
 /**
@@ -993,7 +997,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         highlightState: _ModuleSupport.HighlightState | undefined,
         selectionState: _ModuleSupport.SelectionState | undefined,
         candidateState: _ModuleSupport.SelectionState | undefined
-    ): Required<AgRangeBarSeriesStyle> & { opacity: number } {
+    ): Required<NormalisedRangeBarSeriesStyle> & { opacity: number } {
         const {
             cornerRadius,
             fill,
@@ -1005,15 +1009,14 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
             strokeWidth,
             styler,
         } = this.properties;
-        let stylerResult: AgRangeBarSeriesStyle = {};
+        let stylerResult: NormalisedRangeBarSeriesStyle = {};
         if (!ignoreStylerCallback && styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
-            stylerResult =
-                this.ctx.optionsGraphService.resolvePartial(
-                    ['series', `${this.declarationOrder}`],
-                    this.cachedCallWithContext(styler, stylerParams) ?? {},
-                    { pick: false }
-                ) ?? {};
+            stylerResult = (this.ctx.optionsGraphService.resolvePartial(
+                ['series', `${this.declarationOrder}`],
+                this.cachedCallWithContext(styler, stylerParams) ?? {},
+                { pick: false }
+            ) ?? {}) as NormalisedRangeBarSeriesStyle;
         }
         return {
             cornerRadius: stylerResult.cornerRadius ?? cornerRadius,
@@ -1089,7 +1092,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         highlightState: _ModuleSupport.HighlightState | undefined,
         selectionState: _ModuleSupport.SelectionState | undefined,
         candidateState: _ModuleSupport.SelectionState | undefined
-    ): Required<AgRangeBarSeriesStyle> {
+    ): Required<NormalisedRangeBarSeriesStyle> {
         const { properties, dataModel, processedData } = this;
         const { itemStyler } = properties;
 
@@ -1119,7 +1122,11 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         return style;
     }
 
-    private makeItemStylerParams(datumIndex: number, isHighlight: boolean, style: Required<AgRangeBarSeriesStyle>) {
+    private makeItemStylerParams(
+        datumIndex: number,
+        isHighlight: boolean,
+        style: Required<NormalisedRangeBarSeriesStyle>
+    ) {
         const { id: seriesId, properties, processedData } = this;
         const { xKey, yHighKey, yLowKey } = properties;
 

--- a/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sankey/sankeySeries.ts
@@ -9,6 +9,7 @@ import {
     type CallbackParamRules,
     type DynamicContext,
     Logger,
+    type NormalisedColorType,
     type RequireOptional,
     TextMeasurer,
     cachedTextMeasurer,
@@ -855,7 +856,8 @@ export class SankeySeries extends FlowProportionSeries<
         const highlightState = this.getHighlightStateString(activeHighlight, isHighlight, datumIndex);
         const selectionState = this.getSelectionStateString(datumIndex);
         const candidateState = this.getCandidateStateString(datumIndex);
-        const fill = this.filterItemStylerFillParams(style.fill) ?? style.fill;
+        // `style` is the resolved node style; its `fill` no longer carries unresolved colour refs.
+        const fill = this.filterItemStylerFillParams(style.fill as NormalisedColorType) ?? style.fill;
 
         return {
             seriesId,

--- a/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/sunburst/sunburstSeries.ts
@@ -215,7 +215,8 @@ export class SunburstSeries extends _ModuleSupport.HierarchySeries<
     private makeItemStylerParams(nodeDatum: SunburstNode, style: ItemStyle, highlightState: AgSunburstHighlightState) {
         const { id: seriesId } = this;
         const { colorKey, childrenKey, sizeKey, labelKey, secondaryLabelKey } = this.properties;
-        const fill = this.filterItemStylerFillParams(style.fill) ?? style.fill;
+        // `style` is the resolved item style; its `fill` no longer carries unresolved colour refs.
+        const fill = this.filterItemStylerFillParams(style.fill as InternalAgColorType) ?? style.fill;
 
         return {
             seriesId,
@@ -671,7 +672,6 @@ export class SunburstSeries extends _ModuleSupport.HierarchySeries<
             false
         );
 
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- widen AgColor to InternalAgColorType so downstream gradient props are typeable
         const color = format.fill as InternalAgColorType;
 
         const markerStyle = {

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -401,7 +401,8 @@ export class TreemapSeries extends _ModuleSupport.HierarchySeries<
         const { id: seriesId } = this;
         const { colorKey, childrenKey, sizeKey, labelKey, secondaryLabelKey } = this.properties;
 
-        const fill = this.filterItemStylerFillParams(style.fill) ?? style.fill;
+        // `style` is the resolved item style; its `fill` no longer carries unresolved colour refs.
+        const fill = this.filterItemStylerFillParams(style.fill as InternalAgColorType) ?? style.fill;
 
         return {
             seriesId,
@@ -984,7 +985,6 @@ export class TreemapSeries extends _ModuleSupport.HierarchySeries<
             false
         );
 
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- widen AgColor to InternalAgColorType so downstream gradient props are typeable
         const color = format.fill as InternalAgColorType;
 
         const markerStyle = {

--- a/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
@@ -130,7 +130,8 @@ export function getStyle(
 
     return {
         cornerRadius: stylerResult.cornerRadius ?? series.properties.cornerRadius,
-        fill: stylerResult.fill ?? series.properties.fill,
+        // resolvePartial has resolved any colour refs in the styler result; properties.fill is already resolved.
+        fill: (stylerResult.fill ?? series.properties.fill) as InternalAgColorType,
         fillOpacity: stylerResult.fillOpacity ?? series.properties.fillOpacity,
         lineDash: stylerResult.lineDash ?? series.properties.lineDash,
         lineDashOffset: stylerResult.lineDashOffset ?? series.properties.lineDashOffset,

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -12,7 +12,10 @@ import {
     ChartAxisDirection,
     type DomainWithMetadata,
     type DynamicContext,
+    type FillStrokeMorph,
     type Mutable,
+    type Normalised,
+    type NormalisedColorType,
     type NormalisedTextOrSegments,
     type Point,
     type RequireOptional,
@@ -28,6 +31,9 @@ import type { AgNumericValue, SelectionState } from 'ag-charts-types';
 
 import type { WaterfallSeriesItem, WaterfallSeriesTotal } from './waterfallSeriesProperties';
 import { WaterfallSeriesProperties } from './waterfallSeriesProperties';
+
+/** Post-theme/styler-resolution waterfall style: colour refs are already resolved to concrete colours. */
+type NormalisedWaterfallSeriesStyle = Normalised<AgWaterfallSeriesStyle, never, FillStrokeMorph>;
 
 const {
     adjustLabelPlacement,
@@ -903,7 +909,8 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
         const highlightStateString = this.getHighlightStateString(activeHighlight, isHighlight, datumIndex);
         const selectionStateString = this.getSelectionStateString(datumIndex);
         const candidateStateString = this.getCandidateStateString(datumIndex);
-        const fill = this.filterItemStylerFillParams(style.fill) ?? style.fill;
+        // `style` is the resolved item style; its `fill` no longer carries unresolved colour refs.
+        const fill = this.filterItemStylerFillParams(style.fill as NormalisedColorType) ?? style.fill;
 
         return {
             seriesId,
@@ -984,7 +991,8 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
                 contextNodeData.styles[datum.itemType][
                     this.getHighlightState(highlightedDatum, isHighlight, datum.datumIndex)
                 ];
-            rect.setStyleProperties(style, fillBBox);
+            // `style` is fully resolved by render time; narrow it to the shape-compatible normalised style.
+            rect.setStyleProperties(style as Required<NormalisedWaterfallSeriesStyle>, fillBBox);
 
             rect.cornerRadius = style.cornerRadius ?? 0;
             rect.visible = categoryAlongX ? datum.width > 0 : datum.height > 0;

--- a/packages/ag-charts-types/src/chart/bandHighlightOptions.ts
+++ b/packages/ag-charts-types/src/chart/bandHighlightOptions.ts
@@ -1,11 +1,12 @@
 import type { AgColorType } from '../series/cartesian/commonOptions';
-import type { CssColor, Opacity, PixelSize } from './types';
+import type { AgCssColorOrRef } from './themeParamsOptions';
+import type { Opacity, PixelSize } from './types';
 
 export interface AgBandHighlightOptions {
     /** Whether to show the band highlight. */
     enabled?: boolean;
-    /** The colour of the stroke for the lines. */
-    stroke?: CssColor;
+    /** The colour of the stroke for the lines. A colour string, or a theme-colour reference object. */
+    stroke?: AgCssColorOrRef;
     /** The width in pixels of the stroke for the lines. */
     strokeWidth?: PixelSize;
     /** The opacity of the stroke for the lines. */

--- a/packages/ag-charts-types/src/chart/crossLineOptions.ts
+++ b/packages/ag-charts-types/src/chart/crossLineOptions.ts
@@ -1,11 +1,12 @@
 import type { AgChartLabelStyleOptions } from './labelOptions';
+import type { AgCssColorOrRef } from './themeParamsOptions';
 import type { AxisValue, CssColor, FontFamilyFull, Opacity, PixelSize } from './types';
 
 export interface AgCommonCrossLineOptions<LabelType = AgBaseCrossLineLabelOptions> {
     /** Whether to show the Cross Line. */
     enabled?: boolean;
-    /** The colour of the stroke for the lines. */
-    stroke?: CssColor;
+    /** The colour of the stroke for the lines. A colour string, or a theme-colour reference object. */
+    stroke?: AgCssColorOrRef;
     /** The width in pixels of the stroke for the lines. */
     strokeWidth?: PixelSize;
     /** The opacity of the stroke for the lines. */

--- a/packages/ag-charts-types/src/chart/crosshairOptions.ts
+++ b/packages/ag-charts-types/src/chart/crosshairOptions.ts
@@ -1,5 +1,6 @@
 import type { AgAxisBoundSeries, AgTimeIntervalUnit } from './axisOptions';
 import type { Formatter, Renderer } from './callbackOptions';
+import type { AgCssColorOrRef } from './themeParamsOptions';
 import type { ContextDefault, CssColor, Opacity, PixelSize } from './types';
 
 export interface AgCrosshairOptions<LabelType = AgCrosshairLabel<string, ContextDefault>> {
@@ -7,8 +8,8 @@ export interface AgCrosshairOptions<LabelType = AgCrosshairLabel<string, Context
     enabled?: boolean;
     /** When true, the crosshair snaps to the highlighted data point. By default this property is true. */
     snap?: boolean;
-    /** The colour of the stroke for the lines. */
-    stroke?: CssColor;
+    /** The colour of the stroke for the lines. A colour string, or a theme-colour reference object. */
+    stroke?: AgCssColorOrRef;
     /** The width in pixels of the stroke for the lines. */
     strokeWidth?: PixelSize;
     /** The opacity of the stroke for the lines. */

--- a/packages/ag-charts-types/src/chart/legendOptions.ts
+++ b/packages/ag-charts-types/src/chart/legendOptions.ts
@@ -5,7 +5,6 @@ import type { AgCssColorOrRef } from './themeParamsOptions';
 import type {
     AgMarkerShape,
     ContextDefault,
-    CssColor,
     FontFamilyFull,
     FontSize,
     FontStyle,
@@ -256,7 +255,7 @@ export interface AgPaginationMarkerStyle {
     /** Opacity of the pagination buttons. */
     fillOpacity?: Opacity;
     /** The colour to use for the button strokes. */
-    stroke?: CssColor;
+    stroke?: AgCssColorOrRef;
     /** The width in pixels of the button strokes. */
     strokeWidth?: PixelSize;
     /** Opacity of the button strokes. */

--- a/packages/ag-charts-types/src/series/cartesian/commonOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/commonOptions.ts
@@ -1,5 +1,5 @@
 import type { AgNumericValue } from '../../chart/dataValues';
-import type { AgCssColorOrRef } from '../../chart/themeParamsOptions';
+import type { AgColorRef, AgColorRefMixOnto, AgCssColorOrRef } from '../../chart/themeParamsOptions';
 import type {
     CssColor,
     DatumKey,
@@ -58,21 +58,21 @@ export interface FillCssOptions {
     fillOpacity?: Opacity;
 }
 
-export type AgColorType = CssColor | AgGradientColor | AgPatternColor | AgImageFill;
+export type AgColorType = CssColor | AgColorRef | AgColorRefMixOnto | AgGradientColor | AgPatternColor | AgImageFill;
 export type AgColorTypeStrict = CssColor | AgGradientColorStrict;
 
 export type AgGradientColorMode = 'continuous' | 'discrete';
 
 export interface AgGradientColorStop {
     /** Colour of this category. */
-    color?: CssColor;
+    color?: AgCssColorOrRef;
     /** Stop value of this category. Defaults the maximum value if unset. */
     stop?: Ratio;
 }
 
 export interface AgColorScaleColorStop {
     /** Colour at this position. */
-    color: CssColor;
+    color: AgCssColorOrRef;
     /** Position of this colour in the data domain. In continuous mode, the colour appears exactly at this value. In discrete mode, this is the first value of the next bin. */
     stop?: AgNumericValue;
     /** Display name for this bin, used in legend and tooltip labels. */
@@ -183,7 +183,7 @@ export type AgPatternName =
  */
 export interface StrokeOptions {
     /** The colour for the stroke. */
-    stroke?: CssColor;
+    stroke?: AgCssColorOrRef;
     /** The width of the stroke in pixels. */
     strokeWidth?: PixelSize;
     /** The opacity of the stroke colour. */

--- a/packages/ag-charts-types/src/series/cartesian/rangeAreaOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/rangeAreaOptions.ts
@@ -8,8 +8,9 @@ import type {
 } from '../../chart/callbackOptions';
 import type { AgDropShadowOptions } from '../../chart/dropShadowOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
+import type { AgCssColorOrRef } from '../../chart/themeParamsOptions';
 import type { AgSeriesTooltip } from '../../chart/tooltipOptions';
-import type { ContextDefault, CssColor, DatumDefault, DatumKey, Opacity, PixelSize } from '../../chart/types';
+import type { ContextDefault, DatumDefault, DatumKey, Opacity, PixelSize } from '../../chart/types';
 import type { AgInterpolationType } from '../interpolationOptions';
 import type { AgSeriesMarkerOptions, AgSeriesMarkerStyle } from '../markerOptions';
 import type {
@@ -127,8 +128,8 @@ export interface AgRangeAreaSeriesThemeableOptions<TDatum = DatumDefault, TConte
     extends FillOptions, AgBaseCartesianThemeableOptions<TDatum, TContext> {
     /** Configuration for the markers used in the series.  */
     marker?: AgRangeAreaMarker<TDatum, TContext>;
-    /** The colour for the stroke. */
-    stroke?: CssColor;
+    /** The colour for the stroke. A colour string, or a theme-colour reference object. */
+    stroke?: AgCssColorOrRef;
     /** The width of the stroke in pixels. */
     strokeWidth?: PixelSize;
     /** The opacity of the stroke colour. */

--- a/packages/ag-charts-types/src/series/cartesian/waterfallOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/waterfallOptions.ts
@@ -8,8 +8,9 @@ import type {
 import type { AgNumericValue } from '../../chart/dataValues';
 import type { AgDropShadowOptions } from '../../chart/dropShadowOptions';
 import type { AgChartLabelOptions } from '../../chart/labelOptions';
+import type { AgCssColorOrRef } from '../../chart/themeParamsOptions';
 import type { AgSeriesTooltip, AgTooltipRendererResult } from '../../chart/tooltipOptions';
-import type { ContextDefault, CssColor, DatumDefault, DatumKey, Opacity, PixelSize, Ratio } from '../../chart/types';
+import type { ContextDefault, DatumDefault, DatumKey, Opacity, PixelSize, Ratio } from '../../chart/types';
 import type { AgBaseCartesianThemeableOptions, AgBaseSeriesOptions } from '../seriesOptions';
 import type { AgCartesianSeriesTooltipRendererParams } from './cartesianSeriesTooltipOptions';
 import type { AgBaseCartesianSeriesAxisOptions, FillOptions, LineDashOptions, StrokeOptions } from './commonOptions';
@@ -165,8 +166,8 @@ export interface AgWaterfallSeriesItemOptions<TDatum, TContext = ContextDefault>
 export interface AgWaterfallSeriesLineOptions {
     /** Whether the connector lines should be shown. */
     enabled?: boolean;
-    /** The colour to use for the connector lines. */
-    stroke?: CssColor;
+    /** The colour to use for the connector lines. A colour string, or a theme-colour reference object. */
+    stroke?: AgCssColorOrRef;
     /** The width in pixels of the connector lines. */
     strokeWidth?: PixelSize;
     /** Opacity of the line stroke. */

--- a/packages/ag-charts-types/src/series/topology/mapLineBackgroundOptions.ts
+++ b/packages/ag-charts-types/src/series/topology/mapLineBackgroundOptions.ts
@@ -1,9 +1,10 @@
-import type { CssColor, GeoJSON, Opacity, PixelSize } from '../../chart/types';
+import type { AgCssColorOrRef } from '../../chart/themeParamsOptions';
+import type { GeoJSON, Opacity, PixelSize } from '../../chart/types';
 import type { LineDashOptions } from '../cartesian/commonOptions';
 
 export interface AgMapLineBackgroundThemeableOptions extends LineDashOptions {
-    /** The colour for the stroke of the line. */
-    stroke?: CssColor;
+    /** The colour for the stroke of the line. A colour string, or a theme-colour reference object. */
+    stroke?: AgCssColorOrRef;
     /** The width of the stroke in pixels. */
     strokeWidth?: PixelSize;
     /** The opacity of the stroke colour. */

--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
@@ -42,7 +42,7 @@ const options: AgCartesianChartOptions = {
             yKey: 'revenue',
             yName: 'Revenue',
             // A reference resolves on a series fill as well as on theme parameters.
-            fill: { ref: 'accentColor' } as any,
+            fill: { ref: 'accentColor' },
         },
     ],
     axes: {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
@@ -22,7 +22,7 @@ const options: AgCartesianChartOptions = {
             backgroundColor: '#ffffff',
             foregroundColor: '#1b2a4a',
             // Only the text colour is derived from the controls below.
-            textColor: { ref: colorRef, mix } as any,
+            textColor: { ref: colorRef, mix },
         },
     },
     title: {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
@@ -1,6 +1,7 @@
 import {
     AgCartesianChartOptions,
     AgCharts,
+    AgThemeColorParam,
     BarSeriesModule,
     CategoryAxisModule,
     LegendModule,
@@ -10,8 +11,8 @@ import {
 
 ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
 
-let colorRef = 'accentColor';
-let onto = 'none';
+let colorRef: AgThemeColorParam = 'accentColor';
+let onto: AgThemeColorParam | 'none' = 'none';
 let mix = 0.35;
 
 const options: AgCartesianChartOptions = {
@@ -57,19 +58,19 @@ function updateTextColor() {
             backgroundColor: '#ffffff',
             foregroundColor: '#1b2a4a',
             // Only the text colour is derived from the controls below.
-            textColor: textColor as any,
+            textColor,
         },
     };
     chart.update(options);
 }
 
 function changeRef(event: Event) {
-    colorRef = (event.target as HTMLSelectElement).value;
+    colorRef = (event.target as HTMLSelectElement).value as AgThemeColorParam;
     updateTextColor();
 }
 
 function changeOnto(event: Event) {
-    onto = (event.target as HTMLSelectElement).value;
+    onto = (event.target as HTMLSelectElement).value as AgThemeColorParam | 'none';
     updateTextColor();
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17592

Extends @laurencerobertz's WIP so colour-reference objects (`{ ref }`, `{ ref, mix }`, `{ ref, mix, onto }`) are accepted by the public types on `fill` and `stroke` everywhere the runtime already resolves them, while the internal/resolved code paths stay strongly typed.

### What changed
- **`ag-charts-types`** — widen `stroke` to `AgCssColorOrRef` on the cross-line, crosshair, band-highlight, range-area, waterfall connector-line, map-line-background and sparkline-crosshair options. These are the fields whose option-defs already validate via the shared ref-accepting validators, so the type now matches the runtime. Other narrow `CssColor` fields are intentionally left alone (their validators are still string-only — widening them would be a type-lie and is out of scope).
- **`ag-charts-core`** — complete the normalised-options layer Laurence started: morph `stroke` on the marker / pagination / axis-label / border normalised types, add normalised bar/histogram/line series styles, and relocate the internal colour types (`InternalAg*`, `NormalisedGradientColor`, …) into `normalisedCommonOptions` to break the `optionsDefaults ↔ normalisedCommonOptions` import cycle introduced by the widening.
- **`ag-charts-community` & `ag-charts-enterprise`** — thread the normalised style types through every series/feature that reads a resolved style and pushes it into the scene graph (bar, line, area, bubble, histogram, box-plot, heatmap, candlestick/ohlc, funnel/cone-funnel, chord, flow-proportion, radar/radial/range-area/range-bar, gauges, map-*, sankey/sunburst/treemap/waterfall, plus crosshair, band-highlight, ranges, scrollbar, gradient-legend, error-bar and annotation scenes). Refs are accepted on input; resolved colours flow to render.

### Notes
- **Type-only change** — only type annotations, type aliases, `import type`s and narrowing `as` casts at already-resolved boundaries (no `as any`/`as unknown as` introduced). Emitted JavaScript and runtime behaviour are unchanged.

### Test plan
- `yarn nx build:types` — clean across types/core/locale/community/enterprise.
- `yarn nx lint` — 0 errors across all four packages (pre-existing warnings only).
- `yarn nx test ag-charts-community` — 3687 passed / 6 skipped.
- `yarn nx test ag-charts-enterprise` — 2478 passed; 7 pre-existing transition/update **snapshot** diffs (integrated-charts crossfilter chart-type transitions + error-bar update tests). The diff images show identical rendered content (same colours/structure) — anti-aliasing/animation-frame noise only — and a type-only change cannot alter rendering, so these are environment baseline-drift, not regressions. Snapshots were **not** regenerated.

Fix #AG-17592