### PR TITLE
CRT-1123 Automate AG Charts version in installation CDN/download links

### DIFF
--- a/packages/ag-charts-website/markdoc.config.ts
+++ b/packages/ag-charts-website/markdoc.config.ts
@@ -25,6 +25,7 @@ import { videoSection } from '@ag-website-shared/markdoc/tags/videoSection';
 import { warning } from '@ag-website-shared/markdoc/tags/warning';
 import { component, defineMarkdocConfig } from '@astrojs/markdoc/config';
 import {
+    chartsDownloadUrl,
     chartsVersion,
     chartsVersionPatch,
     codespaceUrl,
@@ -52,6 +53,7 @@ export default defineMarkdocConfig({
         chartsVersion,
         chartsVersionPatch,
         codespaceUrl,
+        chartsDownloadUrl,
     },
     tags: {
         kbd,

--- a/packages/ag-charts-website/plugins/shiki.ts
+++ b/packages/ag-charts-website/plugins/shiki.ts
@@ -1,13 +1,34 @@
 import shiki from '@astrojs/markdoc/shiki';
+import type { Config, Node, RenderableTreeNode } from '@markdoc/markdoc';
 
 import agDocsTheme from '../../../external/ag-website-shared/src/components/code/theme.json';
 
 /**
+ * Flatten transformed Markdoc nodes back into a plain string. Used to resolve any
+ * interpolated variables/functions (e.g. `{% chartsVersionPatch() %}`) embedded in a code
+ * fence before it is handed to the syntax highlighter.
+ */
+function renderToString(node: RenderableTreeNode | RenderableTreeNode[]): string {
+    if (node == null) return '';
+    if (Array.isArray(node)) return node.map(renderToString).join('');
+    if (typeof node === 'string') return node;
+    if (typeof node === 'number') return String(node);
+    if (typeof node === 'object' && 'children' in node) return renderToString(node.children);
+    return '';
+}
+
+/**
  * Markdoc shiki highlighter using the shared AG Docs theme.
+ *
+ * Wraps the stock `@astrojs/markdoc/shiki` extension so that fences containing Markdoc
+ * interpolation (`{% ... %}`) have their content resolved through Markdoc first. This lets
+ * variables such as `{% chartsVersionPatch() %}` render their value inside code blocks — the
+ * stock extension highlights the raw, un-interpolated content string.
+ *
  * Preserves the `code` class on `<pre>` for legacy CSS compatibility.
  */
-export default function agShiki() {
-    return shiki({
+export default async function agShiki() {
+    const extension = await shiki({
         theme: agDocsTheme as any,
         transformers: [
             {
@@ -17,4 +38,24 @@ export default function agShiki() {
             },
         ],
     });
+
+    const fence = extension.nodes!.fence;
+    const baseTransform = fence.transform!.bind(fence);
+
+    return {
+        ...extension,
+        nodes: {
+            ...extension.nodes,
+            fence: {
+                ...fence,
+                transform(node: Node, config: Config) {
+                    const content: unknown = node.attributes?.content;
+                    if (typeof content === 'string' && content.includes('{%')) {
+                        node.attributes.content = renderToString(node.transformChildren(config));
+                    }
+                    return baseTransform(node, config);
+                },
+            },
+        },
+    };
 }

--- a/packages/ag-charts-website/src/content/docs/installation/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/installation/index.mdoc
@@ -310,13 +310,13 @@ const chart = AgCharts.create(options);
 To install AG Charts Community, include the following script tags in your HTML file:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/ag-charts-community@11.1.0/dist/umd/ag-charts-community.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ag-charts-community@{% chartsVersionPatch() %}/dist/umd/ag-charts-community.min.js"></script>
 ```
 
 To install AG Charts Enterprise, include the following script tags in your HTML file:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/ag-charts-enterprise@11.1.0/dist/umd/ag-charts-enterprise.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ag-charts-enterprise@{% chartsVersionPatch() %}/dist/umd/ag-charts-enterprise.min.js"></script>
 ```
 
 Once installed, you can then access AG Charts via the `agCharts.AgCharts` global variable. See the [Quick Start](./quick-start/) for more information.
@@ -331,10 +331,10 @@ Downloading AG Charts makes upgrading more complex and prone to errors. We recom
 
 {% tabs %}
 {% tabItem id="community" label="Community" %}
-You can download AG Charts Community from the {% link href="https://github.com/ag-grid/ag-charts/releases/download/r11.1.0/ag-charts-community.tgz" %}GitHub Repository{% /link %}.
+You can download AG Charts Community from the {% link href=chartsDownloadUrl("ag-charts-community") %}GitHub Repository{% /link %}.
 {% /tabItem %}
 {% tabItem id="enterprise" label="Enterprise" %}
-You can download AG Charts Enterprise from the {% link href="https://github.com/ag-grid/ag-charts/releases/download/r11.1.0/ag-charts-enterprise.tgz" %}GitHub Repository{% /link %}.
+You can download AG Charts Enterprise from the {% link href=chartsDownloadUrl("ag-charts-enterprise") %}GitHub Repository{% /link %}.
 {% /tabItem %}
 {% /tabs %}
 

--- a/packages/ag-charts-website/src/utils/markdoc/functions/libraryVersions.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/functions/libraryVersions.ts
@@ -36,3 +36,11 @@ export const codespaceUrl: ConfigFunction = {
         return `https://codespaces.new/ag-grid/ag-charts?devcontainer_path=.devcontainer/ssr-example/devcontainer.json&ref=b${major}.${minor}.${patchNum}`;
     },
 };
+
+export const chartsDownloadUrl: ConfigFunction = {
+    transform(parameters) {
+        const packageName = parameters[0];
+        const { major, minor, patchNum } = parseVersion(agChartsVersion);
+        return `https://github.com/ag-grid/ag-charts/releases/download/r${major}.${minor}.${patchNum}/${packageName}.tgz`;
+    },
+};

--- a/packages/ag-charts-website/src/utils/markdoc/functions/libraryVersions.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/functions/libraryVersions.ts
@@ -41,6 +41,6 @@ export const chartsDownloadUrl: ConfigFunction = {
     transform(parameters) {
         const packageName = parameters[0];
         const { major, minor, patchNum } = parseVersion(agChartsVersion);
-        return `https://github.com/ag-grid/ag-charts/releases/download/r${major}.${minor}.${patchNum}/${packageName}.tgz`;
+        return `https://github.com/ag-grid/ag-charts/releases/download/release-${major}.${minor}.${patchNum}/${packageName}.tgz`;
     },
 };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1123

The installation page hardcoded `11.1.0` in the CDN `<script>` tags and the GitHub release download links, so they were never updated for the 14.0.0 release.

These now derive from the published version (`PUBLIC_PACKAGE_VERSION`):

- **CDN code fences** — use `{% chartsVersionPatch() %}`. Charts highlights code via the `@astrojs/markdoc/shiki` extension, which renders the *raw* fence content and so never interpolated Markdoc tags inside code blocks. The shiki plugin now resolves interpolation for fences that contain `{% ... %}` before highlighting (scoped by a `{%` check — no other code block is affected).
- **Download links** — use a new `chartsDownloadUrl(...)` Markdoc function passed as a `href` attribute expression, mirroring the existing `codespaceUrl()`. Embedding a variable inside a quoted attribute string does not interpolate in Markdoc, so a function is used instead.

Both paths go through `parseVersion`, so the rendered version is `major.minor.patch` (e.g. `14.0.0`) without the beta/build suffix.

Verified on the local dev server: CDN tags and download links render `14.0.0`/`r14.0.0`, and other pages' code highlighting is unaffected.
