### PR TITLE
AG-3390 Ignore Permissions-Policy console violations in page verification

### DIFF
--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -118,6 +118,11 @@ export function setupIntrinsicAssertions(
             // WebGL GPU driver performance messages are browser/OS noise unrelated to the application.
             if (msg.text().includes('GL Driver Message')) return;
 
+            // Permissions-Policy feature violations (e.g. compute-pressure) are emitted by the browser
+            // when a third-party script probes a feature the server-level Permissions-Policy disallows.
+            // This is browser/third-party noise unrelated to the application.
+            if (msg.text().includes('Permissions policy violation')) return;
+
             // Ignore 404s when expected
             const notFoundMatcher = /the server responded with a status of 404/;
             if (msg.location().url.includes('/favicon.ico')) return;


### PR DESCRIPTION
## What

Filter `Permissions policy violation` browser console messages in the page-verification e2e console-error assertion (`e2e/util.ts`), alongside the existing `GL Driver Message` / Quirks Mode filters.

## Why

The **Post-Deploy Page Verification (Staging)** suite asserts each page emits zero console warnings/errors (`expect(consoleWarnOrErrors).toHaveLength(0)`). It started failing on `community page loads` with:

```
Permissions policy violation: compute-pressure is not allowed in this document.
```

This is **not** a CSP issue and **not** produced by the app:

- `Permissions-Policy` and `Content-Security-Policy` are separate headers. Charts' htaccess generation (`cspRules.ts`) emits **only** `Content-Security-Policy` / `-Report-Only` — it sets **no** `Permissions-Policy` header. `compute-pressure` / `Permissions-Policy` appear nowhere in the codebase or git history.
- The `compute-pressure` restriction comes from the **server-level** Permissions-Policy header. The violation is logged when a third-party script on the page (GTM / ZoomInfo / OneTrust / reCAPTCHA) probes the Compute Pressure API.
- It surfaced after a Chromium bump on the CI runner (the run annotates a Node 20→24 forcing, i.e. the runner image changed) — newer Chromium emits this console message where it didn't before, and the strict assertion trips on it.

This is browser/third-party noise unrelated to the application, so it's filtered like the other known browser-noise messages.

## Verification

- Change matches the surrounding filter style; single added guard clause.
- Post-deploy page verification will no longer fail on this benign browser message.