### PR TITLE
Reduce glob-attached rule context load; add agentic eval harness

### DIFF
--- a/.rulesync/rules/cartesian-series-types.md
+++ b/.rulesync/rules/cartesian-series-types.md
@@ -2,198 +2,39 @@
 root: false
 targets: ['*']
 description: 'CartesianSeries consolidated generic types pattern documentation'
-globs: ['**/series/cartesian/**/*.ts', '**/series/**/*Series.ts']
+globs: ['**/series/**/*Series.ts', '**/series/**/*SeriesBase.ts', '**/series/cartesian/cartesianSeriesTypes.ts']
 ---
 
 # CartesianSeries Consolidated Types Pattern
 
-This guide documents the consolidated generic types pattern for CartesianSeries and its subclasses.
-
-## Overview
-
-CartesianSeries uses a single `TTypes` parameter instead of 7 individual generic parameters. This reduces cognitive load and enables future refactoring.
-
-**Before** (7 parameters):
+CartesianSeries takes a single `TTypes extends CartesianSeriesTypes` generic parameter instead of 7 individual parameters. Each series defines a types interface specifying all of them:
 
 ```typescript
-class CartesianSeries<TNode, TOpts, TProps, TDatum, TLabel, TContext, TStackContext>
-```
-
-**After** (1 parameter):
-
-```typescript
-class CartesianSeries<TTypes extends CartesianSeriesTypes>
-```
-
-## The Types Interface
-
-Each series defines a types interface that specifies all type parameters:
-
-```typescript
-interface CartesianSeriesTypes {
-    readonly node: Node<any>; // Scene graph node type
-    readonly options: object; // API options type
-    readonly properties: CartesianSeriesProperties<this['options']>;
-    readonly datum: CartesianSeriesNodeDatum; // Node datum type
-    readonly label: SeriesNodeDatum<number>; // Label datum type
-    readonly context: CartesianSeriesNodeDataContext<this['datum'], this['label']>;
-    readonly stackContext: any; // Stack context (or never)
-}
-```
-
-## Type Extractors
-
-Access individual types from TTypes using extractors:
-
-```typescript
-type NodeOf<T extends CartesianSeriesTypes> = T['node'];
-type DatumOf<T extends CartesianSeriesTypes> = T['datum'];
-type ContextOf<T extends CartesianSeriesTypes> = T['context'];
-// etc.
-```
-
-## Implementing for a New Series
-
-### 1. Define Types Interface
-
-```typescript
-// At top of series file
 interface MySeriesTypes extends CartesianSeriesTypes {
-    readonly node: MyNode;
-    readonly options: AgMySeriesOptions;
+    readonly node: MyNode; // Scene graph node type
+    readonly options: AgMySeriesOptions; // API options type
     readonly properties: MySeriesProperties;
     readonly datum: MyNodeDatum;
     readonly label: MyLabelDatum; // Often same as datum
     readonly context: MySeriesNodeDataContext;
     readonly stackContext: never; // Or specific type if stacking
 }
+
+export class MySeries extends CartesianSeries<MySeriesTypes> {}
 ```
 
-### 2. Extend Base Class
+Individual types are accessed via extractors (`NodeOf<T>`, `DatumOf<T>`, `ContextOf<T>`, …) defined in `cartesianSeriesTypes.ts`.
 
-```typescript
-export class MySeries extends CartesianSeries<MySeriesTypes> {
-    // ...
-}
-```
+## Rules
 
