### PR TITLE
Gate browser benchmarks on multi-run cross-run variance

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -376,10 +376,13 @@ jobs:
                   merge-multiple: true
 
             # Merge each run's shards into one head/base report per run, then hand every run to
-            # the comparison so it can median across runs and gate on cross-run CV. Soft-fail only
-            # covers failures within a shard; a wholly missing shard would silently shrink a run, so
-            # per-run shard counts are enforced. A flaky run is tolerated as long as >=2 survive
-            # (two runs are the minimum for a cross-run variance estimate).
+            # the comparison so it can median across runs and gate on cross-run CV. Two integrity
+            # checks keep a degraded run out of the gate: a wholly missing shard would silently
+            # shrink a run, so per-run shard counts are enforced; and AG_BENCHMARK_SOFT_FAIL lets a
+            # shard finish with errored/timed-out examples (the report is written before the runner
+            # exits non-zero), so each shard's failure counts are inspected too. A flaky run is
+            # tolerated as long as >=2 clean runs survive (the minimum for a cross-run variance
+            # estimate).
             - name: Merge shard results
               env:
                   SHARDS: ${{ needs.resolve.outputs.shards }}
@@ -392,6 +395,14 @@ jobs:
                     base_shards=(reports/browser-benchmarks/shards/base-*.r${run}.json)
                     if [[ ${#head_shards[@]} -ne $expected || ${#base_shards[@]} -ne $expected ]]; then
                       echo "::warning::Run ${run} incomplete (expected ${expected}, head: ${#head_shards[@]}, base: ${#base_shards[@]}); skipping"
+                      continue
+                    fi
+                    failed=0
+                    for f in "${head_shards[@]}" "${base_shards[@]}"; do
+                      failed=$((failed + $(jq '(.summary.error // 0) + (.summary.timeout // 0)' "$f")))
+                    done
+                    if [[ $failed -ne 0 ]]; then
+                      echo "::warning::Run ${run} has ${failed} failed/timed-out example(s) across its shards; skipping"
                       continue
                     fi
                     node ./tools/benchmark/merge-browser-results.js --output "reports/browser-benchmarks/head.r${run}.json" "${head_shards[@]}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,6 +44,10 @@ env:
     NX_BRANCH: ${{ github.ref }}
     BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     AG_SHARD_COUNT: 5
+    # Repeat each side N times per shard. The report job aggregates the runs and gates on
+    # cross-run CV — a single run per side cannot separate a real change from shared-runner CPU
+    # drift (~half the suite has a >10% run-to-run noise floor on hosted VMs).
+    AG_BENCHMARK_RUNS: 3
 
 permissions:
     contents: read
@@ -254,9 +258,9 @@ jobs:
 
     benchmark:
         runs-on: ubuntu-24.04
-        # Hosted runners are ~2x slower than the previous bare-metal runner;
-        # the slowest examples need generous headroom.
-        timeout-minutes: 45
+        # Hosted runners are ~2x slower than the previous bare-metal runner and we now run each
+        # side AG_BENCHMARK_RUNS times, so the slowest shards need generous headroom.
+        timeout-minutes: 90
         needs: [resolve, build]
         strategy:
             fail-fast: false
@@ -305,28 +309,33 @@ jobs:
                     echo "BASE_PORT=4602" >> $GITHUB_ENV
                   fi
 
-            # Head and base run sequentially on this same VM so the relative
-            # comparison cancels out per-runner hardware differences.
-            - name: Run benchmarks (head then base)
+            # Head and base run sequentially on this same VM so the relative comparison cancels
+            # per-runner hardware differences. We interleave head/base across AG_BENCHMARK_RUNS
+            # passes (head,base,head,base,…) so each pair is adjacent in time, and the report job
+            # gates on the cross-run variance of the per-run medians.
+            - name: Run benchmarks (interleaved head/base, repeated)
               run: |
                   mkdir -p reports/browser-benchmarks/shards
                   run_one() {
                     local role=$1
                     local port=$2
+                    local run=$3
                     ./tools/benchmark/serve-and-run.sh \
                         --dist "${RUNNER_TEMP}/site-${role}" \
                         --port "${port}" \
-                        --output "reports/browser-benchmarks/shards/${role}-${{ strategy.job-index }}.json" \
+                        --output "reports/browser-benchmarks/shards/${role}-${{ strategy.job-index }}.r${run}.json" \
                         -- --examples "${{ matrix.examples }}" --timeout 600000 || {
                       if [[ "${AG_BENCHMARK_SOFT_FAIL}" == "true" ]]; then
-                        echo "::warning::${role} benchmarks had failures (soft-fail mode)"
+                        echo "::warning::${role} run ${run} benchmarks had failures (soft-fail mode)"
                       else
                         return 1
                       fi
                     }
                   }
-                  run_one head 4601
-                  run_one base "${BASE_PORT}"
+                  for run in $(seq 1 "${AG_BENCHMARK_RUNS}"); do
+                    run_one head 4601 "${run}"
+                    run_one base "${BASE_PORT}" "${run}"
+                  done
 
             - name: Upload shard results
               if: always()
@@ -366,44 +375,51 @@ jobs:
                   path: reports/browser-benchmarks/shards
                   merge-multiple: true
 
-            # Soft-fail only covers failures within a shard; a wholly missing
-            # shard result would silently shrink the merged report, so the
-            # expected count is enforced here.
+            # Merge each run's shards into one head/base report per run, then hand every run to
+            # the comparison so it can median across runs and gate on cross-run CV. Soft-fail only
+            # covers failures within a shard; a wholly missing shard would silently shrink a run, so
+            # per-run shard counts are enforced. A flaky run is tolerated as long as >=2 survive
+            # (two runs are the minimum for a cross-run variance estimate).
             - name: Merge shard results
               env:
                   SHARDS: ${{ needs.resolve.outputs.shards }}
               run: |
                   shopt -s nullglob
                   expected=$(echo "$SHARDS" | jq length)
-                  head_shards=(reports/browser-benchmarks/shards/head-*.json)
-                  base_shards=(reports/browser-benchmarks/shards/base-*.json)
-                  if [[ ${#head_shards[@]} -ne $expected || ${#base_shards[@]} -ne $expected ]]; then
-                    echo "::error::Missing shard results (expected ${expected}, head: ${#head_shards[@]}, base: ${#base_shards[@]})"
+                  good_runs=0
+                  for run in $(seq 1 "${AG_BENCHMARK_RUNS}"); do
+                    head_shards=(reports/browser-benchmarks/shards/head-*.r${run}.json)
+                    base_shards=(reports/browser-benchmarks/shards/base-*.r${run}.json)
+                    if [[ ${#head_shards[@]} -ne $expected || ${#base_shards[@]} -ne $expected ]]; then
+                      echo "::warning::Run ${run} incomplete (expected ${expected}, head: ${#head_shards[@]}, base: ${#base_shards[@]}); skipping"
+                      continue
+                    fi
+                    node ./tools/benchmark/merge-browser-results.js --output "reports/browser-benchmarks/head.r${run}.json" "${head_shards[@]}"
+                    node ./tools/benchmark/merge-browser-results.js --output "reports/browser-benchmarks/base.r${run}.json" "${base_shards[@]}"
+                    good_runs=$((good_runs + 1))
+                  done
+                  if [[ $good_runs -lt 2 ]]; then
+                    echo "::error::Need >=2 complete runs for cross-run gating, got ${good_runs}"
                     exit 1
                   fi
-                  node ./tools/benchmark/merge-browser-results.js --output reports/browser-benchmarks/head.json "${head_shards[@]}"
-                  node ./tools/benchmark/merge-browser-results.js --output reports/browser-benchmarks/base.json "${base_shards[@]}"
+                  echo "Merged ${good_runs} complete run(s)."
 
             - name: Compare results
               id: compare
               run: |
                   mkdir -p reports
-                  node ./tools/benchmark/compare-browser-results.js \
-                      --base reports/browser-benchmarks/base.json \
-                      --compare reports/browser-benchmarks/head.json \
-                      --base-label "${{ needs.resolve.outputs.base-label }}" \
-                      --compare-label "${{ needs.resolve.outputs.branch }}" \
-                      --format table \
-                      --report-only \
-                      > reports/browser-benchmark.log
-                  node ./tools/benchmark/compare-browser-results.js \
-                      --base reports/browser-benchmarks/base.json \
-                      --compare reports/browser-benchmarks/head.json \
-                      --base-label "${{ needs.resolve.outputs.base-label }}" \
-                      --compare-label "${{ needs.resolve.outputs.branch }}" \
-                      --format json \
-                      --report-only \
-                      > reports/browser-benchmark.json
+                  base_args=() compare_args=()
+                  for f in reports/browser-benchmarks/base.r*.json; do base_args+=(--base "$f"); done
+                  for f in reports/browser-benchmarks/head.r*.json; do compare_args+=(--compare "$f"); done
+                  compare() {
+                    node ./tools/benchmark/compare-browser-results.js \
+                        "${base_args[@]}" "${compare_args[@]}" \
+                        --base-label "${{ needs.resolve.outputs.base-label }}" \
+                        --compare-label "${{ needs.resolve.outputs.branch }}" \
+                        --report-only --format "$1"
+                  }
+                  compare table > reports/browser-benchmark.log
+                  compare json > reports/browser-benchmark.json
                   cat reports/browser-benchmark.log
                   echo "report<<EOF" >> $GITHUB_OUTPUT
                   cat reports/browser-benchmark.log >> $GITHUB_OUTPUT

--- a/tools/benchmark/browser-benchmark.ts
+++ b/tools/benchmark/browser-benchmark.ts
@@ -17,6 +17,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { discoverExamples } from './benchmark-examples';
+import { type Contention, type HostInfo, diffContention, readCpuSample, readHostInfo } from './contention';
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '../..');
 
@@ -25,6 +26,8 @@ interface BenchmarkExampleResult {
     data?: Record<string, unknown>;
     error?: string;
     durationMs: number;
+    /** Whole-VM CPU contention sampled across this example's window; null on non-Linux hosts. */
+    contention?: Contention | null;
 }
 
 interface BenchmarkReport {
@@ -33,6 +36,8 @@ interface BenchmarkReport {
         viewport: { width: number; height: number };
         devicePixelRatio: number;
         browser: string;
+        /** Runner hardware identity; null on non-Linux hosts. */
+        host?: HostInfo | null;
     };
     summary: {
         total: number;
@@ -133,6 +138,7 @@ async function main() {
             viewport: { width: vpWidth, height: vpHeight },
             devicePixelRatio: argv.dpr,
             browser: 'chromium',
+            host: readHostInfo(),
         },
         summary: { total: exampleNames.length, success: 0, error: 0, timeout: 0, totalDurationMs: 0 },
         examples: {},
@@ -151,7 +157,9 @@ async function main() {
         page.on('pageerror', (err) => pageErrors.push(String(err)));
 
         const exampleStart = Date.now();
+        const cpuBefore = readCpuSample();
         let result: BenchmarkExampleResult;
+        let contention: Contention | null = null;
 
         try {
             const response = await page.goto(url, { waitUntil: 'load', timeout: 30_000 });
@@ -164,6 +172,9 @@ async function main() {
                 timeout: argv.timeout,
                 polling: 1_000,
             });
+
+            // Close the contention window once the measured work is done.
+            contention = diffContention(cpuBefore, readCpuSample(), Date.now() - exampleStart);
 
             // Extract results
             const benchmarkError = await page.evaluate(() => (window as any).__benchmarkError);
@@ -182,6 +193,7 @@ async function main() {
                 };
             }
         } catch (error: unknown) {
+            contention ??= diffContention(cpuBefore, readCpuSample(), Date.now() - exampleStart);
             const isTimeout =
                 error instanceof Error && (error.message.includes('Timeout') || error.name === 'TimeoutError');
             result = {
@@ -190,6 +202,8 @@ async function main() {
                 durationMs: Date.now() - exampleStart,
             };
         }
+
+        result.contention = contention;
 
         if (pageErrors.length > 0) {
             result.error = [result.error, ...pageErrors.map((e) => `[page error] ${e}`)].filter(Boolean).join('\n');

--- a/tools/benchmark/contention.test.ts
+++ b/tools/benchmark/contention.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { diffContention, parseProcStat, parsePsiTotals, readHostInfo } from './contention';
+
+test('parseProcStat extracts steal (8th field) and total', () => {
+    const stat = ['cpu  100 20 30 1000 5 0 10 40 0 0', 'cpu0 50 10 15 500 2 0 5 20 0 0', 'intr 12345'].join('\n');
+    const parsed = parseProcStat(stat);
+    assert.ok(parsed);
+    assert.equal(parsed.stealJiffies, 40);
+    assert.equal(parsed.totalJiffies, 100 + 20 + 30 + 1000 + 5 + 0 + 10 + 40); // guest/guest_nice = 0
+});
+
+test('parseProcStat returns null without an aggregate cpu line', () => {
+    assert.equal(parseProcStat('intr 1 2 3\nctxt 99'), null);
+});
+
+test('parsePsiTotals reads the cumulative some/full totals', () => {
+    const psi = ['some avg10=0.10 avg60=0.05 avg300=0.01 total=123456', 'full avg10=0.00 total=7890'].join('\n');
+    assert.deepEqual(parsePsiTotals(psi), { someUs: 123456, fullUs: 7890 });
+});
+
+test('parsePsiTotals defaults to zero when PSI lines are absent', () => {
+    assert.deepEqual(parsePsiTotals(''), { someUs: 0, fullUs: 0 });
+});
+
+test('diffContention computes a steal percentage over the window', () => {
+    const before = { stealJiffies: 40, totalJiffies: 1000, psiSomeUs: 100, psiFullUs: 10 };
+    const after = { stealJiffies: 70, totalJiffies: 1300, psiSomeUs: 500, psiFullUs: 60 };
+    const c = diffContention(before, after, 250);
+    assert.ok(c);
+    assert.equal(c.stealPct, (30 / 300) * 100); // 10%
+    assert.equal(c.psiSomeUs, 400);
+    assert.equal(c.psiFullUs, 50);
+    assert.equal(c.windowMs, 250);
+});
+
+test('diffContention returns null for a non-Linux side or a zero-width window', () => {
+    assert.equal(diffContention(null, null, 100), null);
+    const s = { stealJiffies: 1, totalJiffies: 1000, psiSomeUs: 0, psiFullUs: 0 };
+    assert.equal(diffContention(s, s, 100), null); // totalDelta === 0
+});
+
+test('readHostInfo returns null on hosts without /proc/cpuinfo (e.g. macOS)', () => {
+    // Pure smoke test: on Linux CI it returns an object; on macOS dev it returns null. Either is valid.
+    const host = readHostInfo();
+    assert.ok(host === null || typeof host === 'object');
+});

--- a/tools/benchmark/contention.ts
+++ b/tools/benchmark/contention.ts
@@ -1,0 +1,127 @@
+/**
+ * Whole-VM CPU-contention and host instrumentation for the browser benchmark runner.
+ *
+ * GitHub-hosted runners are shared Azure VMs: head and base run sequentially on the same VM,
+ * and CPU steal / frequency / noisy-neighbour drift between the two passes produces a systematic
+ * per-VM bias that single-run-per-side comparison cannot distinguish from a real regression.
+ * These helpers expose the contention so the comparison can normalise it out and flag what remains.
+ *
+ * All readers are Linux-only (the signals live under /proc); they return null elsewhere so local
+ * macOS/dev runs degrade gracefully. The parsers are pure and unit-tested.
+ */
+import fs from 'node:fs';
+
+const PROC_STAT = '/proc/stat';
+const PROC_PRESSURE_CPU = '/proc/pressure/cpu';
+const PROC_CPUINFO = '/proc/cpuinfo';
+const PROC_MEMINFO = '/proc/meminfo';
+
+export interface CpuSample {
+    /** Steal jiffies on the aggregate `cpu` line (vCPU runnable but the host scheduled another tenant). */
+    stealJiffies: number;
+    /** Sum of all jiffies on the aggregate `cpu` line. */
+    totalJiffies: number;
+    /** PSI cumulative "some" stall total in microseconds (0 when PSI is unavailable). */
+    psiSomeUs: number;
+    /** PSI cumulative "full" stall total in microseconds (0 when PSI is unavailable). */
+    psiFullUs: number;
+}
+
+export interface Contention {
+    /** Percentage of the window the vCPU was runnable-but-not-scheduled (hypervisor steal). */
+    stealPct: number;
+    /** Microseconds at least one task was stalled waiting for CPU during the window (PSI "some"). */
+    psiSomeUs: number;
+    /** Microseconds every runnable task was stalled during the window (PSI "full"). */
+    psiFullUs: number;
+    /** Wall-clock duration of the sampled window in milliseconds. */
+    windowMs: number;
+}
+
+export interface HostInfo {
+    cpuModel: string | null;
+    nproc: number | null;
+    bogomips: number | null;
+    totalMemMb: number | null;
+}
+
+/** Steal jiffies (8th value) and total jiffies (sum) from a /proc/stat body; null if unparseable. */
+export function parseProcStat(text: string): { stealJiffies: number; totalJiffies: number } | null {
+    const line = text.split('\n').find((l) => l.startsWith('cpu '));
+    if (!line) return null;
+    // Fields after `cpu`: user nice system idle iowait irq softirq steal guest guest_nice
+    const fields = line.trim().split(/\s+/).slice(1).map(Number);
+    if (fields.length < 8 || fields.some((n) => !Number.isFinite(n))) return null;
+    return { stealJiffies: fields[7], totalJiffies: fields.reduce((sum, n) => sum + n, 0) };
+}
+
+/** Cumulative PSI "some"/"full" stall totals (microseconds) from a /proc/pressure/cpu body. */
+export function parsePsiTotals(text: string): { someUs: number; fullUs: number } {
+    const total = (prefix: string) => {
+        const line = text.split('\n').find((l) => l.startsWith(prefix));
+        const match = line && /total=(\d+)/.exec(line);
+        return match ? Number(match[1]) : 0;
+    };
+    return { someUs: total('some'), fullUs: total('full') };
+}
+
+function readFileSafe(filePath: string): string | null {
+    try {
+        return fs.readFileSync(filePath, 'utf8');
+    } catch {
+        return null;
+    }
+}
+
+/** Snapshot the cumulative steal/PSI counters; null on non-Linux hosts where /proc/stat is absent. */
+export function readCpuSample(): CpuSample | null {
+    const stat = readFileSafe(PROC_STAT);
+    if (stat == null) return null;
+    const cpu = parseProcStat(stat);
+    if (!cpu) return null;
+    const psiText = readFileSafe(PROC_PRESSURE_CPU);
+    const psi = psiText ? parsePsiTotals(psiText) : { someUs: 0, fullUs: 0 };
+    return {
+        stealJiffies: cpu.stealJiffies,
+        totalJiffies: cpu.totalJiffies,
+        psiSomeUs: psi.someUs,
+        psiFullUs: psi.fullUs,
+    };
+}
+
+/**
+ * Contention experienced between two samples. The steal fraction is jiffy-based (CLK_TCK
+ * cancels in the ratio), so no tick-rate lookup is needed. Returns null when either sample is
+ * absent (non-Linux) or the counters did not advance (zero-width window).
+ */
+export function diffContention(before: CpuSample | null, after: CpuSample | null, windowMs: number): Contention | null {
+    if (!before || !after) return null;
+    const totalDelta = after.totalJiffies - before.totalJiffies;
+    if (totalDelta <= 0) return null;
+    const stealDelta = Math.max(0, after.stealJiffies - before.stealJiffies);
+    return {
+        stealPct: (stealDelta / totalDelta) * 100,
+        psiSomeUs: Math.max(0, after.psiSomeUs - before.psiSomeUs),
+        psiFullUs: Math.max(0, after.psiFullUs - before.psiFullUs),
+        windowMs,
+    };
+}
+
+/** Identify the runner hardware so cross-run/cross-shard heterogeneity is visible; null on non-Linux. */
+export function readHostInfo(): HostInfo | null {
+    const cpuinfo = readFileSafe(PROC_CPUINFO);
+    if (cpuinfo == null) return null;
+    const firstMatch = (re: RegExp) => {
+        const line = cpuinfo.split('\n').find((l) => re.test(l));
+        return line ? (line.split(':')[1]?.trim() ?? null) : null;
+    };
+    const meminfo = readFileSafe(PROC_MEMINFO);
+    const memKbMatch = meminfo && /MemTotal:\s+(\d+)\s*kB/.exec(meminfo);
+    const bogomips = firstMatch(/^bogomips/i);
+    return {
+        cpuModel: firstMatch(/^model name/i),
+        nproc: cpuinfo.split('\n').filter((l) => /^processor\s*:/.test(l)).length || null,
+        bogomips: bogomips ? Number(bogomips) : null,
+        totalMemMb: memKbMatch ? Math.round(Number(memKbMatch[1]) / 1024) : null,
+    };
+}

--- a/tools/benchmark/merge-browser-results.js
+++ b/tools/benchmark/merge-browser-results.js
@@ -33,6 +33,9 @@ const reports = inputPaths.map((p) => JSON.parse(fs.readFileSync(p, 'utf8')));
 const merged = {
     timestamp: reports[0].timestamp,
     environment: reports[0].environment,
+    // Each shard ran on a different VM; keep every shard's host identity so cross-shard
+    // hardware heterogeneity is visible (a major source of variance independent of steal).
+    shardEnvironments: reports.map((r) => r.environment).filter(Boolean),
     summary: { total: 0, success: 0, error: 0, timeout: 0, totalDurationMs: 0 },
     examples: {},
 };


### PR DESCRIPTION
## Why

A `/benchmarks` run on PR #7217 (CRT-1143) reported a `+39.4%` "notable regression" on `axes-1M-time / Zoom`. It wasn't real: CRT-1143 only touches the `chart.update()` options path (the zoom benchmark drives zoom via synthetic wheel events, never `update()`), and the *same example's* Initial-Load/Chart-Create — a path the change can't run — moved `+30%` in lockstep. The "regressions" clustered **by CI shard/VM, not by code path** (per-shard median offset −0.5% … +7.0%).

Root cause: GitHub-hosted runners are shared Azure VMs. Head runs first, base second on the same VM; CPU drift between the two passes is a systematic per-VM bias. CI ran a **single run per side** (`runCount:1`, `crossRunCv:null`), so only the weak intra-run sample CV gated — which is how `+39.4%` passed as "denoised".

## What changed

- **`benchmark.yml`** — run each shard **`AG_BENCHMARK_RUNS` (=3)** times per side, interleaved (head,base,head,base,…); the report job merges per-run and passes every run to the comparison so the **cross-run-CV gate already in `compare-browser-results.js` engages**. Job timeout 45→90 min. A run is excluded from the gate if it is incomplete (missing shard) or degraded (any errored/timed-out example under soft-fail); ≥2 clean runs are required for a variance estimate.
- **`browser-benchmark.ts` + `contention.ts`** — whole-VM **CPU steal + PSI** sampling per example and runner **host identity**, as *logged diagnostics* (preserved per shard via `merge-browser-results.js` → `shardEnvironments`). Linux-only; `null` on macOS/dev. `contention.ts` parsers are unit-tested.
- No change to the comparison's gating maths — the existing cross-run-CV logic is the denoiser; this PR just feeds it enough runs.

## Experiment (the testing you can reproduce)

3× `workflow_dispatch` of this workflow, head vs `latest` (true delta ≈ 0, so all movement is noise):

| Gate | Run 1 | Run 2 | Run 3 | 3-run aggregated |
|---|---|---|---|---|
| False "notable" regressions | 3 | 2 | 1 | **0** |

`axes-1M-time / Zoom` (the false +39.4% on #7217) shows raw +9.1% but **cross-run CV 23.6% → demoted**. ~**52/116** tests exceed a 10% run-to-run noise floor — invisible to single-run gating.

**Rejected on the data (had been prototyped):**
- **CPU steal gating** — `0.0%` on every Azure EPYC shard; no signal.
- **PSI gating** — real (multi-second stalls) but non-discriminating: the biggest %-movers are micro-benchmarks with *low* PSI; high-PSI heavy examples are %-stable.
- **Calibration auto-normalisation** — *widened* dispersion every run (median |Δ| ~2% → ~3.8%) and added false positives; a short instantaneous probe is too noisy a divisor.

Steal/PSI/host are kept as logged diagnostics only — host identity already proved its worth (3 different EPYC models within one run).

## Test plan

- `npx tsx --test tools/benchmark/contention.test.ts` — pass.
- Reverted comparison over the 3 control runs → **0** notable (cross-run-CV gate alone).
- **Validation run of this multi-run workflow** ([run 28010735948](https://github.com/ag-grid/ag-charts/actions/runs/28010735948)) — **green end-to-end**: 5 shards × 3 runs × 2 sides fanned out, per-run merge produced `head.r1..3`/`base.r1..3`, compare emitted `runCount: 3` and **`notable: []`**. The clearest proof the gate works: `multi-series / Datum Highlight / 15x` moved +11.3% / +19ms (not flagged "noisy") but was correctly demoted because its cross-run CV is 8.27% (noise band 2×8.27% = 16.5% > 11.3%) — under the old single-run YAML (`crossRunCv: null`) that gate is inert and this would have surfaced as a false notable.

**Targets `b14.0.0`** so the multi-run gating is active for the current release cycle's `/benchmarks` runs. Cherry-pick of the `latest` PR #7228 — identical commit (`git range-diff` clean), validated by the same run linked above.

