### PR TITLE
AG-17776 [CLAUDE] Keep axis resize cursor after releasing drag over axis

### DIFF
--- a/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoom.ts
@@ -102,6 +102,7 @@ export class Zoom extends AbstractModuleInstance {
     private readonly buttons: ZoomToolbar;
 
     private hoveredAxisId?: AxisID;
+    private hoveredAxisDirection?: ChartAxisDirection;
 
     // State
     private dragState = DragState.None;
@@ -422,9 +423,20 @@ export class Zoom extends AbstractModuleInstance {
     }
 
     private onAxisMouseEnter(event: _ModuleSupport.ZoomInteractionAxisMouseEvent<'mouseenter'>) {
-        const { anchorPointX, anchorPointY, axisDraggingMode, enabled, enableAxisDragging } = this.opts;
-
         this.hoveredAxisId = event.axisId;
+        this.hoveredAxisDirection = event.direction;
+        this.updateAxisCursor(event.direction, event);
+    }
+
+    // Computes and applies the axis-hover cursor (ew/ns-resize, or grab in pan mode). Extracted from the
+    // mouseenter handler so it can also be re-applied on drag end: releasing the mouse while still hovering
+    // the axis must keep the resize cursor, but no fresh `mouseenter` fires because the pointer never left
+    // the axis region. The optional `event` is only present on the mouseenter path.
+    private updateAxisCursor(
+        direction: ChartAxisDirection,
+        event?: _ModuleSupport.ZoomInteractionAxisMouseEvent<'mouseenter'>
+    ) {
+        const { anchorPointX, anchorPointY, axisDraggingMode, enabled, enableAxisDragging } = this.opts;
 
         if (!enabled || !enableAxisDragging) {
             this.ctx.domManager.updateCursor(CURSOR_ID);
@@ -436,7 +448,7 @@ export class Zoom extends AbstractModuleInstance {
         let cursor: BaseStyleTypeMap['cursor'];
         let showCursor = false;
 
-        if (event.direction === ChartAxisDirection.X) {
+        if (direction === ChartAxisDirection.X) {
             cursor = 'ew-resize';
             showCursor = !isNumberEqual(dx(zoom), UNIT_SIZE);
 
@@ -461,7 +473,7 @@ export class Zoom extends AbstractModuleInstance {
         }
 
         if (showCursor) {
-            event.stopProcessing();
+            event?.stopProcessing();
             this.ctx.domManager.updateCursor(CURSOR_ID, cursor);
         } else {
             this.ctx.domManager.updateCursor(CURSOR_ID);
@@ -470,6 +482,7 @@ export class Zoom extends AbstractModuleInstance {
 
     private onAxisMouseLeave() {
         this.hoveredAxisId = undefined;
+        this.hoveredAxisDirection = undefined;
         this.ctx.domManager.updateCursor(CURSOR_ID);
 
         const { enabled, enableAxisDragging } = this.opts;
@@ -570,7 +583,15 @@ export class Zoom extends AbstractModuleInstance {
         }
 
         axisDragger.stop();
-        domManager.updateCursor(CURSOR_ID);
+        // The pointer never left the axis region during the drag, so no `mouseenter` will re-fire to restore
+        // the hover cursor. Re-apply it here when still hovering an axis; otherwise clear it. In the released-
+        // off-axis case `hoveredAxisId` may momentarily be stale, but the drag machinery synthesises a
+        // `mouseleave` immediately after this handler, which clears it again.
+        if (this.hoveredAxisId != null && this.hoveredAxisDirection != null) {
+            this.updateAxisCursor(this.hoveredAxisDirection);
+        } else {
+            domManager.updateCursor(CURSOR_ID);
+        }
         tooltipManager.removeTooltip(TOOLTIP_ID);
     }
 

--- a/packages/ag-charts-website/e2e/zoom.spec.ts
+++ b/packages/ag-charts-website/e2e/zoom.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from './fixture';
 import { expectChartScreenshot } from './scene-capture';
 import {
     SELECTORS,
+    canvasToPageTransformer,
     delay,
     dragCanvas,
     gotoExample,
@@ -145,6 +146,39 @@ test.describe('zoom', () => {
         await expectChartScreenshot(page, page, 'zoom-axis-overlap-axis-does-drag-without-highlight.png', {
             animations: 'disabled',
         });
+    });
+
+    test('axis drag keeps the resize cursor when released over the axis', async ({ page }) => {
+        const { url } = toExamplePageUrl('zoom-e2e', 'zoom-crosshairs', 'vanilla');
+
+        await gotoExample(page, url);
+
+        const { width, height } = await locateCanvas(page);
+        const toPage = await canvasToPageTransformer(page);
+        const wrapper = page.locator('.ag-charts-wrapper');
+        const readCursor = () => wrapper.evaluate((el) => getComputedStyle(el).cursor);
+
+        // Locate the x-axis band by hovering upward from the bottom until the resize cursor appears,
+        // rather than hard-coding an offset that depends on the axis label geometry.
+        const centreX = Math.round(width / 2);
+        let axisY = -1;
+        for (let y = height - 6; y > height - 70; y -= 4) {
+            const p = toPage(centreX, y);
+            await page.mouse.move(p.x, p.y);
+            await delay(60);
+            if ((await readCursor()) === 'ew-resize') {
+                axisY = y;
+                break;
+            }
+        }
+        expect(axisY).toBeGreaterThan(0);
+
+        // Drag the x-axis and release the mouse while it is still over the axis.
+        await dragCanvas(page, { x: Math.round(width * 0.7), y: axisY }, { x: Math.round(width * 0.4), y: axisY });
+        await waitForAllChartUpdates(page);
+
+        // The pointer never left the axis, so the ew-resize cursor must remain after release.
+        await expect(wrapper).toHaveCSS('cursor', 'ew-resize');
     });
 
     test('AG-13166 zoom keynav focus-visible', async ({ page }) => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17776

Releasing an axis drag while the pointer was still over the axis cleared the ew-resize/ns-resize cursor. onAxisDragEnd unconditionally cleared the zoom cursor, and because the pointer never left the axis region no fresh mouseenter fired to restore it.

Extract the hover-cursor computation from onAxisMouseEnter into updateAxisCursor(direction) and track the hovered axis direction alongside hoveredAxisId. On drag end, re-apply the hover cursor when still hovering an axis instead of clearing it. Recomputing (rather than merely skipping the clear) reproduces exactly what a fresh hover would decide, so a drag that ends fully unzoomed still clears correctly.

Add a self-calibrating Playwright e2e regression test that drags the x-axis and asserts the resize cursor remains after release. The JSDOM unit harness cannot cover this: its zero-size getBoundingClientRect makes the drag layer always synthesise a mouseenter that re-sets the cursor, masking the regression.