### PR TITLE
CRT-1119 Make Data Source example Reload button show fresh data

### DIFF
--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/data.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/data.ts
@@ -5,7 +5,13 @@ import { createSeededRandom } from './seededRandom';
  * frontend developer you can safely ignore this part of the example.
  */
 export const Database = {
-    get: () => (data ??= generate()),
+    get: () => (data ??= generate(seed)),
+    // Re-generate the dataset with a new seed so a reload returns a visibly different price series, mimicking
+    // fresh data arriving from a real server.
+    refresh: () => {
+        seed += 1;
+        data = generate(seed);
+    },
 };
 
 export const minute = 1000 * 60;
@@ -18,19 +24,24 @@ export const dataStart = new Date('2019-01-01 00:00:00').getTime();
 export const dataEnd = new Date('2024-12-30 23:59:59').getTime();
 
 let data: Array<Datum> | undefined;
+let seed = 1;
 
-function generate(): Array<Datum> {
-    const random = createSeededRandom(1);
+const center = 1000;
+
+function generate(seed: number): Array<Datum> {
+    const random = createSeededRandom(seed);
     const result: Array<Datum> = [];
     for (let time = dataStart; time < dataEnd; time += hour) {
         let price;
         if (result.length === 0) {
-            price = 1000 + random() * 100;
+            price = center + random() * 100;
         } else if (result.length < 5) {
             price = result[result.length - 1].price + random() * 20 - 10;
         } else {
             const avg = result.slice(result.length - 5).reduce((a, v) => a + v.price, 0) / 5;
-            price = avg + (random() * 50 - 25);
+            // Mean-reverting random walk: a gentle pull back towards the centre keeps the series within the
+            // chart's fixed y-axis range for any seed, so each reload looks different without clipping.
+            price = avg + (random() * 50 - 25) + (center - avg) * 0.002;
         }
         result.push({ time, price });
     }

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/index.html
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/index.html
@@ -1,6 +1,6 @@
 <div class="example-controls">
     <div class="controls-row">
-        <button onclick="reload()">Reload</button>
+        <button onclick="reload()">Reload Data</button>
     </div>
 </div>
 <div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/main.ts
+++ b/packages/ag-charts-website/src/content/docs/async-data/_examples/async-data/main.ts
@@ -14,6 +14,7 @@ import {
     ZoomModule,
 } from 'ag-charts-enterprise';
 
+import { Database } from './data';
 import { FakeServer } from './fakeServer';
 
 ModuleRegistry.registerModules([
@@ -87,6 +88,9 @@ const options: AgCartesianChartOptions = {
 
 const chart = AgCharts.create(options);
 
+// Refresh the underlying server data, then call updateDelta({}) to re-trigger getData for the
+// current window. The chart shows its loading overlay while the new data is fetched.
 function reload() {
+    Database.refresh();
     chart.updateDelta({});
 }

--- a/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/async-data/index.mdoc
@@ -50,7 +50,8 @@ to load a full-range overview, independent of the main chart's windowed fetches.
 ### Triggering a Reload
 
 Calling `updateDelta({})` with an empty object triggers `getData` to be called again, which is useful for refreshing
-data on demand.
+data on demand. The **Reload Data** button in the example above does exactly this; the loading overlay is shown while
+the request is in progress, and the chart updates with the freshly fetched data once it resolves.
 
 ```js
 chart.updateDelta({});


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1119

The Data Source (async-data) example carried a `Reload` button whose only visible
effect was a brief loading overlay, after which the same deterministic dataset
returned — so the button's purpose was unclear.

This keeps the button and makes a reload produce a visible change:

- The fake server now returns a different randomised price series on each reload
  (a new seed per `Database.refresh()`), so clicking Reload visibly changes the
  chart.
- The price random-walk gains a gentle mean-reversion towards the centre so any
  seed stays within the chart's fixed y-axis range (400..1600) and the line never
  clips off the top or bottom.
- The button is relabelled **Reload Data** to make its purpose obvious.
- The docs `### Triggering a Reload` section now references the labelled button
  and explains the loading-overlay-then-refresh behaviour.

## Validation
- `yarn nx lint ag-charts-website` — 0 errors (pre-existing warnings only)
- `yarn nx generate-examples ag-charts-website` — all framework variants generated cleanly
- The data-generation bounds were verified analytically across 40 successive seeds: the series stays within [518, 1489], comfortably inside the fixed [400, 1600] axis.
- e2e (`test:e2e`) status noted in the PR thread.

Fix #CRT-1119