### PR TITLE
CRT-1132 Ship a .htaccess with archive builds

### DIFF
--- a/packages/ag-charts-website/.env.build.archive
+++ b/packages/ag-charts-website/.env.build.archive
@@ -1,5 +1,12 @@
 # arguments supplied via command line via TC
 # eg PUBLIC_SITE_URL=https://www.ag-grid.com PUBLIC_BASE_URL=/charts/archive/%RELEASE_VERSION% nx build ag-charts-website -c archive
+# Archived versions are deployed to /charts/archive/<version>/ on the production
+# host (www.ag-grid.com) as the QA step before the live /charts switch. Generating
+# the production .htaccess here ships each archive with its own CSP, so QA exercises
+# the real policy without first touching the top-level /charts/.htaccess. The
+# top-level file (which governs the live, non-archive pages) is still refreshed at
+# the production-switch step.
+HTACCESS=production
 PUBLIC_GALLERY_IMAGE_DPR_ENHANCEMENT=true
 PUBLIC_ALGOLIA_APP_ID=O1K1ESGB5K
 PUBLIC_ALGOLIA_SEARCH_KEY=01142fe24ea5d2e36f4eb66b0b2ff872


### PR DESCRIPTION
## Problem

Archived doc versions are deployed to `/charts/archive/<version>/` on the **production host** (`www.ag-grid.com`) as the QA step *before* the live `/charts` switch. But an archive's CSP came **only** from the top-level `/charts/.htaccess` (via its `<If> "%{REQUEST_URI} =~ m#/(examples|archive)/#">` rule), and that file is only refreshed at the production-switch step.

So a freshly-deployed archive is served the **old** production CSP, and QA cannot exercise the new policy before it goes live.

## Fix

Set `HTACCESS=production` in `.env.build.archive` so each archive build emits its own `.htaccess` at `/charts/archive/<version>/`.

- Apache applies `.htaccess` parent→child, and the generated block does `Header always unset` + `set`, so the archive's own policy **wins for that subtree** (which matches the `/(examples|archive)/` `<If>` condition) while the live `/charts` pages keep the existing policy until the production switch — matching the QA-before-prod gate.
- The CSP content is base-URL-independent; the only base-aware line (`ErrorDocument 404`, via `urlWithBaseUrl`) resolves correctly under the archive base.

## Notes

- The top-level `/charts/.htaccess` is **still** refreshed at the production-switch step — it governs the live, non-archive pages.
- Ports [ag-studio#1835](https://github.com/ag-grid/ag-studio/pull/1835) (SR-281) to charts. The charts archive env file has no `PUBLIC_SITE_URL` line (passed via CLI), so the setting sits after the header comments rather than after that line.