### PR TITLE
AG-17729 Fix announcement banner overlapping gallery header

### DIFF
--- a/packages/ag-charts-website/src/pages/gallery.astro
+++ b/packages/ag-charts-website/src/pages/gallery.astro
@@ -126,7 +126,6 @@ const modifiedExamples = getModifiedGalleryExamples();
         flex-direction: row;
         position: relative;
         background-color: var(--color-bg-primary);
-        padding-top: var(--layout-site-header-height);
     }
 
     .menu {
@@ -277,10 +276,13 @@ const modifiedExamples = getModifiedGalleryExamples();
 <style lang="scss" is:global>
     @use 'design-system' as *;
 
+    // Sticky (not fixed) so the header sits below the in-flow announcement banner
+    // and rises as it scrolls away; forced at all widths (default is sticky only ≥1100px).
     .site-header {
-        position: fixed !important;
+        position: sticky !important;
+        top: 0;
         width: 100%;
-        z-index: 2;
+        z-index: 10002;
     }
 
     .icon {


### PR DESCRIPTION
## Summary

The marketing announcement banner overlapped the site header **only on the gallery page**.

## Root cause

The `AnnouncementBanner` (added recently in `21f810a2`) renders in **normal document flow** above the header. The gallery page has carried a `position: fixed !important` override on `.site-header` since 2023. A fixed header is anchored to the viewport, so it ignored the in-flow banner and pinned itself to `top: 0`, overlapping the banner (the banner's higher `z-index` painted over it).

Every other page uses the header's default `position: sticky`, which stays in flow, sits below the banner, and rises to the top as the banner scrolls away — so they were unaffected.

## Fix

- Change the gallery's `.site-header` override from `position: fixed` to `position: sticky; top: 0` (forced at all widths, since the header is only sticky by default ≥1100px), matching how the rest of the site behaves.
- Remove the now-redundant `padding-top: var(--layout-site-header-height)` on `.gallery-outer` — it existed only to reserve space for the out-of-flow fixed header.

## Testing

Verified in the browser across widths (1400px / 1000px / 500px), both scroll states, and the dismissed-banner state:
- **Desktop (reported case):** banner sits above the header with no overlap; on scroll the banner leaves and the header sticks to the top with no gap.
- Also a strict improvement on mobile, where the original fixed header left a ~37px gap above it when scrolled.
- Residual quirks in the 820–1100px range (side menu vs. two-row header) are **pre-existing and banner-independent**, so left out of scope.

`yarn nx format` / `yarn nx lint ag-charts-website` pass (0 errors).