### PR TITLE
Stop integrated-charts gate from riding the nx cache

### DIFF
--- a/.github/workflows/integrated-charts-test.yml
+++ b/.github/workflows/integrated-charts-test.yml
@@ -3,7 +3,7 @@ name: Integrated Charts Test
 on:
     workflow_dispatch: {}
     schedule:
-        - cron: '0 6 * * 1-5' # Weekday mornings UTC
+        - cron: '0 6 * * *' # Every morning UTC, incl. weekends so Fri/weekend breaks are caught next day
 
 env:
     NX_NO_CLOUD: true
@@ -26,9 +26,11 @@ jobs:
                   cache_mode: ro
                   yarn_postinstall: false
 
+            # Skip the nx cache: a cache hit can pack stale type declarations, letting the gate
+            # type-check ag-grid against charts types that differ from current `latest`.
             - name: Build ag-charts packages
               run: |
-                  yarn nx run-many -t build -p ag-charts-types,ag-charts-locale,ag-charts-core,ag-charts-community,ag-charts-enterprise
+                  yarn nx run-many -t build -p ag-charts-types,ag-charts-locale,ag-charts-core,ag-charts-community,ag-charts-enterprise --skip-nx-cache
 
             - name: Pack ag-charts tarballs
               id: pack


### PR DESCRIPTION
## Problem

The daily **Integrated Charts Test** gate (`integrated-charts-test.yml`) silently gave false-green results for ~a week while a real Integrated Charts compile break was already on `latest`.

The break: a combo-chart `TS2322` in ag-grid's `comboChartProxy.ts:103`, where the union of line/area/bar theme-overrides is assigned to an intersection-typed index. The label-placement rework made line/area `label.placement` (`AgChartLabelCollisionPlacement`, includes `'left'`/`'top'`/…) incompatible with bar's restricted `AgBarSeriesLabelPlacement` (`inside-*`/`outside-*`), so the three series' themeable options are no longer mutually assignable.

## Why the gate missed it

The job packs its ag-charts tarballs from `yarn nx run-many -t build …` under `cache_mode: ro`. That build was served from the nx cache (`ag-charts-types:build:types [local cache]`), so the packed `.d.ts` lagged `latest` — ag-grid was type-checked against **stale** charts types. I confirmed this by reproducing the error directly against the last passing run's exact ag-charts checkout: its type sources *and* emitted declarations already fail, yet CI was green. The pass→fail flip on Mon 07-13 lined up exactly with a beta version bump (`beta.20260705`→`20260712`) changing `packages/*/package.json`, which reset the `nx_cache_hash` lineage and forced a from-source rebuild that finally surfaced the break.

Contributing gaps: the schedule was weekday-only (`0 6 * * 1-5`), so a Friday/weekend break wasn't seen until Monday.

## Fix

- **Build the ag-charts packages with `--skip-nx-cache`** so the packed type declarations always reflect current `latest`. This is the change that actually closes the hole. (The second, "Real Implementation" ag-grid build already uses this flag; only the tarball-producing build didn't.)
- **Run the schedule daily including weekends** (`0 6 * * *`) so Friday/weekend breaks are caught the next morning rather than the following Monday.

## Notes / trade-offs

- The five ag-charts packages now rebuild cold on each scheduled run (no read-cache reuse), adding a few minutes — the correct trade-off for a correctness gate, well within `timeout-minutes: 60`.
- `cache_mode: ro` is kept intentionally: the node_modules restore it provides is valuable and safe; `--skip-nx-cache` is the targeted lever for the staleness.
- Not addressed here (separate call): whether the line/area vs bar placement divergence is intended, and whether ag-grid's combo pattern should adapt.

## Testing

This workflow can only be exercised on GitHub Actions (secrets, the `setup-nx` composite, ag-grid clone). YAML validated and `actionlint` run locally — the two `actionlint` findings are pre-existing and outside the changed lines. A `workflow_dispatch` run on this branch is the way to confirm end-to-end.