### PR TITLE
AG-3390 Pre-render homepage FAQ answers server-side (keep Markdoc out of the client)

### DIFF
--- a/external/ag-website-shared/src/components/landing-pages/LandingPageFAQ.tsx
+++ b/external/ag-website-shared/src/components/landing-pages/LandingPageFAQ.tsx
@@ -1,28 +1,17 @@
-import type { Framework } from '@ag-grid-types';
 import { Collapsible } from '@ag-website-shared/components/collapsible/Collapsible';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { useFrameworkSelector } from '@ag-website-shared/utils/useFrameworkSelector';
-import { transformMarkdoc } from '@utils/markdoc/transformMarkdoc';
 import classnames from 'classnames';
 import { useState } from 'react';
 import type { FunctionComponent } from 'react';
 
 import styles from './LandingPageFAQ.module.scss';
-
-interface FAQItemData {
-    question: string;
-    answer: string;
-}
+import type { RenderedFAQItem } from './renderFAQAnswers';
 
 interface Props {
-    FAQData: FAQItemData[];
-    framework: Framework;
+    FAQData: RenderedFAQItem[];
 }
 
-const FAQItem: FunctionComponent<FAQItemData> = ({ itemData, isOpen, onClick }) => {
-    const { framework } = useFrameworkSelector();
-    const { MarkdocContent } = transformMarkdoc({ framework, markdocContent: itemData.answer });
-
+const FAQItem: FunctionComponent<RenderedFAQItem> = ({ itemData, isOpen, onClick }) => {
     return (
         <div className={classnames(styles.questionContainer, 'plausible-event-name=react-table-expand-faq')}>
             <div className={styles.titleContainer} onClick={onClick}>
@@ -31,9 +20,7 @@ const FAQItem: FunctionComponent<FAQItemData> = ({ itemData, isOpen, onClick }) 
             </div>
 
             <Collapsible isOpen={isOpen}>
-                <div className={styles.answerContainer}>
-                    <MarkdocContent />
-                </div>
+                <div className={styles.answerContainer} dangerouslySetInnerHTML={{ __html: itemData.answerHtml }} />
             </Collapsible>
         </div>
     );

--- a/external/ag-website-shared/src/components/landing-pages/LandingPageFAQ.tsx
+++ b/external/ag-website-shared/src/components/landing-pages/LandingPageFAQ.tsx
@@ -7,11 +7,17 @@ import type { FunctionComponent } from 'react';
 import styles from './LandingPageFAQ.module.scss';
 import type { RenderedFAQItem } from './renderFAQAnswers';
 
+interface FAQItemProps {
+    itemData: RenderedFAQItem;
+    isOpen: boolean;
+    onClick: () => void;
+}
+
 interface Props {
     FAQData: RenderedFAQItem[];
 }
 
-const FAQItem: FunctionComponent<RenderedFAQItem> = ({ itemData, isOpen, onClick }) => {
+const FAQItem: FunctionComponent<FAQItemProps> = ({ itemData, isOpen, onClick }) => {
     return (
         <div className={classnames(styles.questionContainer, 'plausible-event-name=react-table-expand-faq')}>
             <div className={styles.titleContainer} onClick={onClick}>
@@ -29,11 +35,11 @@ const FAQItem: FunctionComponent<RenderedFAQItem> = ({ itemData, isOpen, onClick
 export const LandingPageFAQ: FunctionComponent<Props> = ({ FAQData }) => {
     const [activeItemIndex, setActiveItemIndex] = useState(-1);
 
-    const clickHandler = (activeIndex) => {
+    const clickHandler = (activeIndex: number) => {
         setActiveItemIndex(activeIndex !== activeItemIndex ? activeIndex : -1);
     };
 
-    const getColumnItems = (columnIndex) => {
+    const getColumnItems = (columnIndex: number) => {
         return FAQData.map((item, i) => {
             if (i % 2 !== columnIndex) return;
 

--- a/external/ag-website-shared/src/components/landing-pages/renderFAQAnswers.ts
+++ b/external/ag-website-shared/src/components/landing-pages/renderFAQAnswers.ts
@@ -1,0 +1,20 @@
+import type { Framework } from '@ag-grid-types';
+import Markdoc from '@markdoc/markdoc';
+import { transformMarkdoc } from '@utils/markdoc/transformMarkdoc';
+
+import type { FAQItem } from './types';
+
+export interface RenderedFAQItem {
+    question: string;
+    answerHtml: string;
+}
+
+/**
+ * Render FAQ answers to inline HTML on the server so Markdoc stays out of the client bundle.
+ */
+export function renderFAQAnswers(items: FAQItem[], framework: Framework): RenderedFAQItem[] {
+    return items.map(({ question, answer }) => {
+        const { partialRenderTree } = transformMarkdoc({ framework, markdocContent: answer });
+        return { question, answerHtml: Markdoc.renderers.html(partialRenderTree) };
+    });
+}

--- a/external/ag-website-shared/src/components/landing-pages/sections/FAQSection.astro
+++ b/external/ag-website-shared/src/components/landing-pages/sections/FAQSection.astro
@@ -3,6 +3,7 @@ import type { FAQSection, LandingPageContent } from '../types';
 import { LandingPageSection } from '../LandingPageSection';
 import { LandingPageFAQ } from '../LandingPageFAQ';
 import { renderFAQAnswers } from '../renderFAQAnswers';
+import { getFrameworkFromInternalFramework } from '@utils/framework';
 
 interface Props {
     section: FAQSection;
@@ -11,7 +12,8 @@ interface Props {
 
 const { section, pageContent } = Astro.props;
 
-const faqData = renderFAQAnswers(section.items, pageContent.framework || 'react');
+const framework = getFrameworkFromInternalFramework(pageContent.framework);
+const faqData = renderFAQAnswers(section.items, framework);
 ---
 
 <LandingPageSection id="faq" tag={section.tag} heading={section.heading} subHeading={section.subHeading}>

--- a/external/ag-website-shared/src/components/landing-pages/sections/FAQSection.astro
+++ b/external/ag-website-shared/src/components/landing-pages/sections/FAQSection.astro
@@ -2,6 +2,7 @@
 import type { FAQSection, LandingPageContent } from '../types';
 import { LandingPageSection } from '../LandingPageSection';
 import { LandingPageFAQ } from '../LandingPageFAQ';
+import { renderFAQAnswers } from '../renderFAQAnswers';
 
 interface Props {
     section: FAQSection;
@@ -10,10 +11,9 @@ interface Props {
 
 const { section, pageContent } = Astro.props;
 
-// Transform items to the format expected by LandingPageFAQ
-const faqData = section.items;
+const faqData = renderFAQAnswers(section.items, pageContent.framework || 'react');
 ---
 
 <LandingPageSection id="faq" tag={section.tag} heading={section.heading} subHeading={section.subHeading}>
-    <LandingPageFAQ client:load FAQData={faqData} framework={pageContent.framework || 'react'} />
+    <LandingPageFAQ client:load FAQData={faqData} />
 </LandingPageSection>

--- a/external/ag-website-shared/src/components/landing-pages/types.ts
+++ b/external/ag-website-shared/src/components/landing-pages/types.ts
@@ -1,3 +1,5 @@
+import type { InternalFramework } from '@ag-grid-types';
+
 // ============================================================================
 // Section Content Types
 // ============================================================================
@@ -207,7 +209,7 @@ export interface LandingPageContent {
     /** Product name for display (e.g., 'AG Grid', 'AG Charts') */
     productName?: string;
     /** Framework identifier for examples (e.g., 'reactFunctionalTs', 'angular', 'vue3') */
-    framework?: string;
+    framework?: InternalFramework;
     packageName?: string;
     docsPath: string;
     analyticsPrefix: string;

--- a/packages/ag-charts-website/src/pages/index.astro
+++ b/packages/ag-charts-website/src/pages/index.astro
@@ -9,6 +9,7 @@ import { urlWithPrefix } from '@utils/urlWithPrefix';
 import { AutomatedIntegratedChartsWithPackages } from '@ag-website-shared/components/automated-examples/AutomatedIntegratedChartsWithPackages';
 import { LandingPageSection } from '@ag-website-shared/components/landing-pages/LandingPageSection';
 import { LandingPageFAQ } from '@ag-website-shared/components/landing-pages/LandingPageFAQ';
+import { renderFAQAnswers } from '@ag-website-shared/components/landing-pages/renderFAQAnswers';
 import { LandingPageFWSelector } from '@ag-website-shared/components/landing-pages/LandingPageFWSelector';
 import ImageCarousel from '../components/homepage/components/hero/ImageCarousel';
 import { parseVersion } from '@ag-website-shared/utils/parseVersion';
@@ -22,6 +23,7 @@ const { blogPrefix } = whatsNewData['charts'];
 
 // All Gallery Examples
 const { data: FAQData } = (await getEntry('faqs', 'homepage')) as CollectionEntry<'faqs'>;
+const renderedFAQData = renderFAQAnswers(FAQData, 'react');
 const { data: versionsData } = (await getEntry('versions', 'ag-charts-versions')) as CollectionEntry<'versions'>;
 
 const frameworksData = [
@@ -231,7 +233,7 @@ const mapExampleHeights = 360;
             heading="FAQs"
             subHeading="Answers to common questions about AG Charts, and JavaScript Charting in general."
         >
-            <LandingPageFAQ client:load FAQData={FAQData} framework={'react'} />
+            <LandingPageFAQ client:load FAQData={renderedFAQData} />
         </LandingPageSection>
     </div>
 </Layout>

--- a/packages/ag-charts-website/src/pages/index.astro
+++ b/packages/ag-charts-website/src/pages/index.astro
@@ -23,7 +23,7 @@ const { blogPrefix } = whatsNewData['charts'];
 
 // All Gallery Examples
 const { data: FAQData } = (await getEntry('faqs', 'homepage')) as CollectionEntry<'faqs'>;
-const renderedFAQData = renderFAQAnswers(FAQData, 'react');
+const renderedFAQData = renderFAQAnswers(FAQData);
 const { data: versionsData } = (await getEntry('versions', 'ag-charts-versions')) as CollectionEntry<'versions'>;
 
 const frameworksData = [


### PR DESCRIPTION
## What

Pre-render the homepage FAQ answers to HTML on the **server** so `@markdoc/markdoc` is no longer bundled into the client.

## Why

`LandingPageFAQ` rendered `client:load` and called `transformMarkdoc` in the browser. That dragged `@markdoc/markdoc`, `markdoc.config` and the `@astrojs/markdoc` shiki extension (via `@astrojs/markdown-remark`) into the client bundle. That chain reads `process.env` at top level, so the browser threw **"process is not defined"** during hydration — and every visitor downloaded Markdoc for no reason, since the FAQ answers are static inline markdown with no framework-specific content.

This is the proper fix for the dev-only `process.env` define workaround on `AG-3390-fix-faq-markdoc-client`.

## How

- New `renderFAQAnswers` helper transforms each answer to inline HTML server-side via `Markdoc.renderers.html`.
- `LandingPageFAQ.tsx` drops the `transformMarkdoc` / `useFrameworkSelector` / `framework` usage and renders the pre-built HTML via `dangerouslySetInnerHTML`.
- The shared `FAQSection.astro` wrapper (used by the grid homepage too) and the charts `index.astro` both transform in frontmatter.

## Verification

- `nx format` ✅, `nx lint:eslint ag-charts-website` ✅ (0 errors)
- `nx build ag-charts-website` ✅
- Built `_astro` client chunks contain **zero** markdoc references; the FAQ island chunk contains only `dangerouslySetInnerHTML`/`__html`.
- FAQ answers are pre-rendered into the homepage HTML output.

## Notes

- Content is trusted first-party JSON (`content/faqs/homepage.json`), so `dangerouslySetInnerHTML` is acceptable here.
- Touches the shared `ag-website-shared` component — grid homepage FAQ behaviour is unchanged (same inline rendering, now server-side).

🤖 Draft — opened for later review.