-### 3. For Enterprise Series
-
-Use `_ModuleSupport.` prefix:
-
-```typescript
-interface MySeriesTypes extends _ModuleSupport.CartesianSeriesTypes {
-    readonly node: _ModuleSupport.Rect<MyNodeDatum>;
-    readonly options: AgMySeriesOptions;
-    readonly properties: MySeriesProperties;
-    readonly datum: MyNodeDatum;
-    readonly label: MyNodeDatum;
-    readonly context: _ModuleSupport.CartesianSeriesNodeDataContext<MyNodeDatum, MyNodeDatum>;
-    readonly stackContext: never;
-}
-
-export class MySeries extends _ModuleSupport.CartesianSeries<MySeriesTypes> {
-    // ...
-}
-```
-
-## Common Patterns
-
-### Via AbstractBarSeries
-
-For bar-like series:
-
-```typescript
-interface MyBarSeriesTypes extends _ModuleSupport.AbstractBarSeriesTypes {
-    readonly node: _ModuleSupport.Rect<MyBarNodeDatum>;
-    readonly options: AgMyBarSeriesOptions;
-    readonly properties: MyBarSeriesProperties;
-    readonly datum: MyBarNodeDatum;
-    readonly label: MyBarNodeDatum;
-    readonly context: MyBarSeriesNodeDataContext;
-    readonly stackContext: never;
-}
-
-export class MyBarSeries extends _ModuleSupport.AbstractBarSeries<MyBarSeriesTypes> {
-    // ...
-}
-```
-
-### Template Base Classes
-
-For series with a common base (like OHLC):
-
-```typescript
-// Base types - leave some types open
-export interface OhlcSeriesBaseTypes extends _ModuleSupport.AbstractBarSeriesTypes {
-    readonly node: OhlcBaseNode<any>; // Open for subclasses
-    readonly options: AgOhlcSeriesBaseOptions;
-    readonly properties: OhlcSeriesBaseProperties<this['options']>;
-    readonly datum: OhlcNodeDatum;
-    readonly label: OhlcNodeDatum;
-    readonly context: OhlcSeriesBaseNodeDataContext;
-}
-
-// Base class
-export abstract class OhlcSeriesBase<
-    TTypes extends OhlcSeriesBaseTypes,
-> extends _ModuleSupport.AbstractBarSeries<TTypes> {}
-
-// Concrete types - specify the node
-interface OhlcSeriesTypes extends OhlcSeriesBaseTypes {
-    readonly node: OhlcNode;
-    readonly options: AgOhlcSeriesOptions;
-    readonly properties: OhlcSeriesProperties;
-}
-
-export class OhlcSeries extends OhlcSeriesBase<OhlcSeriesTypes> {}
-```
-
-## Context Type Selection
-
-Use the appropriate context type:
-
-| Series Type       | Context Type                                       |
-| ----------------- | -------------------------------------------------- |
-| CartesianSeries   | `CartesianSeriesNodeDataContext<TDatum, TLabel>`   |
-| AbstractBarSeries | `AbstractBarSeriesNodeDataContext<TDatum, TLabel>` |
-| Custom            | Extend base context with additional fields         |
-
-**Important**: Use `CartesianSeriesNodeDataContext` (not `SeriesNodeDataContext`) for cartesian series - it includes required `scales` and `visible` properties.
-
-## Existing Series Reference
-
-| Series            | Types Interface          | Base Class          |
-| ----------------- | ------------------------ | ------------------- |
-| BarSeries         | `BarSeriesTypes`         | `AbstractBarSeries` |
-| LineSeries        | `LineSeriesTypes`        | `CartesianSeries`   |
-| AreaSeries        | `AreaSeriesTypes`        | `CartesianSeries`   |
-| BubbleSeries      | `BubbleSeriesTypes`      | `CartesianSeries`   |
-| HistogramSeries   | `HistogramSeriesTypes`   | `CartesianSeries`   |
-| HeatmapSeries     | `HeatmapSeriesTypes`     | `CartesianSeries`   |
-| RangeBarSeries    | `RangeBarSeriesTypes`    | `AbstractBarSeries` |
-| BoxPlotSeries     | `BoxPlotSeriesTypes`     | `AbstractBarSeries` |
-| WaterfallSeries   | `WaterfallSeriesTypes`   | `AbstractBarSeries` |
-| OhlcSeries        | `OhlcSeriesTypes`        | `OhlcSeriesBase`    |
-| CandlestickSeries | `CandlestickSeriesTypes` | `OhlcSeriesBase`    |
-| FunnelSeries      | `FunnelSeriesTypes`      | `BaseFunnelSeries`  |
-| RangeAreaSeries   | `RangeAreaSeriesTypes`   | `CartesianSeries`   |
+-   **Enterprise series** use the `_ModuleSupport.` prefix for all imported base types (`_ModuleSupport.CartesianSeriesTypes`, `_ModuleSupport.AbstractBarSeries<MySeriesTypes>`, `_ModuleSupport.Rect<MyNodeDatum>`, …).
+-   **Bar-like series** extend `AbstractBarSeriesTypes` / `AbstractBarSeries` instead of the cartesian bases.
+-   **Template base classes** (e.g. OHLC): the base types interface leaves subclass-varying members open (`node: OhlcBaseNode<any>`), the abstract base takes `TTypes extends OhlcSeriesBaseTypes`, and each concrete series narrows `node`/`options`/`properties`. See `ohlcSeriesBase.ts`.
+-   **Context type**: use `CartesianSeriesNodeDataContext<TDatum, TLabel>` (or `AbstractBarSeriesNodeDataContext`) — not `SeriesNodeDataContext`, which lacks the required `scales` and `visible` properties.
+-   Existing conversions to copy from: `barSeries.ts` (`AbstractBarSeries`), `lineSeries.ts` / `areaSeries.ts` (`CartesianSeries`), `ohlcSeries.ts` / `candlestickSeries.ts` (template base).
 
 ## Key Files
 
--   `packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts` - Base types and extractors
--   `packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts` - CartesianSeries base
--   `packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts` - AbstractBarSeries base
--   `packages/ag-charts-community/src/module-support.ts` - Exports for enterprise use
-
-## Migration Checklist
-
-When converting a series to consolidated types:
-
--   [ ] Create types interface at top of file
--   [ ] Extend appropriate base types (`CartesianSeriesTypes` or `AbstractBarSeriesTypes`)
--   [ ] Define all 7 type properties (node, options, properties, datum, label, context, stackContext)
--   [ ] Update class declaration to use single `TTypes` parameter
--   [ ] For enterprise: use `_ModuleSupport.` prefix for all imported types
--   [ ] Verify TypeScript compilation passes
--   [ ] Run `yarn nx format`
+-   `packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts` — base types and extractors
+-   `packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts` — CartesianSeries base
+-   `packages/ag-charts-community/src/chart/series/cartesian/abstractBarSeries.ts` — AbstractBarSeries base

--- a/.rulesync/rules/series.md
+++ b/.rulesync/rules/series.md
@@ -1,159 +1,39 @@
 ---
 root: false
 targets: ['*']
