### PR TITLE
AG-17263 [CLAUDE] Show the pointer cursor over the org-chart expander

### DIFF
--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1121,6 +1121,10 @@ export abstract class Series<
         throw new Error('AG Charts - Series.pickNodeMainAxisFirst() not implemented');
     }
 
+    hasBuiltinListener(_target: Node<unknown> | undefined): boolean {
+        return false;
+    }
+
     protected pickNodesInBBoxPredicate(): PickNodesInBBoxPredicate {
         // By default, pickNodesInBBox just used boxes for hit-testing because it's easier and faster. Series with more
         // complicated shapes (e.g. sectors or pie/donut, paths for maps) need to override this predicate to implement

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -562,6 +562,7 @@ export class SeriesAreaManager extends BaseManager {
                 (found?.series.isSelectionEnabled() && found?.series.isDatumSelectable(found.datumIndex)) ||
                 found?.series.hasEventListener('seriesNodeClick') ||
                 found?.series.hasEventListener('seriesNodeDoubleClick') ||
+                found?.series.hasBuiltinListener(pick?.target) ||
                 (matches != null && matches.length > 1 && this.chart.tooltip.pagination)
             ) {
                 this.chart.ctx.domManager.updateCursor(this.id, 'pointer');

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -12,6 +12,7 @@ import type { AgActiveItemState, AgNumericValue, SelectionState as PublicSelecti
 
 import type { BBox } from '../../scene/bbox';
 import type { Group } from '../../scene/group';
+import type { Node } from '../../scene/node';
 import type { TypedEvent } from '../../util/observable';
 import type { ProcessedData } from '../data/dataModelTypes';
 import type { DataSet } from '../data/dataSet';
@@ -116,6 +117,8 @@ export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesP
     properties: TProps;
     events: { emit: (type: 'data-selection-change', event: null) => void };
     hasEventListener(type: string): boolean;
+    /** Whether a click on `target` triggers a built-in interaction (e.g. the org-chart expander). */
+    hasBuiltinListener(target: Node<unknown> | undefined): boolean;
     hasData: boolean;
     update(opts: { seriesRect?: BBox }): Promise<void> | void;
     updatePlacedLabelData?(labels: PlacedLabel<TLabel>[]): void;

--- a/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/network/networkSeries.ts
@@ -164,7 +164,7 @@ export abstract class AbstractNetworkSeries<
                     clickedNode?.series !== this ||
                     clickedNode.itemId == null ||
                     hasClickSelectionModifier(event, clickModifier) ||
-                    !this.shouldToggleCollapseOnClick(target)
+                    !this.hasBuiltinListener(target)
                 ) {
                     return;
                 }
@@ -179,12 +179,6 @@ export abstract class AbstractNetworkSeries<
                 }
             })
         );
-    }
-
-    // Whether a click on `target` should toggle collapse. The whole node is the target by
-    // default; OrganizationSeries narrows this to the expander control.
-    protected shouldToggleCollapseOnClick(_target: _ModuleSupport.Node<unknown> | undefined): boolean {
-        return true;
     }
 
     abstract createNetworkGraph(): TGraph;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -466,7 +466,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
     }
 
     // Keyboard activations have no pointer target — allow them; pointer clicks must hit the expander.
-    protected override shouldToggleCollapseOnClick(target: _ModuleSupport.Node<unknown> | undefined): boolean {
+    override hasBuiltinListener(target: _ModuleSupport.Node<unknown> | undefined): boolean {
         const expanderTag: number = OrganizationNodeTag.Expander;
         return target == null || target.tag === expanderTag;
     }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17263

Hovering the expander did not switch the cursor to a pointer, so it didn't read as clickable. The series-area cursor logic had no way to know a click on a given scene-node triggers a built-in interaction.

- Add `Series.hasBuiltinListener(target)` (declared on `ISeries`), defaulting to false. It answers "does clicking this scene-node trigger a built-in interaction?".
- OrganizationSeries returns true for the expander (or a null target, i.e. keyboard activation). This replaces the network-only `shouldToggleCollapseOnClick`, which is removed; the click handler now gates on `hasBuiltinListener` instead.
- SeriesAreaManager's hover handler shows the pointer cursor when `hasBuiltinListener` is true for the front-most hit node, reusing the pick result's existing `target`.