### PR TITLE
CRT-1139 Add missing Widget.removeChild() in Widget.remove()

### DIFF
--- a/packages/ag-charts-community/src/widget/listWidget.ts
+++ b/packages/ag-charts-community/src/widget/listWidget.ts
@@ -6,6 +6,15 @@ import { type BeforeWidget, Widget } from './widget';
 
 type TChildWidget = SwitchWidget;
 
+function removeFromDOM(child: Widget) {
+    const elem = child.getElement();
+    if (elem.parentElement) {
+        elem.parentElement.remove();
+    } else {
+        elem.remove();
+    }
+}
+
 export class ListWidget extends RovingTabContainerWidget<TChildWidget> {
     constructor() {
         super('both', 'list');
@@ -13,8 +22,8 @@ export class ListWidget extends RovingTabContainerWidget<TChildWidget> {
     }
 
     protected override destructor(): void {
-        for (const c of this.children) {
-            c.getElement().parentElement!.remove();
+        for (const child of this.children) {
+            removeFromDOM(child);
         }
     }
 
@@ -28,7 +37,7 @@ export class ListWidget extends RovingTabContainerWidget<TChildWidget> {
     }
 
     protected override removeChildFromDOM(child: TChildWidget) {
-        child.getElement().parentElement!.remove();
+        removeFromDOM(child);
         this.setHidden(this.children.length === 0);
     }
 

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -101,7 +101,6 @@ export abstract class Widget<
         }
         this.children.length = 0;
         this.destructor();
-        this.remove();
         this.internalListener?.destroy();
         this.htmlListener?.destroy(this);
     }
@@ -109,6 +108,7 @@ export abstract class Widget<
     remove(): void {
         this.elem.remove();
         this.elemContainer?.remove();
+        this.parent?.removeChild(this);
     }
 
     setHidden(hidden: boolean): void {

--- a/packages/ag-charts-community/src/widget/widget.ts
+++ b/packages/ag-charts-community/src/widget/widget.ts
@@ -108,7 +108,7 @@ export abstract class Widget<
     remove(): void {
         this.elem.remove();
         this.elemContainer?.remove();
-        this.parent?.removeChild(this);
+        this.parent?.removeChildWidget(this);
     }
 
     setHidden(hidden: boolean): void {
@@ -222,7 +222,7 @@ export abstract class Widget<
         this.onChildAdded(child);
     }
 
-    removeChild(child: TChildWidget) {
+    removeChildWidget(child: TChildWidget) {
         const i = this.children.indexOf(child);
         this.children.splice(i, 1);
         this.removeChildFromDOM(child);


### PR DESCRIPTION
The absence of this `removeChild()` was causing the parent widget to retain references (i.e. leak) the old button elements.

Also remove a redundant `remove()` call in `destroy()` (it's already called earlier on in that method).