### PR TITLE
AG-3390 Make page-verification smoke tests fail only on real breakage

### DIFF
--- a/packages/ag-charts-website/e2e/page-verification.spec.ts
+++ b/packages/ag-charts-website/e2e/page-verification.spec.ts
@@ -2,7 +2,76 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import { expect, test } from './fixture';
-import { SELECTORS, gotoExample, gotoUrl, setupIntrinsicAssertions, toPageUrl } from './util';
+import { SELECTORS, gotoExample, gotoUrl, toPageUrl } from './util';
+
+// This is a smoke test suite: a page actually failing to load or render (checked via the
+// assertions in each test, plus gotoUrl/gotoExample's own title/canvas checks) is the main
+// way a test fails. The one other hard-fail signal is a genuinely enforced CSP violation —
+// something the browser actively blocked — since that's a real, actionable break we need to
+// know about immediately, distinct from routine console noise. Everything else (console
+// errors/warnings, uncaught exceptions, dev-server hydration noise, and report-only CSP
+// monitoring that hasn't blocked anything yet) is surfaced as a test annotation for
+// visibility in reports without failing the test. This intentionally doesn't use the shared
+// setupIntrinsicAssertions from util.ts — that helper's zero-tolerance behaviour is right for
+// the feature-level e2e specs that use it, but wrong for a post-deploy smoke test.
+const isCspIssue = (msg: string) => /Content-Security-Policy|Refused to (load|execute|connect)/i.test(msg);
+// An actual enforced block ("Refused to load/execute/connect ...") as opposed to a
+// report-only policy that's merely being monitored ahead of enforcement — browsers
+// prefix/suffix report-only violation messages with "report-only" or "[Report Only]" text
+// (Chrome/Chromium use a space, not a hyphen, in the "[Report Only]" prefix).
+const isEnforcedCspViolation = (msg: string) => /Refused to (load|execute|connect)/i.test(msg) && !/report[ -]only/i.test(msg);
+
+// Console messages that are known browser/environment noise unrelated to the site under
+// test. Matched by substring so new message formats stay filtered; this is report hygiene
+// only, not a safety mechanism, since none of it fails the test anyway.
+const KNOWN_NOISE = [
+    '[astro-island]', // Astro dev-server hydration artefact, doesn't occur in production builds
+    'GL Driver Message',
+    'Permissions policy violation',
+    'This page is in Quirks Mode',
+    'favicon.ico',
+    'the server responded with a status of 404',
+];
+
+function setupPageVerificationAssertions() {
+    let cspViolations: string[] = [];
+
+    test.beforeEach(({ page }, testInfo) => {
+        cspViolations = [];
+
+        const handle = (text: string, annotationPrefix: string) => {
+            if (text.startsWith('*')) return; // AG Charts license text
+            if (KNOWN_NOISE.some((n) => text.includes(n))) return;
+            if (isEnforcedCspViolation(text)) {
+                cspViolations.push(text);
+                return;
+            }
+            const prefix = isCspIssue(text) ? '[CSP]' : annotationPrefix;
+            testInfo.annotations.push({ type: 'warning', description: `${prefix} ${text}` });
+        };
+
+        page.on('console', (msg) => {
+            // Chrome perf violations/interventions are emitted as 'log' type messages.
+            if (msg.type() === 'log') {
+                const text = msg.text();
+                if (text.startsWith('[Violation]') || text.startsWith('[Intervention]')) {
+                    handle(text, '[Console]');
+                }
+                return;
+            }
+            if (msg.type() !== 'warning' && msg.type() !== 'error') return;
+            handle(msg.text(), '[Console]');
+        });
+
+        page.on('pageerror', (err) => {
+            handle(`Uncaught exception: ${err.message}`, '[Exception]');
+        });
+    });
+
+    test.afterEach(() => {
+        expect(cspViolations, 'CSP violations').toEqual([]);
+    });
+}
 
 function getGalleryExamples(): string[] {
     const raw = JSON.parse(readFileSync(join(__dirname, '../src/content/gallery/data.json'), 'utf-8'));
@@ -25,9 +94,7 @@ const GALLERY_EXAMPLES = getGalleryExamples();
 test.use({ viewport: { width: 1400, height: 900 } });
 
 test.describe('Page Verification', () => {
-    // [astro-island] hydration errors are dev-server artefacts that don't occur in production
-    // builds — scope the filter here rather than in shared util.ts.
-    setupIntrinsicAssertions(test, { ignoreConsolePatterns: ['[astro-island]'] });
+    setupPageVerificationAssertions();
 
     // --- Homepage ---
 
@@ -52,7 +119,7 @@ test.describe('Page Verification', () => {
         await expect(page.locator('header h1')).toContainText('AgChartOptions');
     });
 
-    test('community page loads [ignore404s]', async ({ page }) => {
+    test('community page loads', async ({ page }) => {
         await gotoUrl(page, toPageUrl('community'));
         await expect(page).toHaveTitle(/Community/);
         await expect(page.locator('.site-header')).toBeVisible();

--- a/packages/ag-charts-website/e2e/page-verification.spec.ts
+++ b/packages/ag-charts-website/e2e/page-verification.spec.ts
@@ -15,11 +15,15 @@ import { SELECTORS, gotoExample, gotoUrl, toPageUrl } from './util';
 // setupIntrinsicAssertions from util.ts — that helper's zero-tolerance behaviour is right for
 // the feature-level e2e specs that use it, but wrong for a post-deploy smoke test.
 const isCspIssue = (msg: string) => /Content-Security-Policy|Refused to (load|execute|connect)/i.test(msg);
-// An actual enforced block ("Refused to load/execute/connect ...") as opposed to a
-// report-only policy that's merely being monitored ahead of enforcement — browsers
-// prefix/suffix report-only violation messages with "report-only" or "[Report Only]" text
+// An actual enforced block, as opposed to a report-only policy that's merely being
+// monitored ahead of enforcement. Enforced CSP violation messages vary in verb by
+// directive ("Refused to load/execute/connect...", "Refused to apply inline style...",
+// "Refused to frame...", "Refused to create a worker from...", "Refused to evaluate a
+// string as JavaScript...", etc.) so rather than enumerate every verb, treat any
+// CSP-related message that isn't marked report-only as enforced. Browsers prefix/suffix
+// report-only violation messages with "report-only" or "[Report Only]" text
 // (Chrome/Chromium use a space, not a hyphen, in the "[Report Only]" prefix).
-const isEnforcedCspViolation = (msg: string) => /Refused to (load|execute|connect)/i.test(msg) && !/report[ -]only/i.test(msg);
+const isEnforcedCspViolation = (msg: string) => isCspIssue(msg) && !/report[ -]only/i.test(msg);
 
 // Console messages that are known browser/environment noise unrelated to the site under
 // test. Matched by substring so new message formats stay filtered; this is report hygiene


### PR DESCRIPTION
console errors/warnings and uncaught exceptions no longer fail the suite - they're surfaced as test annotations instead, since routine browser/library noise unrelated to the site was causing false failures on post-deploy verification. Pass/fail is now driven by the structural/functional assertions (does the page actually load and render) plus one remaining hard-fail signal: a genuinely enforced CSP violation, since that's a real, actionable break worth failing loudly for. Report-only CSP monitoring is treated as informational.

This is scoped locally to page-verification.spec.ts rather than changing the shared setupIntrinsicAssertions helper in util.ts, which dozens of feature-level e2e specs rely on for its zero-tolerance console behaviour.