### PR TITLE
CRT-1120 Resolve computed type aliases in api-ref via TS checker

### DIFF
--- a/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
+++ b/external/ag-website-shared/src/components/reference-documentation/ApiReference.module.scss
@@ -182,7 +182,11 @@
         margin-top: $spacing-size-3;
         width: 100%;
 
-        .expandedChildProps & {
+        // When the row stacks, the right column drops onto its own line beneath the side-line that
+        // marks the expansion. Indent it past the line so the description and toggle button clear it,
+        // matching the type meta above. Both expanded variants draw the line, so both need the indent.
+        .expandedChildProps &,
+        .expandedUnionTypes & {
             padding-left: $spacing-size-6;
         }
     }

--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -307,6 +307,64 @@ test.describe('api-ref-page', () => {
         await expect(themeRow.locator('[class*="propNameExpander"]')).toHaveCount(0);
     });
 
+    // A special type (`series` -> AgChartSeriesOptions) has its own navigable per-type pages, so its
+    // "See more details" code block lists the union alias only: the variant `Ag…SeriesOptions` names
+    // appear, but their interface bodies are not inlined (which would be redundant noise here).
+    test('special-type code block lists the union alias without inlining sub-interfaces', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/'));
+        await waitForApiReady(page);
+
+        await page.getByRole('button', { name: 'See more details about series', exact: true }).click();
+
+        const details = page.locator('#reference-AgChartOptions-series-details pre');
+        await expect(details).toContainText('type AgChartSeriesOptions =');
+        await expect(details).toContainText('AgBarSeriesOptions');
+        await expect(details).not.toContainText('interface AgBarSeriesOptions');
+    });
+
+    // The type text toggles the inline code block, but only for members that have one. A `code` member
+    // (`series`) is clickable and toggles its details; a plain primitive (`width`) has no code block,
+    // so its type text is inert and keeps the default cursor.
+    test('type text toggles the code block only for members that have one', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/'));
+        await waitForApiReady(page);
+
+        const seriesType = page.locator('#reference-AgChartOptions-series [class*="metaValue"]').first();
+        await expect(seriesType).toHaveClass(/isClickable/);
+
+        const details = page.locator('#reference-AgChartOptions-series-details');
+        await expect(details).toHaveCount(0);
+        await seriesType.click();
+        await expect(details).toBeVisible();
+        await seriesType.click();
+        await expect(details).toHaveCount(0);
+
+        const widthType = page.locator('#reference-AgChartOptions-width [class*="metaValue"]').first();
+        await expect(widthType).not.toHaveClass(/isClickable/);
+    });
+
+    // Below the table breakpoint the row stacks and the right column drops onto its own line beneath
+    // the vertical side-line that marks an expanded union (drawn at left: 8px). The right column must
+    // be indented past that line so its description and toggle button don't collide with it.
+    test('indents the stacked right column clear of the expansion side-line', async ({ page }) => {
+        await page.setViewportSize({ width: 900, height: 900 });
+        await gotoUrl(page, toPageUrl('options/'));
+        await waitForApiReady(page);
+
+        await page.getByRole('button', { name: 'See available interfaces of padding', exact: true }).click();
+
+        const row = page.locator('#reference-AgChartOptions-padding');
+        await expect(row).toHaveCSS('display', 'block');
+
+        const offsets = await row.locator('[class*="rightColumn"]').evaluate((rightColumn) => {
+            const propertyRow = rightColumn.closest('.property-row')!;
+            const style = getComputedStyle(rightColumn);
+            const contentLeft = rightColumn.getBoundingClientRect().left + parseFloat(style.paddingLeft);
+            return { contentLeft, rowLeft: propertyRow.getBoundingClientRect().left };
+        });
+        expect(offsets.contentLeft - offsets.rowLeft).toBeGreaterThanOrEqual(16);
+    });
+
     // The nav's primitive-union entry deep-links to the signature block via the `-details` hash; the
     // reference panel resolves that hash by auto-expanding the signature rather than the variant list.
     test('deep links to a union signature block via the details hash', async ({ page }) => {

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -63,7 +63,6 @@ const hiddenInterfaces = new Set([
     'DurationMs',
     'AgTimeInterval',
     'DatumKey',
-    'AgThemeColorParam',
 ]);
 
 const isTypeNodeObject = (type: TypeNode): type is Exclude<TypeNode, string> => typeof type === 'object';

--- a/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-mapper.ts
+++ b/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-mapper.ts
@@ -1,23 +1,41 @@
+import { dirname, resolve } from 'path';
 import * as ts from 'typescript';
 
 import { formatNode } from './type-utils';
 import type { NodeTypes } from './types';
 
-// Inlined instead of importing `parseFileContents` from `ag-shared/plugin-utils`
-// because ag-shared ships its own typescript@^5.8 install; using the helper made
-// the SourceFile's Node nominally different from this plugin's local ts.Node.
-function parseFileContents(contents: string) {
-    return ts.createSourceFile('tempFile.ts', contents, ts.ScriptTarget.Latest, true);
+const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
+    target: ts.ScriptTarget.Latest,
+    skipLibCheck: true,
+    noEmit: true,
+};
+
+// Resolve the compiler options from the nearest tsconfig.json above the input files so the
+// Program resolves the package's internal imports; fall back to permissive defaults.
+function resolveCompilerOptions(filePaths: string[]): ts.CompilerOptions {
+    const configPath = filePaths.length ? ts.findConfigFile(dirname(filePaths[0]), ts.sys.fileExists) : undefined;
+    if (!configPath) {
+        return DEFAULT_COMPILER_OPTIONS;
+    }
+    const { config } = ts.readConfigFile(configPath, ts.sys.readFile);
+    const { options } = ts.parseJsonConfigFileContent(config, ts.sys, dirname(configPath));
+    return { ...options, skipLibCheck: true, noEmit: true };
 }
 
 export class TypeMapper {
     protected nodeMap: Map<string, NodeTypes> = new Map();
 
     constructor(inputFiles: Iterable<string>) {
-        for (const file of inputFiles) {
-            parseFileContents(file).forEachChild((node) => {
+        const filePaths = Array.from(inputFiles, (filePath) => resolve(filePath));
+        const program = ts.createProgram(filePaths, resolveCompilerOptions(filePaths));
+        const checker = program.getTypeChecker();
+
+        // Iterate the inputs in their original order so declaration insertion order — which the
+        // downstream resolver's generics handling is sensitive to — matches the prior per-file walk.
+        for (const filePath of filePaths) {
+            program.getSourceFile(filePath)?.forEachChild((node) => {
                 if (ts.isEnumDeclaration(node) || ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
-                    this.nodeMap.set(node.name.text, formatNode(node));
+                    this.nodeMap.set(node.name.text, formatNode(node, checker));
                 }
                 return undefined;
             });

--- a/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-utils.ts
+++ b/plugins/ag-charts-generate-code-reference-files/src/doc-interfaces/type-utils.ts
@@ -6,7 +6,7 @@ const tsPrinter = ts.createPrinter({
     omitTrailingSemicolon: true,
 });
 
-export function formatNode<T extends ts.Node>(node: T | undefined): any {
+export function formatNode<T extends ts.Node>(node: T | undefined, checker?: ts.TypeChecker): any {
     if (node == null) {
         throw Error('Node is undefined or null');
     }
@@ -14,21 +14,21 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
     if (ts.isUnionTypeNode(node)) {
         return {
             kind: 'union',
-            type: node.types.map(formatNode),
+            type: node.types.map((n) => formatNode(n)),
         };
     }
 
     if (ts.isIntersectionTypeNode(node)) {
         return {
             kind: 'intersection',
-            type: node.types.map(formatNode),
+            type: node.types.map((n) => formatNode(n)),
         };
     }
 
     if (ts.isTupleTypeNode(node)) {
         return {
             kind: 'tuple',
-            type: node.elements.map(formatNode),
+            type: node.elements.map((n) => formatNode(n)),
         };
     }
 
@@ -44,8 +44,8 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
     if (ts.isFunctionTypeNode(node) || ts.isMethodSignature(node)) {
         return {
             kind: 'function',
-            params: node.parameters?.map(formatNode),
-            typeParams: node.typeParameters?.map(formatNode),
+            params: node.parameters?.map((n) => formatNode(n)),
+            typeParams: node.typeParameters?.map((n) => formatNode(n)),
             returnType: formatNode(node.type),
         };
     }
@@ -68,8 +68,8 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
         return {
             kind: 'typeAlias',
             name: printNode(node.name),
-            type: formatNode(node.type),
-            typeParams: node.typeParameters?.map(formatNode),
+            type: expandComputedType(node, checker) ?? formatNode(node.type),
+            typeParams: node.typeParameters?.map((n) => formatNode(n)),
             docs: getJsDoc(node),
         };
     }
@@ -99,7 +99,7 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
                 type: formatNode(n),
                 optional: Boolean(n.questionToken),
             })),
-            typeParams: node.typeParameters?.map(formatNode),
+            typeParams: node.typeParameters?.map((n) => formatNode(n)),
             docs: getJsDoc(node),
         };
     }
@@ -135,7 +135,7 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
             ? {
                   kind: 'typeRef',
                   type: nodeType,
-                  typeArguments: node.typeArguments.map(formatNode),
+                  typeArguments: node.typeArguments.map((n) => formatNode(n)),
               }
             : nodeType;
     }
@@ -178,6 +178,51 @@ export function formatNode<T extends ts.Node>(node: T | undefined): any {
             // return { _unknown: ts.SyntaxKind[node.kind], _output: printNode(node) };
             throw Error(`Unknown node kind "${ts.SyntaxKind[node.kind]}"\n${printNode(node)}`);
     }
+}
+
+// Mapped/conditional/indexed aliases can't be resolved syntactically. When one reduces to a
+// literal union (e.g. `ColorKeys<Required<AgChartThemeParams>>` → `'accentColor' | ...`), use the
+// checker to emit those concrete values; otherwise return undefined to fall back to raw text.
+function expandComputedType(node: ts.TypeAliasDeclaration, checker?: ts.TypeChecker): any {
+    if (!checker || !isComputedTypeNode(node.type, checker)) {
+        return undefined;
+    }
+
+    const symbol = checker.getSymbolAtLocation(node.name);
+    const aliasType = symbol && checker.getDeclaredTypeOfSymbol(symbol);
+    if (!aliasType) {
+        return undefined;
+    }
+
+    const constituents = aliasType.isUnion() ? aliasType.types : [aliasType];
+    if (!constituents.every((type) => type.isStringLiteral() || type.isNumberLiteral())) {
+        return undefined;
+    }
+
+    const literals = constituents.map((type) =>
+        type.isStringLiteral() ? `'${type.value}'` : String((type as ts.NumberLiteralType).value)
+    );
+    return aliasType.isUnion() ? { kind: 'union', type: literals } : literals[0];
+}
+
+function isComputedTypeNode(typeNode: ts.TypeNode, checker: ts.TypeChecker): boolean {
+    if (ts.isMappedTypeNode(typeNode) || ts.isConditionalTypeNode(typeNode) || ts.isIndexedAccessTypeNode(typeNode)) {
+        return true;
+    }
+    // A reference to an alias that is itself computed (e.g. `ColorKeys<...>`).
+    if (ts.isTypeReferenceNode(typeNode)) {
+        const symbol = checker.getSymbolAtLocation(typeNode.typeName);
+        return Boolean(
+            symbol?.declarations?.some(
+                (decl) =>
+                    ts.isTypeAliasDeclaration(decl) &&
+                    (ts.isMappedTypeNode(decl.type) ||
+                        ts.isConditionalTypeNode(decl.type) ||
+                        ts.isIndexedAccessTypeNode(decl.type))
+            )
+        );
+    }
+    return false;
 }
 
 export function getJsDoc(node: ts.Node & { jsDoc?: { getFullText(): string }[] }) {
@@ -230,7 +275,7 @@ function extractInterfaceHeritage(node: ts.InterfaceDeclaration) {
                 ? {
                       kind: 'typeRef',
                       type: formatNode(expression),
-                      typeArguments: typeArguments.map(formatNode),
+                      typeArguments: typeArguments.map((n) => formatNode(n)),
                   }
                 : formatNode(expression)
         )

--- a/plugins/ag-charts-generate-code-reference-files/src/executors/generate/executor.ts
+++ b/plugins/ag-charts-generate-code-reference-files/src/executors/generate/executor.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { inputGlob, writeJSONFile } from 'ag-shared/plugin-utils';
-import { readFileSync } from 'fs';
 import * as ts from 'typescript';
 
 import { patchDocInterfaces } from '../../doc-interfaces/patch-doc-interfaces';
@@ -29,7 +28,7 @@ export default async function (options: ExecutorOptions) {
 }
 
 async function generateFile(options: ExecutorOptions) {
-    const inputFiles = readInputFiles(options.inputs);
+    const inputFiles = options.inputs.flatMap(inputGlob);
     const typeMapper = new TypeMapper(inputFiles);
 
     switch (options.mode) {
@@ -44,8 +43,4 @@ async function generateFile(options: ExecutorOptions) {
         default:
             throw new Error(`Unsupported mode "${options.mode}"`);
     }
-}
-
-function readInputFiles(inputs: string[]): string[] {
-    return inputs.flatMap(inputGlob).map((filePath: string) => readFileSync(filePath, 'utf8'));
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1120

Build a `ts.Program`/`TypeChecker` in the docs reference generator so non-structural type aliases (mapped / conditional / indexed-access) that reduce to a literal union are expanded into their concrete values instead of being emitted as unrenderable raw text.

`AgThemeColorParam` (`ColorKeys<Required<AgChartThemeParams>>`) previously resolved to an interface with no members, so its api-ref row expanded empty — hence the stop-gap that hid it. The generator now flattens it to the concrete union of theme-param keys, and that stop-gap (`hiddenInterfaces` entry) is removed.

Changes:
- `type-mapper.ts`: construct a `ts.Program` + `TypeChecker` (compiler options from the nearest tsconfig); iterate inputs in their original order so the resolver's order-sensitive generics handling is unchanged.
- `type-utils.ts`: thread an optional `checker` through `formatNode`; new gated `expandComputedType` emits a literal union only when a computed alias genuinely reduces to one, otherwise falls back to existing behaviour.
- `executor.ts`: pass input file paths (not contents) to `TypeMapper`.
- `apiReferenceHelpers.ts`: drop `AgThemeColorParam` from `hiddenInterfaces`.

Regenerating the resolved interfaces changes exactly three keys — all computed types: `AgThemeColorParam` and `SeriesType` now resolve to concrete literal unions, and the internal `ColorKeys` helper sheds a leaked generic binding. Everything else is byte-identical. The independent `compare-types` path (raw-text, no checker) is unaffected.

Note: the expanded `AgThemeColorParam` includes `focusShadow`/`popupShadow` because `CssColor` and `CssShadow` are both bare `string` aliases, so they are structurally assignable to `AgCssColorOrRef`. This is the true type semantics; tightening it would require distinct branding in `ag-charts-types` (out of scope).

Fix #CRT-1120