### PR TITLE
CRT-1148 Hide caption node when disabled via options update

### DIFF
--- a/packages/ag-charts-community/src/chart/caption.test.ts
+++ b/packages/ag-charts-community/src/chart/caption.test.ts
@@ -18,6 +18,7 @@ import {
     setupMockConsole,
     waitForChartStability,
 } from './test/utils';
+import type { AgChartProxy } from './test/utils';
 
 describe('Caption', () => {
     setupMockConsole();
@@ -263,6 +264,41 @@ describe('Caption', () => {
                 expect(proxyBBox.y + proxyBBox.height).toBeLessThanOrEqual(chart.height!);
             }
         });
+    });
+
+    // Caption scene nodes are long-lived and reused across updates, so disabling a caption must
+    // actively reset `node.visible`; the enabled-only positioning path is skipped when disabled.
+    describe('CRT-1148 disabling a caption hides its node', () => {
+        const baseOptions = {
+            data: [
+                { x: 'A', y: 3 },
+                { x: 'B', y: 5 },
+            ],
+            series: [{ type: 'bar' as const, xKey: 'x', yKey: 'y' }],
+            legend: { enabled: false },
+        };
+
+        test.each(['title', 'subtitle', 'footnote'] as const)(
+            'disabling %s hides the node, re-enabling shows it again',
+            async (key) => {
+                const proxy = AgCharts.create(
+                    prepareTestOptions({ ...baseOptions, [key]: { text: 'Caption', enabled: true } })
+                ) as AgChartProxy;
+                const chartInstance = deproxy(proxy);
+                await waitForChartStability(chartInstance);
+                expect(chartInstance[key].node.visible).toBe(true);
+
+                await proxy.update(prepareTestOptions({ ...baseOptions, [key]: { text: 'Caption', enabled: false } }));
+                await waitForChartStability(chartInstance);
+                expect(chartInstance[key].node.visible).toBe(false);
+
+                await proxy.update(prepareTestOptions({ ...baseOptions, [key]: { text: 'Caption', enabled: true } }));
+                await waitForChartStability(chartInstance);
+                expect(chartInstance[key].node.visible).toBe(true);
+
+                proxy.destroy();
+            }
+        );
     });
 
     describe('image segments', () => {

--- a/packages/ag-charts-community/src/chart/chartCaption.ts
+++ b/packages/ag-charts-community/src/chart/chartCaption.ts
@@ -93,7 +93,7 @@ export class ChartCaption implements CaptionLike {
 
     /**
      * Apply the current options subtree to the scene node. Called from
-     * `ChartCaptions.positionCaption` before each layout so visible/text/font
+     * `ChartCaptions.positionCaptions` before each layout so visible/text/font
      * properties land before render.
      */
     applyToNode() {

--- a/packages/ag-charts-community/src/chart/chartCaptions.ts
+++ b/packages/ag-charts-community/src/chart/chartCaptions.ts
@@ -23,6 +23,12 @@ export class ChartCaptions {
         const { title, subtitle, footnote } = this;
         const maxHeight = layoutBox.height / 10; // Limit to 10% of layout initial height
 
+        // Sync `node.visible` for every caption each layout so a disabled caption's long-lived
+        // node is hidden — the enabled-only positioning below never runs for disabled captions.
+        for (const caption of [title, subtitle, footnote]) {
+            caption.applyToNode();
+        }
+
         if (title.enabled) {
             this.positionCaption('top', title, layoutBox, maxHeight);
             this.shrinkLayoutByCaption('top', title, layoutBox);
@@ -65,7 +71,6 @@ export class ChartCaptions {
     }
 
     private positionCaption(vAlign: 'top' | 'bottom', caption: ChartCaption, layoutBox: BBox, maxHeight: number) {
-        caption.applyToNode();
         const opts = caption.opts;
         const font = captionFont(opts);
         const text = opts.text;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1148

A v14 caption migration moved the `node.visible = enabled` write into a code path that `ChartCaptions.positionCaptions()` only reaches inside the `if (caption.enabled)` guard. Caption scene nodes are long-lived and reused across updates, so disabling a previously-enabled title/subtitle/footnote (via options or theme overrides) skipped the write entirely — the node stayed `visible: true` and un-repositioned (hence it also failed to re-centre on resize).

This restores the unconditional pre-migration behaviour: `applyToNode()` is now called for all three captions at the top of `positionCaptions()` on every layout, so `node.visible` is synced to `enabled` even for disabled captions. The now-redundant call inside `positionCaption()` is removed, leaving a single source of truth.

Adds a `test.each` over title/subtitle/footnote covering enable -> disable -> re-enable through the public `proxy.update(options)` API. Verified failing without the fix and passing with it.

Fix #CRT-1148