### PR TITLE
CRT-1124 Fix gauge keyboard navigation stuck across layers

### DIFF
--- a/packages/ag-charts-enterprise/src/series/gauge-util/pick.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/pick.ts
@@ -37,7 +37,17 @@ export function pickGaugeFocus(self: GaugeSeries, opts: PickFocusInputs): PickFo
     const { data, selection } = others[otherIndex];
     if (data == null || data.length === 0) return;
 
-    const datumIndex = clamp(0, opts.datumIndex, data.length - 1);
+    // When focus actually moves between layers (an Up/Down that lands on a different layer),
+    // the carried datumIndex belongs to the previous layer and has no meaning in the new one:
+    // layer 0 is a single merged node (`datumUnion`) and the target layer has no positional
+    // relationship to it. Reset to 0 so the pick always resolves to a datum present in the
+    // chosen layer's selection (the union datum for layer 0, target 0 for the targets layer);
+    // a stale non-zero index could otherwise reference a datum absent from the selection,
+    // failing the pick and leaving keyboard focus stuck. Staying within a layer — including an
+    // Up/Down that clamps back to the same boundary layer — preserves the current position.
+    const previousOtherIndex = opts.otherIndex - opts.otherIndexDelta;
+    const layerChanged = otherIndex !== previousOtherIndex;
+    const datumIndex = layerChanged ? 0 : clamp(0, opts.datumIndex, data.length - 1);
     const datum = data[datumIndex];
 
     for (const node of selection) {

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.test.ts
@@ -244,6 +244,201 @@ describe('LinearGaugeSeries', () => {
         });
     });
 
