### PR TITLE
CRT-1126 Fix gauge line highlighted over empty space

### DIFF
--- a/packages/ag-charts-community/src/chart/marker/marker.test.ts
+++ b/packages/ag-charts-community/src/chart/marker/marker.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { Marker } from './marker';
+
+describe('Marker', () => {
+    describe('distanceSquared', () => {
+        it('measures distance from the translated position, not the untransformed origin', () => {
+            const marker = new Marker();
+            marker.shape = 'square';
+            marker.size = 20;
+            marker.translationX = 100;
+            marker.translationY = 100;
+
+            // Pointer over the marker's rendered centre (its translation) reads as a hit.
+            expect(marker.distanceSquared(100, 100)).toBe(0);
+
+            // Pointer near the scene origin — far from the rendered marker — must not read as a hit.
+            expect(marker.distanceSquared(0, 0)).toBeGreaterThan(0);
+        });
+    });
+});

--- a/packages/ag-charts-community/src/chart/marker/marker.ts
+++ b/packages/ag-charts-community/src/chart/marker/marker.ts
@@ -52,7 +52,7 @@ class InternalMarker<D = any> extends Path<D> {
     }
 
     override isPointInPath(x: number, y: number): boolean {
-        return this.distanceSquared(x, y) <= 0;
+        return this.distanceSquaredLocal(x, y) <= 0;
     }
 
     // Exact hit-test against the shared origin-centred path; for subclasses (e.g. AnnotationShape)
