### PR TITLE
fix(community): show unsupported browser overlay for Chrome < 115

### DIFF
--- a/packages/ag-charts-community/src/util/browser.ts
+++ b/packages/ag-charts-community/src/util/browser.ts
@@ -26,8 +26,7 @@ export function isUnsupportedBrowser() {
         if (versionExec == null) return false;
         const version = Number.parseInt(versionExec[1], 10);
 
-        // 127 as that is the minimum version for Playwright e2e tests.
-        const supported = version > 126;
+        const supported = version >= 115;
 
         if (!supported) {
             Logger.default.warnOnce(`Unsupported Chrome version: ${version}; ${userAgent}`);


### PR DESCRIPTION
## Summary

Updates the "unsupported browser" overlay so it shows for Chrome versions below 115, as requested.

Previously the Chrome support threshold was set to `> 126` (unsupported for anything below Chrome 127, a value that was pinned to the minimum version used by the Playwright e2e tests). This change lowers the threshold so that only Chrome versions **below 115** are flagged as unsupported.

## Changes

- `packages/ag-charts-community/src/util/browser.ts`: Chrome support check changed from `version > 126` to `version >= 115`.

## Impact

- Chrome 115+ is now treated as a supported browser and will no longer trigger the unsupported-browser overlay or the `warnOnce` log.
- The Playwright e2e suite runs Chrome 127+, which remains ≥ 115, so tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXGj3xySS7RRwv1i98bHb)_