### PR TITLE
AG-17916 [CLAUDE] Show overlapping context-menu regions

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
@@ -4,7 +4,7 @@ import type { AgContextMenuItemLiteral, AgContextMenuItemShowOn } from 'ag-chart
 import type { ContextMenuEvent } from '../../core/eventsHub';
 import type { ChartRegistry } from '../../module/moduleContext';
 import type { MouseWidgetEvent } from '../../widget/widgetEvents';
-import type { ContextMenuCallback, ContextShowOnMap } from './contextMenuTypes';
+import type { ContextMenuCallback, ContextMenuRegionContexts, ContextShowOnMap } from './contextMenuTypes';
 import { ContextMenuBuiltins } from './contextMenuTypes';
 
 export class ContextMenuRegistry {
@@ -38,6 +38,16 @@ export class ContextMenuRegistry {
         context: ContextShowOnMap[T]['context'],
         position?: { x: number; y: number }
     ) {
+        this.dispatchContextRegions(showOn, [showOn], { [showOn]: context }, pointerEvent, position);
+    }
+
+    public dispatchContextRegions(
+        primaryShowOn: AgContextMenuItemShowOn,
+        regions: readonly AgContextMenuItemShowOn[],
+        contexts: ContextMenuRegionContexts,
+        pointerEvent: { widgetEvent: MouseWidgetEvent<'contextmenu'>; canvasX: number; canvasY: number },
+        position?: { x: number; y: number }
+    ) {
         const { widgetEvent } = pointerEvent;
         if (widgetEvent.sourceEvent.defaultPrevented) {
             // AG-12894 'contextmenu' event bubbles, do not re-dispatch ContextMenuEvent if we're already draw own menu
@@ -46,7 +56,15 @@ export class ContextMenuRegistry {
         const x = position?.x ?? pointerEvent.canvasX;
         const y = position?.y ?? pointerEvent.canvasY;
 
-        const event: Writeable<ContextMenuEvent> = { showOn, x, y, context, widgetEvent };
+        const event: Writeable<ContextMenuEvent> = {
+            showOn: primaryShowOn,
+            x,
+            y,
+            context: contexts[primaryShowOn],
+            widgetEvent,
+            regions,
+            contexts,
+        };
         this.ctx.eventsHub.emit('context-menu:setup', event);
         this.ctx.eventsHub.emit('context-menu:complete', event);
     }

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
@@ -63,6 +63,11 @@ export interface ContextShowOnMap extends ContextShowOnMapRule {
 
 export type ContextMenuCallback<K extends AgContextMenuItemShowOn> = ContextShowOnMap[K]['callback'];
 
+/** Per-region internal pick contexts for a single context-menu event, keyed by region. */
+export type ContextMenuRegionContexts = {
+    [K in AgContextMenuItemShowOn]?: ContextShowOnMap[K]['context'];
+};
+
 /**
  * Merge a union of objects into one object with all the properties. This is just to check at compile-time that
  * ContextMenuItem implements all properties of AgContextMenuItem API contract.

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1,6 +1,12 @@
-import type { CallbackParamRules, DynamicContext, Point } from 'ag-charts-core';
+import type { CallbackParamRules, DynamicContext, Point, Writeable } from 'ag-charts-core';
 import { ChartUpdateType, Vec4, clamp, createId } from 'ag-charts-core';
-import type { AgActiveItemState, AgChartClickEvent, AgChartDoubleClickEvent, AgInitialFocus } from 'ag-charts-types';
+import type {
+    AgActiveItemState,
+    AgChartClickEvent,
+    AgChartDoubleClickEvent,
+    AgContextMenuItemShowOn,
+    AgInitialFocus,
+} from 'ag-charts-types';
 
 import type {
     ActiveLoadMementoEvent,
@@ -9,6 +15,7 @@ import type {
     HighlightSelectionUpdatedEvent,
     LayoutCompleteEvent,
     SeriesAreaClickEvent,
+    SeriesAreaContextMenuEvent,
     SeriesAreaHoverEvent,
     SeriesKeyNavPanXEvent,
     UpdateOpts,
@@ -36,6 +43,7 @@ import type {
 } from '../../widget/widgetEvents';
 import type { ChartHighlight } from '../chartHighlight';
 import type { ChartType } from '../chartType';
+import type { ContextMenuRegionContexts } from '../interaction/contextMenuTypes';
 import { InteractionState } from '../interaction/interactionManager';
 import { mapKeyboardEventToAction } from '../interaction/keyBindings';
 import { TooltipManager } from '../interaction/tooltipManager';
@@ -485,29 +493,39 @@ export class SeriesAreaManager extends BaseManager {
         const canvasX = event.currentX + current.cssLeft();
         const canvasY = event.currentY + current.cssTop();
         const { datumIndex } = pickedNode ?? {};
+
+        const regions: AgContextMenuItemShowOn[] = ['series-area'];
+        const contexts: ContextMenuRegionContexts = {};
         if (pickedSeries && pickedNode && datumIndex != null) {
-            this.chart.ctx.contextMenuRegistry?.dispatchContext(
-                'series-node',
-                { widgetEvent: event, canvasX, canvasY },
-                { pickedSeries, pickedNode: { ...pickedNode, datumIndex } },
-                position
-            );
-        } else {
-            // Offer the menu to an overlapping axis first; a claim calls preventDefault, so the series-area
-            // dispatch below then no-ops. Must be emitted before that dispatch (mirrors the hover/drag handoff).
-            this.chart.ctx.eventsHub.emit('series-area:contextmenu', {
-                consumed: false,
-                canvasX,
-                canvasY,
-                widgetEvent: event,
-            });
-            this.chart.ctx.contextMenuRegistry?.dispatchContext(
-                'series-area',
-                { widgetEvent: event, canvasX, canvasY },
-                undefined,
-                position
-            );
+            regions.push('series-node');
+            contexts['series-node'] = { pickedSeries, pickedNode: { ...pickedNode, datumIndex } };
         }
+
+        // Ask axis-owning modules whether an axis overlaps this point (mirrors the hover/drag handoff). They
+        // annotate `axis` rather than dispatching, so a single menu can offer both the series and axis regions.
+        const collectEvent: Writeable<SeriesAreaContextMenuEvent> = { canvasX, canvasY, widgetEvent: event };
+        this.chart.ctx.eventsHub.emit('series-area:contextmenu', collectEvent);
+        if (collectEvent.axis) {
+            regions.push('axis');
+            contexts.axis = collectEvent.axis;
+        }
+
+        // Primary region for backwards-compatible `showOn`: a node wins over an overlapping axis, which wins
+        // over the bare series area (matches the pre-multi-region dispatch precedence).
+        let primary: AgContextMenuItemShowOn = 'series-area';
+        if (contexts['series-node']) {
+            primary = 'series-node';
+        } else if (collectEvent.axis) {
+            primary = 'axis';
+        }
+
+        this.chart.ctx.contextMenuRegistry?.dispatchContextRegions(
+            primary,
+            regions,
+            contexts,
+            { widgetEvent: event, canvasX, canvasY },
+            position
+        );
     }
 
     private onLeave(event: MouseWidgetEvent<'mouseleave'>): void {

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -27,9 +27,10 @@ import type {
 } from 'ag-charts-types';
 
 import { DataSet } from '../chart/data/dataSet';
-import type { ContextShowOnMap } from '../chart/interaction/contextMenuTypes';
+import type { ContextMenuRegionContexts, ContextShowOnMap } from '../chart/interaction/contextMenuTypes';
 import type { ChartLegendType } from '../chart/legend/legendDatum';
 import type { ISeries, SeriesNodeDatum } from '../chart/series/seriesTypes';
+import type { AxisValuePick } from '../module/axisContext';
 import type { BBox } from '../scene/bbox';
 import type { Node } from '../scene/node';
 import type { SelectionInterface } from '../scene/selection';
@@ -86,10 +87,14 @@ export interface SeriesAreaClickEvent {
 }
 
 export interface SeriesAreaContextMenuEvent {
-    readonly consumed: boolean;
     readonly canvasX: number;
     readonly canvasY: number;
     readonly widgetEvent: MouseWidgetEvent<'contextmenu'>;
+    /**
+     * The overlapping axis, if any, at the pointer. Modules that own axes annotate this so the series-area
+     * dispatch can offer the axis region alongside the series region rather than dispatching a competing menu.
+     */
+    axis?: AxisValuePick;
 }
 
 export interface DataModelSeriesDiff {
@@ -246,11 +251,16 @@ export interface AxisDOMProxyUpdateEvent {
 }
 
 export type ContextMenuEvent<K extends AgContextMenuItemShowOn = AgContextMenuItemShowOn> = {
+    /** The primary region of this event, for backwards compatibility; `regions` holds the full set. */
     readonly showOn: K;
     readonly x: number;
     readonly y: number;
     readonly context: Readonly<ContextShowOnMap[K]['context']>;
     readonly widgetEvent: MouseWidgetEvent<'contextmenu'> & { sourceEvent: Partial<Pick<PointerEvent, 'pointerType'>> };
+    /** Every region under the pointer (excluding the implicit `always`). Contains more than one entry where regions overlap. */
+    readonly regions: readonly AgContextMenuItemShowOn[];
+    /** Per-region pick contexts, keyed by region; `context` mirrors the primary region's entry. */
+    readonly contexts: Readonly<ContextMenuRegionContexts>;
 };
 
 export interface HighlightChangeEvent {

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -190,16 +190,15 @@ export class AxisDOMProxy extends AbstractModuleInstance {
     private onSeriesAreaContextMenu(event: _ModuleSupport.SeriesAreaContextMenuEvent) {
         if (!this.isEnabled() || !this.isEnabledContextMenu()) return;
 
-        // A series node was hit; leave the context menu to the series area.
-        if (event.consumed) return;
-
         // Only continue if we know we have axes that overlap the series area.
         if (!this.hasOverlappingAxes()) return;
 
         const axis = this.pickAxisAtPoint(event);
         if (!axis) return;
 
-        this.dispatchAxisContextMenu(axis.axisId, event.widgetEvent, event.canvasX, event.canvasY);
+        // Annotate the overlapping axis so the series-area dispatch offers it as an additional region,
+        // rather than dispatching a competing axis-only menu. This lets a node and an axis co-exist.
+        event.axis = this.pickAxisValue(axis.axisId, event.widgetEvent);
     }
 
     private onSeriesAreaDoubleClick(event: _ModuleSupport.DragInterpreterDblClickEvent) {
@@ -279,16 +278,17 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         });
     }
 
+    private pickAxisValue(axisId: AxisID, widgetEvent: _Widget.MouseWidgetEvent<'contextmenu'>) {
+        return this.ctx.axisManager.getAxisIdContext(axisId)?.pickValue(widgetEvent);
+    }
+
     private dispatchAxisContextMenu(
         axisId: AxisID,
         widgetEvent: _Widget.MouseWidgetEvent<'contextmenu'>,
         canvasX: number,
         canvasY: number
     ) {
-        const axisCtx = this.ctx.axisManager.getAxisIdContext(axisId);
-        if (!axisCtx) return;
-
-        const pick = axisCtx.pickValue(widgetEvent);
+        const pick = this.pickAxisValue(axisId, widgetEvent);
         if (!pick) return;
 
         this.ctx.contextMenuRegistry?.dispatchContext('axis', { widgetEvent, canvasX, canvasY }, pick);

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -8,11 +8,12 @@ import type {
     AgContextMenuGetItemsParamsSeriesNode,
     AgContextMenuItem,
     AgContextMenuItemShowOn,
+    AgContextMenuRegions,
     ContextDefault,
     DatumDefault,
 } from 'ag-charts-community';
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { CallbackParamRules, DynamicContext } from 'ag-charts-core';
+import type { DynamicContext } from 'ag-charts-core';
 import {
     AbstractModuleInstance,
     Logger,
@@ -68,6 +69,12 @@ type PickedNode = _ModuleSupport.SeriesNodeDatum & {
     aggregatedValue?: number;
     frequency?: number;
 };
+
+type Regions = AgContextMenuRegions<DatumDefault, ContextDefault>;
+type SeriesNodeRegion = NonNullable<Regions['series-node']>;
+type AxisRegion = NonNullable<Regions['axis']>;
+type CaptionRegion = NonNullable<Regions['caption']>;
+type LegendItemRegion = NonNullable<Regions['legend-item']>;
 
 export class ContextMenu extends AbstractModuleInstance {
     private get opts() {
@@ -157,84 +164,111 @@ export class ContextMenu extends AbstractModuleInstance {
         });
     }
 
-    private makeGetItemsParams(event: ContextMenuEvent): [AgContextMenuGetItemsParams, Caller[]] {
+    private axisRegion(pick: _ModuleSupport.AxisValuePick): AxisRegion {
+        const { axisId, boundSeries, direction, domain, value, index } = pick;
+        return { axisId, boundSeries, direction, domain, value, index };
+    }
+
+    // Regions that can overlap the series area: the area itself, and an axis positioned inside it (e.g. `crossAt`).
+    // `axis` is the only region that appears both as a primary and as a non-primary overlap, so it lives here.
+    private plotOverlapRegions(active: ReadonlySet<AgContextMenuItemShowOn>): Regions {
+        const regions: Regions = {};
+        if (active.has('series-area')) regions['series-area'] = {};
+        if (active.has('axis') && this.pickedAxisCtx != null) regions.axis = this.axisRegion(this.pickedAxisCtx);
+        return regions;
+    }
+
+    private makeGetItemsParams(
+        event: ContextMenuEvent,
+        active: ReadonlySet<AgContextMenuItemShowOn>
+    ): [AgContextMenuGetItemsParams, Caller[]] {
         const { showOn } = event;
         const chart = this.ctx.chartService;
         const items = this.opts.items ?? ['defaults'];
-        const defaultItems: AgContextMenuItem[] = expandBuiltinLists(showOn, items, this.ctx.contextMenuRegistry);
+        const defaultItems: AgContextMenuItem[] = expandBuiltinLists(active, items, this.ctx.contextMenuRegistry);
         switch (showOn) {
             case 'always':
             case 'series-area':
-                return [{ showOn, defaultItems }, [chart]];
+                return [{ showOn, defaultItems, regions: this.plotOverlapRegions(active) }, [chart]];
 
             case 'series-node': {
                 if (this.pickedNode == null) throw new Error(`this.pickedNode is null`);
                 // FIXME: Some optional keys like dataIdKey are not set. Is that a concern?
-                // FIXME: params should be of type CallbackParamRules<AgContextMenuGetItemsParamsSeriesNode>
                 const itemId = getItemId(this.pickedNode, this.pickedNode.series.data?.dataIdKey);
-                const params: AgContextMenuGetItemsParamsSeriesNode = {
-                    showOn,
+                const region: SeriesNodeRegion = {
                     seriesId: this.pickedNode.series.id,
                     itemId,
                     datum: this.pickedNode.datum,
-                    defaultItems,
                     selectionState: this.pickedNode.series.getSelectionStateString(this.pickedNode.datumIndex),
                     isCollapsed: this.ctx.collapsedManager.isCollapsed(itemId),
                 };
 
                 for (const k of DATUM_KEYS) {
                     if (this.pickedNode[k] !== undefined) {
-                        params[k] = this.pickedNode[k];
+                        region[k] = this.pickedNode[k];
                     }
                 }
 
                 // Histogram bins carry standardised bin metadata; binIndex is always set for histogram nodes.
                 if (this.pickedNode.binIndex !== undefined) {
                     const { datums, binIndex, binRange, aggregatedValue, frequency } = this.pickedNode;
-                    Object.assign(params, { datums, binIndex, binRange, aggregatedValue, frequency });
+                    Object.assign(region, { datums, binIndex, binRange, aggregatedValue, frequency });
                 }
+                const regions: Regions = { ...this.plotOverlapRegions(active), 'series-node': region };
+                // FIXME: params should be of type CallbackParamRules<AgContextMenuGetItemsParamsSeriesNode>
+                const params: AgContextMenuGetItemsParamsSeriesNode = { ...region, showOn, defaultItems, regions };
                 const callers: Caller[] = [this.pickedNode.series.properties, chart];
                 return [params, callers];
             }
 
             case 'axis': {
                 if (this.pickedAxisCtx == null) throw new Error(`this.pickedAxisCtx is null`);
-                const { axisId, boundSeries, direction, domain, value, index } = this.pickedAxisCtx;
-                const params: CallbackParamRules<AgContextMenuGetItemsParamsAxis<DatumDefault, ContextDefault>> = {
+                const region = this.axisRegion(this.pickedAxisCtx);
+                const regions: Regions = { axis: region };
+                if (active.has('series-area')) regions['series-area'] = {};
+                const params: AgContextMenuGetItemsParamsAxis<DatumDefault, ContextDefault> = {
+                    ...region,
                     showOn,
                     defaultItems,
-                    axisId,
-                    boundSeries,
-                    direction,
-                    domain,
-                    value,
-                    index,
+                    regions,
                 };
                 const callers: Caller[] = [this.pickedAxisCtx.caller, chart];
                 return [params, callers];
             }
 
             case 'caption': {
-                if (this.pickedCaptionCtx == null) throw new Error(`this.pickedCaptionCtx is null`);
-                const { captionType, text } = this.pickedCaptionCtx;
-                const params: CallbackParamRules<AgContextMenuGetItemsParamsCaption<DatumDefault, ContextDefault>> = {
+                const ctx = this.pickedCaptionCtx;
+                if (ctx == null) throw new Error(`this.pickedCaptionCtx is null`);
+                const region: CaptionRegion = { captionType: ctx.captionType, text: ctx.text };
+                const params: AgContextMenuGetItemsParamsCaption<DatumDefault, ContextDefault> = {
+                    ...region,
                     showOn,
-                    captionType,
-                    text,
                     defaultItems,
+                    regions: { caption: region },
                 };
                 const callers: Caller[] = [chart];
                 return [params, callers];
             }
 
-            case 'legend-item':
+            case 'legend-item': {
                 if (this.pickedLegendItem == null) throw new Error(`this.pickedLegendItem is null`);
                 const { itemId, seriesId, label, enabled } = this.pickedLegendItem;
                 const text = toPlainText(label.text);
-                const params: CallbackParamRules<AgContextMenuGetItemsParamsLegendItem<DatumDefault, ContextDefault>> =
-                    { showOn, itemId, seriesId, text, visible: enabled, defaultItems };
+                const region: LegendItemRegion = {
+                    itemId,
+                    seriesId,
+                    text,
+                    visible: enabled,
+                };
+                const params: AgContextMenuGetItemsParamsLegendItem<DatumDefault, ContextDefault> = {
+                    ...region,
+                    showOn,
+                    defaultItems,
+                    regions: { 'legend-item': region },
+                };
                 const callers: Caller[] = [chart];
                 return [params, callers];
+            }
 
             default:
                 return showOn satisfies never; // unreachable
@@ -244,15 +278,16 @@ export class ContextMenu extends AbstractModuleInstance {
     private expandItemsOptions(event: ContextMenuEvent): ContextMenuItem[] {
         const result: ContextMenuItem[] = [];
         const opts = this.opts;
+        const active = new Set(event.regions);
 
         let items: readonly Readonly<AgContextMenuItem>[] | undefined;
         if (opts.getItems) {
-            const [params, callers] = this.makeGetItemsParams(event);
+            const [params, callers] = this.makeGetItemsParams(event, active);
             items = callWithContext(callers, opts.getItems, params);
         }
         items ??= opts.items ?? ['defaults'];
 
-        expandItems(event.showOn, this.ctx.contextMenuRegistry, items, result);
+        expandItems(active, this.ctx.contextMenuRegistry, items, result);
 
         return result;
     }
@@ -263,18 +298,14 @@ export class ContextMenu extends AbstractModuleInstance {
         event.widgetEvent.sourceEvent.preventDefault();
         this.x = event.x;
         this.y = event.y;
-        this.pickedNode = undefined;
-        this.pickedLegendItem = undefined;
-        this.pickedCaptionCtx = undefined;
-        if (ContextMenuRegistry.check('series-node', event)) {
-            this.pickedNode = event.context.pickedNode;
-        } else if (ContextMenuRegistry.check('legend-item', event)) {
-            this.pickedLegendItem = event.context.legendItem;
-        } else if (ContextMenuRegistry.check('caption', event)) {
-            this.pickedCaptionCtx = event.context;
-        } else if (ContextMenuRegistry.check('axis', event)) {
-            this.pickedAxisCtx = event.context;
-        }
+
+        // Regions can overlap (e.g. a datum node over a crossing axis), so populate every picked context the
+        // event carries rather than a single mutually-exclusive one; item actions route by their own showOn.
+        const { contexts } = event;
+        this.pickedNode = contexts['series-node']?.pickedNode;
+        this.pickedAxisCtx = contexts.axis;
+        this.pickedCaptionCtx = contexts.caption;
+        this.pickedLegendItem = contexts['legend-item']?.legendItem;
 
         const expandedItems = this.expandItemsOptions(event);
         if (expandedItems.length === 0) return;

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -8,7 +8,7 @@ import type {
     AgContextMenuGetItemsParamsSeriesNode,
     AgContextMenuItem,
     AgContextMenuItemShowOn,
-    AgContextMenuRegions,
+    AgContextMenuShowOnParams,
     ContextDefault,
     DatumDefault,
 } from 'ag-charts-community';
@@ -70,11 +70,11 @@ type PickedNode = _ModuleSupport.SeriesNodeDatum & {
     frequency?: number;
 };
 
-type Regions = AgContextMenuRegions<DatumDefault, ContextDefault>;
-type SeriesNodeRegion = NonNullable<Regions['series-node']>;
-type AxisRegion = NonNullable<Regions['axis']>;
-type CaptionRegion = NonNullable<Regions['caption']>;
-type LegendItemRegion = NonNullable<Regions['legend-item']>;
+type ShowOnParams = AgContextMenuShowOnParams<DatumDefault, ContextDefault>;
+type SeriesNodeParams = Extract<ShowOnParams, { showOn: 'series-node' }>;
+type AxisParams = Extract<ShowOnParams, { showOn: 'axis' }>;
+type CaptionParams = Extract<ShowOnParams, { showOn: 'caption' }>;
+type LegendItemParams = Extract<ShowOnParams, { showOn: 'legend-item' }>;
 
 export class ContextMenu extends AbstractModuleInstance {
     private get opts() {
@@ -164,18 +164,18 @@ export class ContextMenu extends AbstractModuleInstance {
         });
     }
 
-    private axisRegion(pick: _ModuleSupport.AxisValuePick): AxisRegion {
+    private axisRegion(pick: _ModuleSupport.AxisValuePick): AxisParams {
         const { axisId, boundSeries, direction, domain, value, index } = pick;
-        return { axisId, boundSeries, direction, domain, value, index };
+        return { showOn: 'axis', axisId, boundSeries, direction, domain, value, index };
     }
 
-    // Regions that can overlap the series area: the area itself, and an axis positioned inside it (e.g. `crossAt`).
-    // `axis` is the only region that appears both as a primary and as a non-primary overlap, so it lives here.
-    private plotOverlapRegions(active: ReadonlySet<AgContextMenuItemShowOn>): Regions {
-        const regions: Regions = {};
-        if (active.has('series-area')) regions['series-area'] = {};
-        if (active.has('axis') && this.pickedAxisCtx != null) regions.axis = this.axisRegion(this.pickedAxisCtx);
-        return regions;
+    // Scopes that can overlap the series area: the area itself, and an axis positioned inside it (e.g. `crossAt`).
+    // `axis` is the only scope that appears both as a primary and as a non-primary overlap, so it lives here.
+    private plotOverlapRegions(active: ReadonlySet<AgContextMenuItemShowOn>): ShowOnParams[] {
+        const params: ShowOnParams[] = [];
+        if (active.has('series-area')) params.push({ showOn: 'series-area' });
+        if (active.has('axis') && this.pickedAxisCtx != null) params.push(this.axisRegion(this.pickedAxisCtx));
+        return params;
     }
 
     private makeGetItemsParams(
@@ -189,13 +189,14 @@ export class ContextMenu extends AbstractModuleInstance {
         switch (showOn) {
             case 'always':
             case 'series-area':
-                return [{ showOn, defaultItems, regions: this.plotOverlapRegions(active) }, [chart]];
+                return [{ showOn, defaultItems, allShowOnParams: this.plotOverlapRegions(active) }, [chart]];
 
             case 'series-node': {
                 if (this.pickedNode == null) throw new Error(`this.pickedNode is null`);
                 // FIXME: Some optional keys like dataIdKey are not set. Is that a concern?
                 const itemId = getItemId(this.pickedNode, this.pickedNode.series.data?.dataIdKey);
-                const region: SeriesNodeRegion = {
+                const region: SeriesNodeParams = {
+                    showOn: 'series-node',
                     seriesId: this.pickedNode.series.id,
                     itemId,
                     datum: this.pickedNode.datum,
@@ -214,9 +215,8 @@ export class ContextMenu extends AbstractModuleInstance {
                     const { datums, binIndex, binRange, aggregatedValue, frequency } = this.pickedNode;
                     Object.assign(region, { datums, binIndex, binRange, aggregatedValue, frequency });
                 }
-                const regions: Regions = { ...this.plotOverlapRegions(active), 'series-node': region };
-                // FIXME: params should be of type CallbackParamRules<AgContextMenuGetItemsParamsSeriesNode>
-                const params: AgContextMenuGetItemsParamsSeriesNode = { ...region, showOn, defaultItems, regions };
+                const allShowOnParams: ShowOnParams[] = [...this.plotOverlapRegions(active), region];
+                const params: AgContextMenuGetItemsParamsSeriesNode = { ...region, defaultItems, allShowOnParams };
                 const callers: Caller[] = [this.pickedNode.series.properties, chart];
                 return [params, callers];
             }
@@ -224,13 +224,12 @@ export class ContextMenu extends AbstractModuleInstance {
             case 'axis': {
                 if (this.pickedAxisCtx == null) throw new Error(`this.pickedAxisCtx is null`);
                 const region = this.axisRegion(this.pickedAxisCtx);
-                const regions: Regions = { axis: region };
-                if (active.has('series-area')) regions['series-area'] = {};
+                const allShowOnParams: ShowOnParams[] = [region];
+                if (active.has('series-area')) allShowOnParams.push({ showOn: 'series-area' });
                 const params: AgContextMenuGetItemsParamsAxis<DatumDefault, ContextDefault> = {
                     ...region,
-                    showOn,
                     defaultItems,
-                    regions,
+                    allShowOnParams,
                 };
                 const callers: Caller[] = [this.pickedAxisCtx.caller, chart];
                 return [params, callers];
@@ -239,12 +238,11 @@ export class ContextMenu extends AbstractModuleInstance {
             case 'caption': {
                 const ctx = this.pickedCaptionCtx;
                 if (ctx == null) throw new Error(`this.pickedCaptionCtx is null`);
-                const region: CaptionRegion = { captionType: ctx.captionType, text: ctx.text };
+                const region: CaptionParams = { showOn: 'caption', captionType: ctx.captionType, text: ctx.text };
                 const params: AgContextMenuGetItemsParamsCaption<DatumDefault, ContextDefault> = {
                     ...region,
-                    showOn,
                     defaultItems,
-                    regions: { caption: region },
+                    allShowOnParams: [region],
                 };
                 const callers: Caller[] = [chart];
                 return [params, callers];
@@ -254,7 +252,8 @@ export class ContextMenu extends AbstractModuleInstance {
                 if (this.pickedLegendItem == null) throw new Error(`this.pickedLegendItem is null`);
                 const { itemId, seriesId, label, enabled } = this.pickedLegendItem;
                 const text = toPlainText(label.text);
-                const region: LegendItemRegion = {
+                const region: LegendItemParams = {
+                    showOn: 'legend-item',
                     itemId,
                     seriesId,
                     text,
@@ -262,9 +261,8 @@ export class ContextMenu extends AbstractModuleInstance {
                 };
                 const params: AgContextMenuGetItemsParamsLegendItem<DatumDefault, ContextDefault> = {
                     ...region,
-                    showOn,
                     defaultItems,
-                    regions: { 'legend-item': region },
+                    allShowOnParams: [region],
                 };
                 const callers: Caller[] = [chart];
                 return [params, callers];

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenuItem.ts
@@ -10,24 +10,22 @@ import { isKeyOf } from 'ag-charts-core';
 type Options = Partial<_ModuleSupport.ContextMenuItemContractNonRecursive>;
 type AgContextMenuItem_NoLists = Exclude<AgContextMenuItem, keyof _ModuleSupport.ContextMenuBuiltins['lists']>;
 
-function showsFor(showOn: AgContextMenuItemShowOn, showing: AgContextMenuItemShowOn): boolean {
+type ActiveRegions = ReadonlySet<AgContextMenuItemShowOn>;
+
+function showsFor(showOn: AgContextMenuItemShowOn, active: ActiveRegions): boolean {
     if (showOn === 'always') return true;
-    if (showOn === 'series-area') return showing === 'series-area' || showing === 'series-node';
-    return showOn === showing;
+    if (showOn === 'series-area') return active.has('series-area') || active.has('series-node');
+    return active.has(showOn);
 }
 
-function appendItem(
-    showing: AgContextMenuItemShowOn,
-    item: Options,
-    result: ContextMenuItem[]
-): ContextMenuItem | undefined {
+function appendItem(active: ActiveRegions, item: Options, result: ContextMenuItem[]): ContextMenuItem | undefined {
     let mustShow: boolean = true;
     if (item.type === 'separator') {
         const last: ContextMenuItem | undefined = result.at(-1);
         mustShow = last !== undefined && last.type !== 'separator';
     }
 
-    mustShow &&= showsFor(item.showOn ?? 'always', showing);
+    mustShow &&= showsFor(item.showOn ?? 'always', active);
     if (mustShow) {
         const menuItem = new ContextMenuItem(item);
         result.push(menuItem);
@@ -36,18 +34,18 @@ function appendItem(
 }
 
 function appendBuiltinItem(
-    showing: AgContextMenuItemShowOn,
+    active: ActiveRegions,
     registry: _ModuleSupport.ContextMenuRegistry,
     keyword: keyof _ModuleSupport.ContextMenuRegistry['builtins']['items'],
     result: ContextMenuItem[]
 ) {
     if (registry.isVisible(keyword)) {
-        appendItem(showing, registry.builtins.items[keyword], result);
+        appendItem(active, registry.builtins.items[keyword], result);
     }
 }
 
 function expandBuiltin(
-    showing: AgContextMenuItemShowOn,
+    active: ActiveRegions,
     registry: _ModuleSupport.ContextMenuRegistry,
     keyword: AgContextMenuItemLiteral,
     result: ContextMenuItem[]
@@ -55,15 +53,15 @@ function expandBuiltin(
     const { builtins } = registry;
     if (isKeyOf(keyword, builtins.lists)) {
         for (const childKeyword of builtins.lists[keyword]) {
-            appendBuiltinItem(showing, registry, childKeyword, result);
+            appendBuiltinItem(active, registry, childKeyword, result);
         }
     } else {
-        appendBuiltinItem(showing, registry, keyword, result);
+        appendBuiltinItem(active, registry, keyword, result);
     }
 }
 
 export function expandBuiltinLists(
-    showing: AgContextMenuItemShowOn,
+    active: ActiveRegions,
     items: readonly Readonly<AgContextMenuItem>[],
     registry: _ModuleSupport.ContextMenuRegistry
 ): AgContextMenuItem_NoLists[] {
@@ -82,26 +80,26 @@ export function expandBuiltinLists(
     return unfiltered.filter((it) => {
         if (typeof it === 'string') {
             const showOn = registry.builtins.items[it].showOn ?? 'always';
-            return registry.isVisible(it) && showsFor(showOn, showing);
+            return registry.isVisible(it) && showsFor(showOn, active);
         } else {
-            return showsFor(it.showOn ?? 'always', showing);
+            return showsFor(it.showOn ?? 'always', active);
         }
     });
 }
 
 export function expandItems(
-    showing: AgContextMenuItemShowOn,
+    active: ActiveRegions,
     registry: _ModuleSupport.ContextMenuRegistry,
     items: readonly Readonly<AgContextMenuItem>[],
     result: ContextMenuItem[]
 ) {
     for (const item of items) {
         if (typeof item === 'string') {
-            expandBuiltin(showing, registry, item, result);
+            expandBuiltin(active, registry, item, result);
         } else {
-            const menuItem = appendItem(showing, item, result);
+            const menuItem = appendItem(active, item, result);
             if (item.items && menuItem && item.items.length > 0) {
-                expandItems(showing, registry, item.items, menuItem.items);
+                expandItems(active, registry, item.items, menuItem.items);
             }
         }
     }

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -136,9 +136,36 @@ export type AgContextMenuItem<TDatum = DatumDefault, TContext = ContextDefault> 
 
 type GetItemsParamsOmissions = 'type' | 'event';
 
+/**
+ * The regions under the pointer when the context menu was opened. More than one entry is present where
+ * regions overlap — for example a datum node drawn over an axis positioned with `crossAt` yields both
+ * `series-node` and `axis`. Each entry carries the same data the corresponding single-region params carry.
+ */
+export interface AgContextMenuRegions<TDatum = DatumDefault, TContext = ContextDefault> {
+    /** Set when the pointer is over a datum node. */
+    'series-node'?: Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, GetItemsParamsOmissions>;
+    /** Set when the pointer is within the series area bounds. */
+    'series-area'?: Omit<AgSeriesAreaContextMenuActionEvent<TContext>, GetItemsParamsOmissions>;
+    /** Set when the pointer is over an axis, including where an axis overlaps the series area (e.g. `crossAt`). */
+    axis?: Omit<AgAxisContextMenuActionEvent<TContext>, GetItemsParamsOmissions>;
+    /** Set when the pointer is over a caption (title, subtitle or footnote). */
+    caption?: Omit<AgCaptionContextMenuActionEvent<TContext>, GetItemsParamsOmissions>;
+    /** Set when the pointer is over a legend item. */
+    'legend-item'?: Omit<AgChartLegendContextMenuEvent<TContext>, GetItemsParamsOmissions> & {
+        /** Whether the series of this legend item is visible or hidden. */
+        visible: boolean;
+    };
+}
+
 interface GetItemsParamsMixin<TDatum, TContext> {
     /** The default menu items that would be shown without customisation. */
     defaultItems: AgContextMenuItem<TDatum, TContext>[];
+    /**
+     * All regions under the pointer, keyed by region. When regions overlap, more than one entry is set,
+     * letting the callback build a single combined menu. `showOn` reports the primary region for
+     * backwards compatibility, but `regions` is the complete set.
+     */
+    regions: AgContextMenuRegions<TDatum, TContext>;
 }
 
 // Note: The unused `_TDatumReserved = never` are reserved for future-proofing.

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -136,38 +136,6 @@ export type AgContextMenuItem<TDatum = DatumDefault, TContext = ContextDefault> 
 
 type GetItemsParamsOmissions = 'type' | 'event';
 
-/**
- * The regions under the pointer when the context menu was opened. More than one entry is present where
- * regions overlap — for example a datum node drawn over an axis positioned with `crossAt` yields both
- * `series-node` and `axis`. Each entry carries the same data the corresponding single-region params carry.
- */
-export interface AgContextMenuRegions<TDatum = DatumDefault, TContext = ContextDefault> {
-    /** Set when the pointer is over a datum node. */
-    'series-node'?: Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, GetItemsParamsOmissions>;
-    /** Set when the pointer is within the series area bounds. */
-    'series-area'?: Omit<AgSeriesAreaContextMenuActionEvent<TContext>, GetItemsParamsOmissions>;
-    /** Set when the pointer is over an axis, including where an axis overlaps the series area (e.g. `crossAt`). */
-    axis?: Omit<AgAxisContextMenuActionEvent<TContext>, GetItemsParamsOmissions>;
-    /** Set when the pointer is over a caption (title, subtitle or footnote). */
-    caption?: Omit<AgCaptionContextMenuActionEvent<TContext>, GetItemsParamsOmissions>;
-    /** Set when the pointer is over a legend item. */
-    'legend-item'?: Omit<AgChartLegendContextMenuEvent<TContext>, GetItemsParamsOmissions> & {
-        /** Whether the series of this legend item is visible or hidden. */
-        visible: boolean;
-    };
-}
-
-interface GetItemsParamsMixin<TDatum, TContext> {
-    /** The default menu items that would be shown without customisation. */
-    defaultItems: AgContextMenuItem<TDatum, TContext>[];
-    /**
-     * All regions under the pointer, keyed by region. When regions overlap, more than one entry is set,
-     * letting the callback build a single combined menu. `showOn` reports the primary region for
-     * backwards compatibility, but `regions` is the complete set.
-     */
-    regions: AgContextMenuRegions<TDatum, TContext>;
-}
-
 // Note: The unused `_TDatumReserved = never` are reserved for future-proofing.
 //
 // Using <TContext> instead of <_TDatum, TContext> would make the API very susceptible to breaking changes and/or inconsistency.
@@ -177,42 +145,42 @@ interface GetItemsParamsMixin<TDatum, TContext> {
 // one position to the right. A workaround could be to change <TContext> to <TContext, TDatum = DatumDefault>, but this
 // is inconsistent with the ordering of other generic types in our API.
 
-export interface AgContextMenuGetItemsParamsAlways<_TDatumReserved = never, TContext = ContextDefault>
-    extends
-        Omit<AgChartContextMenuEvent<TContext>, GetItemsParamsOmissions>,
-        GetItemsParamsMixin<_TDatumReserved, TContext> {
+export interface AgContextMenuShowOnParamsAlways<_TDatumReserved = never, TContext = ContextDefault> extends Omit<
+    AgChartContextMenuEvent<TContext>,
+    GetItemsParamsOmissions
+> {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'always';
 }
 
-export interface AgContextMenuGetItemsParamsAxis<_TDatumReserved = never, TContext = ContextDefault>
-    extends
-        Omit<AgAxisContextMenuActionEvent<TContext>, GetItemsParamsOmissions>,
-        GetItemsParamsMixin<_TDatumReserved, TContext> {
+export interface AgContextMenuShowOnParamsAxis<_TDatumReserved = never, TContext = ContextDefault> extends Omit<
+    AgAxisContextMenuActionEvent<TContext>,
+    GetItemsParamsOmissions
+> {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'axis';
 }
 
-export interface AgContextMenuGetItemsParamsCaption<_TDatumReserved = never, TContext = ContextDefault>
-    extends
-        Omit<AgCaptionContextMenuActionEvent<TContext>, GetItemsParamsOmissions>,
-        GetItemsParamsMixin<_TDatumReserved, TContext> {
+export interface AgContextMenuShowOnParamsCaption<_TDatumReserved = never, TContext = ContextDefault> extends Omit<
+    AgCaptionContextMenuActionEvent<TContext>,
+    GetItemsParamsOmissions
+> {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'caption';
 }
 
-export interface AgContextMenuGetItemsParamsSeriesArea<_TDatumReserved = never, TContext = ContextDefault>
-    extends
-        Omit<AgSeriesAreaContextMenuActionEvent<TContext>, GetItemsParamsOmissions>,
-        GetItemsParamsMixin<_TDatumReserved, TContext> {
+export interface AgContextMenuShowOnParamsSeriesArea<_TDatumReserved = never, TContext = ContextDefault> extends Omit<
+    AgSeriesAreaContextMenuActionEvent<TContext>,
+    GetItemsParamsOmissions
+> {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'series-area';
 }
 
-export interface AgContextMenuGetItemsParamsSeriesNode<TDatum = DatumDefault, TContext = ContextDefault>
-    extends
-        Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, GetItemsParamsOmissions>,
-        GetItemsParamsMixin<TDatum, TContext> {
+export interface AgContextMenuShowOnParamsSeriesNode<TDatum = DatumDefault, TContext = ContextDefault> extends Omit<
+    AgNodeContextMenuActionEvent<TDatum, TContext>,
+    GetItemsParamsOmissions
+> {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'series-node';
     /** The current selection state of this datum. Set to `undefined` if the selection module is not enabled. */
@@ -221,15 +189,69 @@ export interface AgContextMenuGetItemsParamsSeriesNode<TDatum = DatumDefault, TC
     isCollapsed: boolean;
 }
 
-export interface AgContextMenuGetItemsParamsLegendItem<_TDatumReserved = never, TContext = ContextDefault>
-    extends
-        Omit<AgChartLegendContextMenuEvent<TContext>, GetItemsParamsOmissions>,
-        GetItemsParamsMixin<_TDatumReserved, TContext> {
+export interface AgContextMenuShowOnParamsLegendItem<_TDatumReserved = never, TContext = ContextDefault> extends Omit<
+    AgChartLegendContextMenuEvent<TContext>,
+    GetItemsParamsOmissions
+> {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'legend-item';
     /** Whether the series of this legend item is visible or hidden. */
     visible: boolean;
 }
+
+/**
+ * One matched `showOn` scope's params, discriminated by its `showOn` field. This is the element type of
+ * `allShowOnParams` — the same shape a scope passes as its top-level params when it wins outright, without the
+ * callback-level `defaultItems`.
+ *
+ * Keyed by array position rather than by scope so that a future release can surface more than one context for
+ * the same scope — e.g. overlapping markers (multiple `series-node`) or an x/y crossover (multiple `axis`) —
+ * without an API change. Emitting multiple entries per scope is not yet implemented.
+ */
+export type AgContextMenuShowOnParams<TDatum = DatumDefault, TContext = ContextDefault> =
+    | AgContextMenuShowOnParamsAlways<TDatum, TContext>
+    | AgContextMenuShowOnParamsAxis<TDatum, TContext>
+    | AgContextMenuShowOnParamsCaption<TDatum, TContext>
+    | AgContextMenuShowOnParamsSeriesArea<TDatum, TContext>
+    | AgContextMenuShowOnParamsSeriesNode<TDatum, TContext>
+    | AgContextMenuShowOnParamsLegendItem<TDatum, TContext>;
+
+interface GetItemsParamsMixin<TDatum, TContext> {
+    /** The default menu items that would be shown without customisation. */
+    defaultItems: AgContextMenuItem<TDatum, TContext>[];
+    /**
+     * Every `showOn` scope that matched at the click point, including the winning scope carried by these root
+     * params. Lets the callback build one combined menu when scopes overlap — for example a datum node drawn
+     * over an axis positioned with `crossAt`. Scopes that did not match are absent from the array.
+     */
+    allShowOnParams: AgContextMenuShowOnParams<TDatum, TContext>[];
+}
+
+export interface AgContextMenuGetItemsParamsAlways<_TDatumReserved = never, TContext = ContextDefault>
+    extends
+        AgContextMenuShowOnParamsAlways<_TDatumReserved, TContext>,
+        GetItemsParamsMixin<_TDatumReserved, TContext> {}
+
+export interface AgContextMenuGetItemsParamsAxis<_TDatumReserved = never, TContext = ContextDefault>
+    extends AgContextMenuShowOnParamsAxis<_TDatumReserved, TContext>, GetItemsParamsMixin<_TDatumReserved, TContext> {}
+
+export interface AgContextMenuGetItemsParamsCaption<_TDatumReserved = never, TContext = ContextDefault>
+    extends
+        AgContextMenuShowOnParamsCaption<_TDatumReserved, TContext>,
+        GetItemsParamsMixin<_TDatumReserved, TContext> {}
+
+export interface AgContextMenuGetItemsParamsSeriesArea<_TDatumReserved = never, TContext = ContextDefault>
+    extends
+        AgContextMenuShowOnParamsSeriesArea<_TDatumReserved, TContext>,
+        GetItemsParamsMixin<_TDatumReserved, TContext> {}
+
+export interface AgContextMenuGetItemsParamsSeriesNode<TDatum = DatumDefault, TContext = ContextDefault>
+    extends AgContextMenuShowOnParamsSeriesNode<TDatum, TContext>, GetItemsParamsMixin<TDatum, TContext> {}
+
+export interface AgContextMenuGetItemsParamsLegendItem<_TDatumReserved = never, TContext = ContextDefault>
+    extends
+        AgContextMenuShowOnParamsLegendItem<_TDatumReserved, TContext>,
+        GetItemsParamsMixin<_TDatumReserved, TContext> {}
 
 export type AgContextMenuGetItemsParams<TDatum = DatumDefault, TContext = ContextDefault> =
     | AgContextMenuGetItemsParamsAlways<TDatum, TContext>

--- a/packages/ag-charts-website/e2e/context-menu.spec.ts
+++ b/packages/ag-charts-website/e2e/context-menu.spec.ts
@@ -246,7 +246,20 @@ test.describe('context-menu', () => {
         };
 
         const getItemsEvent = (captionType: CaptionType, text: TextType): AgContextMenuGetItemsParamsCaption => {
-            return { captionType, defaultItems: ['download'], context: undefined, showOn: 'caption', text };
+            return {
+                captionType,
+                defaultItems: ['download'],
+                context: undefined,
+                showOn: 'caption',
+                text,
+                allShowOnParams: [
+                    {
+                        captionType,
+                        showOn: 'caption',
+                        text,
+                    },
+                ],
+            };
         };
 
         const rightClick = (page: Page, point: { clientX: number; clientY: number }) =>
@@ -398,6 +411,7 @@ test.describe('context-menu', () => {
                 defaultItems: ['download'],
                 ...commonArg,
                 ...pointArgs,
+                allShowOnParams: [{ showOn: 'axis', ...commonArg, ...pointArgs }],
             };
         }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17637
https://ag-grid.atlassian.net/browse/AG-17916

Right-clicking where regions overlap — such as a datum node drawn over an axis positioned with `crossAt` — now offers every region under the pointer instead of only the one that happened to win the dispatch. Previously the series-node branch never offered an overlapping axis at all, and the item filter matched a single region rather than the set.

The active region is now a set rather than a scalar:

- `ContextMenuEvent` carries `regions` (all regions under the pointer) and `contexts` (their per-region pick contexts). `showOn`/`context` remain as the primary region for backwards compatibility.
- `ContextMenuRegistry.dispatchContextRegions()` dispatches the full set; `dispatchContext()` stays as a single-region wrapper over it.
- `SeriesAreaManager` collects an overlapping axis (via the `series-area:contextmenu` handoff) in both the node and no-node branches, then dispatches once. Axis-owning modules annotate the event with the overlapping axis rather than dispatching a competing menu, so a node and an axis can co-exist.
- Enterprise `showsFor()` tests membership against the region set, and `ContextMenu` populates every picked context so each item's action still routes by its own `showOn`.

The `getItems` params gain a `regions` map (public `AgContextMenuRegions`) listing every region under the pointer, letting a callback build one combined menu; the existing `showOn` and region fields are unchanged. Static `items` are filtered by set membership, so an item shows when its `showOn` matches any overlapping region.