### PR TITLE
SE-62 Server-render top-level content on /options/ API reference pages

### DIFF
--- a/external/ag-website-shared/src/components/link-icon/LinkIcon.tsx
+++ b/external/ag-website-shared/src/components/link-icon/LinkIcon.tsx
@@ -27,7 +27,9 @@ export function LinkIcon({
 
         navigator.clipboard.writeText(redirectUrl ?? href);
 
-        history.replaceState({}, '', hash);
+        // Preserve the existing entry's state: Astro's ClientRouter keeps its scroll and history
+        // index in there, and replacing it wholesale breaks its back/forward handling.
+        history.replaceState(history.state, '', hash);
 
         setLinkCopied(true);
         setlinkActive(true);

--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -183,9 +183,9 @@ test.describe('api-ref-page', () => {
         await selectSearchOption(page, 'series type bar');
         await page.keyboard.press('Enter');
 
-        const url = page.url();
-        expect(url).toContain('/options/series/bar/');
-        expect(url).toContain('#reference-AgBarSeriesOptions-type');
+        // Selecting a result hands off to Astro's router, which swaps in the target document, so
+        // the address bar catches up a tick after the keypress rather than during it.
+        await page.waitForURL(/\/options\/series\/bar\/#reference-AgBarSeriesOptions-type$/);
         await expect(page.locator('header h1')).toContainText("type = 'bar'");
     });
 

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceRouting.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceRouting.ts
@@ -1,0 +1,77 @@
+import { navigate } from 'astro:transitions/client';
+import { useEffect, useState } from 'react';
+
+import type { NavigationData } from './apiReferenceHelpers';
+
+/*
+    Astro's ClientRouter owns `history.state` — it reads `index` to work out popstate direction and
+    `scrollX`/`scrollY` to restore scroll. It spreads any `state` passed to `navigate()` alongside
+    those keys, so nesting the reference selection under a single key lets both live in one entry
+    without either overwriting the other.
+*/
+const SELECTION_STATE_KEY = 'apiReferenceSelection';
+
+interface ApiReferenceLocation {
+    pathname: string;
+    /** Includes the leading `#`, matching `window.location.hash`. */
+    hash: string;
+}
+
+const inBrowser = () => typeof window !== 'undefined';
+
+function currentLocation(): ApiReferenceLocation | null {
+    return inBrowser() ? { pathname: window.location.pathname, hash: window.location.hash } : null;
+}
+
+function hrefFor({ pathname, hash }: NavigationData) {
+    return hash ? `${pathname}#${hash}` : pathname;
+}
+
+export function readSelection(): NavigationData | undefined {
+    if (!inBrowser()) return undefined;
+    return (history.state as Record<string, unknown> | null)?.[SELECTION_STATE_KEY] as NavigationData | undefined;
+}
+
+/**
+ * Attach a selection to the current entry. Entries created by a full page load or by arriving from
+ * a non-reference page carry no selection of their own, so a later back/forward has nothing to
+ * restore without this.
+ */
+export function seedSelection(selection: NavigationData) {
+    // Astro's router seeds `index`/`scrollX`/`scrollY` when its module loads; merging onto a state
+    // it has not written yet would produce an entry it can no longer track.
+    if (!inBrowser() || !history.state || readSelection()) return;
+    history.replaceState({ ...history.state, [SELECTION_STATE_KEY]: selection }, '');
+}
+
+export function navigateToSelection(selection: NavigationData) {
+    return navigate(hrefFor(selection), { state: { [SELECTION_STATE_KEY]: selection } });
+}
+
+/**
+ * Current location, tracked through every route Astro can change it by: `astro:page-load` after a
+ * document swap or full load, `popstate` for back/forward, and `hashchange` for the hash-only path
+ * (which Astro handles by assigning `location.href`, so no swap event fires).
+ */
+export function useApiReferenceLocation(): ApiReferenceLocation | null {
+    const [location, setLocation] = useState(currentLocation);
+
+    useEffect(() => {
+        const update = () => {
+            const next = { pathname: window.location.pathname, hash: window.location.hash };
+            setLocation((prev) => (prev?.pathname === next.pathname && prev?.hash === next.hash ? prev : next));
+        };
+
+        document.addEventListener('astro:page-load', update);
+        window.addEventListener('popstate', update);
+        window.addEventListener('hashchange', update);
+
+        return () => {
+            document.removeEventListener('astro:page-load', update);
+            window.removeEventListener('popstate', update);
+            window.removeEventListener('hashchange', update);
+        };
+    }, []);
+
+    return location;
+}

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
@@ -1,7 +1,7 @@
 import Code from '@ag-website-shared/components/code/Code';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import styles from '@ag-website-shared/components/reference-documentation/ApiReference.module.scss';
-import { navigate, scrollIntoViewById, useLocation } from '@ag-website-shared/utils/navigation';
+import { scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import type {
     InterfaceNode,
     MemberNode,
@@ -48,6 +48,7 @@ import {
     resolveAliasedUnion,
     resolveReferenceType,
 } from '../apiReferenceHelpers';
+import { navigateToSelection, useApiReferenceLocation } from '../apiReferenceRouting';
 import { SelectionContext } from './OptionsNavigation';
 import { type CollapsibleType, PropertyTitle, PropertyType } from './Properties';
 
@@ -191,7 +192,7 @@ function UnionVariantNode({
 }) {
     const [isExpanded, toggleExpanded, setExpanded] = useToggle();
     const config = useContext(ApiReferenceConfigContext);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
     const docs = parseJsDocs(variant.node.docs);
     const { discriminator } = variant;
     const displayName = discriminator ? `[${discriminator.key}='${discriminator.value}']` : variant.anchorSegment;
@@ -279,7 +280,7 @@ export function ApiReference({
     const reference = useContext(ApiReferenceContext);
     const config = useContext(ApiReferenceConfigContext);
     const interfaceRef = reference?.get(id);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     // include / exclude / prioritise scope the top-level interface only; nested interfaces
     // and union variants must render their full member set.
@@ -335,7 +336,7 @@ function NodeFactory({ member, anchorId, genericsMap, prefixPath = [], ...props 
     const [isSignatureExpanded, toggleSignature, setSignatureExpanded] = useToggle();
     const interfaceRef = useMemberAdditionalDetails(member);
     const config = useContext(ApiReferenceConfigContext);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     const hasMembers = hasMembersNode(interfaceRef);
     const hasNestedPages = config.specialTypes?.[getMemberType(member)] === 'NestedPage';
@@ -497,7 +498,7 @@ function ApiReferenceRow({
                                     pageTitle: { name: memberName },
                                 };
                                 selection?.setSelection(selectionState);
-                                navigate(selectionState, { state: selectionState });
+                                navigateToSelection(selectionState);
                             }}
                         >
                             See property details <Icon name="arrowRight" />

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.astro
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.astro
@@ -7,6 +7,7 @@ import {
     processMembers,
 } from '@components/api-documentation/apiReferenceHelpers';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+import styles from './ApiReferenceFallback.module.scss';
 
 interface Props {
     rootInterface: string;
@@ -40,17 +41,17 @@ const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
         x-position as the hydrated layout and the navigation tree fills into reserved space
         without shifting the page horizontally on hydration. */
     }
-    <div class="nav-placeholder" aria-hidden="true"></div>
+    <div class={styles.navPlaceholder} aria-hidden="true"></div>
 
-    <div class="reference-content">
+    <div class={styles.referenceContent}>
         <header>
             <h1 class="text-3xl">
                 {
                     title.type ? (
                         <>
                             {title.name}
-                            {title.name === 'axes' && <span class="record-alias">.key</span>}[type='
-                            <span class="union-discriminator">{title.type}</span>']
+                            {title.name === 'axes' && <span class={styles.recordAlias}>.key</span>}[type='
+                            <span class={styles.unionDiscriminator}>{title.type}</span>']
                         </>
                     ) : (
                         title.name
@@ -60,18 +61,18 @@ const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
             {description && <p class="text-secondary">{description}</p>}
         </header>
 
-        <dl class="reference-list">
+        <dl class={styles.referenceList}>
             {
                 members.map((member) => {
                     const memberDocs = parseJsDocs(member.docs);
                     return (
-                        <div class="reference-row" id={`reference-${id}-${member.name}`}>
+                        <div class={styles.referenceRow} id={`reference-${id}-${member.name}`}>
                             <dt>
-                                <span class="property-name">{cleanupName(member.name)}</span>
-                                {!member.optional && <span class="required">required</span>}
-                                <code class="property-type">{normalizeType(member.type)}</code>
+                                <span class={styles.propertyName}>{cleanupName(member.name)}</span>
+                                {!member.optional && <span class={styles.required}>required</span>}
+                                <code class={styles.propertyType}>{normalizeType(member.type)}</code>
                                 {member.defaultValue != null && (
-                                    <span class="property-default">default: {member.defaultValue}</span>
+                                    <span class={styles.propertyDefault}>default: {member.defaultValue}</span>
                                 )}
                             </dt>
                             {/* Always render the <dd> so every definition-list group has both a
@@ -84,113 +85,3 @@ const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
         </dl>
     </div>
 </div>
-
-<style lang="scss">
-    @use 'design-system' as *;
-
-    /*
-        Mirror the two-column geometry the hydrated <ApiReferencePage> produces (its
-        `.container.layout-grid` + `.objectViewOuter` + `.referenceOuter`) so the swap from this
-        fallback to the React app does not shift the page horizontally.
-    */
-
-    .nav-placeholder {
-        width: calc(100% + var(--layout-horizontal-margins) * 2);
-        margin-left: calc(var(--layout-horizontal-margins) * -1);
-
-        @media screen and (max-width: $breakpoint-options-medium) {
-            /*
-                Below this breakpoint the navigation tree is hidden and the nav stacks above the
-                content as a single search box. Reserve its height so the content does not drop on
-                hydration: the nav's top padding ($spacing-size-5) plus the search box (its text
-                line-box + vertical padding of $spacing-size-3 + 1px border top and bottom).
-            */
-            min-height: calc(#{$spacing-size-5} + var(--text-fs-base) * var(--text-lh-base) + #{$spacing-size-3} + 2px);
-        }
-
-        @media screen and (min-width: $breakpoint-options-medium) {
-            width: calc(var(--layout-width-4-12) + var(--layout-horizontal-margins));
-            box-shadow: -1px 0 0 0 var(--color-border-primary);
-            border-right: 1px solid var(--color-border-primary);
-        }
-
-        @media screen and (min-width: $breakpoint-options-large) {
-            width: calc(var(--layout-width-3-12) + var(--layout-horizontal-margins));
-        }
-    }
-
-    .reference-content {
-        width: calc(100% + var(--layout-gap) * 2);
-        margin-left: calc(var(--layout-gap) * -1);
-
-        @media screen and (max-width: $breakpoint-options-medium) {
-            /* Below this breakpoint the content spans full width with no negative bleed, matching
-               the hydrated `.referenceOuter`; without this the body sits ~32px too far left (and
-               off-screen) until hydration snaps it back. */
-            margin-left: 0;
-        }
-
-        @media screen and (min-width: $breakpoint-options-medium) {
-            width: var(--layout-width-8-12);
-            margin-left: 0;
-        }
-
-        @media screen and (min-width: $breakpoint-options-large) {
-            width: var(--layout-width-9-12);
-        }
-    }
-
-    header {
-        padding-top: $spacing-size-8;
-        padding-bottom: $spacing-size-6;
-        margin-bottom: $spacing-size-4;
-        border-bottom: 1px solid var(--color-border-secondary);
-    }
-
-    .reference-list {
-        margin: 0;
-    }
-
-    .reference-row {
-        padding: $spacing-size-4 0;
-        border-top: 1px solid var(--color-border-secondary);
-
-        dt {
-            display: flex;
-            flex-wrap: wrap;
-            align-items: baseline;
-            gap: $spacing-size-2;
-        }
-
-        dd {
-            margin: $spacing-size-2 0 0;
-
-            &:empty {
-                margin: 0;
-            }
-        }
-    }
-
-    .property-name {
-        font-weight: var(--text-bold);
-    }
-
-    .property-type {
-        color: var(--color-fg-code);
-    }
-
-    .property-default {
-        color: var(--color-fg-secondary);
-        font-size: var(--text-fs-sm);
-    }
-
-    .required {
-        color: red;
-        font-size: var(--text-fs-sm);
-    }
-
-    .record-alias,
-    .union-discriminator {
-        color: var(--color-fg-code);
-    }
-</style>

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.astro
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.astro
@@ -34,7 +34,7 @@ const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
     signatures remain client-rendered.
 */
 }
-<div class="options-reference-fallback layout-grid">
+<div class="api-reference-fallback layout-grid">
     {
         /* Empty column reserving the left-nav width, so the property content lands at the same
         x-position as the hydrated layout and the navigation tree fills into reserved space

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.module.scss
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.module.scss
@@ -1,0 +1,107 @@
+@use 'design-system' as *;
+
+/*
+    Mirror the two-column geometry the hydrated <ApiReferencePage> produces (its
+    `.container.layout-grid` + `.objectViewOuter` + `.referenceOuter`) so the swap from the
+    fallback to the React app does not shift the page horizontally.
+*/
+
+.navPlaceholder {
+    width: calc(100% + var(--layout-horizontal-margins) * 2);
+    margin-left: calc(var(--layout-horizontal-margins) * -1);
+
+    @media screen and (max-width: $breakpoint-options-medium) {
+        /*
+            Below this breakpoint the navigation tree is hidden and the nav stacks above the
+            content as a single search box. Reserve its height so the content does not drop on
+            hydration: the nav's top padding ($spacing-size-5) plus the search box (its text
+            line-box + vertical padding of $spacing-size-3 + 1px border top and bottom).
+        */
+        min-height: calc(#{$spacing-size-5} + var(--text-fs-base) * var(--text-lh-base) + #{$spacing-size-3} + 2px);
+    }
+
+    @media screen and (min-width: $breakpoint-options-medium) {
+        width: calc(var(--layout-width-4-12) + var(--layout-horizontal-margins));
+        box-shadow: -1px 0 0 0 var(--color-border-primary);
+        border-right: 1px solid var(--color-border-primary);
+    }
+
+    @media screen and (min-width: $breakpoint-options-large) {
+        width: calc(var(--layout-width-3-12) + var(--layout-horizontal-margins));
+    }
+}
+
+.referenceContent {
+    width: calc(100% + var(--layout-gap) * 2);
+    margin-left: calc(var(--layout-gap) * -1);
+
+    @media screen and (max-width: $breakpoint-options-medium) {
+        /* Below this breakpoint the content spans full width with no negative bleed, matching
+           the hydrated `.referenceOuter`; without this the body sits ~32px too far left (and
+           off-screen) until hydration snaps it back. */
+        margin-left: 0;
+    }
+
+    @media screen and (min-width: $breakpoint-options-medium) {
+        width: var(--layout-width-8-12);
+        margin-left: 0;
+    }
+
+    @media screen and (min-width: $breakpoint-options-large) {
+        width: var(--layout-width-9-12);
+    }
+
+    header {
+        padding-top: $spacing-size-8;
+        padding-bottom: $spacing-size-6;
+        margin-bottom: $spacing-size-4;
+        border-bottom: 1px solid var(--color-border-secondary);
+    }
+}
+
+.referenceList {
+    margin: 0;
+}
+
+.referenceRow {
+    padding: $spacing-size-4 0;
+    border-top: 1px solid var(--color-border-secondary);
+
+    dt {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: $spacing-size-2;
+    }
+
+    dd {
+        margin: $spacing-size-2 0 0;
+
+        &:empty {
+            margin: 0;
+        }
+    }
+}
+
+.propertyName {
+    font-weight: var(--text-bold);
+}
+
+.propertyType {
+    color: var(--color-fg-code);
+}
+
+.propertyDefault {
+    color: var(--color-fg-secondary);
+    font-size: var(--text-fs-sm);
+}
+
+.required {
+    color: red;
+    font-size: var(--text-fs-sm);
+}
+
+.recordAlias,
+.unionDiscriminator {
+    color: var(--color-fg-code);
+}

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferencePage.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferencePage.tsx
@@ -1,15 +1,14 @@
-import { navigate, useHistory, useLocation } from '@ag-website-shared/utils/navigation';
 import type { InterfaceNode } from '@generate-code-reference-plugin/doc-interfaces/types';
 import { fetchInterfacesReference } from '@utils/client/fetchInterfacesReference';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import classNames from 'classnames';
-import { Action } from 'history';
 import { type CSSProperties, useContext, useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 import { QueryClientProvider, useQuery } from 'react-query';
 import remarkBreaks from 'remark-breaks';
 
 import { type NavigationData, type PageTitle, type SpecialTypesMap, parseJsDocs } from '../apiReferenceHelpers';
+import { readSelection, seedSelection, useApiReferenceLocation } from '../apiReferenceRouting';
 import {
     ApiReference,
     ApiReferenceConfigContext,
@@ -51,23 +50,32 @@ function ApiReferencePageInner({
     noExpand,
 }: ApiReferencePageOptions) {
     const { data: reference } = useQuery(['resolved-interfaces'], fetchInterfacesReference, queryOptions);
-    const location = useLocation();
-    const [selection, setSelection] = useState<NavigationData>({
-        pageInterface: pageInterface ?? rootInterface,
-        pathname: location?.pathname ?? basePath,
-        hash: location?.hash.substring(1) ?? '',
-        pageTitle: pageTitle ?? { name: rootInterface },
-    });
+    const location = useApiReferenceLocation();
+    const [selection, setSelection] = useState<NavigationData>(
+        () =>
+            readSelection() ?? {
+                pageInterface: pageInterface ?? rootInterface,
+                pathname: location?.pathname ?? basePath,
+                hash: location?.hash.substring(1) ?? '',
+                pageTitle: pageTitle ?? { name: rootInterface },
+            }
+    );
 
     useEffect(() => {
-        navigate({ pathname: location?.pathname, hash: location?.hash }, { state: selection, replace: true });
+        seedSelection(selection);
     }, []);
 
-    useHistory(({ location: historyLocation, action }) => {
-        if (action === Action.Pop && historyLocation.state) {
-            setSelection(historyLocation.state as NavigationData);
+    /*
+        The island is persisted across Astro navigations, so props stay at whatever the first-loaded
+        page supplied. Every entry this app creates carries its selection in Astro's history state,
+        which makes that state — not props — the thing to follow on back/forward.
+    */
+    useEffect(() => {
+        const restored = readSelection();
+        if (restored) {
+            setSelection(restored);
         }
-    });
+    }, [location]);
 
     if (!reference) return null;
 

--- a/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { navigate, scrollIntoView, scrollIntoViewById, useLocation } from '@ag-website-shared/utils/navigation';
+import { scrollIntoView, scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import type {
     ApiReferenceNode,
     ApiReferenceType,
@@ -42,6 +42,7 @@ import {
     normalizeType,
     processMembers,
 } from '../apiReferenceHelpers';
+import { navigateToSelection, useApiReferenceLocation } from '../apiReferenceRouting';
 import { ApiReferenceConfigContext, ApiReferenceContext } from './ApiReference';
 import styles from './OptionsNavigation.module.scss';
 import { SearchBox } from './SearchBox';
@@ -62,7 +63,7 @@ export function OptionsNavigation({
     breadcrumbs: string[];
     rootInterface: string;
 }) {
-    const location = useLocation();
+    const location = useApiReferenceLocation();
     const elementRef = useRef<HTMLDivElement>(null);
     const selection = useContext(SelectionContext);
     const reference = useContext(ApiReferenceContext);
@@ -99,7 +100,7 @@ export function OptionsNavigation({
             selection?.setSelection(navData); // trigger change for highlighting selection
         } else {
             selection?.setSelection(navData);
-            navigate(navData, { state: navData });
+            navigateToSelection(navData);
         }
     };
 
@@ -120,7 +121,7 @@ export function OptionsNavigation({
                     onItemClick={(data) => {
                         const navData = getNavigationDataFromPath(data.navPath, config.specialTypes);
                         selection?.setSelection(navData);
-                        navigate(navData, { state: navData });
+                        navigateToSelection(navData);
                     }}
                 />
             </header>
@@ -178,7 +179,7 @@ function NavProperty({
     const selection = useContext(SelectionContext);
     const reference = useContext(ApiReferenceContext);
     const config = useContext(ApiReferenceConfigContext);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     const memberType = getMemberType(member);
     const interfaceRef = reference?.get(memberType);
@@ -520,7 +521,7 @@ function NavBreadcrumb({
         };
         selection?.setSelection(navData);
         window.scrollTo({ behavior: 'smooth', top: 0 });
-        navigate(navData, { state: navData });
+        navigateToSelection(navData);
     };
 
     return (
@@ -622,7 +623,7 @@ function PropertyExpander({ isExpanded, onClick }: { isExpanded?: boolean; onCli
 
 function useAutoExpand(shouldExpand: () => boolean): [boolean, () => void] {
     const [isExpanded, toggleExpanded, setExpanded] = useToggle(shouldExpand);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     useEffect(() => {
         if (!isExpanded) {

--- a/packages/ag-charts-website/src/components/api-documentation/components/OptionsReferenceFallback.astro
+++ b/packages/ag-charts-website/src/components/api-documentation/components/OptionsReferenceFallback.astro
@@ -34,55 +34,112 @@ const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
     signatures remain client-rendered.
 */
 }
-<div class="options-reference-fallback">
-    <header>
-        <h1 class="text-3xl">
-            {
-                title.type ? (
-                    <>
-                        {title.name}
-                        {title.name === 'axes' && <span class="record-alias">.key</span>}[type='
-                        <span class="union-discriminator">{title.type}</span>']
-                    </>
-                ) : (
-                    title.name
-                )
-            }
-        </h1>
-        {description && <p class="text-secondary">{description}</p>}
-    </header>
+<div class="options-reference-fallback layout-grid">
+    {
+        /* Empty column reserving the left-nav width, so the property content lands at the same
+        x-position as the hydrated layout and the navigation tree fills into reserved space
+        without shifting the page horizontally on hydration. */
+    }
+    <div class="nav-placeholder" aria-hidden="true"></div>
 
-    <dl class="reference-list">
-        {
-            members.map((member) => {
-                const memberDocs = parseJsDocs(member.docs);
-                return (
-                    <div class="reference-row" id={`reference-${id}-${member.name}`}>
-                        <dt>
-                            <span class="property-name">{cleanupName(member.name)}</span>
-                            {!member.optional && <span class="required">required</span>}
-                            <code class="property-type">{normalizeType(member.type)}</code>
-                            {member.defaultValue != null && (
-                                <span class="property-default">default: {member.defaultValue}</span>
-                            )}
-                        </dt>
-                        {memberDocs && <dd class="text-secondary">{memberDocs}</dd>}
-                    </div>
-                );
-            })
-        }
-    </dl>
+    <div class="reference-content">
+        <header>
+            <h1 class="text-3xl">
+                {
+                    title.type ? (
+                        <>
+                            {title.name}
+                            {title.name === 'axes' && <span class="record-alias">.key</span>}[type='
+                            <span class="union-discriminator">{title.type}</span>']
+                        </>
+                    ) : (
+                        title.name
+                    )
+                }
+            </h1>
+            {description && <p class="text-secondary">{description}</p>}
+        </header>
+
+        <dl class="reference-list">
+            {
+                members.map((member) => {
+                    const memberDocs = parseJsDocs(member.docs);
+                    return (
+                        <div class="reference-row" id={`reference-${id}-${member.name}`}>
+                            <dt>
+                                <span class="property-name">{cleanupName(member.name)}</span>
+                                {!member.optional && <span class="required">required</span>}
+                                <code class="property-type">{normalizeType(member.type)}</code>
+                                {member.defaultValue != null && (
+                                    <span class="property-default">default: {member.defaultValue}</span>
+                                )}
+                            </dt>
+                            {memberDocs && <dd class="text-secondary">{memberDocs}</dd>}
+                        </div>
+                    );
+                })
+            }
+        </dl>
+    </div>
 </div>
 
 <style lang="scss">
     @use 'design-system' as *;
 
-    .options-reference-fallback {
-        width: 100%;
-        padding-top: $spacing-size-8;
+    /*
+        Mirror the two-column geometry the hydrated <ApiReferencePage> produces (its
+        `.container.layout-grid` + `.objectViewOuter` + `.referenceOuter`) so the swap from this
+        fallback to the React app does not shift the page horizontally.
+    */
+
+    .nav-placeholder {
+        width: calc(100% + var(--layout-horizontal-margins) * 2);
+        margin-left: calc(var(--layout-horizontal-margins) * -1);
+
+        @media screen and (max-width: $breakpoint-options-medium) {
+            /*
+                Below this breakpoint the navigation tree is hidden and the nav stacks above the
+                content as a single search box. Reserve its height so the content does not drop on
+                hydration: the nav's top padding ($spacing-size-5) plus the search box (its text
+                line-box + vertical padding of $spacing-size-3 + 1px border top and bottom).
+            */
+            min-height: calc(#{$spacing-size-5} + var(--text-fs-base) * var(--text-lh-base) + #{$spacing-size-3} + 2px);
+        }
+
+        @media screen and (min-width: $breakpoint-options-medium) {
+            width: calc(var(--layout-width-4-12) + var(--layout-horizontal-margins));
+            box-shadow: -1px 0 0 0 var(--color-border-primary);
+            border-right: 1px solid var(--color-border-primary);
+        }
+
+        @media screen and (min-width: $breakpoint-options-large) {
+            width: calc(var(--layout-width-3-12) + var(--layout-horizontal-margins));
+        }
+    }
+
+    .reference-content {
+        width: calc(100% + var(--layout-gap) * 2);
+        margin-left: calc(var(--layout-gap) * -1);
+
+        @media screen and (max-width: $breakpoint-options-medium) {
+            /* Below this breakpoint the content spans full width with no negative bleed, matching
+               the hydrated `.referenceOuter`; without this the body sits ~32px too far left (and
+               off-screen) until hydration snaps it back. */
+            margin-left: 0;
+        }
+
+        @media screen and (min-width: $breakpoint-options-medium) {
+            width: var(--layout-width-8-12);
+            margin-left: 0;
+        }
+
+        @media screen and (min-width: $breakpoint-options-large) {
+            width: var(--layout-width-9-12);
+        }
     }
 
     header {
+        padding-top: $spacing-size-8;
         padding-bottom: $spacing-size-6;
         margin-bottom: $spacing-size-4;
         border-bottom: 1px solid var(--color-border-secondary);

--- a/packages/ag-charts-website/src/components/api-documentation/components/OptionsReferenceFallback.astro
+++ b/packages/ag-charts-website/src/components/api-documentation/components/OptionsReferenceFallback.astro
@@ -74,7 +74,9 @@ const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
                                     <span class="property-default">default: {member.defaultValue}</span>
                                 )}
                             </dt>
-                            {memberDocs && <dd class="text-secondary">{memberDocs}</dd>}
+                            {/* Always render the <dd> so every definition-list group has both a
+                                term and a description, even for undocumented members. */}
+                            <dd class="text-secondary">{memberDocs}</dd>
                         </div>
                     );
                 })
@@ -162,6 +164,10 @@ const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
 
         dd {
             margin: $spacing-size-2 0 0;
+
+            &:empty {
+                margin: 0;
+            }
         }
     }
 

--- a/packages/ag-charts-website/src/components/api-documentation/components/OptionsReferenceFallback.astro
+++ b/packages/ag-charts-website/src/components/api-documentation/components/OptionsReferenceFallback.astro
@@ -1,0 +1,133 @@
+---
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import {
+    cleanupName,
+    normalizeType,
+    parseJsDocs,
+    processMembers,
+} from '@components/api-documentation/apiReferenceHelpers';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+interface Props {
+    rootInterface: string;
+    pageInterface?: string;
+    pageTitle?: PageTitle;
+}
+
+const { rootInterface, pageInterface, pageTitle } = Astro.props;
+
+const reference = getInterfacesReference();
+const id = pageInterface ?? rootInterface;
+const pageRef = reference.get(id);
+const interfaceRef = pageRef?.kind === 'interface' ? pageRef : undefined;
+
+const title = pageTitle ?? { name: id };
+const description = interfaceRef && parseJsDocs(interfaceRef.docs);
+const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
+---
+
+{
+    /*
+    Server-rendered reference content for crawlers that don't execute JavaScript. Astro shows this
+    until the interactive <ApiReferencePage> island hydrates and replaces it. Deliberately flat:
+    top-level properties only, so the served HTML stays small (SE-53). Nested children and deep type
+    signatures remain client-rendered.
+*/
+}
+<div class="options-reference-fallback">
+    <header>
+        <h1 class="text-3xl">
+            {
+                title.type ? (
+                    <>
+                        {title.name}
+                        {title.name === 'axes' && <span class="record-alias">.key</span>}[type='
+                        <span class="union-discriminator">{title.type}</span>']
+                    </>
+                ) : (
+                    title.name
+                )
+            }
+        </h1>
+        {description && <p class="text-secondary">{description}</p>}
+    </header>
+
+    <dl class="reference-list">
+        {
+            members.map((member) => {
+                const memberDocs = parseJsDocs(member.docs);
+                return (
+                    <div class="reference-row" id={`reference-${id}-${member.name}`}>
+                        <dt>
+                            <span class="property-name">{cleanupName(member.name)}</span>
+                            {!member.optional && <span class="required">required</span>}
+                            <code class="property-type">{normalizeType(member.type)}</code>
+                            {member.defaultValue != null && (
+                                <span class="property-default">default: {member.defaultValue}</span>
+                            )}
+                        </dt>
+                        {memberDocs && <dd class="text-secondary">{memberDocs}</dd>}
+                    </div>
+                );
+            })
+        }
+    </dl>
+</div>
+
+<style lang="scss">
+    @use 'design-system' as *;
+
+    .options-reference-fallback {
+        width: 100%;
+        padding-top: $spacing-size-8;
+    }
+
+    header {
+        padding-bottom: $spacing-size-6;
+        margin-bottom: $spacing-size-4;
+        border-bottom: 1px solid var(--color-border-secondary);
+    }
+
+    .reference-list {
+        margin: 0;
+    }
+
+    .reference-row {
+        padding: $spacing-size-4 0;
+        border-top: 1px solid var(--color-border-secondary);
+
+        dt {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            gap: $spacing-size-2;
+        }
+
+        dd {
+            margin: $spacing-size-2 0 0;
+        }
+    }
+
+    .property-name {
+        font-weight: var(--text-bold);
+    }
+
+    .property-type {
+        color: var(--color-fg-code);
+    }
+
+    .property-default {
+        color: var(--color-fg-secondary);
+        font-size: var(--text-fs-sm);
+    }
+
+    .required {
+        color: red;
+        font-size: var(--text-fs-sm);
+    }
+
+    .record-alias,
+    .union-discriminator {
+        color: var(--color-fg-code);
+    }
+</style>

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -1,6 +1,6 @@
 ---
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
-import OptionsReferenceFallback from '@components/api-documentation/components/OptionsReferenceFallback.astro';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 ---
 
@@ -22,6 +22,6 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
         }}
         noExpand={['theme']}
     >
-        <OptionsReferenceFallback slot="fallback" rootInterface="AgChartOptions" />
+        <ApiReferenceFallback slot="fallback" rootInterface="AgChartOptions" />
     </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -1,5 +1,6 @@
 ---
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
+import OptionsReferenceFallback from '@components/api-documentation/components/OptionsReferenceFallback.astro';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 ---
 
@@ -20,5 +21,7 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
             AgMiniChartSeriesOptions: 'InterfaceArray',
         }}
         noExpand={['theme']}
-    />
+    >
+        <OptionsReferenceFallback slot="fallback" rootInterface="AgChartOptions" />
+    </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -10,6 +10,8 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
 >
     <ApiReferencePage
         client:only="react"
+        transition:persist="options-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartOptions"
         breadcrumbs={['options']}

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
@@ -1,7 +1,7 @@
 ---
 import { getOptionsStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
-import OptionsReferenceFallback from '@components/api-documentation/components/OptionsReferenceFallback.astro';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
 
@@ -35,7 +35,7 @@ const name = capitalizeFirstLetter(Astro.props?.pageTitle?.name);
             AgMiniChartSeriesOptions: 'InterfaceArray',
         }}
     >
-        <OptionsReferenceFallback
+        <ApiReferenceFallback
             slot="fallback"
             rootInterface="AgChartOptions"
             pageInterface={Astro.props.pageInterface}

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
@@ -24,6 +24,8 @@ const name = capitalizeFirstLetter(Astro.props?.pageTitle?.name);
 >
     <ApiReferencePage
         client:only="react"
+        transition:persist="options-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartOptions"
         breadcrumbs={['options']}

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
@@ -1,6 +1,7 @@
 ---
 import { getOptionsStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
+import OptionsReferenceFallback from '@components/api-documentation/components/OptionsReferenceFallback.astro';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
 
@@ -33,5 +34,12 @@ const name = capitalizeFirstLetter(Astro.props?.pageTitle?.name);
             AgChartSeriesOptions: 'InterfaceArray',
             AgMiniChartSeriesOptions: 'InterfaceArray',
         }}
-    />
+    >
+        <OptionsReferenceFallback
+            slot="fallback"
+            rootInterface="AgChartOptions"
+            pageInterface={Astro.props.pageInterface}
+            pageTitle={Astro.props.pageTitle}
+        />
+    </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/themes-api.astro
+++ b/packages/ag-charts-website/src/pages/themes-api.astro
@@ -1,4 +1,5 @@
 ---
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 ---
@@ -17,5 +18,7 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
         specialTypes={{
             AgBaseChartThemeOverrides: 'NestedPage',
         }}
-    />
+    >
+        <ApiReferenceFallback slot="fallback" rootInterface="AgChartTheme" />
+    </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/themes-api.astro
+++ b/packages/ag-charts-website/src/pages/themes-api.astro
@@ -10,6 +10,8 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
 >
     <ApiReferencePage
         client:only="react"
+        transition:persist="themes-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartTheme"
         breadcrumbs={['options', 'theme']}

--- a/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].astro
+++ b/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].astro
@@ -14,6 +14,8 @@ export async function getStaticPaths() {
 <APIViewLayout title="Themes API">
     <ApiReferencePage
         client:only="react"
+        transition:persist="themes-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartTheme"
         breadcrumbs={['options', 'theme']}

--- a/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].astro
+++ b/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].astro
@@ -1,5 +1,6 @@
 ---
 import { getThemesApiStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
@@ -21,5 +22,12 @@ export async function getStaticPaths() {
         specialTypes={{
             AgBaseChartThemeOverrides: 'NestedPage',
         }}
-    />
+    >
+        <ApiReferenceFallback
+            slot="fallback"
+            rootInterface="AgChartTheme"
+            pageInterface={Astro.props.pageInterface}
+            pageTitle={Astro.props.pageTitle}
+        />
+    </ApiReferencePage>
 </APIViewLayout>


### PR DESCRIPTION
## Summary

Closes the SEO/GEO discovery gap on the ~75 `/charts/options/` API reference pages ([SE-62](https://ag-grid.atlassian.net/browse/SE-62)).

Today these pages render the entire property reference client-side (`<ApiReferencePage client:only="react">` fetching a 3.5MB `resolved-interfaces.json`). The **served HTML has no `<h1>` and no property content** — the reference only exists inside a `<script>` block that JS turns into the page. Googlebot runs JS so pages eventually index, but the first-pass crawl reads an empty page and **most AI assistant crawlers don't run JS at all**, so the API reference is invisible to them.

## Approach

Astro renders `slot="fallback"` content of a `client:only` island into the served HTML and swaps it for the React app on hydration. This PR uses that to inject **real, crawlable content** without touching the React path:

- New **`OptionsReferenceFallback.astro`** — a server-only component that reads the reference via the existing `getInterfacesReference()` and emits the `<h1>`, interface description, and a **flat list of top-level properties** (name, type, default value, description), reusing the existing framework-agnostic helpers (`processMembers`, `normalizeType`, `parseJsDocs`, `cleanupName`).
- Wired into **`options.astro`** and **`options/[...memberName]/[type].astro`** as `slot="fallback"` on the existing island.

**Deep nested type signatures / child properties stay client-rendered** (as guided on the ticket) — this keeps the added HTML small and honours the 2MB target from SE-53.

### Why not full SSR of the React island
Astro serialises island props into the HTML for hydration; passing the 3.5MB reference (or the closure hydration would need) blows the 2MB budget, and partial data causes React hydration mismatches. The fallback slot sidesteps both, and keeps a single data source with no duplication of the recursive React logic.

## Verification

Verified via a direct Astro render (dev server):

- `/options/` served HTML now contains `<h1>AgChartOptions</h1>` + **90 top-level property rows** as real text.
- `/options/axes/radius-number/` renders the correct variant H1 `axes.key[type='radius-number']` + 36 rows.
- The fallback is a direct child of the `<astro-island>` → cleanly replaced by React on hydration (no duplicate content); the client data file serves `200`, so the interactive view renders as before.
- Added content is **~37KB** on the largest page — well under SE-53's 2MB target.
- `nx format` ✅ · `nx lint ag-charts-website` ✅ (0 errors) · no render/hydration warnings.

## Notes / follow-ups

- **`nx build` / `e2e` were not run here** — this checkout has a pre-existing, unrelated failure (`ag-charts-generate-example-files` can't resolve `_ag-charts-test`). Please run e2e in a clean environment before merge.
- Descriptions render as **plain text** in the fallback (no server-side markdown lib exists; `react-markdown` is React-only). Fine for crawlers and keeps the zero-dependency rule; the hydrated React view still renders full markdown.
- SE-62 is currently marked de-scoped on JIRA for "high implementation complexity" — this turned out low-complexity; worth reviving the ticket.