### PR TITLE
Animation trajectory testing: -test page gap probes and axis animation suite

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/cartesianAxisAnimation.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxisAnimation.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgCartesianChartOptions, AgChartOptions } from 'ag-charts-types';
+
+import { AgCharts } from '../../api/agCharts';
+import type { AgChartProxy } from '../chartProxy';
+import type { SceneNodeExpectation, ScenePropertyExpectation } from '../test/utils';
+import {
+    createSceneGeometrySampler,
+    expectNoAnimation,
+    expectSceneTrajectory,
+    prepareTestOptions,
+    setupMockCanvas,
+    setupMockConsole,
+    spyOnAnimationFrames,
+} from '../test/utils';
+
+// SPIKE: axis-focused frame-trajectory animation tests. Series tests exercise axes incidentally via
+// axisReflowSpec; this suite drives the axis behaviours directly — per-tick identity across a domain
+// change (which tick leaves, which enters, which slides where), label-rotation interpolation, and
+// out-of-range tick culling — with a minimal line series as scaffolding.
+describe('CartesianAxis animation', () => {
+    setupMockConsole();
+    setupMockCanvas();
+    const frames = spyOnAnimationFrames();
+
+    let chart: AgChartProxy;
+
+    afterEach(() => {
+        chart?.destroy();
+        (chart as unknown) = undefined;
+    });
+
+    const slidesLeft = { during: 'update', expect: ['decreases', 'bounded'] } as const;
+    const fadesOut = { during: ['remove', 'update', 'add'], expect: 'bounded' } as const;
+    const fadesIn = { during: 'add', expect: ['increases', 'bounded'] } as const;
+    // Expand a generic {slide, ...} tick spec onto a node's actual coordinate props.
+    const mapKeyedCoords = (
+        spec: Partial<Record<string, ScenePropertyExpectation>>,
+        ...coords: string[]
+    ): Partial<Record<string, ScenePropertyExpectation>> => {
+        const { slide, ...rest } = spec;
+        if (slide == null) return rest;
+        return { ...rest, ...Object.fromEntries(coords.map((coord) => [coord, slide])) };
+    };
+    // One spec entry per scene node of a bottom-axis tick: label, tick line and gridline.
+    const bottomTick = (
+        id: string,
+        spec: Partial<Record<string, ScenePropertyExpectation>>
+    ): Record<string, SceneNodeExpectation> => ({
+        [`axis[bottom]/text[${id}]`]: mapKeyedCoords(spec, 'x'),
+        [`axis[bottom]/line[${id}]`]: mapKeyedCoords(spec, 'x1', 'x2'),
+        [`axis[bottom]/grid/line[${id}]`]: mapKeyedCoords(spec, 'x1', 'x2'),
+    });
+
+    const numberChartOptions = (
+        data: Array<{ x: number; y: number }>,
+        xAxisExtras: object = {}
+    ): AgCartesianChartOptions =>
+        prepareTestOptions({
+            data,
+            series: [{ type: 'line', xKey: 'x', yKey: 'y', marker: { enabled: false } }],
+            axes: {
+                x: { type: 'number', position: 'bottom', ...xAxisExtras },
+                y: { type: 'number', position: 'left' },
+            },
+        });
+
+    it('number-axis domain growth slides surviving ticks and swaps the tick set with fades', async () => {
+        chart = AgCharts.create(
+            numberChartOptions([
+                { x: 0, y: 0 },
+                { x: 100, y: 100 },
+            ])
+        ) as AgChartProxy;
+        await frames.runToEnd(chart);
+        const sampleScene = createSceneGeometrySampler(chart);
+
+        // Grow the domain via the axis option so the series geometry morphs smoothly and the case
+        // stays focused on the axis: surviving ticks slide, the stale set fades out, the new set
+        // fades in.
+        await chart.updateDelta({ axes: { x: { max: 200 } } });
+        const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+        // Per-tick identity: tick 0 anchors (default constant), tick 100 slides to the domain
+        // midpoint, ticks 20-80 (the stale step-20 set) slide out fading, ticks 50/150/200 (the new
+        // step-50 set) fade in at their final positions during `add`.
+        expectSceneTrajectory(trajectory, {
+            'series[0]/path[stroke]': { width: { during: 'update', expect: ['decreases', 'progresses', 'bounded'] } },
+            ...bottomTick('l:100', { slide: slidesLeft }),
+            ...bottomTick('l:20', { slide: slidesLeft, opacity: fadesOut }),
+            ...bottomTick('l:40', { slide: slidesLeft, opacity: fadesOut }),
+            ...bottomTick('l:60', { slide: slidesLeft, opacity: fadesOut }),
+            ...bottomTick('l:80', { slide: slidesLeft, opacity: fadesOut }),
+            ...bottomTick('l:50', { opacity: fadesIn }),
+            ...bottomTick('l:150', { opacity: fadesIn }),
+            ...bottomTick('l:200', { opacity: fadesIn }),
+        });
+    });
+
+    it('label rotation change interpolates via the shortest arc', async () => {
+        const options = numberChartOptions([
+            { x: 0, y: 0 },
+            { x: 100, y: 100 },
+        ]);
+        chart = AgCharts.create(options) as AgChartProxy;
+        await frames.runToEnd(chart);
+        const sampleScene = createSceneGeometrySampler(chart);
+
+        await chart.updateDelta({ axes: { x: { label: { rotation: 45 } } } });
+        const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+        const duringUpdate = (
+            ...expect_: readonly ('increases' | 'decreases' | 'progresses' | 'bounded')[]
+        ): ScenePropertyExpectation => ({ during: 'update', expect: expect_ });
+
+        // The rotated labels shrink the bottom gutter, so the whole plot reflows a few pixels
+        // downward alongside the rotation tween: the bottom axis groups translate down, the bottom
+        // gridlines' far end (measured upward, negative) follows, and the left axis ticks/labels/grid
+        // slide down with the plot edge.
+        expectSceneTrajectory(trajectory, {
+            'axis[bottom]/text[l:*]': { rotation: duringUpdate('increases', 'progresses', 'bounded') },
+            'axis[bottom]/group[*]': { translationY: duringUpdate('decreases', 'bounded') },
+            'axis[bottom]/grid/line[*]': { y2: duringUpdate('increases', 'bounded') },
+            'axis[left]/text[*]': { y: duringUpdate('decreases', 'bounded') },
+            'axis[left]/line[*]': {
+                y1: duringUpdate('decreases', 'bounded'),
+                y2: duringUpdate('decreases', 'bounded'),
+            },
+            'axis[left]/grid/line[*]': {
+                y1: duringUpdate('decreases', 'bounded'),
+                y2: duringUpdate('decreases', 'bounded'),
+            },
+            'series[0]/path[stroke]': {
+                height: duringUpdate('decreases', 'bounded'),
+                'top@0': duringUpdate('decreases', 'bounded'),
+                'top@1': duringUpdate('decreases', 'bounded'),
+                'top@2': duringUpdate('decreases', 'bounded'),
+                'top@3': duringUpdate('decreases', 'bounded'),
+            },
+        });
+
+        // Shortest-arc: the tween settles at +45° (π/4), not the long way round (-315°).
+        const finalRotation = trajectory.at(-1)!.get('axis[bottom]/text[l:0]')!.rotation;
+        expect(finalRotation).toBeCloseTo(Math.PI / 4, 3);
+    });
+
+    it('ticks sliding out of the range are culled mid-flight', async () => {
+        chart = AgCharts.create(
+            numberChartOptions([
+                { x: 0, y: 0 },
+                { x: 100, y: 100 },
+            ])
+        ) as AgChartProxy;
+        await frames.runToEnd(chart);
+        const sampleScene = createSceneGeometrySampler(chart);
+
+        // Pan the window right: surviving ticks slide left, and any tick crossing the range edge
+        // must flip invisible rather than draw outside the plot. The y-axis is pinned to keep the
+        // case bottom-axis-only (the smaller visible data window would otherwise rescale y too).
+        await chart.updateDelta({ axes: { x: { min: 50, max: 150 }, y: { min: 0, max: 100 } } });
+        const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+        expectSceneTrajectory(trajectory, {
+            'series[0]/path[stroke]': { x: { during: 'update', expect: ['decreases', 'progresses', 'bounded'] } },
+            ...bottomTick('l:60', { slide: slidesLeft }),
+            ...bottomTick('l:80', { slide: slidesLeft }),
+            ...bottomTick('l:100', { slide: slidesLeft }),
+            ...bottomTick('l:0', { slide: slidesLeft, opacity: fadesOut }),
+            ...bottomTick('l:20', { slide: slidesLeft, opacity: fadesOut }),
+            ...bottomTick('l:40', { slide: slidesLeft, opacity: fadesOut }),
+            ...bottomTick('l:120', { opacity: fadesIn }),
+            ...bottomTick('l:140', { opacity: fadesIn }),
+        });
+
+        // Nothing may be drawn outside the range once the pan settles: tick 0 crosses the range
+        // start mid-flight and must be fully faded by the last frame it is still in the scene.
+        // NOTE: the dedicated visibility culling (axisUtil `node.visible = !outOfBounds(node.y)`)
+        // is inert — Line exposes only a `y` SETTER, so `node.y` reads undefined — hence only the
+        // fade is assertable here.
+        const lastPresent = [...trajectory].reverse().find((f) => f.has('axis[bottom]/text[l:0]'));
+        for (const node of ['text[l:0]', 'line[l:0]', 'grid/line[l:0]']) {
+            expect(lastPresent!.get(`axis[bottom]/${node}`)!.opacity).toBe(0);
+        }
+    });
+
+    it('reversed number-axis domain growth slides ticks in the opposite direction', async () => {
+        const options = numberChartOptions(
+            [
+                { x: 0, y: 0 },
+                { x: 100, y: 100 },
+            ],
+            { reverse: true }
+        );
+        chart = AgCharts.create(options) as AgChartProxy;
+        await frames.runToEnd(chart);
+        const sampleScene = createSceneGeometrySampler(chart);
+
+        await chart.updateDelta({ axes: { x: { max: 200 } } });
+        const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+        // Mirror of the unreversed case: tick 100 starts at the range START and slides right.
+        // NOTE: the series stroke path is empty until the trailing phase on a reversed-axis domain
+        // change (the tween hides the line entirely) — the path node therefore carries no drawn
+        // geometry mid-flight and only its settled frames are checked.
+        const slidesRight = { during: 'update', expect: ['increases', 'bounded'] } as const;
+        const rightTick = (id: string): Record<string, SceneNodeExpectation> => ({
+            [`axis[bottom]/text[${id}]`]: { x: slidesRight, opacity: fadesOut },
+            [`axis[bottom]/line[${id}]`]: { x1: slidesRight, x2: slidesRight, opacity: fadesOut },
+            [`axis[bottom]/grid/line[${id}]`]: { x1: slidesRight, x2: slidesRight, opacity: fadesOut },
+        });
+        expectSceneTrajectory(trajectory, {
+            ...rightTick('l:100'),
+            ...rightTick('l:20'),
+            ...rightTick('l:40'),
+            ...rightTick('l:60'),
+            ...rightTick('l:80'),
+            ...bottomTick('l:50', { opacity: fadesIn }),
+            ...bottomTick('l:150', { opacity: fadesIn }),
+            ...bottomTick('l:200', { opacity: fadesIn }),
+        });
+    });
+
+    it('time-axis domain growth re-ticks across the unit change with fades and slides', async () => {
+        const day = (n: number) => new Date(2024, 0, n);
+        const timeChartOptions = (maxDay: number): AgChartOptions =>
+            prepareTestOptions({
+                data: [
+                    { x: day(1), y: 0 },
+                    { x: day(maxDay), y: 100 },
+                ],
+                series: [{ type: 'line', xKey: 'x', yKey: 'y', marker: { enabled: false } }],
+                axes: {
+                    x: { type: 'time', position: 'bottom' },
+                    y: { type: 'number', position: 'left' },
+                },
+            });
+
+        chart = AgCharts.create(timeChartOptions(8)) as AgChartProxy;
+        await frames.runToEnd(chart);
+        const sampleScene = createSceneGeometrySampler(chart);
+
+        await chart.updateDelta({
+            data: [
+                { x: day(1), y: 0 },
+                { x: day(91), y: 100 },
+            ],
+        });
+        const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+        // The day→month unit change replaces the whole tick set (epoch-keyed identities): with no
+        // surviving ticks the `update` phase is empty, so the old day ticks fade out in `remove`
+        // and the month ticks fade in during `add`. All movement stays phase-scoped and bounded.
+        const fadeSwap = { during: ['remove', 'update', 'add'], expect: 'bounded' } as const;
+        const holds = { during: ['update', 'add'], expect: 'bounded' } as const;
+        const lineReticks = { opacity: fadeSwap, x1: holds, x2: holds } as const;
+        const morphs = { during: ['remove', 'add'], expect: 'progresses' } as const;
+        expectSceneTrajectory(trajectory, {
+            'axis[bottom]/text[v:*]': { opacity: fadeSwap, x: holds },
+            'axis[bottom]/line[v:*]': lineReticks,
+            // The changed point is removed and re-added, so the line dips away and back.
+            'series[0]/path[stroke]': {
+                x: { during: ['remove', 'add'], expect: ['increases', 'bounded'] },
+                y: morphs,
+                width: morphs,
+                height: morphs,
+                'top@1': morphs,
+                'top@2': morphs,
+                'top@3': morphs,
+                'top@4': morphs,
+            },
+        });
+
+        // The swap must complete: every surviving (month) tick label is fully opaque at the end.
+        const finalFrame = trajectory.at(-1)!;
+        const monthLabels = [...finalFrame.keys()].filter((k) => /^axis\[bottom\]\/text\[v:/.test(k));
+        expect(monthLabels.length).toBeGreaterThan(0);
+        for (const key of monthLabels) {
+            expect(finalFrame.get(key)!.opacity, key).toBe(1);
+        }
+    });
+
+    it('resize snaps the axes to the new layout without tweening', async () => {
+        const options = numberChartOptions([
+            { x: 0, y: 0 },
+            { x: 100, y: 100 },
+        ]);
+        chart = AgCharts.create(options) as AgChartProxy;
+        await frames.runToEnd(chart);
+        const sampleScene = createSceneGeometrySampler(chart);
+        const tickBefore = sampleScene().get('axis[bottom]/text[l:100]')!.x;
+
+        await chart.update({ ...options, width: 400 });
+        const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+        expectNoAnimation(trajectory);
+        // The resize must have re-laid-out instantly: the end tick is already at its new position
+        // on the first captured frame.
+        const tickAfter = trajectory[0].get('axis[bottom]/text[l:100]')!.x;
+        expect(tickAfter).toBeLessThan(tickBefore - 100);
+    });
+});

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ChartAxisDirection, deepClone } from 'ag-charts-core';
+import { ChartAxisDirection, deepClone, mapValues } from 'ag-charts-core';
 import { classCast } from 'ag-charts-test';
 import type {
     AgAreaSeriesMarkerItemStylerParams,
@@ -43,16 +43,19 @@ import {
 import * as examples from '../../test/examples';
 import { type MockAreaStyler, newFreezableMock } from '../../test/freezableMock';
 import { testLegendItemName } from '../../test/legendItemName';
-import type { CartesianOrPolarTestCase, ChartTestCase } from '../../test/utils';
+import type { CartesianOrPolarTestCase, ChartTestCase, ScenePropertyExpectation } from '../../test/utils';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
     PATTERN_SNAPSHOT_DEFAULTS,
+    axisReflowSpec,
     cartesianChartAssertions,
     clickAction,
     createChart,
+    createSceneGeometrySampler,
     deproxy,
     doubleClickAction,
     doubleTapAction,
+    expectSceneTrajectory,
     expectWarningsCalls,
     extractImageData,
     hoverAction,
@@ -61,6 +64,7 @@ import {
     repeat,
     setupMockCanvas,
     setupMockConsole,
+    spyOnAnimationFrames,
     spyOnAnimationManager,
     tapAction,
     waitForChartStability,
@@ -369,6 +373,190 @@ describe('AreaSeries', () => {
     });
 
     const ctx = setupMockCanvas();
+
+    // SPIKE: frame-trajectory invariant tests for stacked areas. Areas paint one fill Path and one
+    // stroke Path per series; both are sampled with `top@<i>` stations, so the animated top edge of
+    // each layer gets per-point trajectories (the fill's baseline below is invisible to the topmost-y
+    // stations, which is exactly the edge that must not dive to the baseline mid-animation).
+    describe('animation frame-trajectory (spike)', () => {
+        const frames = spyOnAnimationFrames();
+
+        const STACKED_AREA_DATA = [
+            { quarter: 'Q1', apples: 50, oranges: 30 },
+            { quarter: 'Q2', apples: 60, oranges: 40 },
+            { quarter: 'Q3', apples: 70, oranges: 35 },
+        ];
+        const EXTENDED_AREA_DATA = [
+            ...STACKED_AREA_DATA,
+            { quarter: 'Q4', apples: 80, oranges: 45 },
+            { quarter: 'Q5', apples: 65, oranges: 50 },
+        ];
+        const stackedAreaOptions = (data: typeof STACKED_AREA_DATA): AgChartOptions =>
+            prepareTestOptions({
+                data,
+                series: [
+                    { type: 'area', xKey: 'quarter', yKey: 'apples', stacked: true },
+                    { type: 'area', xKey: 'quarter', yKey: 'oranges', stacked: true },
+                ],
+                // The pinned y-domain keeps the y-axis static, isolating the stacked layer edges
+                // (and the x-axis reflow) from y-rescale noise.
+                axes: {
+                    x: { type: 'category', position: 'bottom' },
+                    y: { type: 'number', position: 'left', min: 0, max: 140 },
+                },
+            });
+
+        it('CASE 7: stacked area point-add morphs each layer edge from its cumulative position', async () => {
+            chart = AgCharts.create(stackedAreaOptions(STACKED_AREA_DATA));
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            await chart.updateDelta({ data: EXTENDED_AREA_DATA });
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // A from-the-baseline regression would send the layer edges toward the bottom of the plot;
+            // monotonic, endpoint-bounded station moves during `add` pin them to cumulative positions.
+            // Width dips below both endpoints mid-flight (band squeeze before the new points extend).
+            const layerEdge = (
+                tops: Record<string, 'increases' | 'decreases'>
+            ): Partial<Record<string, ScenePropertyExpectation>> => ({
+                y: { during: 'add', expect: ['decreases', 'bounded'] },
+                width: { during: ['update', 'add'], expect: 'progresses' },
+                height: { during: 'add', expect: ['increases', 'bounded'] },
+                ...mapValues(tops, (direction) => ({ during: 'add', expect: [direction, 'bounded'] }) as const),
+            });
+            const applesTops = {
+                'top@1': 'decreases',
+                'top@2': 'decreases',
+                'top@3': 'decreases',
+                'top@4': 'increases', // Q5 apples (65) sits below Q4 (80), so the right edge drops
+            } as const;
+            const orangesTops = {
+                'top@1': 'decreases',
+                'top@2': 'decreases',
+                'top@3': 'decreases',
+                'top@4': 'decreases',
+            } as const;
+            // The fill is drawn as one closed polygon per span: extending to the new points adds
+            // subpaths during `add`, then the trailing re-plot merges them into a single polygon —
+            // structural, not monotonic, so only the phase window and settle are asserted.
+            const fillSubpaths = { subpaths: { during: ['add', 'trailing'], expect: 'progresses' } } as const;
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': layerEdge(applesTops),
+                'series[0]/background/path[fill]': { ...layerEdge(applesTops), ...fillSubpaths },
+                'series[1]/path[stroke]': layerEdge(orangesTops),
+                'series[1]/background/path[fill]': { ...layerEdge(orangesTops), ...fillSubpaths },
+                ...axisReflowSpec('bottom', { shift: 'left' }),
+            });
+        });
+
+        it('CASE 8: stacked area point-remove morphs each layer edge back monotonically', async () => {
+            chart = AgCharts.create(stackedAreaOptions(EXTENDED_AREA_DATA));
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            await chart.updateDelta({ data: STACKED_AREA_DATA });
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // Mirror of CASE 7: the removed points retract during `remove` (edges rise toward the
+            // smaller stack, right edge collapses), then the surviving band re-widens during `update`;
+            // the fill sheds its extra subpaths during `remove` with a final merge in the trailing
+            // cleanup.
+            const layerEdge = (
+                tops: Record<string, 'increases' | 'decreases'>
+            ): Partial<Record<string, ScenePropertyExpectation>> => ({
+                y: { during: 'remove', expect: ['increases', 'bounded'] },
+                width: { during: ['remove', 'update'], expect: 'progresses' },
+                height: { during: 'remove', expect: ['decreases', 'bounded'] },
+                ...mapValues(tops, (direction) => ({ during: 'remove', expect: [direction, 'bounded'] }) as const),
+            });
+            const applesTops = {
+                'top@1': 'increases',
+                'top@2': 'increases',
+                'top@3': 'increases',
+                'top@4': 'decreases',
+            } as const;
+            const orangesTops = {
+                'top@1': 'increases',
+                'top@2': 'increases',
+                'top@3': 'increases',
+                'top@4': 'increases',
+            } as const;
+            const fillSubpaths = {
+                subpaths: { during: ['remove', 'trailing'], expect: ['decreases', 'bounded'] },
+            } as const;
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': layerEdge(applesTops),
+                'series[0]/background/path[fill]': { ...layerEdge(applesTops), ...fillSubpaths },
+                'series[1]/path[stroke]': layerEdge(orangesTops),
+                'series[1]/background/path[fill]': { ...layerEdge(orangesTops), ...fillSubpaths },
+                ...axisReflowSpec('bottom', { shift: 'right' }),
+            });
+        });
+
+        it('CASE 9: initial load reveals the fully-drawn stacked areas behind a sweeping clip window', async () => {
+            chart = AgCharts.create(stackedAreaOptions(STACKED_AREA_DATA));
+            const sampleScene = createSceneGeometrySampler(chart);
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // Every fill and stroke is fully drawn from frame 0 (their stations must hold constant);
+            // the ONLY thing that moves in the whole scene is the reveal clip window.
+            const revealPath = {
+                clip: { during: ['initial', 'trailing'], expect: ['decreases', 'bounded'] },
+                'clip:x': { during: 'initial', expect: ['increases', 'progresses', 'bounded'] },
+            } as const;
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': revealPath,
+                'series[0]/background/path[fill]': revealPath,
+                'series[1]/path[stroke]': revealPath,
+                'series[1]/background/path[fill]': revealPath,
+            });
+        });
+
+        it('CASE 10: setting a mid-series datum to undefined opens a gap in both layers', async () => {
+            chart = AgCharts.create(stackedAreaOptions(EXTENDED_AREA_DATA));
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            await chart.updateDelta({
+                data: EXTENDED_AREA_DATA.map((d) => (d.quarter === 'Q3' ? { ...d, apples: undefined as any } : d)),
+            });
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // The nulled apples value sinks its station toward the baseline during remove/update,
+            // then the stroke gap opens (station goes non-finite — `degenerate`); the oranges layer
+            // above drops by the same amount (its own value is still defined) and its stroke splits
+            // around the dead base. Fills keep painting to the baseline, so their stations stay
+            // finite while their span count drops.
+            const sinks = { during: ['remove', 'update'], expect: ['increases', 'bounded'] } as const;
+            const respans = (direction: 'increases' | 'decreases') =>
+                ({ during: ['remove', 'update'], expect: [direction, 'bounded'] }) as const;
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': {
+                    height: { during: ['remove', 'update'], expect: 'progresses' },
+                    subpaths: { during: ['remove', 'update'], expect: 'progresses' },
+                    'top@2': { during: ['remove', 'update'], expect: ['degenerate', 'increases', 'bounded'] },
+                },
+                'series[0]/background/path[fill]': { subpaths: respans('decreases'), 'top@2': sinks },
+                'series[1]/path[stroke]': {
+                    height: { during: ['remove', 'update'], expect: ['increases', 'bounded'] },
+                    subpaths: respans('increases'),
+                    'top@2': sinks,
+                },
+                'series[1]/background/path[fill]': {
+                    height: { during: ['remove', 'update'], expect: ['increases', 'bounded'] },
+                    subpaths: respans('decreases'),
+                    'top@2': sinks,
+                },
+                ...axisReflowSpec('bottom', {}),
+            });
+
+            // The gap must persist: the apples stroke ends split with a dead station over Q3.
+            const finalStroke = trajectory.at(-1)!.get('series[0]/path[stroke]')!;
+            expect(finalStroke.subpaths).toBe(2);
+            expect(Number.isFinite(finalStroke['top@2'])).toBe(false);
+        });
+    });
 
     describe('#create', () => {
         beforeEach(() => {

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts
@@ -34,7 +34,7 @@ import {
 import * as examples from '../../test/examples';
 import { type MockBarStyler, newFreezableMock } from '../../test/freezableMock';
 import { testLegendItemName } from '../../test/legendItemName';
-import type { CartesianOrPolarTestCase } from '../../test/utils';
+import type { CartesianOrPolarTestCase, SceneFrameInvariant } from '../../test/utils';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
     MIN_UNHIGHLIGHT_DELAY,
@@ -46,6 +46,7 @@ import {
     createChart,
     createSceneGeometrySampler,
     deproxy,
+    expectSceneSamplesMatch,
     expectSceneTrajectory,
     expectWarningsCalls,
     extractImageData,
@@ -771,8 +772,8 @@ describe('BarSeries', () => {
             const after = sampleScene();
 
             // Endpoints: first frame is the before-state, last frame is the after-state.
-            expect(trajectory[0]).toEqual(before);
-            expect(trajectory.at(-1)).toEqual(after);
+            expectSceneSamplesMatch(trajectory[0], before);
+            expectSceneSamplesMatch(trajectory.at(-1)!, after);
 
             // Bar B shrinks in height only (top edge rises, x/width/opacity implicitly constant);
             // EVERYTHING else in the scene — sibling bars, both axes, gridlines, labels — must not move.
@@ -906,8 +907,8 @@ describe('BarSeries', () => {
             // equality is not a valid invariant for a scale-affecting update.
             const rectsOf = (sample: SceneGeometrySample) =>
                 new Map([...sample].filter(([key]) => key.startsWith('series[0]/rect')));
-            expect(rectsOf(trajectory[0])).toEqual(rectsOf(before));
-            expect(rectsOf(trajectory.at(-1)!)).toEqual(rectsOf(after));
+            expectSceneSamplesMatch(rectsOf(trajectory[0]), rectsOf(before));
+            expectSceneSamplesMatch(rectsOf(trajectory.at(-1)!), rectsOf(after));
 
             // The grown bar B rises; the fixed-value bars A and C shrink as the domain expands beneath
             // them. The wider tick labels (70 -> 200) widen the y-axis gutter, which shifts both axes'
@@ -927,6 +928,63 @@ describe('BarSeries', () => {
                 'series[0]/rect[C]': rescales('decreases'),
                 ...axisReflowSpec('bottom', { shift: 'left', translate: 'right' }),
                 ...axisReflowSpec('left', { shift: 'up', translate: 'right', plotEdge: 'shrinks', grid: true }),
+            });
+        });
+
+        // CASE 10 (CRT-950) — stacked+grouped horizontal bars, removing then re-adding a series.
+        // The essential invariant is CROSS-NODE: the two stacked layers must tile contiguously on
+        // every frame (mac's near edge rides iphone's far edge), which no per-node expectation can
+        // express — this is what `frameInvariants` is for. The sampler reads DRAWN rect geometry, so
+        // the stacked segments (nominal-extent BarShapes segmented in updatePath) compare correctly.
+        it('CASE 10 (CRT-950): stacked layers stay contiguous while a sibling series is removed and re-added', async () => {
+            const stackedContiguous: SceneFrameInvariant = {
+                name: 'stack tiles contiguously',
+                check: (frame) => {
+                    const iphone = frame.get("series[0]/rect[Q1'18]");
+                    const mac = frame.get("series[1]/rect[Q1'18]");
+                    if (iphone == null || mac == null) return undefined;
+                    const gap = Math.abs(mac.x - (iphone.x + iphone.width));
+                    return gap > 1
+                        ? `mac near edge (${mac.x.toFixed(2)}) != iphone far edge (${(iphone.x + iphone.width).toFixed(2)})`
+                        : undefined;
+                },
+            };
+            const bandReflow = (height: 'increases' | 'decreases') =>
+                ({
+                    'series[*]/rect[*]': {
+                        height: { during: 'update', expect: [height, 'bounded'] },
+                        width: { during: 'update', expect: 'bounded' },
+                        x: { during: 'update', expect: 'bounded' },
+                        y: { during: 'update', expect: 'bounded' },
+                        // A re-added series' bars fade in at full size rather than growing.
+                        opacity: { during: ['update', 'add', 'trailing'], expect: ['increases', 'bounded'] },
+                    },
+                    'series[*]/labels/text[*]': {
+                        opacity: { during: ['update', 'add', 'trailing'], expect: ['increases', 'bounded'] },
+                        x: { during: 'update', expect: 'bounded' },
+                        y: { during: 'update', expect: 'bounded' },
+                    },
+                }) as const;
+
+            const options: AgChartOptions = { ...examples.BAR_STACKED_AND_GROUPED_NUMBER_CRT_950 };
+            prepareTestOptions(options);
+            const allSeries = options.series!;
+            chart = AgCharts.create(options);
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            // NOTE: a removed series is dropped from chart.series immediately, so its exit
+            // animation is invisible to the sampler — only the survivors' band reflow is captured.
+            await chart.update({ ...options, series: allSeries.slice(0, 2) });
+            const removeTrajectory = await frames.captureAnimationFrames(chart, sampleScene);
+            expectSceneTrajectory(removeTrajectory, bandReflow('increases'), {
+                frameInvariants: [stackedContiguous],
+            });
+
+            await chart.update({ ...options, series: allSeries });
+            const addTrajectory = await frames.captureAnimationFrames(chart, sampleScene);
+            expectSceneTrajectory(addTrajectory, bandReflow('decreases'), {
+                frameInvariants: [stackedContiguous],
             });
         });
     });

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { deepClone } from 'ag-charts-core';
+import { deepClone, mapValues } from 'ag-charts-core';
 import type {
     AgCartesianChartOptions,
     AgChartInstance,
@@ -13,6 +13,7 @@ import type {
 } from 'ag-charts-types';
 
 import { AgCharts } from '../../../api/agCharts';
+import { AnimationManager } from '../../interaction/animationManager';
 import {
     BIG,
     HIGH_VOLUME_COUNT,
@@ -35,7 +36,7 @@ import {
 import * as examples from '../../test/examples';
 import { type MockLineStyler, newFreezableMock } from '../../test/freezableMock';
 import { testLegendItemName } from '../../test/legendItemName';
-import type { CartesianOrPolarTestCase } from '../../test/utils';
+import type { CartesianOrPolarTestCase, SceneNodeExpectation } from '../../test/utils';
 import {
     IMAGE_SNAPSHOT_DEFAULTS,
     axisReflowSpec,
@@ -43,6 +44,7 @@ import {
     createChart,
     createSceneGeometrySampler,
     deproxy,
+    expectNoAnimation,
     expectSceneTrajectory,
     extractImageData,
     hoverAction,
@@ -242,17 +244,15 @@ describe('LineSeries', () => {
 
     const ctx = setupMockCanvas();
 
-    // SPIKE: frame-trajectory invariant test for a PATH-based series (CASE 3) — the LIMIT of
-    // the approach. Unlike bar/pie, a line exposes NO readable per-vertex geometry: its shape is re-plotted
-    // into a Path2D each frame, so the only per-frame signal is the path bounding box.
-    // The bbox reflects only the data EXTENT, so this case necessarily uses an extent-changing
-    // (scale-affecting) update; a vertex moving *within* the extent would morph the line invisibly to the
-    // bbox. This maps the boundary: the clean node-property invariants of bar/pie degrade to a coarse
-    // extent-level invariant for path series, which is where image snapshots still earn their keep.
+    // SPIKE: frame-trajectory invariant test for a PATH-based series (CASE 3). The sampler reads the
+    // drawn path geometry back each frame: the bbox extent, `top@<i>` (the path's topmost y at fixed
+    // x-stations across its extent, in the path's local space) and `subpaths` (continuity — a gap in
+    // the stroke shows up as extra subpaths). Stations give path series per-point invariants
+    // comparable to bar/pie node properties.
     describe('animation frame-trajectory (spike)', () => {
         const frames = spyOnAnimationFrames();
 
-        it('CASE 3: line data-update morphs the path bbox monotonically (extent-level invariant)', async () => {
+        it('CASE 3: line data-update morphs the path per-station monotonically', async () => {
             const options: AgChartOptions = prepareTestOptions({
                 data: [
                     { x: 0, y: 90 },
@@ -289,6 +289,12 @@ describe('LineSeries', () => {
                     y: { during: 'update', expect: 'increases' },
                     width: { during: 'update', expect: 'decreases' },
                     height: { during: 'update', expect: ['decreases', 'progresses', 'bounded'] },
+                    // Per-station: A's end rides the rescale down while B's end rises toward the new
+                    // floor; the midpoint pivots in place. `subpaths` is unnamed so it must stay 1.
+                    'top@0': { during: 'update', expect: ['increases', 'progresses', 'bounded'] },
+                    'top@1': { during: 'update', expect: ['increases', 'bounded'] },
+                    'top@3': { during: 'update', expect: ['decreases', 'bounded'] },
+                    'top@4': { during: 'update', expect: ['decreases', 'progresses', 'bounded'] },
                 },
                 // The marker fade-in starts in the add phase and completes during trailing.
                 'series[0]/marker[*]': { opacity: { during: ['add', 'trailing'], expect: 'increases' } },
@@ -300,6 +306,303 @@ describe('LineSeries', () => {
             // settled after-state (per-frame direction/progression/bounds are in the spec above).
             expect(trajectory[0].get(pathKey)!.height).toBeCloseTo(before.get(pathKey)!.height, 0);
             expect(trajectory.at(-1)!.get(pathKey)!.height).toBeCloseTo(after.get(pathKey)!.height, 0);
+        });
+
+        it('CASE 6 (CRT-995): stacked line point-add animates cumulative tops, not from the baseline', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { quarter: 'Q1', apples: 50, oranges: 30 },
+                    { quarter: 'Q2', apples: 60, oranges: 40 },
+                    { quarter: 'Q3', apples: 70, oranges: 35 },
+                ],
+                series: [
+                    { type: 'line', xKey: 'quarter', yKey: 'apples', stacked: true },
+                    { type: 'line', xKey: 'quarter', yKey: 'oranges', stacked: true },
+                ],
+                // The pinned y-domain keeps the y-axis static, so the case isolates the stacked
+                // verticals (and the x-axis reflow) from y-rescale noise.
+                axes: {
+                    x: { type: 'category', position: 'bottom' },
+                    y: { type: 'number', position: 'left', min: 0, max: 140 },
+                },
+            });
+
+            chart = AgCharts.create(options);
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            await chart.updateDelta({
+                data: [
+                    { quarter: 'Q1', apples: 50, oranges: 30 },
+                    { quarter: 'Q2', apples: 60, oranges: 40 },
+                    { quarter: 'Q3', apples: 70, oranges: 35 },
+                    { quarter: 'Q4', apples: 80, oranges: 45 },
+                    { quarter: 'Q5', apples: 65, oranges: 50 },
+                ],
+            });
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // The regression mode animated stacked layers up from the baseline on point-add; pinning
+            // every station to a monotonic, endpoint-bounded move during the `add` phase (with `top@0`
+            // — the anchored Q1 point — defaulting to constant) makes any dive to the baseline fail.
+            const stackedLayer = (tops: Record<string, 'increases' | 'decreases'>): SceneNodeExpectation => ({
+                x: { during: 'update', expect: ['decreases', 'bounded'] },
+                y: { during: 'add', expect: ['decreases', 'bounded'] },
+                // Width dips below both endpoints mid-flight: the band squeeze (update) precedes the
+                // extension to the new points (add), so it is progressing but not endpoint-bounded.
+                width: { during: ['update', 'add'], expect: 'progresses' },
+                height: { during: 'add', expect: ['increases', 'bounded'] },
+                ...mapValues(tops, (direction) => ({ during: 'add', expect: [direction, 'bounded'] }) as const),
+            });
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': stackedLayer({
+                    'top@1': 'decreases',
+                    'top@2': 'decreases',
+                    'top@3': 'decreases',
+                    'top@4': 'increases', // Q5 apples (65) sits below Q4 (80), so the right edge drops
+                }),
+                'series[1]/path[stroke]': stackedLayer({
+                    'top@1': 'decreases',
+                    'top@2': 'decreases',
+                    'top@3': 'decreases',
+                    'top@4': 'decreases',
+                }),
+                'series[*]/marker[*]': { opacity: { during: ['add', 'trailing'], expect: 'increases' } },
+                ...axisReflowSpec('bottom', { shift: 'left' }),
+            });
+        });
+
+        it('CASE 9 (CRT-1052): markers stay in overlay drawing mode while fading in over the stroke', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { quarter: 'Q1', iphone: 40 },
+                    { quarter: 'Q2', iphone: 45 },
+                    { quarter: 'Q3', iphone: 35 },
+                ],
+                series: [
+                    {
+                        type: 'line',
+                        xKey: 'quarter',
+                        yKey: 'iphone',
+                        strokeWidth: 4,
+                        marker: { enabled: true, size: 14 },
+                    },
+                ],
+            });
+
+            chart = AgCharts.create(options);
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            // Toggle the series off, then back on: the markers fade in over the stroke.
+            options.series![0].visible = false;
+            await chart.update({ ...options });
+            await frames.runToEnd(chart);
+
+            options.series![0].visible = true;
+            await chart.update({ ...options });
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // A cutout marker composites with destination-out, erasing the stroke underneath while it
+            // is still translucent; overlay mode (cutout === 0) must hold on EVERY frame. Asserted by
+            // value because a regression would be constant-cutout, which a constancy check cannot see.
+            for (const quarter of ['Q1', 'Q2', 'Q3']) {
+                const cutouts = trajectory.map((f) => f.get(`series[0]/marker[${quarter}]`)?.cutout);
+                expect(cutouts).toEqual(repeat(0, trajectory.length));
+            }
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': { opacity: { during: ['update', 'add'], expect: 'increases' } },
+                'series[0]/marker[*]': { opacity: { during: ['add', 'trailing'], expect: 'increases' } },
+                ...axisReflowSpec('left', { translate: 'right', grid: true }),
+                ...axisReflowSpec('bottom', { shift: 'left', translate: 'right' }),
+            });
+        });
+
+        it('CASE 11 (AG-10477): initial load reveals the fully-drawn lines behind a sweeping clip window', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { month: 'Jun', a: 50, b: 50 },
+                    { month: 'Jul', a: 100, b: 0 },
+                    { month: 'Aug', a: 100, b: 0 },
+                    { month: 'Sep', a: 100, b: 0 },
+                    { month: 'Oct', a: 100, b: 0 },
+                ],
+                series: [
+                    { type: 'line', xKey: 'month', yKey: 'a', strokeWidth: 22 },
+                    { type: 'line', xKey: 'month', yKey: 'b', strokeWidth: 22 },
+                ],
+            });
+
+            chart = AgCharts.create(options);
+            const sampleScene = createSceneGeometrySampler(chart);
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // The regression drew outside the reveal window with thick strokes. The invariant: both
+            // lines are FULLY drawn from frame 0 (path stations are unnamed, so they must hold
+            // constant) while only the clip window sweeps across during `initial`, with markers
+            // swipe-scaling in as it passes them.
+            const revealPath = {
+                clip: { during: ['initial', 'trailing'], expect: ['decreases', 'bounded'] },
+                'clip:x': { during: 'initial', expect: ['increases', 'progresses', 'bounded'] },
+            } as const;
+            const swipesIn = {
+                x: { during: 'initial', expect: 'bounded' },
+                y: { during: 'initial', expect: 'bounded' },
+                width: { during: 'initial', expect: ['increases', 'bounded'] },
+                height: { during: 'initial', expect: ['increases', 'bounded'] },
+            } as const;
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': revealPath,
+                'series[1]/path[stroke]': revealPath,
+                'series[*]/marker[*]': swipesIn,
+            });
+
+            // The sweep is sequential: the Jun marker must be fully grown before Oct starts.
+            const grownFrame = (key: string) => trajectory.findIndex((f) => (f.get(key)?.width ?? 0) >= 6.99);
+            expect(grownFrame('series[0]/marker[Jun]')).toBeGreaterThan(0);
+            expect(grownFrame('series[0]/marker[Jun]')).toBeLessThan(grownFrame('series[0]/marker[Oct]'));
+        });
+
+        it('CASE 12: updating a mid-series point to undefined opens a gap without disturbing the rest', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { quarter: 'Q1', iphone: 40 },
+                    { quarter: 'Q2', iphone: 45 },
+                    { quarter: 'Q3', iphone: 35 },
+                    { quarter: 'Q4', iphone: 50 },
+                    { quarter: 'Q5', iphone: 42 },
+                ],
+                series: [{ type: 'line', xKey: 'quarter', yKey: 'iphone', marker: { enabled: true } }],
+                axes: {
+                    x: { type: 'category', position: 'bottom' },
+                    y: { type: 'number', position: 'left', min: 0, max: 60 },
+                },
+            });
+
+            chart = AgCharts.create(options);
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            await chart.updateDelta({
+                data: [
+                    { quarter: 'Q1', iphone: 40 },
+                    { quarter: 'Q2', iphone: 45 },
+                    { quarter: 'Q3', iphone: undefined },
+                    { quarter: 'Q4', iphone: 50 },
+                    { quarter: 'Q5', iphone: 42 },
+                ],
+            });
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': {
+                    // The nulled point retracts during `remove`, splitting the stroke around the gap.
+                    height: { during: 'remove', expect: ['decreases', 'progresses', 'bounded'] },
+                    subpaths: { during: ['remove', 'update'], expect: 'progresses' },
+                    // The station over the gap has no crossing once the point is gone: legitimately
+                    // non-finite, which `degenerate` opts into (anything else must stay constant).
+                    'top@2': ['degenerate'],
+                },
+                'series[0]/marker[*]': {
+                    opacity: { during: ['update', 'add', 'trailing'], expect: ['increases', 'bounded'] },
+                },
+                ...axisReflowSpec('bottom', {}),
+            });
+
+            // The gap must actually open and persist: two subpaths and a dead station at the end.
+            const finalPath = trajectory.at(-1)!.get('series[0]/path[stroke]')!;
+            expect(finalPath.subpaths).toBe(2);
+            expect(Number.isFinite(finalPath['top@2'])).toBe(false);
+        });
+
+        it('CASE 13 (CRT-1025): a series re-shown under an active highlight fades to the dimmed opacity', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { quarter: 'Q1', iphone: 40, macos: 20 },
+                    { quarter: 'Q2', iphone: 45, macos: 25 },
+                    { quarter: 'Q3', iphone: 35, macos: 30 },
+                ],
+                series: [
+                    { type: 'line', xKey: 'quarter', yKey: 'iphone' },
+                    { type: 'line', xKey: 'quarter', yKey: 'macos' },
+                ],
+                axes: {
+                    x: { type: 'category', position: 'bottom' },
+                    y: { type: 'number', position: 'left', min: 0, max: 60 },
+                },
+            });
+
+            chart = AgCharts.create(options);
+            await frames.runToEnd(chart);
+
+            options.series![0].visible = false;
+            await chart.update({ ...options });
+            await frames.runToEnd(chart);
+
+            const chartInstance = deproxy(chart);
+            const macosSeries = chartInstance.series[1] as any;
+            chartInstance.ctx.highlightManager.updateHighlight(
+                chartInstance.id,
+                macosSeries.contextNodeData.nodeData[0]
+            );
+            await frames.runToEnd(chart);
+            expect(chartInstance.ctx.highlightManager.getActiveHighlight()).toBeDefined();
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            options.series![0].visible = true;
+            await chart.update({ ...options });
+            const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+            // The regression targeted opacity 1; the re-shown stroke must fade in but SETTLE at the
+            // dimmed value (unhighlightedSeries.opacity = 0.2), pinned by settlesAt. Markers reset
+            // and fade back for both series, flipping from overlay to cutout only once settled.
+            expectSceneTrajectory(trajectory, {
+                'series[0]/path[stroke]': {
+                    opacity: {
+                        during: ['update', 'add'],
+                        expect: ['increases', 'bounded'],
+                        settlesAt: 0.2,
+                    },
+                },
+                'series[*]/marker[*]': {
+                    opacity: { during: ['add', 'trailing'], expect: ['increases', 'bounded'] },
+                    cutout: { during: 'trailing', expect: ['increases', 'bounded'] },
+                },
+                ...axisReflowSpec('bottom', {}),
+            });
+        });
+
+        it('CASE 14 (CRT-1083): hiding a series while animations are skipped snaps without any tween', async () => {
+            const options: AgChartOptions = prepareTestOptions({
+                data: [
+                    { x: 0, v1: 10, v2: 20 },
+                    { x: 1, v1: 30, v2: 40 },
+                ],
+                series: [
+                    { type: 'line', xKey: 'x', yKey: 'v1' },
+                    { type: 'line', xKey: 'x', yKey: 'v2' },
+                ],
+            });
+
+            chart = AgCharts.create(options);
+            await frames.runToEnd(chart);
+            const sampleScene = createSceneGeometrySampler(chart);
+
+            // Simulate the skipped-animations environment (JSDOM default / AG Grid setLegendState)
+            // on top of the frame harness, which otherwise forces animations on.
+            const skipSpy = vi.spyOn(AnimationManager.prototype, 'isSkipped').mockImplementation(() => true);
+            try {
+                (options.series![1] as any).visible = false;
+                await chart.update({ ...options });
+                const trajectory = await frames.captureAnimationFrames(chart, sampleScene);
+
+                expectNoAnimation(trajectory);
+                // The hide must have taken effect instantly: invisible from the very first frame.
+                expect(trajectory[0].get('series[1]')!.visible).toBe(0);
+                expect(trajectory.at(-1)!.get('series[1]')!.visible).toBe(0);
+            } finally {
+                skipSpy.mockRestore();
+            }
         });
     });
 

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -1,7 +1,7 @@
 import type { MatchImageSnapshotOptions } from 'jest-image-snapshot';
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 
-import { fromPairs, getDocument, mapValues } from 'ag-charts-core';
+import { evaluateBezier, fromPairs, getDocument, mapValues } from 'ag-charts-core';
 import {
     CANVAS_HEIGHT,
     CANVAS_WIDTH,
@@ -900,7 +900,15 @@ export function spyOnAnimationFrames() {
     };
 
     beforeEach(() => {
-        const isSkippedMock = vi.spyOn(AnimationManager.prototype, 'isSkipped').mockImplementation(() => false);
+        // Drop the environment terms (`!rafAvailable` — always true in JSDOM — and `skipAnimations`,
+        // which only the enterprise animation module clears) but PRESERVE batch-level skips: product
+        // snap paths (resize, skipCurrentBatch) must still skip, or trajectories would show tweens
+        // that never happen in a real browser.
+        const isSkippedMock = vi.spyOn(AnimationManager.prototype, 'isSkipped').mockImplementation(function (
+            this: AnimationManager
+        ) {
+            return (this as unknown as { batch: { isSkipped(): boolean } }).batch.isSkipped();
+        });
         const skippingFramesMock = vi
             .spyOn(AnimationManager.prototype, 'isSkippingFrames')
             .mockImplementation(() => false);
@@ -1024,8 +1032,7 @@ export type SceneGeometrySample = Map<string, SceneNodeGeometry>;
  * Map a node's serialised state ({@link Node.serialize}) to the property set trajectory specs assert
  * over; `null` marks node kinds deliberately not sampled (groups are handled separately by the scene
  * walk). The switch is exhaustive over {@link SerializedNodeState}: adding a scene node kind fails
- * compilation here until its sampling is decided. Marker and generic path nodes expose their bbox
- * extents.
+ * compilation here until its sampling is decided.
  */
 function buildGeometry(state: SerializedNodeState): SceneNodeGeometry | null {
     switch (state.type) {
@@ -1037,23 +1044,148 @@ function buildGeometry(state: SerializedNodeState): SceneNodeGeometry | null {
             const { startAngle, endAngle, innerRadius, outerRadius, opacity } = state.props;
             return { startAngle, endAngle, innerRadius, outerRadius, opacity };
         }
-        case 'rect':
-        case 'marker':
-        case 'path': {
+        // Prefer the DRAWN path over the x/y/width/height fields: specialised rects (e.g. stacked
+        // BarShape) keep nominal extents in the fields and derive the painted segment in updatePath,
+        // so only the path reflects what is actually on screen.
+        case 'rect': {
             const { x, y, width, height, opacity } = state.props;
-            return { x, y, width, height, opacity };
+            const drawn = flattenPathPolylines(state.svgPath);
+            if (drawn.length === 0) return { x, y, width, height, opacity };
+            let [minX, minY, maxX, maxY] = [Infinity, Infinity, -Infinity, -Infinity];
+            for (const line of drawn) {
+                for (const p of line) {
+                    minX = Math.min(minX, p.x);
+                    minY = Math.min(minY, p.y);
+                    maxX = Math.max(maxX, p.x);
+                    maxY = Math.max(maxY, p.y);
+                }
+            }
+            return { x: minX, y: minY, width: maxX - minX, height: maxY - minY, opacity };
         }
         case 'text': {
-            const { x, y, opacity } = state.props;
-            return { x, y, opacity };
+            const { x, y, opacity, rotation } = state.props;
+            const props: SceneNodeGeometry = { x, y, opacity };
+            // Rotation only exists on the Rotatable mixin variants (e.g. axis labels).
+            if (typeof rotation === 'number') props.rotation = rotation;
+            return props;
         }
         case 'line': {
             const { x1, y1, x2, y2, opacity } = state.props;
             return { x1, y1, x2, y2, opacity };
         }
+        case 'marker': {
+            const { x, y, width, height, opacity } = state.props;
+            return { x, y, width, height, opacity };
+        }
+        case 'path':
+            return readPathGeometry(state);
         default:
             return state satisfies never;
     }
+}
+
+const PATH_STATION_COUNT = 5;
+const CURVE_FLATTEN_STEPS = 8;
+
+type PolylinePoint = { x: number; y: number };
+
+/** Flatten a node's serialised drawn path (SVG form) into one polyline per subpath. */
+function flattenPathPolylines(svgPath: string | undefined): PolylinePoint[][] {
+    if (svgPath == null) return [];
+    const tokens = svgPath.split(' ').filter((t) => t.length > 0);
+    const polylines: PolylinePoint[][] = [];
+    let current: PolylinePoint[] | undefined;
+    let i = 0;
+    const num = () => Number(tokens[i++]);
+    while (i < tokens.length) {
+        switch (tokens[i++]) {
+            case 'M':
+                current = [{ x: num(), y: num() }];
+                polylines.push(current);
+                break;
+            case 'L':
+                current?.push({ x: num(), y: num() });
+                break;
+            case 'C': {
+                const [x1, y1, x2, y2, x3, y3] = [num(), num(), num(), num(), num(), num()];
+                const from = current?.at(-1);
+                if (from == null) break;
+                for (let step = 1; step <= CURVE_FLATTEN_STEPS; step++) {
+                    const t = step / CURVE_FLATTEN_STEPS;
+                    current!.push({
+                        x: evaluateBezier(from.x, x1, x2, x3, t),
+                        y: evaluateBezier(from.y, y1, y2, y3, t),
+                    });
+                }
+                break;
+            }
+            case 'Z':
+                if (current != null && current.length > 0) current.push({ ...current[0] });
+                break;
+        }
+    }
+    return polylines.filter((p) => p.length > 1);
+}
+
+/**
+ * The topmost (minimum) y where the drawn path crosses each of {@link PATH_STATION_COUNT} x-stations
+ * spread evenly across the path's own x-extent. For a line stroke this traces the line itself; for an
+ * area fill it traces the animated top edge (the baseline below has a larger y). A station with no
+ * crossing (a gap in the drawn path) yields NaN, which trajectory checks reject as non-finite.
+ */
+function pathStationTopYs(polylines: PolylinePoint[][]): number[] {
+    let minX = Infinity;
+    let maxX = -Infinity;
+    for (const line of polylines) {
+        for (const p of line) {
+            minX = Math.min(minX, p.x);
+            maxX = Math.max(maxX, p.x);
+        }
+    }
+    const tops: number[] = new Array(PATH_STATION_COUNT).fill(Number.NaN);
+    if (!Number.isFinite(minX) || maxX <= minX) return tops;
+    for (let station = 0; station < PATH_STATION_COUNT; station++) {
+        const x = minX + ((maxX - minX) * station) / (PATH_STATION_COUNT - 1);
+        let top = Infinity;
+        for (const line of polylines) {
+            for (let i = 1; i < line.length; i++) {
+                const a = line[i - 1];
+                const b = line[i];
+                if ((a.x - x) * (b.x - x) > 0) continue;
+                const y = a.x === b.x ? Math.min(a.y, b.y) : a.y + ((x - a.x) / (b.x - a.x)) * (b.y - a.y);
+                top = Math.min(top, y);
+            }
+        }
+        tops[station] = Number.isFinite(top) ? top : Number.NaN;
+    }
+    return tops;
+}
+
+/**
+ * Paths get interior geometry on top of the bbox: `subpaths` (drawn-gap detector — a stroke that
+ * should be continuous must keep `subpaths` at 1) and `top@<i>` per x-station (see
+ * {@link pathStationTopYs}), so path-based series (line/area) can assert per-point trajectories
+ * rather than extent-level bbox movement only. Paths with nothing drawn get the bbox props only.
+ */
+function readPathGeometry(s: Extract<SerializedNodeState, { type: 'path' }>): SceneNodeGeometry {
+    const polylines = flattenPathPolylines(s.svgPath);
+    // An empty drawn path has no meaningful geometry (its bbox is ±Infinity): emit paint props only,
+    // so geometry checks span just the frames where something is actually drawn.
+    if (polylines.length === 0) return { opacity: s.props.opacity };
+    const { x, y, width, height, opacity } = s.props;
+    const props: SceneNodeGeometry = { x, y, width, height, opacity };
+    // The reveal (swipe-in) animation masks the fully-drawn path behind a growing clip window, so
+    // the clip fields are the only per-frame signal of the sweep.
+    props.clip = s.props.clip ? 1 : 0;
+    if (s.props.clip) {
+        props['clip:x'] = s.props.clipX;
+        props['clip:y'] = s.props.clipY;
+    }
+    props.subpaths = polylines.length;
+    for (const [i, topY] of pathStationTopYs(polylines).entries()) {
+        props[`top@${i}`] = topY;
+    }
+    return props;
 }
 
 function readNodeGeometry(state: SerializedNodeState): { label: string; props: SceneNodeGeometry } | undefined {
@@ -1065,6 +1197,11 @@ function readNodeGeometry(state: SerializedNodeState): { label: string; props: S
         props.translationX = translationX;
         props.translationY = translationY;
     }
+    // Cutout compositing (destination-out) punches holes through siblings — a marker left in cutout
+    // mode while translucent erases the series stroke underneath it, which no geometry check can see.
+    if (state.type !== 'node' && state.type !== 'group') {
+        props.cutout = state.props.drawingMode === 'cutout' ? 1 : 0;
+    }
     props.visible = state.props.visible ? 1 : 0;
     return { label: state.type, props };
 }
@@ -1073,9 +1210,15 @@ function readNodeGeometry(state: SerializedNodeState): { label: string; props: S
 function datumKeyOf(node: Node<any>, state: SerializedNodeState): string | undefined {
     const datum: any = node.datum;
     if (datum != null && typeof datum !== 'object') return String(datum);
-    const value = datum?.xValue ?? datum?.angleValue ?? datum?.itemId ?? datum?.index;
+    const value = datum?.xValue ?? datum?.angleValue ?? datum?.itemId ?? datum?.tickId ?? datum?.index;
     if (value != null) return String(value);
     if (state.type === 'text' && state.props.text != null) return state.props.text;
+    // Series paint one Path per role (e.g. area fill vs stroke), distinguishable by which paint is set.
+    if (state.type === 'path') {
+        const { hasFill, hasStroke } = state.props;
+        if (hasFill && !hasStroke) return 'fill';
+        if (hasStroke && !hasFill) return 'stroke';
+    }
     return undefined;
 }
 
@@ -1118,10 +1261,9 @@ export function createSceneGeometrySampler(chartOrProxy: ChartOrProxy<any>): () 
                 sample.set(assignKey(node, baseKey), geometry.props);
             } else if (state.type === 'group' && node instanceof Group) {
                 const props: SceneNodeGeometry = { opacity: state.props.opacity };
-                const { translationX, translationY } = state.props;
-                if (typeof translationX === 'number' && typeof translationY === 'number') {
-                    props.translationX = translationX;
-                    props.translationY = translationY;
+                for (const name of ['translationX', 'translationY', 'scalingX', 'scalingY', 'rotation'] as const) {
+                    const value = state.props[name];
+                    if (typeof value === 'number') props[name] = value;
                 }
                 props.visible = state.props.visible ? 1 : 0;
                 sample.set(assignKey(node, node === root ? rootPath : `${rootPath}/group[${node.name ?? ''}]`), props);
@@ -1139,25 +1281,54 @@ export function createSceneGeometrySampler(chartOrProxy: ChartOrProxy<any>): () 
         for (const [i, series] of (chart.series as any[]).entries()) {
             sampleInto(sample, `series[${i}]`, series.contentGroup);
             sampleInto(sample, `series[${i}]/labels`, series.labelGroup);
+            // Some series paint outside contentGroup (e.g. area fills render behind in backgroundGroup).
+            if (series.backgroundGroup != null) {
+                sampleInto(sample, `series[${i}]/background`, series.backgroundGroup);
+            }
         }
         for (const axis of (chart as any).axes) {
             const position = axis.position ?? 'unknown';
             sampleInto(sample, `axis[${position}]`, axis.axisGroup);
             sampleInto(sample, `axis[${position}]/grid`, axis.gridGroup);
         }
+        // Cartesian charts clip the series area to an animated rect (the `clip-rect` motion group).
+        const clipRect = (chart as any).lastUpdateClipRect;
+        if (clipRect != null) {
+            sample.set('chart/clipRect', {
+                x: clipRect.x,
+                y: clipRect.y,
+                width: clipRect.width,
+                height: clipRect.height,
+            });
+        }
         return sample;
     };
 }
 
-export type TrajectoryExpectation = 'constant' | 'increases' | 'decreases' | 'progresses' | 'bounded' | 'any';
+/**
+ * `degenerate` opts a property into legitimately non-finite frames (e.g. a line gap where a datum is
+ * `undefined` leaves stations with no crossing): non-finite samples are treated as absent instead of
+ * failing, and any other expectations in the same list are checked over the finite frames only.
+ */
+export type TrajectoryExpectation =
+    | 'constant'
+    | 'increases'
+    | 'decreases'
+    | 'progresses'
+    | 'bounded'
+    | 'degenerate'
+    | 'any';
 /**
  * Scopes a property expectation to the animation phase(s) it may change in: outside `during`, the
  * property must hold constant frame-to-frame; the `expect` trajectory checks still apply to the whole
  * trajectory. Requires phase data captured by {@link spyOnAnimationFrames}' `captureAnimationFrames`.
  */
 export type PhasedPropertyExpectation = {
-    during: AnimationPhase | readonly AnimationPhase[];
-    expect: TrajectoryExpectation | readonly TrajectoryExpectation[];
+    during?: AnimationPhase | readonly AnimationPhase[];
+    expect?: TrajectoryExpectation | readonly TrajectoryExpectation[];
+    /** The value the property must have settled at by the final frame (within constantTol) — for
+     * targets that directional checks cannot pin, e.g. "fades to the DIMMED opacity, not to 1". */
+    settlesAt?: number;
 };
 export type ScenePropertyExpectation =
     | TrajectoryExpectation
@@ -1232,6 +1403,55 @@ export function axisReflowSpec(
         spec[`axis[${position}]/grid/line[*]`] = { ...fades, ...lineSlide, ...edge };
     }
     return spec;
+}
+
+/**
+ * Assert a captured trajectory shows NO animation: no batch phase ran on any interval, and every
+ * node property holds constant across all frames (a skipped batch must SNAP to the end state before
+ * the first frame, not tween towards it). The complement of {@link expectSceneTrajectory} specs —
+ * use it for skipped-animation paths (animation disabled, resize).
+ */
+export function expectNoAnimation(trajectory: SceneGeometrySample[]): void {
+    // A skipped batch still advances through its phases (they just do no work), so phase data can't
+    // distinguish a snap from a tween — full-scene constancy from the first frame is the signal.
+    expectSceneTrajectory(trajectory, {});
+}
+
+/**
+ * Endpoint sanity: two whole-scene samples describe the same scene within a pixel tolerance. Strict
+ * deep-equality is too brittle for drawn geometry — the crisp-pixel snap when an animation settles
+ * shifts values fractionally depending on when the scene last rendered.
+ */
+export function expectSceneSamplesMatch(actual: SceneGeometrySample, expected: SceneGeometrySample, tol = 1): void {
+    const byName = (a: string, b: string) => a.localeCompare(b);
+    expect([...actual.keys()].sort(byName)).toEqual([...expected.keys()].sort(byName));
+    for (const [key, expectedProps] of expected) {
+        const actualProps = actual.get(key)!;
+        expect(Object.keys(actualProps).sort(byName), key).toEqual(Object.keys(expectedProps).sort(byName));
+        for (const prop of Object.keys(expectedProps)) {
+            const expectedValue = expectedProps[prop];
+            const actualValue = actualProps[prop];
+            if (Number.isFinite(expectedValue)) {
+                expect(
+                    Math.abs(actualValue - expectedValue),
+                    `${key}.${prop}: ${actualValue} vs ${expectedValue}`
+                ).toBeLessThanOrEqual(tol);
+            } else {
+                expect(actualValue, `${key}.${prop}`).toBe(expectedValue);
+            }
+        }
+    }
+}
+
+/**
+ * A cross-node check evaluated on every captured frame — for relationships no per-node/per-property
+ * expectation can express (e.g. "stacked layer N's far edge equals layer N+1's near edge on every
+ * frame"). Return a message to fail, undefined to pass; only the first failing frame per invariant is
+ * reported.
+ */
+export interface SceneFrameInvariant {
+    name: string;
+    check(frame: SceneGeometrySample, frameIndex: number): string | undefined;
 }
 
 interface TrajectoryViolation {
@@ -1375,9 +1595,17 @@ export function expectSceneTrajectory(
     spec: Record<string, SceneNodeExpectation> = {},
     {
         constantTol = 0.5,
-        monotonicTol = 1e-6,
+        // Drawn geometry snaps to crisp pixels when an animation settles, so a sub-pixel "reversal"
+        // on the final frame is rounding, not a direction change.
+        monotonicTol = 0.5,
         progressTol = 1e-3,
-    }: { constantTol?: number; monotonicTol?: number; progressTol?: number } = {}
+        frameInvariants = [],
+    }: {
+        constantTol?: number;
+        monotonicTol?: number;
+        progressTol?: number;
+        frameInvariants?: readonly SceneFrameInvariant[];
+    } = {}
 ): void {
     expect(trajectory.length).toBeGreaterThan(1);
     const tolerances = { constant: constantTol, monotonic: monotonicTol, progress: progressTol };
@@ -1386,7 +1614,9 @@ export function expectSceneTrajectory(
     const usesPhases = Object.values(spec).some(
         (nodeExpectation) =>
             typeof nodeExpectation === 'object' &&
-            Object.values(nodeExpectation).some((p) => typeof p === 'object' && !Array.isArray(p))
+            Object.values(nodeExpectation).some(
+                (p) => typeof p === 'object' && !Array.isArray(p) && (p as PhasedPropertyExpectation).during != null
+            )
     );
     if (usesPhases && phaseIntervals == null) {
         throw new Error(
@@ -1463,26 +1693,44 @@ export function expectSceneTrajectory(
         for (const prop of props) {
             const raw = expectation === 'constant' ? 'constant' : ((expectation as any)[prop] ?? 'constant');
             const isPhased = typeof raw === 'object' && !Array.isArray(raw);
-            const propExpectations: TrajectoryExpectation[] = [isPhased ? raw.expect : raw].flat();
+            const propExpectations: TrajectoryExpectation[] = [isPhased ? (raw.expect ?? []) : raw].flat();
             const rawValues = rawValuesFor(prop);
             const values = rawValues.filter((v): v is number => v != null);
             if (values.length < 2) continue;
             // NaN compares false against everything, so it would sail through every check below.
+            const allowsDegenerate = propExpectations.includes('degenerate');
             const nonFinite = values.findIndex((v) => !Number.isFinite(v));
-            if (nonFinite >= 0) {
+            if (nonFinite >= 0 && !allowsDegenerate) {
                 violations.push({ key, prop, message: `non-finite value at frame ${nonFinite}`, values: rawValues });
                 continue;
             }
+            const checkedValues = allowsDegenerate ? values.filter((v) => Number.isFinite(v)) : values;
+            const checkedRawValues = allowsDegenerate
+                ? rawValues.map((v) => (v != null && Number.isFinite(v) ? v : undefined))
+                : rawValues;
+            if (checkedValues.length < 2) continue;
             for (const propExpectation of propExpectations) {
-                const failure = checkPropertyTrajectory(values, propExpectation, tolerances);
+                if (propExpectation === 'degenerate') continue;
+                const failure = checkPropertyTrajectory(checkedValues, propExpectation, tolerances);
                 if (failure != null) {
                     violations.push({ key, prop, message: failure, values: rawValues });
                 }
             }
-            if (isPhased) {
-                const failure = checkPhaseWindows(rawValues, [raw.during].flat(), phaseIntervals, constantTol);
+            if (isPhased && raw.during != null) {
+                const failure = checkPhaseWindows(checkedRawValues, [raw.during].flat(), phaseIntervals, constantTol);
                 if (failure != null) {
                     violations.push({ key, prop, message: failure, values: rawValues });
+                }
+            }
+            if (isPhased && raw.settlesAt != null) {
+                const finalValue = checkedValues.at(-1)!;
+                if (Math.abs(finalValue - raw.settlesAt) > constantTol) {
+                    violations.push({
+                        key,
+                        prop,
+                        message: `expected to settle at ${raw.settlesAt}, ended at ${finalValue.toFixed(2)}`,
+                        values: rawValues,
+                    });
                 }
             }
         }
@@ -1491,6 +1739,19 @@ export function expectSceneTrajectory(
     for (const specKey of Object.keys(spec)) {
         if (!matchedSpecKeys.has(specKey)) {
             violations.push({ key: specKey, message: 'spec entry matched no sampled scene node (typo?)' });
+        }
+    }
+
+    for (const invariant of frameInvariants) {
+        for (const [frameIndex, frame] of trajectory.entries()) {
+            const failure = invariant.check(frame, frameIndex);
+            if (failure != null) {
+                violations.push({
+                    key: `frameInvariant[${invariant.name}]`,
+                    message: `frame ${frameIndex}: ${failure}`,
+                });
+                break;
+            }
         }
     }
 

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -1098,7 +1098,8 @@ function flattenPathPolylines(svgPath: string | undefined): PolylinePoint[][] {
     let i = 0;
     const num = () => Number(tokens[i++]);
     while (i < tokens.length) {
-        switch (tokens[i++]) {
+        const token = tokens[i++];
+        switch (token) {
             case 'M':
                 current = [{ x: num(), y: num() }];
                 polylines.push(current);
@@ -1122,6 +1123,10 @@ function flattenPathPolylines(svgPath: string | undefined): PolylinePoint[][] {
             case 'Z':
                 if (current != null && current.length > 0) current.push({ ...current[0] });
                 break;
+            default:
+                // A command this parser does not consume would desynchronise the token stream and
+                // silently corrupt every downstream geometry assertion — fail loudly instead.
+                throw new Error(`flattenPathPolylines: unsupported SVG path command '${token}' in '${svgPath}'`);
         }
     }
     return polylines.filter((p) => p.length > 1);
@@ -1703,6 +1708,15 @@ export function expectSceneTrajectory(
             if (nonFinite >= 0 && !allowsDegenerate) {
                 violations.push({ key, prop, message: `non-finite value at frame ${nonFinite}`, values: rawValues });
                 continue;
+            }
+            // `degenerate` must not pass vacuously: it asserts the property actually collapses.
+            if (allowsDegenerate && nonFinite < 0) {
+                violations.push({
+                    key,
+                    prop,
+                    message: 'expected degenerate (non-finite) samples but every value was finite',
+                    values: rawValues,
+                });
             }
             const checkedValues = allowsDegenerate ? values.filter((v) => Number.isFinite(v)) : values;
             const checkedRawValues = allowsDegenerate


### PR DESCRIPTION
Follows #7328 and #7322 (both now merged to `latest`). Tracked under [AG-17755](https://ag-grid.atlassian.net/browse/AG-17755).

Extends the trajectory harness with the capabilities needed to replace the `-test` page animation cases (bar/line/area, including their regression scenarios) and adds first-class axis animation coverage.

## Harness capabilities added (`chart/test/utils.ts`)

- **Path interior geometry** — drawn paths are read back per frame from the serialised SVG form: `top@<i>` y-values at 5 x-stations, `subpaths` continuity (gap detector), plus a `cutout` compositing flag. Unlocks line/area per-point trajectory assertions.
- **Cross-node frame invariants** — `frameInvariants` evaluates whole-scene predicates on every frame (e.g. stacked bar layers stay contiguous through remove + re-add, trailing tail included). Rect sampling now prefers DRAWN geometry over nominal fields (stacked `BarShape` derives the painted segment in `updatePath`).
- **Clip-window sampling** — per-series reveal clip (`clip`, `clip:x`) and the chart-level clip rect, so initial-load reveal asserts "fully drawn from frame 0, only the clip sweeps".
- **`'degenerate'` expectation** — opts a property into legitimately non-finite frames (datum → `undefined` gaps), phase-scoped.
- **`settlesAt`** — endpoint-value assertion, composable with phase windows; used with injected highlight interaction.
- **`expectNoAnimation`** + a skip mock that delegates to `batch.isSkipped()`, preserving the product's own snap paths (resize/`skipCurrentBatch`) instead of masking them.

## Axis animation suite

New `chart/axis/cartesianAxisAnimation.test.ts`: per-tick identity (keys like `text[l:100]`), number-axis domain growth and range pan, label rotation (shortest-arc), reversed axis, time-axis day→month re-ticking, resize snap.

## Retrofitted regression cases

CRT-950 (stacked contiguity), CRT-995 (stacked line point add), CRT-1025 (highlight + toggle, dimmed-opacity settle), CRT-1052 (marker overlay mode), CRT-1083 (skipped animations), AG-10477 (reveal clip), line/area undefined-datum, area add/remove/initial-load.

## Product findings (asserted around, not fixed — noted on AG-17755)

1. Out-of-bounds tick culling in `axisUtil.ts` is dead code: `Line` has only a `y` *setter*, so `outOfBounds(node.y)` reads `undefined`.
2. A reversed-axis domain change leaves the series stroke undrawn until the trailing phase.
3. A removed series is dropped from `chart.series` immediately, so its exit animation is invisible to the sampler.

## Verification

Full `ag-charts-community` + `ag-charts-enterprise` suites, `build:test` type-checks for both, lint and format all green. Each new assertion shape was negative-tested (deliberately wrong direction/phase fails naming the actual behaviour).
