### PR TITLE
AG-17637 [CLAUDE] Match reversed-axis picked index to label formatter

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1253,8 +1253,14 @@ export abstract class Axis<
         return result;
     }
 
-    protected setPickTickData(ticks: readonly { readonly index: number; readonly translation: number }[]): void {
-        this.pickTickData = ticks.map(({ index, translation }) => ({ index, translation }));
+    protected setPickTickData(
+        ticks: readonly { readonly index: number; readonly translation: number }[],
+        firstTickIndex = 0
+    ): void {
+        // A picked value's index must match what the axis label formatter reports for the same tick. The
+        // formatter numbers ticks by their 0-based position among the generated ticks, whereas TickDatum.index
+        // is the absolute index (offset by firstTickIndex on reversed/zoomed axes), so subtract it here.
+        this.pickTickData = ticks.map(({ index, translation }) => ({ index: index - firstTickIndex, translation }));
     }
 
     /**

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.test.ts
@@ -1414,4 +1414,68 @@ describe('CartesianAxis', () => {
             expect(bottomAxisLabelNodes()).toHaveLength(0);
         });
     });
+
+    describe('AG-17637 picked index matches the label formatter index', () => {
+        const REVERSE_DATA = [
+            { category: 'Jan', value: 8 },
+            { category: 'Mar', value: 6 },
+            { category: 'Jun', value: 18 },
+            { category: 'Aug', value: 14 },
+        ];
+
+        // Drive the real label formatter and record the index it reports for each tick value (last write wins,
+        // since the formatter runs once per layout pass).
+        const formatterIndexByValue = new Map<number, number>();
+        const baseOptions = (reverse: boolean): AgCartesianChartOptions => ({
+            data: REVERSE_DATA,
+            series: [{ type: 'line', xKey: 'category', yKey: 'value' }],
+            axes: {
+                x: { type: 'category', position: 'bottom' },
+                y: {
+                    type: 'number',
+                    position: 'left',
+                    reverse,
+                    label: {
+                        formatter: (p) => {
+                            formatterIndexByValue.set(p.value, p.index);
+                            return String(p.value);
+                        },
+                    },
+                },
+            },
+        });
+
+        beforeEach(() => formatterIndexByValue.clear());
+
+        const expectPickIndexMatchesFormatter = async (reverse: boolean) => {
+            const options = baseOptions(reverse);
+            prepareTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            const chartInstance = deproxy(chart as any) as any;
+            const yAxis = chartInstance.axes.find((axis: any) => axis.position === 'left');
+            expect(yAxis).toBeDefined();
+            expect(formatterIndexByValue.size).toBeGreaterThan(0);
+
+            for (const [value, formatterIndex] of formatterIndexByValue) {
+                const pick = yAxis.pickValue({ currentX: 0, currentY: yAxis.scale.convert(value) });
+                expect(pick).toBeDefined();
+                expect(pick.index).toBe(formatterIndex);
+            }
+        };
+
+        it('matches for a normal axis', async () => {
+            await expectPickIndexMatchesFormatter(false);
+        });
+
+        it('matches for a reversed axis', async () => {
+            await expectPickIndexMatchesFormatter(true);
+
+            // Guard the concrete regression: on the reversed axis the lowest-value tick must still be index 0,
+            // not the negative offset (i + rawFirstTickIndex) the pick previously returned.
+            const [minValue] = [...formatterIndexByValue.keys()].sort((a, b) => a - b);
+            expect(formatterIndexByValue.get(minValue)).toBe(0);
+        });
+    });
 });

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -396,9 +396,18 @@ export abstract class CartesianAxis<
             }
         }
 
-        const { ticks, tickDomain, rawTicks, rawTickCount, fractionDigits, timeInterval, niceDomain } = tickData;
+        const {
+            ticks,
+            tickDomain,
+            rawTicks,
+            rawTickCount,
+            fractionDigits,
+            timeInterval,
+            niceDomain,
+            rawFirstTickIndex,
+        } = tickData;
 
-        this.setPickTickData(ticks);
+        this.setPickTickData(ticks, rawFirstTickIndex);
 
         const labels = ticks.map((d) => this.getTickLabelProps(d, tickGenerationResult, scrollbarThickness));
 

--- a/packages/ag-charts-community/src/chart/axis/generateTicks.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.ts
@@ -96,6 +96,7 @@ export function generateTicks<TScale extends Scale<TDatum, number, TickInterval<
         rawTickCount: undefined,
         timeInterval: undefined,
         fractionDigits: 0,
+        rawFirstTickIndex: 0,
     };
 
     while (labelOverlap && index <= maxIterations) {
@@ -234,6 +235,7 @@ function buildTickData<TScale extends Scale<TDatum, number, TickInterval<TScale>
             rawTickCount,
             fractionDigits,
             timeInterval,
+            rawFirstTickIndex: rawFirstTickIndex ?? 0,
             ticks: formatTicks(options, {
                 niceDomain,
                 rawTicks,

--- a/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicksUtils.ts
@@ -98,6 +98,9 @@ export interface TickData<D = any> {
     fractionDigits: number;
     ticks: TickDatum[];
     timeInterval: AnyTimeInterval | undefined;
+    // Absolute index of the first generated tick. TickDatum.index is offset by this (non-zero on
+    // reversed/zoomed axes), so subtract it to recover the 0-based index the label formatter reports.
+    rawFirstTickIndex: number;
 }
 
 enum ParentLevelMode {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17637

On a reversed axis the picked value's index (used by the `showOn: 'axis'` context menu) disagreed with the axis label formatter for the same tick: the formatter numbers ticks by their 0-based position while the pick used the absolute `TickDatum.index`, which is offset by `rawFirstTickIndex` (-6 on a reversed axis). Right-clicking reported e.g. value 6 as index -6 and value 18 as index 0, instead of 0 and 6.

Thread `rawFirstTickIndex` through `TickData` to `Axis.setPickTickData`, which now subtracts it so the picked index matches the formatter. This is a no-op for normal, unzoomed axes (offset 0) and also corrects the same divergence on zoomed axes. `TickDatum.index` is left unchanged so grid-line and grid-fill striping (which wants the absolute, scroll-stable index) is unaffected.

Add a unit test driving the real `label.formatter` and asserting `pickValue().index` matches it on both normal and reversed axes.

Crosshair `index: NaN` is out of scope and left for a separate ticket.