### PR TITLE
docs(charts): refine colour, selection, styler and theme reference pages

### DIFF
--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
@@ -22,6 +22,7 @@ const options: AgCartesianChartOptions = {
             backgroundColor,
             // Text and axes are derived from the accent and background colours.
             foregroundColor: { ref: 'accentColor', mix, onto: 'backgroundColor' },
+            axisLineColor: { ref: 'accentColor', mix: 0.5 },
         },
     },
     title: {
@@ -60,6 +61,7 @@ function updateTheme() {
             accentColor,
             backgroundColor,
             foregroundColor: { ref: 'accentColor', mix, onto: 'backgroundColor' },
+            axisLineColor: { ref: 'accentColor', mix: 0.5 },
         },
     };
     chart.update(options);

--- a/packages/ag-charts-website/src/content/docs/colours/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/colours/index.mdoc
@@ -39,7 +39,7 @@ CSS variables can be used anywhere a colour is accepted. These are referenced as
 }
 ```
 
-In the above example: 
+In the above example:
 
 - Click the button to change the CSS variables only and the series, background, axes and text all update.
 - The chart re-renders automatically whenever a variable changes. There is no need to call `chart.update()`.
@@ -50,7 +50,7 @@ The `--ag-charts-*` namespace is reserved for internal use.
 
 ## Theme Parameter References
 
-A colour can reference a [theme parameter](./themes/#parameters) instead of a literal value, keeping related colours in sync. 
+A colour can reference a [theme parameter](./themes/#parameters) instead of a literal value, keeping related colours in sync.
 
 {% chartExampleRunner title="Theme Parameter References" name="colour-references" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/colours/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/colours/index.mdoc
@@ -7,7 +7,7 @@ AG Charts accepts standard CSS colour strings, CSS variables, and theme paramete
 
 ## Colour Formats
 
-Any colour string accepted by CSS can be used wherever a colour is set — series fills, strokes, text colours, and theme parameters.
+Any colour string accepted by CSS can be used wherever a colour is set, including series fills, strokes, text colours, and theme parameters.
 
 {% chartExampleRunner title="Colour Formats" name="colour-formats" type="generated" /%}
 
@@ -20,7 +20,7 @@ Any colour string accepted by CSS can be used wherever a colour is set — serie
 
 ## CSS Variables
 
-Use a CSS custom property such as `var(--brand-primary)` anywhere a colour is accepted.
+CSS variables can be used anywhere a colour is accepted. These are referenced as `var(--brand-primary)`.
 
 {% chartExampleRunner title="CSS Variables" name="css-variables" type="generated" /%}
 
@@ -39,8 +39,10 @@ Use a CSS custom property such as `var(--brand-primary)` anywhere a colour is ac
 }
 ```
 
-- **Toggle palette** changes the variables only; the series, background, axes and text all follow.
-- The chart re-renders automatically when a variable changes — no `chart.update()` needed.
+In the above example: 
+
+- Click the button to change the CSS variables only and the series, background, axes and text all update.
+- The chart re-renders automatically whenever a variable changes. There is no need to call `chart.update()`.
 
 {% note %}
 The `--ag-charts-*` namespace is reserved for internal use.
@@ -48,7 +50,7 @@ The `--ag-charts-*` namespace is reserved for internal use.
 
 ## Theme Parameter References
 
