### PR TITLE
CRT-1122 Only show pointer cursor when datum selection is enabled

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.test.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgBarSeriesOptions, AgCartesianChartOptions } from 'ag-charts-types';
+
+import {
+    createChart,
+    getCursor,
+    hoverAction,
+    setupMockCanvas,
+    setupMockConsole,
+    waitForChartStability,
+} from '../test/utils';
+
+const data = [
+    { month: 'January', sales: 1200, expenses: 800 },
+    { month: 'February', sales: 1500, expenses: 950 },
+    { month: 'March', sales: 1700, expenses: 1100 },
+];
+
+// Coordinate over the first 'sales' bar; bar Rect nodes are hit-testable in JSDOM.
+const overBar = { x: 133, y: 333 } as const;
+
+function barOptions(extra?: Partial<AgBarSeriesOptions>): AgCartesianChartOptions {
+    return {
+        data,
+        series: [
+            { type: 'bar', xKey: 'month', yKey: 'sales', ...extra },
+            { type: 'bar', xKey: 'month', yKey: 'expenses', ...extra },
+        ],
+    };
+}
+
+describe('CRT-1122 hover cursor', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let chart: Awaited<ReturnType<typeof createChart>>;
+
+    afterEach(() => {
+        chart?.destroy();
+    });
+
+    it('shows the default cursor on a non-interactive series', async () => {
+        chart = await createChart(barOptions());
+
+        await hoverAction(overBar.x, overBar.y)(chart);
+        await waitForChartStability(chart);
+
+        expect(getCursor(chart)).toBe('default');
+    });
+
+    it('shows the pointer cursor when selection is enabled', async () => {
+        chart = await createChart(barOptions({ selection: { enabled: true } }));
+
+        await hoverAction(overBar.x, overBar.y)(chart);
+        await waitForChartStability(chart);
+
+        expect(getCursor(chart)).toBe('pointer');
+    });
+
+    it('shows the pointer cursor when a seriesNodeClick listener is present', async () => {
+        chart = await createChart(barOptions({ listeners: { seriesNodeClick: () => undefined } }));
+
+        await hoverAction(overBar.x, overBar.y)(chart);
+        await waitForChartStability(chart);
+
+        expect(getCursor(chart)).toBe('pointer');
+    });
+});

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -558,7 +558,7 @@ export class SeriesAreaManager extends BaseManager {
             const matches = pick?.matches;
             const found = matches?.[0];
             if (
-                found?.series.isDatumSelectable(found.datumIndex) ||
+                (found?.series.isSelectionEnabled() && found?.series.isDatumSelectable(found.datumIndex)) ||
                 found?.series.hasEventListener('seriesNodeClick') ||
                 found?.series.hasEventListener('seriesNodeDoubleClick') ||
                 (matches != null && matches.length > 1 && this.chart.tooltip.pagination)


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1122

The hover pointer cursor was gated on `series.isDatumSelectable(datumIndex)` alone. The base `Series.isDatumSelectable()` returns `true` unconditionally — it is a per-datum refinement intended to run *after* selection is confirmed enabled — so the pointer cursor was applied on hover to every series and gauge regardless of interactivity, falsely implying clickability.

The fix requires `isSelectionEnabled()` as well, restoring the pre-regression intent while preserving the new per-datum selectability check. The same gate covers the treemap (whose `isDatumSelectable` checks `isLeaf` but not `selection.enabled`) and all gauges.

**Test plan**

Added `seriesAreaManager.test.ts` (bar series, whose Rect nodes are hit-testable in JSDOM):
- non-interactive series → default cursor (fails before the fix, passes after)
- `selection.enabled: true` → pointer cursor
- `seriesNodeClick` listener present → pointer cursor

Verified: `yarn nx test ag-charts-community` (3690 pass), `build:types`, `lint` clean.

Fix #CRT-1122