### PR TITLE
CRT-1132 Allow data: in frame-src CSP so Firefox chart PNG download works

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
@@ -50,6 +50,10 @@ describe('cspRules', () => {
             expect(getCspDirectives({ env: 'production', scope: 'site' })['connect-src']).toContain('data:');
         });
 
+        it('frame-src allows data: so Firefox does not block the chart PNG export download', () => {
+            expect(getCspDirectives({ env: 'production', scope: 'site' })['frame-src']).toContain('data:');
+        });
+
         it('style-src and font-src allow cdnjs for the font-icons docs example', () => {
             const site = getCspDirectives({ env: 'production', scope: 'site' });
             expect(site['style-src']).toContain('https://cdnjs.cloudflare.com');

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -157,6 +157,10 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         ],
         'frame-src': [
             SELF,
+            // Chart PNG export clicks an <a download href="data:image/png;…">. Firefox routes that
+            // data: load through frame-src and blocks the download (Moz bug 1194734); Chromium honours
+            // the download attribute and never checks frame-src. img-src/media-src already allow data:.
+            'data:',
             'https://www.googletagmanager.com',
             'https://www.youtube.com',
             'https://www.google.com', // reCAPTCHA challenge iframe


### PR DESCRIPTION
## Summary

The chart **PNG export** (toolbar "Download" / context-menu download) fails in **Firefox** on pages served with our CSP, while working fine in Chromium. Reported on e.g. `/charts/archive/14.0.0/gallery/100--stacked-area/`:

```
Content-Security-Policy: The page's settings blocked the loading of a resource (frame-src)
at data:image/png;base64,iVBORw0KGgo… because it violates the following directive:
"frame-src 'self' https://www.googletagmanager.com https://www.youtube.com https://www.google.com"
```

## Root cause

The export path (`downloadUrl()` in `ag-charts-core/src/utils/dom/domDownload.ts`) creates an `<a download href="data:image/png;base64,…">` and clicks it. This is a well-documented Firefox/Chromium CSP divergence:

- **Chromium** honours the `download` attribute, recognises the `data:` URL is not loaded into a frame, and never consults `frame-src` — download succeeds.
- **Firefox** evaluates CSP first, treats navigating the anchor to the `data:` URL as a (sub)frame navigation, and checks it against `frame-src`. Our `frame-src` did not include `data:`, so the download was blocked.

Mozilla considers this correct-by-spec and will not change it: [bug 1194734](https://bugzilla.mozilla.org/show_bug.cgi?id=1194734), [bug 1862553](https://bugzilla.mozilla.org/show_bug.cgi?id=1862553). The documented workaround is to allow `data:` in `frame-src`.

## Change

- Add `'data:'` to the `frame-src` directive in `cspRules.ts` (with a WHY comment citing the upstream Firefox bug). `img-src`/`media-src` already allow `data:`; this brings `frame-src` in line for the download path and widens the directive only to `data:`.
- Add a `cspRules.test.ts` assertion mirroring the existing `connect-src` `data:` test.

## Testing

- `cspRules` + `htaccessRules` vitest suites pass (12 + 7).
- `yarn nx lint ag-charts-website` clean (pre-existing warnings only).
- `yarn nx format` applied.
- ⚠️ Could not drive Firefox end-to-end from the dev environment (no browser automation available). Recommend a manual Firefox check of a gallery chart download on a build carrying this CSP before merge.