### PR TITLE
CRT-1140 - Fix arrow keys moving annotations by bandwidth instead of 1px

### DIFF
--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.test.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { type AgCartesianChartOptions, AgCharts } from 'ag-charts-community';
-import { extractImageData, setupMockCanvas, setupMockConsole, waitForChartStability } from 'ag-charts-community-test';
+import {
+    deproxy,
+    extractImageData,
+    setupMockCanvas,
+    setupMockConsole,
+    waitForChartStability,
+} from 'ag-charts-community-test';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 
@@ -826,6 +832,112 @@ describe('Annotations', () => {
             ]);
             expect(numberImage).not.toMatchImage(baseline, { writeDiff: false });
             expect(bigintImage).toMatchImage(numberImage);
+        });
+    });
+
+    // A band/ordinal x-axis (bandwidth > 1px) is required: the plain-arrow step must stay at 1px
+    // regardless of bandwidth. On a number axis bandwidth is 0, which would not distinguish the cases.
+    describe('keyboard arrow key move step', () => {
+        // Four categories in 800px gives a bandwidth well above 1px.
+        const BAND_AXIS_OPTIONS: AgCartesianChartOptions = {
+            data: [
+                { category: 'Q1', value: 50 },
+                { category: 'Q2', value: 70 },
+                { category: 'Q3', value: 60 },
+                { category: 'Q4', value: 80 },
+            ],
+            series: [{ type: 'bar', xKey: 'category', yKey: 'value' }],
+            axes: {
+                x: { type: 'category', position: 'bottom' },
+                y: { type: 'number', position: 'left' },
+            },
+            annotations: { enabled: true, toolbar: { enabled: false } },
+            width: 800,
+            height: 400,
+        };
+
+        async function prepareChartWithAnnotation() {
+            await prepareChart(
+                {
+                    annotations: [
+                        {
+                            type: 'vertical-line',
+                            value: { value: 'Q2', groupPercentage: 0 },
+                        },
+                    ],
+                },
+                BAND_AXIS_OPTIONS
+            );
+        }
+
+        function getAnnotationsModule() {
+            return (deproxy(chart) as any).modulesManager.getModule('annotations');
+        }
+
+        // Converts a vertical-line annotation value (on a band x-axis) to a pixel x-position,
+        // matching the convert arithmetic in utils/values.ts (band offset via groupPercentage).
+        function toPx(value: any, xScale: any): number {
+            const categoryValue = value != null && typeof value === 'object' ? value.value : value;
+            const groupPct = value != null && typeof value === 'object' ? (value.groupPercentage ?? 0) : 0;
+            const bandwidth: number = xScale.bandwidth ?? 0;
+            const width: number = bandwidth === 0 ? (xScale.step ?? 0) : bandwidth;
+            return xScale.convert(categoryValue) + width * groupPct;
+        }
+
+        it('plain ArrowRight moves a selected annotation by 1px on a band x-axis', async () => {
+            await prepareChartWithAnnotation();
+
+            const annotationsModule = getAnnotationsModule();
+            expect(annotationsModule).toBeDefined();
+
+            const xScale = annotationsModule.xAxis.context.scale;
+            const bandwidth: number = xScale.bandwidth ?? 0;
+            // Guard the precondition: a meaningful test needs bandwidth above the 1px fine step.
+            expect(Math.max(bandwidth, xScale.step ?? 0)).toBeGreaterThan(1);
+
+            // The active annotation is owned by the Main child of the parallel state machine
+            // (index 2: [0]=Snapping, [1]=Update, [2]=Main); only it exposes the `active` index.
+            const mainSM = annotationsModule.state.stateMachines[2];
+            mainSM.active = 0;
+
+            const valueBefore = annotationsModule.annotationData.at(0).value;
+            const pxBefore = toPx(valueBefore, xScale);
+
+            annotationsModule.onKeyDown({
+                type: 'keydown' as const,
+                sourceEvent: new KeyboardEvent('keydown', { key: 'ArrowRight', code: 'ArrowRight' }),
+            });
+
+            const valueAfter = annotationsModule.annotationData.at(0).value;
+            const pxAfter = toPx(valueAfter, xScale);
+
+            expect(Math.abs(pxAfter - pxBefore)).toBeCloseTo(1, 5);
+        });
+
+        it('Shift+ArrowRight moves a selected annotation by 10px on a band x-axis', async () => {
+            await prepareChartWithAnnotation();
+
+            const annotationsModule = getAnnotationsModule();
+            const xScale = annotationsModule.xAxis.context.scale;
+
+            annotationsModule.state.stateMachines[2].active = 0;
+
+            const valueBefore = annotationsModule.annotationData.at(0).value;
+            const pxBefore = toPx(valueBefore, xScale);
+
+            annotationsModule.onKeyDown({
+                type: 'keydown' as const,
+                sourceEvent: new KeyboardEvent('keydown', {
+                    key: 'ArrowRight',
+                    code: 'ArrowRight',
+                    shiftKey: true,
+                }),
+            });
+
+            const valueAfter = annotationsModule.annotationData.at(0).value;
+            const pxAfter = toPx(valueAfter, xScale);
+
+            expect(Math.abs(pxAfter - pxBefore)).toBeCloseTo(10, 5);
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -1128,8 +1128,8 @@ export class Annotations extends AbstractModuleInstance {
 
         const translation = { x: 0, y: 0 };
 
-        const xStep = Math.max(context?.xAxis.scale.bandwidth ?? 0, ctrlShift ? 10 : 1);
-        const yStep = Math.max(context?.yAxis.scale.bandwidth ?? 0, ctrlShift ? 10 : 1);
+        const xStep = ctrlShift ? 10 : 1;
+        const yStep = ctrlShift ? 10 : 1;
         switch (sourceEvent.key) {
             case 'ArrowDown':
                 translation.y = yStep;


### PR DESCRIPTION
## Summary

Fixes [CRT-1140](https://ag-grid.atlassian.net/browse/CRT-1140) — arrow keys move a selected annotation by ~10px instead of the documented 1px.

The keyboard move step in `onKeyDown` was clamped to a floor of the axis `bandwidth`:

```ts
const xStep = Math.max(context?.xAxis.scale.bandwidth ?? 0, ctrlShift ? 10 : 1);
const yStep = Math.max(context?.yAxis.scale.bandwidth ?? 0, ctrlShift ? 10 : 1);
```

The move is performed in **pixel space**, so the intended semantic is the literal pixel step. On band/ordinal x-axes (e.g. the financial preset's `ordinal-time` axis) the per-band width is several pixels, inflating an unmodified arrow press to roughly the band width rather than 1px. The fix removes the bandwidth floor:

```ts
const xStep = ctrlShift ? 10 : 1;
const yStep = ctrlShift ? 10 : 1;
```

## Changes

- `packages/ag-charts-enterprise/src/features/annotations/annotations.ts` — remove the `bandwidth` floor from the keyboard move step.
- `packages/ag-charts-enterprise/src/features/annotations/annotations.test.ts` — add a regression block asserting a plain arrow moves 1px and Ctrl/Shift + arrow moves 10px on a band/ordinal x-axis, independent of bandwidth.

## Testing

- `yarn nx build:types ag-charts-enterprise` — PASS
- `yarn nx lint ag-charts-enterprise` — PASS (0 errors)
- Annotation suite — 37/37 PASS (2 new regression tests). Verified the new tests fail against the old code (annotation moved ~128px) and pass against the new code.

## Notes

- No docs change required — docs already state the correct 1px / 10px behaviour; the code was the defect.
- Pre-existing regression (shipped in 13.x), low-risk single-file change. Category-snapping (`groupPercentage`) is a separate downstream concern and is unaffected by the step size.