### PR TITLE
Add -e2e doc-page suffix, treated as internal like -test

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -16,7 +16,8 @@
         "**/*.map",
         "**/_examples/**",
         "**/generated-example-contents.json",
-        "**/docs/*-test/**"
+        "**/docs/*-test/**",
+        "**/docs/*-e2e/**"
     ],
     "useGitignore": true,
     "ignoreRegExpList": ["/id=\"[A-Za-z0-9_-]{11}\"/g"],

--- a/packages/ag-charts-website/e2e/generate-test-files.ts
+++ b/packages/ag-charts-website/e2e/generate-test-files.ts
@@ -24,6 +24,18 @@ interface TestCategory {
 const FRAMEWORKS = ['vanilla', 'typescript', 'reactFunctional', 'reactFunctionalTs', 'angular', 'vue3'];
 const TESTS_PER_EXAMPLE = FRAMEWORKS.length; // Each example generates tests for each framework
 
+// Internal test pages merge into their base page category (e.g. 'line-series-test' -> 'line-series').
+const INTERNAL_PAGE_SUFFIXES = ['-test', '-e2e'];
+
+function toBasePageCategory(page: string): string {
+    for (const suffix of INTERNAL_PAGE_SUFFIXES) {
+        if (page.endsWith(suffix)) {
+            return page.slice(0, -suffix.length);
+        }
+    }
+    return page;
+}
+
 function getExamples(): Example[] {
     const examples = glob
         .sync('./src/content/**/_examples/*/main.ts')
@@ -33,8 +45,7 @@ function getExamples(): Example[] {
             const example = examplePath.replace(/\/[a-zA-Z-]+\.ts$/, '');
             const page = pagePath.replace(/^docs\//, '');
 
-            // Merge -test pages into their base page (e.g., 'line-series-test' -> 'line-series')
-            const category = page.endsWith('-test') ? page.slice(0, -5) : page;
+            const category = toBasePageCategory(page);
 
             return {
                 path,

--- a/packages/ag-charts-website/src/utils/sitemap.test.ts
+++ b/packages/ag-charts-website/src/utils/sitemap.test.ts
@@ -1,0 +1,19 @@
+import { isInternalPage } from './sitemap';
+
+describe('isInternalPage', () => {
+    test.each`
+        page                              | expected
+        ${'/javascript/bar-series-test/'} | ${true}
+        ${'/javascript/bar-series-test'}  | ${true}
+        ${'/react/sync-e2e/'}             | ${true}
+        ${'/react/sync-e2e'}              | ${true}
+        ${'/javascript/active-e2e-test/'} | ${true}
+        ${'/charts/benchmarks'}           | ${true}
+        ${'/javascript/bar-series/'}      | ${false}
+        ${'/javascript/tooltips/'}        | ${false}
+        ${'/javascript/latest/'}          | ${false}
+        ${'/javascript/contest/'}         | ${false}
+    `('$page -> $expected', ({ page, expected }) => {
+        expect(isInternalPage(page)).toBe(expected);
+    });
+});

--- a/packages/ag-charts-website/src/utils/sitemap.ts
+++ b/packages/ag-charts-website/src/utils/sitemap.ts
@@ -37,17 +37,25 @@ const isNonPublicContent = (page: string) => {
 };
 
 /*
- * Test pages for integration testing
+ * Internal pages for integration and end-to-end testing. The `-test` suffix denotes
+ * manual regression harnesses; `-e2e` denotes pages backing automated Playwright specs.
+ * Both are excluded from search engines and navigation.
  */
-export const isTestPage = (page: string) => {
-    return page.endsWith('-test/') || page.endsWith('-test') || page.endsWith('/benchmarks');
+export const isInternalPage = (page: string) => {
+    return (
+        page.endsWith('-test/') ||
+        page.endsWith('-test') ||
+        page.endsWith('-e2e/') ||
+        page.endsWith('-e2e') ||
+        page.endsWith('/benchmarks')
+    );
 };
 
 const filterIgnoredPages = (page: string) => {
     return (
         !isExamplePage(page) &&
         !isDebugPage(page) &&
-        !isTestPage(page) &&
+        !isInternalPage(page) &&
         !isRedirectPage(page) &&
         !isNonPublicContent(page)
     );

--- a/packages/ag-charts-website/src/utils/sitemapPages.ts
+++ b/packages/ag-charts-website/src/utils/sitemapPages.ts
@@ -14,8 +14,13 @@ const getDocsExamplePaths = () => {
     return [urlWithBaseUrl('/*/*/examples/')];
 };
 
-const getTestPages = () => {
-    return [urlWithBaseUrl('/*/*-test/'), urlWithBaseUrl('/gallery-test'), urlWithBaseUrl('/*/benchmarks/')];
+const getInternalPages = () => {
+    return [
+        urlWithBaseUrl('/*/*-test/'),
+        urlWithBaseUrl('/*/*-e2e/'),
+        urlWithBaseUrl('/gallery-test'),
+        urlWithBaseUrl('/*/benchmarks/'),
+    ];
 };
 
 const getHiddenPages = async () => {
@@ -42,7 +47,7 @@ const getIgnoredPages = () => {
 
 export async function getSitemapIgnorePaths() {
     const asyncPages = (await Promise.all([getHiddenPages(), getDebugPageUrls()])).flat();
-    const paths = [getDocsExamplePaths(), getTestPages(), getIgnoredPages(), asyncPages];
+    const paths = [getDocsExamplePaths(), getInternalPages(), getIgnoredPages(), asyncPages];
 
     return paths.flat();
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17752

Introduces a `-e2e` documentation-page slug suffix treated identically to the existing `-test` suffix for search/robots/sitemap exclusion and Playwright generated-test grouping. This is the enabling infrastructure (Phase A) for a wider effort to migrate e2e-backed examples off manual `-test` regression pages onto dedicated, search-excluded `-e2e` pages, and to retire redundant manual checks.

## Changes
- **`src/utils/sitemap.ts`** — `isTestPage` → `isInternalPage`; now also matches `-e2e`/`-e2e/`, so these pages are excluded from the generated sitemap.
- **`src/utils/sitemapPages.ts`** — add `/*/*-e2e/` to the robots disallow globs.
- **`e2e/generate-test-files.ts`** — generated-spec category derivation strips `-e2e` as well as `-test` (via a small `toBasePageCategory` helper), keeping example→category grouping stable and avoiding spec-file proliferation.
- **`src/utils/sitemap.test.ts`** — new unit coverage for `isInternalPage`, including `/latest/` and `/contest/` false-positive guards.

Search/nav exclusion remains convention-driven (pages are simply omitted from `nav.json` and carry `hidden: true`), so no code change is needed there.

**This change is inert until `-e2e` pages exist** — no pages are renamed in this PR.

## Test plan
- `yarn nx test ag-charts-website` — new `sitemap.test.ts` passes 10/10
- `yarn nx lint ag-charts-website` — 0 errors (pre-existing React-hook warnings unaffected)
- `yarn nx format` — clean