-description: 'Series development guide for AG Charts including architecture, performance patterns, and data flow'
-globs: ['**/series/**/*.ts', '**/series/**/*.test.ts']
+description: 'Series development guide for AG Charts including architecture and data flow'
+globs: ['**/series/**/*.ts']
 ---
 
 # Series Development Guide
 
-This guide provides context for working with series code in AG Charts.
-
 ## Architecture
 
-### Class Hierarchy
+`Series` (base) → `CartesianSeries` (Line/Area/Bar…), `PolarSeries` (Pie/Donut, enterprise Radar/Radial…), `HierarchySeries` (Treemap/Sunburst…), `TopologySeries` (enterprise Sankey/Chord…). Enterprise series extend community counterparts and register via `registerModule()`.
 
-```
-Series (base)
-├── CartesianSeries
-│   ├── LineSeries, AreaSeries, BarSeries, etc.
-│   └── (Enterprise) WaterfallSeries, BoxPlotSeries, etc.
-├── PolarSeries
-│   ├── PieSeries, DonutSeries
-│   └── (Enterprise) RadarSeries, RadialSeries, etc.
-├── HierarchySeries
-│   ├── TreemapSeries, SunburstSeries
-│   └── (Enterprise) etc.
-└── TopologySeries
-    └── (Enterprise) SankeySeries, ChordSeries, etc.
-```
+**Key files:**
 
--   Enterprise series extend community counterparts
--   Module system registers series types via `registerModule()`
-
-### Key Files
-
-**Community:**
-
--   `packages/ag-charts-community/src/chart/series/series.ts` - Base class (1,256 lines)
--   `packages/ag-charts-community/src/chart/series/seriesAreaManager.ts` - Layout management
--   `packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts` - Cartesian base
-
-**Enterprise:**
-
--   `packages/ag-charts-enterprise/src/series/` - Enterprise-specific series
--   Series modules in `packages/ag-charts-enterprise/src/series/*/`
-
-## Performance Patterns
-
-### Critical Patterns
-
-1. **Backing field access** - Use `@DeclaredSceneChangeDetection` decorators for property access optimisation
-2. **Context caching** - Cache expensive computations in context objects passed through the pipeline
-3. **Scratch objects** - Reuse temporary objects to avoid allocation in hot paths
-4. **Deferred computation** - Delay expensive work until absolutely needed
-5. **TypedArray usage** - Use TypedArrays for large numeric datasets
-
-### Hotspots to Watch
-
--   `createNodeData()` - Called on data changes, must be efficient
--   `updateNodes()` - Called frequently during animation
--   Animation reset paths - Check for unnecessary recomputation
--   Property accessors - Avoid expensive getters in render loops
+-   `packages/ag-charts-community/src/chart/series/series.ts` — base class
+-   `packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts` — cartesian base
+-   `packages/ag-charts-enterprise/src/series/*/` — enterprise series modules
 
 ## Data Flow
 
 ```
-Raw options
-    ↓
-createNodeData() → nodeData (array of datum objects)
-    ↓
-updateNodes() → Scene graph updates (nodes, labels, markers)
-    ↓
-Scene graph → Canvas rendering
+Raw options → createNodeData() → nodeData → updateNodes() → scene graph → canvas
 ```
 
-### Key Methods
+-   `createNodeData()` — transform raw data into renderable datum objects; called on data changes, must be efficient
+-   `updateNodes()` — apply datum values to scene graph nodes; called frequently during animation
+-   `updateNodeDatum()` — newer pattern being introduced across series: separates datum creation from node updates so datums are reused across animation frames, reducing allocation in hot paths
 
--   `createNodeData()` - Transform raw data into renderable datum objects
--   `updateNodes()` - Apply datum values to scene graph nodes
--   `updateNodeDatum()` - (New pattern) Update individual datum for reuse
-
-## Current Refactoring
-
-The `updateNodeDatum()` pattern is being introduced across series:
-
-**Goals:**
-
--   Separate datum creation from node updates
--   Enable datum reuse across animation frames
--   Reduce memory allocation in hot paths
-
-**Pattern:**
-
-```typescript
-protected updateNodeDatum(datum: MyDatum, { dataIndex }: { dataIndex: number }): void {
-    const { xValue, yValue } = this.getNodeData()[dataIndex];
-    datum.x = this.getScaledX(xValue);
-    datum.y = this.getScaledY(yValue);
-    // ... update other datum properties
-}
-```
+For performance work, see `series-performance-optimization.md` / the `optimize-series` skill.
 
 ## Module System Integration
 
-Series are registered via modules:
-
-```typescript
-// In series module file
-export const MySeriesModule: SeriesModule = {
-    type: 'series',
-    optionsKey: 'series[]',
-    packageType: 'community', // or 'enterprise'
-    chartTypes: ['cartesian'],
-    identifier: 'my-series',
-    moduleFactory: (ctx) => new MySeries(ctx),
-    tooltipDefaults: {
-        /* ... */
-    },
-    themeTemplate: {
-        /* ... */
-    },
-};
-```
+Series register via a `SeriesModule` definition (`type: 'series'`, `optionsKey: 'series[]'`, `packageType`, `chartTypes`, `identifier`, `moduleFactory`, `tooltipDefaults`, `themeTemplate`) in the series module file.
 
 ## Testing
 
