### PR TITLE
Add SONARCLOUD_ENABLED variable kill-switch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1190,6 +1190,10 @@ jobs:
                   exit 1
 
     sonarqube:
+        # Org-scoped GHA variable kill-switch: set SONARCLOUD_ENABLED=false to
+        # skip the scan (e.g. during a SonarCloud infra outage). Absent/any other
+        # value keeps it running. Sonar is advisory, so a skip is not a failure.
+        if: vars.SONARCLOUD_ENABLED != 'false'
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Adds an org-scoped GitHub Actions variable `SONARCLOUD_ENABLED` as a kill-switch for the `sonarqube` CI job, so SonarCloud can be turned off without a code change during SonarCloud infrastructure outages.

- `if: vars.SONARCLOUD_ENABLED != 'false'` on the `sonarqube` job.
- Absent (or any value other than `false`) → Sonar runs as before (fails safe / default-on).
- Set the org variable to `false` → the job is skipped.

A skipped job reports `skipped`, not `failure`, and Sonar is already advisory in the `report` job (a Sonar failure maps to `partial`, not `failure`), so disabling produces no false CI failures or Slack alerts.

To use: in the GitHub org settings → Secrets and variables → Actions → Variables, set `SONARCLOUD_ENABLED=false` to disable, remove it (or set anything else) to re-enable.