### PR TITLE
fix(ci): use pushed branch as snapshot source_branch instead of hardcoded latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,7 @@ jobs:
               uses: ./.github/actions/snapshot-branch
               with:
                   path: packages/ag-charts-{community,enterprise,server-side}/src/
-                  source_branch: ${{ github.head_ref || 'latest' }}
+                  source_branch: ${{ github.head_ref || github.ref_name }}
                   branch: ${{ needs.init.outputs.snapshot_branch }}
                   type: test (shard ${{matrix.shard}})
 
@@ -690,7 +690,7 @@ jobs:
               uses: ./.github/actions/snapshot-branch
               with:
                   path: packages/ag-charts-website/e2e/
-                  source_branch: ${{ github.head_ref || 'latest' }}
+                  source_branch: ${{ github.head_ref || github.ref_name }}
                   branch: ${{ needs.init.outputs.snapshot_branch }}
                   type: test:e2e (shard ${{matrix.shard}})
 
@@ -804,7 +804,7 @@ jobs:
               uses: ./.github/actions/snapshot-branch
               with:
                   path: tests/*-package-tests/e2e/*-snapshots/
-                  source_branch: ${{ github.head_ref || 'latest' }}
+                  source_branch: ${{ github.head_ref || github.ref_name }}
                   branch: ${{ needs.init.outputs.snapshot_branch }}
                   type: ${{ matrix.framework }}-package-tests:test:package
 


### PR DESCRIPTION
Ports the CI fix from #7414 (which landed on `b14.0.1`) to `latest`.

## Problem

The `snapshot-branch` action was invoked with `source_branch: ${{ github.head_ref || 'latest' }}`. `github.head_ref` is only populated for `pull_request` events, so **push** builds (e.g. a release-branch version bump) fell through to the literal `'latest'` — committing regenerated snapshots against the wrong base. When the pushed branch has diverged from `latest`, the regenerated snapshot can be byte-identical to `latest`, producing an empty commit that hard-fails the job (as seen on the `b14.0.1` version-bump run: https://github.com/ag-grid/ag-charts/actions/runs/29330419312/job/87078086522).

## Fix

All three call sites changed to `${{ github.head_ref || github.ref_name }}` — the idiom already used for `BRANCH_NAME` elsewhere in this workflow:

- PR builds → `head_ref` (PR source branch) — unchanged.
- Push builds → `ref_name` (the pushed branch) instead of always `latest`.

Cherry-pick of `0355ce9185` from `b14.0.1`; applies cleanly to `latest`. YAML-only.