### PR TITLE
Harden dataSource tests against async-effect timing races

### DIFF
--- a/packages/ag-charts-enterprise/src/features/data-source/dataSource.test.ts
+++ b/packages/ag-charts-enterprise/src/features/data-source/dataSource.test.ts
@@ -171,11 +171,6 @@ describe('DataSource', () => {
         throw new Error(`Timed out waiting for ${description}`);
     };
 
-    const zoomRatioKey = () => {
-        const ratioX = chart.getState().zoom?.ratioX;
-        return ratioX ? `${ratioX.start}:${ratioX.end}` : 'full';
-    };
-
     it('should load data asynchronously', async () => {
         const response = delay(1).then(() => [
             { time: new Date('2024-01-01 00:00:00'), price: 0 },
@@ -281,12 +276,24 @@ describe('DataSource', () => {
         });
 
         it('should change the window after a change in zoom', async () => {
-            await prepareChart(dataSource);
+            let callCount = 0;
+            await prepareChart({
+                getData: (window) => {
+                    callCount++;
+                    return dataSource!.getData(window);
+                },
+            });
             await response;
             await compare();
-            const zoomBefore = zoomRatioKey();
+
+            // The wheel zoom commits a frame before the windowed data is re-requested and re-rendered;
+            // wait for that fetch and let it settle, otherwise the snapshot can capture the pre-refetch
+            // frame.
+            const callsBeforeZoom = callCount;
             await scrollAction(cx, cy, -1)(chart);
-            await settleUntil(() => zoomRatioKey() !== zoomBefore, 'the wheel zoom to commit');
+            await settleUntil(() => callCount > callsBeforeZoom, 'the zoom-triggered data request');
+            await delay(1);
+            await waitForChartStability(chart);
             await compare();
         });
     });
@@ -504,7 +511,7 @@ describe('DataSource', () => {
             sources.length = 0;
 
             await chart.updateDelta({});
-            await delay(1);
+            await settleUntil(() => sources.includes('chart-update'), 'the programmatic-refresh data request');
             await waitForChartStability(chart);
 
             expect(sources).toContain('chart-update');
@@ -540,7 +547,7 @@ describe('DataSource', () => {
             sources.length = 0;
 
             await chart.setState(zoomedState);
-            await delay(1);
+            await settleUntil(() => sources.includes('state-change'), 'the state-change data request');
             await waitForChartStability(chart);
 
             expect(sources).toContain('state-change');


### PR DESCRIPTION
Follow-up to the dataSource scroll-zoom hardening. Three tests in `dataSource.test.ts` asserted or captured a snapshot before an asynchronously-delivered effect had landed, relying on a fixed wait instead of polling until the effect was observed. Under CPU load the effect could arrive late — drifting a snapshot or leaving an array the assertion depended on empty. This surfaced as an intermittent `~0.39% / 1861px` diff on the post-zoom snapshot (seen on an unrelated open PR, since its CI merges with `latest`).

## What changed
- **`should change the window after a change in zoom`** — the wheel zoom commits a frame before the windowed `getData` re-fetch is issued and re-rendered, so the post-zoom snapshot could capture the pre-refetch frame. Now waits for the zoom-triggered request (`settleUntil(callCount)`) and lets it settle before capturing, matching the sibling `compare`-after-zoom tests. Removes the now-unused `zoomRatioKey` helper.
- **`reports a non-user source for a programmatic refresh`** and **`reports a state-change source for a programmatic setState`** — both asserted on a `source` pushed by an async `getData` using only `delay(1) + waitForChartStability`. Now poll until the expected source is observed (`settleUntil(() => sources.includes(...))`), matching the already-correct `user-interaction` sibling in the same block.

No assertions were loosened — `settleUntil` is bounded and still throws on a genuine failure.

## Test plan
- `yarn nx build:test ag-charts-enterprise` (noImplicitAny typecheck) ✅
- `yarn nx lint ag-charts-enterprise` ✅, `yarn nx format` ✅
- Contention reproduction: the zoom test failed **2/50** under oversubscribed parallelism before the fix.
- After the fix: **100/50/50** zoom-test runs and **2×64** full-suite runs under the same contention, all green.