### PR TITLE
Release resolved themes for inline theme option objects

### DIFF
--- a/packages/ag-charts-community/src/chart/mapping/themes.test.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.test.ts
@@ -318,4 +318,35 @@ describe('themes.ts', () => {
             expect(logs[1][1]).toBe('miss');
         });
     });
+
+    // Heap/finalizer timing can be flaky - retry to keep the signal reliable.
+    describe('theme cache memory', { retry: 5 }, () => {
+        async function collectGarbage() {
+            for (let i = 0; i < 10; i++) {
+                globalThis.gc?.();
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+        }
+
+        it('releases resolved themes once their inline theme options object is unreferenced', async () => {
+            const total = 20;
+            const collected = new Set<number>();
+            const registry = new FinalizationRegistry<number>((id) => collected.add(id));
+
+            for (let i = 0; i < total; i++) {
+                // Fresh options object per iteration, mirroring per-chart inline themes; keep no
+                // strong reference to the input or the resolved theme so both are collectable.
+                let themeOptions: AgChartTheme | undefined = {
+                    baseTheme: 'ag-default',
+                    overrides: { line: { series: { strokeWidth: i } } },
+                };
+                registry.register(getChartTheme(themeOptions), i);
+                themeOptions = undefined;
+            }
+
+            await collectGarbage();
+
+            expect(collected.size).toBe(total);
+        });
+    });
 });

--- a/packages/ag-charts-community/src/chart/mapping/themes.ts
+++ b/packages/ag-charts-community/src/chart/mapping/themes.ts
@@ -90,19 +90,32 @@ export const themes: ThemeMap = {
     'ag-financial': memoizeByRegistry(() => new FinancialLight()),
 };
 
-const chartThemeCache = new Map<unknown, ChartTheme>();
+// Primitive keys (stock theme names) are bounded and held strongly. Object keys (inline theme
+// option objects) are held weakly: a fresh options object per chart would otherwise pin its
+// resolved ChartTheme — and the deep config tree it owns — for the lifetime of the process,
+// leaking memory for consumers that render many charts with distinct inline themes.
+const chartThemeCache = new Map<string | null | undefined, ChartTheme>();
+let chartThemeObjectCache = new WeakMap<object, ChartTheme>();
 let chartThemeCacheRevision = -1;
 const themeCacheDebug = Debug.create(true, 'perf', 'theme');
 
 export const getChartTheme: typeof createChartTheme = (value) => {
     chartThemeCacheRevision = ModuleRegistry.ifRegistryChanged(chartThemeCacheRevision, () => {
         chartThemeCache.clear();
+        chartThemeObjectCache = new WeakMap();
     });
-    let theme = chartThemeCache.get(value);
+    const objectKey = typeof value === 'object' && value !== null ? value : undefined;
+    let theme = objectKey
+        ? chartThemeObjectCache.get(objectKey)
+        : chartThemeCache.get(value as string | null | undefined);
     if (theme == null) {
         themeCacheDebug('[CACHE] ChartTheme', 'miss', createChartTheme.name, [value]);
         theme = createChartTheme(value);
-        chartThemeCache.set(value, theme);
+        if (objectKey) {
+            chartThemeObjectCache.set(objectKey, theme);
+        } else {
+            chartThemeCache.set(value as string | null | undefined, theme);
+        }
     } else {
         themeCacheDebug('[CACHE] ChartTheme', 'hit', createChartTheme.name, [value]);
     }
@@ -112,6 +125,7 @@ export const getChartTheme: typeof createChartTheme = (value) => {
 /** Test-only: drop all cached entries so cases start from a known cold state. */
 export function __clearChartThemeCacheForTests() {
     chartThemeCache.clear();
+    chartThemeObjectCache = new WeakMap();
     chartThemeCacheRevision = -1;
 }
 


### PR DESCRIPTION
`getChartTheme` cached resolved `ChartTheme` instances in a `Map` keyed by the input `value`. For object-valued inputs the key was held **strongly**, so a fresh inline theme object per chart pinned its resolved theme — and the deep config tree it owns — for the process lifetime. Workloads that render many charts with distinct inline theme objects (dashboards, SSR, chart thumbnail generation) leaked memory unboundedly.

This was the root cause of the website-build memory exhaustion that PR #7395 mitigated by recycling batch workers; that mitigation stays in place as a safety net.

## Change
- Key object-valued theme inputs in a `WeakMap` so resolved themes become collectable once their options object is unreferenced.
- Keep the bounded stock-name (string) keys in the strong `Map`.
- Reset both caches on module-registry change.

Theme resolution and cache-hit semantics for live references are unchanged.

## Evidence
Repeatedly rendering one example (10 themes × 2 DPI) through a single process:

| | JS heap growth / iteration |
|---|---|
| Before | ~40 MB, linear (unbounded → runner OOM) |
| After | ~0.3 MB, flat |

## Test
Added a `FinalizationRegistry` regression test asserting resolved themes are collected once their inline options object is dropped. Verified it fails (0/20 collected) with the strong-Map behaviour and passes (20/20) with the fix. Full community (3801) and enterprise (2551) suites pass.