### PR TITLE
CRT-1143 Make full update() replace options, dropping omitted subtrees

### DIFF
--- a/packages/ag-charts-community/src/chart/agChartV2.test.ts
+++ b/packages/ag-charts-community/src/chart/agChartV2.test.ts
@@ -370,4 +370,55 @@ describe('AgChartV2', () => {
             await waitForChartStability(chart);
         });
     });
+
+    describe('CRT-1143 update() replace semantics', () => {
+        const withSubtitle = (): AgChartOptions => ({
+            title: { text: 'Title' },
+            subtitle: { text: 'Subtitle' },
+            data: [
+                { x: 'a', y: 1 },
+                { x: 'b', y: 2 },
+            ],
+            series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+        });
+
+        const withoutSubtitle = (): AgChartOptions => ({
+            title: { text: 'Title' },
+            data: [
+                { x: 'a', y: 1 },
+                { x: 'b', y: 2 },
+            ],
+            series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+        });
+
+        it('should drop a subtitle omitted from a full update()', async () => {
+            const initial = withSubtitle();
+            prepareTestOptions(initial, container);
+            chart = AgCharts.create(initial);
+            await waitForChartStability(chart);
+            expect(chart.getOptions().subtitle).toEqual({ text: 'Subtitle' });
+
+            const updated = withoutSubtitle();
+            prepareTestOptions(updated, container);
+            await chart.update(updated);
+            await waitForChartStability(chart);
+
+            // update() replaces options, so the omitted subtitle must be gone.
+            expect(chart.getOptions().subtitle).toBeUndefined();
+        });
+
+        it('should retain a subtitle omitted from a partial updateDelta()', async () => {
+            const initial = withSubtitle();
+            prepareTestOptions(initial, container);
+            chart = AgCharts.create(initial);
+            await waitForChartStability(chart);
+
+            // updateDelta() merges, so omitting the subtitle leaves it in place.
+            await chart.updateDelta({ title: { text: 'Changed' } });
+            await waitForChartStability(chart);
+
+            expect(chart.getOptions().subtitle).toEqual({ text: 'Subtitle' });
+            expect(chart.getOptions().title).toEqual({ text: 'Changed' });
+        });
+    });
 });

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -169,6 +169,8 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         assign: new Set(['data', 'context', 'theme']),
     };
     public static readonly JSON_DIFF_OPTS = new Set<any>(['data', 'localeText']);
+    // Sentinel marking a key removed by a full `update()` so it is dropped on merge (replace semantics).
+    private static readonly REMOVED = Symbol('UNSET');
 
     private static readonly perfDebug = Debug.create(true, 'perf');
 
@@ -190,6 +192,18 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         }
         ChartOptions.perfDebug(`ChartOptions.isFastPathDelta() - fast path possible.`);
         return true;
+    }
+
+    private static containsRemovalSentinel(node: unknown): boolean {
+        // `jsonDiff` only places the removal sentinel directly on a key, so a shallow scan that
+        // recurses into nested objects (skipping the opaque `data` payload) suffices.
+        if (!isObject(node) || isArray(node)) return false;
+        for (const key of Object.keys(node)) {
+            const value = (node as Record<string, unknown>)[key];
+            if (isSymbol(value)) return true;
+            if (key !== 'data' && ChartOptions.containsRemovalSentinel(value)) return true;
+        }
+        return false;
     }
 
     activeTheme: ChartTheme;
@@ -241,12 +255,20 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
                 this.userDeltaKeys = new Set(Object.keys(deltaOptions));
             }
 