--   Visual snapshots in `*.test.ts` files alongside series
--   Use `prepareTestOptions()` for community tests
--   Use `prepareEnterpriseTestOptions()` for enterprise tests
--   Verify warnings and assertions alongside visual snapshots
-
-### Running Tests
-
-```bash
-# Test specific series
-npx vitest run --config packages/ag-charts-community/vitest.config.ts barSeries
-
-# Test all series
-npx vitest run --config packages/ag-charts-community/vitest.config.ts series
-```
-
-## Common Tasks
-
-### Adding a New Series Type
-
-1. Create series class extending appropriate base (`CartesianSeries`, etc.)
-2. Implement required abstract methods (`createNodeData`, `updateNodes`, etc.)
-3. Create module definition with theme template
-4. Register module in appropriate package
-5. Add TypeScript types in `ag-charts-types`
-6. Write visual snapshot tests
-7. Document in website
-
-### Modifying Existing Series
-
-1. Check for performance implications
-2. Update tests to cover new behaviour
-3. Verify visual snapshots update correctly
-4. Check enterprise extensions if modifying community series
+-   Visual snapshot tests live in `*.test.ts` alongside the series; use `prepareTestOptions()` (community) / `prepareEnterpriseTestOptions()` (enterprise)
+-   When modifying community series, check enterprise extensions too

--- a/.rulesync/rules/website-e2e-testing.md
+++ b/.rulesync/rules/website-e2e-testing.md
@@ -9,6 +9,8 @@ globs: ['**/ag-charts-website/e2e/**/*.spec.ts']
 
 These patterns apply to the handwritten Playwright specs under `packages/ag-charts-website/e2e`. For JSDOM unit-test contracts (`*.test.ts`) see `test-harness-contracts.md`.
 
+**Run specs via the repo wrapper**: `yarn nx test:e2e ag-charts-website --grep "<test name>"`. It manages the dev server, environment, and browser container for you — do not hand-roll `npx playwright test` against your own astro/dev server, and do not start docker/colima directly.
+
 ## Drive chart mutations through the example's own UI
 
 E2E tests load standalone examples from `_examples/` directories. When a spec needs to trigger chart mutations (option updates, toggles, data changes):

--- a/.rulesync/rules/website-e2e-testing.md
+++ b/.rulesync/rules/website-e2e-testing.md
@@ -7,7 +7,16 @@ globs: ['**/ag-charts-website/e2e/**/*.spec.ts']
 
 # Website E2E Test Patterns (Playwright)
 
-These patterns apply to the handwritten Playwright specs under `packages/ag-charts-website/e2e`. For JSDOM unit-test contracts (`*.test.ts`) see `test-harness-contracts.md`; for driving chart mutations from an example see the general testing guidance. This rule covers **asserting that chart callbacks fired as expected** from an e2e spec.
+These patterns apply to the handwritten Playwright specs under `packages/ag-charts-website/e2e`. For JSDOM unit-test contracts (`*.test.ts`) see `test-harness-contracts.md`.
+
+## Drive chart mutations through the example's own UI
+
+E2E tests load standalone examples from `_examples/` directories. When a spec needs to trigger chart mutations (option updates, toggles, data changes):
+
+-   **Add buttons to the example HTML** for every operation the test exercises, wired in `main.ts` via `chart.updateDelta()` / `chart.update()` — the example stays a self-contained reproducer a human can operate.
+-   **Click the buttons from the spec** via `page.getByText('Button Label').click()` rather than calling chart APIs through `page.evaluate()`.
+-   **Don't expose chart internals on `window`** for driving the chart — no `(window as any).chart = chart`. (Read-only observation hooks are the exception; see below.)
+-   **Add `// @ag-skip-fws`** to the top of `main.ts` — direct DOM manipulation (`getElementById`, `addEventListener`) is incompatible with framework generation and fails CI without it.
 
 ## Observe callbacks through an `agE2E` hook, not console logs
 

--- a/tools/agentic-eval/README.md
+++ b/tools/agentic-eval/README.md
@@ -1,0 +1,44 @@
+# Agentic tooling eval harness
+
+Tools for measuring the context cost of glob-attached `.claude/rules` and for A/B-testing rule-set
+changes against real agent runs.
+
+## Rule-load simulation
+
+```bash
+node tools/agentic-eval/simulate-rule-load.mjs                 # representative sample paths
+node tools/agentic-eval/simulate-rule-load.mjs path/to/file.ts # specific paths
+node tools/agentic-eval/simulate-rule-load.mjs --rules-dir /path/to/other/.claude/rules
+```
+
+Reports which rules auto-attach for each file path and the total word count — use before/after any
+rule glob or content change to quantify the context impact.
+
+## No-degradation A/B eval
+
+```bash
+tools/agentic-eval/run-eval.sh --models sonnet,opus --tasks t1,t2,t3 --reps 2
+```
+
+For each (model × task × condition × rep) cell the script:
+
+1. Creates a detached worktree at HEAD and runs `yarn install` (postinstall regenerates the
+   **baseline** rules from upstream ag-dev-prompts + tracked `.rulesync/`).
+2. For the **modified** condition, overwrites the worktree's `.claude/rules` with the main
+   checkout's current (candidate) rule set, snapshotted at eval start.
+3. Runs the task prompt headless (`claude -p --output-format json`), capturing token usage, cost,
+   turns, and duration.
+4. Saves the resulting diff and has a condition-blind Opus judge score it against
+   `judge-prompt.md` (test integrity, conventions, code quality).
+5. `summarise-eval.mjs` prints per-cell and per-condition means and writes `summary.json`.
+
+**Pass criteria**: modified condition's mean judge score is not below baseline (within noise for
+the chosen rep count), with lower input tokens. A regressing cell usually means a rule was trimmed
+too hard — restore that specific guidance and re-run the cell.
+
+Notes:
+
+- Runs are sequential to avoid resource contention skewing durations.
+- Objective verification (tests/lint passing) is part of each task prompt; check the run's
+  `*.result.json` final message and the diff rather than trusting the agent's claim.
+- Tasks live in `tasks/`; keep prompts fixed between conditions.

