### PR TITLE
CRT-1120 Refine union-types API reference display

### DIFF
--- a/external/ag-website-shared/src/components/link-icon/LinkIcon.module.scss
+++ b/external/ag-website-shared/src/components/link-icon/LinkIcon.module.scss
@@ -9,6 +9,7 @@
 }
 
 .docsHeaderIcon {
+    flex: 0 0 28px;
     width: 28px;
     height: 28px;
     padding: 0;

--- a/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
+++ b/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
@@ -145,6 +145,9 @@
 
     &.expandedUnionTypes > .expandedContent {
         margin-left: $spacing-size-6;
+        // Account for the left margin so the code block stays within the row's bounds.
+        flex-basis: calc(100% - #{$spacing-size-6});
+        min-width: calc(100% - #{$spacing-size-6});
     }
 
     &.expandedChildProps::after,

--- a/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
+++ b/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
@@ -287,6 +287,10 @@
     }
 }
 
+.metaValue.isClickable {
+    cursor: pointer;
+}
+
 .defaultValue {
     font-size: var(--text-fs-sm);
     padding: 2px 8px;
@@ -340,6 +344,7 @@ a.metaValue {
 
 .childButton {
     font-weight: var(--text-semibold);
+    cursor: pointer;
 
     svg {
         transition: transform 0.33s ease-in-out;
@@ -362,6 +367,7 @@ a.metaValue {
 
 .unionTypesButton {
     font-weight: var(--text-semibold);
+    cursor: pointer;
 
     svg {
         transition: transform 0.33s ease-in-out;
@@ -378,6 +384,7 @@ a.metaValue {
 
 button.seeMore {
     color: var(--color-link);
+    cursor: pointer;
     justify-content: center;
     align-items: center;
     display: flex;

--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -93,8 +93,8 @@ test.describe('api-ref-page', () => {
         await gotoUrl(page, toPageUrl('options/series/bar/#reference-AgBarSeriesOptions-fill'));
         await expect(getNavigationProperty(page, /^fill/)).toBeVisible();
 
-        // TC1: the "See available types" action expands the union into discrete variant rows.
-        await page.getByRole('button', { name: 'See available types of fill', exact: true }).click();
+        // TC1: the "See available interfaces" action expands the union into discrete variant rows.
+        await page.getByRole('button', { name: 'See available interfaces of fill', exact: true }).click();
 
         // TC2: each named interface member of the union renders as its own variant row.
         const gradientVariant = page.locator('#reference-AgBarSeriesOptions-fill-gradient');
@@ -272,7 +272,7 @@ test.describe('api-ref-page', () => {
         await gotoUrl(page, toPageUrl('options/'));
         await waitForApiReady(page);
 
-        await page.getByRole('button', { name: 'See available types of padding', exact: true }).click();
+        await page.getByRole('button', { name: 'See available interfaces of padding', exact: true }).click();
         const paddingOptions = page.locator('#reference-AgChartOptions-padding-PaddingOptions');
         await expect(paddingOptions).toBeVisible();
 
@@ -281,7 +281,7 @@ test.describe('api-ref-page', () => {
     });
 
     // A mixed union keeps its non-interface members (here the primitive `PixelSize`) in a signature
-    // code block reached through "See more details", distinct from the "See available types" variant
+    // code block reached through "See more details", distinct from the "See available interfaces" variant
     // rows. This guards the regression where expanding the union dropped the primitive members.
     test('preserves the primitive members of a mixed union in its signature block', async ({ page }) => {
         await gotoUrl(page, toPageUrl('options/'));
@@ -291,6 +291,20 @@ test.describe('api-ref-page', () => {
         const details = page.locator('#reference-AgChartOptions-padding-details');
         await expect(details).toBeVisible();
         await expect(details.locator('pre')).not.toHaveCount(0);
+    });
+
+    // `theme` has its own dedicated page (themes-api), so it renders as a plain, non-expandable row:
+    // no "See available interfaces" action and no expander chevron on its name.
+    test('renders theme as a plain non-expandable row', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/'));
+        await waitForApiReady(page);
+
+        const themeRow = page.locator('#reference-AgChartOptions-theme');
+        await expect(themeRow).toBeVisible();
+        await expect(page.getByRole('button', { name: 'See available interfaces of theme', exact: true })).toHaveCount(
+            0
+        );
+        await expect(themeRow.locator('[class*="propNameExpander"]')).toHaveCount(0);
     });
 
     // The nav's primitive-union entry deep-links to the signature block via the `-details` hash; the

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
@@ -7,6 +7,9 @@ import {
     getAliasedUnionVariants,
 } from './apiReferenceHelpers';
 
+const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
+const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
+
 // Regression for the themes-api page failing to load with "RangeError: Maximum call stack size
 // exceeded". The crash was not infinite recursion — `extractSearchData` builds a finite but very
 // large index (the AgChartTheme tree reaches ~150k entries), and the previous implementation
@@ -35,8 +38,6 @@ function makeLargeReference(breadth: number) {
 }
 
 describe('formatUnionSignature', () => {
-    const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
-    const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
     const iface = (name: string) => ({ kind: 'interface' as const, name, members: [] });
 
     // Mirrors `TextOrSegments = TextValue | ContentSegment[]` where ContentSegment is a nested union
@@ -86,8 +87,6 @@ describe('formatUnionSignature', () => {
 });
 
 describe('formatTypeToCode', () => {
-    const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
-    const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
     const iface = (name: string, memberName: string) => ({
         kind: 'interface' as const,
         name,
@@ -138,8 +137,6 @@ describe('formatTypeToCode', () => {
 });
 
 describe('getAliasedUnionVariants', () => {
-    const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
-    const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
     const variant = (name: string, typeValue: string) => ({
         kind: 'interface' as const,
         name,

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractSearchData, formatUnionSignature, getAliasedUnionVariants } from './apiReferenceHelpers';
+import {
+    extractSearchData,
+    formatTypeToCode,
+    formatUnionSignature,
+    getAliasedUnionVariants,
+} from './apiReferenceHelpers';
 
 // Regression for the themes-api page failing to load with "RangeError: Maximum call stack size
 // exceeded". The crash was not infinite recursion — `extractSearchData` builds a finite but very
@@ -77,6 +82,58 @@ describe('formatUnionSignature', () => {
     it('returns undefined for a pure interface-only union', () => {
         const node = reference.get('PureUnion');
         expect(formatUnionSignature(node.type, 'PureUnion', reference as any)).toBeUndefined();
+    });
+});
+
+describe('formatTypeToCode', () => {
+    const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
+    const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
+    const iface = (name: string, memberName: string) => ({
+        kind: 'interface' as const,
+        name,
+        members: [{ kind: 'member', name: memberName, type: 'string', optional: false }],
+    });
+
+    // Mirrors `AgChartSeriesOptions = AgAreaSeriesOptions | AgBarSeriesOptions`, where each variant is
+    // an interface with its own navigable page.
+    const reference = new Map<string, any>(
+        Object.entries({
+            AgChartSeriesOptions: alias('AgChartSeriesOptions', union('AgAreaSeriesOptions', 'AgBarSeriesOptions')),
+            AgAreaSeriesOptions: iface('AgAreaSeriesOptions', 'fillOpacity'),
+            AgBarSeriesOptions: iface('AgBarSeriesOptions', 'cornerRadius'),
+        })
+    );
+    const member = { kind: 'member', name: 'series', type: 'AgChartSeriesOptions', optional: false } as any;
+
+    it('renders only the union alias when references are not expanded', () => {
+        const code = formatTypeToCode(
+            reference.get('AgChartSeriesOptions'),
+            member,
+            reference as any,
+            new Set(),
+            'series',
+            false
+        );
+
+        expect(code).toContain('type AgChartSeriesOptions =');
+        expect(code).toContain('AgAreaSeriesOptions');
+        expect(code).toContain('AgBarSeriesOptions');
+        expect(code).not.toContain('interface AgAreaSeriesOptions');
+        expect(code).not.toContain('interface AgBarSeriesOptions');
+    });
+
+    it('inlines the variant interfaces by default', () => {
+        const code = formatTypeToCode(
+            reference.get('AgChartSeriesOptions'),
+            member,
+            reference as any,
+            new Set(),
+            'series'
+        );
+
+        expect(code).toContain('type AgChartSeriesOptions =');
+        expect(code).toContain('interface AgAreaSeriesOptions');
+        expect(code).toContain('interface AgBarSeriesOptions');
     });
 });
 

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -63,6 +63,7 @@ const hiddenInterfaces = new Set([
     'DurationMs',
     'AgTimeInterval',
     'DatumKey',
+    'AgThemeColorParam',
 ]);
 
 const isTypeNodeObject = (type: TypeNode): type is Exclude<TypeNode, string> => typeof type === 'object';

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -184,7 +184,8 @@ export function formatTypeToCode(
     member: MemberNode,
     reference: ApiReferenceType,
     seen: Set<string>,
-    nodeName?: string
+    nodeName?: string,
+    expandReferences = true
 ): string {
     if (apiNode.kind === 'interface' || apiNode.kind === 'typeAlias') {
         seen.add(apiNode.name);
@@ -195,7 +196,7 @@ export function formatTypeToCode(
     }
 
     if (apiNode.kind === 'typeAlias') {
-        return formatTypeAliasCode(apiNode, member, reference, seen, nodeName);
+        return formatTypeAliasCode(apiNode, member, reference, seen, nodeName, expandReferences);
     }
 
     if (apiNode.kind === 'member') {
@@ -449,14 +450,15 @@ function formatTypeAliasCode(
     member: MemberNode,
     reference: ApiReferenceType,
     seen: Set<string>,
-    nodeName?: string
+    nodeName?: string,
+    expandReferences = true
 ) {
     if (isFunctionNode(apiNode.type)) {
         return formatFunctionCode(nodeName ?? apiNode.name, apiNode.type, member, reference);
     }
 
     if (isUnionNode(apiNode.type)) {
-        return formatUnionTypeAlias(apiNode, apiNode.type, member, reference, seen);
+        return formatUnionTypeAlias(apiNode, apiNode.type, member, reference, seen, expandReferences);
     }
 
     return `type ${apiNode.name} = ${normalizeType(apiNode.type)};`;
@@ -467,7 +469,8 @@ function formatUnionTypeAlias(
     unionType: MultiTypeNode & { kind: 'union' },
     member: MemberNode,
     reference: ApiReferenceType,
-    seen: Set<string>
+    seen: Set<string>,
+    expandReferences = true
 ) {
     let nodeType = normalizeType({
         kind: 'union',
@@ -478,6 +481,13 @@ function formatUnionTypeAlias(
     nodeType = '\n    ' + addNewLineOnPipe(nodeType);
 
     const result = [`type ${apiNode.name} = ${nodeType};`];
+
+    // Special-type code blocks (series, axes, annotations) show the alias only; each variant has
+    // its own navigable page, so inlining the sub-interfaces here is redundant noise.
+    if (!expandReferences) {
+        return result[0];
+    }
+
     const additionalTypes = new Set(unionType.type.map((type) => normalizeType(type)));
 
     for (const type of additionalTypes) {

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
@@ -85,6 +85,7 @@ export interface ApiReferenceConfig {
     hideRequired?: boolean;
     specialTypes?: SpecialTypesMap;
     keepExpanded?: string[];
+    noExpand?: string[];
 }
 
 interface ApiReferenceOptions {
@@ -113,11 +114,14 @@ export function ApiReferenceWithContext({
     exclude,
     hideHeader,
     hideRequired,
+    noExpand,
     ...props
 }: ApiReferenceOptions & ApiReferenceConfig) {
     return (
         <QueryClientProvider client={queryClient}>
-            <ApiReferenceConfigContext.Provider value={{ prioritise, include, exclude, hideHeader, hideRequired }}>
+            <ApiReferenceConfigContext.Provider
+                value={{ prioritise, include, exclude, hideHeader, hideRequired, noExpand }}
+            >
                 <ApiReferenceWithReferenceContext {...props} />
             </ApiReferenceConfigContext.Provider>
         </QueryClientProvider>
@@ -164,10 +168,10 @@ function UnionTypesButton({ name, isExpanded, onClick }: { name: string; isExpan
                 [styles.isExpanded]: isExpanded,
             })}
             onClick={onClick}
-            aria-label={`See available types of ${name}`}
+            aria-label={`See available interfaces of ${name}`}
         >
             <Icon svgClasses={styles.childChevron} name="chevronRight" />
-            <span>{isExpanded ? 'Hide' : 'See'} available types</span>
+            <span>{isExpanded ? 'Hide' : 'See'} available interfaces</span>
         </button>
     );
 }
@@ -404,6 +408,7 @@ function ApiReferenceRow({
     const hasChildProps = collapsibleType === 'childrenProperties';
     const isUnionTypes = collapsibleType === 'unionTypes';
     const signature = isUnionTypesDetails(additionalDetails) ? additionalDetails.signature : undefined;
+    const isSpecialType = Boolean(config.specialTypes?.[getMemberType(member)]);
 
     return (
         <div
@@ -490,7 +495,11 @@ function ApiReferenceRow({
 
             {collapsibleType === 'code' && isExpanded && (
                 <div id={getDetailsId(anchorId)} className={classnames(styles.expandedContent)}>
-                    <TypeCodeBlock apiNode={additionalDetails as NodeTypes | NodeTypes[]} member={member} />
+                    <TypeCodeBlock
+                        apiNode={additionalDetails as NodeTypes | NodeTypes[]}
+                        member={member}
+                        expandReferences={!isSpecialType}
+                    />
                 </div>
             )}
 
@@ -503,7 +512,15 @@ function ApiReferenceRow({
     );
 }
 
-export function TypeCodeBlock({ apiNode, member }: { apiNode: NodeTypes | NodeTypes[]; member: MemberNode }) {
+export function TypeCodeBlock({
+    apiNode,
+    member,
+    expandReferences = true,
+}: {
+    apiNode: NodeTypes | NodeTypes[];
+    member: MemberNode;
+    expandReferences?: boolean;
+}) {
     const reference = useContext(ApiReferenceContext);
 
     if (!reference) {
@@ -512,8 +529,10 @@ export function TypeCodeBlock({ apiNode, member }: { apiNode: NodeTypes | NodeTy
 
     const seen = new Set<string>();
     const codeSample = Array.isArray(apiNode)
-        ? apiNode.map((arrayApiNode) => formatTypeToCode(arrayApiNode, member, reference, seen, member.name))
-        : formatTypeToCode(apiNode, member, reference, seen, member.name);
+        ? apiNode.map((arrayApiNode) =>
+              formatTypeToCode(arrayApiNode, member, reference, seen, member.name, expandReferences)
+          )
+        : formatTypeToCode(apiNode, member, reference, seen, member.name, expandReferences);
 
     if (!codeSample?.length) {
         // eslint-disable-next-line no-console
@@ -545,6 +564,11 @@ function useMemberAdditionalDetails(member: MemberNode): MemberAdditionalDetails
     const reference = useContext(ApiReferenceContext);
     const config = useContext(ApiReferenceConfigContext);
     const memberType = getMemberType(member);
+
+    // A member with its own dedicated page (e.g. `theme`) renders as a plain, non-expandable row.
+    if (config.noExpand?.includes(cleanupName(member.name))) {
+        return undefined;
+    }
 
     if (memberType === 'function') {
         return member;

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
@@ -21,6 +21,7 @@ import {
     isValidElement,
     useContext,
     useEffect,
+    useMemo,
 } from 'react';
 import Markdown from 'react-markdown';
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
@@ -277,6 +278,13 @@ export function ApiReference({
     const interfaceRef = reference?.get(id);
     const location = useLocation();
 
+    // include / exclude / prioritise scope the top-level interface only; nested interfaces
+    // and union variants must render their full member set.
+    const nestedConfig = useMemo(
+        () => ({ ...config, include: undefined, exclude: undefined, prioritise: undefined }),
+        [config]
+    );
+
     useEffect(() => {
         const hash = location?.hash.substring(1);
         if (typeof anchorId === 'string' && hash === anchorId) {
@@ -304,14 +312,16 @@ export function ApiReference({
                 ))}
 
             <div className={classnames(styles.reference, styles.apiReference, 'no-zebra')}>
-                {processMembers(interfaceRef, config).map((member) => (
-                    <NodeFactory
-                        key={member.name}
-                        member={member}
-                        anchorId={`reference-${id}-${member.name}`}
-                        genericsMap={interfaceRef.genericsMap}
-                    />
-                ))}
+                <ApiReferenceConfigContext.Provider value={nestedConfig}>
+                    {processMembers(interfaceRef, config).map((member) => (
+                        <NodeFactory
+                            key={member.name}
+                            member={member}
+                            anchorId={`reference-${id}-${member.name}`}
+                            genericsMap={interfaceRef.genericsMap}
+                        />
+                    ))}
+                </ApiReferenceConfigContext.Provider>
             </div>
         </div>
     );

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferencePage.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferencePage.tsx
@@ -29,6 +29,7 @@ interface ApiReferencePageOptions {
     basePath: string;
     specialTypes?: SpecialTypesMap;
     keepExpanded?: string[];
+    noExpand?: string[];
 }
 
 export function ApiReferencePage(props: ApiReferencePageOptions) {
@@ -47,6 +48,7 @@ function ApiReferencePageInner({
     basePath,
     specialTypes,
     keepExpanded,
+    noExpand,
 }: ApiReferencePageOptions) {
     const { data: reference } = useQuery(['resolved-interfaces'], fetchInterfacesReference, queryOptions);
     const location = useLocation();
@@ -80,7 +82,7 @@ function ApiReferencePageInner({
 
     return (
         <ApiReferenceContext.Provider value={reference}>
-            <ApiReferenceConfigContext.Provider value={{ hideHeader: true, specialTypes, keepExpanded }}>
+            <ApiReferenceConfigContext.Provider value={{ hideHeader: true, specialTypes, keepExpanded, noExpand }}>
                 <SelectionContext.Provider value={{ selection, setSelection, rootInterface, basePath }}>
                     <div className={classNames(styles.container, 'layout-grid')}>
                         <div className={styles.objectViewOuter}>

--- a/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
@@ -192,7 +192,8 @@ function NavProperty({
             ? getAliasedUnionVariants(interfaceRef, reference)
             : undefined;
     const isTypedUnion = Boolean(unionVariants);
-    const expandable = isInterface || isInterfaceArray || isInterfaceRecord || isTypedUnion;
+    const noExpand = config.noExpand?.includes(cleanupName(member.name));
+    const expandable = !noExpand && (isInterface || isInterfaceArray || isInterfaceRecord || isTypedUnion);
     const isObjectArray =
         !isInterfaceArray &&
         !isInterfaceRecord &&

--- a/packages/ag-charts-website/src/components/api-documentation/components/Properties.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/Properties.tsx
@@ -135,11 +135,14 @@ export function PropertyType({
     const isExpandable = isCollapsibleCode || collapsibleType === 'unionTypes';
     // The square chevron toggles the inline code block — the type alias' own definition for a `code`
     // member, or the union signature for a mixed-union member. Union variant rows have their own
-    // ("See available types") affordance.
+    // ("See available interfaces") affordance.
     const showCodeButton = isCollapsibleCode || Boolean(hasSignature);
     const codeButtonExpanded = isCollapsibleCode ? isExpanded : isSignatureExpanded;
     const codeButtonOnClick = isCollapsibleCode ? onCollapseClick : onSignatureToggle;
 
+    // The type text only toggles the inline code block — a `code` member's definition or a
+    // mixed-union signature. Child-property rows, union variant lists and plain `none` rows have no
+    // code block, so they are not clickable and keep the default cursor.
     return (
         <div className={styles.metaItem}>
             <div className={styles.metaRow}>
@@ -157,9 +160,10 @@ export function PropertyType({
                     </a>
                 ) : (
                     <span
-                        onClick={onCollapseClick}
+                        onClick={showCodeButton ? codeButtonOnClick : undefined}
                         className={classnames(styles.metaValue, {
                             [styles.isExpandable]: isExpandable,
+                            [styles.isClickable]: showCodeButton,
                         })}
                     >
                         {type}

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -19,5 +19,6 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
             AgChartSeriesOptions: 'InterfaceArray',
             AgMiniChartSeriesOptions: 'InterfaceArray',
         }}
+        noExpand={['theme']}
     />
 </APIViewLayout>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1120

Follow-up refinements from the AG-14806 review (union-types API display, shipped in #7160) plus related polish on the website API reference page.

### What changed
- **`theme` renders as a plain, non-expandable row.** It has its own dedicated themes-api page, so it links there rather than expanding inline. Added a `noExpand` config (`noExpand={['theme']}` on the options page), threaded through the reference components and the options navigation.
- **Renamed the affordance** "See/Hide available types" → "See/Hide available interfaces" across the UI, e2e tests, and comments.
- **Type text (pink) is clickable only when it has a code block** to toggle — a `code` member's definition or a mixed-union signature. Such rows now show a pointer cursor; child-property rows, union variant lists and plain rows keep the default cursor.
- **Special-type union code blocks show the alias only.** `formatTypeToCode` gained an `expandReferences` flag so series/axes/annotations unions no longer inline their sub-interfaces (each variant has its own navigable page).
- **Scoped include/exclude/prioritise to the top-level interface only** — nested interfaces and union variants render their full member set.
- **Hid `AgThemeColorParam`** from the api-ref, and **constrained the expanded code block width** so it stays within the row bounds.
- **Prevented the docs header link icon from shrinking** (`flex: 0 0 28px`).

### Test plan
- `apiReferenceHelpers.test.ts`: added `formatTypeToCode` coverage for both `expandReferences` modes.
- `e2e/api-ref-page.spec.ts`: added a test asserting `theme` renders as a plain non-expandable row; updated affordance-label assertions.
- `yarn nx test ag-charts-website` (388 passed) and `yarn nx lint ag-charts-website` green locally.

### Notes for reviewers
- SCSS changes live in `external/ag-website-shared` (shared with the AG Grid website via git-subrepo). The cursor additions are inert for Grid; please sanity-check the `flex-basis`/`min-width` constraint on `.expandedUnionTypes` against Grid's reference docs.
- `noExpand` matches by member name (like the existing `keepExpanded`), so it is global to any member named `theme`; currently only `AgChartOptions.theme` exists.

Fix #CRT-1120