### PR TITLE
ci(pr-review): default ag-charts PR review to the claude driver

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,6 +24,17 @@ on:
                 description: 'PR number to review'
                 type: string
                 required: true
+            driver:
+                description: 'Review engine. codex = current single-turn Codex review (default). claude = Claude Code orchestrates a chunked Codex review — same standard pass, split across per-turn-safe chunks (survives large PRs that exceed Codex per-turn input limits).'
+                type: choice
+                options: [codex, claude]
+                default: codex
+                required: false
+            quiet:
+                description: 'Quiet/soak mode: post nothing to the PR; upload the review as an artifact (pr-review-<driver>-<pr#>) instead. Use to compare drivers without touching the PR.'
+                type: boolean
+                default: false
+                required: false
 
 permissions:
     contents: read
@@ -109,3 +120,9 @@ jobs:
                   github-token: ${{ github.token }}
                   inline-comments: 'true'
                   dev-prompts-version: ${{ env.DEV_PROMPTS_CHANNEL }}
+                  # Driver/quiet only come from a deliberate workflow_dispatch (or a
+                  # /pr-review --claude comment); pull_request / issue_comment supply
+                  # neither, so they fall through to the unchanged codex + comment flow.
+                  driver: ${{ inputs.driver || 'codex' }}
+                  quiet: ${{ inputs.quiet || 'false' }}
+                  anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -25,10 +25,10 @@ on:
                 type: string
                 required: true
             driver:
-                description: 'Review engine. codex = current single-turn Codex review (default). claude = Claude Code orchestrates a chunked Codex review — same standard pass, split across per-turn-safe chunks (survives large PRs that exceed Codex per-turn input limits).'
+                description: 'Review engine. claude (default) = Claude Code orchestrates a chunked Codex review — same standard pass, split across per-turn-safe chunks (survives large PRs that exceed Codex per-turn input limits). codex = legacy single-turn Codex review (can fail on large PRs that exceed the per-turn input limit).'
                 type: choice
-                options: [codex, claude]
-                default: codex
+                options: [claude, codex]
+                default: claude
                 required: false
             quiet:
                 description: 'Quiet/soak mode: post nothing to the PR; upload the review as an artifact (pr-review-<driver>-<pr#>) instead. Use to compare drivers without touching the PR.'
@@ -120,9 +120,10 @@ jobs:
                   github-token: ${{ github.token }}
                   inline-comments: 'true'
                   dev-prompts-version: ${{ env.DEV_PROMPTS_CHANNEL }}
-                  # Driver/quiet only come from a deliberate workflow_dispatch (or a
-                  # /pr-review --claude comment); pull_request / issue_comment supply
-                  # neither, so they fall through to the unchanged codex + comment flow.
-                  driver: ${{ inputs.driver || 'codex' }}
+                  # claude is the default driver. pull_request / plain /pr-review supply
+                  # no driver input, so they fall through to the `|| 'claude'` default.
+                  # To force codex on a one-off, dispatch with driver=codex. quiet stays
+                  # false → claude reviews post to the PR as normal.
+                  driver: ${{ inputs.driver || 'claude' }}
                   quiet: ${{ inputs.quiet || 'false' }}
                   anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## What

Switches ag-charts' PR Review to the **`claude`** driver **by default**, and adds the `driver` / `quiet` `workflow_dispatch` inputs so codex stays selectable and drivers can be compared.

- `workflow_dispatch.inputs.driver` — `claude` | `codex`, **default `claude`**.
- Step fallback `driver: ${{ inputs.driver || 'claude' }}` — governs automatic `pull_request` reviews and plain `/pr-review` comments, so **they now use claude too**.
- `quiet` input (default `false`) + `anthropic-api-key` forwarded to the action. Claude reviews post to the PR as normal (quiet stays off).

Net diff: `.github/workflows/pr-review.yml` only.

## Why

`ag-dev-prompts` ships a `driver: claude` path: Claude reads the diff, splits it into per-turn-safe **chunks**, and runs the **same single standard Codex review pass** over each, then merges. It fixes the recurring Codex **input-size failures on large PRs** — the whole diff no longer has to fit one `codex exec` turn. It is *not* the noisy multi-pass fan-out (that was removed); an A/B in `ag-dev-prompts` showed the two drivers now agree on verdicts with broadly-equivalent findings.

## Behaviour

| Trigger | Driver |
|---|---|
| `pull_request` (auto) | **claude** |
| `/pr-review` comment | **claude** |
| `/pr-review --claude` | claude |
| `workflow_dispatch` (no selection) | claude |
| `workflow_dispatch` `driver=codex` | codex (one-off escape hatch) |
| any of the above + `quiet=true` | posts nothing; uploads `pr-review-<driver>-<pr#>` artifact |

**Codex is still the reviewer on both drivers** (findings keep the `<!-- codex-pr-review -->` marker, so the review-in-the-loop gate is unaffected). `ANTHROPIC_API_KEY` is already an org secret available to ag-charts.

## Worth knowing before merge

- **This makes claude the live path for every ag-charts review**, ahead of a long soak. The chunked single-pass behaviour is verified in `ag-dev-prompts`' dogfood, but the **multi-chunk split itself hasn't been exercised on a real >1 MiB PR** yet (no dogfood PR was big enough) — ag-charts is where that finally gets tested, on live reviews.
- **No automatic codex fallback:** if the claude path errors (e.g. an Anthropic API hiccup), the action's verify step goes red and that PR gets no posted review, rather than silently falling back to codex. Force codex on a one-off with `gh workflow run pr-review.yml -f pr_number=<PR> -f driver=codex`. I can add an automatic codex fallback to the action if you'd prefer that safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)