### PR TITLE
AG-17592 Remove colour-ref `as any` casts from examples

### DIFF
--- a/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/colours/_examples/colour-references/main.ts
@@ -42,7 +42,7 @@ const options: AgCartesianChartOptions = {
             yKey: 'revenue',
             yName: 'Revenue',
             // A reference resolves on a series fill as well as on theme parameters.
-            fill: { ref: 'accentColor' } as any,
+            fill: { ref: 'accentColor' },
         },
     ],
     axes: {

--- a/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
+++ b/packages/ag-charts-website/src/content/docs/themes/_examples/theme-colour-references/main.ts
@@ -22,7 +22,7 @@ const options: AgCartesianChartOptions = {
             backgroundColor: '#ffffff',
             foregroundColor: '#1b2a4a',
             // Only the text colour is derived from the controls below.
-            textColor: { ref: colorRef, mix } as any,
+            textColor: { ref: colorRef, mix },
         },
     },
     title: {
@@ -57,7 +57,7 @@ function updateTextColor() {
             backgroundColor: '#ffffff',
             foregroundColor: '#1b2a4a',
             // Only the text colour is derived from the controls below.
-            textColor: textColor as any,
+            textColor,
         },
     };
     chart.update(options);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17592

Removes the `as any` casts that two generated examples used to compile colour-ref objects against the public types (added in PR #7162). The types now accept colour-ref objects on series `fill` and theme params, so the casts are no longer needed.

- `colours/_examples/colour-references/main.ts` — `fill: { ref: 'accentColor' }` (series fill)
- `themes/_examples/theme-colour-references/main.ts` — `textColor: { ref, mix }` theme-param refs (two sites)

## ⚠️ Merge order
Depends on the AG-17592 type widening (**PR #7195**) landing first. Merging this before #7195 will break example type-checking.

## Test plan
- [ ] After #7195 lands: `yarn nx validate-examples`
- [ ] Confirm the colour-references and theme-colour-references examples render across frameworks

Fix #AG-17592