### PR TITLE
CRT-1140 Make annotation keyboard move step snap-aware

### DIFF
--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.test.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.test.ts
@@ -835,8 +835,9 @@ describe('Annotations', () => {
         });
     });
 
-    // A band/ordinal x-axis (bandwidth > 1px) is required: the plain-arrow step must stay at 1px
-    // regardless of bandwidth. On a number axis bandwidth is 0, which would not distinguish the cases.
+    // A band/ordinal x-axis (bandwidth > 1px) is required: without snapping the plain-arrow step
+    // must stay at 1px regardless of bandwidth. On a number axis bandwidth is 0, which would not
+    // distinguish the cases.
     describe('keyboard arrow key move step', () => {
         // Four categories in 800px gives a bandwidth well above 1px.
         const BAND_AXIS_OPTIONS: AgCartesianChartOptions = {
@@ -938,6 +939,83 @@ describe('Annotations', () => {
             const pxAfter = toPx(valueAfter, xScale);
 
             expect(Math.abs(pxAfter - pxBefore)).toBeCloseTo(10, 5);
+        });
+
+        // With snapping enabled (the financial preset default) a band axis locks annotations to
+        // band centres, so a sub-band move re-snaps to the same centre and appears to do nothing.
+        // A plain arrow must advance exactly one band; Ctrl/Shift advances ten.
+        describe('with snapping enabled', () => {
+            const CATEGORIES = Array.from({ length: 20 }, (_, i) => String.fromCharCode(65 + i));
+            const START_INDEX = 5;
+
+            const SNAP_AXIS_OPTIONS: AgCartesianChartOptions = {
+                data: CATEGORIES.map((category, i) => ({ category, value: 50 + (i % 5) * 10 })),
+                series: [{ type: 'bar', xKey: 'category', yKey: 'value' }],
+                axes: {
+                    x: { type: 'category', position: 'bottom' },
+                    y: { type: 'number', position: 'left' },
+                },
+                annotations: {
+                    enabled: true,
+                    toolbar: { enabled: false },
+                    // @ts-expect-error snap is an undocumented option
+                    snap: true,
+                },
+                width: 800,
+                height: 400,
+            };
+
+            async function prepareSnappedChart() {
+                await prepareChart(
+                    {
+                        annotations: [
+                            {
+                                type: 'vertical-line',
+                                value: { value: CATEGORIES[START_INDEX], groupPercentage: 0 },
+                            },
+                        ],
+                    },
+                    SNAP_AXIS_OPTIONS
+                );
+            }
+
+            function snappedCategoryIndex(annotationsModule: any): number {
+                return CATEGORIES.indexOf(annotationsModule.annotationData.at(0).value.value);
+            }
+
+            it('plain ArrowRight advances a snapped annotation by exactly one band', async () => {
+                await prepareSnappedChart();
+
+                const annotationsModule = getAnnotationsModule();
+                annotationsModule.state.stateMachines[2].active = 0;
+                expect(snappedCategoryIndex(annotationsModule)).toBe(START_INDEX);
+
+                annotationsModule.onKeyDown({
+                    type: 'keydown' as const,
+                    sourceEvent: new KeyboardEvent('keydown', { key: 'ArrowRight', code: 'ArrowRight' }),
+                });
+
+                expect(snappedCategoryIndex(annotationsModule)).toBe(START_INDEX + 1);
+            });
+
+            it('Shift+ArrowRight advances a snapped annotation by ten bands', async () => {
+                await prepareSnappedChart();
+
+                const annotationsModule = getAnnotationsModule();
+                annotationsModule.state.stateMachines[2].active = 0;
+                expect(snappedCategoryIndex(annotationsModule)).toBe(START_INDEX);
+
+                annotationsModule.onKeyDown({
+                    type: 'keydown' as const,
+                    sourceEvent: new KeyboardEvent('keydown', {
+                        key: 'ArrowRight',
+                        code: 'ArrowRight',
+                        shiftKey: true,
+                    }),
+                });
+
+                expect(snappedCategoryIndex(annotationsModule)).toBe(START_INDEX + 10);
+            });
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -23,6 +23,7 @@ import { AxesButtons } from './annotationAxesButtons';
 import { AnnotationDefaults } from './annotationDefaults';
 import { AnnotationOptionsToolbar } from './annotationOptionsToolbar';
 import type {
+    AnnotationAxisContext,
     AnnotationContext,
     AnnotationOptionsColorPickerType,
     DataPoint,
@@ -1128,8 +1129,8 @@ export class Annotations extends AbstractModuleInstance {
 
         const translation = { x: 0, y: 0 };
 
-        const xStep = ctrlShift ? 10 : 1;
-        const yStep = ctrlShift ? 10 : 1;
+        const xStep = this.keyboardMoveStep(context.xAxis, ctrlShift);
+        const yStep = this.keyboardMoveStep(context.yAxis, ctrlShift);
         switch (sourceEvent.key) {
             case 'ArrowDown':
                 translation.y = yStep;
@@ -1174,6 +1175,21 @@ export class Annotations extends AbstractModuleInstance {
                 this.recordActionAfterNextUpdate('Paste annotation');
                 return;
         }
+    }
+
+    private keyboardMoveStep(axis: AnnotationAxisContext, fast: boolean): number {
+        const multiplier = fast ? 10 : 1;
+        const { scale, snapToGroup } = axis;
+        const bandwidth = scale.bandwidth ?? 0;
+
+        // A snapping band axis locks annotations to band centres, so a sub-band move re-snaps to
+        // the same centre and appears to do nothing. Step by the band-to-band distance instead so
+        // a plain arrow crosses exactly one band; the step falls back to bandwidth when undefined.
+        if (snapToGroup && bandwidth > 0) {
+            return multiplier * (scale.step ?? bandwidth);
+        }
+
+        return multiplier;
     }
 
     private onKeyUp(event: _Widget.KeyboardWidgetEvent<'keyup'>) {

--- a/packages/ag-charts-website/src/content/docs/annotations/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/annotations/index.mdoc
@@ -68,7 +68,8 @@ The following keyboard shortcuts can be used.
 - {% kbd "^ Ctrl"/%}+{% kbd "V"/%} / {% kbd "⌘"/%}+{% kbd "V"/%} will paste the copied drawing or annotation.
 - {% kbd "Delete"/%} or {% kbd "⌫ Backspace" /%} will delete the selected item.
 - Arrow keys ({% kbd "←"/%} {% kbd "↑"/%} {% kbd "→"/%} {% kbd "↓"/%}) will move the selected drawing or annotation by 1 pixel.  
-  Use in combination with {% kbd "^ Ctrl"/%} or {% kbd "⇧ Shift"/%} to move by 10 pixels.
+  Use in combination with {% kbd "^ Ctrl"/%} or {% kbd "⇧ Shift"/%} to move by 10 pixels.  
+  Where annotations snap to data points, such as on financial charts, each press moves by one data point instead — ten with {% kbd "^ Ctrl"/%} or {% kbd "⇧ Shift"/%}.
 - Holding down {% kbd "⇧ Shift"/%} whilst creating a drawing or dragging a handle will snap it to the nearest 45° angle.
 
 ## Save & Restore


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1140

Follow-up to #7210, which failed verification: after removing the bandwidth floor from the annotation keyboard move step, LEFT/RIGHT arrows stopped moving annotations on the financial example (UP/DOWN still worked).

## Root cause

The financial (price-volume) preset enables `annotations.snap: true`. With snapping on, `convert()` locks the annotation x to the **band centre** and discards the per-pixel `groupPercentage`. On the ordinal-time x-axis a 1px nudge therefore stays inside the same band, re-snaps to the same centre, and does nothing. The y-axis (continuous price) takes a different path where 1px works — hence LEFT/RIGHT dead, UP/DOWN fine. The bandwidth floor #7210 removed was load-bearing: it moved one whole band per press.

#7210's regression test missed this because it used a band axis **without** `snap: true`, where 1px genuinely works.

## Change

`keyboardMoveStep` computes the step per axis:

| Axis | Plain arrow | Ctrl/Shift |
|------|-------------|------------|
| Continuous (any) | 1px | 10px |
| Band, no snap | 1px | 10px |
| Band + snap (financial) | one band | ten bands |

Continuous axes keep the documented 1px / 10px; snapping band axes step by whole candles.

## Changes

- `annotations.ts` — `keyboardMoveStep` helper replacing the bare `ctrlShift ? 10 : 1`.
- `annotations.test.ts` — two snap regression tests (verified to fail against the merged #7210 code, pass with this fix).
- `annotations/index.mdoc` — note that snapping axes step by data point, not pixel.

## Testing

- `build:types ag-charts-enterprise` — PASS
- `lint ag-charts-enterprise` — PASS (0 errors)
- Annotation suite — 39/39 PASS (2 new snap tests; confirmed they fail against #7210's code).
- Pre-existing failures in `errorBar.test.ts` and `integratedChartsExamples.test.ts` (crossfilter) reproduce identically on clean `b14.0.0` and are unrelated to this change.

Fix #CRT-1140