### PR TITLE
CRT-1137 Remove inaccurate tooltip test instruction from org-chart-test

### DIFF
--- a/packages/ag-charts-website/src/content/docs/org-chart-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/org-chart-test/index.mdoc
@@ -8,7 +8,6 @@ enterprise: true
 What to test:
 
 - The organisation series lays out a large default dataset without overlapping nodes or clipped labels.
-- Hover nodes; tooltips appear at the correct positions.
 
 {% chartExampleRunner title="Org Chart Many Nodes" name="org-chart-many-nodes" type="generated" /%}
 


### PR DESCRIPTION
## Summary

Follow-up (pt2) to [CRT-1137](https://ag-grid.atlassian.net/browse/CRT-1137). The ticket's repro listed **two** `-test` harness pages; PR #7222 fixed only the first (`axes-types-test`), which is why verification recorded step 1 Pass / step 2 TODO. This closes the gap by removing the second inaccurate instruction.

Removes from `org-chart-test/index.mdoc`:

> - Hover nodes; tooltips appear at the correct positions.

## Why

The bullet is a QA instruction on an internal `*-test` page that doesn't reflect what the example demonstrates. Mirrors the pt1 resolution (`d60bbe61e0`) — delete the inaccurate instruction rather than reword.

## Scope

- Docs-only, single-line deletion on an internal test-harness page.
- No example, nav, or library changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)