### PR TITLE
AG-3390 - Ignore ag-website-shared in watch

### DIFF
--- a/external/ag-shared/scripts/watch/chartsWatch.config.js
+++ b/external/ag-shared/scripts/watch/chartsWatch.config.js
@@ -1,5 +1,5 @@
 // Projects whose file changes are never processed by the watch loop.
-const IGNORED_PROJECTS = ['all', 'ag-charts-website'];
+const IGNORED_PROJECTS = ['all', 'ag-charts-website', 'ag-website-shared'];
 
 // Framework wrappers are only rebuilt when BUILD_FWS=1 (opt-in, slower).
 if ((process.env.BUILD_FWS ?? '0') !== '1') {


### PR DESCRIPTION
It gets managed automatically by vite's module graph, and including it leads to nx errors trying to build.

Needed in charts and not in grid because charts has a catchall watch task that fails for `ag-website-shared`: https://github.com/ag-grid/ag-charts/blob/691fd602b1008b4f1735e6bced8b226d12987de3/external/ag-shared/scripts/watch/chartsWatch.config.js#L55

Same as https://github.com/ag-grid/ag-studio/pull/1768