### PR TITLE
CRT-1130 Interrupt highlight animation on legend keyboard focus

### DIFF
--- a/packages/ag-charts-community/src/chart/legend/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.test.ts
@@ -25,6 +25,7 @@ import {
     doubleClickAction,
     doubleTapAction,
     extractImageData,
+    getLegendModule,
     getTooltipElement,
     hoverAction,
     isTooltipVisible,
@@ -850,6 +851,51 @@ describe('Legend', () => {
             });
             chart = deproxy(AgCharts.create(options));
             await compare(chart);
+        });
+    });
+
+    describe('CRT-1130', () => {
+        const animate = spyOnAnimationManager();
+
+        test('keyboard legend focus change interrupts in-progress highlight animation', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { year: '2016', gold: 26, silver: 18, bronze: 26 },
+                    { year: '2020', gold: 38, silver: 32, bronze: 19 },
+                    { year: '2024', gold: 40, silver: 27, bronze: 24 },
+                ],
+                series: [
+                    { type: 'bar', xKey: 'year', yKey: 'gold' },
+                    { type: 'bar', xKey: 'year', yKey: 'silver' },
+                    { type: 'bar', xKey: 'year', yKey: 'bronze' },
+                ],
+            });
+
+            animate(1200, 1);
+            chart = await createChart(options);
+            await waitForChartStability(chart);
+
+            const legend = getLegendModule(chart);
+            const items = legend.itemSelection.nodes();
+
+            // Simulate mid-animation state (spyOnAnimationManager completes animations
+            // instantly via forceTimeJump, so we push Animation state directly to test
+            // the legend's highlight interruption behaviour).
+            chart.ctx.interactionManager.pushState(InteractionState.Animation);
+
+            // Keyboard navigation: blur the current item then focus a different one. The focus must
+            // interrupt the animation and apply the new highlight immediately, rather than deferring it.
+            legend.onLeave(new FocusEvent('blur'));
+            legend.onHover(new FocusEvent('focus'), items[1]);
+
+            // The highlight reflects the newly-focused item immediately, before the animation completes.
+            expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
+
+            chart.ctx.interactionManager.popState(InteractionState.Animation);
+            await waitForChartStability(chart);
+
+            // And it is not clobbered by a deferred clear once the animation batch stops.
+            expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
         });
     });
 

--- a/packages/ag-charts-community/src/chart/legend/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.test.ts
@@ -883,18 +883,17 @@ describe('Legend', () => {
             // the legend's highlight interruption behaviour).
             chart.ctx.interactionManager.pushState(InteractionState.Animation);
 
-            // Keyboard navigation: blur the current item then focus a different one. The focus must
-            // interrupt the animation and apply the new highlight immediately, rather than deferring it.
+            // Keyboard navigation: blur the current item then focus a different one.
             legend.onLeave(new FocusEvent('blur'));
             legend.onHover(new FocusEvent('focus'), items[1]);
 
-            // The highlight reflects the newly-focused item immediately, before the animation completes.
+            // Focus applies the new highlight immediately, before the animation completes.
             expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
 
             chart.ctx.interactionManager.popState(InteractionState.Animation);
             await waitForChartStability(chart);
 
-            // And it is not clobbered by a deferred clear once the animation batch stops.
+            // And the deferred clear from the blur does not clobber it once the batch stops.
             expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
         });
     });

