### PR TITLE
AG-17134 externalise inline landing-page and 404 scripts for CSP

### DIFF
--- a/packages/ag-charts-website/public/scripts/landing-page-feature-tabs.js
+++ b/packages/ag-charts-website/public/scripts/landing-page-feature-tabs.js
@@ -1,0 +1,22 @@
+/*
+ * Toggles the active landing-page example panel in response to tab changes
+ * dispatched by the React tabs component (the 'landing-page-feature-tab-change'
+ * event). Externalised to a 'self' script so the site Content-Security-Policy can
+ * drop script-src 'unsafe-inline': an import-less hoisted <script> gets inlined into
+ * the page HTML by Astro, which the hash-based policy blocks — and the minified
+ * bytes make a static SHA-256 hash unstable.
+ */
+(function () {
+    document.addEventListener('landing-page-feature-tab-change', function (event) {
+        var index = event.detail.index;
+
+        document.querySelectorAll('.landing-page-example-panel').forEach(function (panel) {
+            panel.classList.remove('active');
+        });
+
+        var activePanel = document.querySelector('.landing-page-example-panel[data-index="' + index + '"]');
+        if (activePanel) {
+            activePanel.classList.add('active');
+        }
+    });
+})();

--- a/packages/ag-charts-website/public/scripts/track-404.js
+++ b/packages/ag-charts-website/public/scripts/track-404.js
@@ -1,0 +1,16 @@
+/*
+ * Reports a Plausible '404' event with the current path once the page loads.
+ * Externalised to a 'self' script so the site Content-Security-Policy can drop
+ * script-src 'unsafe-inline': an import-less hoisted <script> gets inlined into
+ * the page HTML by Astro, which the hash-based policy blocks — and the minified
+ * bytes make a static SHA-256 hash unstable.
+ */
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        if (!window.plausible) {
+            return;
+        }
+
+        window.plausible('404', { props: { path: document.location.pathname } });
+    });
+})();

--- a/packages/ag-charts-website/src/components/landing-pages/sections/features-with-examples/FeaturesWithExamples.astro
+++ b/packages/ag-charts-website/src/components/landing-pages/sections/features-with-examples/FeaturesWithExamples.astro
@@ -3,6 +3,7 @@ import type { InternalFramework } from '@ag-grid-types';
 import ExampleRunner from '../example-runner/ExampleRunner.astro';
 import { FeaturesWithExamplesContent, type FeatureConfig } from './FeaturesWithExamplesContent';
 import styles from './FeaturesWithExamples.module.scss';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 interface Props {
     features: FeatureConfig[];
@@ -90,22 +91,8 @@ const { features, framework } = Astro.props;
     }
 </style>
 
-<script>
-    // Listen for tab changes from the React component
-    document.addEventListener('landing-page-feature-tab-change', ((
-        event: CustomEvent<{ index: number; featureId: string }>
-    ) => {
-        const { index } = event.detail;
-
-        // Hide all panels
-        document.querySelectorAll('.landing-page-example-panel').forEach((panel) => {
-            panel.classList.remove('active');
-        });
-
-        // Show the selected panel
-        const activePanel = document.querySelector(`.landing-page-example-panel[data-index="${index}"]`);
-        if (activePanel) {
-            activePanel.classList.add('active');
-        }
-    }) as EventListener);
-</script>
+{
+    /* Externalised to a 'self' script so the site CSP can drop script-src
+    'unsafe-inline' — see public/scripts/landing-page-feature-tabs.js. */
+}
+<script is:inline src={urlWithBaseUrl('/scripts/landing-page-feature-tabs.js')} defer></script>

--- a/packages/ag-charts-website/src/pages/404.astro
+++ b/packages/ag-charts-website/src/pages/404.astro
@@ -24,12 +24,8 @@ const { data: docsNavData } = (await getEntry('docsNav', 'nav')) as CollectionEn
     </div>
 </Layout>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        if (!window.plausible) {
-            return;
-        }
-
-        window.plausible('404', { props: { path: document.location.pathname } });
-    });
-</script>
+{
+    /* Externalised to a 'self' script so the site CSP can drop script-src
+    'unsafe-inline' — see public/scripts/track-404.js. */
+}
+<script is:inline src={urlWithBaseUrl('/scripts/track-404.js')} defer></script>


### PR DESCRIPTION
## Summary

Two import-less hoisted Astro `<script>` blocks were being **inlined into page HTML** by Astro and then **blocked by the site Content-Security-Policy**, which authorises inline scripts only via a fixed SHA-256 allowlist (`cspRules.ts`):

- **`FeaturesWithExamples.astro`** — the `landing-page-feature-tab-change` listener. Blocked on all five landing pages (react/js/vue/angular/enterprise-charts). Surfaced on https://charts-staging.ag-grid.com/enterprise-charts/ as:
  > Executing inline script violates the following Content Security Policy directive 'script-src 'self' … ' (hash `sha256-nL+b29NYG+U0zX70C/HBHhfo2cjYkq2TGWBa6mDCc6Y=`).
- **`404.astro`** — the Plausible `'404'` tracker. Blocked on the 404 page (hash `sha256-XrtwE6XLSiwyFtEiKQ4OrJuLt5YjByl0qQjJDEC6NUk=`), so 404 analytics were silently not firing.

## Fix

Externalise each to a `'self'` script under `public/scripts/`, referenced via `<script is:inline src={urlWithBaseUrl(...)}>` — matching the existing pattern (`site-header-scroll.js`, `gtm-init.js`, etc.). This avoids needing an unstable static hash for minified inline bytes. Scripts use the same `(function () { … })();` IIFE convention as their siblings.

## Scope note

A repo-wide sweep found the only other import-less hoisted scripts live in the example-runner (`FrameworkTemplate.astro`, `PostInitMessageScript.astro`), which are served under `/examples/` where the CSP still allows `'unsafe-inline'` — so they are not affected. Import-bearing hoisted scripts are externalised by Astro automatically and were already safe.

## Verification

- `yarn nx format` — clean
- `yarn nx lint ag-charts-website` — 0 errors
- `yarn nx build ag-charts-website` — succeeded
- Hashed every inline script in the built `enterprise-charts/index.html` and `404.html`: **0 un-allowlisted inline scripts**, external `/scripts/*.js` references present.

## Follow-up

AG Grid and AG Studio likely share this CSP architecture (the GTM/ZoomInfo hash note in `cspRules.ts` already references AG-17134 across all three sites) — worth checking them for the same inlining pitfall.