### PR TITLE
AG-17263 [CLAUDE] Restore org-chart Enter/Space expand/collapse when clickToExpand

### DIFF
--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.test.ts
@@ -1769,6 +1769,24 @@ describe('OrganizationSeries', () => {
             seriesArea.dispatchEvent(new KeyboardEvent('keydown', { key, code: key, bubbles: true }));
         }
 
+        function pressKeyOnSeriesArea(key: string, code: string) {
+            const seriesArea = document.querySelector<HTMLElement>('.ag-charts-series-area');
+            if (!seriesArea) throw new Error('series-area element not found');
+            seriesArea.dispatchEvent(new KeyboardEvent('keydown', { key, code, bubbles: true }));
+        }
+
+        async function setupChartWithClickToExpand(clickToExpand: boolean) {
+            const baseSeries = (SIMPLE_ORG_CHART.series as any)[0];
+            const options: AgChartOptions = {
+                ...SIMPLE_ORG_CHART,
+                series: [{ ...baseSeries, node: { ...baseSeries.node, clickToExpand } }],
+            };
+            prepareEnterpriseTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+            return deproxy(chart).ctx.collapsedManager;
+        }
+
         it('announces a parent node identity-first with level, position, and expanded state', async () => {
             await setupChart();
             // Default focus sits on the root (ceo); ArrowDown moves to its first child (cto).
@@ -1776,7 +1794,7 @@ describe('OrganizationSeries', () => {
             await waitForChartStability(chart);
             // Identity-first ordering matches WAI-ARIA tree conventions: name before metadata.
             expect(readLiveAnnouncement()).toBe(
-                'Bob Smith, Chief Technology Officer, London, level 2, 1 of 2, expanded, 2 children. Press ALT UP to collapse this node'
+                'Bob Smith, Chief Technology Officer, London, level 2, 1 of 2, expanded, 2 children. Press ALT UP to collapse this node. Press Space or Enter to expand or collapse this node'
             );
         });
 
@@ -1803,7 +1821,7 @@ describe('OrganizationSeries', () => {
             pressArrowOnSeriesArea('ArrowRight');
             await waitForChartStability(chart);
             expect(readLiveAnnouncement()).toBe(
-                'Carol Wu, Chief Financial Officer, London, level 2, 2 of 2, expanded, 1 child. Press ALT UP to collapse this node'
+                'Carol Wu, Chief Financial Officer, London, level 2, 2 of 2, expanded, 1 child. Press ALT UP to collapse this node. Press Space or Enter to expand or collapse this node'
             );
         });
 
@@ -1815,8 +1833,58 @@ describe('OrganizationSeries', () => {
             pressArrowOnSeriesArea('ArrowDown');
             await waitForChartStability(chart);
             expect(readLiveAnnouncement()).toBe(
-                'Bob Smith, Chief Technology Officer, London, level 2, 1 of 2, collapsed, 2 children. Press ALT DOWN to expand this node'
+                'Bob Smith, Chief Technology Officer, London, level 2, 1 of 2, collapsed, 2 children. Press ALT DOWN to expand this node. Press Space or Enter to expand or collapse this node'
             );
+        });
+
+        // AG-17263 regression: Alt+Up/Down keybindings were added but Enter/Space toggling was lost.
+        // With clickToExpand enabled (the default) Enter/Space must still expand/collapse the node.
+        it('Enter toggles the focused parent node when clickToExpand is enabled', async () => {
+            const collapsedManager = await setupChartWithClickToExpand(true);
+            // ceo → cto (a parent node).
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            expect(collapsedManager.isCollapsed('cto')).toBe(false);
+
+            pressKeyOnSeriesArea('Enter', 'Enter');
+            await waitForChartStability(chart);
+            expect(collapsedManager.isCollapsed('cto')).toBe(true);
+
+            pressKeyOnSeriesArea('Enter', 'Enter');
+            await waitForChartStability(chart);
+            expect(collapsedManager.isCollapsed('cto')).toBe(false);
+        });
+
+        it('Space toggles the focused parent node when clickToExpand is enabled', async () => {
+            const collapsedManager = await setupChartWithClickToExpand(true);
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            expect(collapsedManager.isCollapsed('cto')).toBe(false);
+
+            pressKeyOnSeriesArea(' ', 'Space');
+            await waitForChartStability(chart);
+            expect(collapsedManager.isCollapsed('cto')).toBe(true);
+        });
+
+        it('Enter does not toggle a node when clickToExpand is disabled', async () => {
+            const collapsedManager = await setupChartWithClickToExpand(false);
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            expect(collapsedManager.isCollapsed('cto')).toBe(false);
+
+            pressKeyOnSeriesArea('Enter', 'Enter');
+            await waitForChartStability(chart);
+            // clickToExpand off → Enter/Space are inert; use Alt+Up/Down instead.
+            expect(collapsedManager.isCollapsed('cto')).toBe(false);
+        });
+
+        it('omits the Enter/Space instruction from announcements when clickToExpand is disabled', async () => {
+            await setupChartWithClickToExpand(false);
+            pressArrowOnSeriesArea('ArrowDown');
+            await waitForChartStability(chart);
+            const announcement = readLiveAnnouncement();
+            expect(announcement).toContain('Press ALT UP to collapse this node');
+            expect(announcement).not.toContain('Press Space or Enter');
         });
     });
 

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -388,11 +388,13 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         }
     }
 