@@ -70,6 +70,13 @@ class InternalMarker<D = any> extends Path<D> {
     }
 
     override distanceSquared(x: number, y: number): number {
+        return this.distanceSquaredLocal(x, y);
+    }
+
+    // Local-space hit-test, shared by both pick entry points so neither transforms twice: the
+    // public distanceSquared() is transform-wrapped by the MatrixTransform mixin, while
+    // isPointInPath() is reached via pickNode() which has already inverse-transformed the point.
+    protected distanceSquaredLocal(x: number, y: number): number {
         const anchor = Marker.anchor(this.shape);
         const dx = x - this.x + (anchor.x - 0.5) * this.size;
         const dy = y - this.y + (anchor.y - 0.5) * this.size;

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -366,6 +366,10 @@ export abstract class Node<TDatum = unknown> {
         return false;
     }
 
+    distanceSquared(_x: number, _y: number): number {
+        return Infinity;
+    }
+
     pickNode(x: number, y: number): Node | undefined {
         if (!this.visible || this.pointerEvents === PointerEvents.None) {
             return;

--- a/packages/ag-charts-community/src/scene/shape/line.ts
+++ b/packages/ag-charts-community/src/scene/shape/line.ts
@@ -60,7 +60,7 @@ export class Line<D = unknown> extends Shape<D> implements DistantObject {
         return false;
     }
 
-    distanceSquared(px: number, py: number): number {
+    override distanceSquared(px: number, py: number): number {
         const { x1, y1, x2, y2 } = this;
         return lineDistanceSquared(px, py, x1, y1, x2, y2, Infinity);
     }

--- a/packages/ag-charts-community/src/scene/shape/path.ts
+++ b/packages/ag-charts-community/src/scene/shape/path.ts
@@ -100,7 +100,7 @@ export class Path<D = unknown> extends Shape<D> implements DistantObject {
         return this.path.closedPath && this.path.isPointInPath(x, y);
     }
 
-    distanceSquared(x: number, y: number): number {
+    override distanceSquared(x: number, y: number): number {
         return this.distanceSquaredTransformedPoint(x, y);
     }
 

--- a/packages/ag-charts-community/src/scene/transformable.ts
+++ b/packages/ag-charts-community/src/scene/transformable.ts
@@ -124,6 +124,11 @@ function MatrixTransform<N extends Node>(Parent: Constructor<N>) {
             return super.pickNodes(x, y, into);
         }
 
+        override distanceSquared(x: number, y: number): number {
+            ({ x, y } = this.fromParentPoint(x, y));
+            return super.distanceSquared(x, y);
+        }
+
         override render(renderCtx: RenderContext): void {
             this.computeTransformMatrix();
 

--- a/packages/ag-charts-enterprise/src/series/gauge-util/lineMarker.test.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/lineMarker.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { LineMarker, lineMarker } from './lineMarker';
+
+describe('LineMarker', () => {
+    function createLineTarget() {
+        const marker = new LineMarker();
+        marker.shape = lineMarker;
+        marker.size = 40; // segment runs vertically from y-20 to y+20 in local space
+        marker.strokeWidth = 2; // hit-test tolerance band of 1px each side
+        marker.translationX = 100;
+        marker.translationY = 100;
+        return marker;
+    }
+
+    describe('distanceSquared', () => {
+        it('reads as a hit anywhere along the rendered line', () => {
+            const marker = createLineTarget();
+            expect(marker.distanceSquared(100, 100)).toBe(0); // centre
+            expect(marker.distanceSquared(100, 115)).toBe(0); // along the segment
+            expect(marker.distanceSquared(100, 80)).toBe(0); // segment end
+        });
+
+        it('does not read as a hit in empty space beside the line', () => {
+            const marker = createLineTarget();
+            // Perpendicular to the line, well within the old circular (radius = size/2) hit zone.
+            expect(marker.distanceSquared(110, 100)).toBeGreaterThan(0);
+            // Beyond the segment ends.
+            expect(marker.distanceSquared(100, 130)).toBeGreaterThan(0);
+        });
+
+        it('measures distance from the translated position, not the untransformed origin', () => {
+            const marker = createLineTarget();
+            expect(marker.distanceSquared(0, 0)).toBeGreaterThan(0);
+        });
+
+        it('falls back to the circular hit-test for non-line target shapes', () => {
+            const marker = createLineTarget();
+            marker.shape = 'square';
+            expect(marker.distanceSquared(100, 100)).toBe(0);
+            expect(marker.distanceSquared(115, 100)).toBe(0); // within radius = size/2
+        });
+    });
+});

--- a/packages/ag-charts-enterprise/src/series/gauge-util/lineMarker.ts
+++ b/packages/ag-charts-enterprise/src/series/gauge-util/lineMarker.ts
@@ -1,6 +1,26 @@
+import { _ModuleSupport } from 'ag-charts-community';
 import type { AgMarkerShapeFnParams } from 'ag-charts-community';
+import { clamp } from 'ag-charts-core';
+
+const { Marker } = _ModuleSupport;
 
 export function lineMarker({ path, x, y, size }: AgMarkerShapeFnParams) {
     path.moveTo(x, y - size / 2);
     path.lineTo(x, y + size / 2);
+}
+
+export class LineMarker<D = unknown> extends Marker<D> {
+    // The line target renders as a thin segment of length `size`, but the generic Marker hit-test
+    // models every marker as a circle of radius size/2 — half the line's length — so it highlights
+    // a large empty area around the line. Hit-test against the segment itself instead.
+    protected override distanceSquaredLocal(x: number, y: number): number {
+        if (this.shape !== lineMarker) {
+            return super.distanceSquaredLocal(x, y);
+        }
+
+        const half = this.size / 2;
+        const dy = y - clamp(-half, y, half);
+        const tolerance = this.strokeWidth / 2;
+        return Math.max(x * x + dy * dy - tolerance * tolerance, 0);
+    }
 }

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import type { AgLinearGaugeLabelPlacement, AgLinearGaugeOptions } from 'ag-charts-community';
-import { AgCharts } from 'ag-charts-community';
+import { AgCharts, _ModuleSupport } from 'ag-charts-community';
 import {
     GALLERY_EXAMPLES,
     IMAGE_SNAPSHOT_DEFAULTS,
@@ -241,6 +241,42 @@ describe('LinearGaugeSeries', () => {
             await waitForChartStability(chart);
             await hoverAction(750, 320)(chart);
             expect(0).toBe(0); // do nothing (just check MockConsole warn/error output).
+        });
+    });
+
+    describe('CRT-1126 line target hover region', () => {
+        it('should highlight the line when hovered but not in empty space away from it', async () => {
+            const options: AgLinearGaugeOptions = {
+                type: 'linear-gauge',
+                direction: 'horizontal',
+                value: 55,
+                scale: { min: 0, max: 100 },
+                targets: [{ value: 90, shape: 'line' }],
+                tooltip: { enabled: true },
+            };
+            prepareEnterpriseTestOptions(options);
+            chart = deproxy(AgCharts.createGauge(options));
+            await waitForChartStability(chart);
+
+            const series = chart.series[0];
+            const lineNode = [...series.targetSelection.nodes()][0];
+            const lineBBox = _ModuleSupport.Transformable.toCanvas(lineNode);
+            const lineCx = lineBBox.x + lineBBox.width / 2;
+            const lineCy = lineBBox.y + lineBBox.height / 2;
+            // The line's local origin maps to this canvas point: empty space above the bar, far
+            // enough from the line that it must not register as hovered.
+            const emptyX = lineCx - lineNode.translationX + 4;
+            const emptyY = lineCy - lineNode.translationY + 4;
+
+            const { highlightManager } = chart.ctx;
+
+            await hoverAction(emptyX, emptyY)(chart);
+            await waitForChartStability(chart);
+            expect(highlightManager.getActiveHighlight()).toBeUndefined();
+
+            await hoverAction(lineCx, lineCy)(chart);
+            await waitForChartStability(chart);
+            expect(highlightManager.getActiveHighlight()).toBeDefined();
         });
     });
 

--- a/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/linear-gauge/linearGaugeSeries.ts
@@ -32,7 +32,7 @@ import { formatWithContext } from '../../utils/formatter';
 import { DatumUnion } from '../gauge-util/datumUnion';
 import { getGaugeTooltipInfo } from '../gauge-util/gaugeTooltip';
 import { fadeInFns, formatLabel, getLabelText } from '../gauge-util/label';
-import { lineMarker } from '../gauge-util/lineMarker';
+import { LineMarker, lineMarker } from '../gauge-util/lineMarker';
 import { findGaugeNodeDatum, pickGaugeFocus, pickGaugeNearestDatum } from '../gauge-util/pick';
 import {
     type LinearGaugeLabelDatum,
@@ -61,7 +61,6 @@ const {
     Rect,
     Text,
     TransformableText,
-    Marker,
     LinearScale,
     generateTicks,
     NiceMode,
@@ -242,7 +241,7 @@ export class LinearGaugeSeries extends _ModuleSupport.Series<
     }
 
     private markerFactory(): _ModuleSupport.Marker<LinearGaugeTargetDatum> {
-        return new Marker<LinearGaugeTargetDatum>();
+        return new LineMarker<LinearGaugeTargetDatum>();
     }
 
     override processData() {

--- a/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-gauge/radialGaugeSeries.ts
@@ -34,7 +34,7 @@ import { formatWithContext } from '../../utils/formatter';
 import { DatumUnion } from '../gauge-util/datumUnion';
 import { getGaugeTooltipInfo } from '../gauge-util/gaugeTooltip';
 import { fadeInFns, formatLabel, getLabelText } from '../gauge-util/label';
-import { lineMarker } from '../gauge-util/lineMarker';
+import { LineMarker, lineMarker } from '../gauge-util/lineMarker';
 import { findGaugeNodeDatum, pickGaugeFocus, pickGaugeNearestDatum } from '../gauge-util/pick';
 import { RadialGaugeNeedle } from './radialGaugeNeedle';
 import {
@@ -68,7 +68,6 @@ const {
     Transformable,
     TransformableText,
     Text,
-    Marker,
 } = _ModuleSupport;
 
 type SeriesNodeDatum = _ModuleSupport.SeriesNodeDatum;
@@ -273,7 +272,7 @@ export class RadialGaugeSeries
     }
 
     private markerFactory(): _ModuleSupport.Marker<RadialGaugeTargetDatum> {
-        const marker = new Marker<RadialGaugeTargetDatum>();
+        const marker = new LineMarker<RadialGaugeTargetDatum>();
         marker.size = 1;
         return marker;
     }


### PR DESCRIPTION
## Summary

Linear and radial gauges highlighted their **line target** when hovering empty space far from the line (e.g. above the bar, under the top label of the simple-bullet example). The line registered as "hovered" almost anywhere in the gauge area.

**Root cause:** the highlight comes from the `NEAREST_NODE` pick fallback, which calls `node.distanceSquared`. Gauge target markers are positioned via `translationX/Y` (their `x/y` stay `0`), but `Marker.distanceSquared` reads `this.x/this.y` — and the `MatrixTransform` mixin inverse-transformed the point for `pickNode`/`pickNodes` but **not** for `distanceSquared`. So the picker measured the target's distance from the scene **origin**, not its rendered position; near the gauge's local origin the distance collapsed toward `0` and the line won the pick. Secondarily, the `line` marker (a thin segment of length `size`) was modelled as a circle of radius `size/2`, giving an oversized hit zone even when positioned correctly.

**Fix:** make `distanceSquared` transform-aware in the `MatrixTransform` mixin (mirroring the existing `pickNode` override), and hit-test the line target against its actual segment instead of a bounding circle.

## Changes

- `transformable.ts` — `MatrixTransform.distanceSquared` now inverse-transforms the point before measuring, matching `pickNode`/`pickNodes`.
- `node.ts` — base `distanceSquared` default (`Infinity`), mirroring `containsPoint`, so the mixin's `super` call is valid for non-shape nodes. `path.ts`/`line.ts` gain the now-required `override` keyword (no behaviour change).
- `marker.ts` — split the circle hit-test into a non-transforming `distanceSquaredLocal` seam called directly by `isPointInPath` (already-local coords) and via the transform-wrapped public `distanceSquared`, so the exact and nearest pick paths can't double-transform.
- `gauge-util/lineMarker.ts` — new `LineMarker` overriding `distanceSquaredLocal` to measure distance to the line segment (thin band) for `line` targets; other target shapes fall back to the circle.
- `linearGaugeSeries.ts` / `radialGaugeSeries.ts` — `markerFactory` builds `LineMarker`.

## Test plan

- New `marker.test.ts` — a translated `Marker` measures distance from its rendered position, not the origin (confirmed failing pre-fix: `19900` vs `0`).
- New `gauge-util/lineMarker.test.ts` — `LineMarker` hits along the line, misses beside/beyond it, is transform-correct, and falls back to the circle for non-line shapes.
- `linearGaugeSeries.test.ts` (CRT-1126) — hovering empty space near the line registers no highlight, hovering the line does. Verified non-vacuous: fails when the `MatrixTransform` fix is reverted.
- `build:types` and `lint` pass for `ag-charts-community` and `ag-charts-enterprise`.
- `yarn nx test ag-charts-community` — all pass (3693). Both gauge snapshot suites pass (no visual regression from the `LineMarker` swap).
- `yarn nx test ag-charts-enterprise` — only the pre-existing crossfilter (integratedChartsExamples) and ErrorBars (AG-16943) snapshot failures remain; confirmed present on the base branch and unrelated to this change.

Shares the root cause with **AG-15859**.

Fix #CRT-1126