### PR TITLE
CRT-1132 Allow data: in frame-src CSP so Firefox chart PNG download works (#7226)

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
@@ -50,6 +50,10 @@ describe('cspRules', () => {
             expect(getCspDirectives({ env: 'production', scope: 'site' })['connect-src']).toContain('data:');
         });
 
+        it('frame-src allows data: so Firefox does not block the chart PNG export download', () => {
+            expect(getCspDirectives({ env: 'production', scope: 'site' })['frame-src']).toContain('data:');
+        });
+
         it('style-src and font-src allow cdnjs for the font-icons docs example', () => {
             const site = getCspDirectives({ env: 'production', scope: 'site' });
             expect(site['style-src']).toContain('https://cdnjs.cloudflare.com');

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -157,6 +157,10 @@ export function getCspDirectives(options: CspOptions): CspDirectives {
         ],
         'frame-src': [
             SELF,
+            // Chart PNG export clicks an <a download href="data:image/png;…">. Firefox routes that
+            // data: load through frame-src and blocks the download (Moz bug 1194734); Chromium honours
+            // the download attribute and never checks frame-src. img-src/media-src already allow data:.
+            'data:',
             'https://www.googletagmanager.com',
             'https://www.youtube.com',
             'https://www.google.com', // reCAPTCHA challenge iframe


### PR DESCRIPTION
Port of https://github.com/ag-grid/ag-charts/pull/7226