### PR TITLE
AG-17355 remove Bryntum Gantt link from docs nav

### DIFF
--- a/packages/ag-charts-website/src/content/docs-nav/nav.json
+++ b/packages/ag-charts-website/src/content/docs-nav/nav.json
@@ -428,17 +428,6 @@
                 },
                 {
                     "type": "group",
-                    "title": "Gantt Charts",
-                    "children": [
-                        {
-                            "type": "item",
-                            "title": "See Bryntum Gantt",
-                            "url": "https://www.ag-grid.com/campaigns/bryntum-gantt"
-                        }
-                    ]
-                },
-                {
-                    "type": "group",
                     "title": "Maps",
                     "isEnterprise": true,
                     "isPricingFeature": true,


### PR DESCRIPTION
Removes the "Gantt Charts" nav group (single external "See Bryntum Gantt" campaign link) added in #7194.

- File: `packages/ag-charts-website/src/content/docs-nav/nav.json`
- The group contained only an outbound link to `ag-grid.com/campaigns/bryntum-gantt` — no chart-type page.

Reverts the nav addition only.