### PR TITLE
fix: avoid _previousSplit TypeError when destroy races performUpdate

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -1607,4 +1607,29 @@ describe('Chart destroy() / performUpdate() race condition', () => {
         'does not throw TypeError when destroy() races with a %s series update',
         testDestroyRace
     );
+
+    it('does not throw when updateSplits runs after the chart instance is frozen', async () => {
+        const proxy = AgCharts.create({
+            container: document.body,
+            data,
+            series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+        }) as AgChartProxy;
+        const innerChart = deproxy(proxy);
+        await waitForChartStability(innerChart);
+
+        const chartProto = Object.getPrototypeOf(innerChart);
+        const origUpdateSplits = chartProto.updateSplits;
+        vi.spyOn(chartProto, 'updateSplits').mockImplementationOnce(function (this: any, name: string) {
+            // Mirror performTeardown's terminal state mid-update (Object.freeze(this)).
+            this.destroyed = true;
+            Object.freeze(this);
+            return origUpdateSplits.call(this, name);
+        });
+
+        innerChart.update(ChartUpdateType.FULL);
+        await waitForChartStability(innerChart);
+
+        // setupMockConsole afterEach asserts console.error was not called
+        // (would see: Cannot assign to read only property '_previousSplit').
+    });
 });

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -977,6 +977,10 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
     private _previousSplit: number = 0;
 
     private updateSplits(splitName: string) {
+        // destroy() sets `destroyed` before teardown is mutex-queued; skip timing
+        // writes if the chart is already gone so a racing performUpdate cannot throw
+        // on a frozen instance (Object.freeze in performTeardown).
+        if (this.destroyed) return;
         const splits = this._performUpdateSplits;
         splits[splitName] ??= 0;
         splits[splitName] += performance.now() - this._previousSplit;
@@ -990,13 +994,17 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
                 await this.performUpdate(count);
             });
         } catch (error: any) {
-            this.ctx.logger.error('update error', error, error.stack);
-            this.validationCollector.add({
-                severity: 'error',
-                message: String(error?.message ?? error),
-                code: typeof error?.stack === 'string' ? error.stack : undefined,
-            });
-            this.runningUpdateType = ChartUpdateType.NONE;
+            // If destroy() won the race, the instance may already be frozen — avoid
+            // further writes / error noise for an abandoned update.
+            if (!this.destroyed) {
+                this.ctx.logger.error('update error', error, error.stack);
+                this.validationCollector.add({
+                    severity: 'error',
+                    message: String(error?.message ?? error),
+                    code: typeof error?.stack === 'string' ? error.stack : undefined,
+                });
+                this.runningUpdateType = ChartUpdateType.NONE;
+            }
             this._performUpdateNotify.notify();
         }
     }


### PR DESCRIPTION
## Summary

Fixes #7464.

When `destroy()` races an in-flight `performUpdate`, `updateSplits` could assign `_previousSplit` after `Object.freeze(this)` in `performTeardown`, producing:

`AG Charts - update error TypeError: Cannot assign to read only property '_previousSplit'`

(Firefox: `"_previousSplit" is read-only`).

`destroy()` already sets `destroyed` early and queues teardown behind the update mutex; this change makes the update path honor that:

- `updateSplits` no-ops when `destroyed`
- `tryPerformUpdate` catch skips logging / further instance writes when `destroyed` (avoids a follow-on read-only error on `runningUpdateType`)

## Test plan

- [x] Extended `Chart destroy() / performUpdate() race condition` with a case that freezes during `updateSplits` (asserts no `console.error` via `setupMockConsole`)
- [ ] Existing destroy/performUpdate race tests still pass