### PR TITLE
AG-17263 [CLAUDE] Enrich Series.pickNodes() to expose the picked scene-node

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -969,7 +969,7 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         return result;
     }
 
-    protected pickNodeDataExactShape(point: Point): SeriesNodeDatum[] | undefined {
+    protected pickNodeDataExactShape(point: Point): SeriesNodePickMatch[] | undefined {
         const { x, y } = point;
 
         const { dataNodeGroup } = this;
@@ -979,22 +979,21 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         });
 
         if (matches.length !== 0) {
-            const datums = matches.map((match) => match.datum);
-            return datums;
+            return matches.map((match) => ({ datum: match.datum, distance: 0, target: match }));
         }
     }
 
-    protected pickModulesExactShape(point: Point): SeriesNodeDatum[] | undefined {
+    protected pickModulesExactShape(point: Point): SeriesNodePickMatch[] | undefined {
         for (const mod of this.moduleMap.modules()) {
             const { unsafeDatum } = mod.pickNodeExact(point) ?? {};
             if (unsafeDatum == null) continue;
             if (unsafeDatum?.missing === true) continue;
 
-            return [unsafeDatum];
+            return [{ datum: unsafeDatum, distance: 0, target: this.contentGroup }];
         }
     }
 
-    protected override pickNodesExactShape(point: Point): SeriesNodeDatum[] {
+    protected override pickNodesExactShape(point: Point): SeriesNodePickMatch[] {
         const result = super.pickNodesExactShape(point);
 
         if (result.length !== 0) {
@@ -1078,7 +1077,7 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         }
 
         if (closestDatum) {
-            return { datum: closestDatum, distance: minDistance };
+            return { datum: closestDatum, distance: minDistance, target: this.contentGroup };
         }
     }
 
@@ -1159,6 +1158,7 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
             return {
                 datum: closestDatum!,
                 distance: Math.sqrt(closestDistanceSquared),
+                target: this.contentGroup,
             };
         }
     }

--- a/packages/ag-charts-community/src/chart/series/cartesian/quadtreeUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/quadtreeUtil.ts
@@ -35,7 +35,7 @@ export function findQuadtreeMatch<TDatum extends SeriesNodeDatum>(
     const { x, y } = point;
     const { nearest, distanceSquared } = series.getQuadTree().find(x, y);
     if (nearest !== undefined) {
-        return { datum: nearest.value, distance: Math.sqrt(distanceSquared) };
+        return { datum: nearest.value, distance: Math.sqrt(distanceSquared), target: series.contentGroup };
     }
 
     return undefined;

--- a/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/dataModelSeries.ts
@@ -9,7 +9,13 @@ import type { DataController } from '../data/dataController';
 import type { DataModel, DataModelOptions, ProcessedData } from '../data/dataModel';
 import type { PropertyDefinition } from '../data/dataModelTypes';
 import { DataSet } from '../data/dataSet';
-import type { PickFocusInputs, PickFocusOutputs, SeriesConstructorOpts, SeriesNodeDataContext } from './series';
+import type {
+    PickFocusInputs,
+    PickFocusOutputs,
+    SeriesConstructorOpts,
+    SeriesNodeDataContext,
+    SeriesNodePickMatch,
+} from './series';
 import { Series } from './series';
 import type { SeriesProperties } from './seriesProperties';
 import { type SeriesNodeDatum } from './seriesTypes';
@@ -155,10 +161,10 @@ export abstract class DataModelSeries<
         }
     }
 