-            // No diff case - null means diff was a no-op.
-            deltaOptions ??= jsonDiff(
-                baseChartOptions.userOptions as T,
-                newUserOptions,
-                ChartOptions.JSON_DIFF_OPTS
-            ) as DeepPartial<T>;
+            // A null `deltaOptions` means this is a full `update()` rather than `updateDelta()`. Per
+            // its contract, `update()` replaces the options, so diff against the previous options
+            // marking omitted subtrees for removal; `updateDelta()` keeps its merge semantics.
+            if (deltaOptions == null) {
+                deltaOptions = jsonDiff(
+                    baseChartOptions.userOptions as T,
+                    newUserOptions,
+                    ChartOptions.JSON_DIFF_OPTS,
+                    ChartOptions.REMOVED
+                ) as DeepPartial<T>;
+                // Only strip symbols (and so take the slow path) when the diff actually removed a
+                // subtree; a fast-path-only change (e.g. width/data) must stay on the fast path.
+                stripSymbols ||= ChartOptions.containsRemovalSentinel(deltaOptions);
+            }
 
             this.userOptions = deepClone(merge(deltaOptions, baseChartOptions.userOptions), {
                 ...ChartOptions.OPTIONS_CLONE_OPTS_SLOW,

--- a/packages/ag-charts-core/src/utils/data/json.test.ts
+++ b/packages/ag-charts-core/src/utils/data/json.test.ts
@@ -134,6 +134,60 @@ describe('json module', () => {
                 expect(diff).toEqual(null);
             });
         });
