### PR TITLE
CRT-1143 Skip opaque option keys in removal-sentinel scan

### DIFF
--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -98,6 +98,12 @@ export function createOptionsGraph(
     });
 }
 
+// Opaque user pass-through payloads: stored shallow in the options graph and skipped by the
+// removal-sentinel scan in `optionsModule`. Never descended into, so user-supplied cycles in these
+// values (e.g. `context` set to a grid component or a self-referential object) cannot drive an
+// options walk into a stack overflow.
+export const SHALLOW_OPTION_KEYS = new Set<string>(['context', 'data', 'topology']);
+
 /**
  * The OptionsGraph combines the theme config, params, palette, overrides and user options into a graph which can then
  * be resolved down into an object.
@@ -107,9 +113,6 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
     private static readonly EDGE_PRIORITY = [USER_OPTIONS_EDGE, OVERRIDES_EDGE, DEFAULTS_EDGE];
 
     private static readonly GRAFT_EDGE = DEFAULTS_EDGE;
-
-    // These keys must be stored as shallow objects in the graph and not manipulated.
-    private static readonly SHALLOW_KEYS = new Set(['context', 'data', 'topology']);
 
     // These keys must be excluded when building the graph, they are instead resolved separately since they are objects
     // that must be applied to arrays.
@@ -798,7 +801,7 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
         edgeValue: string,
         object: PlainObject,
         pathArrayVertex?: Vertex<unknown>,
-        shallowPaths: Set<string> = OptionsGraph.SHALLOW_KEYS,
+        shallowPaths: Set<string> = SHALLOW_OPTION_KEYS,
         ignorePaths?: Set<string>
     ) {
         const keys = Object.keys(object);

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -508,6 +508,70 @@ describe('ChartOptions', () => {
         });
     });
 
+    describe('circular opaque payloads (CRT-1143 regression)', () => {
+        // AG Grid's cross-filter integration passes `context: this` - a component instance whose object
+        // graph contains back-references; a `context` can equally be a plain object that references
+        // itself. A full `update()` diffs the options and walks the diff, which must skip these opaque
+        // pass-throughs by name rather than by type, or it follows the cycle into a stack overflow.
+        class CrossFilterContext {
+            readonly self = this;
+            readonly gui: { owner: CrossFilterContext };
+            constructor() {
+                this.gui = { owner: this };
+            }
+        }
+
+        const lineOptions = (): AgChartOptions => ({
+            series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+        });
+
+        it('survives a full update() when the context payload reference changes', () => {
+            const base = new ChartOptions(
+                { ...lineOptions(), context: new CrossFilterContext() } as AgChartOptions,
+                {} as AgChartOptions,
+                {},
+                {},
+                {}
+            );
+
+            const nextContext = new CrossFilterContext();
+            let updated!: ChartOptions;
+            expect(() => {
+                updated = new ChartOptions(
+                    base,
+                    { ...lineOptions(), context: nextContext } as AgChartOptions,
+                    {},
+                    {},
+                    {}
+                );
+            }).not.toThrow();
+            expect(updated.processedOptions.context).toBe(nextContext);
+        });
+
+        it('survives a full update() when a circular context is newly introduced', () => {
+            const base = new ChartOptions(lineOptions(), {} as AgChartOptions, {}, {}, {});
+
+            const context = new CrossFilterContext();
+            let updated!: ChartOptions;
+            expect(() => {
+                updated = new ChartOptions(base, { ...lineOptions(), context } as AgChartOptions, {}, {}, {});
+            }).not.toThrow();
+            expect(updated.processedOptions.context).toBe(context);
+        });
+
+        it('survives a full update() when context is a self-referential plain object', () => {
+            const base = new ChartOptions(lineOptions(), {} as AgChartOptions, {}, {}, {});
+
+            const context: Record<string, unknown> = {};
+            context.context = context;
+            let updated!: ChartOptions;
+            expect(() => {
+                updated = new ChartOptions(base, { ...lineOptions(), context } as AgChartOptions, {}, {}, {});
+            }).not.toThrow();
+            expect(updated.processedOptions.context).toBe(context);
+        });
+    });
+
     describe('#processSeriesOptions', () => {
         test('Simple series options processing works as expected', () => {
             const { series: options } = prepareOptions({ series: seriesOptions });

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -62,7 +62,12 @@ import {
 import { getChartTheme } from '../chart/mapping/themes';
 import { detectChartType } from '../chart/mapping/types';
 import { ChartTheme } from '../chart/themes/chartTheme';
-import { type OptionsGraphAccessor, createOptionsGraph, createOptionsGraphMemoised } from './optionsGraph';
+import {
+    type OptionsGraphAccessor,
+    SHALLOW_OPTION_KEYS,
+    createOptionsGraph,
+    createOptionsGraphMemoised,
+} from './optionsGraph';
 import {
     type StructuralCacheEntry,
     VOLATILE_KEYS,
@@ -195,13 +200,15 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     }
 
     private static containsRemovalSentinel(node: unknown): boolean {
-        // `jsonDiff` only places the removal sentinel directly on a key, so a shallow scan that
-        // recurses into nested objects (skipping the opaque `data` payload) suffices.
-        if (!isObject(node) || isArray(node)) return false;
+        // The removal sentinel is only ever written as a direct value on a plain-object node. Skip the
+        // opaque pass-through payloads by name (`SHALLOW_OPTION_KEYS`) and never descend into non-plain
+        // objects (e.g. a DOM `container`): both can hold user-supplied cycles, and neither can contain
+        // a sentinel - so declining to recurse cannot miss one, it only avoids the stack overflow.
+        if (!isPlainObject(node)) return false;
         for (const key of Object.keys(node)) {
             const value = (node as Record<string, unknown>)[key];
             if (isSymbol(value)) return true;
-            if (key !== 'data' && ChartOptions.containsRemovalSentinel(value)) return true;
+            if (!SHALLOW_OPTION_KEYS.has(key) && ChartOptions.containsRemovalSentinel(value)) return true;
         }
         return false;
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1143

Follow-up to the CRT-1143 full-`update()` replace fix, which introduced a stack overflow.

`ChartOptions.containsRemovalSentinel` walks the option diff to decide whether a subtree was removed. It descended into `context` — an opaque user pass-through that AG Grid's cross-filter integration sets to a component instance (`context: this`), and which can equally be a self-referential plain object — following its internal cycle until the stack overflowed.

Skip the opaque pass-through payloads **by name**, reusing the shallow-key set already defined for the options graph (`SHALLOW_OPTION_KEYS`: `context`, `data`, `topology`), and gate the walk on `isPlainObject` so non-plain pass-throughs such as a DOM `container` are not descended either. The removal sentinel is only ever written onto plain-object nodes, so declining to recurse cannot miss one — it only avoids following the cycle.

## Test plan
- New regression tests in `optionsModule.test.ts`: a full `update()` no longer throws when `context` carries circular references — class instance (reference changed / newly introduced) or a self-referential plain object.
- `nx build:types`, `nx lint`, and `nx test ag-charts-community` (full suite) all green.

## Scope
Fixes the CRT-1143 regression in the removal-sentinel scan. The real AG Grid integration (`context: this`, a class instance) is fully handled on every update path. Fully hardening *every* options walk against a self-referential **plain-object** context (e.g. a changed-reference plain-object cycle in `jsonDiff`, or the font/CSS walks on a slow-path update) is a broader, pre-existing concern those walks predate CRT-1143 and lack cycle guards; tracked separately rather than widened into this release-branch fix.

Fix #CRT-1143