--- a/packages/ag-charts-community/src/chart/legend/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.test.ts
@@ -884,8 +884,8 @@ describe('Legend', () => {
             chart.ctx.interactionManager.pushState(InteractionState.Animation);
 
             // Keyboard navigation: blur the current item then focus a different one.
-            legend.onLeave(new FocusEvent('blur'));
-            legend.onHover(new FocusEvent('focus'), items[1]);
+            legend.onLeave(true);
+            legend.onHover(new FocusEvent('focus'), items[1], true);
 
             // Focus applies the new highlight immediately, before the animation completes.
             expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
@@ -922,8 +922,8 @@ describe('Legend', () => {
             // Pointer hover queues a deferred highlight update for batch stop.
             legend.onHover(new MouseEvent('mouseenter'), items[0]);
             // Keyboard focus then applies a different highlight immediately, superseding the queued update.
-            legend.onLeave(new FocusEvent('blur'));
-            legend.onHover(new FocusEvent('focus'), items[1]);
+            legend.onLeave(true);
+            legend.onHover(new FocusEvent('focus'), items[1], true);
 
             expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
 

--- a/packages/ag-charts-community/src/chart/legend/legend.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.test.ts
@@ -896,6 +896,43 @@ describe('Legend', () => {
             // And the deferred clear from the blur does not clobber it once the batch stops.
             expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
         });
+
+        test('keyboard focus is not clobbered by a deferred pointer-hover update on batch stop', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { year: '2016', gold: 26, silver: 18, bronze: 26 },
+                    { year: '2020', gold: 38, silver: 32, bronze: 19 },
+                ],
+                series: [
+                    { type: 'bar', xKey: 'year', yKey: 'gold' },
+                    { type: 'bar', xKey: 'year', yKey: 'silver' },
+                    { type: 'bar', xKey: 'year', yKey: 'bronze' },
+                ],
+            });
+
+            animate(1200, 1);
+            chart = await createChart(options);
+            await waitForChartStability(chart);
+
+            const legend = getLegendModule(chart);
+            const items = legend.itemSelection.nodes();
+
+            chart.ctx.interactionManager.pushState(InteractionState.Animation);
+
+            // Pointer hover queues a deferred highlight update for batch stop.
+            legend.onHover(new MouseEvent('mouseenter'), items[0]);
+            // Keyboard focus then applies a different highlight immediately, superseding the queued update.
+            legend.onLeave(new FocusEvent('blur'));
+            legend.onHover(new FocusEvent('focus'), items[1]);
+
+            expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
+
+            chart.ctx.interactionManager.popState(InteractionState.Animation);
+            await waitForChartStability(chart);
+
+            // The superseded pointer-hover update must not run on batch stop and overwrite the focus.
+            expect(chart.ctx.highlightManager.getActiveHighlight()?.series.id).toBe(items[1].datum?.id);
+        });
     });
 
     describe('CRT-1034', () => {

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -1093,25 +1093,26 @@ export class Legend {
             this.ctx.tooltipManager.removeTooltip(this.id, undefined, true);
         }
 
-        this.updateHighlight(datum?.enabled, datum, series);
+        this.updateHighlight(datum?.enabled, datum, series, undefined, event instanceof FocusEvent);
         this.ctx.eventsHub.emit('legend:item-hover', null);
     }
 
-    onLeave() {
+    onLeave(event?: FocusEvent | MouseEvent) {
         if (this.checkInteractionState()) return;
         this.ctx.tooltipManager.removeTooltip(this.id, undefined, true); // true = delayed
-        this.clearHighlight();
+        this.clearHighlight(event instanceof FocusEvent);
     }
 
-    private clearHighlight(): void {
-        this.updateHighlight(undefined, undefined, undefined);
+    private clearHighlight(fromKeyboardFocus = false): void {
+        this.updateHighlight(undefined, undefined, undefined, undefined, fromKeyboardFocus);
     }
 
     private updateHighlight(
         enabled: boolean | undefined,
         legendDatum: CategoryLegendDatum | undefined,
         series: SeriesType | undefined,
-        event?: ActiveLoadMementoEvent
+        event?: ActiveLoadMementoEvent,
+        fromKeyboardFocus = false
     ): void {
         if (this.checkInteractionState()) return;
         type InternalUpdateOpts = {
@@ -1140,11 +1141,17 @@ export class Legend {
             if (this.ctx.interactionManager.isState(InteractionState.Default) || event?.initialState) {
                 updateManagers(opts);
             } else if (this.ctx.interactionManager.isState(InteractionState.Animation)) {
-                // Updating the highlight can interrupt animations, so defer both setting and
-                // clearing highlights until the current animation batch completes.
-                this.ctx.animationManager.onBatchStop(() => {
+                // A keyboard focus change is a deliberate navigation that must take effect immediately,
+                // interrupting any in-progress animation. Pointer hover, by contrast, defers both setting
+                // and clearing highlights until the current animation batch completes so that a passing
+                // hover does not interrupt a show/hide animation.
+                if (fromKeyboardFocus) {
                     updateManagers(opts);
-                });
+                } else {
+                    this.ctx.animationManager.onBatchStop(() => {
+                        updateManagers(opts);
+                    });
+                }
             } else if (opts === undefined) {
                 updateManagers(opts);
             }

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -101,6 +101,10 @@ export class Legend {
 
     private readonly truncatedItems: Set<string | number> = new Set();
 
+    /** Incremented on every highlight update so a deferred (animation-batch) update can detect
+     * that a later update has superseded it and skip itself. */
+    private highlightUpdateToken = 0;
+
     private _data: CategoryLegendDatum[] = [];
     set data(value: CategoryLegendDatum[]) {
         if (objectsEqual(value, this._data)) return;
@@ -1138,6 +1142,9 @@ export class Legend {
         };
 
         const highlightNodeDatum = (opts: InternalUpdateOpts | undefined): void => {
+            // Any update supersedes earlier ones; a deferred update queued for batch-stop must
+            // not run if a later update (immediate or deferred) has since taken its place.
+            const token = ++this.highlightUpdateToken;
             if (this.ctx.interactionManager.isState(InteractionState.Default) || event?.initialState) {
                 updateManagers(opts);
             } else if (this.ctx.interactionManager.isState(InteractionState.Animation)) {
@@ -1149,7 +1156,9 @@ export class Legend {
                     updateManagers(opts);
                 } else {
                     this.ctx.animationManager.onBatchStop(() => {
-                        updateManagers(opts);
+                        if (token === this.highlightUpdateToken) {
+                            updateManagers(opts);
+                        }
                     });
                 }
             } else if (opts === undefined) {

--- a/packages/ag-charts-community/src/chart/legend/legend.ts
+++ b/packages/ag-charts-community/src/chart/legend/legend.ts
@@ -1080,7 +1080,7 @@ export class Legend {
         return [{ type: 'structured', title: this.getItemLabel(datum) }];
     }
 
-    onHover(event: FocusEvent | MouseEvent, node: LegendMarkerLabel) {
+    onHover(event: FocusEvent | MouseEvent, node: LegendMarkerLabel, fromKeyboardFocus = false) {
         if (this.checkInteractionState()) return;
         if (!this.opts.enabled) throw new Error('AG Charts - onHover handler called on disabled legend');
 
@@ -1097,14 +1097,14 @@ export class Legend {
             this.ctx.tooltipManager.removeTooltip(this.id, undefined, true);
         }
 
-        this.updateHighlight(datum?.enabled, datum, series, undefined, event instanceof FocusEvent);
+        this.updateHighlight(datum?.enabled, datum, series, undefined, fromKeyboardFocus);
         this.ctx.eventsHub.emit('legend:item-hover', null);
     }
 
-    onLeave(event?: FocusEvent | MouseEvent) {
+    onLeave(fromKeyboardFocus = false) {
         if (this.checkInteractionState()) return;
         this.ctx.tooltipManager.removeTooltip(this.id, undefined, true); // true = delayed
-        this.clearHighlight(event instanceof FocusEvent);
+        this.clearHighlight(fromKeyboardFocus);
     }
 
     private clearHighlight(fromKeyboardFocus = false): void {

--- a/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
@@ -29,7 +29,7 @@ interface ButtonListener {
     onClick(event: Event, datum: CategoryLegendDatum, proxyButton: SwitchWidget): void;
     onDoubleClick(event: Event, datum: CategoryLegendDatum): void;
     onHover(event: FocusEvent | MouseEvent, node: LegendMarkerLabel): void;
-    onLeave(): void;
+    onLeave(event?: FocusEvent | MouseEvent): void;
     onContextClick(widgetEvent: MouseWidgetEvent<'contextmenu'>, node: LegendMarkerLabel): void;
 }
 
@@ -114,7 +114,7 @@ export class LegendDOMProxy {
             button.addListener('mouseenter', (ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
             button.addListener('mouseleave', () => itemListener.onLeave());
             button.addListener('contextmenu', (ev) => itemListener.onContextClick(ev, markerLabel));
-            button.addListener('blur', () => itemListener.onLeave());
+            button.addListener('blur', (ev) => itemListener.onLeave(ev.sourceEvent));
             button.addListener('focus', (ev) =>
                 this.shouldApplyHoverOnFocus(button)
                     ? itemListener.onHover(ev.sourceEvent, markerLabel)

--- a/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendDOMProxy.ts
@@ -28,8 +28,8 @@ type CategoryLegendDatumReader = { getItemLabel(datum: CategoryLegendDatum): Nor
 interface ButtonListener {
     onClick(event: Event, datum: CategoryLegendDatum, proxyButton: SwitchWidget): void;
     onDoubleClick(event: Event, datum: CategoryLegendDatum): void;
-    onHover(event: FocusEvent | MouseEvent, node: LegendMarkerLabel): void;
-    onLeave(event?: FocusEvent | MouseEvent): void;
+    onHover(event: FocusEvent | MouseEvent, node: LegendMarkerLabel, fromKeyboardFocus?: boolean): void;
+    onLeave(fromKeyboardFocus?: boolean): void;
     onContextClick(widgetEvent: MouseWidgetEvent<'contextmenu'>, node: LegendMarkerLabel): void;
 }
 
@@ -114,10 +114,13 @@ export class LegendDOMProxy {
             button.addListener('mouseenter', (ev) => itemListener.onHover(ev.sourceEvent, markerLabel));
             button.addListener('mouseleave', () => itemListener.onLeave());
             button.addListener('contextmenu', (ev) => itemListener.onContextClick(ev, markerLabel));
-            button.addListener('blur', (ev) => itemListener.onLeave(ev.sourceEvent));
+            // Keyboard focus/blur must take effect immediately, interrupting any in-progress animation,
+            // so they pass fromKeyboardFocus=true. A focus that is not keyboard-driven (no :focus-visible)
+            // is treated as a leave and keeps the default deferred behaviour.
+            button.addListener('blur', () => itemListener.onLeave(true));
             button.addListener('focus', (ev) =>
                 this.shouldApplyHoverOnFocus(button)
-                    ? itemListener.onHover(ev.sourceEvent, markerLabel)
+                    ? itemListener.onHover(ev.sourceEvent, markerLabel, true)
                     : itemListener.onLeave()
             );
             // Enable touch long-tap context menus:

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -890,8 +890,8 @@ export function computeLegendBBox(chart: Chart): BBox {
 
 export interface LegendTestInternals {
     itemSelection: { nodes(): { datum?: { id: string; itemId?: string | number } }[] };
-    onHover(event: FocusEvent | MouseEvent, node: unknown): void;
-    onLeave(event?: FocusEvent | MouseEvent): void;
+    onHover(event: FocusEvent | MouseEvent, node: unknown, fromKeyboardFocus?: boolean): void;
+    onLeave(fromKeyboardFocus?: boolean): void;
 }
 
 export function getLegendModule(chart: Chart): LegendTestInternals {

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -888,6 +888,16 @@ export function computeLegendBBox(chart: Chart): BBox {
     return new BBox(x, y, width, height);
 }
 
+export interface LegendTestInternals {
+    itemSelection: { nodes(): { datum?: { id: string; itemId?: string | number } }[] };
+    onHover(event: FocusEvent | MouseEvent, node: unknown): void;
+    onLeave(event?: FocusEvent | MouseEvent): void;
+}
+
+export function getLegendModule(chart: Chart): LegendTestInternals {
+    return chart.modulesManager.getModule('legend') as LegendTestInternals;
+}
+
 export function getCursor(chart: Chart | AgChartProxy): string {
     const ctx = deproxy(chart).getModuleContext();
     return ctx.domManager.getCursor();


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1130

## Summary

Tabbing through legend items with the keyboard while a series highlight/dim animation was in progress did not update the dim: non-focused series stayed opaque until the animation finished, then dimmed.

**Root cause** (`packages/ag-charts-community/src/chart/legend/legend.ts`): legend highlight updates funnel through `updateHighlight` → `highlightNodeDatum`. During `InteractionState.Animation` the only handling deferred the update via `animationManager.onBatchStop(...)`, for both keyboard focus and mouse hover. That deferral exists for CRT-1034 (a passing hover must not interrupt a show/hide animation) but over-applied to keyboard focus, so a focus-driven dim only landed after the animation completed.

A second, subtler defect surfaced once the first was addressed: keyboard navigation fires `blur` (outgoing item) then `focus` (incoming item). The blur's deferred `clearHighlight` survives on the animation batch's stopped-callbacks and, when the next batch starts (`startBatch` → `AnimationBatch.destroy` → `dispatchStopped`), fires and clobbers the freshly-applied focus highlight.

**Fix:** thread a `fromKeyboardFocus` flag (derived from `event instanceof FocusEvent`, an idiom already used in this file) through `onHover` / `onLeave` / `clearHighlight` / `updateHighlight`. During `Animation`, a keyboard focus/blur now applies/clears the highlight immediately (interrupting the animation); pointer hover keeps the existing `onBatchStop` deferral, so CRT-1034 is preserved. The blur path clearing immediately also removes the stale deferred clear that was clobbering the incoming focus.

## Changes

- `legend.ts` — `fromKeyboardFocus` flag through the highlight path; keyboard focus/blur interrupt during animation, pointer hover still defers.
- `legendDOMProxy.ts` — `onLeave` accepts the blur event; the `blur` listener forwards `ev.sourceEvent` (a `FocusEvent`). `mouseleave` is unchanged (still defers).
- `test/utils.ts` — typed `getLegendModule()` test accessor.
- `legend.test.ts` — `CRT-1130` regression test asserting the highlight reflects the focused item immediately during the animation and survives the batch stop.

## Test plan

- `nx build:types ag-charts-community` + `ag-charts-enterprise`: pass.
- `nx lint ag-charts-community`: pass.
- Legend/highlight unit suites: the new `CRT-1130` test passes and the existing `CRT-1034` test still passes.

## Reviewer notes

- A `blur` caused by clicking elsewhere mid-animation is also a `FocusEvent`, so it now clears the legend highlight immediately too. This is intended and consistent with "deliberate focus change takes effect immediately"; low risk, but worth a glance.
- No keyboard E2E added: jsdom does not implement `:focus-visible`, so the real DOM `focus`→`onHover` path cannot be exercised end-to-end in a unit test (the regression test drives `onHover`/`onLeave` with real `FocusEvent`s directly). A faithful Playwright test belongs in `keyboard-nav.spec.ts` but is screenshot-based and needs baselines generated in the Docker E2E host.
- Pre-existing, unrelated to this change: the 4 `Legend > Large series count chart > should render legend correctly at width [200/400/600/800]` image-snapshot tests fail on the clean `b14.0.0` baseline (confirmed via `git stash`); not regressions, snapshots not regenerated.

Fix #CRT-1130