### PR TITLE
AG-17637 Dispatch `contextmenu` events on axes to contextMenu.ts

### DIFF
--- a/packages/ag-charts-angular/tests/zone-callback-inventory.json
+++ b/packages/ag-charts-angular/tests/zone-callback-inventory.json
@@ -67,6 +67,10 @@
         "classification": "zone-wrap",
         "reason": "Context-menu action dispatched from out-of-zone DOM listeners; re-entered into the zone by patchContextMenu."
     },
+    "AgContextMenuItemAxis.action": {
+        "classification": "zone-wrap",
+        "reason": "Context-menu action dispatched from out-of-zone DOM listeners; re-entered into the zone by patchContextMenu."
+    },
     "AgContextMenuItemCaption.action": {
         "classification": "zone-wrap",
         "reason": "Context-menu action dispatched from out-of-zone DOM listeners; re-entered into the zone by patchContextMenu."

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -161,7 +161,7 @@ export abstract class CartesianAxis<
                 }
                 previousSize = size;
             }),
-            this.caption.registerInteraction(this.moduleCtx, 'afterend')
+            this.caption.registerInteraction(this.moduleCtx, this.id)
         );
     }
 

--- a/packages/ag-charts-community/src/chart/caption.ts
+++ b/packages/ag-charts-community/src/chart/caption.ts
@@ -1,4 +1,4 @@
-import type { DynamicContext, NormalisedTextOrSegments } from 'ag-charts-core';
+import type { AxisID, DynamicContext, NormalisedTextOrSegments } from 'ag-charts-core';
 import {
     BaseProperties,
     FONT_SIZE,
@@ -124,9 +124,11 @@ export class Caption extends BaseProperties implements CaptionLike {
     private proxyTextListeners?: Array<() => void>;
     private lastProxyTextContent?: string;
     private lastProxyBBox?: { x: number; y: number; width: number; height: number };
+    private a11yContext?: { moduleCtx: DynamicContext<ChartRegistry>; axisId: AxisID };
 
-    registerInteraction(moduleCtx: DynamicContext<ChartRegistry>, where: 'beforebegin' | 'afterend') {
-        return moduleCtx.eventsHub.on('layout:complete', () => this.updateA11yText(moduleCtx, where));
+    registerInteraction(moduleCtx: DynamicContext<ChartRegistry>, axisId: AxisID) {
+        this.a11yContext = { moduleCtx, axisId };
+        return moduleCtx.eventsHub.on('layout:complete', () => this.updateA11yText(moduleCtx, axisId));
     }
 
     computeTextWrap(containerWidth: number, containerHeight: number) {
@@ -153,8 +155,7 @@ export class Caption extends BaseProperties implements CaptionLike {
         this.node.text = wrappedText;
     }
 
-    private updateA11yText(moduleCtx: DynamicContext<ChartRegistry>, where: 'beforebegin' | 'afterend') {
-        const { proxyInteractionService } = moduleCtx;
+    private updateA11yText(moduleCtx: DynamicContext<ChartRegistry>, axisId: AxisID) {
         if (!this.enabled || !this.text) {
             this.destroyProxyText();
             return;
@@ -163,9 +164,8 @@ export class Caption extends BaseProperties implements CaptionLike {
         const bbox = Transformable.toCanvas(this.node);
         if (!bbox) return;
 
-        const { id: domManagerId } = this;
         if (this.proxyText == null) {
-            this.proxyText = proxyInteractionService.createProxyElement({ type: 'text', domManagerId, where });
+            this.proxyText = moduleCtx.widgets.axisWidgets.acquireTitle(axisId);
             this.proxyTextListeners = [
                 this.proxyText.addListener('mousemove', (ev) => this.handleMouseMove(moduleCtx, ev)),
                 this.proxyText.addListener('mouseleave', () => this.handleTooltipHide(moduleCtx)),
@@ -189,7 +189,7 @@ export class Caption extends BaseProperties implements CaptionLike {
             bbox.width !== lastProxyBBox?.width ||
             bbox.height !== lastProxyBBox?.height
         ) {
-            this.proxyText.setBounds(bbox);
+            moduleCtx.widgets.axisWidgets.setTitleBounds(axisId, bbox);
             this.lastProxyBBox = { x: bbox.x, y: bbox.y, width: bbox.width, height: bbox.height };
         }
     }
@@ -261,7 +261,8 @@ export class Caption extends BaseProperties implements CaptionLike {
             cleanup();
         }
         this.proxyTextListeners = undefined;
-        this.proxyText.destroy();
+        // The widget itself is owned by AxisWidgets, not the caption; release it there.
+        this.a11yContext?.moduleCtx.widgets.axisWidgets.releaseTitle(this.a11yContext.axisId);
         this.proxyText = undefined;
         this.lastProxyTextContent = undefined;
         this.lastProxyBBox = undefined;

--- a/packages/ag-charts-community/src/chart/chartContext.ts
+++ b/packages/ag-charts-community/src/chart/chartContext.ts
@@ -119,7 +119,7 @@ export function createChartContext(chart: ChartHost, vars: ChartContextVars): Dy
         .service('interactionManager', () => new InteractionManager())
         .service('optionsGraphService', () => new OptionsGraphService())
         .service('chartTypeOriginator', () => new ChartTypeOriginator(chart))
-        .service('widgets', (c) => new WidgetSet(c.domManager, { withDragInterpretation: vars.withDragInterpretation }))
+        .service('widgets', (c) => new WidgetSet(c, { withDragInterpretation: vars.withDragInterpretation }))
         .service('axisManager', (c) => new AxisManager(c.eventsHub, vars.root))
         .service('highlightManager', (c) => new HighlightManager(c))
         .service('layoutManager', (c) => new LayoutManager(c.eventsHub))

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
@@ -8,6 +8,7 @@ import type {
     AgContextMenuItemShowOn,
 } from 'ag-charts-types';
 
+import type { Axis } from '../axis/axis';
 import type { CategoryLegendDatum } from '../legend/legendDatum';
 import type { ISeries, SeriesNodeDatum } from '../series/seriesTypes';
 
@@ -29,6 +30,11 @@ export interface ContextShowOnMap extends ContextShowOnMapRule {
         event: InferTEvent<'always'>;
         callback: (param: InferTEvent<'always'>) => void;
         context: undefined;
+    };
+    axis: {
+        event: InferTEvent<'axis'>;
+        callback: (param: InferTEvent<'axis'>) => void;
+        context: { axis: Axis };
     };
     caption: {
         event: InferTEvent<'caption'>;

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
@@ -1,4 +1,4 @@
-import type { RequireOptional } from 'ag-charts-core';
+import type { AxisID, ChartAxisDirection, RequireOptional } from 'ag-charts-core';
 import type {
     AgContextMenuGetItemsParamsCaption,
     AgContextMenuItem,
@@ -8,7 +8,6 @@ import type {
     AgContextMenuItemShowOn,
 } from 'ag-charts-types';
 
-import type { Axis } from '../axis/axis';
 import type { CategoryLegendDatum } from '../legend/legendDatum';
 import type { ISeries, SeriesNodeDatum } from '../series/seriesTypes';
 
@@ -34,7 +33,7 @@ export interface ContextShowOnMap extends ContextShowOnMapRule {
     axis: {
         event: InferTEvent<'axis'>;
         callback: (param: InferTEvent<'axis'>) => void;
-        context: { axis: Axis };
+        context: { axisId: AxisID; direction: ChartAxisDirection };
     };
     caption: {
         event: InferTEvent<'caption'>;

--- a/packages/ag-charts-community/src/chart/interaction/widgetSet.ts
+++ b/packages/ag-charts-community/src/chart/interaction/widgetSet.ts
@@ -1,4 +1,8 @@
-import type { DOMManager } from '../../dom/domManager';
+import type { AxisID, BoxBounds, DynamicContext } from 'ag-charts-core';
+
+import type { ChartRegistry } from '../../module/moduleContext';
+import type { AxisWidget } from '../../widget/axisWidget';
+import type { BoundedTextWidget } from '../../widget/boundedTextWidget';
 import { NativeWidget } from '../../widget/nativeWidget';
 import { type Widget } from '../../widget/widget';
 import { DragInterpreter } from './dragInterpreter';
@@ -16,13 +20,188 @@ class DOMManagerWidget extends NativeWidget {
     }
 }
 
+type AxisEntry = {
+    region?: AxisWidget;
+    text?: BoundedTextWidget;
+    textNested: boolean;
+    regionBounds?: BoxBounds;
+    titleBounds?: BoxBounds;
+};
+
+/**
+ * Owns the per-axis proxy widgets exposed on the `widgets` service: the interaction region
+ * (`AxisWidget`) and the axis title text (`BoundedTextWidget`). The title exists whenever the axis
+ * has a caption; the region only while an interaction feature (zoom / scrollbar / context-menu)
+ * requests one. When both are present the title is a descendant of the region so it is not occluded
+ * by it; otherwise the title is attached standalone next to the series area, exactly as before.
+ *
+ * Lives in this file (rather than its own module) to avoid a circular dependency: `WidgetSet` needs
+ * to construct it, but the `DynamicContext<ChartRegistry>` type it depends on resolves back through
+ * `WidgetSet`.
+ */
+export class AxisWidgets {
+    private static readonly TITLE_ID_SUFFIX = '__axis-title';
+
+    private readonly entries = new Map<AxisID, AxisEntry>();
+
+    constructor(private readonly ctx: DynamicContext<ChartRegistry>) {}
+
+    /** The axis title text widget, created on first request. Callers configure content/bounds/listeners. */
+    acquireTitle(axisId: AxisID): BoundedTextWidget {
+        const entry = this.getEntry(axisId);
+        if (!entry.text) {
+            entry.text = this.ctx.proxyInteractionService.createProxyElement({
+                type: 'text',
+                domManagerId: this.titleId(axisId),
+                where: 'afterend',
+            });
+            entry.textNested = false;
+            if (entry.region) {
+                this.nestTitle(axisId, entry);
+            }
+        }
+        return entry.text;
+    }
+
+    releaseTitle(axisId: AxisID): void {
+        const entry = this.entries.get(axisId);
+        if (!entry?.text) return;
+        if (entry.textNested && entry.region) {
+            entry.region.removeChildWidget(entry.text);
+        }
+        entry.text.destroy();
+        entry.text = undefined;
+        entry.textNested = false;
+        this.pruneEntry(axisId, entry);
+    }
+
+    /** The axis interaction region, created on first request. Callers set bounds/pointer-events/listeners. */
+    acquireRegion(axisId: AxisID): AxisWidget {
+        const entry = this.getEntry(axisId);
+        if (!entry.region) {
+            entry.region = this.ctx.proxyInteractionService.createProxyElement({
+                type: 'axis',
+                domManagerId: axisId,
+                where: 'afterend',
+                role: 'region',
+            });
+            if (entry.text && !entry.textNested) {
+                this.nestTitle(axisId, entry);
+            }
+        }
+        return entry.region;
+    }
+
+    releaseRegion(axisId: AxisID): void {
+        const entry = this.entries.get(axisId);
+        if (!entry?.region) return;
+        if (entry.text && entry.textNested) {
+            this.unnestTitle(axisId, entry);
+        }
+        entry.region.destroy();
+        entry.region = undefined;
+        this.pruneEntry(axisId, entry);
+    }
+
+    // Bounds must be routed through these setters (rather than the widgets' own `setBounds`) because
+    // the axis title text lives in one of two coordinate systems depending on interactivity:
+    //   - Non-interactive axis: there is no region, so the title is a standalone element in the
+    //     canvas-proxy container and is positioned in canvas coordinates.
+    //   - Interactive axis: the title is nested inside the region widget, whose bounds are a subset
+    //     of the canvas bounds. A nested element is positioned relative to the region's origin, not
+    //     the canvas, so the title's canvas bounds must be translated by the region origin.
+    // The region bounds (from the interaction feature) and title bounds (from the caption) arrive
+    // from independent `layout:complete` listeners in an unspecified order, so both are stored and
+    // the title position is re-derived on every update — never depending on which arrived last.
+
+    setRegionBounds(axisId: AxisID, bounds: BoxBounds): void {
+        const entry = this.getEntry(axisId);
+        entry.regionBounds = bounds;
+        entry.region?.setBounds(bounds);
+        this.applyTitleBounds(entry);
+    }
+
+    setTitleBounds(axisId: AxisID, bounds: BoxBounds): void {
+        const entry = this.getEntry(axisId);
+        entry.titleBounds = bounds;
+        this.applyTitleBounds(entry);
+    }
+
+    destroy(): void {
+        for (const entry of this.entries.values()) {
+            entry.text?.destroy();
+            entry.region?.destroy();
+        }
+        this.entries.clear();
+    }
+
+    private applyTitleBounds(entry: AxisEntry): void {
+        const { text, titleBounds } = entry;
+        if (!text || !titleBounds) return;
+
+        if (entry.textNested && entry.regionBounds) {
+            text.setBounds({
+                x: titleBounds.x - entry.regionBounds.x,
+                y: titleBounds.y - entry.regionBounds.y,
+                width: titleBounds.width,
+                height: titleBounds.height,
+            });
+        } else {
+            text.setBounds(titleBounds);
+        }
+    }
+
+    private titleId(axisId: AxisID): string {
+        return `${axisId}${AxisWidgets.TITLE_ID_SUFFIX}`;
+    }
+
+    private getEntry(axisId: AxisID): AxisEntry {
+        let entry = this.entries.get(axisId);
+        if (!entry) {
+            entry = { textNested: false };
+            this.entries.set(axisId, entry);
+        }
+        return entry;
+    }
+
+    // Move the standalone title element out of the DOM manager and into the region widget. The
+    // domManager entry must be cleared first, otherwise a later re-attach would be a no-op (addChild
+    // is keyed by id and returns the existing element).
+    private nestTitle(axisId: AxisID, entry: AxisEntry): void {
+        if (!entry.region || !entry.text) return;
+        this.ctx.domManager.removeChild('canvas-proxy', this.titleId(axisId));
+        entry.region.addChild(entry.text);
+        entry.textNested = true;
+        this.applyTitleBounds(entry);
+    }
+
+    private unnestTitle(axisId: AxisID, entry: AxisEntry): void {
+        if (!entry.region || !entry.text) return;
+        entry.region.removeChildWidget(entry.text);
+        this.ctx.domManager.addChild('canvas-proxy', this.titleId(axisId), entry.text.getElement(), {
+            where: 'afterend',
+            query: '.ag-charts-series-area',
+        });
+        entry.textNested = false;
+        this.applyTitleBounds(entry);
+    }
+
+    private pruneEntry(axisId: AxisID, entry: AxisEntry): void {
+        if (!entry.region && !entry.text) {
+            this.entries.delete(axisId);
+        }
+    }
+}
+
 export class WidgetSet {
     readonly seriesWidget: Widget;
     readonly chartWidget: Widget;
     readonly containerWidget: Widget;
     readonly seriesDragInterpreter?: DragInterpreter;
+    readonly axisWidgets: AxisWidgets;
 
-    constructor(domManager: DOMManager, opts: { withDragInterpretation: boolean }) {
+    constructor(ctx: DynamicContext<ChartRegistry>, opts: { withDragInterpretation: boolean }) {
+        const { domManager } = ctx;
         this.seriesWidget = new DOMManagerWidget(domManager.getParent('series-area'));
         this.chartWidget = new DOMManagerWidget(domManager.getParent('canvas-proxy'));
         this.containerWidget = new DOMManagerWidget(domManager.getParent('canvas-container'));
@@ -31,9 +210,11 @@ export class WidgetSet {
         if (opts.withDragInterpretation) {
             this.seriesDragInterpreter = new DragInterpreter(this.seriesWidget);
         }
+        this.axisWidgets = new AxisWidgets(ctx);
     }
 
     destroy(): void {
+        this.axisWidgets.destroy();
         this.seriesDragInterpreter?.destroy();
         this.seriesWidget.destroy();
         this.chartWidget.destroy();

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -493,6 +493,14 @@ export class SeriesAreaManager extends BaseManager {
                 position
             );
         } else {
+            // Offer the menu to an overlapping axis first; a claim calls preventDefault, so the series-area
+            // dispatch below then no-ops. Must be emitted before that dispatch (mirrors the hover/drag handoff).
+            this.chart.ctx.eventsHub.emit('series-area:contextmenu', {
+                consumed: false,
+                canvasX,
+                canvasY,
+                widgetEvent: event,
+            });
             this.chart.ctx.contextMenuRegistry?.dispatchContext(
                 'series-area',
                 { widgetEvent: event, canvasX, canvasY },

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -85,6 +85,13 @@ export interface SeriesAreaClickEvent {
     readonly target: Node<unknown> | undefined;
 }
 
+export interface SeriesAreaContextMenuEvent {
+    readonly consumed: boolean;
+    readonly canvasX: number;
+    readonly canvasY: number;
+    readonly widgetEvent: MouseWidgetEvent<'contextmenu'>;
+}
+
 export interface DataModelSeriesDiff {
     readonly changed: boolean;
     readonly added: Set<string>;
@@ -144,6 +151,7 @@ export interface EventsHubMap {
     'series:keynav-panx': SeriesKeyNavPanXEvent;
     'series-area:hover': SeriesAreaHoverEvent;
     'series-area:click': SeriesAreaClickEvent;
+    'series-area:contextmenu': SeriesAreaContextMenuEvent;
     'series:redo': null;
     'series:undo': null;
     'update:complete': UpdateCompleteEvent;
@@ -232,6 +240,7 @@ export interface AxisDOMProxyUpdateEvent {
     enableDoubleClick: boolean;
     enableDragging: boolean;
     enableScrolling: boolean;
+    enableContextMenu: boolean;
 }
 
 export type ContextMenuEvent<K extends AgContextMenuItemShowOn = AgContextMenuItemShowOn> = {

--- a/packages/ag-charts-community/src/dom/proxyInteractionService.ts
+++ b/packages/ag-charts-community/src/dom/proxyInteractionService.ts
@@ -9,6 +9,7 @@ import {
 import type { Direction } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../module/moduleContext';
+import { AxisWidget } from '../widget/axisWidget';
 import { BoundedTextWidget } from '../widget/boundedTextWidget';
 import { ButtonWidget } from '../widget/buttonWidget';
 import { GroupWidget } from '../widget/groupWidget';
@@ -75,6 +76,10 @@ type ProxyMeta = {
         params: ParentProperties<GroupWidget> & ElemParams<'region'> & { readonly role?: string };
         result: NativeWidget<HTMLDivElement>;
     };
+    axis: {
+        params: ParentProperties<GroupWidget> & ElemParams<'axis'> & { readonly role?: string };
+        result: AxisWidget;
+    };
 
     // Containers
     toolbar: {
@@ -91,7 +96,7 @@ type ProxyMeta = {
     };
 };
 
-type ProxyElementType = 'button' | 'slider' | 'text' | 'listswitch' | 'region';
+type ProxyElementType = 'button' | 'slider' | 'text' | 'listswitch' | 'region' | 'axis';
 type ProxyContainerType = 'toolbar' | 'group' | 'list';
 
 function checkType<T extends keyof ProxyMeta>(type: T, meta: ProxyMeta[keyof ProxyMeta]): meta is ProxyMeta[T] {
@@ -111,6 +116,8 @@ function allocateResult<T extends keyof ProxyMeta>(type: T): ProxyMeta[T]['resul
         return new ListWidget();
     } else if ('region' === type) {
         return new NativeWidget<HTMLDivElement>(createElement('div'));
+    } else if ('axis' === type) {
+        return new AxisWidget();
     } else if ('text' === type) {
         return new BoundedTextWidget();
     } else if ('listswitch' === type) {
@@ -218,6 +225,14 @@ export class ProxyInteractionService {
             const region = result.getElement();
             this.initInteract(params, result);
             region.role = params.role ?? 'region';
+            this.setParent(meta.params, meta.result);
+        }
+
+        if (checkType('axis', meta)) {
+            const { params, result } = meta;
+            const axis = result.getElement();
+            this.initInteract(params, result);
+            axis.role = params.role ?? 'region';
             this.setParent(meta.params, meta.result);
         }
 

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -115,6 +115,7 @@ export type {
     LayoutCompleteEvent,
     ScrollbarWheelEvent,
     SeriesAreaClickEvent,
+    SeriesAreaContextMenuEvent,
     SeriesAreaHoverEvent,
     SeriesKeyNavZoomEvent,
     SeriesKeyNavPanXEvent,

--- a/packages/ag-charts-community/src/widget/axisWidget.ts
+++ b/packages/ag-charts-community/src/widget/axisWidget.ts
@@ -1,0 +1,17 @@
+import { createElement } from 'ag-charts-core';
+
+import { NativeWidget } from './nativeWidget';
+
+/**
+ * Proxy element for a single axis. Exposed as `role="region"` when an interaction feature is
+ * active, and optionally wraps the axis title text (a `BoundedTextWidget`) so the title is a
+ * descendant of the region — remaining hit-testable rather than being occluded by it.
+ *
+ * Lifecycle, DOM attachment and title re-parenting are owned by `AxisWidgets`; this class only
+ * provides the distinct widget type.
+ */
+export class AxisWidget extends NativeWidget<HTMLDivElement> {
+    constructor() {
+        super(createElement('div'));
+    }
+}

--- a/packages/ag-charts-community/src/widget/exports.ts
+++ b/packages/ag-charts-community/src/widget/exports.ts
@@ -1,6 +1,7 @@
 export * from './widget';
 export * from './widgetEvents';
 export * from './nativeWidget';
+export * from './axisWidget';
 export * from './toolbarWidget';
 export * from './buttonWidget';
 export * from './sliderWidget';

--- a/packages/ag-charts-core/src/config/chartDefaults.ts
+++ b/packages/ag-charts-core/src/config/chartDefaults.ts
@@ -231,7 +231,14 @@ const contextMenuItemLiterals: AgContextMenuItemLiteral[] = [
 
 const contextMenuItemObjectDef: OptionsDefs<Extract<AgContextMenuItem, object>> = {
     type: strictUnion<AgContextMenuItemType>()('action', 'separator'),
-    showOn: strictUnion<AgContextMenuItemShowOn>()('always', 'caption', 'series-area', 'series-node', 'legend-item'),
+    showOn: strictUnion<AgContextMenuItemShowOn>()(
+        'always',
+        'axis',
+        'caption',
+        'series-area',
+        'series-node',
+        'legend-item'
+    ),
     label: required(string),
     enabled: boolean,
     action: callback,

--- a/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
+++ b/packages/ag-charts-enterprise/src/axes/radius/radiusAxis.ts
@@ -64,7 +64,7 @@ export abstract class RadiusAxis<
 
         this.headingLabelGroup.appendChild(this.caption.node);
 
-        this.cleanup.register(this.caption.registerInteraction(this.moduleCtx, 'afterend'));
+        this.cleanup.register(this.caption.registerInteraction(this.moduleCtx, this.id));
     }
 
     private getAxisTransform() {

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -6,7 +6,7 @@ type AxisHit = { axisId: AxisID; direction: ChartAxisDirection };
 type ProxyAxis = {
     axisId: AxisID;
     direction: ChartAxisDirection;
-    div: _Widget.NativeWidget<HTMLDivElement>;
+    div: _Widget.AxisWidget;
     bounds?: _ModuleSupport.BBox;
 };
 
@@ -58,7 +58,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
     private teardown() {
         for (const a of this.axes) {
-            a.div.destroy();
+            this.ctx.widgets.axisWidgets.releaseRegion(a.axisId);
         }
     }
 
@@ -107,7 +107,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             this.axes = this.axes.filter((entry) => {
                 if (!removed.includes(entry.axisId)) return true;
 
-                entry.div.destroy();
+                this.ctx.widgets.axisWidgets.releaseRegion(entry.axisId);
                 this.overlappingAxisIds.delete(entry.axisId);
 
                 if (this.hoveredAxisId === entry.axisId) this.hoveredAxisId = undefined;
@@ -131,7 +131,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             if (bbox == undefined) {
                 axis.bounds = undefined;
             } else {
-                axis.div.setBounds(bbox);
+                this.ctx.widgets.axisWidgets.setRegionBounds(axis.axisId, bbox);
                 axis.bounds = new _ModuleSupport.BBox(bbox.x, bbox.y, bbox.width, bbox.height);
             }
         }
@@ -345,12 +345,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
     }
 
     private createAxisDOMProxy(axisId: AxisID, direction: ChartAxisDirection): ProxyAxis {
-        const {
-            ctx: { proxyInteractionService },
-        } = this;
-
-        const where = 'afterend';
-        const div = proxyInteractionService.createProxyElement({ type: 'region', domManagerId: axisId, where });
+        const div = this.ctx.widgets.axisWidgets.acquireRegion(axisId);
         const proxyAxis: ProxyAxis = { axisId, div, direction };
 
         div.addListener('drag-start', (event) => {
@@ -390,9 +385,10 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         });
         div.addListener('contextmenu', (event) => {
             if (!this.isEnabled() || !this.isEnabledContextMenu()) return;
-            const { bounds } = proxyAxis;
-            const canvasX = event.offsetX + (bounds?.x ?? 0);
-            const canvasY = event.offsetY + (bounds?.y ?? 0);
+            // currentX/currentY are relative to the region regardless of which descendant (e.g. the
+            // nested axis title) was actually hit, so they stay correct once the title is nested.
+            const canvasX = event.currentX + div.cssLeft();
+            const canvasY = event.currentY + div.cssTop();
             this.dispatchAxisContextMenu(axisId, direction, event, canvasX, canvasY);
         });
 

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -22,6 +22,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
     private readonly enableDoubleClick = new Map<string, boolean>();
     private readonly enableDragging = new Map<string, boolean>();
     private readonly enableScrolling = new Map<string, boolean>();
+    private readonly enableContextMenu = new Map<string, boolean>();
 
     private axes: ProxyAxis[] = [];
 
@@ -50,6 +51,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             ctx.eventsHub.on('axis-dom-proxy:update', (event) => this.onUpdate(event)),
             ctx.eventsHub.on('series-area:hover', (event) => this.onSeriesAreaHover(event)),
             ctx.eventsHub.on('series-area:click', (event) => this.onSeriesAreaClick(event)),
+            ctx.eventsHub.on('series-area:contextmenu', (event) => this.onSeriesAreaContextMenu(event)),
             () => this.teardown()
         );
     }
@@ -65,15 +67,20 @@ export class AxisDOMProxy extends AbstractModuleInstance {
     }
 
     private onUpdate(event: _ModuleSupport.AxisDOMProxyUpdateEvent) {
-        const { enabled, enableDoubleClick, enableDragging, enableScrolling, source } = event;
+        const { enabled, enableDoubleClick, enableDragging, enableScrolling, enableContextMenu, source } = event;
 
         this.enabled.set(source, enabled);
         this.enableDoubleClick.set(source, enableDoubleClick);
         this.enableDragging.set(source, enableDragging);
         this.enableScrolling.set(source, enableScrolling);
+        this.enableContextMenu.set(source, enableContextMenu);
 
         const isEnabled =
-            this.isEnabled() && (this.isEnabledDoubleClick() || this.isEnabledDragging() || this.isEnabledScrolling());
+            this.isEnabled() &&
+            (this.isEnabledDoubleClick() ||
+                this.isEnabledDragging() ||
+                this.isEnabledScrolling() ||
+                this.isEnabledContextMenu());
 
         for (const axis of this.axes) {
             axis.div.setHidden(!isEnabled);
@@ -180,6 +187,21 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         });
     }
 
+    private onSeriesAreaContextMenu(event: _ModuleSupport.SeriesAreaContextMenuEvent) {
+        if (!this.isEnabled() || !this.isEnabledContextMenu()) return;
+
+        // A series node was hit; leave the context menu to the series area.
+        if (event.consumed) return;
+
+        // Only continue if we know we have axes that overlap the series area.
+        if (!this.hasOverlappingAxes()) return;
+
+        const axis = this.pickAxisAtPoint(event);
+        if (!axis) return;
+
+        this.dispatchAxisContextMenu(axis.axisId, axis.direction, event.widgetEvent, event.canvasX, event.canvasY);
+    }
+
     private onSeriesAreaDoubleClick(event: _ModuleSupport.DragInterpreterDblClickEvent) {
         if (!this.isEnabled() || !this.isEnabledDoubleClick()) return;
 
@@ -257,6 +279,16 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         });
     }
 
+    private dispatchAxisContextMenu(
+        axisId: AxisID,
+        direction: ChartAxisDirection,
+        widgetEvent: _Widget.MouseWidgetEvent<'contextmenu'>,
+        canvasX: number,
+        canvasY: number
+    ) {
+        this.ctx.contextMenuRegistry?.dispatchContext('axis', { widgetEvent, canvasX, canvasY }, { axisId, direction });
+    }
+
     private pickAxisAtPoint(point: { canvasX: number; canvasY: number }): AxisHit | undefined {
         for (const axis of this.axes) {
             if (!this.overlappingAxisIds.has(axis.axisId)) continue;
@@ -280,7 +312,8 @@ export class AxisDOMProxy extends AbstractModuleInstance {
     private updateOverlappingAxisPointerEvents() {
         this.overlappingAxisIds.clear();
 
-        const shouldEnableInteraction = (this.isEnabledDragging() || this.isEnabledScrolling()) && this.seriesRect;
+        const shouldEnableInteraction =
+            (this.isEnabledDragging() || this.isEnabledScrolling() || this.isEnabledContextMenu()) && this.seriesRect;
 
         for (const axis of this.axes) {
             if (!shouldEnableInteraction) {
@@ -318,6 +351,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
         const where = 'afterend';
         const div = proxyInteractionService.createProxyElement({ type: 'region', domManagerId: axisId, where });
+        const proxyAxis: ProxyAxis = { axisId, div, direction };
 
         div.addListener('drag-start', (event) => {
             if (!this.isEnabled() || !this.isEnabledDragging()) return;
@@ -354,8 +388,15 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             if (!this.isEnabled() || !this.isEnabledScrolling()) return;
             this.ctx.eventsHub.emit('axis-dom-proxy:wheel', { axisId, direction, event });
         });
+        div.addListener('contextmenu', (event) => {
+            if (!this.isEnabled() || !this.isEnabledContextMenu()) return;
+            const { bounds } = proxyAxis;
+            const canvasX = event.offsetX + (bounds?.x ?? 0);
+            const canvasY = event.offsetY + (bounds?.y ?? 0);
+            this.dispatchAxisContextMenu(axisId, direction, event, canvasX, canvasY);
+        });
 
-        return { axisId, div, direction };
+        return proxyAxis;
     }
 
     private diffAxisIds(axesCtx: _ModuleSupport.AxisContext[]) {
@@ -382,6 +423,10 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
     private isEnabledScrolling() {
         return this.isBooleanMap(this.enableScrolling);
+    }
+
+    private isEnabledContextMenu() {
+        return this.isBooleanMap(this.enableContextMenu);
     }
 
     private isBooleanMap(map: Map<string, boolean>) {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -172,6 +172,10 @@ export class ContextMenu extends AbstractModuleInstance {
                 return params;
             }
 
+            case 'axis': {
+                throw new Error('not yet implemented');
+            }
+
             case 'caption': {
                 if (this.pickedCaptionCtx == null) throw new Error(`this.pickedCaptionCtx is null`);
                 const { captionType, text } = this.pickedCaptionCtx;
@@ -385,6 +389,8 @@ export class ContextMenu extends AbstractModuleInstance {
                 }
                 this.hide();
             };
+        } else if (ContextMenuRegistry.checkCallback('axis', showOn, callback)) {
+            throw new Error('not yet implemented');
         } else if (ContextMenuRegistry.checkCallback('caption', showOn, callback)) {
             return () => {
                 if (this.pickedCaptionCtx) {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -132,7 +132,22 @@ export class ContextMenu extends AbstractModuleInstance {
             });
         };
 
-        this.cleanup.register(this.ctx.eventsHub.on('context-menu:complete', (e) => this.onContext(e)));
+        this.cleanup.register(
+            this.ctx.eventsHub.on('context-menu:complete', (e) => this.onContext(e)),
+            this.ctx.eventsHub.on('layout:complete', () => this.updateAxisDOMProxy())
+        );
+    }
+
+    private updateAxisDOMProxy() {
+        const enabled = this.opts.enabled ?? true;
+        this.ctx.eventsHub.emit('axis-dom-proxy:update', {
+            source: moduleId,
+            enabled,
+            enableDoubleClick: false,
+            enableDragging: false,
+            enableScrolling: false,
+            enableContextMenu: enabled,
+        });
     }
 
     private makeGetItemsParams(event: ContextMenuEvent): AgContextMenuGetItemsParams {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuModule.ts
@@ -8,6 +8,7 @@ import {
     undocumented,
 } from 'ag-charts-core';
 
+import { AxisDOMProxyModule } from '../axis-dom-proxy/axisDomProxyModule';
 import { ContextMenu, type ContextMenuCtx } from './contextMenu';
 
 export const ContextMenuModule: PluginModuleDefinition<AgContextMenuOptions, _ModuleSupport.ChartRegistry> = {
@@ -15,6 +16,7 @@ export const ContextMenuModule: PluginModuleDefinition<AgContextMenuOptions, _Mo
     name: 'contextMenu',
     enterprise: true,
     version: VERSION,
+    dependencies: [AxisDOMProxyModule],
 
     options: {
         enabled: boolean,

--- a/packages/ag-charts-enterprise/src/features/scrollbar/scrollbar.ts
+++ b/packages/ag-charts-enterprise/src/features/scrollbar/scrollbar.ts
@@ -197,6 +197,7 @@ export class Scrollbar extends AbstractModuleInstance {
             enableDoubleClick: false,
             enableDragging: false,
             enableScrolling: opts.enableAxisScrolling,
+            enableContextMenu: false,
         });
 
         this.seriesRect = event.series.rect;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -770,6 +770,7 @@ export class Zoom extends AbstractModuleInstance {
             enableDoubleClick: enableDoubleClickToReset,
             enableDragging: enableAxisDragging,
             enableScrolling: enableAxisScrolling,
+            enableContextMenu: false,
         });
 
         if (!enabled) return;

--- a/packages/ag-charts-types/src/chart/axisOptions.ts
+++ b/packages/ag-charts-types/src/chart/axisOptions.ts
@@ -15,6 +15,10 @@ import type {
     TextWrap,
 } from './types';
 
+export type AgAxisDomain = number[] | bigint[] | string[] | Date[];
+
+export type AgAxisDirection = 'x' | 'y' | 'angle' | 'radius';
+
 export interface AgAxisBoundSeries {
     /** ID of the series for values on the related axis. */
     seriesId: string;
@@ -28,7 +32,7 @@ export interface AgAxisCaptionFormatterParams {
     /** Default value to be used for the axis title (as specified in chart options or theme). */
     defaultValue?: string;
     /** Direction of the axis the title belongs to. */
-    direction: 'x' | 'y' | 'angle' | 'radius';
+    direction: AgAxisDirection;
     /** Metadata about series bound to the axis the title belongs to. */
     boundSeries: AgAxisBoundSeries[];
     /** Computed domain of the axis */

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -1,5 +1,6 @@
 import type { SelectionState } from './callbackOptions';
 import type {
+    AgAxisContextMenuActionEvent,
     AgCaptionContextMenuActionEvent,
     AgChartContextMenuEvent,
     AgNodeContextMenuActionEvent,
@@ -18,7 +19,7 @@ export type AgContextMenuItemLiteral =
     | 'toggle-other-series'
     | 'separator';
 
-export type AgContextMenuItemShowOn = 'always' | 'caption' | 'series-area' | 'series-node' | 'legend-item';
+export type AgContextMenuItemShowOn = 'always' | 'axis' | 'caption' | 'series-area' | 'series-node' | 'legend-item';
 
 export type AgContextMenuItemType = 'action' | 'separator';
 
@@ -58,6 +59,20 @@ export interface AgContextMenuItemAlways<TDatum = DatumDefault, TContext = Conte
     showOn?: 'always';
     /** Function called when clicking on this menu item. */
     action?: (event: AgChartContextMenuEvent<TContext>) => void;
+}
+
+export interface AgContextMenuItemAxis<TDatum = DatumDefault, TContext = ContextDefault> extends ItemMixin<
+    TDatum,
+    TContext
+> {
+    /**
+     * Which clicked element this menu item should be shown for. `'axis'` menu items are when clicking any part of an axis.
+     *
+     * Default: `'axis'`
+     */
+    showOn: 'axis';
+    /** Function called when clicking on this menu item. */
+    action?: (event: AgAxisContextMenuActionEvent<TContext>) => void;
 }
 
 export interface AgContextMenuItemCaption<TDatum = DatumDefault, TContext = ContextDefault> extends ItemMixin<
@@ -113,6 +128,7 @@ export interface AgContextMenuItemLegendItem<TDatum = DatumDefault, TContext = C
 export type AgContextMenuItem<TDatum = DatumDefault, TContext = ContextDefault> =
     | AgContextMenuItemLiteral
     | AgContextMenuItemAlways<TDatum, TContext>
+    | AgContextMenuItemAxis<TDatum, TContext>
     | AgContextMenuItemCaption<TDatum, TContext>
     | AgContextMenuItemSeriesArea<TDatum, TContext>
     | AgContextMenuItemSeriesNode<TDatum, TContext>
@@ -140,6 +156,14 @@ export interface AgContextMenuGetItemsParamsAlways<_TDatumReserved = never, TCon
         GetItemsParamsMixin<_TDatumReserved, TContext> {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'always';
+}
+
+export interface AgContextMenuGetItemsParamsAxis<_TDatumReserved = never, TContext = ContextDefault>
+    extends
+        Omit<AgAxisContextMenuActionEvent<TContext>, GetItemsParamsOmissions>,
+        GetItemsParamsMixin<_TDatumReserved, TContext> {
+    /** Which clicked element this menu item should be shown for. */
+    showOn: 'axis';
 }
 
 export interface AgContextMenuGetItemsParamsCaption<_TDatumReserved = never, TContext = ContextDefault>

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -2,6 +2,7 @@ import type { AgActiveState } from '../api/activeState';
 import type { AgStateGroupingValueType, AgStateValueType } from '../api/stateTypes';
 import type { TextOrSegments } from '../series/cartesian/commonOptions';
 import type { AgAnnotation } from './annotationsOptions';
+import type { AgAxisBoundSeries, AgAxisDirection, AgAxisDomain } from './axisOptions';
 import type { AgItemType, Listener, SelectionState } from './callbackOptions';
 import type { AgNumericValue } from './dataValues';
 import type { ContextDefault, DatumDefault, Ratio, ResolvedDatumKey } from './types';
@@ -168,6 +169,22 @@ export type AgSeriesAreaContextMenuActionEvent<TContext = ContextDefault> = AgCh
 >;
 
 export type AgCaptionType = 'title' | 'subtitle' | 'footnote';
+
+export interface AgAxisContextMenuActionEvent<TContext = ContextDefault> extends AgChartEvent<
+    'axisContextMenuAction',
+    TContext
+> {
+    /** Axis ID, as specified in `axes`. */
+    axisId: string;
+    /** TODO: TBD */
+    value: number | bigint | string | Date;
+    /** Direction of the axis the title belongs to. */
+    direction: AgAxisDirection;
+    /** Metadata about series bound to the axis the title belongs to. */
+    boundSeries: AgAxisBoundSeries[];
+    /** Computed domain of the axis */
+    domain: AgAxisDomain[];
+}
 
 export interface AgCaptionContextMenuActionEvent<TContext = ContextDefault> extends AgChartEvent<
     'captionContextMenuAction',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17637

Done:
- Adds `showOn:'axis'` types to ag-charts-types
- Adds dispatching of `AxisContext` to the context-menu module

TODO:
- Context-menu module uses stubs for `showOn:'axis'` (throws error).