### PR TITLE
AG-17637 Initial implementation of `showOn:'axis'`

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1076,10 +1076,6 @@ export abstract class Axis<
         return resolvedDirection;
     }
 
-    public getFormatterBoundSeries(): AgAxisBoundSeries[] {
-        return this.formatterBoundSeries.get();
-    }
-
     protected getTitleFormatterParams(domain: D[]) {
         const { direction } = this;
         const boundSeries = this.formatterBoundSeries.get();
@@ -1193,6 +1189,7 @@ export abstract class Axis<
             getRangeOverflow: (value) => this.getRangeOverflow(value),
             pickBand: (point) => this.pickBand(point),
             measureBand: (value) => this.measureBand(value),
+            getFormatterBoundSeries: () => this.formatterBoundSeries.get(),
         };
     }
 

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1076,6 +1076,10 @@ export abstract class Axis<
         return resolvedDirection;
     }
 
+    public getFormatterBoundSeries(): AgAxisBoundSeries[] {
+        return this.formatterBoundSeries.get();
+    }
+
     protected getTitleFormatterParams(domain: D[]) {
         const { direction } = this;
         const boundSeries = this.formatterBoundSeries.get();

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
@@ -1,4 +1,4 @@
-import type { AxisID, ChartAxisDirection, RequireOptional } from 'ag-charts-core';
+import type { RequireOptional } from 'ag-charts-core';
 import type {
     AgContextMenuGetItemsParamsCaption,
     AgContextMenuItem,
@@ -8,6 +8,7 @@ import type {
     AgContextMenuItemShowOn,
 } from 'ag-charts-types';
 
+import type { AxisContext } from '../../module/axisContext';
 import type { CategoryLegendDatum } from '../legend/legendDatum';
 import type { ISeries, SeriesNodeDatum } from '../series/seriesTypes';
 
@@ -33,7 +34,7 @@ export interface ContextShowOnMap extends ContextShowOnMapRule {
     axis: {
         event: InferTEvent<'axis'>;
         callback: (param: InferTEvent<'axis'>) => void;
-        context: { axisId: AxisID; direction: ChartAxisDirection };
+        context: AxisContext;
     };
     caption: {
         event: InferTEvent<'caption'>;

--- a/packages/ag-charts-community/src/module/axisContext.ts
+++ b/packages/ag-charts-community/src/module/axisContext.ts
@@ -1,5 +1,5 @@
 import type { AxisID, BoxBounds, ChartAxisDirection, NormalisedTextOrSegments, Point, Scale } from 'ag-charts-core';
-import type { AgCartesianAxisPosition, FormatterParams } from 'ag-charts-types';
+import type { AgAxisBoundSeries, AgCartesianAxisPosition, FormatterParams } from 'ag-charts-types';
 
 import type { Group } from '../scene/group';
 import type { Node } from '../scene/node';
@@ -84,4 +84,5 @@ export interface AxisContext {
     measureBand(value: string): AxisBandMeasurement | undefined;
     /** Defined only on polar axes; cartesian axes leave it undefined. */
     getPolarLayout?(): PolarAxisLayout;
+    getFormatterBoundSeries(): AgAxisBoundSeries[];
 }

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -199,7 +199,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         const axis = this.pickAxisAtPoint(event);
         if (!axis) return;
 
-        this.dispatchAxisContextMenu(axis, event.widgetEvent, event.canvasX, event.canvasY);
+        this.dispatchAxisContextMenu(axis.axisId, event.widgetEvent, event.canvasX, event.canvasY);
     }
 
     private onSeriesAreaDoubleClick(event: _ModuleSupport.DragInterpreterDblClickEvent) {
@@ -347,7 +347,6 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
     private createAxisDOMProxy(axisId: AxisID, direction: ChartAxisDirection): ProxyAxis {
         const div = this.ctx.widgets.axisWidgets.acquireRegion(axisId);
-        const proxyAxis: ProxyAxis = { axisId, div, direction };
 
         div.addListener('drag-start', (event) => {
             if (!this.isEnabled() || !this.isEnabledDragging()) return;
@@ -390,7 +389,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             // nested axis title) was actually hit, so they stay correct once the title is nested.
             const canvasX = event.currentX + div.cssLeft();
             const canvasY = event.currentY + div.cssTop();
-            this.dispatchAxisContextMenu(axis, event, canvasX, canvasY);
+            this.dispatchAxisContextMenu(axisId, event, canvasX, canvasY);
         });
 
         return { axisId, div, direction };

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -199,7 +199,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         const axis = this.pickAxisAtPoint(event);
         if (!axis) return;
 
-        this.dispatchAxisContextMenu(axis.axisId, axis.direction, event.widgetEvent, event.canvasX, event.canvasY);
+        this.dispatchAxisContextMenu(axis, event.widgetEvent, event.canvasX, event.canvasY);
     }
 
     private onSeriesAreaDoubleClick(event: _ModuleSupport.DragInterpreterDblClickEvent) {
@@ -281,12 +281,13 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
     private dispatchAxisContextMenu(
         axisId: AxisID,
-        direction: ChartAxisDirection,
         widgetEvent: _Widget.MouseWidgetEvent<'contextmenu'>,
         canvasX: number,
         canvasY: number
     ) {
-        this.ctx.contextMenuRegistry?.dispatchContext('axis', { widgetEvent, canvasX, canvasY }, { axisId, direction });
+        const axisCtx = this.ctx.axisManager.getAxisIdContext(axisId);
+        if (!axisCtx) return;
+        this.ctx.contextMenuRegistry?.dispatchContext('axis', { widgetEvent, canvasX, canvasY }, axisCtx);
     }
 
     private pickAxisAtPoint(point: { canvasX: number; canvasY: number }): AxisHit | undefined {
@@ -389,10 +390,10 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             // nested axis title) was actually hit, so they stay correct once the title is nested.
             const canvasX = event.currentX + div.cssLeft();
             const canvasY = event.currentY + div.cssTop();
-            this.dispatchAxisContextMenu(axisId, direction, event, canvasX, canvasY);
+            this.dispatchAxisContextMenu(axis, event, canvasX, canvasY);
         });
 
-        return proxyAxis;
+        return { axisId, div, direction };
     }
 
     private diffAxisIds(axesCtx: _ModuleSupport.AxisContext[]) {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -1,14 +1,18 @@
 import type {
+    AgAxisContextMenuActionEvent,
     AgCaptionContextMenuActionEvent,
     AgContextMenuGetItemsParams,
+    AgContextMenuGetItemsParamsAxis,
     AgContextMenuGetItemsParamsSeriesNode,
     AgContextMenuItem,
     AgContextMenuItemShowOn,
+    ContextDefault,
+    DatumDefault,
 } from 'ag-charts-community';
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
+import type { DynamicContext, RequireOptional } from 'ag-charts-core';
 import {
     AbstractModuleInstance,
-    type DynamicContext,
     Logger,
     callWithContext,
     clamp,
@@ -19,6 +23,7 @@ import {
 
 import { ContextMenuItem, expandBuiltinLists, expandItems } from './contextMenuItem';
 import { DEFAULT_CONTEXT_MENU_CLASS } from './contextMenuStyles';
+import { type PublicAxisContext, toPublicAxisContext } from './contextMenuUtil';
 
 type ContextShowOnMap = _ModuleSupport.ContextShowOnMap;
 type ContextMenuEvent<K extends AgContextMenuItemShowOn = AgContextMenuItemShowOn> = _ModuleSupport.ContextMenuEvent<K>;
@@ -75,6 +80,7 @@ export class ContextMenu extends AbstractModuleInstance {
     private pickedNode: PickedNode | undefined = undefined;
     private pickedLegendItem?: _ModuleSupport.CategoryLegendDatum;
     private pickedCaptionCtx?: ContextShowOnMap['caption']['context'];
+    private pickedAxisCtx?: PublicAxisContext;
     private x: number = 0;
     private y: number = 0;
     private collapsingSubMenus = 0;
@@ -188,7 +194,19 @@ export class ContextMenu extends AbstractModuleInstance {
             }
 
             case 'axis': {
-                throw new Error('not yet implemented');
+                if (this.pickedAxisCtx == null) throw new Error(`this.pickedAxisCtx is null`);
+                const { axisId, boundSeries, direction, domain, value } = this.pickedAxisCtx;
+                const params: RequireOptional<AgContextMenuGetItemsParamsAxis<DatumDefault, ContextDefault>> = {
+                    showOn,
+                    context: this.pickedAxisCtx.context ?? context,
+                    defaultItems,
+                    axisId,
+                    boundSeries,
+                    direction,
+                    domain,
+                    value,
+                };
+                return params;
             }
 
             case 'caption': {
@@ -239,6 +257,8 @@ export class ContextMenu extends AbstractModuleInstance {
             this.pickedLegendItem = event.context.legendItem;
         } else if (ContextMenuRegistry.check('caption', event)) {
             this.pickedCaptionCtx = event.context;
+        } else if (ContextMenuRegistry.check('axis', event)) {
+            this.pickedAxisCtx = toPublicAxisContext(event);
         }
 
         const expandedItems = this.expandItemsOptions(event);
@@ -405,7 +425,25 @@ export class ContextMenu extends AbstractModuleInstance {
                 this.hide();
             };
         } else if (ContextMenuRegistry.checkCallback('axis', showOn, callback)) {
-            throw new Error('not yet implemented');
+            return () => {
+                if (this.pickedAxisCtx) {
+                    const { axisId, direction, boundSeries, domain, value } = this.pickedAxisCtx;
+                    const callers: Caller[] = [this.pickedAxisCtx, this.ctx.chartService];
+                    const apiEvent: Omit<AgAxisContextMenuActionEvent<never>, 'context'> = {
+                        type: 'axisContextMenuAction',
+                        event: showEvent,
+                        axisId,
+                        direction,
+                        boundSeries,
+                        domain,
+                        value,
+                    };
+                    callWithContext(callers, callback, apiEvent);
+                } else {
+                    Logger.error('axis item not found');
+                }
+                this.hide();
+            };
         } else if (ContextMenuRegistry.checkCallback('caption', showOn, callback)) {
             return () => {
                 if (this.pickedCaptionCtx) {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuUtil.ts
@@ -16,6 +16,6 @@ export function toPublicAxisContext(event: _ModuleSupport.ContextMenuEvent<'axis
     const { axisId, direction } = axisCtx;
     const { domain } = axisCtx.scale;
     const boundSeries = axisCtx.getFormatterBoundSeries();
-    const value = NaN; // not yet implemented
+    const value = Number.NaN; // not yet implemented
     return { axisId, direction, context: userCtx, boundSeries, domain, value };
 }

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuUtil.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuUtil.ts
@@ -1,0 +1,21 @@
+import { _ModuleSupport } from 'ag-charts-community';
+import type { AgContextMenuGetItemsParamsAlways, AgContextMenuGetItemsParamsAxis } from 'ag-charts-types';
+
+// Dynamically extract properties of `AgContextMenuGetItemsParamsAxis` that are not present in the base
+// `AgContextMenuGetItemsParamsAlways` (except for `context` because we need to broadcast the user option
+// `axes[key].context` if defined).
+export type PublicAxisContext = Omit<
+    AgContextMenuGetItemsParamsAxis,
+    Exclude<keyof AgContextMenuGetItemsParamsAlways, 'context'>
+>;
+
+export function toPublicAxisContext(event: _ModuleSupport.ContextMenuEvent<'axis'>): PublicAxisContext {
+    const axisCtx = event.context;
+    const userCtx = event.context.context;
+
+    const { axisId, direction } = axisCtx;
+    const { domain } = axisCtx.scale;
+    const boundSeries = axisCtx.getFormatterBoundSeries();
+    const value = NaN; // not yet implemented
+    return { axisId, direction, context: userCtx, boundSeries, domain, value };
+}

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -204,6 +204,7 @@ export interface AgContextMenuGetItemsParamsLegendItem<_TDatumReserved = never, 
 
 export type AgContextMenuGetItemsParams<TDatum = DatumDefault, TContext = ContextDefault> =
     | AgContextMenuGetItemsParamsAlways<TDatum, TContext>
+    | AgContextMenuGetItemsParamsAxis<TDatum, TContext>
     | AgContextMenuGetItemsParamsCaption<TDatum, TContext>
     | AgContextMenuGetItemsParamsSeriesArea<TDatum, TContext>
     | AgContextMenuGetItemsParamsSeriesNode<TDatum, TContext>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17637

TODO:
- The event uses a placeholder `value: NaN`. The requirements of this property are still TBD.