-    protected override pickNodesExactShape(point: Point): SeriesNodeDatum[] {
-        const datums = super.pickNodesExactShape(point) as DataModelSeriesNodeDatum[];
-        datums.sort((a, b) => a.datumIndex - b.datumIndex);
-        return datums;
+    protected override pickNodesExactShape(point: Point): SeriesNodePickMatch[] {
+        const matches = super.pickNodesExactShape(point);
+        matches.sort((a, b) => a.datum.datumIndex - b.datum.datumIndex);
+        return matches;
     }
 
     protected isDatumEnabled(nodeData: TDatum[], datumIndex: number): boolean {

--- a/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/pieUtil.ts
@@ -147,6 +147,7 @@ type SectorSceneNode = SectorVariables & { readonly datum: any };
 type SectorSeries = {
     centerX: number;
     centerY: number;
+    contentGroup: Group;
     getItemNodes(): SectorSceneNode[];
 };
 
@@ -166,7 +167,7 @@ export function pickByMatchingAngle(series: SectorSeries, point: Point): SeriesN
             } else if (radius > sector.outerRadius) {
                 distance = radius - sector.outerRadius;
             }
-            return { datum: sector.datum, distance };
+            return { datum: sector.datum, distance, target: series.contentGroup };
         }
     }
     return undefined;

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -117,6 +117,12 @@ export type SeriesNodePickIntent = 'tooltip' | 'highlight' | 'highlight-tooltip'
 export type SeriesNodePickMatch = {
     datum: SeriesNodeDatum;
     distance: number;
+    /**
+     * The scene-node hit under the pointer, as accurate as possible. Exact-shape and
+     * nearest-object picks report the matched leaf; modes that match on datum geometry (e.g.
+     * "closest") cannot resolve the leaf efficiently and fall back to the series `contentGroup`.
+     */
+    target: Node<unknown>;
 };
 
 export type PickFocusInputs = {
@@ -146,8 +152,7 @@ export type PickFocusOutputs = {
 
 export type PickResult = {
     pickMode: SeriesNodePickMode;
-    datums: SeriesNodeDatum[];
-    distance: number;
+    picks: SeriesNodePickMatch[];
 };
 
 export type PickNodesInBBoxPredicate = (selectionBox: BoxBounds, node: Node<unknown>) => boolean;
@@ -1044,12 +1049,12 @@ export abstract class Series<
         }
 
         for (const pickMode of selectedPickModes) {
-            let result: { datums: SeriesNodeDatum[]; distance: number } | undefined;
+            let picks: SeriesNodePickMatch[] | undefined;
 
             switch (pickMode) {
                 case SeriesNodePickMode.EXACT_SHAPE_MATCH: {
                     const exact = this.pickNodesExactShape(point);
-                    result = exact.length === 0 ? undefined : { datums: exact, distance: 0 };
+                    if (exact.length !== 0) picks = exact;
                     break;
                 }
 
@@ -1057,11 +1062,9 @@ export abstract class Series<
                     const closest = this.pickNodeClosestDatum(point);
                     const exact = closest?.distance === 0 ? this.pickNodesExactShape(point) : undefined;
                     if (exact != null && exact.length !== 0) {
-                        result = { datums: exact, distance: 0 };
+                        picks = exact;
                     } else if (closest) {
-                        result = { datums: [closest.datum], distance: closest.distance };
-                    } else {
-                        result = undefined;
+                        picks = [closest];
                     }
                     break;
                 }
@@ -1071,28 +1074,28 @@ export abstract class Series<
                         pickModeAxis == null
                             ? undefined
                             : this.pickNodeMainAxisFirst(point, pickModeAxis === 'main-category');
-                    result = closest == null ? undefined : { datums: [closest.datum], distance: closest.distance };
+                    if (closest != null) picks = [closest];
                     break;
                 }
             }
 
-            if (result && result.distance <= maxDistance) {
-                return this._pickNodeCache.set(key, { pickMode, datums: result.datums, distance: result.distance });
+            if (picks && picks[0].distance <= maxDistance) {
+                return this._pickNodeCache.set(key, { pickMode, picks });
             }
         }
 
         return this._pickNodeCache.set(key, undefined);
     }
 