+    describe('keyboard navigation (CRT-1124)', () => {
+        // Options that reproduce the bug: a segmented bar (so nodeData.length > 1 in contextNodeData)
+        // combined with enough targets that a Right→Right sequence lands on target index 2 before Up.
+        // Layer 0 (datumUnion) is always a SINGLE focusable node regardless of segmentation;
+        // layer 1 (targetSelection) has one node per target.
+        const SEGMENTED_WITH_TARGETS: AgLinearGaugeOptions = {
+            type: 'linear-gauge',
+            value: 60,
+            scale: { min: 0, max: 100 },
+            segmentation: { enabled: true, interval: { count: 5 } },
+            targets: [
+                { value: 20, text: 'Low' },
+                { value: 50, text: 'Mid' },
+                { value: 80, text: 'High' },
+            ],
+        };
+
+        async function setupKeyNavChart(opts: AgLinearGaugeOptions) {
+            const options: AgLinearGaugeOptions = { ...opts };
+            prepareEnterpriseTestOptions(options);
+            chart = deproxy(AgCharts.createGauge(options));
+            await waitForChartStability(chart);
+            return chart;
+        }
+
+        // Dispatches a keydown event on the .ag-charts-series-area DOM element, which is the
+        // element the seriesAreaManager's seriesWidget listens on.
+        function pressArrowOnSeriesArea(key: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') {
+            const seriesArea = document.querySelector<HTMLElement>('.ag-charts-series-area');
+            if (!seriesArea) throw new Error('series-area element not found');
+            seriesArea.dispatchEvent(new KeyboardEvent('keydown', { key, code: key, bubbles: true }));
+        }
+
+        // Read the internal focus state written back by updatePickedFocus after each successful pick.
+        function getFocusState(c: any) {
+            return c.seriesAreaManager.focus as {
+                seriesIndex: number;
+                datumIndex: number;
+                datum: unknown;
+            };
+        }
+
+        // AC1: repro case — segmented bar + 3 targets.
+        // ArrowDown enters the targets layer; ArrowRight×2 moves to target index 2.
+        // ArrowUp MUST return focus to layer 0 (the bar) — not get stuck.
+        describe('AC1 – ArrowUp from non-first target returns to bar (regression)', () => {
+            it('direct pickFocus: ArrowUp with datumIndex=2 in layer 1 resolves to layer 0 at datumIndex 0', async () => {
+                const c = await setupKeyNavChart(SEGMENTED_WITH_TARGETS);
+                const series = c.series[0];
+
+                // Simulate the exact inputs onArrow produces after Down→Right→Right→Up:
+                // focus.seriesIndex was incremented to 1 then back to 0, focus.datumIndex is 2.
+                const pick = series.pickFocus({
+                    datumIndex: 2,
+                    datumIndexDelta: 0,
+                    otherIndex: 0, // post-increment: Up moved seriesIndex from 1 → 0
+                    otherIndexDelta: -1, // Up
+                });
+
+                expect(pick).toBeDefined();
+                expect(pick!.otherIndex).toBe(0); // returned to layer 0
+                expect(pick!.datumIndex).toBe(0); // reset to 0 on layer change
+            });
+
+            it('full pipeline: focus does not get stuck after Down→Right→Right→Up', async () => {
+                const c = await setupKeyNavChart(SEGMENTED_WITH_TARGETS);
+
+                // ArrowDown: layer 0 → layer 1, target index 0.
+                pressArrowOnSeriesArea('ArrowDown');
+                await waitForChartStability(c);
+
+                // ArrowRight×2: target index 0 → 1 → 2.
+                pressArrowOnSeriesArea('ArrowRight');
+                await waitForChartStability(c);
+                pressArrowOnSeriesArea('ArrowRight');
+                await waitForChartStability(c);
+
+                // Verify we are on target index 2 before the Up.
+                expect(getFocusState(c).seriesIndex).toBe(1);
+                expect(getFocusState(c).datumIndex).toBe(2);
+
+                // ArrowUp: should return to layer 0 (bar).
+                pressArrowOnSeriesArea('ArrowUp');
+                await waitForChartStability(c);
+
+                expect(getFocusState(c).seriesIndex).toBe(0); // back on layer 0
+                expect(getFocusState(c).datumIndex).toBe(0); // reset to 0 on layer change
+
+                // Arrows must remain responsive: one more ArrowDown must move into targets again.
+                pressArrowOnSeriesArea('ArrowDown');
+                await waitForChartStability(c);
+
+                expect(getFocusState(c).seriesIndex).toBe(1);
+                expect(getFocusState(c).datumIndex).toBe(0);
+            });
+        });
+
+        // AC2a: first-item path — Down then immediately Up.  Must not regress.
+        describe('AC2 – no regression of first-item and single-layer paths', () => {
+            it('Down then immediately Up still returns to layer 0', async () => {
+                const c = await setupKeyNavChart(SEGMENTED_WITH_TARGETS);
+
+                pressArrowOnSeriesArea('ArrowDown');
+                await waitForChartStability(c);
+                expect(getFocusState(c).seriesIndex).toBe(1);
+
+                pressArrowOnSeriesArea('ArrowUp');
+                await waitForChartStability(c);
+                expect(getFocusState(c).seriesIndex).toBe(0);
+                expect(getFocusState(c).datumIndex).toBe(0);
+            });
+
+            it('ArrowDown while on a non-first target is a no-op (stays on that target, does not jump to target 0)', async () => {
+                const c = await setupKeyNavChart(SEGMENTED_WITH_TARGETS);
+
+                // Move into the targets layer and along to target index 2.
+                pressArrowOnSeriesArea('ArrowDown');
+                await waitForChartStability(c);
+                pressArrowOnSeriesArea('ArrowRight');
+                await waitForChartStability(c);
+                pressArrowOnSeriesArea('ArrowRight');
+                await waitForChartStability(c);
+                expect(getFocusState(c).datumIndex).toBe(2);
+
+                // ArrowDown at the bottom layer clamps back to the same layer — it must NOT
+                // reset the target index to 0 (the layer did not actually change).
+                pressArrowOnSeriesArea('ArrowDown');
+                await waitForChartStability(c);
+                expect(getFocusState(c).seriesIndex).toBe(1);
+                expect(getFocusState(c).datumIndex).toBe(2);
+            });
+
+            it('direct pickFocus: ArrowUp with datumIndex=0 in layer 1 also resolves to layer 0', async () => {
+                const c = await setupKeyNavChart(SEGMENTED_WITH_TARGETS);
+                const series = c.series[0];
+
+                const pick = series.pickFocus({
+                    datumIndex: 0,
+                    datumIndexDelta: 0,
+                    otherIndex: 0,
+                    otherIndexDelta: -1, // Up from layer 1
+                });
+
+                expect(pick).toBeDefined();
+                expect(pick!.otherIndex).toBe(0);
+                expect(pick!.datumIndex).toBe(0);
+            });
+
+            it('single-layer gauge (no targets): ArrowDown and ArrowUp stay on layer 0 without getting stuck', async () => {
+                const noTargets: AgLinearGaugeOptions = {
+                    type: 'linear-gauge',
+                    value: 60,
+                    scale: { min: 0, max: 100 },
+                    segmentation: { enabled: true, interval: { count: 5 } },
+                };
+                const c = await setupKeyNavChart(noTargets);
+
+                // ArrowDown: no second layer — must not throw or get stuck.
+                pressArrowOnSeriesArea('ArrowDown');
+                await waitForChartStability(c);
+
+                const after = getFocusState(c);
+                expect(after.seriesIndex).toBe(0); // clamped: only one layer
+                expect(after.datum).toBeDefined(); // a valid datum was found
+
+                // A second ArrowDown must also not throw or get stuck.
+                pressArrowOnSeriesArea('ArrowDown');
+                await waitForChartStability(c);
+                expect(getFocusState(c).datum).toBeDefined();
+            });
+
+            it('direct pickFocus: single-layer, ArrowDown returns a defined pick on layer 0', async () => {
+                const noTargets: AgLinearGaugeOptions = {
+                    type: 'linear-gauge',
+                    value: 60,
+                    scale: { min: 0, max: 100 },
+                    segmentation: { enabled: true, interval: { count: 5 } },
+                };
+                const c = await setupKeyNavChart(noTargets);
+                const series = c.series[0];
+
+                const pick = series.pickFocus({
+                    datumIndex: 0,
+                    datumIndexDelta: 0,
+                    otherIndex: 1, // would go to layer 1, but only layer 0 exists → clamped
+                    otherIndexDelta: 1, // Down
+                });
+
+                // With only layer 0 available, clamp ensures we stay on layer 0.
+                expect(pick).toBeDefined();
+                expect(pick!.otherIndex).toBe(0);
+            });
+        });
+    });
+
     describe('bigint values (AG-16608)', () => {
         // A value beyond Number.MAX_SAFE_INTEGER that would lose precision if narrowed to Number.
         const BIG_VALUE = 9_007_199_254_740_993n;

--- a/packages/ag-charts-website/e2e/keyboard-nav.spec.ts
+++ b/packages/ag-charts-website/e2e/keyboard-nav.spec.ts
@@ -318,6 +318,19 @@ test.describe('keyboard-nav', () => {
         await page.keyboard.press('ArrowRight');
         await expect(page.locator(SELECTORS.canvasCenter)).toHaveScreenshot(`linear-gauge-target2-highlight.png`);
 
+        // CRT-1124: ArrowUp directly from a non-first target must return to the main bar
+        // (previously got stuck because the carried target index had no valid landing in
+        // the single-node main section).
+        await page.keyboard.press('ArrowUp');
+        await expect(page.locator(SELECTORS.canvasCenter)).toHaveScreenshot(`linear-gauge-bar-highlight.png`);
+
+        await page.keyboard.press('ArrowDown');
+        await expect(page.locator(SELECTORS.canvasCenter)).toHaveScreenshot(`linear-gauge-target0-highlight.png`);
+
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('ArrowRight');
+        await expect(page.locator(SELECTORS.canvasCenter)).toHaveScreenshot(`linear-gauge-target2-highlight.png`);
+
         await page.keyboard.press('ArrowLeft');
         await page.keyboard.press('ArrowLeft');
         await page.keyboard.press('ArrowLeft'); // should have no effect


### PR DESCRIPTION
## Ticket

[CRT-1124](https://ag-grid.atlassian.net/browse/CRT-1124) — [NR] Gauge keyboard navigation buggy with multiple layers

## Problem

Gauge keyboard navigation could get stuck. On a gauge with multiple layers (e.g. a segmented bar plus targets), navigating Down into the targets, Right to a non-first target, then Up should return focus to the main section — but the arrow keys stopped responding.

### Root cause

In `pickGaugeFocus`, an Up/Down move that changes layer carried the previous within-layer `datumIndex` across to the new layer and clamped it. When the new layer collapsed its data into a single focusable node (segmented bar `datumUnion`), the clamped index pointed at a datum that no longer existed as a focusable node, so the pick returned `undefined`. The focus write-back was then skipped and the stale focus state persisted, leaving navigation stuck until a later delta happened to re-land on a valid index. Non-segmented configurations masked the bug because their `nodeData.length === 1` forced the index to 0.

## Fix

`packages/ag-charts-enterprise/src/series/gauge-util/pick.ts`: when focus actually moves to a different layer, reset the within-layer datum index to 0; otherwise clamp-preserve it. This guarantees the pick always resolves to a valid datum (the union node on layer 0, target 0 on layer 1) so the focus write-back always runs. Covers both linear and radial gauges via the shared `pickFocus`.

## Tests

- `linearGaugeSeries.test.ts`: 7 keyboard-navigation unit tests — AC1 regression (direct `pickFocus` and full JSDOM keyboard pipeline), AC2 first-item path, single-layer/no-target no-op, and a non-first-target ArrowDown boundary no-op.
- `keyboard-nav.spec.ts` (E2E): extended the gauge case with the direct ArrowUp-from-target → bar assertion (reuses existing screenshots).

## Acceptance criteria

| AC | Criterion | Status |
|----|-----------|--------|
| 1 | Up from a non-first lower-layer item returns to the main section (not stuck) | PASS |
| 2 | No regression of first-item / single-layer cases | PASS |

## Notes

Pre-existing enterprise a11y defect (not a b14 regression). No public API or documentation changes. The shared `seriesAreaManager` focus structure (write-back-on-failure) was left untouched to keep blast radius minimal late in the release; a candidate follow-up tech-debt note.