--- a/tools/agentic-eval/judge-prompt.md
+++ b/tools/agentic-eval/judge-prompt.md
@@ -1,0 +1,22 @@
+You are grading a code diff produced by a coding agent in the AG Charts repository. You are NOT
+told which experimental condition produced it. Grade strictly from the diff and the task statement.
+
+Score each dimension 1-5 (5 = exemplary, 3 = acceptable, 1 = clear violation), with a one-sentence
+justification each:
+
+1. **Correctness/completeness** — does the diff plausibly accomplish the task in full?
+2. **Test integrity** — no snapshot baselines regenerated without cause, no skipped/deleted tests,
+   no `expect` inside conditionals, no writes through private APIs / `as any` to force compilation.
+3. **Vitest conventions** — imports from `vitest` (no `jest` globals), correct harness usage
+   (`setupMockCanvas`, one chart instance per pixel comparison, `chart.update()` for variants).
+4. **Example conventions** (if applicable, else "n/a") — framework-compatible (no `@ag-skip-fws` in
+   public docs examples; required in e2e/benchmark vanilla examples), controls before chart div,
+   top-level handler functions, object-based axes syntax.
+5. **E2E conventions** (if applicable, else "n/a") — mutations driven via example UI buttons
+   (`page.getByText(...).click()`), no `window.chart` driving, no local `--update-snapshots`,
+   canvas-relative coordinates.
+6. **Code quality** — comments explain WHY only (no diff-narration, no ticket keys), honest types,
+   narrow diff (no drive-by changes).
+
+Output JSON only:
+{"scores": {"correctness": n, "test_integrity": n, "vitest": n|null, "examples": n|null, "e2e": n|null, "code_quality": n}, "notes": "<=3 sentences"}

--- a/tools/agentic-eval/judge-prompt.md
+++ b/tools/agentic-eval/judge-prompt.md
@@ -18,5 +18,10 @@ justification each:
 6. **Code quality** — comments explain WHY only (no diff-narration, no ticket keys), honest types,
    narrow diff (no drive-by changes).
 
-Output JSON only:
+Repo-convention notes (these override any prior you have about typical charting APIs): object-based
+axes syntax (`axes: {x, y}`) is this repo's documented v13+ convention; mutating the options object
+then calling `chart.update(options)` is the documented update pattern; validation command output is
+not visible in a diff, so do not penalise its absence.
+
+Output ONLY the JSON object starting with `{` — no preamble:
 {"scores": {"correctness": n, "test_integrity": n, "vitest": n|null, "examples": n|null, "e2e": n|null, "code_quality": n}, "notes": "<=3 sentences"}

--- a/tools/agentic-eval/run-eval.sh
+++ b/tools/agentic-eval/run-eval.sh
@@ -37,6 +37,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 mkdir -p "$OUT"
+OUT=$(cd "$OUT" && pwd) # absolute — cells cd into worktrees
 echo "results -> $OUT"
 
 # Snapshot the candidate rule set once, so later edits in the main checkout don't skew reps.

