### PR TITLE
AG-17637 Fix DevRegression where dragging on axis title does nothing

### DIFF
--- a/packages/ag-charts-community/src/widget/widgetEvents.ts
+++ b/packages/ag-charts-community/src/widget/widgetEvents.ts
@@ -96,6 +96,8 @@ export type WheelWidgetEvent = {
     readonly offsetY: number;
     readonly clientX: number;
     readonly clientY: number;
+    readonly currentX: number;
+    readonly currentY: number;
     readonly deltaX: number;
     readonly deltaY: number;
     readonly sourceEvent: WheelEvent;
@@ -233,8 +235,9 @@ const WIDGET_META = {
     // WheelEvent
     wheel: {
         isNative: true,
-        allocator(sourceEvent: WheelEvent, _current: HTMLElement): WheelWidgetEvent {
+        allocator(sourceEvent: WheelEvent, current: HTMLElement): WheelWidgetEvent {
             const { offsetX, offsetY, clientX, clientY } = sourceEvent;
+            const { currentX, currentY } = WidgetEventUtil.calcCurrentXY(current, sourceEvent);
 
             // AG-10475 On Chrome (Windows), wheel clicks send deltaMode: 0 events with deltaY: -100 or +100.
             // So we divide this by 100 to give us the desired step.
@@ -249,7 +252,18 @@ const WIDGET_META = {
                 [deltaX, deltaY] = [deltaY, deltaX];
             }
 
-            return { type: 'wheel', offsetX, offsetY, clientX, clientY, deltaX, deltaY, sourceEvent };
+            return {
+                type: 'wheel',
+                offsetX,
+                offsetY,
+                clientX,
+                clientY,
+                currentX,
+                currentY,
+                deltaX,
+                deltaY,
+                sourceEvent,
+            };
         },
     },
 

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -10,20 +10,30 @@ type EventHandler<T, K extends EventType = EventType> = (event: EventMap[K], cur
 type Targetable = { getElement(): HTMLElement };
 
 type DragEvents = 'drag-start' | 'drag-move' | 'drag-end';
-type DragOrigin = { pageX: number; pageY: number; offsetX: number; offsetY: number };
+type DragOrigin = {
+    pageX: number;
+    pageY: number;
+    currentX: number;
+    currentY: number;
+    offsetX: number;
+    offsetY: number;
+};
 
-function makeMouseDrag<K extends DragEvents>(
-    current: Targetable,
-    type: K,
-    origin: DragOrigin,
-    sourceEvent: MouseEvent
-): DragWidgetEvent<K> {
-    const { currentX, currentY } = WidgetEventUtil.calcCurrentXY(current.getElement(), sourceEvent);
+function makeMouseDrag<K extends DragEvents>(type: K, origin: DragOrigin, sourceEvent: MouseEvent): DragWidgetEvent<K> {
     // [offsetX, offsetY] is relative to the sourceEvent.target, which can be another element
     // such as a legend button. Therefore, calculate [offsetX, offsetY] relative to the axis
     // element that fired the 'mousedown' event.
     const originDeltaX = sourceEvent.pageX - origin.pageX;
     const originDeltaY = sourceEvent.pageY - origin.pageY;
+
+    // FIXME: This is not entirely honest. At the time of writing, there's a weird quirk where dragging an axis can
+    // cause the HTML bounds to change, with change produce a twitch-like animation. The axis bounds change because
+    // the tick labels change/move, which causes the bounds to be recalculated. The ideal solution would be for the
+    // axis element bounds to remain constant when the user drags the mouse, but unfortunately that's very difficult
+    // to achieve. As a workaround, just calculate currentXY relative to the origin (before any resizes happened).
+    const currentX = origin.currentX + originDeltaX;
+    const currentY = origin.currentY + originDeltaY;
+
     return {
         type,
         device: 'mouse',
@@ -54,15 +64,18 @@ export function getTouchOffsets(current: Targetable, touch: Touch): { offsetX: n
 }
 
 function makeTouchDrag<K extends DragEvents>(
-    current: Targetable,
     type: K,
     origin: DragOrigin,
     sourceEvent: TouchEvent,
     touch: Touch
 ): DragWidgetEvent<K> {
-    const { currentX, currentY } = WidgetEventUtil.calcCurrentXY(current.getElement(), touch);
     const originDeltaX = touch.pageX - origin.pageX;
     const originDeltaY = touch.pageY - origin.pageY;
+
+    // FIXME: Same as makeMouseDrag
+    const currentX = origin.currentX + originDeltaX;
+    const currentY = origin.currentY + originDeltaY;
+
     return {
         type,
         device: 'touch',
@@ -160,20 +173,28 @@ export class WidgetListenerInternal {
     }
 
     private startMouseDrag<T extends Targetable>(current: T, initialDownEvent: MouseEvent) {
-        const origin: DragOrigin = { pageX: Number.NaN, pageY: Number.NaN, offsetX: Number.NaN, offsetY: Number.NaN };
+        const { currentX, currentY } = WidgetEventUtil.calcCurrentXY(current.getElement(), initialDownEvent);
+        const origin: DragOrigin = {
+            pageX: Number.NaN,
+            pageY: Number.NaN,
+            offsetX: Number.NaN,
+            offsetY: Number.NaN,
+            currentX,
+            currentY,
+        };
         partialAssign(['pageX', 'pageY', 'offsetX', 'offsetY'], origin, initialDownEvent);
 
         const dragCallbacks: MouseDragCallbacks = {
             mousedown: (downEvent: MouseEvent) => {
-                const dragStartEvent = makeMouseDrag(current, 'drag-start', origin, downEvent);
+                const dragStartEvent = makeMouseDrag('drag-start', origin, downEvent);
                 this.dispatch('drag-start', current, dragStartEvent);
             },
             mousemove: (moveEvent: MouseEvent) => {
-                const dragMoveEvent = makeMouseDrag(current, 'drag-move', origin, moveEvent);
+                const dragMoveEvent = makeMouseDrag('drag-move', origin, moveEvent);
                 this.dispatch('drag-move', current, dragMoveEvent);
             },
             mouseup: (upEvent: MouseEvent) => {
-                const dragEndEvent = makeMouseDrag(current, 'drag-end', origin, upEvent);
+                const dragEndEvent = makeMouseDrag('drag-end', origin, upEvent);
                 this.dispatch('drag-end', current, dragEndEvent);
                 this.endDrag(current, dragEndEvent);
             },
@@ -199,16 +220,23 @@ export class WidgetListenerInternal {
     }
 
     private startOneFingerTouch<T extends Targetable>(current: T, initialEvent: TouchEvent, initialTouch: Touch) {
-        const origin: DragOrigin = { pageX: Number.NaN, pageY: Number.NaN, ...getTouchOffsets(current, initialTouch) };
+        const { currentX, currentY } = WidgetEventUtil.calcCurrentXY(current.getElement(), initialTouch);
+        const origin: DragOrigin = {
+            pageX: Number.NaN,
+            pageY: Number.NaN,
+            currentX,
+            currentY,
+            ...getTouchOffsets(current, initialTouch),
+        };
         partialAssign(['pageX', 'pageY'], origin, initialTouch);
 
         const dragCallbacks: TouchDragCallbacks = {
             touchmove: (moveEvent: TouchEvent, touch: Touch) => {
-                const dragMoveEvent = makeTouchDrag(current, 'drag-move', origin, moveEvent, touch);
+                const dragMoveEvent = makeTouchDrag('drag-move', origin, moveEvent, touch);
                 this.dispatch('drag-move', current, dragMoveEvent);
             },
             touchend: (cancelEvent: TouchEvent, touch: Touch) => {
-                const dragMoveEvent = makeTouchDrag(current, 'drag-end', origin, cancelEvent, touch);
+                const dragMoveEvent = makeTouchDrag('drag-end', origin, cancelEvent, touch);
                 this.dispatch('drag-end', current, dragMoveEvent);
             },
         };
@@ -216,7 +244,7 @@ export class WidgetListenerInternal {
         const target = current.getElement();
         this.touchDragger = startOneFingerTouch(GlobalCallbacks, this, dragCallbacks, initialTouch, target);
 
-        const dragStartEvent = makeTouchDrag(current, 'drag-start', origin, initialEvent, initialTouch);
+        const dragStartEvent = makeTouchDrag('drag-start', origin, initialEvent, initialTouch);
         this.dispatch('drag-start', current, dragStartEvent);
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -527,7 +527,7 @@ export class Zoom extends AbstractModuleInstance {
         const zoom = this.getZoom();
 
         if (dragState === DragState.Pan) {
-            this.panner.update({ currentX: event.offsetX, currentY: event.offsetY });
+            this.panner.update(event);
         } else {
             let anchor = direction === ChartAxisDirection.X ? anchorPointX : anchorPointY;
             if (shouldFlipXY) anchor = direction === ChartAxisDirection.X ? anchorPointY : anchorPointX;

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -10,7 +10,7 @@ export class ZoomAxisDragger {
     private oldZoom?: DefinedZoomState;
 
     update(
-        event: { offsetX: number; offsetY: number },
+        event: { currentX: number; currentY: number },
         direction: ChartAxisDirection,
         anchor: AgZoomAnchorPoint,
         bbox: BoxBounds,
@@ -22,7 +22,7 @@ export class ZoomAxisDragger {
             direction === ChartAxisDirection.X ? { ...zoom, x: axisZoom } : { ...zoom, y: axisZoom }
         );
 
-        this.updateCoords(event.offsetX, event.offsetY);
+        this.updateCoords(event.currentX, event.currentY);
         return this.updateZoom(direction, anchor, bbox);
     }
 

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomScroller.ts
@@ -10,16 +10,11 @@ type StateRetrieval = _ModuleSupport.CoreZoomStateSafeRetrieval;
 
 export class ZoomScroller {
     updateAxes(event: _Widget.WheelWidgetEvent, props: ZoomProperties, bbox: BoxBounds, zooms: StateRetrieval): State {
-        const sourceEvent = event.sourceEvent;
         const newZooms: State = {};
         const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
 
-        // Convert the cursor position to coordinates as a ratio of 0 to 1
-        const origin = pointToRatio(
-            bbox,
-            sourceEvent.offsetX ?? sourceEvent.clientX,
-            sourceEvent.offsetY ?? sourceEvent.clientY
-        );
+        // Convert the cursor position to coordinates as a ratio of 0 to 1.
+        const origin = pointToRatio(bbox, event.currentX, event.currentY);
 
         for (const [axisId, value] of entries(zooms)) {
             if (value == null) continue;
@@ -57,8 +52,8 @@ export class ZoomScroller {
     ): DefinedZoomState | undefined {
         const { anchorPointX, anchorPointY, isScalingX, isScalingY, scrollingStep } = props;
 
-        const canvasX = event.offsetX + bbox.x;
-        const canvasY = event.offsetY + bbox.y;
+        const canvasX = event.currentX + bbox.x;
+        const canvasY = event.currentY + bbox.y;
         const origin = pointToRatio(bbox, canvasX, canvasY);
 
         // Scale the zoom bounding box


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17637

Axes Event Listeners should be using `currentXY` (relative to the `role="region"` proxy-elem that's listened to) instead of `offsetXY` (relative to target, which is the deepest element that responds to pointer-events).

With the new AxisWidgets refactor, the a11y axis title is now a descendant of the axis `role="region"` proxy (the once that listens for wheel/mouse events on an axis). This can meddle with the `offsetXY` values when entering/leaving the a11y axis title element. Whereas the `currentXY` values are always relative to the element that's being listened to.