+
+        describe('with a removal sentinel', () => {
+            const REMOVED = Symbol('REMOVED');
+
+            it('should mark a top-level key omitted from target as removed', () => {
+                const source = { title: { text: 'A' }, subtitle: { text: 'B' } };
+                const target = { title: { text: 'A' } };
+
+                const diff = jsonDiff<typeof source | typeof target>(source, target, undefined, REMOVED);
+                expect(diff).toStrictEqual({ subtitle: REMOVED });
+            });
+
+            it('should mark a nested key omitted from target as removed', () => {
+                const source = { title: { text: 'A', color: 'red' } };
+                const target = { title: { text: 'A' } };
+
+                const diff = jsonDiff(source, target, undefined, REMOVED);
+                expect(diff).toStrictEqual({ title: { color: REMOVED } });
+            });
+
+            it('should not mark removals when no sentinel is supplied', () => {
+                const source = { title: { text: 'A' }, subtitle: { text: 'B' } };
+                const target = { title: { text: 'A' } };
+
+                const diff = jsonDiff<typeof source | typeof target>(source, target);
+                expect(diff).toStrictEqual({ subtitle: undefined });
+            });
+
+            it('should return null when source and target are identical', () => {
+                const source = { title: { text: 'A' } };
+                const target = { title: { text: 'A' } };
+
+                const diff = jsonDiff(source, target, undefined, REMOVED);
+                expect(diff).toBeNull();
+            });
+
+            it('should not flag a key present in both but undefined in source', () => {
+                const source = { title: undefined };
+                const target = {};
+
+                const diff = jsonDiff<typeof source | typeof target>(source, target, undefined, REMOVED);
+                expect(diff).toBeNull();
+            });
+
+            it('should not emit a sentinel for a same-shape value change (fast-path safety)', () => {
+                // The sparkline fast path replaces same-shape `context`/`data` on every update; a
+                // value-only change must never produce a removal sentinel that forces the slow path.
+                const source = { context: { row: 0, cellData: 0.1 } };
+                const target = { context: { row: 1, cellData: 0.42 } };
+
+                const diff = jsonDiff(source, target, undefined, REMOVED);
+                expect(diff).toStrictEqual({ context: { row: 1, cellData: 0.42 } });
+            });
+        });
     });
 
     describe('#mergeDefaults', () => {

--- a/packages/ag-charts-core/src/utils/data/json.ts
+++ b/packages/ag-charts-core/src/utils/data/json.ts
@@ -16,14 +16,17 @@ export type CloneOptions = { shallow?: StringSet; assign?: StringSet; seen?: unk
  * @param source starting point for diff
  * @param target target for diff vs. source
  * @param shallow object keys to only shallow compare during diff
+ * @param removed when supplied, keys present in `source` but absent in `target` are emitted with this
+ *  sentinel value to express a removal, rather than being dropped from the diff. This enables replace
+ *  semantics when the diff is subsequently merged onto `source`.
  * @returns `null` if no differences, or an object with the subset of properties that have changed.
  */
-export function jsonDiff<T>(source: T, target: T, shallow?: Set<keyof T>): Partial<T> | null {
+export function jsonDiff<T>(source: T, target: T, shallow?: Set<keyof T>, removed?: symbol): Partial<T> | null {
     if (isArray(target)) {
         if (
             !isArray(source) ||
             source.length !== target.length ||
-            target.some((v, i) => jsonDiff(source[i], v, shallow) != null)
+            target.some((v, i) => jsonDiff(source[i], v, shallow, removed) != null)
         ) {
             return target;
         }
@@ -40,10 +43,13 @@ export function jsonDiff<T>(source: T, target: T, shallow?: Set<keyof T>): Parti
             // Cheap-and-easy equality check.
             if (source[key] === target[key]) {
                 continue;
+            } else if (removed !== undefined && !(key in target) && source[key] !== undefined) {
+                // Key was present in source but is omitted from target - express an explicit removal.
+                result[key] = removed as T[keyof T];
             } else if (shallow?.has(key)) {
                 result[key] = target[key];
             } else if (typeof source[key] === typeof target[key]) {
-                const diff = jsonDiff(source[key], target[key], shallow);
+                const diff = jsonDiff(source[key], target[key], shallow, removed);
                 if (diff !== null) {
                     result[key] = diff as T[keyof T];
                 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1143

Switching between chart configurations via `AgChartInstance.update()` — e.g. nightingale to radar-area in the homepage gallery switcher — left a stale subtitle on screen. The same latent problem affected any option subtree (legend, axes, zoom, captions) omitted from a subsequent `update()`.

`update()` is documented to take complete options — its JSDoc states "Options provided should be complete and not partial" — i.e. REPLACE semantics. The live-update path instead computed `jsonDiff(prev, new)` and merged the diff onto the previous user options. `jsonDiff` had no removal channel — an omitted key looked identical to "unchanged" — and `merge` ignores `undefined`, so any subtree present before and omitted now was retained.

This restores the intended replace semantics for `update()`, while `updateDelta()` remains the deep-merge API:

- `jsonDiff` gains an opt-in removal sentinel: keys present in the source but omitted from the target are expressed as removals rather than dropped. Default behaviour is unchanged for the existing caller.
- The full-update path (reached only when no explicit delta is supplied) uses the sentinel and strips the resulting symbols, reusing the existing `merge`/`removeLeftoverSymbols` removal pipeline.
- `updateDelta()` always supplies an explicit delta (`DeepPartial`), so it never enters this branch — its merge semantics are unchanged.

### Performance — fast path is preserved for no-removal updates

The fix deliberately does **not** disable `update()`'s fast-path cache for all calls. Symbols are stripped — and the slow path taken — **only when the diff actually contains a removal sentinel** (an omitted subtree). The decision is `stripSymbols ||= containsRemovalSentinel(diff)`, gated on a real removal rather than on "is this an `update()`".

- A normal no-removal `update()` (re-applying complete options where nothing was dropped) produces a diff with no sentinels, so it keeps the existing fast path — no behavioural or caching change.
- `containsRemovalSentinel` is an early-exit recursive scan over the (small) diff — not the full options — and skips the opaque `data` payload.
- The Grid sparkline cell-renderer hot path uses `updateDelta()`, which never enters this branch at all — zero overhead, zero behaviour change there. Normal fast-path `update()`/`updateDelta()` calls (incl. the sparkline `context`/`data` path) are untouched.
- All 16 sparkline fast-path optimisation assertions (fast setup for `width`/`height`/`data`/`container`/`context` via both `update()` and `updateDelta()`, pooling, instance reuse) pass.

Trade-off: an `update()` that genuinely removes a subtree now takes the slow path — correct, since a removal needs full reprocessing, and exactly the CRT-1143 scenario that was previously broken.

Test plan:
- `jsonDiff` unit tests for the removal sentinel, including a fast-path-safety case (same-shape value change emits no sentinel).
- Integration tests: a full `update()` drops an omitted subtitle; `updateDelta()` retains it.
- Full community suite green (3694). Enterprise pre-existing/flaky snapshot failures verified identical on the clean base branch (unrelated to this change).
- core + community lint/types/format green.
- Website e2e deferred to CI: the local Dockerised Playwright runner is infra-flaky here (mount-permission/timeout), and the CRT-1143 repro is already covered by the integration test above. CI runs it cleanly.

Fix #CRT-1143