-    // Keyboard activations have no pointer target — allow them; pointer clicks must hit the expander.
+    // A pointer click toggles collapse only when it lands on the expander pill; `clickToExpand`
+    // widens that to the whole card. Keyboard Enter/Space activations arrive with no pointer target,
+    // so they toggle exactly when `clickToExpand` is enabled — restoring the pre-Alt+Up/Down behaviour.
     override hasBuiltinListener(target: _ModuleSupport.Node<unknown> | undefined): boolean {
         const { clickToExpand } = this.properties.node;
         const Expander: number = OrganizationNodeTag.Expander;
-        return target != null && (target.tag === Expander || clickToExpand);
+        return target?.tag === Expander || clickToExpand;
     }
 
     override pickFocus(opts: _ModuleSupport.PickFocusInputs): _ModuleSupport.PickFocusOutputs | undefined {
@@ -458,9 +460,14 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         const itemId = vertex.value as string;
         const isCollapsed = this.ctx.collapsedManager.isCollapsed(itemId);
         const collapsedState = this.ctx.localeManager.t(isCollapsed ? 'ariaOrgChartCollapsed' : 'ariaOrgChartExpanded');
-        const instruction = this.ctx.localeManager.t(
-            isCollapsed ? 'ariaDescriptionExpandNode' : 'ariaDescriptionCollapseNode'
-        );
+        // Alt+Down/Up always toggle a node, so advertise them unconditionally. Enter/Space only
+        // toggle when `clickToExpand` is enabled (see `hasBuiltinListener`), so only mention them then.
+        const instructions = [
+            this.ctx.localeManager.t(isCollapsed ? 'ariaDescriptionExpandNode' : 'ariaDescriptionCollapseNode'),
+        ];
+        if (this.properties.node.clickToExpand) {
+            instructions.push(this.ctx.localeManager.t('ariaDescriptionToggleNode'));
+        }
         // Locale tooling has no `[plural]` annotation, so split the key by child count.
         const key = childCount === 1 ? 'ariaAnnounceOrgChartParentSingular' : 'ariaAnnounceOrgChartParent';
         return {
@@ -472,7 +479,7 @@ export class OrganizationSeries extends AbstractNetworkSeries<
                 childCount,
                 collapsedState,
             }),
-            instructions: [instruction],
+            instructions,
         };
     }
 

