### PR TITLE
AG-17333 [CLAUDE] Fix drag-selection hit-testing for org/network series

### DIFF
--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1127,12 +1127,12 @@ export abstract class Series<
         switch (containment) {
             case 'any':
                 return (selectionBox: BoxBounds, node: Node<unknown>): boolean => {
-                    const nodeBox = Transformable.toCanvas(this.contentGroup, node.getBBox());
+                    const nodeBox = Transformable.toCanvas(node);
                     return boxCollides(selectionBox, nodeBox.x, nodeBox.y, nodeBox.width, nodeBox.height);
                 };
             case 'all':
                 return (selectionBox: BoxBounds, node: Node<unknown>): boolean => {
-                    const nodeBox = Transformable.toCanvas(this.contentGroup, node.getBBox());
+                    const nodeBox = Transformable.toCanvas(node);
                     return boxContains(selectionBox, nodeBox.x, nodeBox.y, nodeBox.width, nodeBox.height);
                 };
             default:


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17333

The default pickNodesInBBox predicate computed each node's canvas bounds via `Transformable.toCanvas(this.contentGroup, node.getBBox())`, which only applies contentGroup's transform chain. This assumes picked nodes are effectively contentGroup-relative — true for cartesian/polar series, but not for organization/network series, where nodes sit under a `viewportGroup` (zoom scale + translate) and a `dataNodeGroup` (pan offset). Those intermediate transforms were skipped, so hit-test boxes were mis-scaled and mis-offset relative to the canvas-space drag rect: nodes got selected, but not the ones actually under the drag rectangle.

Use the canonical `Transformable.toCanvas(node)` instead, which walks the node's real ancestor chain and applies every transform between the node and the canvas. This is the same structure-agnostic primitive already used for highlight/caption/legend/axis bounds, so correctness no longer depends on any scene-graph nesting assumption.

Verified a no-op for cartesian and polar series (their intermediate node groups are identity, and polar uses a separate sector predicate): the data-selection drag suite, organization series, and bubble series tests all pass.