### PR TITLE
AG-3390 - fix(benchmark): sanitise reflected URL in serve-static 404 response

### DIFF
--- a/tools/benchmark/serve-static.js
+++ b/tools/benchmark/serve-static.js
@@ -79,6 +79,15 @@ if (!fs.existsSync(root)) {
 const baseSegment = base.slice(1);
 const baseIsRealDir = baseSegment.length > 0 && fs.existsSync(path.join(root, baseSegment));
 
+function escapeHtml(value) {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 function resolveFile(urlPath) {
     let relPath = decodeURIComponent(urlPath.split('?')[0]);
 
@@ -111,7 +120,7 @@ const server = http.createServer((req, res) => {
     const filePath = resolveFile(req.url ?? '/');
     if (!filePath) {
         res.writeHead(404, { 'content-type': 'text/plain' });
-        res.end(`Not found: ${req.url}`);
+        res.end(`Not found: ${escapeHtml(req.url ?? '')}`);
         return;
     }
 


### PR DESCRIPTION
## Problem

The scheduled Security workflow ([run 28140069837](https://github.com/ag-grid/ag-charts/actions/runs/28140069837)) failed on `sast-code-scan`. Snyk SAST flagged a reflected XSS at `tools/benchmark/serve-static.js:114`:

```js
res.end(`Not found: ${req.url}`);
```

The 404 handler echoed the user-controlled request URL straight into the response body — a reflected-XSS sink in Snyk's taint analysis.

## Fix

Added an `escapeHtml()` helper and HTML-escape the URL before reflecting it. The path is still shown for debugging, but `<`, `>`, `&`, `"`, and `'` are neutralised, removing the sink.

## Testing

- `node --check` passes.
- Confirmed `/foo<script>alert(1)</script>` renders as `Not found: /foo&lt;script&gt;alert(1)&lt;/script&gt;`.