### PR TITLE
Add a scene-graph serialisation contract for animation trajectory tests

### DIFF
--- a/packages/ag-charts-community/src/chart/marker/marker.ts
+++ b/packages/ag-charts-community/src/chart/marker/marker.ts
@@ -191,6 +191,10 @@ export class Marker<_D = unknown> extends Rotatable(Scalable(Translatable(Intern
     declare __translationX: number;
     declare __translationY: number;
 
+    protected override get serializedType(): string {
+        return 'marker';
+    }
+
     static anchor(shape: AgMarkerShape | undefined): Point {
         if (shape === 'pin') {
             return PIN_ANCHOR;

--- a/packages/ag-charts-community/src/chart/marker/marker.ts
+++ b/packages/ag-charts-community/src/chart/marker/marker.ts
@@ -191,7 +191,7 @@ export class Marker<_D = unknown> extends Rotatable(Scalable(Translatable(Intern
     declare __translationX: number;
     declare __translationY: number;
 
-    protected override get serializedType(): string {
+    protected override get serializedType(): 'marker' {
         return 'marker';
     }
 

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -1021,32 +1021,45 @@ export function expectProgresses(values: number[], tol = 1e-3): void {
 export type SceneNodeGeometry = Record<string, number>;
 export type SceneGeometrySample = Map<string, SceneNodeGeometry>;
 
-type GeometryBuilder = (state: SerializedNodeState) => SceneNodeGeometry;
-
-function pickProps(state: SerializedNodeState, names: string[]): SceneNodeGeometry {
-    const props: SceneNodeGeometry = {};
-    for (const name of names) {
-        props[name] = state.props[name] as number;
+/**
+ * Map a node's serialised state ({@link Node.serialize}) to the property set trajectory specs assert
+ * over; `null` marks node kinds deliberately not sampled (groups are handled separately by the scene
+ * walk). The switch is exhaustive over {@link SerializedNodeState}: adding a scene node kind fails
+ * compilation here until its sampling is decided. Marker and generic path nodes expose their bbox
+ * extents.
+ */
+function buildGeometry(state: SerializedNodeState): SceneNodeGeometry | null {
+    switch (state.type) {
+        case 'node':
+        case 'group':
+        case 'range':
+            return null;
+        case 'sector': {
+            const { startAngle, endAngle, innerRadius, outerRadius, opacity } = state.props;
+            return { startAngle, endAngle, innerRadius, outerRadius, opacity };
+        }
+        case 'rect':
+        case 'marker':
+        case 'path': {
+            const { x, y, width, height, opacity } = state.props;
+            return { x, y, width, height, opacity };
+        }
+        case 'text': {
+            const { x, y, opacity } = state.props;
+            return { x, y, opacity };
+        }
+        case 'line': {
+            const { x1, y1, x2, y2, opacity } = state.props;
+            return { x1, y1, x2, y2, opacity };
+        }
+        default:
+            return state satisfies never;
     }
-    return props;
 }
 
-// Builders map each node's serialised state ({@link Node.serialize}) to the property set trajectory
-// specs assert over. Node kinds without a builder are not sampled. Marker and generic path nodes
-// expose their bbox extents.
-const GEOMETRY_BUILDERS: Record<string, GeometryBuilder> = {
-    sector: (s) => pickProps(s, ['startAngle', 'endAngle', 'innerRadius', 'outerRadius', 'opacity']),
-    rect: (s) => pickProps(s, ['x', 'y', 'width', 'height', 'opacity']),
-    text: (s) => pickProps(s, ['x', 'y', 'opacity']),
-    line: (s) => pickProps(s, ['x1', 'y1', 'x2', 'y2', 'opacity']),
-    marker: (s) => pickProps(s, ['x', 'y', 'width', 'height', 'opacity']),
-    path: (s) => pickProps(s, ['x', 'y', 'width', 'height', 'opacity']),
-};
-
 function readNodeGeometry(state: SerializedNodeState): { label: string; props: SceneNodeGeometry } | undefined {
-    const builder = GEOMETRY_BUILDERS[state.type];
-    if (builder == null) return undefined;
-    const props = builder(state);
+    const props = buildGeometry(state);
+    if (props == null) return undefined;
     // Translation-positioned shapes (e.g. markers) move via translationX/Y, not their local geometry.
     const { translationX, translationY } = state.props;
     if (typeof translationX === 'number' && typeof translationY === 'number') {
@@ -1104,8 +1117,8 @@ export function createSceneGeometrySampler(chartOrProxy: ChartOrProxy<any>): () 
                 const identity = datumKeyOf(node);
                 const baseKey = `${rootPath}/${geometry.label}[${identity ?? ''}]`;
                 sample.set(assignKey(node, baseKey), geometry.props);
-            } else if (node instanceof Group) {
-                const props: SceneNodeGeometry = { opacity: state.props.opacity as number };
+            } else if (state.type === 'group' && node instanceof Group) {
+                const props: SceneNodeGeometry = { opacity: state.props.opacity };
                 const { translationX, translationY } = state.props;
                 if (typeof translationX === 'number' && typeof translationY === 'number') {
                     props.translationX = translationX;

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -39,7 +39,6 @@ import { type AnimationPhase, type IAnimation, PHASE_METADATA, PHASE_ORDER } fro
 import { BBox } from '../../scene/bbox';
 import { Group } from '../../scene/group';
 import type { Node, SerializedNodeState } from '../../scene/node';
-import { Text } from '../../scene/shape/text';
 import type { Chart } from '../chart';
 import type { AgChartProxy } from '../chartProxy';
 import { AnimationManager } from '../interaction/animationManager';
@@ -1070,13 +1069,13 @@ function readNodeGeometry(state: SerializedNodeState): { label: string; props: S
     return { label: state.type, props };
 }
 
-/** Best-effort human-readable identity for a scene node, derived from its datum. */
-function datumKeyOf(node: Node<any>): string | undefined {
+/** Best-effort human-readable identity for a scene node, derived from its datum or serialised state. */
+function datumKeyOf(node: Node<any>, state: SerializedNodeState): string | undefined {
     const datum: any = node.datum;
     if (datum != null && typeof datum !== 'object') return String(datum);
     const value = datum?.xValue ?? datum?.angleValue ?? datum?.itemId ?? datum?.index;
     if (value != null) return String(value);
-    if (node instanceof Text && node.text != null) return String(node.text);
+    if (state.type === 'text' && state.props.text != null) return state.props.text;
     return undefined;
 }
 
@@ -1114,7 +1113,7 @@ export function createSceneGeometrySampler(chartOrProxy: ChartOrProxy<any>): () 
             const state = node.serialize();
             const geometry = readNodeGeometry(state);
             if (geometry != null) {
-                const identity = datumKeyOf(node);
+                const identity = datumKeyOf(node, state);
                 const baseKey = `${rootPath}/${geometry.label}[${identity ?? ''}]`;
                 sample.set(assignKey(node, baseKey), geometry.props);
             } else if (state.type === 'group' && node instanceof Group) {

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -38,16 +38,11 @@ import { AgCharts } from '../../api/agCharts';
 import { type AnimationPhase, type IAnimation, PHASE_METADATA, PHASE_ORDER } from '../../motion/animation';
 import { BBox } from '../../scene/bbox';
 import { Group } from '../../scene/group';
-import type { Node } from '../../scene/node';
-import { Line } from '../../scene/shape/line';
-import { Path } from '../../scene/shape/path';
-import { Rect } from '../../scene/shape/rect';
-import { Sector } from '../../scene/shape/sector';
+import type { Node, SerializedNodeState } from '../../scene/node';
 import { Text } from '../../scene/shape/text';
 import type { Chart } from '../chart';
 import type { AgChartProxy } from '../chartProxy';
 import { AnimationManager } from '../interaction/animationManager';
-import { Marker } from '../marker/marker';
 import { findChartTarget } from './findTarget';
 
 export type { Chart } from '../chart';
@@ -1026,68 +1021,40 @@ export function expectProgresses(values: number[], tol = 1e-3): void {
 export type SceneNodeGeometry = Record<string, number>;
 export type SceneGeometrySample = Map<string, SceneNodeGeometry>;
 
-interface GeometryReader {
-    label: string;
-    matches(node: Node<any>): boolean;
-    read(node: any): SceneNodeGeometry;
+type GeometryBuilder = (state: SerializedNodeState) => SceneNodeGeometry;
+
+function pickProps(state: SerializedNodeState, names: string[]): SceneNodeGeometry {
+    const props: SceneNodeGeometry = {};
+    for (const name of names) {
+        props[name] = state.props[name] as number;
+    }
+    return props;
 }
 
-// Ordered most-specific first: Rect/Sector/Text/Line before the generic Path (bbox) fallback, which
-// covers markers, segmented line/area paths and any other shape.
-const GEOMETRY_READERS: GeometryReader[] = [
-    {
-        label: 'sector',
-        matches: (n) => n instanceof Sector,
-        read: (n: Sector) => ({
-            startAngle: n.startAngle,
-            endAngle: n.endAngle,
-            innerRadius: n.innerRadius,
-            outerRadius: n.outerRadius,
-            opacity: n.opacity ?? 1,
-        }),
-    },
-    {
-        label: 'rect',
-        matches: (n) => n instanceof Rect,
-        read: (n: Rect) => ({ x: n.x, y: n.y, width: n.width, height: n.height, opacity: n.opacity ?? 1 }),
-    },
-    {
-        label: 'text',
-        matches: (n) => n instanceof Text,
-        read: (n: Text) => ({ x: n.x, y: n.y, opacity: n.opacity ?? 1 }),
-    },
-    {
-        label: 'line',
-        matches: (n) => n instanceof Line,
-        read: (n: Line) => ({ x1: n.x1, y1: n.y1, x2: n.x2, y2: n.y2, opacity: n.opacity ?? 1 }),
-    },
-    { label: 'marker', matches: (n) => n instanceof Marker, read: readBBoxGeometry },
-    { label: 'path', matches: (n) => n instanceof Path, read: readBBoxGeometry },
-];
+// Builders map each node's serialised state ({@link Node.serialize}) to the property set trajectory
+// specs assert over. Node kinds without a builder are not sampled. Marker and generic path nodes
+// expose their bbox extents.
+const GEOMETRY_BUILDERS: Record<string, GeometryBuilder> = {
+    sector: (s) => pickProps(s, ['startAngle', 'endAngle', 'innerRadius', 'outerRadius', 'opacity']),
+    rect: (s) => pickProps(s, ['x', 'y', 'width', 'height', 'opacity']),
+    text: (s) => pickProps(s, ['x', 'y', 'opacity']),
+    line: (s) => pickProps(s, ['x1', 'y1', 'x2', 'y2', 'opacity']),
+    marker: (s) => pickProps(s, ['x', 'y', 'width', 'height', 'opacity']),
+    path: (s) => pickProps(s, ['x', 'y', 'width', 'height', 'opacity']),
+};
 
-function readBBoxGeometry(n: Path): SceneNodeGeometry {
-    const bbox = n.getBBox();
-    return {
-        x: bbox?.x ?? Number.NaN,
-        y: bbox?.y ?? Number.NaN,
-        width: bbox?.width ?? Number.NaN,
-        height: bbox?.height ?? Number.NaN,
-        opacity: n.opacity ?? 1,
-    };
-}
-
-function readNodeGeometry(node: Node<any>): { label: string; props: SceneNodeGeometry } | undefined {
-    const reader = GEOMETRY_READERS.find((r) => r.matches(node));
-    if (reader == null) return undefined;
-    const props = reader.read(node);
+function readNodeGeometry(state: SerializedNodeState): { label: string; props: SceneNodeGeometry } | undefined {
+    const builder = GEOMETRY_BUILDERS[state.type];
+    if (builder == null) return undefined;
+    const props = builder(state);
     // Translation-positioned shapes (e.g. markers) move via translationX/Y, not their local geometry.
-    const { translationX, translationY } = node as any;
+    const { translationX, translationY } = state.props;
     if (typeof translationX === 'number' && typeof translationY === 'number') {
         props.translationX = translationX;
         props.translationY = translationY;
     }
-    props.visible = node.visible ? 1 : 0;
-    return { label: reader.label, props };
+    props.visible = state.props.visible ? 1 : 0;
+    return { label: state.type, props };
 }
 
 /** Best-effort human-readable identity for a scene node, derived from its datum. */
@@ -1131,18 +1098,20 @@ export function createSceneGeometrySampler(chartOrProxy: ChartOrProxy<any>): () 
 
     const sampleInto = (sample: SceneGeometrySample, rootPath: string, root: Node<any>) => {
         const visit = (node: Node<any>) => {
-            const geometry = readNodeGeometry(node);
+            const state = node.serialize();
+            const geometry = readNodeGeometry(state);
             if (geometry != null) {
                 const identity = datumKeyOf(node);
                 const baseKey = `${rootPath}/${geometry.label}[${identity ?? ''}]`;
                 sample.set(assignKey(node, baseKey), geometry.props);
             } else if (node instanceof Group) {
-                const { translationX, translationY } = node as any;
-                const props: SceneNodeGeometry = { opacity: node.opacity ?? 1, visible: node.visible ? 1 : 0 };
+                const props: SceneNodeGeometry = { opacity: state.props.opacity as number };
+                const { translationX, translationY } = state.props;
                 if (typeof translationX === 'number' && typeof translationY === 'number') {
                     props.translationX = translationX;
                     props.translationY = translationY;
                 }
+                props.visible = state.props.visible ? 1 : 0;
                 sample.set(assignKey(node, node === root ? rootPath : `${rootPath}/group[${node.name ?? ''}]`), props);
                 for (const child of node.children()) {
                     visit(child);

--- a/packages/ag-charts-community/src/scene/group.ts
+++ b/packages/ag-charts-community/src/scene/group.ts
@@ -51,6 +51,16 @@ export class Group<TDatum = unknown> extends Node<TDatum> {
     @SceneChangeDetection({ convertor: (v: number) => clamp(0, v, 1) })
     opacity: number = 1;
 
+    protected override get serializedType(): string {
+        return 'group';
+    }
+
+    override serialize() {
+        const state = super.serialize();
+        state.props.opacity = this.opacity;
+        return state;
+    }
+
     private _childFontDirty = true;
     private _cachedChildFont: string | undefined;
 

--- a/packages/ag-charts-community/src/scene/group.ts
+++ b/packages/ag-charts-community/src/scene/group.ts
@@ -2,7 +2,7 @@ import { clamp, toIterable } from 'ag-charts-core';
 
 import { BBox } from './bbox';
 import { HdpiOffscreenCanvas } from './canvas/hdpiOffscreenCanvas';
-import type { ChildNodeCounts, IScene, RenderContext } from './node';
+import type { ChildNodeCounts, IScene, RenderContext, SerializedGroupProps, SerializedNodeState } from './node';
 import { Node, PointerEvents, SceneChangeDetection } from './node';
 import { type CanvasContext, Shape } from './shape/shape';
 import {
@@ -51,14 +51,12 @@ export class Group<TDatum = unknown> extends Node<TDatum> {
     @SceneChangeDetection({ convertor: (v: number) => clamp(0, v, 1) })
     opacity: number = 1;
 
-    protected override get serializedType(): string {
-        return 'group';
+    override serialize(): SerializedNodeState {
+        return { type: 'group', props: this.serializeProps() };
     }
 
-    override serialize() {
-        const state = super.serialize();
-        state.props.opacity = this.opacity;
-        return state;
+    protected override serializeProps(): SerializedGroupProps {
+        return { ...super.serializeProps(), opacity: this.opacity };
     }
 
     private _childFontDirty = true;

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -43,6 +43,17 @@ export interface NodeOptions {
 
 export type NodeWithOpacity<D> = Node<D> & { opacity: number };
 
+/**
+ * Plain-data snapshot of a node's rendered state (see {@link Node.serialize}). `type` discriminates
+ * the node kind (e.g. `'rect'`, `'text'`) independently of subclassing; `svgPath` carries the drawn
+ * path commands in SVG form for path-painting nodes.
+ */
+export interface SerializedNodeState {
+    type: string;
+    props: Record<string, number | string | boolean>;
+    svgPath?: string;
+}
+
 export type ChildNodeCounts = {
     groups: number;
     nonGroups: number;
@@ -392,6 +403,20 @@ export abstract class Node<TDatum = unknown> {
     getBBox(): BBox {
         this.cachedBBox ??= Object.freeze(this.computeBBox()) as BBox;
         return this.cachedBBox;
+    }
+
+    /** Node-kind discriminator for {@link serialize}, stable across subclassing. */
+    protected get serializedType(): string {
+        return 'node';
+    }
+
+    /**
+     * Serialise this node's rendered state to plain data, so consumers (tests, debug tooling) can
+     * inspect scene state without reaching into shape internals. Each subclass and transform mixin
+     * contributes the properties it owns.
+     */
+    serialize(): SerializedNodeState {
+        return { type: this.serializedType, props: { visible: this.visible } };
     }
 
     protected computeBBox(): BBox | undefined {

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -1,4 +1,5 @@
 import { DeclaredSceneChangeDetection, Logger, createId, createSvgElement, objectsEqual } from 'ag-charts-core';
+import type { AgDrawingMode } from 'ag-charts-types';
 
 import { BBox } from './bbox';
 import type { ImageLoader } from './image/imageLoader';
@@ -44,15 +45,74 @@ export interface NodeOptions {
 export type NodeWithOpacity<D> = Node<D> & { opacity: number };
 
 /**
- * Plain-data snapshot of a node's rendered state (see {@link Node.serialize}). `type` discriminates
- * the node kind (e.g. `'rect'`, `'text'`) independently of subclassing; `svgPath` carries the drawn
- * path commands in SVG form for path-painting nodes.
+ * Properties every node contributes to its serialised state (see {@link Node.serialize}). The
+ * transform properties are contributed by the Translatable/Scalable/Rotatable mixins when applied,
+ * so they are optional on every node kind.
  */
-export interface SerializedNodeState {
-    type: string;
-    props: Record<string, number | string | boolean>;
-    svgPath?: string;
+export interface SerializedNodeProps {
+    visible: boolean;
+    translationX?: number;
+    translationY?: number;
+    scalingX?: number;
+    scalingY?: number;
+    rotation?: number;
 }
+
+export interface SerializedGroupProps extends SerializedNodeProps {
+    opacity: number;
+}
+
+export interface SerializedShapeProps extends SerializedNodeProps {
+    opacity: number;
+    drawingMode: AgDrawingMode;
+}
+
+export interface SerializedPathProps extends SerializedShapeProps {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    clip: boolean;
+    clipX: number;
+    clipY: number;
+}
+
+export interface SerializedSectorProps extends SerializedPathProps {
+    startAngle: number;
+    endAngle: number;
+    innerRadius: number;
+    outerRadius: number;
+}
+
+export interface SerializedLineProps extends SerializedShapeProps {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+}
+
+export interface SerializedTextProps extends SerializedShapeProps {
+    x: number;
+    y: number;
+}
+
+/**
+ * Plain-data snapshot of a node's rendered state (see {@link Node.serialize}), discriminated by node
+ * kind independently of subclassing (e.g. a specialised bar shape still reads as `'rect'`); `svgPath`
+ * carries the drawn path commands in SVG form for path-painting nodes. This union is closed: a new
+ * node kind must add its variant here, which forces every exhaustive consumer to decide how to
+ * handle it.
+ */
+export type SerializedNodeState =
+    | { type: 'node'; props: SerializedNodeProps }
+    | { type: 'group'; props: SerializedGroupProps }
+    | { type: 'path'; props: SerializedPathProps; svgPath?: string }
+    | { type: 'marker'; props: SerializedPathProps; svgPath?: string }
+    | { type: 'rect'; props: SerializedPathProps; svgPath?: string }
+    | { type: 'sector'; props: SerializedSectorProps; svgPath?: string }
+    | { type: 'line'; props: SerializedLineProps }
+    | { type: 'range'; props: SerializedLineProps }
+    | { type: 'text'; props: SerializedTextProps };
 
 export type ChildNodeCounts = {
     groups: number;
@@ -405,18 +465,18 @@ export abstract class Node<TDatum = unknown> {
         return this.cachedBBox;
     }
 
-    /** Node-kind discriminator for {@link serialize}, stable across subclassing. */
-    protected get serializedType(): string {
-        return 'node';
-    }
-
     /**
      * Serialise this node's rendered state to plain data, so consumers (tests, debug tooling) can
-     * inspect scene state without reaching into shape internals. Each subclass and transform mixin
-     * contributes the properties it owns.
+     * inspect scene state without reaching into shape internals. Each subclass returns its own
+     * {@link SerializedNodeState} variant, accumulating inherited property contributions (including
+     * the transform mixins') via {@link serializeProps}.
      */
     serialize(): SerializedNodeState {
-        return { type: this.serializedType, props: { visible: this.visible } };
+        return { type: 'node', props: this.serializeProps() };
+    }
+
+    protected serializeProps(): SerializedNodeProps {
+        return { visible: this.visible };
     }
 
     protected computeBBox(): BBox | undefined {

--- a/packages/ag-charts-community/src/scene/node.ts
+++ b/packages/ag-charts-community/src/scene/node.ts
@@ -65,6 +65,8 @@ export interface SerializedGroupProps extends SerializedNodeProps {
 export interface SerializedShapeProps extends SerializedNodeProps {
     opacity: number;
     drawingMode: AgDrawingMode;
+    hasFill: boolean;
+    hasStroke: boolean;
 }
 
 export interface SerializedPathProps extends SerializedShapeProps {
@@ -94,6 +96,7 @@ export interface SerializedLineProps extends SerializedShapeProps {
 export interface SerializedTextProps extends SerializedShapeProps {
     x: number;
     y: number;
+    text?: string;
 }
 
 /**

--- a/packages/ag-charts-community/src/scene/scene.ts
+++ b/packages/ag-charts-community/src/scene/scene.ts
@@ -291,7 +291,6 @@ export class Scene extends EventEmitter<EventMap> {
                 });
                 // Uncomment to write tree to filesystem from tests / Node.js.
                 // require('fs').writeFileSync('scene.json', JSON.stringify(buildTree(root, 'json')));
-                // console.log('Skipped properties', skippedProperties);
             }
 
             if (root.visible) {

--- a/packages/ag-charts-community/src/scene/sceneDebug.ts
+++ b/packages/ag-charts-community/src/scene/sceneDebug.ts
@@ -310,42 +310,6 @@ export function debugSceneNodeHighlight(ctx: CanvasRenderingContext2D, debugNode
     }
 }
 
-export const skippedProperties = new Set<string>();
-const allowedProperties = new Set([
-    'gradient',
-    // '_datum',
-    'zIndex',
-    'clipRect',
-    'cachedBBox',
-    'childNodeCounts',
-    'path',
-    '__zIndex',
-    'name',
-    '__scalingCenterX',
-    '__scalingCenterY',
-    '__rotationCenterX',
-    '__rotationCenterY',
-    '_previousDatum',
-    '__fill',
-    '__lineDash',
-    'borderPath',
-    'borderClipPath',
-    '_clipPath',
-]);
-
-function nodeProps(node: Node) {
-    const { ...allProps } = node as any;
-    for (const prop of Object.keys(allProps)) {
-        if (allowedProperties.has(prop)) continue;
-        if (typeof allProps[prop] === 'number') continue;
-        if (typeof allProps[prop] === 'string') continue;
-        if (typeof allProps[prop] === 'boolean') continue;
-        skippedProperties.add(prop);
-        delete allProps[prop];
-    }
-    return allProps;
-}
-
 export function buildTree(node: Node, mode: 'json' | 'console'): BuildTree {
     if (!Debug.check(true, DebugSelectors.SCENE)) {
         return {};
@@ -353,23 +317,24 @@ export function buildTree(node: Node, mode: 'json' | 'console'): BuildTree {
 
     let order = 0;
     return {
-        node: mode === 'json' ? nodeProps(node) : node,
+        node: mode === 'json' ? node.serialize() : node,
         name: node.name ?? node.id,
         dirty: node instanceof Group ? node.dirty : undefined,
-        ...Array.from(node instanceof Group ? node.children() : [], (c) => buildTree(c, mode)).reduce<
-            Record<string, object>
-        >((result, childTree) => {
-            let { name: treeNodeName } = childTree;
-            const {
-                node: { visible, opacity, zIndex, translationX, translationY, rotation, scalingX, scalingY },
-                node: childNode,
-            } = childTree;
+        ...Array.from(node instanceof Group ? node.children() : [], (child) => ({
+            child,
+            tree: buildTree(child, mode),
+        })).reduce<Record<string, object>>((result, { child, tree }) => {
+            let { name: treeNodeName } = tree;
+            const { props } = child.serialize();
+            const { visible, translationX, translationY, rotation, scalingX, scalingY } = props;
+            const opacity = 'opacity' in props ? props.opacity : 1;
             if (!visible || opacity <= 0) {
                 treeNodeName = `(${treeNodeName})`;
             }
-            if (Group.is(childNode) && childNode.renderToOffscreenCanvas) {
+            if (Group.is(child) && child.renderToOffscreenCanvas) {
                 treeNodeName = `*${treeNodeName}*`;
             }
+            const { zIndex } = child;
             const zIndexString = Array.isArray(zIndex) ? `(${zIndex.join(', ')})` : zIndex;
             const key = [
                 `${(order++).toString().padStart(3, '0')}|`,
@@ -389,7 +354,7 @@ export function buildTree(node: Node, mode: 'json' | 'console'): BuildTree {
             while (result[selectedKey] != null && index < 100) {
                 selectedKey = `${key} (${index++})`;
             }
-            result[selectedKey] = childTree;
+            result[selectedKey] = tree;
             return result;
         }, {}),
     };

--- a/packages/ag-charts-community/src/scene/shape/line.ts
+++ b/packages/ag-charts-community/src/scene/shape/line.ts
@@ -37,6 +37,19 @@ export class Line<D = unknown> extends Shape<D> implements DistantObject {
         this.y2 = value;
     }
 
+    protected override get serializedType(): string {
+        return 'line';
+    }
+
+    override serialize() {
+        const state = super.serialize();
+        state.props.x1 = this.x1;
+        state.props.y1 = this.y1;
+        state.props.x2 = this.x2;
+        state.props.y2 = this.y2;
+        return state;
+    }
+
     get midPoint(): { x: number; y: number } {
         return { x: (this.x1 + this.x2) / 2, y: (this.y1 + this.y2) / 2 };
     }

--- a/packages/ag-charts-community/src/scene/shape/line.ts
+++ b/packages/ag-charts-community/src/scene/shape/line.ts
@@ -2,7 +2,7 @@ import type { DistantObject } from 'ag-charts-core';
 import { createSvgElement, lineDistanceSquared } from 'ag-charts-core';
 
 import { BBox } from '../bbox';
-import type { NodeOptions, RenderContext } from '../node';
+import type { NodeOptions, RenderContext, SerializedLineProps, SerializedNodeState } from '../node';
 import { SceneChangeDetection } from '../node';
 import { Shape } from './shape';
 
@@ -37,17 +37,12 @@ export class Line<D = unknown> extends Shape<D> implements DistantObject {
         this.y2 = value;
     }
 
-    protected override get serializedType(): string {
-        return 'line';
+    override serialize(): SerializedNodeState {
+        return { type: 'line', props: this.serializeProps() };
     }
 
-    override serialize() {
-        const state = super.serialize();
-        state.props.x1 = this.x1;
-        state.props.y1 = this.y1;
-        state.props.x2 = this.x2;
-        state.props.y2 = this.y2;
-        return state;
+    protected override serializeProps(): SerializedLineProps {
+        return { ...super.serializeProps(), x1: this.x1, y1: this.y1, x2: this.x2, y2: this.y2 };
     }
 
     get midPoint(): { x: number; y: number } {

--- a/packages/ag-charts-community/src/scene/shape/path.ts
+++ b/packages/ag-charts-community/src/scene/shape/path.ts
@@ -46,6 +46,26 @@ export class Path<D = unknown> extends Shape<D> implements DistantObject {
         this.dirtyPath = true;
     }
 
+    protected override get serializedType(): string {
+        return 'path';
+    }
+
+    override serialize() {
+        const state = super.serialize();
+        const bbox: BBox | undefined = this.getBBox();
+        state.props.x = bbox?.x ?? Number.NaN;
+        state.props.y = bbox?.y ?? Number.NaN;
+        state.props.width = bbox?.width ?? Number.NaN;
+        state.props.height = bbox?.height ?? Number.NaN;
+        state.props.clip = this.clip;
+        state.props.clipX = this._clipX;
+        state.props.clipY = this._clipY;
+        // Read `_path` directly: serialisation must reflect the path as last drawn, without forcing
+        // lazy allocation (Marker) or a premature updatePath.
+        state.svgPath = this._path?.toSVG();
+        return state;
+    }
+
     /**
      * The path only has to be updated when certain attributes change.
      * For example, if transform attributes (such as `translationX`)

--- a/packages/ag-charts-community/src/scene/shape/path.ts
+++ b/packages/ag-charts-community/src/scene/shape/path.ts
@@ -3,7 +3,7 @@ import { SceneChangeDetection, createSvgElement } from 'ag-charts-core';
 
 import type { BBox } from '../bbox';
 import { ExtendedPath2D } from '../extendedPath2D';
-import type { ChildNodeCounts, RenderContext } from '../node';
+import type { ChildNodeCounts, RenderContext, SerializedNodeState, SerializedPathProps } from '../node';
 import { Shape } from './shape';
 
 export class Path<D = unknown> extends Shape<D> implements DistantObject {
@@ -46,24 +46,35 @@ export class Path<D = unknown> extends Shape<D> implements DistantObject {
         this.dirtyPath = true;
     }
 
-    protected override get serializedType(): string {
+    /** Serialised-state discriminator for subclasses (e.g. `Marker`) that share the path property set. */
+    protected get serializedType(): 'path' | 'marker' {
         return 'path';
     }
 
-    override serialize() {
-        const state = super.serialize();
+    override serialize(): SerializedNodeState {
+        return { type: this.serializedType, props: this.serializeProps(), svgPath: this.serializeSvgPath() };
+    }
+
+    protected override serializeProps(): SerializedPathProps {
         const bbox: BBox | undefined = this.getBBox();
-        state.props.x = bbox?.x ?? Number.NaN;
-        state.props.y = bbox?.y ?? Number.NaN;
-        state.props.width = bbox?.width ?? Number.NaN;
-        state.props.height = bbox?.height ?? Number.NaN;
-        state.props.clip = this.clip;
-        state.props.clipX = this._clipX;
-        state.props.clipY = this._clipY;
-        // Read `_path` directly: serialisation must reflect the path as last drawn, without forcing
-        // lazy allocation (Marker) or a premature updatePath.
-        state.svgPath = this._path?.toSVG();
-        return state;
+        return {
+            ...super.serializeProps(),
+            x: bbox?.x ?? Number.NaN,
+            y: bbox?.y ?? Number.NaN,
+            width: bbox?.width ?? Number.NaN,
+            height: bbox?.height ?? Number.NaN,
+            clip: this.clip,
+            clipX: this._clipX,
+            clipY: this._clipY,
+        };
+    }
+
+    /**
+     * The drawn path in SVG form, read from `_path` directly: serialisation must reflect the path as
+     * last drawn, without forcing lazy allocation (Marker) or a premature updatePath.
+     */
+    protected serializeSvgPath(): string | undefined {
+        return this._path?.toSVG();
     }
 
     /**

--- a/packages/ag-charts-community/src/scene/shape/range.ts
+++ b/packages/ag-charts-community/src/scene/shape/range.ts
@@ -1,5 +1,5 @@
 import { BBox } from '../bbox';
-import type { NodeOptions, RenderContext } from '../node';
+import type { NodeOptions, RenderContext, SerializedLineProps, SerializedNodeState } from '../node';
 import { SceneChangeDetection } from '../node';
 import { Shape } from './shape';
 
@@ -31,6 +31,14 @@ export class Range<D = any> extends Shape<D> {
 
     @SceneChangeDetection()
     horizontal: boolean = false;
+
+    override serialize(): SerializedNodeState {
+        return { type: 'range', props: this.serializeProps() };
+    }
+
+    protected override serializeProps(): SerializedLineProps {
+        return { ...super.serializeProps(), x1: this.x1, y1: this.y1, x2: this.x2, y2: this.y2 };
+    }
 
     protected override computeBBox(): BBox {
         return new BBox(this.x1, this.y1, this.x2 - this.x1, this.y2 - this.y1);

--- a/packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.ts
@@ -276,6 +276,19 @@ export class Rect<D = unknown> extends Path<D> implements DistantObject {
     bottomLeftCornerRadius: number = 0;
     declare __bottomLeftCornerRadius: number; // optimised field accessor
 
+    protected override get serializedType(): string {
+        return 'rect';
+    }
+
+    override serialize() {
+        const state = super.serialize();
+        state.props.x = this.x;
+        state.props.y = this.y;
+        state.props.width = this.width;
+        state.props.height = this.height;
+        return state;
+    }
+
     set cornerRadius(cornerRadius: number) {
         this.topLeftCornerRadius = cornerRadius;
         this.topRightCornerRadius = cornerRadius;

--- a/packages/ag-charts-community/src/scene/shape/rect.ts
+++ b/packages/ag-charts-community/src/scene/shape/rect.ts
@@ -4,6 +4,7 @@ import type { AgDrawingMode } from 'ag-charts-types';
 import { BBox } from '../bbox';
 import type { DropShadow } from '../dropShadow';
 import { ExtendedPath2D } from '../extendedPath2D';
+import type { SerializedNodeState, SerializedPathProps } from '../node';
 import { type Corner, drawCorner } from '../util/corner';
 import { Path } from './path';
 import { type CanvasContext } from './shape';
@@ -276,17 +277,12 @@ export class Rect<D = unknown> extends Path<D> implements DistantObject {
     bottomLeftCornerRadius: number = 0;
     declare __bottomLeftCornerRadius: number; // optimised field accessor
 
-    protected override get serializedType(): string {
-        return 'rect';
+    override serialize(): SerializedNodeState {
+        return { type: 'rect', props: this.serializeProps(), svgPath: this.serializeSvgPath() };
     }
 
-    override serialize() {
-        const state = super.serialize();
-        state.props.x = this.x;
-        state.props.y = this.y;
-        state.props.width = this.width;
-        state.props.height = this.height;
-        return state;
+    protected override serializeProps(): SerializedPathProps {
+        return { ...super.serializeProps(), x: this.x, y: this.y, width: this.width, height: this.height };
     }
 
     set cornerRadius(cornerRadius: number) {

--- a/packages/ag-charts-community/src/scene/shape/sector.ts
+++ b/packages/ag-charts-community/src/scene/shape/sector.ts
@@ -100,6 +100,19 @@ export class Sector<D = unknown> extends Path<D> {
     @SceneChangeDetection()
     endInnerCornerRadius: number = 0;
 
+    protected override get serializedType(): string {
+        return 'sector';
+    }
+
+    override serialize() {
+        const state = super.serialize();
+        state.props.startAngle = this.startAngle;
+        state.props.endAngle = this.endAngle;
+        state.props.innerRadius = this.innerRadius;
+        state.props.outerRadius = this.outerRadius;
+        return state;
+    }
+
     set inset(value: number) {
         this.concentricEdgeInset = value;
         this.radialEdgeInset = value;

--- a/packages/ag-charts-community/src/scene/shape/sector.ts
+++ b/packages/ag-charts-community/src/scene/shape/sector.ts
@@ -2,6 +2,7 @@ import type { Point } from 'ag-charts-core';
 import { SceneChangeDetection, SceneObjectChangeDetection } from 'ag-charts-core';
 
 import type { BBox } from '../bbox';
+import type { SerializedNodeState, SerializedSectorProps } from '../node';
 import { SectorBox } from '../sectorBox';
 import {
     arcCircleIntersectionAngle,
@@ -100,17 +101,18 @@ export class Sector<D = unknown> extends Path<D> {
     @SceneChangeDetection()
     endInnerCornerRadius: number = 0;
 
-    protected override get serializedType(): string {
-        return 'sector';
+    override serialize(): SerializedNodeState {
+        return { type: 'sector', props: this.serializeProps(), svgPath: this.serializeSvgPath() };
     }
 
-    override serialize() {
-        const state = super.serialize();
-        state.props.startAngle = this.startAngle;
-        state.props.endAngle = this.endAngle;
-        state.props.innerRadius = this.innerRadius;
-        state.props.outerRadius = this.outerRadius;
-        return state;
+    protected override serializeProps(): SerializedSectorProps {
+        return {
+            ...super.serializeProps(),
+            startAngle: this.startAngle,
+            endAngle: this.endAngle,
+            innerRadius: this.innerRadius,
+            outerRadius: this.outerRadius,
+        };
     }
 
     set inset(value: number) {

--- a/packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/packages/ag-charts-community/src/scene/shape/shape.ts
@@ -190,6 +190,13 @@ export abstract class Shape<TDatum = unknown> extends Node<TDatum> {
     opacity: number = 1;
     declare __opacity: number; // optimised field accessor
 
+    override serialize() {
+        const state = super.serialize();
+        state.props.opacity = this.opacity;
+        state.props.drawingMode = this.drawingMode;
+        return state;
+    }
+
     @SceneObjectChangeDetection({ equals: TRIPLE_EQ, checkDirtyOnAssignment: true })
     fillShadow: DropShadow | undefined;
     declare __fillShadow: DropShadow | undefined; // optimised field accessor

--- a/packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/packages/ag-charts-community/src/scene/shape/shape.ts
@@ -195,7 +195,13 @@ export abstract class Shape<TDatum = unknown> extends Node<TDatum> {
     abstract override serialize(): SerializedNodeState;
 
     protected override serializeProps(): SerializedShapeProps {
-        return { ...super.serializeProps(), opacity: this.opacity, drawingMode: this.drawingMode };
+        return {
+            ...super.serializeProps(),
+            opacity: this.opacity,
+            drawingMode: this.drawingMode,
+            hasFill: this.fill != null,
+            hasStroke: this.stroke != null,
+        };
     }
 
     @SceneObjectChangeDetection({ equals: TRIPLE_EQ, checkDirtyOnAssignment: true })

--- a/packages/ag-charts-community/src/scene/shape/shape.ts
+++ b/packages/ag-charts-community/src/scene/shape/shape.ts
@@ -32,6 +32,7 @@ import { LinearGradient } from '../gradient/linearGradient';
 import { RadialGradient } from '../gradient/radialGradient';
 import { getColorStops } from '../gradient/stops';
 import { Image } from '../image/image';
+import type { SerializedNodeState, SerializedShapeProps } from '../node';
 import { Node } from '../node';
 import { Pattern } from '../pattern/pattern';
 import { align } from '../util/pixel';
@@ -190,11 +191,11 @@ export abstract class Shape<TDatum = unknown> extends Node<TDatum> {
     opacity: number = 1;
     declare __opacity: number; // optimised field accessor
 
-    override serialize() {
-        const state = super.serialize();
-        state.props.opacity = this.opacity;
-        state.props.drawingMode = this.drawingMode;
-        return state;
+    /** Every concrete shape must declare which {@link SerializedNodeState} variant it serialises as. */
+    abstract override serialize(): SerializedNodeState;
+
+    protected override serializeProps(): SerializedShapeProps {
+        return { ...super.serializeProps(), opacity: this.opacity, drawingMode: this.drawingMode };
     }
 
     @SceneObjectChangeDetection({ equals: TRIPLE_EQ, checkDirtyOnAssignment: true })

--- a/packages/ag-charts-community/src/scene/shape/text.ts
+++ b/packages/ag-charts-community/src/scene/shape/text.ts
@@ -86,7 +86,12 @@ export class Text<D = unknown> extends Shape<D> {
     }
 
     protected override serializeProps(): SerializedTextProps {
-        return { ...super.serializeProps(), x: this.x, y: this.y };
+        return {
+            ...super.serializeProps(),
+            x: this.x,
+            y: this.y,
+            text: this.text == null ? undefined : String(this.text),
+        };
     }
 
     private lines: string[] = [];

--- a/packages/ag-charts-community/src/scene/shape/text.ts
+++ b/packages/ag-charts-community/src/scene/shape/text.ts
@@ -81,6 +81,17 @@ export class Text<D = unknown> extends Shape<D> {
     @SceneChangeDetection()
     y: number = 0;
 
+    protected override get serializedType(): string {
+        return 'text';
+    }
+
+    override serialize() {
+        const state = super.serialize();
+        state.props.x = this.x;
+        state.props.y = this.y;
+        return state;
+    }
+
     private lines: string[] = [];
     private onTextChange() {
         this.richText?.clear();

--- a/packages/ag-charts-community/src/scene/shape/text.ts
+++ b/packages/ag-charts-community/src/scene/shape/text.ts
@@ -28,7 +28,7 @@ import type { FontStyle, FontWeight, Opacity, Padding, PixelSize } from 'ag-char
 
 import { BBox } from '../bbox';
 import { Group } from '../group';
-import type { IScene, Node, NodeOptions, RenderContext } from '../node';
+import type { IScene, Node, NodeOptions, RenderContext, SerializedNodeState, SerializedTextProps } from '../node';
 import { SceneChangeDetection } from '../node';
 import { DebugSelectors } from '../sceneDebug';
 import { Rotatable, type RotatableType, Translatable, type TranslatableType } from '../transformable';
@@ -81,15 +81,12 @@ export class Text<D = unknown> extends Shape<D> {
     @SceneChangeDetection()
     y: number = 0;
 
-    protected override get serializedType(): string {
-        return 'text';
+    override serialize(): SerializedNodeState {
+        return { type: 'text', props: this.serializeProps() };
     }
 
-    override serialize() {
-        const state = super.serialize();
-        state.props.x = this.x;
-        state.props.y = this.y;
-        return state;
+    protected override serializeProps(): SerializedTextProps {
+        return { ...super.serializeProps(), x: this.x, y: this.y };
     }
 
     private lines: string[] = [];

--- a/packages/ag-charts-community/src/scene/transformable.ts
+++ b/packages/ag-charts-community/src/scene/transformable.ts
@@ -197,6 +197,12 @@ export function Rotatable<N extends Node<any>>(Parent: Constructor<N>): Construc
         @SceneChangeDetection()
         rotation: number = 0;
 
+        override serialize() {
+            const state = super.serialize();
+            state.props.rotation = this.rotation;
+            return state;
+        }
+
         override updateMatrix(matrix: Matrix) {
             super.updateMatrix(matrix);
 
@@ -261,6 +267,13 @@ export function Scalable<N extends Node<any>>(Parent: Constructor<N>): Construct
         scalingCenterY: number = 0;
         declare __scalingCenterY: number; // optimised field accessor
 
+        override serialize() {
+            const state = super.serialize();
+            state.props.scalingX = this.scalingX;
+            state.props.scalingY = this.scalingY;
+            return state;
+        }
+
         override updateMatrix(matrix: Matrix) {
             super.updateMatrix(matrix);
 
@@ -314,6 +327,13 @@ export function Translatable<N extends Node<any>>(Parent: Constructor<N>): Const
         translationX: number = 0;
         @SceneChangeDetection()
         translationY: number = 0;
+
+        override serialize() {
+            const state = super.serialize();
+            state.props.translationX = this.translationX;
+            state.props.translationY = this.translationY;
+            return state;
+        }
 
         override updateMatrix(matrix: Matrix) {
             super.updateMatrix(matrix);


### PR DESCRIPTION
Stacked on #7322. Tracked under [AG-17755](https://ag-grid.atlassian.net/browse/AG-17755).

Addresses the review feedback on #7322 that the trajectory harness's per-shape geometry readers were fragile: extraction knowledge lived in test utils (`instanceof` matching + property poking) and would need extending for every new shape class.

## Scene-graph serialisation contract

Every scene `Node` now exposes `serialize()`, returning a plain-data snapshot of its rendered state:

- a `type` discriminator (`'rect'`, `'text'`, `'sector'`, …) stable across subclassing, so e.g. `BarShape` still reads as a rect;
- a typed props object of animatable/paint state — each class contributes what it owns through a `serializeProps()` chain (`Shape` adds opacity/drawingMode, `Line`/`Text`/`Rect`/`Sector` their geometry fields, `Path` adds bbox + clip state, and the `Translatable`/`Scalable`/`Rotatable` mixins their transform props);
- the drawn path in SVG form for path-painting nodes.

## Closed discriminated union (second commit)

`SerializedNodeState` is a **closed discriminated union** — one typed variant per node kind — rather than a stringly-typed prop bag. This makes the coupling between scene and consumers compiler-enforced in both directions:

- `Shape.serialize` is abstract, so a new concrete shape **cannot compile** without declaring which variant it serialises as (either reusing an existing kind, an explicit reviewable line, or adding a new variant to the union);
- the trajectory sampler consumes the union through an exhaustive switch (`state satisfies never` default), so a new variant fails compilation in the test harness until its sampling behaviour is decided;
- each variant's props are typed, so renaming/removing an emitted property breaks the consumer at compile time — no blind `as number` casts selecting props that might not exist.

A bonus: the `as unknown as` cast used to reach `Path`'s private clip backing fields is gone — the class serialises them itself.

## Contract reuse beyond the test harness (third commit)

The scene debug tree (`buildTree` in `sceneDebug.ts`) now consumes `serialize()` too: the `'json'` dump emits the typed serialised state instead of reflectively scraping instance fields through a hand-maintained allowlist (the same external-knowledge fragility this PR removes from the test harness), and the `'console'` tree decorations read from serialised state. Shapes additionally serialise `hasFill`/`hasStroke` and `Text` its rendered text, which lets the trajectory sampler derive node identity from serialised state — the last `instanceof` reads are gone from the sampler.

No trajectory spec changed — all spike CASEs pass unchanged, demonstrating the assertion abstraction is decoupled from the extraction mechanism.

This is also a first step toward a formal `chart.getState()`-style scene serialisation if we decide we want one.

## Verification

`ag-charts-community` + `ag-charts-enterprise` full test suites, `build:test` type-checks, lint and format all green.

Follow-up (stacked): #7329 extends the harness for the `-test` page animation coverage and adds the axis animation suite.

