### PR TITLE
AG-17333 PoC click-selection on org-chart (add undocumented `clickModifier` option)

### DIFF
--- a/packages/ag-charts-community/src/chart/series/seriesProperties.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesProperties.ts
@@ -212,8 +212,13 @@ export class SeriesSelectionProperties<TOpts extends object> extends BasePropert
     @Property
     readonly unselectedSeries: SelectionOptions<TOpts> = {};
 
+    // Undocumented:
     @Property
     selectedOffset = 0; // pie-only
+
+    // Undocumented:
+    @Property
+    clickModifier: 'none' | 'alt' = 'none'; // org-chart only
 
     getStyle(selectionState: SelectionState): SelectionOptions<TOpts> {
         const keys = getSelectionStyleOptionKeys(selectionState);

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -105,6 +105,7 @@ export interface ISeriesProperties {
     yKey?: string;
     context?: unknown;
     tooltip: { enabled?: boolean };
+    selection: { clickModifier: 'none' | 'alt' };
 }
 
 export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesProperties, TLabel = TDatum> {

--- a/packages/ag-charts-community/src/module/__snapshots__/optionsModule.test.ts.snap
+++ b/packages/ag-charts-community/src/module/__snapshots__/optionsModule.test.ts.snap
@@ -327,6 +327,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CHART_CUSTOMISATION it should 
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -399,6 +400,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CHART_CUSTOMISATION it should 
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -471,6 +473,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CHART_CUSTOMISATION it should 
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -893,6 +896,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_COMBINATION_SERIES_CHART_EXAMP
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -974,6 +978,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_COMBINATION_SERIES_CHART_EXAMP
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1059,6 +1064,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_COMBINATION_SERIES_CHART_EXAMP
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1429,6 +1435,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE i
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1503,6 +1510,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE i
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1577,6 +1585,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE i
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1651,6 +1660,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE i
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1725,6 +1735,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE i
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1799,6 +1810,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE i
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -1873,6 +1885,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_MARKER_SHAPES_EXAMPLE i
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2236,6 +2249,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2318,6 +2332,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2400,6 +2415,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2482,6 +2498,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2564,6 +2581,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2646,6 +2664,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2728,6 +2747,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -2810,6 +2830,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_CUSTOM_TOOLTIPS_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -3174,6 +3195,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_PER_MARKER_CUSTOMISATION_EXAMP
       "maxSize": 100,
       "minSize": 5,
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -3564,6 +3586,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_TIME_AXIS_WITH_IRREGULAR_INTER
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -3636,6 +3659,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_TIME_AXIS_WITH_IRREGULAR_INTER
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -3708,6 +3732,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_TIME_AXIS_WITH_IRREGULAR_INTER
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -3780,6 +3805,7 @@ exports[`ChartOptions > #prepareOptions > for ADV_TIME_AXIS_WITH_IRREGULAR_INTER
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -4152,6 +4178,7 @@ exports[`ChartOptions > #prepareOptions > for AREA_GRAPH_WITH_NEGATIVE_VALUES_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -4237,6 +4264,7 @@ exports[`ChartOptions > #prepareOptions > for AREA_GRAPH_WITH_NEGATIVE_VALUES_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -4322,6 +4350,7 @@ exports[`ChartOptions > #prepareOptions > for AREA_GRAPH_WITH_NEGATIVE_VALUES_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -4407,6 +4436,7 @@ exports[`ChartOptions > #prepareOptions > for AREA_GRAPH_WITH_NEGATIVE_VALUES_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -4492,6 +4522,7 @@ exports[`ChartOptions > #prepareOptions > for AREA_GRAPH_WITH_NEGATIVE_VALUES_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -4861,6 +4892,7 @@ exports[`ChartOptions > #prepareOptions > for BAR_CHART_EXAMPLE it should prepar
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -5240,6 +5272,7 @@ exports[`ChartOptions > #prepareOptions > for BAR_CHART_WITH_LABELS_EXAMPLE it s
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -5615,6 +5648,7 @@ exports[`ChartOptions > #prepareOptions > for BUBBLE_GRAPH_WITH_CATEGORIES_EXAMP
       "maxSize": 30,
       "minSize": 0,
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -5976,6 +6010,7 @@ exports[`ChartOptions > #prepareOptions > for BUBBLE_GRAPH_WITH_NEGATIVE_VALUES_
       "maxSize": 100,
       "minSize": 5,
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -6342,6 +6377,7 @@ exports[`ChartOptions > #prepareOptions > for COLUMN_CHART_WITH_NEGATIVE_VALUES_
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -6421,6 +6457,7 @@ exports[`ChartOptions > #prepareOptions > for COLUMN_CHART_WITH_NEGATIVE_VALUES_
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -6797,6 +6834,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_BAR_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -6881,6 +6919,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_BAR_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -7263,6 +7302,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_COLUMN_EXAMPLE it should p
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -7349,6 +7389,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_COLUMN_EXAMPLE it should p
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -7435,6 +7476,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_COLUMN_EXAMPLE it should p
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -7521,6 +7563,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_COLUMN_EXAMPLE it should p
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -7607,6 +7650,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_COLUMN_EXAMPLE it should p
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -7693,6 +7737,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_COLUMN_EXAMPLE it should p
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -7779,6 +7824,7 @@ exports[`ChartOptions > #prepareOptions > for GROUPED_COLUMN_EXAMPLE it should p
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8164,6 +8210,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8239,6 +8286,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8314,6 +8362,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8389,6 +8438,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8464,6 +8514,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8539,6 +8590,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8614,6 +8666,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8689,6 +8742,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8764,6 +8818,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8839,6 +8894,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8914,6 +8970,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -8989,6 +9046,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -9064,6 +9122,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -9139,6 +9198,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -9214,6 +9274,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -9289,6 +9350,7 @@ exports[`ChartOptions > #prepareOptions > for LINE_GRAPH_WITH_GAPS_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -9650,6 +9712,7 @@ exports[`ChartOptions > #prepareOptions > for LOG_AXIS_EXAMPLE it should prepare
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10023,6 +10086,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_AREA_G
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10116,6 +10180,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_AREA_G
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10209,6 +10274,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_AREA_G
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10302,6 +10368,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_AREA_G
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10395,6 +10462,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_AREA_G
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10488,6 +10556,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_AREA_G
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10581,6 +10650,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_AREA_G
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -10963,6 +11033,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_BAR_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11048,6 +11119,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_BAR_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11133,6 +11205,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_BAR_EX
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11510,6 +11583,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_COLUMN
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11592,6 +11666,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_COLUMN
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11674,6 +11749,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_COLUMN
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11756,6 +11832,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_COLUMN
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11838,6 +11915,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_COLUMN
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -11920,6 +11998,7 @@ exports[`ChartOptions > #prepareOptions > for ONE_HUNDRED_PERCENT_STACKED_COLUMN
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -12331,6 +12410,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_AREA_GRAPH_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -12413,6 +12493,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_AREA_GRAPH_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -12495,6 +12576,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_AREA_GRAPH_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -12577,6 +12659,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_AREA_GRAPH_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -12948,6 +13031,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_COLUMN_CHART_EXAMPLE it sho
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -13282,6 +13366,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_DONUT_CHART_EXAMPLE it shou
       "sectorLabelKey": "count",
       "sectorSpacing": 1,
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -13699,6 +13784,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_LINE_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -13772,6 +13858,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_LINE_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -14059,6 +14146,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_PIE_CHART_EXAMPLE it should
       "sectorLabelKey": "population",
       "sectorSpacing": 1,
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -14425,6 +14513,7 @@ exports[`ChartOptions > #prepareOptions > for SIMPLE_SCATTER_CHART_EXAMPLE it sh
       },
       "maxRenderedItems": 2000,
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -14821,6 +14910,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_AREA_GRAPH_EXAMPLE it shou
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -14910,6 +15000,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_AREA_GRAPH_EXAMPLE it shou
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -14999,6 +15090,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_AREA_GRAPH_EXAMPLE it shou
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -15088,6 +15180,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_AREA_GRAPH_EXAMPLE it shou
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -15177,6 +15270,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_AREA_GRAPH_EXAMPLE it shou
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -15266,6 +15360,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_AREA_GRAPH_EXAMPLE it shou
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -15646,6 +15741,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_BAR_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -15730,6 +15826,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_BAR_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -15814,6 +15911,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_BAR_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -15898,6 +15996,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_BAR_CHART_EXAMPLE it shoul
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -16278,6 +16377,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_COLUMN_GRAPH_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -16362,6 +16462,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_COLUMN_GRAPH_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -16446,6 +16547,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_COLUMN_GRAPH_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -16530,6 +16632,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_COLUMN_GRAPH_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,
@@ -16614,6 +16717,7 @@ exports[`ChartOptions > #prepareOptions > for STACKED_COLUMN_GRAPH_EXAMPLE it sh
         "key": "x",
       },
       "selection": {
+        "clickModifier": "none",
         "enabled": false,
         "selectedItem": {
           "strokeWidth": 2,

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -615,6 +615,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -695,6 +696,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -775,6 +777,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -855,6 +858,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -938,6 +942,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1007,6 +1012,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1084,6 +1090,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1164,6 +1171,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1244,6 +1252,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1324,6 +1333,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1407,6 +1417,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1476,6 +1487,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1553,6 +1565,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1633,6 +1646,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1713,6 +1727,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1793,6 +1808,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1876,6 +1892,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,
@@ -1945,6 +1962,7 @@ describe('ChartOptions', () => {
                     "key": "x",
                   },
                   "selection": {
+                    "clickModifier": "none",
                     "enabled": false,
                     "selectedItem": {
                       "strokeWidth": 2,

--- a/packages/ag-charts-core/src/config/optionsDefaults.ts
+++ b/packages/ag-charts-core/src/config/optionsDefaults.ts
@@ -359,6 +359,7 @@ export function selectionOptionsDef<T>(itemSelectionOptionsDef: T) {
         selectedItem: itemSelectionOptionsDef,
         unselectedItem: itemSelectionOptionsDef,
         unselectedSeries: itemSelectionOptionsDef,
+        clickModifier: undocumented(union('none', 'alt')),
     };
 }
 

--- a/packages/ag-charts-core/src/config/themeUtil.ts
+++ b/packages/ag-charts-core/src/config/themeUtil.ts
@@ -411,7 +411,10 @@ export const SINGLE_SERIES_HIGHLIGHT_STYLE: WithThemeParams<AgHighlightOptions<A
     },
 };
 
-export const SERIES_SELECTION_THEME: WithThemeParams<AgSelectionOptions<AgSelectionStyleOptions>> = {
+export type SelectionStyleOptionsWithUndocumented = AgSelectionOptions<AgSelectionStyleOptions> & {
+    clickModifier: 'none' | 'alt';
+};
+export const SERIES_SELECTION_THEME: WithThemeParams<SelectionStyleOptionsWithUndocumented> = {
     enabled: { $path: ['/selection/enabled', false] },
     containment: { $path: '/selection/containment' },
     selectedItem: {
@@ -423,6 +426,7 @@ export const SERIES_SELECTION_THEME: WithThemeParams<AgSelectionOptions<AgSelect
     unselectedSeries: {
         opacity: 0.2,
     },
+    clickModifier: 'none',
 };
 
 export const LEGEND_CONTAINER_THEME: any = {

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -217,7 +217,7 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const { type, clickedNode } = event;
         if (type !== 'click') return;
 
-        const clickModifier = clickedNode?.series.properties.selection.clickModifier ?? 'none';
+        const clickModifier = clickedNode?.series.properties.selection.clickModifier;
         const clickModifierPressed = hasClickSelectionModifier(event, clickModifier);
         const unionModifierPressed = hasAddToSelectionModifier(event);
         const clickMiss = clickedNode === undefined || (!clickedNode.series.isSelectionEnabled() satisfies boolean);

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.ts
@@ -29,6 +29,7 @@ import {
     type SelectionChanges,
     clearAllSelections,
     hasAddToSelectionModifier,
+    hasClickSelectionModifier,
     isAgSelectionItem,
     isUnknownIterable,
     rollbackChanges,
@@ -216,10 +217,12 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         const { type, clickedNode } = event;
         if (type !== 'click') return;
 
-        const modifierPressed = hasAddToSelectionModifier(event);
+        const clickModifier = clickedNode?.series.properties.selection.clickModifier ?? 'none';
+        const clickModifierPressed = hasClickSelectionModifier(event, clickModifier);
+        const unionModifierPressed = hasAddToSelectionModifier(event);
         const clickMiss = clickedNode === undefined || (!clickedNode.series.isSelectionEnabled() satisfies boolean);
 
-        if (clickMiss && (modifierPressed || !enableClickAwayToClear)) {
+        if (clickMiss && (unionModifierPressed || !enableClickAwayToClear)) {
             // Ctrl+Click only toggles selection; it shouldn't clear the selection.
             // Click-missing with enableClickAwayToClear:false should also do nothing.
             return;
@@ -230,9 +233,9 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
         if (clickMiss) {
             clearAllSelections(changes, this.service);
             internalRefreshTargets = this.ctx.chartService.series;
-        } else {
+        } else if (clickModifierPressed) {
             const { series, datumIndex } = clickedNode;
-            if (clickMode === 'multiple' || modifierPressed) {
+            if (clickMode === 'multiple' || unionModifierPressed) {
                 toggleSelection(changes, series, this.service, datumIndex);
                 internalRefreshTargets = [series];
             } else {
@@ -241,6 +244,11 @@ export class DataSelection extends AbstractModuleInstance implements _ModuleSupp
                 setSelected(changes, series, this.service, datumIndex);
                 internalRefreshTargets = this.ctx.chartService.series;
             }
+        } else {
+            // If clickMiss and clickModifierPressed are both false, then we should do nothing because the click event
+            // is being used for something else. This can happen in org-charts, for example, where you can click on a
+            // node to expand/collapse it.
+            return;
         }
         // AG-17445 Use `finally` to cleanup if the `selectionChange` user-callback throws an error
         try {

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
@@ -1,6 +1,6 @@
 import type { AgSelectionItemIds } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import { type AreExact } from 'ag-charts-core';
+import { type AreExact, type Nullable } from 'ag-charts-core';
 
 import type { DataSelectionChangeMap } from './dataSelectionChangeMap';
 import type { DataSetSelection } from './dataSetSelection';
@@ -15,7 +15,7 @@ type Group = _ModuleSupport.Group<unknown>;
 
 type ClickedNode = NonNullable<_ModuleSupport.SeriesAreaClickEvent['clickedNode']>;
 type DragWidgetEvent = _ModuleSupport.DragWidgetEvent;
-type ClickModifier = ClickedNode['series']['properties']['selection']['clickModifier'];
+type ClickModifier = ClickedNode['series']['properties']['selection']['clickModifier'] | undefined;
 
 type EventModifiers = {
     readonly altKey: boolean;
@@ -57,7 +57,7 @@ export function hasAddToSelectionModifier(event: WidgetEventModifiers): boolean 
 }
 
 export function hasClickSelectionModifier(event: WidgetEventModifiers, clickModifier: ClickModifier): boolean {
-    if (clickModifier === 'none') return true;
+    if (clickModifier === 'none' || clickModifier === undefined) return true;
     if (clickModifier === 'alt') return event.sourceEvent.altKey;
     return clickModifier satisfies never;
 }

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
@@ -15,6 +15,14 @@ type Group = _ModuleSupport.Group<unknown>;
 
 type ClickedNode = NonNullable<_ModuleSupport.SeriesAreaClickEvent['clickedNode']>;
 type DragWidgetEvent = _ModuleSupport.DragWidgetEvent;
+type ClickModifier = ClickedNode['series']['properties']['selection']['clickModifier'];
+
+type EventModifiers = {
+    readonly altKey: boolean;
+    readonly ctrlKey: boolean;
+    readonly metaKey: boolean;
+};
+type WidgetEventModifiers = { sourceEvent: EventModifiers };
 
 type Service = {
     clearSelection(): void;
@@ -44,8 +52,14 @@ export function toCanvasBBox(seriesRoot: Group, event1: DragWidgetEvent, event2:
     return _ModuleSupport.Transformable.toCanvas(seriesRoot, seriesBounds);
 }
 
-export function hasAddToSelectionModifier(event: { sourceEvent: { ctrlKey: boolean; metaKey: boolean } }): boolean {
+export function hasAddToSelectionModifier(event: WidgetEventModifiers): boolean {
     return event.sourceEvent.ctrlKey || event.sourceEvent.metaKey;
+}
+
+export function hasClickSelectionModifier(event: WidgetEventModifiers, clickModifier: ClickModifier): boolean {
+    if (clickModifier === 'none') return true;
+    if (clickModifier === 'alt') return event.sourceEvent.altKey;
+    return clickModifier satisfies never;
 }
 
 export function rollbackChanges(changes: SelectionChangesWithItems, service: Service): void {

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelectionUtil.ts
@@ -1,6 +1,6 @@
 import type { AgSelectionItemIds } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
-import { type AreExact, type Nullable } from 'ag-charts-core';
+import { type AreExact } from 'ag-charts-core';
 
 import type { DataSelectionChangeMap } from './dataSelectionChangeMap';
 import type { DataSetSelection } from './dataSetSelection';

--- a/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
@@ -11,6 +11,7 @@ import {
     Vertex,
 } from 'ag-charts-core';
 
+import { hasClickSelectionModifier } from '../../features/data-selection/dataSelectionUtil';
 import { NetworkGraph } from './networkGraph';
 import type { NetworkLayout, NetworkLayoutUpdateOptions } from './networkLayout';
 import { NetworkLinkNode } from './networkLinkNode';
@@ -155,8 +156,17 @@ export abstract class AbstractNetworkSeries<
         );
 
         this.cleanup.register(
-            ctx.eventsHub.on('series-area:click', ({ type, clickedNode, sourceEvent }) => {
-                if (type !== 'click' || clickedNode?.series !== this || clickedNode.itemId == null) return;
+            ctx.eventsHub.on('series-area:click', (event) => {
+                const { type, clickedNode, sourceEvent } = event;
+                const clickModifier = clickedNode?.series.properties.selection.clickModifier;
+                if (
+                    type !== 'click' ||
+                    clickedNode?.series !== this ||
+                    clickedNode.itemId == null ||
+                    hasClickSelectionModifier(event, clickModifier)
+                ) {
+                    return;
+                }
                 const point = {
                     x: 'layerX' in sourceEvent ? sourceEvent.layerX : Number.NaN,
                     y: 'layerY' in sourceEvent ? sourceEvent.layerY : Number.NaN,

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeriesTheme.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeriesTheme.ts
@@ -1,5 +1,5 @@
 import type { ExtensibleTheme } from 'ag-charts-community';
-import { BASE_FONT_SIZE, FONT_SIZE_RATIO } from 'ag-charts-core';
+import { BASE_FONT_SIZE, FONT_SIZE_RATIO, SERIES_SELECTION_THEME } from 'ag-charts-core';
 
 export const organizationSeriesTheme: ExtensibleTheme<'organization'> = {
     zoom: {
@@ -48,6 +48,10 @@ export const organizationSeriesTheme: ExtensibleTheme<'organization'> = {
                 strokeWidth: 2,
             },
         },
+        selection: {
+            ...SERIES_SELECTION_THEME,
+            clickModifier: 'alt',
+        } satisfies Partial<typeof SERIES_SELECTION_THEME> as Partial<typeof SERIES_SELECTION_THEME>,
         link: {
             interpolation: {
                 type: 'step',

--- a/packages/ag-charts-types/src/series/standalone/organizationOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/organizationOptions.ts
@@ -21,7 +21,7 @@ import type { AgBaseSeriesOptions, AgBaseSeriesThemeableOptions } from '../serie
 
 export interface AgOrganizationSeriesOptions<TDatum = DatumDefault, TContext = ContextDefault>
     extends
-        Omit<AgBaseSeriesOptions<TDatum, TContext>, 'selection'>,
+        AgBaseSeriesOptions<TDatum, TContext>,
         AgOrganizationSeriesOptionsKeys,
         AgOrganizationSeriesThemeableOptions<TDatum, TContext> {
     /** Configuration for the Organization Series. */
@@ -31,10 +31,10 @@ export interface AgOrganizationSeriesOptions<TDatum = DatumDefault, TContext = C
     node?: AgOrganizationSeriesOptionsNode<TDatum, TContext>;
 }
 
-export interface AgOrganizationSeriesThemeableOptions<TDatum = DatumDefault, TContext = ContextDefault> extends Omit<
-    AgBaseSeriesThemeableOptions<TDatum, TContext>,
-    'selection'
-> {
+export interface AgOrganizationSeriesThemeableOptions<
+    TDatum = DatumDefault,
+    TContext = ContextDefault,
+> extends AgBaseSeriesThemeableOptions<TDatum, TContext> {
     /**
      * Gap in pixels between sibling nodes (nodes that share the same parent).
      *


### PR DESCRIPTION
This defaults to 'none' on all series (no change), except for org-charts where is defaults to 'alt'.

This avoids a clash with the default "click to expand/collapse" action.