-A colour can reference a [theme parameter](./themes/#parameters) instead of a literal value, keeping related colours in sync. A reference can be used anywhere a colour is accepted — including a series `fill` — but can only point _to_ a theme parameter.
+A colour can reference a [theme parameter](./themes/#parameters) instead of a literal value, keeping related colours in sync. 
 
 {% chartExampleRunner title="Theme Parameter References" name="colour-references" type="generated" /%}
 
@@ -59,7 +61,7 @@ A colour can reference a [theme parameter](./themes/#parameters) instead of a li
             accentColor: '#2f6df0',
             backgroundColor: '#ffffff',
             foregroundColor: { ref: 'accentColor', mix: 0.85, onto: 'backgroundColor' },
-            axisColor: { ref: 'accentColor', mix: 0.5 },
+            axisLineColor: { ref: 'accentColor', mix: 0.5 },
         },
     },
     series: [{ type: 'bar', xKey: 'month', yKey: 'revenue', fill: { ref: 'accentColor' } }],
@@ -68,12 +70,18 @@ A colour can reference a [theme parameter](./themes/#parameters) instead of a li
 
 The reference forms are:
 
-- `{ ref: 'accentColor' }` — resolve to another theme parameter.
-- `{ ref: 'accentColor', mix: 0.5 }` — mix the referenced parameter towards transparency.
-- `{ ref: 'accentColor', mix: 0.85, onto: 'backgroundColor' }` — blend one parameter onto another.
+- `{ ref: 'accentColor' }` - resolve to another theme parameter.
+- `{ ref: 'accentColor', mix: 0.5 }` - the referenced parameter at `mix` opacity (`0` fully transparent, `1` fully opaque).
+- `{ ref: 'accentColor', mix: 0.85, onto: 'backgroundColor' }` - blend one parameter onto another.
+
+{% note %}
+
+A reference can be used anywhere a colour is accepted, but can only point to a theme parameter.
+
+{% /note %}
 
 See [Themes](./themes/#colour-references) for more details.
 
 ## Gradient, Pattern & Image Fills
 
-`fill` properties also accept gradient, pattern, and image fills — on series, markers, [legend](./legend/) backgrounds, and label boxes. See [Series Fills](./fills/) for the full reference. A `stroke` accepts a colour string only.
+Most `fill` properties also accept gradient, pattern, and image fills. See [Series Fills](./fills/) for the full reference.

--- a/packages/ag-charts-website/src/content/docs/selection/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/selection/index.mdoc
@@ -120,14 +120,14 @@ In this example:
     - Selected bars are rendered in `'skyblue'` colour.
     - Unselected bars are dimmed.
 - When dragging is in progress:
-    - Bars that are will be added to the selection are rendered in `'green'` colour.
-    - Bars that are will be removed from the selection are rendered in `'red'` colour.
+    - Bars that will be added to the selection are rendered in `'green'` colour.
+    - Bars that will be removed from the selection are rendered in `'red'` colour.
 
-The `candidateState` property can be:   
+The `candidateState` property includes:
 - `undefined` - no drag selection is in progress.
 - `'selected-item'` - the datum will become selected after the drag completes.
-- `unselected-item'` - the datum will become unselected after the drag completes.
-- `none` - there will be nothing selected after the drag completes.
+- `'unselected-item'` - the datum will become unselected after the drag completes.
+- `'none'` - there will be nothing selected after the drag completes.
 
 Once the drag completes, the `candidateState` becomes the new `selectionState`. If the user cancels the drag, the `candidateState` is cleared and the `selectionState` remains unchanged.
 

--- a/packages/ag-charts-website/src/content/docs/selection/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/selection/index.mdoc
@@ -124,6 +124,7 @@ In this example:
     - Bars that will be removed from the selection are rendered in `'red'` colour.
 
 The `candidateState` property includes:
+
 - `undefined` - no drag selection is in progress.
 - `'selected-item'` - the datum will become selected after the drag completes.
 - `'unselected-item'` - the datum will become unselected after the drag completes.

--- a/packages/ag-charts-website/src/content/docs/selection/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/selection/index.mdoc
@@ -110,7 +110,7 @@ In this example:
 
 ### Candidacy
 
-The `candidateState` property can be used to customise the styling when a drag motion is in progress.
+The `candidateState` property in [Styler](./stylers/) callbacks can be used to customise the styling while a drag motion is in progress based on the pending selection state.
 
 {% chartExampleRunner title="Candidate Styling" name="candidate-styling" type="generated" /%}
 
@@ -122,6 +122,14 @@ In this example:
 - When dragging is in progress:
     - Bars that are will be added to the selection are rendered in `'green'` colour.
     - Bars that are will be removed from the selection are rendered in `'red'` colour.
+
+The `candidateState` property can be:   
+- `undefined` - no drag selection is in progress.
+- `'selected-item'` - the datum will become selected after the drag completes.
+- `unselected-item'` - the datum will become unselected after the drag completes.
+- `none` - there will be nothing selected after the drag completes.
+
+Once the drag completes, the `candidateState` becomes the new `selectionState`. If the user cancels the drag, the `candidateState` is cleared and the `selectionState` remains unchanged.
 
 ## Selection API
 

--- a/packages/ag-charts-website/src/content/docs/stylers/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/stylers/index.mdoc
@@ -142,6 +142,7 @@ Each `styler` receives a `params` object containing:
 - Relevant details of the series, such as the `seriesId`, and `_Keys`.
 - The style properties currently applied to the series.
 - The [highlight state](./series-highlighting/#stylers) of the series.
+- The [selected and candidate state](./selection/#candidacy) of the series.
 
 It should return an object containing the styles to be applied to the series.
 Styling of nested property objects other than `marker` must be done with an `itemStyler`.

--- a/packages/ag-charts-website/src/content/docs/stylers/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/stylers/index.mdoc
@@ -84,6 +84,7 @@ Each `itemStyler` receives a `params` object containing:
 - Relevant details of the item, such as the `datum`, `seriesId`, and `_Keys`.
 - The style properties currently applied to the item.
 - The [highlight state](./series-highlighting/#stylers) of the item.
+- The [selected and candidate state](./selection/#candidacy) of the item.
 
 It should return an object containing the styles to be applied to the item.
 

--- a/packages/ag-charts-website/src/content/docs/text/_examples/inline-images/main.ts
+++ b/packages/ag-charts-website/src/content/docs/text/_examples/inline-images/main.ts
@@ -58,6 +58,8 @@ const options: AgChartOptions = {
             yName: 'Revenue',
             label: {
                 enabled: true,
+                fill: { ref: 'backgroundColor' } as any,
+                color: { ref: 'foregroundColor' },
                 formatter: ({ datum }) => {
                     const d = datum as TData;
                     return [

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/index.html
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-borders/index.html
@@ -1,21 +1,35 @@
 <div class="example-controls">
     <div class="controls-row">
-        <div class="gap-right">
-            <label for="color-select">color:</label>
-            <select id="color-select" onchange="changeColor(event)">
-                <option value="accentColor">accentColor (ref)</option>
-                <option value="#d1495b">#d1495b</option>
-                <option value="#21b372">#21b372</option>
-            </select>
-        </div>
-        <div class="gap-right">
-            <label for="width-range">width: <span id="width-value">2</span></label>
-            <input id="width-range" type="range" min="0" max="8" step="1" value="2" oninput="changeWidth(event)" />
-        </div>
-        <div>
-            <label for="radius-range">radius: <span id="radius-value">8</span></label>
-            <input id="radius-range" type="range" min="0" max="20" step="1" value="8" oninput="changeRadius(event)" />
-        </div>
+        <label for="color-select">color:</label>
+        <select id="color-select" class="gap-right" onchange="changeColor(event)">
+            <option value="accentColor">accentColor (ref)</option>
+            <option value="#d1495b">#d1495b</option>
+            <option value="#21b372">#21b372</option>
+        </select>
+        <label for="width-range">width:</label>
+        <input
+            id="width-range"
+            type="range"
+            min="0"
+            max="8"
+            step="1"
+            value="2"
+            oninput="changeWidth(event)"
+            onchange="changeWidth(event)"
+        />
+        <span id="width-value" class="gap-right">2</span>
+        <label for="radius-range">radius:</label>
+        <input
+            id="radius-range"
+            type="range"
+            min="0"
+            max="20"
+            step="1"
+            value="8"
+            oninput="changeRadius(event)"
+            onchange="changeRadius(event)"
+        />
+        <span id="radius-value">8</span>
     </div>
 </div>
 <div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/themes/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/themes/index.mdoc
@@ -110,7 +110,7 @@ Any colour parameter can reference another instead of a fixed value, keeping rel
 
 {% chartExampleRunner title="Colour References" name="theme-colour-references" type="generated" /%}
 
-The chart `textColor` is derived from the controls. With `onto` set to `none`, `mix` fades the referenced colour towards transparency.
+The chart `textColor` is derived from the controls. With no `onto`, `mix` fades the referenced colour towards transparency.
 
 ```js format="snippet"
 const myTheme = {
@@ -130,9 +130,9 @@ const myTheme = {
 
 Border parameters use a consistent `{ width, color }` shape across every element.
 
-{% chartExampleRunner title="Borders" name="theme-borders" type="generated" /%}
+<!-- {% chartExampleRunner title="Borders" name="theme-borders" type="generated" /%}
 
-The controls style `buttonBorder`, shown on the zoom buttons.
+The controls style `buttonBorder`, shown on the zoom buttons. -->
 
 ```js format="snippet"
 const myTheme = {


### PR DESCRIPTION
## Summary

Documentation copy and example refinements across several reference pages.

- **Colours** — clearer wording for CSS variables and theme parameter references; reference forms now describe `mix` opacity semantics; the "anywhere a colour is accepted" caveat moved to a note. Examples use `axisLineColor` instead of the removed `axisColor`.
- **Selection** — document the `candidateState` values (`undefined`, `'selected-item'`, `'unselected-item'`, `'none'`) and their drag/commit lifecycle.
- **Stylers** — cross-link the selected/candidate state from the `itemStyler` params list.
- **Text** — style label `fill`/`color` via theme parameter refs in the inline-images example.
- **Themes** — tidy the theme-borders example controls markup and temporarily comment out the borders example runner; minor `onto` wording fix.

## Test plan

- [ ] Verify the affected docs pages render correctly in the dev server (colours, selection, stylers, text, themes).
- [ ] Confirm the colour-references and inline-images examples render across frameworks.