### PR TITLE
AG-17350 Update skills repo name to ag-grid/skills

### DIFF
--- a/packages/ag-charts-website/src/content/docs/skills/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/skills/index.mdoc
@@ -7,7 +7,7 @@ We are building a set of AI skills for developing grid and charts applications u
 We currently publish one skill, [ag-update](#using-ag-update), which handles version upgrades. We plan to add more over time.
 
 {% note %}
-We are actively developing and releasing new versions of our skills. Feedback is welcome - [open an issue](https://github.com/ag-grid/ag-skills/issues) on GitHub.
+We are actively developing and releasing new versions of our skills. Feedback is welcome - [open an issue](https://github.com/ag-grid/skills/issues) on GitHub.
 {% /note %}
 
 ## Installation
@@ -15,7 +15,7 @@ We are actively developing and releasing new versions of our skills. Feedback is
 A skill is just a folder of files that can be installed in your project repo, or your home directory. Use the skills CLI to copy the files to your computer:
 
 ```
-npx skills add ag-grid/ag-skills
+npx skills add ag-grid/skills
 ```
 
 ## Updating
@@ -23,7 +23,7 @@ npx skills add ag-grid/ag-skills
 Update to the latest version at any time:
 
 ```
-npx skills update ag-grid/ag-skills
+npx skills update ag-grid/skills
 ```
 
 ## Using ag-update


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17350

The `ag-skills` repository was renamed to `skills`. Update the AI skills docs page so the install/update commands and the issues link point to `ag-grid/skills`.

Fix #AG-17350