-    protected pickNodesExactShape(point: Point): SeriesNodeDatum[] {
-        const datums: SeriesNodeDatum[] = [];
+    protected pickNodesExactShape(point: Point): SeriesNodePickMatch[] {
+        const picks: SeriesNodePickMatch[] = [];
         for (const node of this.contentGroup.pickNodes(point.x, point.y)) {
             const datum = node.unsafeClosestDatum();
             if (typeof datum === 'object' && datum != null && datum.missing !== true) {
-                datums.push(datum);
+                picks.push({ datum, distance: 0, target: node });
             }
         }
-        return datums;
+        return picks;
     }
 
     protected pickNodeClosestDatum(_point: Point): SeriesNodePickMatch | undefined {
@@ -1105,10 +1108,10 @@ export abstract class Series<
         point: Point,
         items: Iterable<T>
     ): SeriesNodePickMatch | undefined {
-        const match = nearestSquared(point.x, point.y, items);
-        const datum = match.nearest?.unsafeClosestDatum();
-        if (typeof datum === 'object' && datum != null && datum.missing !== true) {
-            return { datum, distance: Math.sqrt(match.distanceSquared) };
+        const { nearest, distanceSquared } = nearestSquared(point.x, point.y, items);
+        const datum = nearest?.unsafeClosestDatum();
+        if (nearest != null && typeof datum === 'object' && datum != null && datum.missing !== true) {
+            return { datum, distance: Math.sqrt(distanceSquared), target: nearest };
         }
     }
 

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1448,10 +1448,10 @@ export class SeriesAreaManager extends BaseManager {
             }
 
             const pick = series.pickNodes(point, intent, exactMatchOnly);
-            if (pick == null || pick.datums.length === 0) continue;
+            if (pick == null || pick.picks.length === 0) continue;
 
-            const { datums, distance } = pick;
-            if (pick.datums.length === 0) continue;
+            const { picks } = pick;
+            const distance = picks[0].distance;
 
             if (distance === 0) {
                 // Accumulate multiple series when the nodes are under the cursor
@@ -1460,12 +1460,12 @@ export class SeriesAreaManager extends BaseManager {
                     result = { matches: [], distance: 0 };
                 }
 
-                for (const datum of datums) {
+                for (const { datum } of picks) {
                     result.matches.push(datum);
                 }
             } else if (result == null || result.distance > distance) {
                 // Don't accumulate multiple datums when matching by nearest distance
-                result = { matches: datums, distance };
+                result = { matches: picks.map((p) => p.datum), distance };
             }
         }
 

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -695,12 +695,14 @@ export abstract class FlowProportionSeries<
     override pickNodeClosestDatum({ x, y }: Point): _ModuleSupport.SeriesNodePickMatch | undefined {
         let minDistanceSquared = Infinity;
         let minDatum: _ModuleSupport.SeriesNodeDatum | undefined;
+        let minNode: _ModuleSupport.Node<unknown> | undefined;
 
         this.linkSelection.each((node, datum) => {
             const distanceSquared = node.distanceSquared(x, y);
             if (distanceSquared < minDistanceSquared) {
                 minDistanceSquared = distanceSquared;
                 minDatum = datum;
+                minNode = node;
             }
         });
         this.nodeSelection.each((node, datum) => {
@@ -708,10 +710,13 @@ export abstract class FlowProportionSeries<
             if (distanceSquared < minDistanceSquared) {
                 minDistanceSquared = distanceSquared;
                 minDatum = datum;
+                minNode = node;
             }
         });
 
-        return minDatum == null ? undefined : { datum: minDatum, distance: Math.sqrt(minDistanceSquared) };
+        return minDatum == null || minNode == null
+            ? undefined
+            : { datum: minDatum, distance: Math.sqrt(minDistanceSquared), target: minNode };
     }
 
     getDatumAriaText(datum: TDatum<TNodeDatum, TLinkDatum>, description: string) {

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -928,9 +928,9 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
         addHitTestersToQuadtree(quadtree, this.datumNodesIter());
     }
 
-    protected override pickNodesExactShape(point: Point): _ModuleSupport.SeriesNodeDatum[] {
+    protected override pickNodesExactShape(point: Point): _ModuleSupport.SeriesNodePickMatch[] {
         const item = findQuadtreeMatch(this, point);
-        return item != null && item.distance <= 0 ? [item.datum] : [];
+        return item != null && item.distance <= 0 ? [item] : [];
     }
 
     protected override pickNodeClosestDatum(point: Point): _ModuleSupport.SeriesNodePickMatch | undefined {

--- a/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-line/mapLineSeries.ts
@@ -666,16 +666,20 @@ export class MapLineSeries
     override pickNodeClosestDatum({ x, y }: Point): _ModuleSupport.SeriesNodePickMatch | undefined {
         let minDistanceSquared = Infinity;
         let minDatum: _ModuleSupport.SeriesNodeDatum | undefined;
+        let minNode: _ModuleSupport.Node<unknown> | undefined;
 
         this.datumSelection.each((node, datum) => {
             const distanceSquared = node.distanceSquared(x, y);
             if (distanceSquared < minDistanceSquared) {
                 minDistanceSquared = distanceSquared;
                 minDatum = datum;
+                minNode = node;
             }
         });
 
-        return minDatum == null ? undefined : { datum: minDatum, distance: Math.sqrt(minDistanceSquared) };
+        return minDatum == null || minNode == null
+            ? undefined
+            : { datum: minDatum, distance: Math.sqrt(minDistanceSquared), target: minNode };
     }
 
     private _previousDatumMidPoint: { datum: _ModuleSupport.SeriesNodeDatum; point: Point | undefined } | undefined =

--- a/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-marker/mapMarkerSeries.ts
@@ -952,7 +952,9 @@ export class MapMarkerSeries
             }
         }
 
-        return minDatum == null ? undefined : { datum: minDatum, distance: Math.sqrt(minDistanceSquared) };
+        return minDatum == null
+            ? undefined
+            : { datum: minDatum, distance: Math.sqrt(minDistanceSquared), target: this.contentGroup };
     }
 
     private legendItemSymbol(datumIndex?: number): _ModuleSupport.LegendSymbolOptions {

--- a/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/map-shape/mapShapeSeries.ts
@@ -728,16 +728,20 @@ export class MapShapeSeries
     override pickNodeClosestDatum({ x, y }: Point): _ModuleSupport.SeriesNodePickMatch | undefined {
         let minDistanceSquared = Infinity;
         let minDatum: _ModuleSupport.SeriesNodeDatum | undefined;
+        let minNode: _ModuleSupport.Node<unknown> | undefined;
 
         this.datumSelection.each((node, datum) => {
             const distanceSquared = node.distanceSquared(x, y);
             if (distanceSquared < minDistanceSquared) {
                 minDistanceSquared = distanceSquared;
                 minDatum = datum;
+                minNode = node;
             }
         });
 
-        return minDatum == null ? undefined : { datum: minDatum, distance: Math.sqrt(minDistanceSquared) };
+        return minDatum == null || minNode == null
+            ? undefined
+            : { datum: minDatum, distance: Math.sqrt(minDistanceSquared), target: minNode };
     }
 
     private _previousDatumMidPoint: { datum: _ModuleSupport.SeriesNodeDatum; point: Point | undefined } | undefined =

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -740,16 +740,20 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
     override pickNodeClosestDatum({ x, y }: Point): _ModuleSupport.SeriesNodePickMatch | undefined {
         let minDistanceSquared = Infinity;
         let minDatum: _ModuleSupport.SeriesNodeDatum | undefined;
+        let minNode: _ModuleSupport.Node<unknown> | undefined;
 
         this.datumSelection.each((node, datum) => {
             const distanceSquared = node.distanceSquared(x, y);
             if (distanceSquared < minDistanceSquared) {
                 minDistanceSquared = distanceSquared;
                 minDatum = datum;
+                minNode = node;
             }
         });
 
-        return minDatum == null ? undefined : { datum: minDatum, distance: Math.sqrt(minDistanceSquared) };
+        return minDatum == null || minNode == null
+            ? undefined
+            : { datum: minDatum, distance: Math.sqrt(minDistanceSquared), target: minNode };
     }
 
     private legendItemSymbol(datumIndex: number) {

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -698,7 +698,7 @@ export abstract class RadarSeries<
 
         if (closestDatum) {
             const distance = Math.max(minDistance - (closestDatum.point?.size ?? 0) / 2, 0);
-            return { datum: closestDatum, distance };
+            return { datum: closestDatum, distance, target: this.contentGroup };
         }
     }
 

--- a/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/treemap/treemapSeries.ts
@@ -895,16 +895,16 @@ export class TreemapSeries extends _ModuleSupport.HierarchySeries<
         return true;
     }
 
-    override pickNodesExactShape(point: Point): TreemapNode[] {
-        const nodes = super.pickNodesExactShape(point) as TreemapNode[];
-        nodes.sort((a, b) => b.path.length - a.path.length);
-        return nodes;
+    override pickNodesExactShape(point: Point): _ModuleSupport.SeriesNodePickMatch[] {
+        const matches = super.pickNodesExactShape(point);
+        matches.sort((a, b) => (b.datum as TreemapNode).path.length - (a.datum as TreemapNode).path.length);
+        return matches;
     }
 
     protected override pickNodeClosestDatum(point: Point): _ModuleSupport.SeriesNodePickMatch | undefined {
         const exactMatch = this.pickNodesExactShape(point);
         if (exactMatch.length !== 0) {
-            return { datum: exactMatch[0], distance: 0 };
+            return exactMatch[0];
         }
 
         // We don't need to recurse on the tree because the root's nodes bounding-box contain all bounding boxes


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17263

Hit-testing already resolves the exact scene-node under the pointer, but pickNodes() discarded it and returned only node-data. Because the org-chart card and expander share one datum, the click handler cannot tell them apart.

This enriches the pick result so the scene-node is carried through, without changing any behaviour. Phase 2 will use Node.tag on the exposed node to make the expander the sole expand/collapse target.

- Add `target: Node<unknown>` to `SeriesNodePickMatch`; the field is as accurate as possible, falling back to the series `contentGroup` for hit-test modes (e.g. "closest") that match on datum geometry and cannot resolve the leaf efficiently.
- Replace `PickResult.datums`/`distance` with `picks: SeriesNodePickMatch[]`.
- `pickNodesExactShape()` now returns matches carrying the hit node.
- Populate `target` with the real leaf where it is already in hand: base exact-shape, `pickNodeNearestDistantObject`, cartesian data exact-shape, and the pyramid/map-shape/map-line/flow-proportion node-selection picks. Gauges, sunburst and radial series inherit this via the helpers they delegate to.
- Update the only `PickResult` consumer (the seriesAreaManager aggregator) and the treemap (`path.length`) and dataModel (`datumIndex`) exact-shape sorts to the new shape.