### PR TITLE
AG-17134 Externalise ImageCaption dark-mode script for the site CSP

### DIFF
--- a/external/ag-website-shared/src/components/imageCaption/ImageCaption.astro
+++ b/external/ag-website-shared/src/components/imageCaption/ImageCaption.astro
@@ -1,6 +1,7 @@
 ---
 import { getPageImages } from '@components/docs/utils/filesData';
 import { getPageNameFromPath } from '@components/docs/utils/urlPaths';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 import styles from './ImageCaption.module.scss';
 
@@ -71,29 +72,18 @@ const imageId = id ? id : `image-${imagePath}`;
     ]}
     style={style}
 >
-    <img id={imageId} src={imageSrc} class={styles.image} alt={alt} />
+    <img
+        id={imageId}
+        src={imageSrc}
+        class={styles.image}
+        alt={alt}
+        data-darkmode-img={enableDarkModeFilter ? undefined : ''}
+        data-light-src={enableDarkModeFilter ? undefined : imageSrc}
+        data-dark-src={enableDarkModeFilter ? undefined : darkModeImageSrc}
+    />
     <div class={styles.body}>
         <slot />
     </div>
 </div>
 
-<script
-    define:vars={{
-        imageId,
-        imageSrc,
-        darkModeImageSrc,
-        skip: enableDarkModeFilter,
-    }}
->
-    if (skip) {
-        return;
-    }
-    const image = document.getElementById(imageId);
-    globalThis.addDarkmodeOnChange((darkMode) => {
-        if (darkModeImageSrc && darkMode) {
-            image.src = darkModeImageSrc;
-        } else {
-            image.src = imageSrc;
-        }
-    });
-</script>
+<script is:inline src={urlWithBaseUrl('/scripts/image-caption-darkmode.js')}></script>

--- a/packages/ag-charts-website/public/scripts/image-caption-darkmode.js
+++ b/packages/ag-charts-website/public/scripts/image-caption-darkmode.js
@@ -1,0 +1,41 @@
+/*
+ * Dark-mode image swapping for <ImageCaption>. Externalised from a per-instance
+ * inline `define:vars` script so the site Content-Security-Policy can drop
+ * script-src 'unsafe-inline'. Each image's light/dark sources arrive via data-
+ * attributes, so this file is static and served from 'self'. Loaded once per page
+ * (guarded), it wires up every ImageCaption image.
+ */
+(function () {
+    if (window.__agImageCaptionDarkModeInit) {
+        return;
+    }
+    window.__agImageCaptionDarkModeInit = true;
+
+    function init() {
+        var onChange = window.addDarkmodeOnChange;
+        if (!onChange) {
+            return;
+        }
+        var images = document.querySelectorAll('img[data-darkmode-img]');
+        for (var i = 0, len = images.length; i < len; ++i) {
+            wireImage(onChange, images[i]);
+        }
+    }
+
+    function wireImage(onChange, image) {
+        var lightSrc = image.dataset.lightSrc;
+        var darkSrc = image.dataset.darkSrc;
+        if (!lightSrc) {
+            return;
+        }
+        onChange(function (darkMode) {
+            image.src = darkSrc && darkMode ? darkSrc : lightSrc;
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## What

Externalises the `ImageCaption` dark-mode image-swap from a per-instance inline `<script define:vars>` to a `'self'`-served `public/scripts/image-caption-darkmode.js`, with each image's light/dark sources passed via `data-` attributes.

## Why

The site CSP no longer allows `script-src 'unsafe-inline'` (AG-17134, #7123). The inline `define:vars` script was therefore blocked on every page using `ImageCaption` (e.g. the `*/themes/` pages), surfacing as an enforced-CSP violation on staging:

```
Executing inline script violates ... script-src ... a hash ('sha256-ZehXxHICMssRgf4yLx3m3kgm+uSVrjzRTRse2sgcsRY=') ... is required ...
```

The script embeds a build-hashed image path, so a static SHA-256 hash would be unstable — externalising is the correct fix (matches the existing `gtm-init.js` / `homepage-gallery.js` pattern).

This is a shared-component sync gap: **ag-grid and ag-studio already externalised this component** and ship `image-caption-darkmode.js`. Charts' vendored `ag-website-shared` copy was stale and never shipped the script. This change makes charts byte-identical to the grid/studio canonical.

## Verification

- Rebuilt the site: the blocked `sha256-ZehX…` inline script no longer appears in any page (0 matches).
- `/charts/scripts/image-caption-darkmode.js` is referenced on the themes pages and shipped to `dist`.
- `data-darkmode-img` / `data-light-src` render on `ImageCaption` images; dark-mode swapping behaviour is preserved (images with no dark variant remain a no-op, as before).
- `ImageCaption.astro` and the JS file are byte-identical to the ag-grid / ag-studio versions.

## Notes

- No runtime/behaviour change for users — purely moves an inline script to a `'self'` file.
- Worth porting back: any other site (or future component) carrying inline `define:vars` scripts will hit the same wall once `'unsafe-inline'` is dropped.