### PR TITLE
AG-17263 [CLAUDE] Restrict org-chart expand/collapse to the expander control

### DIFF
--- a/packages/ag-charts-community/src/chart/series/pickManager.ts
+++ b/packages/ag-charts-community/src/chart/series/pickManager.ts
@@ -1,6 +1,7 @@
 import { objectsEqual } from 'ag-charts-core';
 import type { AgActiveItemState } from 'ag-charts-types';
 
+import type { Node } from '../../scene/node';
 import type { ActiveManager } from '../interaction/activeManager';
 import type { SeriesNodeDatum } from './seriesTypes';
 
@@ -18,6 +19,8 @@ export type PickedNode = SeriesNodeDatum;
 export type PickedNodes = {
     matches: PickedNode[];
     distance: number;
+    /** Topmost scene-node under the pointer for the primary match; undefined for datum-geometry picks. */
+    target: Node<unknown> | undefined;
 };
 
 export function getItemId(node: PickedNode, dataIdKey?: string): NonNullable<AgActiveItemState['itemId']> {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -19,6 +19,7 @@ import { FocusSwapChain } from '../../dom/focusSwapChain';
 import type { ChartRegistry } from '../../module/moduleContext';
 import { BBox } from '../../scene/bbox';
 import type { TranslatableGroup } from '../../scene/group';
+import type { Node as SceneNode } from '../../scene/node';
 import { Transformable } from '../../scene/transformable';
 import { BaseManager } from '../../util/baseManager';
 import type { TypedEvent } from '../../util/observable';
@@ -619,9 +620,9 @@ export class SeriesAreaManager extends BaseManager {
         }
 
         if (isSeriesWidget) {
-            const clickedNode: PickedNode | undefined = this.checkSeriesNodeClick(event);
-            if (clickedNode) {
-                this.emitSeriesAreaClickEvent(event, true, clickedNode);
+            const clicked = this.checkSeriesNodeClick(event);
+            if (clicked) {
+                this.emitSeriesAreaClickEvent(event, true, clicked.node, clicked.target);
                 this.update(ChartUpdateType.SERIES_UPDATE);
                 event.sourceEvent.preventDefault();
                 return;
@@ -645,10 +646,11 @@ export class SeriesAreaManager extends BaseManager {
     private emitSeriesAreaClickEvent(
         event: ClickLikeEvent | KeyboardSyntheticMouseWidgetEvent,
         consumed: boolean,
-        clickedNode?: PickedNode
+        clickedNode?: PickedNode,
+        target?: SceneNode<unknown>
     ): void {
         const { type, sourceEvent } = event;
-        const payload: SeriesAreaClickEvent = { type, consumed, sourceEvent, clickedNode };
+        const payload: SeriesAreaClickEvent = { type, consumed, sourceEvent, clickedNode, target };
 
         const { datum } = this.focus;
         const oldSelectionState = datum?.series.getDataSelectionState(datum.datumIndex);
@@ -797,7 +799,9 @@ export class SeriesAreaManager extends BaseManager {
         }
     }
 
-    private checkSeriesNodeClick(event: ClickLikeEvent & { preventZoomDblClick?: boolean }): PickedNode | undefined {
+    private checkSeriesNodeClick(
+        event: ClickLikeEvent & { preventZoomDblClick?: boolean }
+    ): { node: PickedNode; target: SceneNode<unknown> | undefined } | undefined {
         const pickedNodes = this.pickNodes({ x: event.currentX, y: event.currentY }, 'event');
         const updated = this.pickManager.onPickedNodesTooltip(pickedNodes);
         if (pickedNodes === undefined || updated.active === undefined) return undefined;
@@ -820,7 +824,7 @@ export class SeriesAreaManager extends BaseManager {
                     });
                 }
             }
-            return updated.active;
+            return { node: updated.active, target: pickedNodes.target };
         }
 
         if (event.type === 'dblclick') {
@@ -835,7 +839,7 @@ export class SeriesAreaManager extends BaseManager {
             event.preventZoomDblClick = distance === 0;
 
             updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, updated.active);
-            return updated.active;
+            return { node: updated.active, target: pickedNodes.target };
         }
 
         return undefined;
@@ -1452,12 +1456,15 @@ export class SeriesAreaManager extends BaseManager {
 
             const { picks } = pick;
             const distance = picks[0].distance;
+            // The topmost (last-rendered) hit; for org-charts this is the expander when it
+            // overlaps the card, so the click resolves to the control the user sees.
+            const target = picks.at(-1)?.target;
 
             if (distance === 0) {
                 // Accumulate multiple series when the nodes are under the cursor
                 // I.e. the distance is 0
                 if (result?.distance !== 0) {
-                    result = { matches: [], distance: 0 };
+                    result = { matches: [], distance: 0, target };
                 }
 
                 for (const { datum } of picks) {
@@ -1465,7 +1472,7 @@ export class SeriesAreaManager extends BaseManager {
                 }
             } else if (result == null || result.distance > distance) {
                 // Don't accumulate multiple datums when matching by nearest distance
-                result = { matches: picks.map((p) => p.datum), distance };
+                result = { matches: picks.map((p) => p.datum), distance, target };
             }
         }
 
@@ -1605,6 +1612,6 @@ export class SeriesAreaManager extends BaseManager {
             return undefined;
         }
 
-        return { matches: [desiredDatum], distance: 0 };
+        return { matches: [desiredDatum], distance: 0, target: undefined };
     }
 }

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -78,6 +78,11 @@ export interface SeriesAreaClickEvent {
     readonly consumed: boolean;
     readonly sourceEvent: MouseEvent | TouchEvent | KeyboardEvent;
     readonly clickedNode: SeriesNodeDatum | undefined;
+    /**
+     * The scene-node under the pointer for `clickedNode`. Undefined for keyboard-synthesised
+     * clicks (Enter/Space on a focused node), which have no pointer position to hit-test.
+     */
+    readonly target: Node<unknown> | undefined;
 }
 
 export interface DataModelSeriesDiff {

--- a/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
@@ -157,13 +157,14 @@ export abstract class AbstractNetworkSeries<
 
         this.cleanup.register(
             ctx.eventsHub.on('series-area:click', (event) => {
-                const { type, clickedNode, sourceEvent } = event;
+                const { type, clickedNode, target, sourceEvent } = event;
                 const clickModifier = clickedNode?.series.properties.selection.clickModifier;
                 if (
                     type !== 'click' ||
                     clickedNode?.series !== this ||
                     clickedNode.itemId == null ||
-                    hasClickSelectionModifier(event, clickModifier)
+                    hasClickSelectionModifier(event, clickModifier) ||
+                    !this.shouldToggleCollapseOnClick(target)
                 ) {
                     return;
                 }
@@ -178,6 +179,12 @@ export abstract class AbstractNetworkSeries<
                 }
             })
         );
+    }
+
+    // Whether a click on `target` should toggle collapse. The whole node is the target by
+    // default; OrganizationSeries narrows this to the expander control.
+    protected shouldToggleCollapseOnClick(_target: _ModuleSupport.Node<unknown> | undefined): boolean {
+        return true;
     }
 
     abstract createNetworkGraph(): TGraph;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationNode.ts
@@ -1,5 +1,5 @@
 import { type TextAlign, _ModuleSupport } from 'ag-charts-community';
-import { type NormalisedTextOrSegments, type Point, wrapTextOrSegments } from 'ag-charts-core';
+import { type NormalisedTextOrSegments, wrapTextOrSegments } from 'ag-charts-core';
 
 import { layoutScenesColumn, layoutScenesRow } from '../../utils/sceneLayout';
 import type {
@@ -9,6 +9,12 @@ import type {
     OrganizationNodeFields,
 } from './organizationTypes';
 import { applyFillStyles, applyStrokeStyles, applyTextBoxingStyles, applyTextStyles } from './organizationUtils';
+
+// Scene-node `tag` selector so hit-testing can tell the card apart from the expander control.
+export enum OrganizationNodeTag {
+    Card,
+    Expander,
+}
 
 // Sub-pixel slack on the overflow check; pure float-comparison guard, not user-tunable.
 const CLIP_EPSILON = 0.5;
@@ -47,7 +53,7 @@ export class OrganizationNode extends _ModuleSupport.TranslatableGroup<Organizat
     // appended later in `updateExpanderNode` so it stays visually on top. `contentGroup`
     // also carries the conditional clip applied in `updateBBox` when `maxWidth`/`maxHeight`
     // clamp the card under its intrinsic content size.
-    private readonly shapeNode = this.appendChild(new _ModuleSupport.Rect());
+    private readonly shapeNode = this.appendChild(new _ModuleSupport.Rect({ tag: OrganizationNodeTag.Card }));
     private readonly contentGroup = this.appendChild(new _ModuleSupport.Group());
     private imageNode?: _ModuleSupport.Rect;
     private titleNode?: _ModuleSupport.Text;
@@ -226,11 +232,6 @@ export class OrganizationNode extends _ModuleSupport.TranslatableGroup<Organizat
         }
     }
 
