### PR TITLE
CRT-1125 [CLAUDE] Drive focus indicator via native focus({ focusVisible })

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -636,7 +636,7 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
     }
 
     overrideFocusVisible(visible: boolean | undefined): void {
-        this.seriesAreaManager.focusIndicator?.overrideFocusVisible(visible);
+        this.seriesAreaManager.focusIndicator?.setDesiredFocusVisible(visible);
     }
 
     // Use a wrapper to comply with the @typescript-eslint/unbound-method rule.

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -228,7 +228,7 @@ export class SeriesAreaManager extends BaseManager {
         this.swapChain.addListener('focus', () => this.onFocus());
         if (chart.ctx.domManager.mode === 'normal') {
             this.focusIndicator = new FocusIndicator(this.swapChain);
-            this.focusIndicator.overrideFocusVisible(
+            this.focusIndicator.setDesiredFocusVisible(
                 chart.ctx.chartState.getValue('options', 'mode') === 'integrated' ? false : undefined // AG-13197
             );
         }
@@ -520,13 +520,13 @@ export class SeriesAreaManager extends BaseManager {
 
     private onWheel(_event: WheelWidgetEvent): void {
         if (!this.isState(InteractionState.Hoverable)) return;
-        this.focusIndicator?.overrideFocusVisible(false);
+        this.focusIndicator?.setDesiredFocusVisible(false);
         this.setHoverDevice('pointer');
     }
 
     private onDragMove(event: DragWidgetEvent<'drag-move'>, current: Widget): void {
         if (!this.isState(InteractionState.Hoverable)) return;
-        this.focusIndicator?.overrideFocusVisible(false);
+        this.focusIndicator?.setDesiredFocusVisible(false);
         this.onHoverLikeEvent(event, current);
     }
 
@@ -604,7 +604,7 @@ export class SeriesAreaManager extends BaseManager {
             return;
         }
 
-        this.focusIndicator?.overrideFocusVisible(false);
+        this.focusIndicator?.setDesiredFocusVisible(false);
 
         this.onHoverLikeEvent(event, current);
 
@@ -694,7 +694,7 @@ export class SeriesAreaManager extends BaseManager {
 
         const action = mapKeyboardEventToAction(widgetEvent.sourceEvent);
         if (action?.activatesFocusIndicator === false) {
-            this.focusIndicator?.overrideFocusVisible(this.getHoverDevice() === 'keyboard');
+            this.focusIndicator?.setDesiredFocusVisible(this.getHoverDevice() === 'keyboard');
         }
 
         switch (action?.name) {
@@ -741,7 +741,7 @@ export class SeriesAreaManager extends BaseManager {
     private onNav(event: KeyboardWidgetEvent<'keydown'>): boolean {
         if (!this.isState(InteractionState.Focusable)) return false;
         this.setHoverDevice('keyboard');
-        this.focusIndicator?.overrideFocusVisible(true);
+        this.focusIndicator?.setDesiredFocusVisible(true);
         event.sourceEvent.preventDefault();
         return true;
     }

--- a/packages/ag-charts-community/src/dom/focusIndicator.ts
+++ b/packages/ag-charts-community/src/dom/focusIndicator.ts
@@ -3,6 +3,7 @@ import { createElement, createSvgElement, setElementBBox } from 'ag-charts-core'
 import { BBox } from '../scene/bbox';
 import { Path } from '../scene/shape/path';
 import { Transformable } from '../scene/transformable';
+import type { FocusOptionsExperimental } from './focusOptions';
 import type { FocusSwapChain } from './focusSwapChain';
 
 export class FocusIndicator {
@@ -67,7 +68,6 @@ export class FocusIndicator {
         if (newParent === this.element.parentElement) return;
         this.element.remove();
         newParent.appendChild(this.element);
-        this.overrideFocusVisible(this.focusVisible);
     }
 
     private show(child: Element) {
@@ -75,49 +75,49 @@ export class FocusIndicator {
         this.element.append(child);
     }
 
-    // Use with caution! The focus must be visible when using the keyboard.
+    // The desired `:focus-visible` state, which the browser applies via `focus({ focusVisible })`.
+    // `undefined` means "waiting for the first focus-frame": defer to the browser's own decision.
     private focusVisible?: boolean;
-    // Cached `:focus-visible` CSS state. getComputedStyle() is very expensive. So this should only be check for the
-    // :focus-visible pseudo-class when we receive a 'focus' .
-    private focusVisibleStyle: boolean = false;
     private hasFocus: boolean = false;
 
-    public focus(opts: { preventScroll?: boolean; focusVisible?: boolean }) {
+    public focus(opts: FocusOptionsExperimental) {
+        if (this.hasFocus) return;
         this.focusVisible = opts.focusVisible;
-        if (!this.hasFocus) {
-            if (opts.focusVisible !== undefined) {
-                // Override is set, so we don't need to read `:focus-visible`, skip onFocus() handling:
-                this.hasFocus = true;
-            }
-            this.swapChain.focus(opts);
+        if (opts.focusVisible !== undefined) {
+            // Visibility is explicit, so onFocus() doesn't need to read the browser's `:focus-visible`.
+            this.hasFocus = true;
+        }
+        this.swapChain.focus(opts);
+    }
+
+    setDesiredFocusVisible(focusVisible: boolean | undefined) {
+        this.focusVisible = focusVisible;
+        if (this.hasFocus && focusVisible !== undefined) {
+            // Re-focus the already-focused announcer to update `:focus-visible` without re-announcing.
+            this.swapChain.focus({ focusVisible });
         }
     }
 
-    overrideFocusVisible(focusVisible: boolean | undefined) {
-        this.focusVisible = focusVisible;
-        const opacity = { true: '1', false: '0', undefined: '' } as const;
-        const parent = this.element.parentElement;
-        parent?.style.setProperty('opacity', opacity[`${focusVisible}`]);
-    }
-
     public isFocusVisible(): boolean {
-        return this.focusVisible ?? this.focusVisibleStyle;
+        return this.focusVisible ?? false;
     }
 
     public onFocus(): boolean {
-        if (this.hasFocus) return this.isFocusVisible();
-        this.overrideFocusVisible(undefined);
-        const parent = this.element.parentElement;
-        const elWin = this.element.ownerDocument.defaultView!;
-        // !!!SLOW!!! Only call this when you receive a 'focus' event.
-        this.focusVisibleStyle = parent != null && elWin.getComputedStyle(parent).opacity === '1';
+        if (this.hasFocus) return this.focusVisible ?? false;
         this.hasFocus = true;
-        return this.focusVisibleStyle;
+        if (this.focusVisible === undefined) {
+            const parent = this.element.parentElement;
+            const elWin = this.element.ownerDocument.defaultView!;
+            // !!!SLOW!!! Read the browser's `:focus-visible` decision once, on the first focus-frame.
+            this.focusVisible = parent != null && elWin.getComputedStyle(parent).opacity === '1';
+        }
+        // Re-assert the visibility so subsequent announcer swaps keep the indicator stable.
+        this.swapChain.focus({ focusVisible: this.focusVisible });
+        return this.focusVisible;
     }
 
     public onBlur(): void {
-        this.overrideFocusVisible(undefined);
-        this.focusVisibleStyle = false;
+        this.focusVisible = undefined;
         this.hasFocus = false;
     }
 }

--- a/packages/ag-charts-community/src/dom/focusOptions.ts
+++ b/packages/ag-charts-community/src/dom/focusOptions.ts
@@ -1,0 +1,11 @@
+import type { AreMutuallyExclusive } from 'ag-charts-core';
+
+// EXPERIMENTAL WORKAROUND: the bundled TypeScript lib.dom `FocusOptions` does not yet declare the
+// experimental `focusVisible` option of `HTMLElement.focus()`. We extend it locally rather than
+// augmenting the global type, so the assertion below keeps guarding the workaround.
+//
+// This assertion stops compiling once lib.dom gains a native `focusVisible`. When that happens,
+// delete `FocusOptionsExperimental` and use `FocusOptions` directly at every call site.
+true satisfies AreMutuallyExclusive<keyof FocusOptions, 'focusVisible'>;
+
+export type FocusOptionsExperimental = FocusOptions & { focusVisible?: boolean };

--- a/packages/ag-charts-community/src/dom/focusSwapChain.ts
+++ b/packages/ag-charts-community/src/dom/focusSwapChain.ts
@@ -8,6 +8,8 @@ import {
     setElementStyle,
 } from 'ag-charts-core';
 
+import type { FocusOptionsExperimental } from './focusOptions';
+
 type SwapChainEventMap = { focus: FocusEvent; blur: FocusEvent; swap: HTMLElement };
 
 /**
@@ -19,7 +21,7 @@ export class FocusSwapChain {
     private inactiveAnnouncer: HTMLElement & { tabIndex: 0 | -1 };
     private activeAnnouncer: HTMLElement & { tabIndex: 0 | -1 };
 
-    private focusOptions?: FocusOptions;
+    private focusOptions?: FocusOptionsExperimental;
     private hasFocus = false;
     private skipDispatch = false;
 
@@ -76,16 +78,17 @@ export class FocusSwapChain {
         }
     }
 
-    focus(opts?: FocusOptions) {
+    focus(opts?: FocusOptionsExperimental) {
+        // Persist the options so that announcer swaps re-focus with the same `focusVisible` state.
         this.focusOptions = opts;
         this.activeAnnouncer.focus(opts);
-        this.focusOptions = undefined;
     }
 
     update(newLabel: string) {
         this.skipDispatch = true;
         this.swap(newLabel);
         if (this.hasFocus) {
+            // Re-focus to re-announce, forwarding the persisted `focusVisible` so the indicator is stable.
             this.activeAnnouncer.focus(this.focusOptions);
         }
         this.skipDispatch = false;
@@ -101,7 +104,10 @@ export class FocusSwapChain {
 
     private dispatch<T extends keyof SwapChainEventMap>(type: T, param: SwapChainEventMap[T]) {
         if (type === 'focus') this.hasFocus = true;
-        else if (type === 'blur') this.hasFocus = false;
+        else if (type === 'blur') {
+            this.hasFocus = false;
+            this.focusOptions = undefined;
+        }
         for (const fn of this.listeners[type]) {
             fn(param);
         }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1125

Move focus-visibility state tracking out of the library and into the browser by using the experimental `focusVisible` option of `HTMLElement.focus()`.

Previously the focus indicator was shown/hidden via an inline `opacity` override on the swap-chain announcer, with `:focus-visible` only read once (via getComputedStyle) on the first focus event. This was flimsy and never forwarded the desired visibility across announcer swaps.

Now:
  - The first focus-frame defers to the browser's `:focus-visible` decision.
  - A mouse-click on the focused series-area forces the indicator hidden, and a keydown forces it visible, by re-focusing the already-focused announcer with `focus({ focusVisible })`. This is a no-op refocus, so it updates `:focus-visible` without swapping announcers or re-announcing to screenreaders. Re-announcement still happens only when the focused content changes.
  - Blur returns to the "waiting for first focus-frame" state.
  - The desired `focusVisible` is persisted on the swap chain and forwarded on every announcer swap, so the indicator no longer flickers during keyboard navigation.

`FocusIndicator.overrideFocusVisible` (the inline-opacity hack) is replaced by `setDesiredFocusVisible`; the public `chartService.overrideFocusVisible` contract name is retained.

lib.dom (TS 5.8) does not yet type `focusVisible` on `FocusOptions`, so a local `FocusOptionsExperimental` type adds it. A static assertion guards the workaround and fails to compile once the bundled TS lib gains `focusVisible` natively, signalling that the local type can be removed.

Note: this is an experimental branch; the two-latest-major-versions browser support policy is intentionally relaxed (Safari < 18.4 lacks `focusVisible`).