### PR TITLE
docs(charts): add missing v14 breaking changes to migration guide

### DIFF
--- a/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-create-update/index.mdoc
@@ -91,7 +91,7 @@ Although rendering may be complete, browsers may not repaint until Javascript ex
 `Promise`s do not take animations into account, they resolve after the first rendering in an animation sequence.
 {% /note %}
 
-This example demonstrates how these APIs be used to create to continuously update a chart, with each update only being
+This example demonstrates how these APIs can be used to continuously update a chart, with each update only being
 applied once the previous update has been rendered.
 
 {% chartExampleRunner title="Wait for Options Update" name="wait-for-update" type="generated" /%}
@@ -103,7 +103,7 @@ applied once the previous update has been rendered.
 {% if isFramework("javascript") %}
 Charts can be destroyed by using the `AgChartInstance.destroy()` method.
 
-{% apiReference id="_AgChartInstance" include=["destroy"] hideHeader=true hideRequired=true /%}
+{% apiReference id="_AgChartInstanceInterface" include=["destroy"] hideHeader=true hideRequired=true /%}
 {% /if %}
 
 {% if isNotJavascriptFramework() %}

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14/index.mdoc
@@ -91,6 +91,7 @@ This release includes the following breaking changes:
 
 ### Theme Params
 
+- `axisColor` is removed. Use `axisLineColor` instead.
 - `separationLinesColor` is removed. Use `groupedCategoryLineColor` instead.
 
 ### Range Buttons
@@ -99,6 +100,7 @@ This release includes the following breaking changes:
 
 ### Padding
 
+- `paddingX` and `paddingY` are removed from the legend item. Use `padding (number | PaddingOptions)` to set left/right and top/bottom spacing instead.
 - `AgChartPaddingOptions` and `AgNavigatorMiniChartPadding` are removed. Use `Padding` (`number | PaddingOptions`) instead.
 
 {% /expandingSection %}


### PR DESCRIPTION
## Summary

The v14 migration guide was missing two breaking changes. Both are now documented:

- **Theme Params** — `axisColor` removed, renamed to `axisLineColor` (sibling of the already-documented `separationLinesColor` → `groupedCategoryLineColor` rename).
- **Padding** — legend item `paddingX` / `paddingY` removed in favour of `padding` (`number | PaddingOptions`).

## Test plan

- `yarn nx format` and `yarn nx format:mdoc ag-charts-website` — clean.
- Docs-only change; renders within the existing Breaking Changes section.

Tracked by [CRT-1121](https://ag-grid.atlassian.net/browse/CRT-1121).