### PR TITLE
AG-17592 Return Resolved<T> from resolvePartial to drop boundary casts

### DIFF
--- a/packages/ag-charts-community/src/chart/labelUtil.ts
+++ b/packages/ag-charts-community/src/chart/labelUtil.ts
@@ -102,11 +102,12 @@ export function getLabelStyles<TParams>(
             selectionState: series.getSelectionStateString(nodeDatum?.datumIndex),
             candidateState: series.getCandidateStateString(nodeDatum?.datumIndex),
         };
-        const stylerResult = (series.ctx.optionsGraphService.resolvePartial(
-            labelPath,
-            series.cachedCallWithContext(label.itemStyler, { ...params, ...styleParams }),
-            { pick: false }
-        ) ?? {}) as NormalisedChartLabelStyleOptions;
+        const stylerResult =
+            series.ctx.optionsGraphService.resolvePartial(
+                labelPath,
+                series.cachedCallWithContext(label.itemStyler, { ...params, ...styleParams }),
+                { pick: false }
+            ) ?? {};
 
         return mergeDefaults(stylerResult, styleParams);
     }

--- a/packages/ag-charts-community/src/chart/optionsGraphService.ts
+++ b/packages/ag-charts-community/src/chart/optionsGraphService.ts
@@ -1,4 +1,4 @@
-import type { PlainObject } from 'ag-charts-core';
+import type { PlainObject, Resolved } from 'ag-charts-core';
 
 import type { OptionsGraphAccessor, OptionsGraphAccessorResolvePartialOptions } from '../module/optionsGraph';
 
@@ -18,7 +18,7 @@ export class OptionsGraphService {
         partialOptions?: T,
         resolveOptions?: OptionsGraphAccessorResolvePartialOptions,
         cssVariables?: Record<string, string>
-    ): Partial<T> | undefined {
+    ): Resolved<Partial<T>> | undefined {
         return this.resolvePartialCallback?.(path, partialOptions, resolveOptions, cssVariables);
     }
 }

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -1854,7 +1854,7 @@ export class AreaSeries extends CartesianSeries<AreaSeriesTypes> {
                 ['series', `${this.declarationOrder}`],
                 cbResult,
                 { pick: false }
-            ) as NormalisedAreaSeriesStylerResult;
+            );
             stylerResult = resolved ?? {};
         }
         stylerResult.marker ??= {};

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -1454,11 +1454,12 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
         let stylerResult: NormalisedBarSeriesStyle = {};
         if (!ignoreStylerCallback && styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
-            stylerResult = (this.ctx.optionsGraphService.resolvePartial(
-                ['series', `${this.declarationOrder}`],
-                this.cachedCallWithContext(styler, stylerParams) ?? {},
-                { pick: false }
-            ) ?? {}) as NormalisedBarSeriesStyle;
+            stylerResult =
+                this.ctx.optionsGraphService.resolvePartial(
+                    ['series', `${this.declarationOrder}`],
+                    this.cachedCallWithContext(styler, stylerParams) ?? {},
+                    { pick: false }
+                ) ?? {};
         }
         return {
             cornerRadius: stylerResult.cornerRadius ?? cornerRadius,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -1310,7 +1310,7 @@ export class LineSeries extends CartesianSeries<LineSeriesTypes> {
                 ['series', `${this.declarationOrder}`],
                 cbResult,
                 { pick: false }
-            ) as NormalisedLineSeriesStylerResult | undefined;
+            );
             stylerResult = resolved ?? {};
         }
         stylerResult.marker ??= {};

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -761,7 +761,7 @@ export class DonutSeries extends PolarSeries<
                         ['series', `${this.declarationOrder}`],
                         this.callWithContext(itemStyler, params),
                         { proxyPaths: { fill: ['fills', `${datumIndex}`], stroke: ['strokes', `${datumIndex}`] } }
-                    ) as NormalisedDonutSeriesStyle;
+                    );
                 }
             );
         }

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1491,10 +1491,7 @@ export abstract class Series<
                 candidateState: candidateStateString,
                 datum,
             });
-            const resolved = this.ctx.optionsGraphService.resolvePartial(
-                getResolvePath(),
-                style
-            ) as NormalisedSeriesMarkerStyle;
+            const resolved = this.ctx.optionsGraphService.resolvePartial(getResolvePath(), style);
 
             markerStyle = mergeMarkerStylesPair(resolved, markerStyle);
         }

