### PR TITLE
CRT-1128 Fix Safari I-beam cursor over chart captions

### DIFF
--- a/packages/ag-charts-community/src/widget/boundedTextWidget.test.ts
+++ b/packages/ag-charts-community/src/widget/boundedTextWidget.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { BoundedTextWidget } from './boundedTextWidget';
+
+describe('BoundedTextWidget', () => {
+    it('forces the default cursor on the SVG text to avoid the Safari I-beam', () => {
+        const widget = new BoundedTextWidget();
+
+        const text = widget.getElement().querySelector('text');
+        expect(text).not.toBeNull();
+        expect(text!.style.cursor).toBe('default');
+    });
+});

--- a/packages/ag-charts-community/src/widget/boundedTextWidget.ts
+++ b/packages/ag-charts-community/src/widget/boundedTextWidget.ts
@@ -29,6 +29,10 @@ export class BoundedTextWidget extends Widget<HTMLDivElement> {
         this.textElement = createSvgElement('text');
         this.textElement.role = 'presentation';
 
+        // Safari shows the I-beam cursor over SVG <text> on hover; this proxy is presentational,
+        // so force the default cursor on the text to keep the arrow cursor.
+        this.textElement.style.cursor = 'default';
+
         this.svgElement = createSvgElement('svg');
         this.svgElement.appendChild(this.textElement);
         this.svgElement.style.width = '100%';


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1128

## Problem

In Safari, hovering over a chart caption (title/subtitle/footnote) showed the I-beam (text) cursor instead of the default arrow, even though the caption text is not selectable.

## Root cause

Captions create an accessibility text proxy (`BoundedTextWidget`) layered over the canvas — an absolutely-positioned `<div>` containing an `<svg><text>` that mirrors the caption text for screenreaders. Safari renders the I-beam cursor over SVG `<text>` content on hover, and no cursor was being set on the proxy, so it defaulted to the text cursor over the glyphs.

## Fix

Force `cursor: default` on the proxy's `<text>` element in the `BoundedTextWidget` constructor. The `<text>` is the element Safari computes the I-beam for, and (unlike the wrapper `<div>`) it is never re-styled by `ProxyInteractionService.initElement`, so the cursor survives the proxy-creation flow. Accessibility is unaffected — role, content, bounds and listeners are unchanged; only the visual cursor changes.

## Test plan

- Added a unit test asserting the proxy `<text>` carries `cursor: default`.
- `yarn nx build:types ag-charts-community`, `yarn nx lint ag-charts-community` and the new vitest test all pass.
- **Manual Safari check still required** (cannot be asserted in jsdom): open the `grouped-horizontal-bar` gallery example in Safari, hover the caption without first touching the series-area, and confirm the arrow cursor instead of the I-beam.

Fix #CRT-1128