--- a/packages/ag-charts-locale/src/ar-EG.ts
+++ b/packages/ag-charts-locale/src/ar-EG.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_AR_EG: Record<string, string> = {
     ariaOrgChartExpanded: 'موسع',
     ariaDescriptionExpandNode: 'اضغط على Alt + السهم لأسفل لتوسيع هذه العقدة',
     ariaDescriptionCollapseNode: 'اضغط على Alt + السهم لأعلى لطي هذه العقدة',
+    ariaDescriptionToggleNode: 'اضغط على Space أو Enter لتوسيع أو طي هذه العقدة',
     ariaAnnounceGaugeChart: 'مخطط المقياس، ${caption}',
     ariaAnnounceHierarchyChart: 'مخطط هرمي، ${caption}',
     ariaAnnounceHierarchyDatum: 'المستوى ${level}[number]، ${count}[number] أطفال، ${description}',

--- a/packages/ag-charts-locale/src/bg-BG.ts
+++ b/packages/ag-charts-locale/src/bg-BG.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_BG_BG: Record<string, string> = {
     ariaOrgChartExpanded: 'разгънато',
     ariaDescriptionExpandNode: 'Натиснете Alt + стрелка надолу, за да разгънете този възел',
     ariaDescriptionCollapseNode: 'Натиснете Alt + стрелка нагоре, за да свиете този възел',
+    ariaDescriptionToggleNode: 'Натиснете Space или Enter, за да разгънете или свиете този възел',
     ariaAnnounceGaugeChart: 'графика тип манометър, ${caption}',
     ariaAnnounceHierarchyChart: 'йерархична диаграма, ${caption}',
     ariaAnnounceHierarchyDatum: 'ниво ${level}[number], ${count}[number] деца, ${description}',

--- a/packages/ag-charts-locale/src/cs-CZ.ts
+++ b/packages/ag-charts-locale/src/cs-CZ.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_CS_CZ: Record<string, string> = {
     ariaOrgChartExpanded: 'rozbalený',
     ariaDescriptionExpandNode: 'Stiskněte Alt + šipku dolů pro rozbalení tohoto uzlu',
     ariaDescriptionCollapseNode: 'Stiskněte Alt + šipku nahoru pro sbalení tohoto uzlu',
+    ariaDescriptionToggleNode: 'Stiskněte Space nebo Enter pro rozbalení nebo sbalení tohoto uzlu',
     ariaAnnounceGaugeChart: 'graf měřidla, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchický graf, ${caption}',
     ariaAnnounceHierarchyDatum: 'úroveň ${level}[number], ${count}[number] děti, ${description}',

--- a/packages/ag-charts-locale/src/da-DK.ts
+++ b/packages/ag-charts-locale/src/da-DK.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_DA_DK: Record<string, string> = {
     ariaOrgChartExpanded: 'udvidet',
     ariaDescriptionExpandNode: 'Tryk på Alt + Pil ned for at udvide denne node',
     ariaDescriptionCollapseNode: 'Tryk på Alt + Pil op for at skjule denne node',
+    ariaDescriptionToggleNode: 'Tryk på Space eller Enter for at udvide eller skjule denne node',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkisk diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] børn, ${description}',

--- a/packages/ag-charts-locale/src/de-DE.ts
+++ b/packages/ag-charts-locale/src/de-DE.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_DE_DE: Record<string, string> = {
     ariaOrgChartExpanded: 'ausgeklappt',
     ariaDescriptionExpandNode: 'Drücken Sie Alt + Pfeil nach unten, um diesen Knoten zu erweitern',
     ariaDescriptionCollapseNode: 'Drücken Sie Alt + Pfeil nach oben, um diesen Knoten zu reduzieren',
+    ariaDescriptionToggleNode: 'Drücken Sie Space oder Enter, um diesen Knoten zu erweitern oder zu reduzieren',
     ariaAnnounceGaugeChart: 'Tachometerdiagramm, ${caption}',
     ariaAnnounceHierarchyChart: 'Hierarchiediagramm, ${caption}',
     ariaAnnounceHierarchyDatum: 'Ebene ${level}[number], ${count}[number] Kinder, ${description}',

--- a/packages/ag-charts-locale/src/el-GR.ts
+++ b/packages/ag-charts-locale/src/el-GR.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_EL_GR: Record<string, string> = {
     ariaOrgChartExpanded: 'αναπτυγμένο',
     ariaDescriptionExpandNode: 'Πατήστε Alt + Κάτω βέλος για ανάπτυξη αυτού του κόμβου',
     ariaDescriptionCollapseNode: 'Πατήστε Alt + Πάνω βέλος για σύμπτυξη αυτού του κόμβου',
+    ariaDescriptionToggleNode: 'Πατήστε Space ή Enter για ανάπτυξη ή σύμπτυξη αυτού του κόμβου',
     ariaAnnounceGaugeChart: 'διάγραμμα δείκτη, ${caption}',
     ariaAnnounceHierarchyChart: 'διάγραμμα ιεραρχίας, ${caption}',
     ariaAnnounceHierarchyDatum: 'επίπεδο ${level}[number], ${count}[number] παιδιά, ${description}',

--- a/packages/ag-charts-locale/src/en-US.ts
+++ b/packages/ag-charts-locale/src/en-US.ts
@@ -35,6 +35,8 @@ export const AG_CHARTS_LOCALE_EN_US: Record<string, string> = {
     ariaDescriptionExpandNode: 'Press ALT DOWN to expand this node',
     // Screen reader description for the keybinding to collapse a node (such as in an Organization chart)
     ariaDescriptionCollapseNode: 'Press ALT UP to collapse this node',
+    // Screen reader description for the Enter/Space keybinding to expand or collapse a node when clickToExpand is enabled
+    ariaDescriptionToggleNode: 'Press Space or Enter to expand or collapse this node',
     // Screen reader description for legend items
     ariaDescriptionLegendItem: 'Press Space or Enter to toggle visibility',
     // Screen reader for the '+' horizontal line button on the Y-axis

--- a/packages/ag-charts-locale/src/es-ES.ts
+++ b/packages/ag-charts-locale/src/es-ES.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_ES_ES: Record<string, string> = {
     ariaOrgChartExpanded: 'expandido',
     ariaDescriptionExpandNode: 'Presiona Alt + Flecha abajo para expandir este nodo',
     ariaDescriptionCollapseNode: 'Presiona Alt + Flecha arriba para contraer este nodo',
+    ariaDescriptionToggleNode: 'Presiona Space o Enter para expandir o contraer este nodo',
     ariaAnnounceGaugeChart: 'gráfico de velocímetro, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico de jerarquía, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivel ${level}[number], ${count}[number] hijos, ${description}',

--- a/packages/ag-charts-locale/src/fa-IR.ts
+++ b/packages/ag-charts-locale/src/fa-IR.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_FA_IR: Record<string, string> = {
     ariaOrgChartExpanded: 'بازشده',
     ariaDescriptionExpandNode: 'برای گسترش این گره، Alt + پیکان پایین را فشار دهید',
     ariaDescriptionCollapseNode: 'برای جمع کردن این گره، Alt + پیکان بالا را فشار دهید',
+    ariaDescriptionToggleNode: 'برای گسترش یا جمع کردن این گره، Space یا Enter را فشار دهید',
     ariaAnnounceGaugeChart: 'چارت سنجشی، ${caption}',
     ariaAnnounceHierarchyChart: 'نمودار سلسله مراتبی، ${caption}',
     ariaAnnounceHierarchyDatum: 'سطح ${level}[number]، ${count}[number] فرزند، ${description}',

--- a/packages/ag-charts-locale/src/fi-FI.ts
+++ b/packages/ag-charts-locale/src/fi-FI.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_FI_FI: Record<string, string> = {
     ariaOrgChartExpanded: 'avattu',
     ariaDescriptionExpandNode: 'Paina Alt + Nuoli alas laajentaaksesi tämän solmun',
     ariaDescriptionCollapseNode: 'Paina Alt + Nuoli ylös tiivistääksesi tämän solmun',
+    ariaDescriptionToggleNode: 'Paina Space tai Enter laajentaaksesi tai tiivistääksesi tämän solmun',
     ariaAnnounceGaugeChart: 'mittarikaavio, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkkinen kaavio, ${caption}',
     ariaAnnounceHierarchyDatum: 'taso ${level}[number], ${count}[number] lasta, ${description}',

--- a/packages/ag-charts-locale/src/fr-FR.ts
+++ b/packages/ag-charts-locale/src/fr-FR.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_FR_FR: Record<string, string> = {
     ariaOrgChartExpanded: 'développé',
     ariaDescriptionExpandNode: 'Appuyez sur Alt + Flèche bas pour développer ce nœud',
     ariaDescriptionCollapseNode: 'Appuyez sur Alt + Flèche haut pour réduire ce nœud',
+    ariaDescriptionToggleNode: 'Appuyez sur Space ou Enter pour développer ou réduire ce nœud',
     ariaAnnounceGaugeChart: 'graphique en jauge, ${caption}',
     ariaAnnounceHierarchyChart: 'graphique hiérarchique, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] enfants, ${description}',

--- a/packages/ag-charts-locale/src/he-IL.ts
+++ b/packages/ag-charts-locale/src/he-IL.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_HE_IL: Record<string, string> = {
     ariaOrgChartExpanded: 'מורחב',
     ariaDescriptionExpandNode: 'לחץ על Alt + חץ למטה כדי להרחיב את הצומת הזה',
     ariaDescriptionCollapseNode: 'לחץ על Alt + חץ למעלה כדי לכווץ את הצומת הזה',
+    ariaDescriptionToggleNode: 'לחץ על Space או Enter כדי להרחיב או לכווץ את הצומת הזה',
     ariaAnnounceGaugeChart: 'תרשים מד, ${caption}',
     ariaAnnounceHierarchyChart: 'תרשים היררכי, ${caption}',
     ariaAnnounceHierarchyDatum: 'רמה ${level}[number], ${count}[number] ילדים, ${description}',

--- a/packages/ag-charts-locale/src/hr-HR.ts
+++ b/packages/ag-charts-locale/src/hr-HR.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_HR_HR: Record<string, string> = {
     ariaOrgChartExpanded: 'prošireno',
     ariaDescriptionExpandNode: 'Pritisnite Alt + strelicu dolje za proširenje ovog čvora',
     ariaDescriptionCollapseNode: 'Pritisnite Alt + strelicu gore za sažimanje ovog čvora',
+    ariaDescriptionToggleNode: 'Pritisnite Space ili Enter za proširenje ili sažimanje ovog čvora',
     ariaAnnounceGaugeChart: 'mjerna ljestvica, ${caption}',
     ariaAnnounceHierarchyChart: 'hijerarhijski grafikon, ${caption}',
     ariaAnnounceHierarchyDatum: 'razina ${level}[number], ${count}[number] djece, ${description}',

--- a/packages/ag-charts-locale/src/hu-HU.ts
+++ b/packages/ag-charts-locale/src/hu-HU.ts
@@ -26,6 +26,7 @@ export const AG_CHARTS_LOCALE_HU_HU: Record<string, string> = {
     ariaOrgChartExpanded: 'kinyitott',
     ariaDescriptionExpandNode: 'Nyomja meg az Alt + Lefelé nyilat a csomópont kibontásához',
     ariaDescriptionCollapseNode: 'Nyomja meg az Alt + Felfelé nyilat a csomópont összecsukásához',
+    ariaDescriptionToggleNode: 'Nyomja meg a Space vagy Enter billentyűt a csomópont kibontásához vagy összecsukásához',
     ariaAnnounceGaugeChart: 'mérőműszer diagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchia diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'szint ${level}[number], ${count}[number] gyermek, ${description}',

--- a/packages/ag-charts-locale/src/it-IT.ts
+++ b/packages/ag-charts-locale/src/it-IT.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_IT_IT: Record<string, string> = {
     ariaOrgChartExpanded: 'espanso',
     ariaDescriptionExpandNode: 'Premi Alt + Freccia giù per espandere questo nodo',
     ariaDescriptionCollapseNode: 'Premi Alt + Freccia su per comprimere questo nodo',
+    ariaDescriptionToggleNode: 'Premi Space o Enter per espandere o comprimere questo nodo',
     ariaAnnounceGaugeChart: 'grafico a tachimetro, ${caption}',
     ariaAnnounceHierarchyChart: 'grafico gerarchico, ${caption}',
     ariaAnnounceHierarchyDatum: 'livello ${level}[number], ${count}[number] figli, ${description}',

--- a/packages/ag-charts-locale/src/ja-JP.ts
+++ b/packages/ag-charts-locale/src/ja-JP.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_JA_JP: Record<string, string> = {
     ariaOrgChartExpanded: '展開',
     ariaDescriptionExpandNode: 'Alt + 下矢印キーを押してこのノードを展開します',
     ariaDescriptionCollapseNode: 'Alt + 上矢印キーを押してこのノードを折りたたみます',
+    ariaDescriptionToggleNode: 'Space または Enter キーを押してこのノードを展開または折りたたみます',
     ariaAnnounceGaugeChart: 'ゲージチャート、${caption}',
     ariaAnnounceHierarchyChart: '階層チャート, ${caption}',
     ariaAnnounceHierarchyDatum: 'レベル ${level}[number]、${count}[number] の子供、${description}',

--- a/packages/ag-charts-locale/src/ko-KR.ts
+++ b/packages/ag-charts-locale/src/ko-KR.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_KO_KR: Record<string, string> = {
     ariaOrgChartExpanded: '확장됨',
     ariaDescriptionExpandNode: 'Alt + 아래쪽 화살표를 눌러 이 노드를 펼치세요',
     ariaDescriptionCollapseNode: 'Alt + 위쪽 화살표를 눌러 이 노드를 접으세요',
+    ariaDescriptionToggleNode: 'Space 또는 Enter를 눌러 이 노드를 펼치거나 접으세요',
     ariaAnnounceGaugeChart: '게이지 차트, ${caption}',
     ariaAnnounceHierarchyChart: '계층 차트, ${caption}',
     ariaAnnounceHierarchyDatum: '레벨 ${level}[number], ${count}[number] 자식, ${description}',

--- a/packages/ag-charts-locale/src/nb-NO.ts
+++ b/packages/ag-charts-locale/src/nb-NO.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_NB_NO: Record<string, string> = {
     ariaOrgChartExpanded: 'utvidet',
     ariaDescriptionExpandNode: 'Trykk på Alt + Pil ned for å utvide denne noden',
     ariaDescriptionCollapseNode: 'Trykk på Alt + Pil opp for å skjule denne noden',
+    ariaDescriptionToggleNode: 'Trykk på Space eller Enter for å utvide eller skjule denne noden',
     ariaAnnounceGaugeChart: 'målerdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkidiagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivå ${level}[number], ${count}[number] barn, ${description}',

--- a/packages/ag-charts-locale/src/nl-NL.ts
+++ b/packages/ag-charts-locale/src/nl-NL.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_NL_NL: Record<string, string> = {
     ariaOrgChartExpanded: 'uitgeklapt',
     ariaDescriptionExpandNode: 'Druk op Alt + Pijl omlaag om dit knooppunt uit te vouwen',
     ariaDescriptionCollapseNode: 'Druk op Alt + Pijl omhoog om dit knooppunt samen te vouwen',
+    ariaDescriptionToggleNode: 'Druk op Space of Enter om dit knooppunt uit of samen te vouwen',
     ariaAnnounceGaugeChart: 'meterdiagram, ${caption}',
     ariaAnnounceHierarchyChart: 'hiërarchie diagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'niveau ${level}[number], ${count}[number] kinderen, ${description}',

--- a/packages/ag-charts-locale/src/pl-PL.ts
+++ b/packages/ag-charts-locale/src/pl-PL.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_PL_PL: Record<string, string> = {
     ariaOrgChartExpanded: 'rozwinięty',
     ariaDescriptionExpandNode: 'Naciśnij Alt + Strzałkę w dół, aby rozwinąć ten węzeł',
     ariaDescriptionCollapseNode: 'Naciśnij Alt + Strzałkę w górę, aby zwinąć ten węzeł',
+    ariaDescriptionToggleNode: 'Naciśnij Space lub Enter, aby rozwinąć lub zwinąć ten węzeł',
     ariaAnnounceGaugeChart: 'wykres wskaźnikowy, ${caption}',
     ariaAnnounceHierarchyChart: 'wykres hierarchii, ${caption}',
     ariaAnnounceHierarchyDatum: 'poziom ${level}[number], ${count}[number] dzieci, ${description}',

--- a/packages/ag-charts-locale/src/pt-BR.ts
+++ b/packages/ag-charts-locale/src/pt-BR.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_PT_BR: Record<string, string> = {
     ariaOrgChartExpanded: 'expandido',
     ariaDescriptionExpandNode: 'Pressione Alt + Seta para baixo para expandir este nó',
     ariaDescriptionCollapseNode: 'Pressione Alt + Seta para cima para recolher este nó',
+    ariaDescriptionToggleNode: 'Pressione Space ou Enter para expandir ou recolher este nó',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico de hierarquia, ${caption}',
     ariaAnnounceHierarchyDatum: 'nível ${level}[number], ${count}[number] filhos, ${description}',

--- a/packages/ag-charts-locale/src/pt-PT.ts
+++ b/packages/ag-charts-locale/src/pt-PT.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_PT_PT: Record<string, string> = {
     ariaOrgChartExpanded: 'expandido',
     ariaDescriptionExpandNode: 'Pressione Alt + Seta para baixo para expandir este nó',
     ariaDescriptionCollapseNode: 'Pressione Alt + Seta para cima para recolher este nó',
+    ariaDescriptionToggleNode: 'Pressione Space ou Enter para expandir ou recolher este nó',
     ariaAnnounceGaugeChart: 'gráfico de medidor, ${caption}',
     ariaAnnounceHierarchyChart: 'gráfico hierárquico, ${caption}',
     ariaAnnounceHierarchyDatum: 'nível ${level}[number], ${count}[number] filhos, ${description}',

--- a/packages/ag-charts-locale/src/ro-RO.ts
+++ b/packages/ag-charts-locale/src/ro-RO.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_RO_RO: Record<string, string> = {
     ariaOrgChartExpanded: 'extins',
     ariaDescriptionExpandNode: 'Apăsați Alt + Săgeată jos pentru a extinde acest nod',
     ariaDescriptionCollapseNode: 'Apăsați Alt + Săgeată sus pentru a restrânge acest nod',
+    ariaDescriptionToggleNode: 'Apăsați Space sau Enter pentru a extinde sau restrânge acest nod',
     ariaAnnounceGaugeChart: 'grafic indicator, ${caption}',
     ariaAnnounceHierarchyChart: 'diagramă ierarhică, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivel ${level}[number], ${count}[number] copii, ${description}',

--- a/packages/ag-charts-locale/src/sk-SK.ts
+++ b/packages/ag-charts-locale/src/sk-SK.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_SK_SK: Record<string, string> = {
     ariaOrgChartExpanded: 'rozbalený',
     ariaDescriptionExpandNode: 'Stlačením Alt + šípka nadol rozbalíte tento uzol',
     ariaDescriptionCollapseNode: 'Stlačením Alt + šípka nahor zbalíte tento uzol',
+    ariaDescriptionToggleNode: 'Stlačením Space alebo Enter rozbalíte alebo zbalíte tento uzol',
     ariaAnnounceGaugeChart: 'stupnicový graf, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarchický graf, ${caption}',
     ariaAnnounceHierarchyDatum: 'úroveň ${level}[number], ${count}[number] detí, ${description}',

--- a/packages/ag-charts-locale/src/sv-SE.ts
+++ b/packages/ag-charts-locale/src/sv-SE.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_SV_SE: Record<string, string> = {
     ariaOrgChartExpanded: 'expanderad',
     ariaDescriptionExpandNode: 'Tryck på Alt + Nedåtpil för att expandera denna nod',
     ariaDescriptionCollapseNode: 'Tryck på Alt + Uppåtpil för att komprimera denna nod',
+    ariaDescriptionToggleNode: 'Tryck på Space eller Enter för att expandera eller komprimera denna nod',
     ariaAnnounceGaugeChart: 'mätargraf, ${caption}',
     ariaAnnounceHierarchyChart: 'hierarkidiagram, ${caption}',
     ariaAnnounceHierarchyDatum: 'nivå ${level}[number], ${count}[number] barn, ${description}',

--- a/packages/ag-charts-locale/src/tr-TR.ts
+++ b/packages/ag-charts-locale/src/tr-TR.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_TR_TR: Record<string, string> = {
     ariaOrgChartExpanded: 'genişletilmiş',
     ariaDescriptionExpandNode: 'Bu düğümü genişletmek için Alt + Aşağı Ok tuşuna basın',
     ariaDescriptionCollapseNode: 'Bu düğümü daraltmak için Alt + Yukarı Ok tuşuna basın',
+    ariaDescriptionToggleNode: 'Bu düğümü genişletmek veya daraltmak için Space veya Enter tuşuna basın',
     ariaAnnounceGaugeChart: 'gösterge grafik, ${caption}',
     ariaAnnounceHierarchyChart: 'hiyerarşi grafiği, ${caption}',
     ariaAnnounceHierarchyDatum: 'seviye ${level}[number], ${count}[number] çocuk, ${description}',

--- a/packages/ag-charts-locale/src/uk-UA.ts
+++ b/packages/ag-charts-locale/src/uk-UA.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_UK_UA: Record<string, string> = {
     ariaOrgChartExpanded: 'розгорнуто',
     ariaDescriptionExpandNode: 'Натисніть Alt + стрілку вниз, щоб розгорнути цей вузол',
     ariaDescriptionCollapseNode: 'Натисніть Alt + стрілку вгору, щоб згорнути цей вузол',
+    ariaDescriptionToggleNode: 'Натисніть Space або Enter, щоб розгорнути або згорнути цей вузол',
     ariaAnnounceGaugeChart: 'діаграма циферблата, ${caption}',
     ariaAnnounceHierarchyChart: 'ієрархічна діаграма, ${caption}',
     ariaAnnounceHierarchyDatum: 'рівень ${level}[number], ${count}[number] дочірні, ${description}',

--- a/packages/ag-charts-locale/src/ur-PK.ts
+++ b/packages/ag-charts-locale/src/ur-PK.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_UR_PK: Record<string, string> = {
     ariaOrgChartExpanded: 'پھیلا ہوا',
     ariaDescriptionExpandNode: 'اس نوڈ کو پھیلانے کے لیے Alt + نیچے تیر دبائیں',
     ariaDescriptionCollapseNode: 'اس نوڈ کو سمیٹنے کے لیے Alt + اوپر تیر دبائیں',
+    ariaDescriptionToggleNode: 'اس نوڈ کو پھیلانے یا سمیٹنے کے لیے Space یا Enter دبائیں',
     ariaAnnounceGaugeChart: 'گیج چارٹ, ${caption}',
     ariaAnnounceHierarchyChart: 'درجہ بندی چارٹ، ${caption}',
     ariaAnnounceHierarchyDatum: 'سطح ${level}[number], ${count}[number] بچے, ${description}',

--- a/packages/ag-charts-locale/src/vi-VN.ts
+++ b/packages/ag-charts-locale/src/vi-VN.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_VI_VN: Record<string, string> = {
     ariaOrgChartExpanded: 'đã mở rộng',
     ariaDescriptionExpandNode: 'Nhấn Alt + Mũi tên xuống để mở rộng nút này',
     ariaDescriptionCollapseNode: 'Nhấn Alt + Mũi tên lên để thu gọn nút này',
+    ariaDescriptionToggleNode: 'Nhấn Space hoặc Enter để mở rộng hoặc thu gọn nút này',
     ariaAnnounceGaugeChart: 'biểu đồ đồng hồ đo, ${caption}',
     ariaAnnounceHierarchyChart: 'biểu đồ phân cấp, ${caption}',
     ariaAnnounceHierarchyDatum: 'cấp độ ${level}[number], ${count}[number] con, ${description}',

--- a/packages/ag-charts-locale/src/zh-CN.ts
+++ b/packages/ag-charts-locale/src/zh-CN.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_ZH_CN: Record<string, string> = {
     ariaOrgChartExpanded: '已展开',
     ariaDescriptionExpandNode: '按 Alt + 向下箭头展开此节点',
     ariaDescriptionCollapseNode: '按 Alt + 向上箭头折叠此节点',
+    ariaDescriptionToggleNode: '按 Space 或 Enter 展开或折叠此节点',
     ariaAnnounceGaugeChart: '仪表盘图表, ${caption}',
     ariaAnnounceHierarchyChart: '层次图表, ${caption}',
     ariaAnnounceHierarchyDatum: '级别 ${level}[number], ${count}[number] 子项, ${description}',

--- a/packages/ag-charts-locale/src/zh-HK.ts
+++ b/packages/ag-charts-locale/src/zh-HK.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_ZH_HK: Record<string, string> = {
     ariaOrgChartExpanded: '已展開',
     ariaDescriptionExpandNode: '按 Alt + 向下箭嘴展開此節點',
     ariaDescriptionCollapseNode: '按 Alt + 向上箭嘴摺疊此節點',
+    ariaDescriptionToggleNode: '按 Space 或 Enter 展開或摺疊此節點',
     ariaAnnounceGaugeChart: '儀表圖, ${caption}',
     ariaAnnounceHierarchyChart: '層次圖, ${caption}',
     ariaAnnounceHierarchyDatum: '層級 ${level}[number]，${count}[number] 個子項，${description}',

--- a/packages/ag-charts-locale/src/zh-TW.ts
+++ b/packages/ag-charts-locale/src/zh-TW.ts
@@ -25,6 +25,7 @@ export const AG_CHARTS_LOCALE_ZH_TW: Record<string, string> = {
     ariaOrgChartExpanded: '已展開',
     ariaDescriptionExpandNode: '按 Alt + 向下箭頭展開此節點',
     ariaDescriptionCollapseNode: '按 Alt + 向上箭頭收合此節點',
+    ariaDescriptionToggleNode: '按 Space 或 Enter 展開或收合此節點',
     ariaAnnounceGaugeChart: '儀表板圖表, ${caption}',
     ariaAnnounceHierarchyChart: '階層圖表, ${caption}',
     ariaAnnounceHierarchyDatum: '層級 ${level}[number]，${count}[number] 個子項目，${description}',

--- a/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
@@ -306,8 +306,10 @@ zoom options.
 
 ## Accessibility
 
-Organisation Charts support full keyboard navigation using arrow keys, {% kbd "Enter" /%} to toggle
-expand/collapse as well as screen reader support.
+Organisation Charts support full keyboard navigation and screen readers. Use the arrow keys to move
+focus between nodes, {% kbd "Alt ↓" /%} and {% kbd "Alt ↑" /%} to expand and collapse the focused
+node, and—when `clickToExpand` is enabled (the default)—{% kbd "↵ Enter" /%} or
+{% kbd "␣ Space" /%} to toggle it.
 
 See [Accessibility](./accessibility/) for details.
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17263

The Alt+Up/Down keybindings landed alongside a change to OrganizationSeries.hasBuiltinListener (commit 413ab9f2c6, "TC4 Fix clickToExpand on card images/text") that switched the guard from `target == null || ...` to `target != null && ...`. Keyboard Enter/Space activations emit a synthetic click with no pointer target, so the new `target != null` guard silently dropped them, even though the comment still claimed keyboard activations were allowed. Result: Enter/Space no longer expanded/collapsed the focused node — a breaking change.

- hasBuiltinListener now returns `target?.tag === Expander || clickToExpand`. For any non-null (pointer) target this is identical to the previous expression, so click behaviour is unchanged; the only behavioural difference is the null (keyboard) case, which now toggles when clickToExpand is enabled (the default). Alt+Up/Down remain independent of clickToExpand.
- Re-add a screen-reader instruction advertising Enter/Space, shown only when clickToExpand is enabled (matching where the keys actually work); the Alt instruction is still announced unconditionally. New ariaDescriptionToggleNode locale key added to en-US and translated across all locale files to keep key parity.
- Update the Organisation Chart docs Accessibility section to describe arrow-key navigation, Alt+Down/Up, and Enter/Space (when clickToExpand is enabled).
- Add keyboard tests covering Enter/Space toggling with clickToExpand on, the no-op when it is off, and the corresponding announcement instructions.