### PR TITLE
Deflake website-build thumbnail generation

### DIFF
--- a/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/batch-executor.ts
+++ b/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/batch-executor.ts
@@ -9,7 +9,9 @@ if (versions.node < '18.18') {
     console.warn('Upgrade Node.js to v18.18.0 for multi-threaded thumbnail generation; found: ' + versions.node);
     executor = batchExecutor(generateFiles);
 } else {
-    executor = batchWorkerExecutor(`${module.path}/batch-instance.js`);
+    // Generous per-task budget: a task renders every theme x DPI variant, and tail tasks on
+    // contended CI runners have been observed stalling well past the worker's 60s default.
+    executor = batchWorkerExecutor(`${module.path}/batch-instance.js`, undefined, 120_000);
 }
 
 export default executor;

--- a/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/patchOptions.ts
+++ b/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/patchOptions.ts
@@ -125,15 +125,12 @@ const maybeApplySubstitutions = (node: unknown) => {
     return node;
 };
 
-// Substituted strings (including base64-inlined images) are identical across the theme x DPI
-// render loop, so cache per original string to avoid re-reading and re-encoding per render.
-// The cache is only safe because substitutions are always DEFAULT_SUBSTITUTIONS (fixed per
-// process) — do not reintroduce a caller-supplied substitutions parameter without keying on it.
+// Caches base64 image inlining, which repeats across the theme x DPI render loop. Safe to key
+// on content alone only while substitutions are always DEFAULT_SUBSTITUTIONS (fixed per process).
 const substitutionCache = new Map<string, string>();
 
 const applySubstitutions = (content: string) => {
-    const substitutions = DEFAULT_SUBSTITUTIONS;
-    if (content == null || !content.includes('${')) {
+    if (!content.includes('${')) {
         return content;
     }
 
@@ -143,8 +140,8 @@ const applySubstitutions = (content: string) => {
     }
     const original = content;
 
-    Object.keys(substitutions).forEach((key) => {
-        const value = substitutions[key];
+    Object.keys(DEFAULT_SUBSTITUTIONS).forEach((key) => {
+        const value = DEFAULT_SUBSTITUTIONS[key];
         if (value == null) {
             throw new Error(`Substitution value is null for key: ${key}`);
         }

--- a/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/patchOptions.ts
+++ b/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/patchOptions.ts
@@ -109,7 +109,7 @@ const maybeApplySubstitutions = (node: unknown) => {
                 const value = nodes[key];
                 if (typeof value === 'string') {
                     // Inline static string case.
-                    const newValue = applySubstitutions(value, DEFAULT_SUBSTITUTIONS);
+                    const newValue = applySubstitutions(value);
                     safeSet(nodes, key, newValue);
                 } else if (typeof value === 'function') {
                     // Callback function case (apply substitutions to the result).
@@ -119,7 +119,7 @@ const maybeApplySubstitutions = (node: unknown) => {
             }
         });
     } else if (typeof node === 'string') {
-        return applySubstitutions(node, DEFAULT_SUBSTITUTIONS);
+        return applySubstitutions(node);
     }
 
     return node;
@@ -127,10 +127,13 @@ const maybeApplySubstitutions = (node: unknown) => {
 
 // Substituted strings (including base64-inlined images) are identical across the theme x DPI
 // render loop, so cache per original string to avoid re-reading and re-encoding per render.
+// The cache is only safe because substitutions are always DEFAULT_SUBSTITUTIONS (fixed per
+// process) — do not reintroduce a caller-supplied substitutions parameter without keying on it.
 const substitutionCache = new Map<string, string>();
 
-const applySubstitutions = (content: string, substitutions?: ExampleSubstitutions) => {
-    if (content == null || substitutions == null || !content.includes('${')) {
+const applySubstitutions = (content: string) => {
+    const substitutions = DEFAULT_SUBSTITUTIONS;
+    if (content == null || !content.includes('${')) {
         return content;
     }
 

--- a/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/patchOptions.ts
+++ b/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/patchOptions.ts
@@ -125,10 +125,20 @@ const maybeApplySubstitutions = (node: unknown) => {
     return node;
 };
 
+// Substituted strings (including base64-inlined images) are identical across the theme x DPI
+// render loop, so cache per original string to avoid re-reading and re-encoding per render.
+const substitutionCache = new Map<string, string>();
+
 const applySubstitutions = (content: string, substitutions?: ExampleSubstitutions) => {
     if (content == null || substitutions == null || !content.includes('${')) {
         return content;
     }
+
+    const cached = substitutionCache.get(content);
+    if (cached != null) {
+        return cached;
+    }
+    const original = content;
 
     Object.keys(substitutions).forEach((key) => {
         const value = substitutions[key];
@@ -146,5 +156,6 @@ const applySubstitutions = (content: string, substitutions?: ExampleSubstitution
         }
     });
 
+    substitutionCache.set(original, content);
     return content;
 };

--- a/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/thumbnailGenerator.ts
+++ b/plugins/ag-charts-generate-chart-thumbnail/src/executors/generate/generator/thumbnailGenerator.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'fs';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import sharp from 'sharp';
@@ -139,19 +140,14 @@ export async function generateThumbnail({ example, theme, outputPath, dpi, mockT
 
     const buffer = output.multiple === true ? output.canvas.toBufferSync('png') : output.buffer;
 
-    const sharpBuffer = sharp(buffer);
-
     const dpiExt = dpi === 1 ? '' : `@${dpi}x`;
     const fontExt = mockText ? '-platform-agnostic' : '';
     const baseFilename = `${theme}${fontExt}${dpiExt}`;
 
+    // The canvas buffer is already PNG-encoded; only the webp output needs a sharp re-encode.
     await Promise.all([
-        sharpBuffer
-            .clone()
-            .png()
-            .toFile(path.join(outputPath, `${baseFilename}.png`)),
-        sharpBuffer
-            .clone()
+        fs.writeFile(path.join(outputPath, `${baseFilename}.png`), buffer),
+        sharp(buffer)
             .webp({ quality: 90 })
             .toFile(path.join(outputPath, `${baseFilename}.webp`)),
     ]);


### PR DESCRIPTION
The Website Build CI job has been flaking since 2026-07-01 with `generate-thumbnail:staging` tasks timing out (observed on `latest` runs 29031583453, 29081655254, 28514828220 — first attempts only, retried to green).

Investigation showed no example is individually slow: the heaviest (`simple-org-chart-with-images`) generates all 21 theme×DPI variants in ~3s locally. The failures are contended-runner stalls at the tail of the 126-task batch — one failing attempt shows an 85s pool-wide stall before the 4 in-flight tasks all hit the worker's 60s default timeout together, and a timed-out worker fails the whole job (no retry).

Changes:
- Pass an explicit 120s per-task timeout to `batchWorkerExecutor` (previously defaulted to 60s inside the worker).
- Cache option-string substitutions (incl. base64 image inlining) across the per-example render loop instead of re-reading/re-encoding per render.
- Write skia's already-PNG-encoded buffer directly to disk; sharp now only produces the webp (removes a redundant PNG decode/re-encode per output).

Validation: outputs are pixel-identical to baseline for all 21 PNG variants of the heaviest example, and webp outputs are byte-identical. PNG sizes within ±10%.