### PR TITLE
CRT-1145 Test partial user padding merges per-side over override

### DIFF
--- a/packages/ag-charts-community/src/module/optionsGraph.test.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.test.ts
@@ -920,6 +920,26 @@ describe('OptionsGraph', () => {
                     axes: expect.any(Object),
                 });
             });
+
+            it('should merge a partial user option over a partial theme-override per side', () => {
+                const themeConfig = {
+                    line: {
+                        padding: {
+                            $applyPadding: { top: 4, right: 8, bottom: 4, left: 8 },
+                        },
+                    },
+                };
+                const userOptions = prepareOptions({ padding: { left: 20 } });
+                const overrides = { line: { padding: { right: 15, bottom: 15 } } };
+                const options = new OptionsGraph(themeConfig, userOptions, undefined, {}, {}, overrides).resolve();
+                // Per-side precedence user > override > default: left from user, right/bottom from
+                // override, top falls through to the default. A partial user object must not discard
+                // the override- or default-supplied sides.
+                expect(options).toStrictEqual({
+                    padding: { top: 4, right: 15, bottom: 15, left: 20 },
+                    axes: expect.any(Object),
+                });
+            });
         });
 
         describe('$applySwitch', () => {

--- a/packages/ag-charts-community/src/module/optionsGraph.test.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.test.ts
@@ -930,7 +930,10 @@ describe('OptionsGraph', () => {
                     },
                 };
                 const userOptions = prepareOptions({ padding: { left: 20 } });
-                const overrides = { line: { padding: { right: 15, bottom: 15 } } };
+                // Override supplied via the `common` namespace while the default comes from the
+                // series-type (`line`) namespace, exercising the common-namespace fallback in
+                // dangerouslyGetThemeOverride alongside the per-side merge.
+                const overrides = { common: { padding: { right: 15, bottom: 15 } } };
                 const options = new OptionsGraph(themeConfig, userOptions, undefined, {}, {}, overrides).resolve();
                 // Per-side precedence user > override > default: left from user, right/bottom from
                 // override, top falls through to the default. A partial user object must not discard


### PR DESCRIPTION
## What

Follow-up to #7215 (merged). Adds one unit test in `optionsGraph.test.ts` covering a gap in the `$applyPadding` merge coverage.

## Why

#7215 made `$applyPadding` resolve with **per-side** precedence `user > override > default`, but the added unit cases only covered:
- single-number override expanded to every side
- partial override merged over defaults
- full user option preferred over a full override

They did **not** assert a *partial user object* layered over a *partial theme-override* — i.e. that each side resolves independently and a partial user object does not wholesale-replace the override/default sides.

## Test

```
default:  { top: 4, right: 8, bottom: 4, left: 8 }   ($applyPadding)
override: { right: 15, bottom: 15 }
user:     { left: 20 }
=> result: { top: 4, right: 15, bottom: 15, left: 20 }
```

Each side is sourced from a different layer (top→default, right/bottom→override, left→user), so a regression to wholesale object replacement is caught. Passes against the merged implementation; `format`, `build:types`, and `lint` all green.