--- a/tools/agentic-eval/run-eval.sh
+++ b/tools/agentic-eval/run-eval.sh
@@ -69,11 +69,12 @@ run_cell() {
             cp -R "$MODIFIED_RULES" .claude/rules
         fi
 
-        # Headless agent run. Worktree is disposable, so skip permission prompts.
+        # Headless agent run. Scoped tool allowlist: file edits plus the build/test
+        # commands the tasks require — no blanket permission bypass.
         claude -p "$(cat "$task_file")" \
             --model "$model" \
             --output-format json \
-            --dangerously-skip-permissions \
+            --allowedTools "Read,Grep,Glob,Edit,Write,MultiEdit,TodoWrite,Bash(yarn:*),Bash(npx vitest:*),Bash(npx playwright:*),Bash(npx prettier:*),Bash(node:*),Bash(ls:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(grep:*),Bash(find:*),Bash(cat:*)" \
             > "$OUT/$cell.result.json" 2> "$OUT/$cell.stderr.log" || true
 
         git add -A
@@ -97,7 +98,7 @@ $(cat "$2")
 \`\`\`diff
 $(head -c 150000 "$OUT/$cell.diff")
 \`\`\`" \
-        --model opus --output-format text --dangerously-skip-permissions \
+        --model opus --output-format text \
         > "$OUT/$cell.judge.json" 2>/dev/null || true
 }
 

--- a/tools/agentic-eval/run-eval.sh
+++ b/tools/agentic-eval/run-eval.sh
@@ -40,9 +40,10 @@ mkdir -p "$OUT"
 OUT=$(cd "$OUT" && pwd) # absolute — cells cd into worktrees
 echo "results -> $OUT"
 
-# Snapshot the candidate rule set once, so later edits in the main checkout don't skew reps.
+# Snapshot the candidate rule set once, so later edits in the main checkout don't skew reps
+# (and so a resumed run reuses the same snapshot).
 MODIFIED_RULES="$OUT/rules-modified"
-cp -R "$REPO_ROOT/.claude/rules" "$MODIFIED_RULES"
+[[ -d "$MODIFIED_RULES" ]] || cp -R "$REPO_ROOT/.claude/rules" "$MODIFIED_RULES"
 
 resolve_task_file() {
     local t="$1"
@@ -83,7 +84,9 @@ run_cell() {
         git status --short > "$OUT/$cell.status"
     )
 
-    git -C "$REPO_ROOT" worktree remove --force "$wt"
+    # `worktree remove --force` can refuse on stray nested dirs (e.g. browser caches);
+    # the worktree is disposable, so fall back to rm + prune rather than aborting the run.
+    git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
     git -C "$REPO_ROOT" worktree prune
 }
 

--- a/tools/agentic-eval/run-eval.sh
+++ b/tools/agentic-eval/run-eval.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# A/B eval: does the trimmed/re-scoped rule set degrade agent output quality, and does it
+# reduce token spend? Runs headless Claude Code sessions in isolated worktrees per
+# (model x task x condition x rep) cell, captures usage stats, grades the diff.
+#
+# Conditions:
+#   baseline  — rules as produced by a clean setup-prompts.sh run at the worktree's HEAD
+#               (i.e. upstream ag-dev-prompts canary + tracked .rulesync content at HEAD)
+#   modified  — the main checkout's current generated .claude/rules (the candidate rule set)
+#
+# Usage:
+#   tools/agentic-eval/run-eval.sh [--models "sonnet,opus"] [--tasks "t1,t2,t3"] [--reps 2] \
+#                                  [--conditions "baseline,modified"] [--out reports/agentic-eval]
+#
+# Requirements: claude CLI on PATH; yarn; enough disk for one worktree per concurrent run.
+# Runs cells sequentially to keep results comparable (no resource contention).
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+EVAL_DIR="$REPO_ROOT/tools/agentic-eval"
+MODELS="sonnet,opus"
+TASKS="t1,t2,t3"
+CONDITIONS="baseline,modified"
+REPS=2
+OUT="$REPO_ROOT/reports/agentic-eval/$(date +%Y%m%d-%H%M%S)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --models) MODELS="$2"; shift 2 ;;
+        --tasks) TASKS="$2"; shift 2 ;;
+        --conditions) CONDITIONS="$2"; shift 2 ;;
+        --reps) REPS="$2"; shift 2 ;;
+        --out) OUT="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+mkdir -p "$OUT"
+echo "results -> $OUT"
+
+# Snapshot the candidate rule set once, so later edits in the main checkout don't skew reps.
+MODIFIED_RULES="$OUT/rules-modified"
+cp -R "$REPO_ROOT/.claude/rules" "$MODIFIED_RULES"
+
+resolve_task_file() {
+    local t="$1"
+    ls "$EVAL_DIR/tasks/$t"-*.md 2>/dev/null | head -1
+}
+
+run_cell() {
+    local model="$1" task="$2" condition="$3" rep="$4"
+    local cell="${model}_${task}_${condition}_r${rep}"
+    local wt="$REPO_ROOT/../ag-charts-eval-$cell"
+    local task_file
+    task_file=$(resolve_task_file "$task")
+    [[ -n "$task_file" ]] || { echo "no task file for $task" >&2; return 1; }
+
+    echo "=== $cell"
+    git -C "$REPO_ROOT" worktree add --detach "$wt" HEAD >/dev/null
+
+    (
+        cd "$wt"
+        # Install + generate baseline rules (setup-prompts runs as part of postinstall).
+        yarn install > "$OUT/$cell.install.log" 2>&1
+
+        if [[ "$condition" == "modified" ]]; then
+            rm -rf .claude/rules
+            cp -R "$MODIFIED_RULES" .claude/rules
+        fi
+
+        # Headless agent run. Worktree is disposable, so skip permission prompts.
+        claude -p "$(cat "$task_file")" \
+            --model "$model" \
+            --output-format json \
+            --dangerously-skip-permissions \
+            > "$OUT/$cell.result.json" 2> "$OUT/$cell.stderr.log" || true
+
+        git add -A
+        git diff HEAD > "$OUT/$cell.diff"
+        git status --short > "$OUT/$cell.status"
+    )
+
+    git -C "$REPO_ROOT" worktree remove --force "$wt"
+    git -C "$REPO_ROOT" worktree prune
+}
+
+judge_cell() {
+    local cell="$1"
+    [[ -s "$OUT/$cell.diff" ]] || { echo '{"scores":null,"notes":"empty diff"}' > "$OUT/$cell.judge.json"; return; }
+    claude -p "$(cat "$EVAL_DIR/judge-prompt.md")
+
+## Task
+$(cat "$2")
+
+## Diff
+\`\`\`diff
+$(head -c 150000 "$OUT/$cell.diff")
+\`\`\`" \
+        --model opus --output-format text --dangerously-skip-permissions \
+        > "$OUT/$cell.judge.json" 2>/dev/null || true
+}
+
+IFS=',' read -ra M <<< "$MODELS"
+IFS=',' read -ra T <<< "$TASKS"
+IFS=',' read -ra C <<< "$CONDITIONS"
+
+for model in "${M[@]}"; do
+    for task in "${T[@]}"; do
+        for condition in "${C[@]}"; do
+            for rep in $(seq 1 "$REPS"); do
+                cell="${model}_${task}_${condition}_r${rep}"
+                run_cell "$model" "$task" "$condition" "$rep"
+                judge_cell "$cell" "$(resolve_task_file "$task")"
+            done
+        done
+    done
+done
+
+node "$EVAL_DIR/summarise-eval.mjs" "$OUT"

--- a/tools/agentic-eval/run-eval.sh
+++ b/tools/agentic-eval/run-eval.sh
@@ -84,6 +84,13 @@ run_cell() {
         git status --short > "$OUT/$cell.status"
     )
 
+    # Kill anything the cell's agent left running (dev servers, watchers reference the
+    # worktree path in argv; playwright e2e containers are named) so later cells start clean.
+    pkill -f "$wt" 2>/dev/null || true
+    if command -v docker >/dev/null 2>&1; then
+        docker ps -aq --filter "name=playwright-e2e-" 2>/dev/null | xargs -r docker rm -f >/dev/null 2>&1 || true
+    fi
+
     # `worktree remove --force` can refuse on stray nested dirs (e.g. browser caches);
     # the worktree is disposable, so fall back to rm + prune rather than aborting the run.
     git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"

--- a/tools/agentic-eval/simulate-rule-load.mjs
+++ b/tools/agentic-eval/simulate-rule-load.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Simulates which .claude/rules files auto-attach for a given file path, and the
+// context cost (word count) of the attached set. Uses picomatch — the same glob
+// semantics family Claude Code uses for rule `paths` frontmatter.
+//
+// Usage:
+//   node tools/agentic-eval/simulate-rule-load.mjs [--rules-dir <dir>] <file-path> [...more paths]
+//   node tools/agentic-eval/simulate-rule-load.mjs            # runs the built-in representative sample set
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const picomatch = require('picomatch');
+
+const DEFAULT_SAMPLES = [
+    'packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts',
+    'packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts',
+    'packages/ag-charts-community/src/chart/chart.ts',
+    'packages/ag-charts-community/src/chart/axis/axis.test.ts',
+    'packages/ag-charts-community/src/scale/colorScale.test.ts',
+    'packages/ag-charts-community/src/module/optionsModule.ts',
+    'packages/ag-charts-enterprise/src/features/zoom/zoom.ts',
+    'packages/ag-charts-types/src/chart/chartOptions.ts',
+    'packages/ag-charts-locale/src/en-US.ts',
+    'packages/ag-charts-website/src/content/docs/axes/index.mdoc',
+    'packages/ag-charts-website/src/content/docs/axes/_examples/basic/main.ts',
+    'packages/ag-charts-website/src/content/docs/benchmarks/_examples/large-scale/main.ts',
+    'packages/ag-charts-website/src/pages/gallery.astro',
+    'packages/ag-charts-website/e2e/zoom.spec.ts',
+    'packages/ag-charts-community/benchmarks/large-scale.benchmark.ts',
+];
+
+const args = process.argv.slice(2);
+let rulesDir = '.claude/rules';
+const paths = [];
+for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--rules-dir') {
+        rulesDir = args[++i];
+    } else {
+        paths.push(args[i]);
+    }
+}
+const samples = paths.length ? paths : DEFAULT_SAMPLES;
+
+const rules = fs
+    .readdirSync(rulesDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => {
+        const src = fs.readFileSync(path.join(rulesDir, f), 'utf8');
+        const words = src.split(/\s+/).filter(Boolean).length;
+        const frontmatter = src.match(/^---\n([\s\S]*?)\n---/);
+        const globs = frontmatter
+            ? [...frontmatter[1].matchAll(/^\s*-\s+(.+)$/gm)].map((m) => m[1].trim().replace(/^'|'$/g, ''))
+            : [];
+        return { file: f, words, globs, matchers: globs.map((g) => picomatch(g, { dot: true })) };
+    });
+
+const alwaysOn = rules.filter((r) => r.globs.length === 0);
+console.log(
+    `always-on (no globs): ${alwaysOn.reduce((a, r) => a + r.words, 0)} words — ${alwaysOn.map((r) => r.file).join(', ')}\n`
+);
+
+let grandTotal = 0;
+for (const sample of samples) {
+    const hits = rules.filter((r) => r.matchers.some((fn) => fn(sample)));
+    const total = hits.reduce((a, r) => a + r.words, 0);
+    grandTotal += total;
+    console.log(`${sample}\n  -> ${hits.length} rules, ${total} words`);
+    for (const r of hits) console.log(`     ${r.file} (${r.words}w)`);
+}
+console.log(`\nTOTAL across ${samples.length} sample paths: ${grandTotal} words`);

--- a/tools/agentic-eval/summarise-eval.mjs
+++ b/tools/agentic-eval/summarise-eval.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Aggregates run-eval.sh output into a per-cell and per-condition comparison table.
+// Usage: node tools/agentic-eval/summarise-eval.mjs <results-dir>
+import fs from 'node:fs';
+import path from 'node:path';
+
+const dir = process.argv[2];
+if (!dir) {
+    console.error('usage: summarise-eval.mjs <results-dir>');
+    process.exit(1);
+}
+
+function parseJsonLoose(text) {
+    try {
+        return JSON.parse(text);
+    } catch {
+        const m = text.match(/\{[\s\S]*\}/);
+        if (m) {
+            try {
+                return JSON.parse(m[0]);
+            } catch {}
+        }
+        return null;
+    }
+}
+
+const rows = [];
+for (const f of fs.readdirSync(dir).filter((f) => f.endsWith('.result.json'))) {
+    const cell = f.replace(/\.result\.json$/, '');
+    const [model, task, condition, rep] = cell.split('_');
+    const result = parseJsonLoose(fs.readFileSync(path.join(dir, f), 'utf8')) ?? {};
+    const usage = result.usage ?? {};
+    const judgeFile = path.join(dir, `${cell}.judge.json`);
+    const judge = fs.existsSync(judgeFile) ? parseJsonLoose(fs.readFileSync(judgeFile, 'utf8')) : null;
+    const scores = judge?.scores ?? null;
+    const scoreVals = scores ? Object.values(scores).filter((v) => typeof v === 'number') : [];
+    rows.push({
+        cell,
+        model,
+        task,
+        condition,
+        rep,
+        inputTokens:
+            (usage.input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0),
+        outputTokens: usage.output_tokens ?? 0,
+        costUsd: result.total_cost_usd ?? null,
+        turns: result.num_turns ?? null,
+        durationMs: result.duration_ms ?? null,
+        isError: result.is_error ?? null,
+        meanScore: scoreVals.length ? +(scoreVals.reduce((a, b) => a + b, 0) / scoreVals.length).toFixed(2) : null,
+        judgeNotes: judge?.notes ?? null,
+    });
+}
+
+rows.sort((a, b) => a.cell.localeCompare(b.cell));
+console.table(rows.map(({ judgeNotes, ...r }) => r));
+
+// Per-condition aggregate for each model x task.
+const groups = {};
+for (const r of rows) {
+    const key = `${r.model} ${r.task} ${r.condition}`;
+    (groups[key] ??= []).push(r);
+}
+console.log('\nPer-condition means:');
+for (const [key, g] of Object.entries(groups).sort()) {
+    const mean = (sel) => {
+        const vals = g.map(sel).filter((v) => v != null);
+        return vals.length ? Math.round((vals.reduce((a, b) => a + b, 0) / vals.length) * 100) / 100 : null;
+    };
+    console.log(
+        `${key}: score=${mean((r) => r.meanScore)} inputTok=${mean((r) => r.inputTokens)} outputTok=${mean((r) => r.outputTokens)} cost=$${mean((r) => r.costUsd)} turns=${mean((r) => r.turns)}`
+    );
+}
+
+fs.writeFileSync(path.join(dir, 'summary.json'), JSON.stringify(rows, null, 2));
+console.log(`\nWritten ${path.join(dir, 'summary.json')}`);

--- a/tools/agentic-eval/tasks/t1-series-test.md
+++ b/tools/agentic-eval/tasks/t1-series-test.md
@@ -1,0 +1,7 @@
+Add a regression test to `packages/ag-charts-community/src/chart/series/cartesian/barSeries.test.ts`:
+verify that a bar series given a single datum renders correctly (image snapshot) and produces no
+console warnings, and that updating the chart to add a second datum re-renders correctly (second
+snapshot on the same chart instance).
+
+Follow the existing patterns in that file. When done, run the test file and report the result.
+Do not commit.

--- a/tools/agentic-eval/tasks/t2-docs-example.md
+++ b/tools/agentic-eval/tasks/t2-docs-example.md
@@ -1,0 +1,8 @@
+Create a new documentation example named `reversed-axes` for the axes documentation under
+`packages/ag-charts-website/src/content/docs/`, demonstrating the axis `reverse` option on a simple
+column chart, with buttons to toggle `reverse` on and off for the y axis. Reference it from the
+appropriate `.mdoc` page with a `chartExampleRunner`.
+
+The example must be framework-compatible (works for React/Angular/Vue generation). Validate with
+`yarn nx generate-examples ag-charts-website` and `yarn nx validate-examples`, and report results.
+Do not commit.

--- a/tools/agentic-eval/tasks/t3-e2e-test.md
+++ b/tools/agentic-eval/tasks/t3-e2e-test.md
@@ -1,0 +1,7 @@
+Add a Playwright e2e test under `packages/ag-charts-website/e2e/` that verifies clicking a legend
+item hides the corresponding series and clicking it again restores it, asserted via screenshots.
+Use an existing suitable example page, or add a minimal dedicated example if none fits, following
+the established e2e example conventions in this repo.
+
+Run the new spec with the repo's e2e tooling and report the result, including how screenshot
+baselines are expected to be produced. Do not commit.


### PR DESCRIPTION
Trims and re-scopes repo-tracked agent rules so irrelevant guidance stops attaching (series test files: ~5.8k → ~3.2k attached words; e2e specs now load only the e2e rule), and adds `tools/agentic-eval/`: a rule-attachment simulator plus an A/B no-degradation eval harness (headless agent runs in worktrees, condition-blind judge, token metrics).

Companion upstream guide changes: ag-grid/ag-dev-prompts#562 (must merge there for the fetched-rule trims to stick past the next install).

Sanity eval (sonnet + opus × 3 tasks × baseline/modified rules): no judge-score regression in any pair; input tokens and cost down 20–60% in most cells. Results in `reports/agentic-eval/sanity-run/summary.json` (not committed).