### PR TITLE
CRT-1149 Fix Control key state tracking on Windows

### DIFF
--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -21,7 +21,6 @@ import { DataSelectionService } from './dataSelectionService';
 import {
     type SelectionChanges,
     clearAllSelections,
-    countAddToSelectionModifier,
     hasAddToSelectionModifier,
     isAgSelectionItem,
     isUnknownIterable,
@@ -245,7 +244,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
         this.service.totalCandidacyCount = 0;
         this.service.candidacyInProgress ||= canvasBounds.width > 0 || canvasBounds.height > 0;
-        this.service.candidacyUnion = countAddToSelectionModifier(dragMoveEvent);
+        this.service.candidacyUnion = hasAddToSelectionModifier(dragMoveEvent);
         for (const series of this.iterateSelectableSeries()) {
             const data = series.data;
             if (!data) continue;
@@ -275,7 +274,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const { dragStartEvent, service } = this;
 
         service.totalCandidacyCount = 0;
-        service.candidacyUnion = countAddToSelectionModifier(dragEndEvent);
+        service.candidacyUnion = hasAddToSelectionModifier(dragMoveEvent);
         if (!enabled || !enableDrag || !dragStartEvent) {
             this.dragRect.visible = false;
             return;
@@ -350,7 +349,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         // without moving the mouse; which would mean that any itemStyler callbacks that read candidateState would need
         // to invoked again.
         const oldCandidacyUnion = this.service.candidacyUnion;
-        const newCandidacyUnion = countAddToSelectionModifier(widgetEvent);
+        const newCandidacyUnion = hasAddToSelectionModifier(widgetEvent);
         if (oldCandidacyUnion !== newCandidacyUnion) {
             this.service.candidacyUnion = newCandidacyUnion;
             this.redraw(ChartUpdateType.FULL);

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -274,7 +274,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const { dragStartEvent, service } = this;
 
         service.totalCandidacyCount = 0;
-        service.candidacyUnion = hasAddToSelectionModifier(dragMoveEvent);
+        service.candidacyUnion = hasAddToSelectionModifier(dragEndEvent);
         if (!enabled || !enableDrag || !dragStartEvent) {
             this.dragRect.visible = false;
             return;

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -344,14 +344,24 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         }
     }
 
-    private onKeyDown(widgetEvent: _ModuleSupport.KeyboardWidgetEvent<'keydown'>): void {
-        if (!this.opts.enabled) return;
-
-        const { key, code } = widgetEvent.sourceEvent;
-        if (key === 'Meta' || key === 'Control') {
-            this.service.candidacyUnion++;
+    private refreshCandidacyUnion(widgetEvent: _ModuleSupport.KeyboardWidgetEvent<'keydown' | 'keyup'>): void {
+        // The drag-move / drag-end events include the state of all modifiers in the events, therefore those event
+        // handlers always refresh the candidacyUnion count. However, the user can also press/release the modifier keys
+        // without moving the mouse; which would mean that any itemStyler callbacks that read candidateState would need
+        // to invoked again.
+        const oldCandidacyUnion = this.service.candidacyUnion;
+        const newCandidacyUnion = countAddToSelectionModifier(widgetEvent);
+        if (oldCandidacyUnion !== newCandidacyUnion) {
+            this.service.candidacyUnion = newCandidacyUnion;
             this.redraw(ChartUpdateType.FULL);
         }
+    }
+
+    private onKeyDown(widgetEvent: _ModuleSupport.KeyboardWidgetEvent<'keydown'>): void {
+        if (!this.opts.enabled) return;
+        this.refreshCandidacyUnion(widgetEvent);
+
+        const { code } = widgetEvent.sourceEvent;
         if (code === 'Escape') {
             this.endDrag();
         }
@@ -359,16 +369,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
 
     private onKeyUp(widgetEvent: _ModuleSupport.KeyboardWidgetEvent<'keyup'>): void {
         if (!this.opts.enabled) return;
-
-        // The drag-move / drag-end events include the state of all modifiers in the events, therefore those event
-        // handlers always refresh the candidacyUnion count. However, the user can also press/release the modifier keys
-        // without moving the mouse; which would mean that any itemStyler callbacks that read candidateState would be
-        // updated.
-        const { key } = widgetEvent.sourceEvent;
-        if (key === 'Meta' || key === 'Control') {
-            this.service.candidacyUnion--;
-            this.redraw(ChartUpdateType.FULL);
-        }
+        this.refreshCandidacyUnion(widgetEvent);
     }
 
     private endDrag(): void {

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionService.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionService.ts
@@ -218,7 +218,7 @@ export class DataSelectionService extends AbstractModuleInstance implements IDat
     getDataCandidateState(series: SeriesLike, datumIndex: number | undefined): SelectionStateEnum | undefined {
         if (!this.candidacyInProgress || !this.isSeriesSelectionEnabled(series)) return undefined;
 
-        if (this.candidacyUnion > 0) {
+        if (this.candidacyUnion) {
             const selectedState = this.getDataSelectionState(series, datumIndex);
             if (selectedState === SelectionState.Item) {
                 return SelectionState.Item;

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionService.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionService.ts
@@ -34,9 +34,8 @@ export class DataSelectionService extends AbstractModuleInstance implements IDat
     // 2.  A drag motion is in progress, but the candidacy list is empty.
     public candidacyInProgress = false;
     // The Control/Cmd keys can be used to add everything in candidacy to the existing selections rather than setting
-    // the selection (i.e. the union of candidate + selection). Multiple keys can toggle the union behaviour, so we
-    // use a number to track how many of those keys are pressed.
-    public candidacyUnion = 0;
+    // the selection (i.e. the union of candidate + selection).
+    public candidacyUnion = false;
 
     /** Per-series selection state. Keyed by `seriesId`. */
     selections = new Map<string, DataSetSelection>();

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
@@ -48,10 +48,6 @@ export function hasAddToSelectionModifier(event: { sourceEvent: { ctrlKey: boole
     return event.sourceEvent.ctrlKey || event.sourceEvent.metaKey;
 }
 
-export function countAddToSelectionModifier(event: { sourceEvent: { ctrlKey: boolean; metaKey: boolean } }): number {
-    return Number(event.sourceEvent.ctrlKey) + Number(event.sourceEvent.metaKey);
-}
-
 export function rollbackChanges(changes: SelectionChangesWithItems, service: Service): void {
     type K = Series['id'];
     type V = { dataSet: DataSet; selection: DataSetSelection };


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1149

Claude diagnosed that the root cause is that holding down the Control key on Windows send repeated keydown events but only one keyup events when releasing. Whereas on macOS, holding down and releasing the the Control key always sends exactly 1 keydown and 1 keyup event. This causes the candidacyUnion counter to never reach 0 on Windows.

Fortunately, the KeyboardEvents `ctrlKey` and `metaKey` properties are consistent across all platform, so we can reuse the mousemove counting mechanism.