-    expanderContainsPoint(point: Point) {
-        if (!this.expanderNode) return false;
-        return this.expanderNode.containsPoint(point.x, point.y);
-    }
-
     // Card-only bbox in node-local coords; excludes the expander pill that hangs below.
     getCardBBox(): _ModuleSupport.BBox {
         return new _ModuleSupport.BBox(0, 0, this.shapeNode.width, this.shapeNode.height);
@@ -367,14 +368,14 @@ class OrganizationExpanderNode extends _ModuleSupport.TranslatableGroup {
     private chevronNode?: ChevronPath;
 
     update(descendantsCount: number, isCollapsed: boolean, isRtl: boolean, styles: NormalisedOrganizationNodeStyle) {
-        this.shapeNode ??= this.appendChild(new _ModuleSupport.Rect());
+        this.shapeNode ??= this.appendChild(new _ModuleSupport.Rect({ tag: OrganizationNodeTag.Expander }));
 
-        this.countNode ??= this.appendChild(new _ModuleSupport.Text());
+        this.countNode ??= this.appendChild(new _ModuleSupport.Text({ tag: OrganizationNodeTag.Expander }));
         this.countNode.y = styles.expander.padding.top;
         this.countNode.text = `${descendantsCount}`;
         applyTextStyles(this.countNode, styles.expander.text);
 
-        this.chevronNode ??= this.appendChild(new ChevronPath());
+        this.chevronNode ??= this.appendChild(new ChevronPath({ tag: OrganizationNodeTag.Expander }));
         this.chevronNode.update(
             styles.expander.text.fontSize * (7 / 12),
             styles.expander.text.fontSize * (3.5 / 12),

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -37,7 +37,7 @@ import { AbstractNetworkSeries } from '../network/networkSeries';
 import { NetworkTreeLayout, type NetworkTreeLayoutUpdateOptions } from '../network/networkTreeLayout';
 import type { NetworkLinkInterpolation } from '../network/networkTypes';
 import { OrganizationGraph } from './organizationGraph';
-import { OrganizationNode } from './organizationNode';
+import { OrganizationNode, OrganizationNodeTag } from './organizationNode';
 import { OrganizationSeriesNodeTextProperties, OrganizationSeriesProperties } from './organizationSeriesProperties';
 import type {
     NormalisedOrganizationNodeStyle,
@@ -451,14 +451,6 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const id = this.getItemId(itemIdOrIndex);
         if (id == null) return;
 
-        const vertex = this.graph.findVertexById(id);
-        if (vertex == null) return;
-
-        // const node = this.datumSelection.at(this.graph.findNeighbourValue(vertex, 'datumIndex') as number);
-        // if (node == null || !node.expanderContainsPoint(point)) {
-        //     return;
-        // }
-
         if (this.ctx.collapsedManager.expand([id])) {
             this.markNodeDataDirty();
         }
@@ -471,6 +463,12 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         if (this.ctx.collapsedManager.collapseAppend([id])) {
             this.markNodeDataDirty();
         }
+    }
+
+    // Keyboard activations have no pointer target — allow them; pointer clicks must hit the expander.
+    protected override shouldToggleCollapseOnClick(target: _ModuleSupport.Node<unknown> | undefined): boolean {
+        const expanderTag: number = OrganizationNodeTag.Expander;
+        return target == null || target.tag === expanderTag;
     }
 
     public override pickFocus(opts: _ModuleSupport.PickFocusInputs): _ModuleSupport.PickFocusOutputs | undefined {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17263

Clicking a node's card toggled its collapse state, the same as clicking the expander. Only the expander should do this. Building on the enriched pick result, the clicked scene-node is now threaded to the click handler so it can tell the card and expander apart via Node.tag.

- Tag the expander's scene-nodes (pill, count, chevron) and the card surface with a new `OrganizationNodeTag` selector.
- Carry the hit scene-node through to the click event: `PickedNodes.target` and `SeriesAreaClickEvent.target`, sourced from the topmost match so an expander that overlaps the card bottom still resolves to the expander.
- Gate the toggle behind `shouldToggleCollapseOnClick(target)` in the network click handler. The base allows any click; OrganizationSeries requires the expander tag. A missing target (keyboard Enter/Space on a focused node) still toggles, preserving keyboard accessibility.
- Remove the obsolete commented-out geometric expander hit-test and the now-dead `expanderContainsPoint` helper.