### PR TITLE
Make setup-nx free-disk-space conditional and parallelise the delete

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -33,6 +33,13 @@ inputs:
             - 'rw'
             - 'ro'
             - 'off'
+    free_disk_space:
+        description: 'Delete large preinstalled toolchains to reclaim root-partition space (avoids runner ENOSPC). Set false on jobs that do not exhaust disk to skip the slow delete.'
+        required: false
+        default: 'true'
+        options:
+            - 'true'
+            - 'false'
 outputs:
     base:
         description: 'Base branch/SHA for diff detection'
@@ -45,10 +52,22 @@ runs:
     using: 'composite'
     steps:
         - name: Free disk space
-          if: runner.os == 'Linux'
+          if: runner.os == 'Linux' && inputs.free_disk_space == 'true'
           shell: bash
           run: |
-              sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+              # Log starting headroom (before the delete) and the amount reclaimed.
+              df -h /
+              # Best-effort reclaim of root-partition space to avoid runner ENOSPC by
+              # deleting large preinstalled toolchains this repo never uses. Disjoint
+              # trees are unlinked concurrently to overlap I/O latency; cost is dominated
+              # by the many-small-file android/tool-cache trees.
+              # ($AGENT_TOOLSDIRECTORY == /opt/hostedtoolcache, so it is not listed twice.)
+              sudo rm -rf /usr/local/lib/android &
+              sudo rm -rf /opt/hostedtoolcache &
+              sudo rm -rf /usr/share/dotnet &
+              sudo rm -rf /opt/ghc /usr/local/share/boost &
+              wait
+              df -h /
 
         - name: Dump GitHub context
           env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,7 @@ jobs:
               with:
                   cache_mode: ro
                   base_ref: ${{ github.event.pull_request.base.ref || github.event.base_ref }}
+                  free_disk_space: false
 
             - name: nx format:check
               id: format
@@ -379,6 +380,7 @@ jobs:
               with:
                   cache_mode: ro
                   base_ref: ${{ github.event.pull_request.base.ref || github.event.base_ref }}
+                  free_disk_space: false
 
             - name: nx run-many -t validate-examples
               id: validate


### PR DESCRIPTION
Adds a `free_disk_space` input (default `true`) to the `setup-nx` composite action so jobs that don't exhaust runner disk can opt out of the cleanup, following the ag-grid precedent (#14371). The delete now runs the disjoint trees concurrently (best-effort), drops the redundant `$AGENT_TOOLSDIRECTORY` entry (it resolves to `/opt/hostedtoolcache`), and is bracketed with `df -h /` to log starting headroom and the amount reclaimed.

Opts out the `lint` and `validate` jobs — read-only checks with no build artifacts or Docker image loads. Further opt-outs will be validated by flipping a candidate job to `free_disk_space: false` and confirming CI stays green (the `df` output helps spot jobs that start with ample space); the default stays protective so no other job silently loses the cleanup.

First step toward reconciling the duplicated `setup-nx` action across ag-grid/ag-charts/ag-studio into `ag-shared`; landing the fix here first so the shared version starts from the corrected code.