### PR TITLE
CRT-1142 Fix linear-gauge labels example for Angular generation

### DIFF
--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/labels/index.html
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/labels/index.html
@@ -24,8 +24,8 @@
             min="0"
             max="100"
             value="50"
-            oninput="setValue(Number(event.target.value))"
-            onchange="setValue(Number(event.target.value))"
+            oninput="setValue(event.target.value)"
+            onchange="setValue(event.target.value)"
         />
         <span id="gaugeValueLabel">50</span>
     </div>

--- a/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/labels/main.ts
+++ b/packages/ag-charts-website/src/content/docs/linear-gauge/_examples/labels/main.ts
@@ -55,8 +55,8 @@ function setAvoidCollisions(avoidCollisions: boolean) {
     chart.update(options);
 }
 
-function setValue(value: number) {
-    document.getElementById('gaugeValueLabel')!.innerHTML = String(value);
-    options.value = value;
+function setValue(value: string) {
+    document.getElementById('gaugeValueLabel')!.innerHTML = value;
+    options.value = Number(value);
     chart.update(options);
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1142

The linear-gauge "labels" example wrapped the range-input value with the global `Number()` inside its inline event handler. Angular evaluates template expressions against the component instance, so the generated Angular example resolved `Number` to `ctx.Number` and threw `TypeError: ctx.Number is not a function` at runtime.

Move the string-to-number coercion into the `setValue` handler (where globals are available) and pass the raw DOM value from the template, matching the example's sibling handlers (`setLabelPlacement`, `setAvoidCollisions`). The generated output is now clean and idiomatic across all frameworks; no generator change required.

Validated with `yarn nx validate-examples ag-charts-website` (872 examples, no issues) and by inspecting the regenerated Angular/React/Vue/TS output.

Fix #CRT-1142