### PR TITLE
Add async non-gating snapshot-review job to CI

### DIFF
--- a/.github/actions/snapshot-review-run/action.yml
+++ b/.github/actions/snapshot-review-run/action.yml
@@ -1,0 +1,130 @@
+name: Snapshot Review Run
+description: >-
+    Generate the asynchronous /snapshot-review reports for a PR and write the `snapshot-review`
+    section fragment for the consolidated PR comment. Produces up to two reports: "current PR
+    state" (committed baselines vs the merge-base with the base branch) and, when CI regenerated
+    baselines onto the snapshot branch, "regenerated" (committed baselines vs the snapshot branch).
+    Pixel review is the backbone; scene-graph review is attempted best-effort and skipped cleanly
+    when the CI scene captures are unavailable. Never fails the caller — this is advisory only.
+
+inputs:
+    snapshot_branch:
+        description: 'The gha/snapshots-<head-ref> branch name (from the init job).'
+        required: true
+    base_branch:
+        description: 'Base branch to diff the current PR state against.'
+        required: false
+        default: latest
+    scripts_root:
+        description: 'Directory containing the installed snapshot-review scripts.'
+        required: false
+        default: .ag-dev-prompts/node_modules/@ag-grid/dev-prompts/plugins/ag-eng/skills/snapshot-review
+    github_token:
+        description: 'Token for gh (scene-fetch downloads CI artifacts).'
+        required: true
+
+outputs:
+    html_dir:
+        description: 'Directory holding the generated HTML report(s), for artifact upload.'
+        value: ${{ steps.run.outputs.html_dir }}
+    produced:
+        description: "'true' when a snapshot-review section was written."
+        value: ${{ steps.run.outputs.produced }}
+
+runs:
+    using: composite
+    steps:
+        - name: Generate snapshot-review reports
+          id: run
+          shell: bash
+          env:
+              SNAPSHOT_BRANCH: ${{ inputs.snapshot_branch }}
+              BASE_BRANCH: ${{ inputs.base_branch }}
+              SCRIPTS: ${{ inputs.scripts_root }}
+              GH_TOKEN: ${{ inputs.github_token }}
+              # Point the run's artifacts page from inside the section text.
+              RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          run: |
+              set -uo pipefail
+
+              COLLECT="${SCRIPTS}/snapshot-collect.sh"
+              REPORT="${SCRIPTS}/snapshot-report.py"
+              WORK="${RUNNER_TEMP}/snapreview"
+              HTML_DIR="${WORK}/html"
+              SECTIONS="${RUNNER_TEMP}/pr-sections"
+              mkdir -p "$HTML_DIR" "$SECTIONS"
+              echo "html_dir=${HTML_DIR}" >> "$GITHUB_OUTPUT"
+              echo "produced=false" >> "$GITHUB_OUTPUT"
+
+              if [[ ! -f "$COLLECT" || ! -f "$REPORT" ]]; then
+                  echo "::warning::snapshot-review scripts not found under ${SCRIPTS}; skipping."
+                  exit 0
+              fi
+
+              # PNG families: unit image snapshots (__image_snapshots__) and e2e/package (*-snapshots).
+              # These are git pathspecs — '*' matches '/', so they scope to the two snapshot dir shapes.
+              INCLUDES=(--include '*__image_snapshots__/*.png' --include '*-snapshots/*.png')
+
+              # Build one report; append its summary to the section body. Args: <label> <before> <after> <slug>
+              SECTION="${SECTIONS}/25-snapshot-review.md"
+              : > "${WORK}/section-body.md"
+              ANY=0
+
+              build_report() {
+                  local label="$1" before="$2" after="$3" slug="$4"
+                  local dir="${WORK}/${slug}"
+                  mkdir -p "$dir"
+                  echo "--- ${label}: collecting ${before}...${after}" >&2
+                  bash "$COLLECT" --before "$before" --after "$after" --out "$dir" "${INCLUDES[@]}" >&2 || {
+                      echo "::warning::collect failed for ${label}; skipping."; return 1; }
+
+                  # Skip a report with no changed images (keeps the section relevant, not noisy).
+                  if [[ ! -s "${dir}/diffs.tsv" ]]; then
+                      echo "--- ${label}: no changed snapshots" >&2
+                      return 1
+                  fi
+
+                  local html="${HTML_DIR}/snapshot-${slug}.html"
+                  local md="${dir}/summary.md"
+                  if ! python3 "$REPORT" --in "$dir" --out "$html" --summary-md "$md" \
+                        --title "Snapshot review — ${label}" >&2; then
+                      echo "::warning::report builder failed for ${label} (needs --summary-md support); skipping."
+                      return 1
+                  fi
+
+                  {
+                      echo "### ${label}"
+                      echo
+                      cat "$md"
+                      echo
+                      echo "[Full interactive report: \`snapshot-${slug}.html\` in run artifacts](${RUN_URL}#artifacts)"
+                      echo
+                  } >> "${WORK}/section-body.md"
+                  ANY=1
+                  return 0
+              }
+
+              # Report A — current PR state: merge-base(base, HEAD) .. HEAD (committed baselines).
+              git fetch --no-tags --quiet origin "$BASE_BRANCH" || true
+              MB="$(git merge-base "origin/${BASE_BRANCH}" HEAD 2>/dev/null || true)"
+              if [[ -n "$MB" ]]; then
+                  build_report "Current PR state" "$MB" "HEAD" "current" || true
+              else
+                  echo "::warning::could not resolve merge-base with ${BASE_BRANCH}; skipping current-state report."
+              fi
+
+              # Report B — regenerated snapshots: HEAD .. gha/snapshots-<head-ref> (when CI pushed to it).
+              if [[ -n "${SNAPSHOT_BRANCH}" ]] && git ls-remote --exit-code --heads origin "${SNAPSHOT_BRANCH}" >/dev/null 2>&1; then
+                  git fetch --no-tags --force --quiet origin "${SNAPSHOT_BRANCH}:refs/snap/review" || true
+                  if git rev-parse --verify --quiet refs/snap/review >/dev/null; then
+                      build_report "Regenerated by CI" "HEAD" "refs/snap/review" "regenerated" || true
+                  fi
+              fi
+
+              if [[ "$ANY" -eq 1 ]]; then
+                  { echo '## Snapshot review'; echo; cat "${WORK}/section-body.md"; } > "$SECTION"
+                  echo "produced=true" >> "$GITHUB_OUTPUT"
+                  echo "Wrote ${SECTION}"
+              else
+                  echo "No snapshot changes to review; no section written."
+              fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1018,7 +1018,12 @@ jobs:
               with:
                   pr_number: ${{ github.event.pull_request.number }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-                  remove_sections: ${{ steps.snapshot-notify.outputs.updated != 'true' && 'snapshot-status' || '' }}
+                  # Clear snapshot-status when snapshots weren't regenerated, and clear snapshot-review
+                  # when full CI (hence the snapshot_review job) didn't run — the report job is the
+                  # always-running GC point for sections whose producing job was skipped this build.
+                  remove_sections: >-
+                      ${{ steps.snapshot-notify.outputs.updated != 'true' && 'snapshot-status' || '' }}
+                      ${{ needs.detect-changes.outputs.run_full_ci != 'true' && 'snapshot-review' || '' }}
 
             - name: Merge JUnit Report XMLs
               if: needs.test.result != 'skipped' || needs.e2e.result != 'skipped' || needs.demos_e2e.result != 'skipped'
@@ -1279,6 +1284,78 @@ jobs:
               run: |
                   echo "Workflow failed, failing the build."
                   exit 1
+
+    # Asynchronous, NON-GATING snapshot review. Runs the /snapshot-review reports for the PR and
+    # writes the `snapshot-review` section of the consolidated PR comment. `report` does NOT depend
+    # on this job and it must be excluded from branch-protection required checks — merge never waits
+    # on it. `continue-on-error` + `!cancelled()` keep it off the critical path (the snapshot jobs
+    # deliberately exit 1 when they regenerate baselines, so this must tolerate their failure).
+    snapshot_review:
+        runs-on: ubuntu-24.04
+        name: Snapshot Review
+        continue-on-error: true
+        needs: [detect-changes, init, test, e2e, fw_pkg_test]
+        if: |
+            !cancelled() &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            needs.detect-changes.outputs.run_full_ci == 'true'
+        permissions:
+            contents: read
+            pull-requests: write
+            packages: read
+            # scene-graph review (follow-up) downloads CI artifacts via gh — needs actions: read.
+            actions: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Install ImageMagick
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  # snapshot-collect.sh drives ImageMagick via the v7-style `magick <subcommand>`
+                  # entrypoint (`magick identify`, `magick compare`). ubuntu-24.04 ships ImageMagick 6,
+                  # which exposes those as standalone `identify`/`compare` and has no `magick` binary.
+                  # Install v6 and provide a thin shim that dispatches `magick <sub> …` -> `<sub> …`
+                  # (self-contained; no fragile AppImage download).
+                  sudo apt-get update -qq
+                  sudo apt-get install -y -qq imagemagick
+                  printf '#!/usr/bin/env bash\nexec "$@"\n' | sudo tee /usr/local/bin/magick >/dev/null
+                  sudo chmod +x /usr/local/bin/magick
+                  magick identify -version | head -1
+
+            - name: Install @ag-grid/dev-prompts
+              uses: ./external/ag-shared/github/actions/install-ag-dev-prompts
+              with:
+                  channel: canary
+
+            - name: Generate snapshot-review reports
+              id: review
+              uses: ./.github/actions/snapshot-review-run
+              with:
+                  snapshot_branch: ${{ needs.init.outputs.snapshot_branch }}
+                  base_branch: ${{ github.base_ref }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Upload snapshot-review HTML reports
+              if: steps.review.outputs.produced == 'true'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: snapshot-review-html
+                  path: ${{ steps.review.outputs.html_dir }}/*.html
+                  if-no-files-found: ignore
+
+            # Upsert the snapshot-review section when reports were produced; otherwise clear any
+            # stale section from an earlier push (snapshots since fixed / no longer changed).
+            - name: Upsert snapshot-review section
+              uses: ./.github/actions/pr-report-comment
+              with:
+                  pr_number: ${{ github.event.pull_request.number }}
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  remove_sections: ${{ steps.review.outputs.produced != 'true' && 'snapshot-review' || '' }}
 
     sonarqube:
         # Org-scoped GHA variable kill-switch: set SONARCLOUD_ENABLED=false to


### PR DESCRIPTION
Stacked on #7510 (the consolidated PR-comment framework). Adds an **async, non-gating** `snapshot_review` CI job that runs `/snapshot-review` pixel reports and writes the `snapshot-review` section of the consolidated comment — off the merge-gating critical path.

**What it does**
- New `.github/actions/snapshot-review-run`: drives `snapshot-collect` + `snapshot-report` (from the installed `@ag-grid/dev-prompts` package) to produce up to two reports — *current PR state* (merge-base vs HEAD) and *regenerated by CI* (HEAD vs the snapshot branch) — each an HTML artifact + a markdown summary.
- New `snapshot_review` job: `continue-on-error` + `!cancelled()`, NOT in `report.needs`. **Must be excluded from branch-protection required checks** so it never gates merge. Installs ImageMagick 7 + `@ag-grid/dev-prompts@canary`.
- Self-clears its section when there are no changes (uses the `remove_sections` support added in #7510).

**Dependencies / notes**
- Requires the `snapshot-report.py --summary-md` mode — **merged to canary in ag-dev-prompts#626**; needs the canary republish to have landed for CI to run fully green.
- **Scene-graph review is not yet wired** (the in-run `scene-fetch` run-resolution is circular mid-run); pixel review is the backbone. Scene is a follow-up.
- Draft until #7510 merges and the canary package is confirmed available.