### PR TITLE
AG-17729 Update banner copy (b14.0.0)

### DIFF
--- a/external/ag-website-shared/src/components/announcement-banner/AnnouncementBanner.astro
+++ b/external/ag-website-shared/src/components/announcement-banner/AnnouncementBanner.astro
@@ -1,0 +1,43 @@
+---
+import { Icon } from '@ag-website-shared/components/icon/Icon';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import styles from './AnnouncementBanner.module.scss';
+
+interface Props {
+    /** Link target for the whole banner (same-origin or absolute). */
+    href: string;
+    /** Primary headline text. */
+    title: string;
+    /** Optional supporting copy after the title. */
+    description?: string;
+    /** Call-to-action label on the right-hand side. */
+    ctaLabel?: string;
+    /** Whether the link should open in a new tab. */
+    external?: boolean;
+}
+
+const { href, title, description, ctaLabel = 'Learn more', external = false } = Astro.props;
+
+const targetAttrs = external ? { target: '_blank', rel: 'noopener' } : {};
+---
+
+<div class={styles.banner} data-announcement-banner>
+    <a class={styles.link} href={href} {...targetAttrs}>
+        <span class={styles.inner}>
+            <span class={styles.text}>
+                <span class={styles.title}>{title}</span>
+                {description && <span class={styles.description}>{description}</span>}
+            </span>
+            <span class={styles.cta}>
+                <span class={styles.ctaLabel}>{ctaLabel}</span>
+                <Icon name="chevronRight" />
+            </span>
+        </span>
+    </a>
+
+    <button type="button" class={styles.close} data-announcement-dismiss aria-label="Dismiss announcement">
+        <Icon name="cross" />
+    </button>
+</div>
+
+<script is:inline defer src={urlWithBaseUrl('/scripts/announcement-banner.js')}></script>

--- a/external/ag-website-shared/src/components/announcement-banner/AnnouncementBanner.module.scss
+++ b/external/ag-website-shared/src/components/announcement-banner/AnnouncementBanner.module.scss
@@ -1,0 +1,167 @@
+@use 'design-system' as *;
+
+.banner {
+    display: none;
+    position: relative;
+    overflow: hidden;
+    max-height: 200px;
+    background-color: var(--color-brand-900);
+    z-index: 10005;
+    transition:
+        max-height $transition-default-timing,
+        transform $transition-default-timing,
+        opacity $transition-default-timing;
+
+    &:global(.is-dismissing) {
+        max-height: 0;
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(-100%);
+    }
+}
+
+:global(html[data-show-announcement='true']) .banner {
+    display: block;
+}
+
+.link {
+    display: block;
+    color: var(--color-white);
+    text-decoration: none;
+    transition: background-color $transition-default-timing;
+
+    &:hover {
+        background-color: var(--color-brand-950);
+        color: var(--color-white);
+        text-decoration: none;
+
+        .ctaLabel {
+            text-decoration: underline;
+        }
+
+        .cta :global(.icon) {
+            transform: translateX(2px);
+        }
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-button-primary-shadow-focus);
+        outline-offset: -2px;
+    }
+}
+
+.inner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: $spacing-size-3;
+    max-width: calc(var(--layout-max-width) + var(--layout-horizontal-margins) * 2);
+    margin: 0 auto;
+    padding: $spacing-size-2 calc(var(--layout-horizontal-margins) + #{$spacing-size-6}) $spacing-size-2
+        var(--layout-horizontal-margins);
+    line-height: 1.3;
+    text-align: center;
+
+    @media screen and (min-width: $breakpoint-site-header-small) {
+        gap: $spacing-size-4;
+    }
+}
+
+.close {
+    position: absolute;
+    top: 50%;
+    right: $spacing-size-2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0 0 0 2px;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-white);
+    opacity: 0.8;
+    cursor: pointer;
+    transform: translateY(-50%);
+    transition:
+        opacity $transition-default-timing,
+        background-color $transition-default-timing;
+
+    &:hover {
+        opacity: 1;
+        background-color: rgb(255 255 255 / 10%);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-button-primary-shadow-focus);
+        outline-offset: -2px;
+        opacity: 1;
+    }
+
+    :global(.icon) {
+        --icon-size: 16px;
+        --icon-color: var(--color-white);
+
+        fill: var(--color-white);
+    }
+}
+
+.badge {
+    flex-shrink: 0;
+    padding: 2px $spacing-size-2;
+    border-radius: var(--radius-md);
+    background-color: var(--color-util-brand-500);
+    color: var(--color-white);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.text {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: center;
+    gap: $spacing-size-1 $spacing-size-2;
+    min-width: 0;
+}
+
+.title {
+    font-weight: 600;
+}
+
+.description {
+    opacity: 0.8;
+
+    // Keep the headline on its own line on very small viewports where wrapping
+    // becomes messy.
+    @media screen and (max-width: $breakpoint-site-header-extra-small) {
+        display: none;
+    }
+}
+
+.cta {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: $spacing-size-1;
+    font-weight: 500;
+    white-space: nowrap;
+
+    :global(.icon) {
+        --icon-size: 16px;
+        --icon-color: var(--color-white);
+
+        fill: var(--color-white);
+        transition: transform $transition-default-timing;
+    }
+}
+
+.ctaLabel {
+    // Hide the CTA label on narrow viewports — the chevron still signals clickability.
+    @media screen and (max-width: $breakpoint-site-header-extra-small) {
+        display: none;
+    }
+}

--- a/packages/ag-charts-website/public/scripts/announcement-banner.js
+++ b/packages/ag-charts-website/public/scripts/announcement-banner.js
@@ -1,0 +1,37 @@
+/*
+ * Dismiss handler for the announcement banner. Externalised from an inline <script>
+ * so the site Content-Security-Policy can drop script-src 'unsafe-inline'. Static,
+ * served from 'self'. Guarded so it is safe to load once per page.
+ */
+(function () {
+    if (window.__agAnnouncementBannerInit) {
+        return;
+    }
+    window.__agAnnouncementBannerInit = true;
+
+    var STORAGE_KEY = 'documentation:announcement-banner-dismissed';
+    var banner = document.querySelector('[data-announcement-banner]');
+    var button = banner && banner.querySelector('[data-announcement-dismiss]');
+
+    if (!button) {
+        return;
+    }
+
+    button.addEventListener('click', function () {
+        try {
+            localStorage.setItem(STORAGE_KEY, 'true');
+        } catch (_) {
+            // localStorage unavailable (private mode, quota); dismiss for this session only.
+        }
+
+        banner.classList.add('is-dismissing');
+
+        banner.addEventListener(
+            'transitionend',
+            function () {
+                banner.remove();
+            },
+            { once: true }
+        );
+    });
+})();

--- a/packages/ag-charts-website/src/content.config.ts
+++ b/packages/ag-charts-website/src/content.config.ts
@@ -53,6 +53,18 @@ const apiMenu = defineCollection({
     }),
 });
 
