### PR TITLE
AG-17660 allow narrowing PR benchmarks to specific examples

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -178,10 +178,22 @@ jobs:
                     echo 'build-matrix=[{"role":"head","port":4601},{"role":"base","port":4602}]' >> $GITHUB_OUTPUT
                   fi
 
+            # A `/benchmarks [name...]` PR comment narrows the run to the named
+            # examples; a bare `/benchmarks` (or any non-comment trigger) shards the
+            # full set. The comment body is read from env — never interpolated into
+            # the script — so untrusted comment text cannot inject shell. An unknown
+            # example name fails benchmark-examples.js, so a typo fails loudly here.
             - name: Compute shard matrix
               id: shards
+              env:
+                  COMMENT_BODY: ${{ github.event.comment.body }}
               run: |
-                  shards=$(node ./tools/benchmark/benchmark-examples.js --shards "$AG_SHARD_COUNT")
+                  examples=""
+                  if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+                    first_line=${COMMENT_BODY%%$'\n'*}
+                    examples=${first_line#/benchmarks}
+                  fi
+                  shards=$(node ./tools/benchmark/benchmark-examples.js --shards "$AG_SHARD_COUNT" --examples "${examples}")
                   echo "shards=${shards}" >> $GITHUB_OUTPUT
                   echo "Shard matrix: ${shards}"
 

--- a/tools/benchmark/benchmark-examples.js
+++ b/tools/benchmark/benchmark-examples.js
@@ -9,8 +9,14 @@
  * dependencies so CI can invoke it before `yarn install`.
  *
  * CLI usage:
- *   node benchmark-examples.js                # list runnable examples, one per line
- *   node benchmark-examples.js --shards 4     # JSON array of comma-separated example lists
+ *   node benchmark-examples.js                            # list runnable examples, one per line
+ *   node benchmark-examples.js --shards 4                 # JSON array of comma-separated example lists
+ *   node benchmark-examples.js --shards 4 --examples a,b  # shard only the named examples
+ *
+ * The --examples value accepts names separated by commas and/or whitespace, so
+ * the `/benchmarks [name...]` PR comment body can be forwarded verbatim. Unknown
+ * names are rejected (see resolveExamples) so a typo fails the run loudly rather
+ * than silently benchmarking the wrong subset.
  */
 
 const fs = require('node:fs');
@@ -32,31 +38,71 @@ function discoverExamples() {
         .sort();
 }
 
+/** Split an --examples value (or `/benchmarks` comment remainder) into example names. */
+function parseExamplesArg(value) {
+    return value.split(/[\s,]+/).filter(Boolean);
+}
+
+/**
+ * Resolve a requested subset of example names against the runnable set.
+ *
+ * An empty request resolves to every runnable example — the default
+ * `/benchmarks` behaviour. Naming a subset narrows the run to those examples,
+ * preserving discovery (sorted) order. Unknown names throw, so a mistyped
+ * `/benchmarks <name>` comment fails the run rather than silently producing an
+ * empty or partial comparison.
+ */
+function resolveExamples(requested = []) {
+    const available = discoverExamples();
+    const names = requested.map((name) => name.trim()).filter(Boolean);
+    if (names.length === 0) {
+        return available;
+    }
+    const requestedSet = new Set(names);
+    const unknown = [...requestedSet].filter((name) => !available.includes(name));
+    if (unknown.length > 0) {
+        throw new Error(`Unknown benchmark example(s): ${unknown.join(', ')}\nAvailable: ${available.join(', ')}`);
+    }
+    return available.filter((name) => requestedSet.has(name));
+}
+
 /**
  * Partition examples into shards round-robin over the sorted names. Heavy
  * example families share a common prefix (high-freq-*, high-perf-*, axes-1M-*,
  * data-selection-zoom-*), so round-robin spreads each family evenly across
  * shards.
+ *
+ * `requested` narrows the input set to the named examples (see resolveExamples);
+ * an empty request shards every runnable example.
  */
-function shardExamples(shardCount) {
-    const names = discoverExamples();
+function shardExamples(shardCount, requested = []) {
+    const names = resolveExamples(requested);
     const shards = Array.from({ length: shardCount }, () => []);
     names.forEach((name, i) => shards[i % shardCount].push(name));
     return shards.filter((shard) => shard.length > 0);
 }
 
-module.exports = { discoverExamples, shardExamples, EXCLUDED_EXAMPLES };
+module.exports = { discoverExamples, parseExamplesArg, resolveExamples, shardExamples, EXCLUDED_EXAMPLES };
 
 if (require.main === module) {
-    const shardsArgIndex = process.argv.indexOf('--shards');
-    if (shardsArgIndex !== -1) {
-        const shardCount = Number(process.argv[shardsArgIndex + 1]);
-        if (!Number.isInteger(shardCount) || shardCount < 1) {
-            console.error('Usage: benchmark-examples.js [--shards <count>]');
-            process.exit(1);
+    const { argv } = process;
+    const examplesArgIndex = argv.indexOf('--examples');
+    const requested = examplesArgIndex !== -1 ? parseExamplesArg(argv[examplesArgIndex + 1] ?? '') : [];
+
+    const shardsArgIndex = argv.indexOf('--shards');
+    try {
+        if (shardsArgIndex !== -1) {
+            const shardCount = Number(argv[shardsArgIndex + 1]);
+            if (!Number.isInteger(shardCount) || shardCount < 1) {
+                console.error('Usage: benchmark-examples.js [--shards <count>] [--examples <names>]');
+                process.exit(1);
+            }
+            console.log(JSON.stringify(shardExamples(shardCount, requested).map((shard) => shard.join(','))));
+        } else {
+            console.log(resolveExamples(requested).join('\n'));
         }
-        console.log(JSON.stringify(shardExamples(shardCount).map((shard) => shard.join(','))));
-    } else {
-        console.log(discoverExamples().join('\n'));
+    } catch (e) {
+        console.error(e.message);
+        process.exit(1);
     }
 }

--- a/tools/benchmark/benchmark-examples.js
+++ b/tools/benchmark/benchmark-examples.js
@@ -39,7 +39,7 @@ function discoverExamples() {
 }
 
 /** Split an --examples value (or `/benchmarks` comment remainder) into example names. */
-function parseExamplesArg(value) {
+function parseExamplesArg(value = '') {
     return value.split(/[\s,]+/).filter(Boolean);
 }
 

--- a/tools/benchmark/benchmark-examples.test.js
+++ b/tools/benchmark/benchmark-examples.test.js
@@ -1,0 +1,32 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { discoverExamples, parseExamplesArg, resolveExamples, shardExamples } = require('./benchmark-examples');
+
+test('parseExamplesArg splits on commas and/or whitespace and drops empties', () => {
+    assert.deepEqual(parseExamplesArg('a,b'), ['a', 'b']);
+    assert.deepEqual(parseExamplesArg('a b'), ['a', 'b']);
+    assert.deepEqual(parseExamplesArg('  a , b ,, c '), ['a', 'b', 'c']);
+    assert.deepEqual(parseExamplesArg(''), []);
+});
+
+test('resolveExamples with no request returns every runnable example', () => {
+    assert.deepEqual(resolveExamples([]), discoverExamples());
+});
+
+test('resolveExamples narrows to the requested names in discovery order', () => {
+    const all = discoverExamples();
+    assert.ok(all.length >= 2, 'expected at least two runnable examples to exercise narrowing');
+    const [first, second] = all;
+    // Request out of order to prove the result is re-sorted into discovery order.
+    assert.deepEqual(resolveExamples([second, first]), [first, second]);
+});
+
+test('resolveExamples rejects unknown example names', () => {
+    assert.throws(() => resolveExamples(['__definitely-not-an-example__']), /Unknown benchmark example/);
+});
+
+test('shardExamples narrows the input set before sharding', () => {
+    const [first] = discoverExamples();
+    assert.deepEqual(shardExamples(5, [first]), [[first]]);
+});

--- a/tools/benchmark/benchmark-examples.test.js
+++ b/tools/benchmark/benchmark-examples.test.js
@@ -8,6 +8,9 @@ test('parseExamplesArg splits on commas and/or whitespace and drops empties', ()
     assert.deepEqual(parseExamplesArg('a b'), ['a', 'b']);
     assert.deepEqual(parseExamplesArg('  a , b ,, c '), ['a', 'b', 'c']);
     assert.deepEqual(parseExamplesArg(''), []);
+    // Defaulting to '' keeps the full-run path safe when no value is supplied.
+    assert.deepEqual(parseExamplesArg(), []);
+    assert.deepEqual(parseExamplesArg(undefined), []);
 });
 
 test('resolveExamples with no request returns every runnable example', () => {

--- a/tools/benchmark/browser-benchmark.ts
+++ b/tools/benchmark/browser-benchmark.ts
@@ -16,7 +16,7 @@ import { chromium } from 'playwright';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import { discoverExamples } from './benchmark-examples';
+import { parseExamplesArg, resolveExamples } from './benchmark-examples';
 import { type Contention, type HostInfo, diffContention, readCpuSample, readHostInfo } from './contention';
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '../..');
@@ -99,17 +99,13 @@ async function main() {
         process.exit(1);
     }
 
-    // Discover and filter examples
-    let exampleNames = discoverExamples();
-    if (argv.examples) {
-        const filter = new Set(argv.examples.split(',').map((s) => s.trim()));
-        const unknown = [...filter].filter((name) => !exampleNames.includes(name));
-        if (unknown.length > 0) {
-            console.error(`Unknown example(s): ${unknown.join(', ')}`);
-            console.error(`Available: ${exampleNames.join(', ')}`);
-            process.exit(1);
-        }
-        exampleNames = exampleNames.filter((name) => filter.has(name));
+    // Discover and filter examples (empty --examples resolves to the full set).
+    let exampleNames: string[];
+    try {
+        exampleNames = resolveExamples(parseExamplesArg(argv.examples));
+    } catch (e) {
+        console.error((e as Error).message);
+        process.exit(1);
     }
 
     console.log(`Running ${exampleNames.length} benchmark example(s)`);


### PR DESCRIPTION
## What

CI supports `/benchmarks` on a PR to compare the head against its base. This adds the ability to **narrow the run to specific examples**:

```
/benchmarks simple-sparkline
/benchmarks simple-sparkline simple-chart
```

A bare `/benchmarks` (and every non-comment trigger — schedule, push, workflow_dispatch) still runs the full example set, so existing behaviour is unchanged.

## How

- **`tools/benchmark/benchmark-examples.js`** — new `resolveExamples()` is the single source of truth for resolving + validating a requested subset (empty request → all runnable examples; unknown names throw). It's threaded through `shardExamples()` and a new CLI `--examples` flag, which accepts names separated by commas and/or whitespace so the comment body can be forwarded verbatim.
- **`tools/benchmark/browser-benchmark.ts`** — its existing `--examples` filtering now routes through the shared `resolveExamples()`, removing a duplicated validate-and-filter block.
- **`.github/workflows/benchmark.yml`** — the *Compute shard matrix* step parses the `/benchmarks [name...]` comment body and forwards the requested names. The comment body is read via `env:` (never interpolated into the `run:` script) to avoid shell injection from untrusted comment text. An unknown example name fails `benchmark-examples.js`, so a typo fails the resolve job loudly rather than silently benchmarking the wrong subset.
- **`tools/benchmark/benchmark-examples.test.js`** — new `node:test` unit tests covering parse / resolve / shard, matching the zero-dependency convention of the sibling `contention.test.ts`.

Narrowing reduces the shard matrix to only the requested examples (e.g. one example → a single shard), and the report job's per-run shard-count integrity check derives its expected count from the same matrix, so it stays consistent.

## Verification

- `node --test tools/benchmark/benchmark-examples.test.js` — 5/5 pass
- CLI checked for narrow / bare / unknown inputs (unknown exits non-zero with an `Available:` list)
- Simulated the workflow's bash parse across bare `/benchmarks`, single/multiple names, multiline bodies, and bad names
- `browser-benchmark.ts` type-checks; prettier clean; workflow YAML parses

Jira: https://ag-grid.atlassian.net/browse/AG-17660