### PR TITLE
AG-17637 TC4 [CLAUDE] Implement axis context-menu `index` param

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -232,6 +232,14 @@ export abstract class Axis<
     dataDomain: { domain: D[]; clipped: boolean } = { domain: [], clipped: false };
     private allowNull = false;
 
+    /**
+     * Rendered-tick positions captured by the tick-layout pass, used by {@link pickValue}
+     * to resolve a click position to a tick index. Populated by subclasses that generate
+     * ticks (see `CartesianAxis`); left empty by axes that do not, in which case no tick
+     * index can be resolved.
+     */
+    private pickTickData: { readonly index: number; readonly translation: number }[] = [];
+
     readonly caption = new Caption();
 
     /**
@@ -1225,6 +1233,8 @@ export abstract class Axis<
             return undefined;
         }
 
+        const index = this.resolveTickIndex(position);
+
         // Dynamically extract properties of `AgContextMenuGetItemsParamsAxis` that are not present in the base
         // `AgContextMenuGetItemsParamsAlways` (and also add `caller` so that we can run the context-menu callbacks
         // `callWithContext`).
@@ -1234,12 +1244,38 @@ export abstract class Axis<
             caller: this,
             axisId: this.userKey,
             value,
+            index,
             direction: this.direction,
             boundSeries: this.formatterBoundSeries.get(),
             domain,
         } satisfies Rules;
 
         return result;
+    }
+
+    protected setPickTickData(ticks: readonly { readonly index: number; readonly translation: number }[]): void {
+        this.pickTickData = ticks.map(({ index, translation }) => ({ index, translation }));
+    }
+
+    /**
+     * Resolve a click position to the index of the nearest rendered tick, clamping
+     * out-of-range positions to the closest end tick. Returns -1 when no ticks are
+     * available (e.g. an axis with labels, ticks and grid lines all disabled).
+     */
+    private resolveTickIndex(position: number): number {
+        const ticks = this.pickTickData;
+        if (ticks.length === 0) return -1;
+
+        let nearestIndex = ticks[0].index;
+        let nearestDistance = Math.abs(ticks[0].translation - position);
+        for (let i = 1; i < ticks.length; i++) {
+            const distance = Math.abs(ticks[i].translation - position);
+            if (distance < nearestDistance) {
+                nearestDistance = distance;
+                nearestIndex = ticks[i].index;
+            }
+        }
+        return nearestIndex;
     }
 
     pickBand(point: Point): AxisBandDatum | undefined {

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -328,6 +328,7 @@ export abstract class CartesianAxis<
         ) {
             const { bbox, spacing } = this.measureAxisLayout(domain, [], [], scrollbar, scrollbarThickness);
             // Performance optimization: if ticks have no effect, don't generate them
+            this.setPickTickData([]);
             const layout: GeneratedTicks = {
                 ticks: [],
                 tickLines: [],
@@ -396,6 +397,8 @@ export abstract class CartesianAxis<
         }
 
         const { ticks, tickDomain, rawTicks, rawTickCount, fractionDigits, timeInterval, niceDomain } = tickData;
+
+        this.setPickTickData(ticks);
 
         const labels = ticks.map((d) => this.getTickLabelProps(d, tickGenerationResult, scrollbarThickness));
 

--- a/packages/ag-charts-community/src/module/axisContext.ts
+++ b/packages/ag-charts-community/src/module/axisContext.ts
@@ -28,6 +28,7 @@ export interface AxisValuePick {
     readonly caller: { context?: unknown };
     readonly axisId: string;
     readonly value: AgAxisValue;
+    readonly index: number;
     readonly direction: ChartAxisDirection;
     readonly boundSeries: AgAxisBoundSeries[];
     readonly domain: AgAxisDomain;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -199,7 +199,7 @@ export class ContextMenu extends AbstractModuleInstance {
 
             case 'axis': {
                 if (this.pickedAxisCtx == null) throw new Error(`this.pickedAxisCtx is null`);
-                const { axisId, boundSeries, direction, domain, value } = this.pickedAxisCtx;
+                const { axisId, boundSeries, direction, domain, value, index } = this.pickedAxisCtx;
                 const params: CallbackParamRules<AgContextMenuGetItemsParamsAxis<DatumDefault, ContextDefault>> = {
                     showOn,
                     defaultItems,
@@ -208,6 +208,7 @@ export class ContextMenu extends AbstractModuleInstance {
                     direction,
                     domain,
                     value,
+                    index,
                 };
                 const callers: Caller[] = [this.pickedAxisCtx.caller, chart];
                 return [params, callers];
@@ -441,7 +442,7 @@ export class ContextMenu extends AbstractModuleInstance {
         } else if (ContextMenuRegistry.checkCallback('axis', showOn, callback)) {
             return () => {
                 if (this.pickedAxisCtx) {
-                    const { axisId, direction, boundSeries, domain, value } = this.pickedAxisCtx;
+                    const { axisId, direction, boundSeries, domain, value, index } = this.pickedAxisCtx;
                     const callers: Caller[] = [this.pickedAxisCtx.caller, this.ctx.chartService];
                     const apiEvent: Omit<AgAxisContextMenuActionEvent<never>, 'context'> = {
                         type: 'axisContextMenuAction',
@@ -451,6 +452,7 @@ export class ContextMenu extends AbstractModuleInstance {
                         boundSeries,
                         domain,
                         value,
+                        index,
                     };
                     callWithContext(callers, callback, apiEvent);
                 } else {

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -202,6 +202,8 @@ export interface AgAxisContextMenuActionEvent<TContext = ContextDefault> extends
     value: AgAxisValue;
     /** Direction of the axis the title belongs to. */
     direction: AgAxisDirection;
+    /** The index of the resolved value */
+    index: number;
     /** Metadata about series bound to the axis the title belongs to. */
     boundSeries: AgAxisBoundSeries[];
     /** Computed domain of the axis */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17637

Add the `index` (tick index of the resolved value) parameter to `AgAxisContextMenuActionEvent`, mirroring the `index` on `AgAxisLabelFormatterParams`.

The tick index is a property of the axis's generated ticks, not the scale, so it is resolved at the axis layer rather than duplicated across axis subclasses:

- `Axis` now retains the rendered tick positions (`index` + `translation`) captured during the tick-layout pass, and `pickValue()` resolves a click position to the nearest tick via a new `resolveTickIndex()` helper. Out-of-range clicks clamp to the closest end tick; axes that generate no ticks resolve to -1.
- `CartesianAxis` populates the tick positions from the tick data it already computes during `calculateTickLayout()`, covering all cartesian axis types (number, category, time, log) in one place.
- Thread `index` through `AxisValuePick` and both axis event-assembly sites in the enterprise context menu.