### PR TITLE
Add AI Skills documentation page

### DIFF
--- a/packages/ag-charts-website/src/content/docs-nav/nav.json
+++ b/packages/ag-charts-website/src/content/docs-nav/nav.json
@@ -85,6 +85,16 @@
             ]
         },
         {
+            "title": "AI Features",
+            "children": [
+                {
+                    "type": "item",
+                    "title": "Skills",
+                    "path": "skills"
+                }
+            ]
+        },
+        {
             "title": "Core features",
             "children": [
                 {

--- a/packages/ag-charts-website/src/content/docs/migration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/migration/index.mdoc
@@ -7,7 +7,7 @@ Learn how to upgrade AG Charts to a specific version.
 These guides explain how to move from one version of AG Charts to another. They outline breaking changes, new features, and the adjustments you need to make in your code.
 
 {% note %}
-Use the [ag-update skill](./skills/#using-ag-update) to help your AI tooling migrate your AG Charts applications to a new version.   
+Use the [ag-update skill](./skills/#using-ag-update) to help your AI tooling migrate your AG Charts applications to a new version.  
 See [Skills](./skills/) for more information.
 {% /note %}
 

--- a/packages/ag-charts-website/src/content/docs/migration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/migration/index.mdoc
@@ -6,6 +6,11 @@ Learn how to upgrade AG Charts to a specific version.
 
 These guides explain how to move from one version of AG Charts to another. They outline breaking changes, new features, and the adjustments you need to make in your code.
 
+{% note %}
+Use the [ag-update skill](./skills/#using-ag-update) to help your AI tooling migrate your AG Charts applications to a new version.   
+See [Skills](./skills/) for more information.
+{% /note %}
+
 ## Version 14
 
 {% majorTable library="charts" major=14 /%}

--- a/packages/ag-charts-website/src/content/docs/skills/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/skills/index.mdoc
@@ -7,7 +7,7 @@ We are building a set of AI skills for developing grid and charts applications u
 We currently publish one skill, [ag-update](#using-ag-update), which handles version upgrades. We plan to add more over time.
 
 {% note %}
-We are actively developing and releasing new versions of our skills. Feedback is welcome [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
+We are actively developing and releasing new versions of our skills. Feedback is welcome - [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
 {% /note %}
 
 ## Installation

--- a/packages/ag-charts-website/src/content/docs/skills/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/skills/index.mdoc
@@ -1,0 +1,47 @@
+---
+title: 'AG Skills'
+---
+
+We are building a set of AI skills for developing grid and charts applications using coding agents such as Claude and Codex.
+
+We currently publish one skill, [ag-update](#using-ag-update), which handles version upgrades. We plan to add more over time.
+
+{% note %}
+We are actively developing and releasing new versions of our skills. Feedback is welcome [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
+{% /note %}
+
+## Installation
+
+A skill is just a folder of files that can be installed in your project repo, or your home directory. Use the skills CLI to copy the files to your computer:
+
+```
+npx skills add ag-grid/skills
+```
+
+## Updating
+
+Update to the latest version at any time:
+
+```
+npx skills update ag-grid/skills
+```
+
+## Using ag-update
+
+The skill produces a markdown file detailing all the changes that need to be applied to your project in order to update to a new version.
+
+In your coding agent you can invoke the skill and it will analyse your codebase and propose what updates can be applied:
+
+```
+Use the ag-update skill
+```
+
+Alternatively, tell the skill exactly what you want to update:
+
+```
+Use the ag-update skill to update all projects in this monorepo except apps/demo-app to ag charts v14
+```
+
+The skill will analyse your repo and our breaking change documentation and produce a markdown file containing a list of changes to apply. In the case of optional changes you'll be asked whether you want to apply them.
+
+You can then review the generated file and ask your agent to make an implementation plan based on it.


### PR DESCRIPTION
Add a documentation page for the AG AI skills published at [ag-grid/skills](https://github.com/ag-grid/skills), linked under a new **AI Features** nav section.

The page covers what a skill is, how to install one, how to update, and how to use the `ag-update` skill for version upgrades. Mirrors the equivalent AG Grid docs page, with the upgrade example adapted to AG Charts v14.

We currently publish one skill and plan to add more.