--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -4,6 +4,7 @@ import {
     Logger,
     ModuleRegistry,
     type PlainObject,
+    type Resolved,
     type Vertex,
     isObject,
     isObjectLike,
@@ -49,7 +50,7 @@ export interface OptionsGraphAccessor {
         partialOptions?: T,
         resolveOptions?: OptionsGraphAccessorResolvePartialOptions,
         csssVariables?: Record<string, string>
-    ): Partial<T> | undefined;
+    ): Resolved<Partial<T>> | undefined;
     clearSafe(): void;
 }
 
@@ -378,7 +379,7 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
             proxyPaths?: Record<string, Array<string>>;
         },
         cssVariables?: Record<string, string>
-    ): Partial<T> | undefined {
+    ): Resolved<Partial<T>> | undefined {
         if (!partialOptions) return;
 
         // If the graph has been cleared, do not attempt to resolve. This will occur when no `styler` options are provided.
@@ -393,7 +394,7 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
             console.groupCollapsed(`OptionsGraph.resolvePartial() - ${path.join('.')} [${partialKeys}]`);
         }
 
-        if (partialKeys.length === 0) return {};
+        if (partialKeys.length === 0) return {} as Resolved<Partial<T>>;
 
         if (cssVariables) {
             this.cssVariables = { ...this.cssVariables, ...cssVariables };
@@ -483,7 +484,7 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
             console.groupEnd();
         }
 
