### PR TITLE
docs(charts): register LegendModule in scrollbar and band-alignment examples

### DIFF
--- a/packages/ag-charts-website/src/content/docs/axes-position/_examples/band-alignment/main.ts
+++ b/packages/ag-charts-website/src/content/docs/axes-position/_examples/band-alignment/main.ts
@@ -5,13 +5,14 @@ import {
     AgCharts,
     BarSeriesModule,
     CategoryAxisModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
 } from 'ag-charts-enterprise';
 
 import { DataType, getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule]);
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, NumberAxisModule, LegendModule]);
 
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-placement/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-placement/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgScrollbarPlacement,
     BarSeriesModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
     OrdinalTimeAxisModule,
@@ -11,7 +12,13 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, ScrollbarModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    NumberAxisModule,
+    OrdinalTimeAxisModule,
+    ScrollbarModule,
+    LegendModule,
+]);
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),
@@ -56,9 +63,6 @@ const options: AgCartesianChartOptions = {
         placement: 'inner',
         spacing: 0,
         tickSpacing: 0,
-    },
-    legend: {
-        enabled: false,
     },
 };
 

--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-position/main.ts
@@ -2,6 +2,7 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     AreaSeriesModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
     OrdinalTimeAxisModule,
@@ -17,6 +18,7 @@ ModuleRegistry.registerModules([
     OrdinalTimeAxisModule,
     ScrollbarModule,
     ZoomModule,
+    LegendModule,
 ]);
 
 const options: AgCartesianChartOptions = {
@@ -64,9 +66,6 @@ const options: AgCartesianChartOptions = {
             ratioX: { start: 0.1, end: 0.5 },
             ratioY: { start: 0.2, end: 0.75 },
         },
-    },
-    legend: {
-        enabled: false,
     },
 };
 

--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-scrolling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-scrolling/main.ts
@@ -2,6 +2,7 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     BarSeriesModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
     OrdinalTimeAxisModule,
@@ -10,7 +11,13 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, ScrollbarModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    NumberAxisModule,
+    OrdinalTimeAxisModule,
+    ScrollbarModule,
+    LegendModule,
+]);
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-styling/main.ts
@@ -2,6 +2,7 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     BarSeriesModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
     OrdinalTimeAxisModule,
@@ -10,7 +11,13 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, ScrollbarModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    NumberAxisModule,
+    OrdinalTimeAxisModule,
+    ScrollbarModule,
+    LegendModule,
+]);
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-visibility/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar-visibility/main.ts
@@ -3,6 +3,7 @@ import {
     AgCharts,
     AgScrollbarVisibility,
     BarSeriesModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
     OrdinalTimeAxisModule,
@@ -11,7 +12,13 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, ScrollbarModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    NumberAxisModule,
+    OrdinalTimeAxisModule,
+    ScrollbarModule,
+    LegendModule,
+]);
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/scrollbar/main.ts
@@ -2,6 +2,7 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     BarSeriesModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
     OrdinalTimeAxisModule,
@@ -10,7 +11,13 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, ScrollbarModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    NumberAxisModule,
+    OrdinalTimeAxisModule,
+    ScrollbarModule,
+    LegendModule,
+]);
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/scrollbar/_examples/vertical-scrollbar/main.ts
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/_examples/vertical-scrollbar/main.ts
@@ -2,6 +2,7 @@ import {
     AgCartesianChartOptions,
     AgCharts,
     BarSeriesModule,
+    LegendModule,
     ModuleRegistry,
     NumberAxisModule,
     OrdinalTimeAxisModule,
@@ -10,7 +11,13 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([BarSeriesModule, NumberAxisModule, OrdinalTimeAxisModule, ScrollbarModule]);
+ModuleRegistry.registerModules([
+    BarSeriesModule,
+    NumberAxisModule,
+    OrdinalTimeAxisModule,
+    ScrollbarModule,
+    LegendModule,
+]);
 
 const options: AgCartesianChartOptions = {
     container: document.getElementById('myChart'),


### PR DESCRIPTION
JIRA: [CRT-1127](https://ag-grid.atlassian.net/browse/CRT-1127)

## Summary

Several multi-series documentation examples relied on the default-enabled legend but never registered `LegendModule`. Because these examples use explicit (tree-shakeable) module registration, the legend silently failed to render.

This registers `LegendModule` in each affected example:

- `axes-position/band-alignment`
- `scrollbar/vertical-scrollbar`
- `scrollbar/scrollbar`
- `scrollbar/scrollbar-visibility`
- `scrollbar/scrollbar-styling`
- `scrollbar/scrollbar-scrolling`
- `scrollbar/scrollbar-position`
- `scrollbar/scrollbar-placement`

For `scrollbar-position` and `scrollbar-placement`, which had `legend: { enabled: false }`, the disable block is removed so the legend now shows consistently with the rest of the scrollbar page.

## Test plan

- [ ] Open each affected example across frameworks and confirm the legend renders.

Fix #CRT-1127