### PR TITLE
CRT-1129 Preserve x-position when keyboard focus crosses series of differing node density

### DIFF
--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -256,4 +256,15 @@ export abstract class DataModelSeries<
             if (objectsEqual(categoryValue, xValue)) return datumIndex;
         }
     }
+
+    public override focusDatumIndexForCategoryValue(categoryValue: any): number | undefined {
+        const dataIndex = this.datumIndexForCategoryValue(categoryValue);
+        const nodeData = this.getNodeData();
+        if (dataIndex === undefined || nodeData === undefined) return;
+        for (let i = 0; i < nodeData.length; i += 1) {
+            if (nodeData[i].datumIndex === dataIndex && this.isDatumEnabled(nodeData, i)) {
+                return i;
+            }
+        }
+    }
 }

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1669,6 +1669,12 @@ export abstract class Series<
 
     abstract datumIndexForCategoryValue(categoryValue: any): DatumIndex | undefined;
 
+    // Index into the focusable nodeData for a category value. Defaults to the data index, which
+    // matches series with one nodeData entry per x-position; series with denser nodeData override.
+    focusDatumIndexForCategoryValue(categoryValue: any): DatumIndex | undefined {
+        return this.datumIndexForCategoryValue(categoryValue);
+    }
+
     // @todo(AG-13777) - Remove this function (see CartesianSeries.ts)
     minTimeInterval(): number | undefined {
         return;

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -908,9 +908,28 @@ export class SeriesAreaManager extends BaseManager {
         const oldDatumIndex = focus.datumIndex - datumIndexDelta;
         const oldOtherIndex = focus.seriesIndex - otherIndexDelta;
 
+        const previousSeries = focus.series;
+        const previousDatum = focus.datum;
+
         // Update focused series:
         focus.seriesIndex = clamp(0, focus.seriesIndex, visibleSeries.length - 1);
         focus.series = visibleSeries[focus.seriesIndex];
+
+        // Moving between series preserves the x-position rather than the raw node index, since
+        // series can have differing node densities (e.g. range-area has two nodes per x-position).
+        if (
+            otherIndexDelta !== 0 &&
+            focus.series !== previousSeries &&
+            previousSeries != null &&
+            previousDatum != null
+        ) {
+            const categoryValue = previousSeries.getCategoryValue(previousDatum.datumIndex);
+            const remapped =
+                categoryValue == null ? undefined : focus.series.focusDatumIndexForCategoryValue(categoryValue);
+            if (remapped != null) {
+                focus.datumIndex = remapped;
+            }
+        }
 
         // Update focused datum:
         const datumIndex = this.focus.datumIndex;

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -127,6 +127,7 @@ export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesP
     getDatumAriaText?(seriesDatum: TDatum, description: string): string | undefined;
     getCategoryValue(datumIndex: number): any;
     datumIndexForCategoryValue(categoryValue: any): DatumIndex | undefined;
+    focusDatumIndexForCategoryValue(categoryValue: any): DatumIndex | undefined;
     isHighlightEnabled(): boolean;
     isSelectionEnabled(): boolean;
     isDatumSelectable(datumIndex: DatumIndex): boolean;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.keyboardNav.test.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.keyboardNav.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { type AgCartesianChartOptions, AgCharts } from 'ag-charts-community';
+import { deproxy, setupMockCanvas, setupMockConsole, waitForChartStability } from 'ag-charts-community-test';
+
+import { prepareEnterpriseTestOptions } from '../../test/utils';
+
+// Crossing focus between series of differing node density (range-area packs two nodeData
+// entries per x-position, line packs one) must keep the same x-position, not the raw node index.
+describe('RangeAreaSeries keyboard navigation (CRT-1129)', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let chart: any;
+
+    afterEach(() => {
+        if (chart) {
+            chart.destroy();
+            (chart as unknown) = undefined;
+        }
+    });
+
+    const DATA = [
+        { month: 'Jan', value: 10, low: 5, high: 15 },
+        { month: 'Feb', value: 20, low: 8, high: 22 },
+        { month: 'Mar', value: 30, low: 12, high: 28 },
+        { month: 'Apr', value: 25, low: 10, high: 26 },
+    ];
+
+    const LINE_AND_RANGE: AgCartesianChartOptions = {
+        data: DATA,
+        series: [
+            { type: 'line', xKey: 'month', yKey: 'value' },
+            { type: 'range-area', xKey: 'month', yLowKey: 'low', yHighKey: 'high' },
+        ],
+    };
+
+    async function setupKeyNavChart(opts: AgCartesianChartOptions) {
+        const options: AgCartesianChartOptions = { ...opts };
+        prepareEnterpriseTestOptions(options as any);
+        chart = deproxy(AgCharts.create(options));
+        await waitForChartStability(chart);
+        return chart;
+    }
+
+    function pressArrowOnSeriesArea(key: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') {
+        const seriesArea = document.querySelector<HTMLElement>('.ag-charts-series-area');
+        if (!seriesArea) throw new Error('series-area element not found');
+        seriesArea.dispatchEvent(new KeyboardEvent('keydown', { key, code: key, bubbles: true }));
+    }
+
+    function getFocusState(c: any) {
+        return c.seriesAreaManager.focus as {
+            seriesIndex: number;
+            datumIndex: number;
+            datum: { datumIndex: number; xValue: unknown };
+        };
+    }
+
+    it('preserves the x-position when crossing between line and range-area', async () => {
+        const c = await setupKeyNavChart(LINE_AND_RANGE);
+
+        // Move to the 3rd x-position (data index 2) within the first series.
+        pressArrowOnSeriesArea('ArrowRight');
+        await waitForChartStability(c);
+        pressArrowOnSeriesArea('ArrowRight');
+        await waitForChartStability(c);
+
+        const start = getFocusState(c);
+        expect(start.seriesIndex).toBe(0);
+        expect(start.datum.datumIndex).toBe(2);
+        const startXValue = start.datum.xValue;
+
+        // Cross to the other series — the x-position must be preserved.
+        pressArrowOnSeriesArea('ArrowDown');
+        await waitForChartStability(c);
+
+        const crossed = getFocusState(c);
+        expect(crossed.seriesIndex).toBe(1);
+        expect(crossed.datum.datumIndex).toBe(2);
+        expect(crossed.datum.xValue).toEqual(startXValue);
+
+        // Cross back — still preserved.
+        pressArrowOnSeriesArea('ArrowUp');
+        await waitForChartStability(c);
+
+        const back = getFocusState(c);
+        expect(back.seriesIndex).toBe(0);
+        expect(back.datum.datumIndex).toBe(2);
+        expect(back.datum.xValue).toEqual(startXValue);
+    });
+});


### PR DESCRIPTION
## Summary

Keyboard focus navigation between cartesian series did not preserve the x-position when the two series had different node densities. In a chart mixing a **range-area** series (two nodeData entries per x-position — low + high markers, only even indices focus-enabled) with a **line** series (one per x-position), arrowing between them landed on the wrong x: range→line jumped to x×2 and line→range jumped to x÷2.

**Root cause:** focus tracks `focus.datumIndex` as a raw *nodeData array index* and `onArrow` carried it unchanged across series boundaries, assuming a 1:1 index↔x mapping that range-area violates.

**Fix:** when focus moves to a different series, translate the position by **category (x) value** rather than carrying the raw node index — reusing the same `getCategoryValue` ⇄ `datumIndexForCategoryValue` mechanism that shared tooltips already use (`chart.ts`).

## Changes

- `series.ts` — new `focusDatumIndexForCategoryValue` (base default = data index; correct for one-node-per-x series).
- `dataModelSeries.ts` — generic override mapping a category value to the first **focus-enabled** nodeData index for that data point. Yields `2k` for range-area and `k` for line automatically via the existing `isDatumEnabled` filter, so no range-area-specific code is required and any future N-per-x series benefits.
- `seriesTypes.ts` — added to the `ISeries` contract.
- `seriesAreaManager.ts` — remap `focus.datumIndex` through the new method when the focused series actually changes; falls back to the previous behaviour when the x-domains don't overlap. The standalone (gauge/hierarchy) and within-series left/right paths are untouched.

## Test plan

- New enterprise test `rangeArea.keyboardNav.test.ts` (line + range-area sharing x categories): navigate to a known x, cross with ArrowDown/ArrowUp in both directions, assert the logical data index / x-value is preserved. Confirmed it fails without the fix (`expected 1 to be 2` — the x÷2 bug) and passes with it.
- `build:types` and `lint` (0 errors) pass for `ag-charts-community` and `ag-charts-enterprise`.
- `yarn nx test ag-charts-community` — all pass.
- `yarn nx test ag-charts-enterprise` — only two pre-existing ErrorBars (AG-16943) snapshot failures, confirmed present on the base branch and unrelated to this change.

Manual: verified the `step-interpolation-combination` example no longer shifts the x-position when arrowing between the line and range-area series.

Fix #CRT-1129