+const announcementBanner = defineCollection({
+    loader: glob({ base: './src/content/announcement-banner', pattern: 'announcement-banner.json' }),
+    schema: z.object({
+        enabled: z.boolean(),
+        href: z.string(),
+        title: z.string(),
+        description: z.string().optional(),
+        ctaLabel: z.string().optional(),
+        external: z.boolean().optional(),
+    }),
+});
+
 const footer = defineCollection({
     loader: glob({ base: './src/content/footer', pattern: 'footer.json' }),
     schema: z.array(
@@ -250,6 +262,7 @@ export const collections = {
     docs,
     apiMenu,
     footer,
+    announcementBanner,
     faqs,
     siteHeader,
     versions,

--- a/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
+++ b/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
@@ -1,0 +1,8 @@
+{
+    "enabled": true,
+    "href": "https://app.livestorm.co/ag-grid/whats-new-in-ag-grid-36-and-ag-charts-14?s=bb9ec924-9814-49ad-bafb-9e8e65492caa",
+    "title": "AG Grid & AG Charts webinar",
+    "description": "Join us for an AG Grid & AG Charts webinar DAY TIME TIMEZONE",
+    "ctaLabel": "Register",
+    "external": true
+}

--- a/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
+++ b/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
@@ -2,7 +2,7 @@
     "enabled": true,
     "href": "https://app.livestorm.co/ag-grid/whats-new-in-ag-grid-36-and-ag-charts-14?s=bb9ec924-9814-49ad-bafb-9e8e65492caa",
     "title": "What's new webinar: AG Grid 36 and AG Charts 14",
-    "description": "Join us for a webinar on 14th July at 2pm",
+    "description": "Join us for a webinar on 14th July at 2pm UTC+1",
     "ctaLabel": "Register",
     "external": true
 }

--- a/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
+++ b/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
@@ -1,8 +1,8 @@
 {
     "enabled": true,
     "href": "https://app.livestorm.co/ag-grid/whats-new-in-ag-grid-36-and-ag-charts-14?s=bb9ec924-9814-49ad-bafb-9e8e65492caa",
-    "title": "AG Grid & AG Charts webinar",
-    "description": "Join us for an AG Grid & AG Charts webinar DAY TIME TIMEZONE",
+    "title": "What's new webinar: AG Grid 36 and AG Charts 14",
+    "description": "Join us for a webinar on 14th July at 2pm",
     "ctaLabel": "Register",
     "external": true
 }

--- a/packages/ag-charts-website/src/layouts/Layout.astro
+++ b/packages/ag-charts-website/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ import { FRAMEWORKS, SITE_BASE_URL, PUBLIC_GTM_ID, PUBLIC_GTM_AUTH, PUBLIC_GTM_P
 import { DevTools } from '@ag-website-shared/components/dev-tools/DevTools';
 import GoogleTagManager from '@ag-website-shared/components/google-tag-manager/GoogleTagManager.astro';
 import GoogleTagManagerBody from '@ag-website-shared/components/google-tag-manager/GoogleTagManagerBody.astro';
+import AnnouncementBanner from '@ag-website-shared/components/announcement-banner/AnnouncementBanner.astro';
 import JsonLd from '@ag-website-shared/components/structured-data/JsonLd.astro';
 import {
     buildOrganization,
@@ -34,11 +35,16 @@ export interface Props {
     hideHeader?: boolean;
     hideFooter?: boolean;
     noIndex?: boolean;
+    showAnnouncementBanner?: boolean;
     pageStructuredData?: JsonLdObject[];
 }
 
 const { data: metadata } = await getEntry('metadata', 'metadata') as CollectionEntry<'metadata'>;
 const { data: footerItems } = await getEntry('footer', 'footer') as CollectionEntry<'footer'>;
+const { data: announcementBannerContent } = (await getEntry(
+    'announcementBanner',
+    'announcement-banner'
+)) as CollectionEntry<'announcementBanner'>;
 
 const {
     title = metadata.title,
@@ -48,6 +54,7 @@ const {
     hideHeader,
     hideFooter,
     noIndex,
+    showAnnouncementBanner = announcementBannerContent.enabled,
     pageStructuredData,
 } = Astro.props;
 
@@ -212,6 +219,18 @@ const structuredData: JsonLdObject[] = includeStructuredData
         {/* Authorised in script-src by SHA-256 hash (not 'unsafe-inline'); body lives in
             @utils/csp/inlineScripts so the rendered bytes match the hashed source. */}
         <script is:inline set:html={DARK_MODE_INIT_SCRIPT} />
+
+        {
+            !isArchive && showAnnouncementBanner && (
+                <AnnouncementBanner
+                    href={urlWithBaseUrl(announcementBannerContent.href)}
+                    title={announcementBannerContent.title}
+                    description={announcementBannerContent.description}
+                    ctaLabel={announcementBannerContent.ctaLabel}
+                    external={announcementBannerContent.external}
+                />
+            )
+        }
 
         <div class="mainContainer">
             {!hideHeader && <SiteHeader showSearchBar={showSearchBar} showDocsNav={showDocsNav} apiPaths={apiPaths}/>}

--- a/packages/ag-charts-website/src/utils/csp/inlineScripts.ts
+++ b/packages/ag-charts-website/src/utils/csp/inlineScripts.ts
@@ -55,6 +55,10 @@ export const DARK_MODE_INIT_SCRIPT = `
         });
     });
     observer.observe(htmlEl, { attributes: true });
+
+    if (localStorage.getItem('documentation:announcement-banner-dismissed') !== 'true') {
+        document.documentElement.dataset.showAnnouncement = 'true';
+    }
 `;
 
 // Plausible analytics queue stub. The tagged-events script itself loads externally


### PR DESCRIPTION
Backports the announcement banner config to the `b14.0.0` release branch and applies the webinar copy, matching `latest`.

Cherry-picked from `latest`:
- `AG 17729 announcement banner (#7323)` — `announcementBanner` content collection + `announcement-banner.json`
- `AG-17729 move inline script to external (#7324)` — externalised dismiss script
- `Update banner copy` + `AG-17729 - Add timezone` (#7330) — webinar title/description

Banner copy:
- **Title:** What's new webinar: AG Grid 36 and AG Charts 14
- **Description:** Join us for a webinar on 14th July at 2pm UTC+1

Note: on ag-charts `latest`, the banner is currently config-only — the collection, JSON, and dismiss script exist, but nothing renders the `[data-announcement-banner]` element yet (no shared component / Layout wiring, unlike ag-grid and ag-studio). This backport faithfully mirrors that `latest` state. If the banner needs to visibly render on the ag-charts site, the shared renderer wiring has to land on `latest` first.

Equivalent backport PRs: ag-grid b36.0.0 and ag-studio b2.0.1.