-        return partial;
+        return partial as Resolved<Partial<T>>;
     }
 
     findVertexAtPath(path: Array<string>) {

--- a/packages/ag-charts-core/src/main.ts
+++ b/packages/ag-charts-core/src/main.ts
@@ -14,6 +14,7 @@ export * from './types/normalised-options/normalisedLabelOptions';
 export * from './types/normalised-options/normalisedLegendOptions';
 export * from './types/normalised-options/normalisedSelectionOptions';
 export * from './types/normalised-options/normalisedZoomOptions';
+export * from './types/normalised-options/resolved';
 export * from './modules/moduleDefinition';
 export * from './types/scene';
 export * from './types/scales';

--- a/packages/ag-charts-core/src/types/normalised-options/resolved.ts
+++ b/packages/ag-charts-core/src/types/normalised-options/resolved.ts
@@ -1,0 +1,25 @@
+import type { AgColorRef, AgColorRefMixOnto } from 'ag-charts-types';
+
+/** Theme colour-reference object members of the public colour unions. Always resolved away at render time. */
+type ColorRef = AgColorRef | AgColorRefMixOnto;
+
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+
+/**
+ * Transforms a public options shape into its post-resolution colour shape: theme colour references
+ * (`AgColorRef`/`AgColorRefMixOnto`) are stripped from every colour union, leaving the resolved
+ * `CssColor`/gradient/pattern/image members, recursing through nested objects and arrays.
+ *
+ * Mirrors the runtime guarantee that `optionsGraphService.resolvePartial(...)` (and static
+ * options-graph processing) has already resolved all refs by the time a value is consumed.
+ */
+export type Resolved<T> = T extends Primitive
+    ? T
+    : // Functions (e.g. marker-shape callbacks) and other non-data values pass through untouched.
+      T extends (...args: any[]) => any
+      ? T
+      : T extends ReadonlyArray<infer E>
+        ? Array<Resolved<E>>
+        : T extends ColorRef
+          ? never
+          : { [K in keyof T]: Resolved<Exclude<T[K], ColorRef>> };

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -803,12 +803,11 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
         if (!ignoreStylerCallback && styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
             stylerResult =
-                // resolvePartial resolves colour refs, so the result is a normalised style.
-                (this.ctx.optionsGraphService.resolvePartial(
+                this.ctx.optionsGraphService.resolvePartial(
                     ['series', `${this.declarationOrder}`],
                     this.cachedCallWithContext(styler, stylerParams) ?? {},
                     { pick: false }
-                ) as NormalisedBoxPlotSeriesStyle) ?? {};
+                ) ?? {};
         }
         return {
             cornerRadius: stylerResult.cornerRadius ?? cornerRadius,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -1012,11 +1012,12 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
         let stylerResult: NormalisedRangeBarSeriesStyle = {};
         if (!ignoreStylerCallback && styler) {
             const stylerParams = this.makeStylerParams(highlightState, selectionState, candidateState);
-            stylerResult = (this.ctx.optionsGraphService.resolvePartial(
-                ['series', `${this.declarationOrder}`],
-                this.cachedCallWithContext(styler, stylerParams) ?? {},
-                { pick: false }
-            ) ?? {}) as NormalisedRangeBarSeriesStyle;
+            stylerResult =
+                this.ctx.optionsGraphService.resolvePartial(
+                    ['series', `${this.declarationOrder}`],
+                    this.cachedCallWithContext(styler, stylerParams) ?? {},
+                    { pick: false }
+                ) ?? {};
         }
         return {
             cornerRadius: stylerResult.cornerRadius ?? cornerRadius,

--- a/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
+++ b/packages/ag-charts-enterprise/src/series/util/radialUtil.ts
@@ -8,7 +8,14 @@ import type {
     Styler,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import type { Callback, CallbackParam, CallbackParamRules, DynamicContext, InternalAgColorType } from 'ag-charts-core';
+import type {
+    Callback,
+    CallbackParam,
+    CallbackParamRules,
+    DynamicContext,
+    InternalAgColorType,
+    Resolved,
+} from 'ag-charts-core';
 import { mergeDefaults } from 'ag-charts-core';
 
 const { createDatumId, toHighlightString, toSelectionString } = _ModuleSupport;
@@ -117,7 +124,7 @@ export function getStyle(
     candidateState: _ModuleSupport.SelectionState | undefined
 ): RadialSeriesStyleResult {
     const { styler } = series.properties;
-    let stylerResult: AgRadialSeriesStyle = {};
+    let stylerResult: Resolved<Partial<AgRadialSeriesStyle>> = {};
     if (!ignoreStylerCallback && styler) {
         const stylerParams = makeStylerParams(series, highlightState, selectionState, candidateState);
         stylerResult =
@@ -130,8 +137,7 @@ export function getStyle(
 
     return {
         cornerRadius: stylerResult.cornerRadius ?? series.properties.cornerRadius,
-        // resolvePartial has resolved any colour refs in the styler result; properties.fill is already resolved.
-        fill: (stylerResult.fill ?? series.properties.fill) as InternalAgColorType,
+        fill: stylerResult.fill ?? series.properties.fill,
         fillOpacity: stylerResult.fillOpacity ?? series.properties.fillOpacity,
         lineDash: stylerResult.lineDash ?? series.properties.lineDash,
         lineDashOffset: stylerResult.lineDashOffset ?? series.properties.lineDashOffset,


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17592

**Stacked on #7195** (base branch `ag-17592/fix-fill-and-stroke-types`) — review/merge that first.

### Why
#7195 widened public colour options to accept theme colour references and threads normalised (ref-free) colour types through render code. Colour refs (`ref`/`mix`/`onto`, incl. gradient stops) are resolved by the options-graph resolver — for runtime styler callbacks, via `optionsGraphService.resolvePartial(...)` — before any value reaches render code. But `resolvePartial` was typed to return the public, ref-inclusive shape (`Partial<T>`), so every styler boundary had to re-narrow with an `as` cast.

### What
- Add `Resolved<T>` (`ag-charts-core`): a mapped type that strips the `AgColorRef`/`AgColorRefMixOnto` members from every colour union, recursing through nested objects and arrays. Functions (e.g. marker-shape callbacks) and primitives pass through unchanged — the function guard is load-bearing, otherwise callbacks collapse to `{}`.
- Retarget `resolvePartial` (`OptionsGraph`, the `OptionsGraphAccessor` interface, and `OptionsGraphService`) to return `Resolved<Partial<T>>`.
- Remove the now-redundant colour-ref casts at the styler boundaries: `labelUtil`, `areaSeries`, `barSeries`, `lineSeries`, `donutSeries`, series marker (`series.ts`), `boxPlotSeries`, `rangeBarSeries`, and `radialUtil` (whose local `stylerResult` is retyped so its `fill` cast drops).

This encodes the refs-resolved guarantee in the type system rather than asserting it by hand at each call site.

### Scope
Type-only; emitted JS is unchanged. Removes ~13 boundary casts (≈25–30% of the colour casts in #7195). Out of scope, left for a possible follow-up: downstream casts on Properties-stored / node-datum styles (candlestick, ohlc, pyramid, map-shape/line, scrollbar, radial-gauge, error-bar background), which would need those fields retyped; and orthogonal `Required<>`/`RequireOptional<>`/`ResolvedStyleMixin` requiredness casts.

### Test plan
- `build:types` passes for `ag-charts-core`, `ag-charts-community`, `ag-charts-enterprise`.
- `lint` clean for all three; `nx format` applied.

Fix #AG-17592