### PR TITLE
CRT-1137 Remove inaccurate tooltip test instruction from axes-types-test

### DIFF
--- a/packages/ag-charts-website/src/content/docs/axes-types-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-types-test/index.mdoc
@@ -64,7 +64,6 @@ What to test:
 What to test:
 
 - Each of the three series renders its own error bars on the grouped axis without overlap.
-- Tooltips report the correct high/low values per category.
 
 {% chartExampleRunner title="Grouped Category" name="grouped-category-6" type="generated" /%}
 


### PR DESCRIPTION
## CRT-1137 — [NR] [Docs] Test instructions references tooltips that aren't there

### Problem

The `axes-types-test` QA harness page, in its "Grouped Category — Multi-Series Error Bars" section, instructed the tester to verify "Tooltips report the correct high/low values per category". The example (`grouped-category-6`) uses the default tooltip with no custom `tooltip.renderer`, so the default tooltip only surfaces the bar's y-value — never the error-bar high/low values. The instruction described behaviour the default configuration was never designed to produce.

The library behaves as designed; the instruction was the regression (introduced this cycle).

### Fix

Removed the inaccurate bullet at `packages/ag-charts-website/src/content/docs/axes-types-test/index.mdoc:67`. The remaining bullet ("Each of the three series renders its own error bars on the grouped axis without overlap") is the meaningful test check.

Per the ticket's Expected resolution ("the tooltips do, or the instructions don't mention it"), removal was chosen over adding a behaviour-changing `tooltip.renderer` that the ticket explicitly does not require.

### Scope

Docs-only edit on an internal QA harness page. No library, type, or test changes. The ticket's second repro URL (`org-chart-test`) has only a tooltip *position* check, which is unrelated and accurate — no change needed there.

### Validation

- `yarn nx format:mdoc ag-charts-website` — clean
- Diff is a single-line deletion