### PR TITLE
release-review: self-dispatch workflow_dispatch instead of running on push

### DIFF
--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -16,6 +16,15 @@ name: Release Review
 #     (`github.event.created`). The branch filter keeps unrelated branch pushes
 #     out of this workflow entirely; the `created` guard ensures the review runs
 #     once when the release branch is cut, not on every subsequent commit to it.
+#     The push itself never runs the review jobs directly — anthropics/
+#     claude-code-action@v1 only supports entity (issues/PR/comment) or
+#     automation (workflow_dispatch/repository_dispatch/schedule/workflow_run)
+#     events and throws "Unsupported event type: push" otherwise, and
+#     GITHUB_EVENT_NAME can't be remapped from a step (it's a reserved default
+#     env var the runner re-asserts, so a step-level override is silently
+#     discarded). Instead, `dispatch-on-push` re-fires this same workflow via a
+#     genuine `workflow_dispatch` call against the new branch — same
+#     self-dispatch pattern ci.yml uses for the canary auto-bump.
 #
 # Each job uploads the full report as an artifact and posts a concise summary +
 # the full report (as a file) to #charts_teamcity_status.
@@ -74,11 +83,28 @@ env:
     DEV_PROMPTS_CHANNEL: canary
 
 jobs:
+    dispatch-on-push:
+        name: Dispatch review (push → workflow_dispatch)
+        # Re-fires this workflow as a genuine workflow_dispatch against the new
+        # branch; see the "Triggers" note above for why the push event can't
+        # run the review jobs directly.
+        if: github.event_name == 'push' && github.event.created
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+        steps:
+            - name: Trigger release review via workflow_dispatch
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh workflow run release-review.yml \
+                      --repo "${{ github.repository }}" \
+                      --ref "${{ github.ref_name }}" \
+                      -f review=both
+
     docs-review:
         name: Documentation review
-        if: >-
-            (github.event_name == 'push' && github.event.created) ||
-            (github.event_name == 'workflow_dispatch' && (inputs.review == 'docs' || inputs.review == 'both'))
+        if: github.event_name == 'workflow_dispatch' && (inputs.review == 'docs' || inputs.review == 'both')
         runs-on: ubuntu-latest
         timeout-minutes: 120
         steps:
@@ -124,9 +150,7 @@ jobs:
 
     options-review:
         name: Options (API) review
-        if: >-
-            (github.event_name == 'push' && github.event.created) ||
-            (github.event_name == 'workflow_dispatch' && (inputs.review == 'options' || inputs.review == 'both'))
+        if: github.event_name == 'workflow_dispatch' && (inputs.review == 'options' || inputs.review == 'both')
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:


### PR DESCRIPTION
## Summary
- Every real release-branch cut (b14.0.0, b14.0.1, b14.0.2) has failed both `release-review.yml` jobs with `Action failed with error: Unsupported event type: push` from `anthropics/claude-code-action@v1` — it only supports entity (issues/PR/comment) or automation (workflow_dispatch/repository_dispatch/schedule/workflow_run) events.
- The existing workaround (remapping `GITHUB_EVENT_NAME` via a step env override in the shared `release-review` composite action) doesn't work: it's a reserved default env var the Actions runner re-asserts, so the override is silently discarded. Companion PR (ag-grid/ag-dev-prompts#642) removes that dead code.
- Fix: add a `dispatch-on-push` job that fires a genuine `workflow_dispatch` against the new branch on creation, instead of running `docs-review`/`options-review` directly off `push`. Same self-dispatch pattern ag-dev-prompts' `ci.yml` already uses for its canary auto-bump — proven to work (manual `workflow_dispatch` runs of this same workflow have always succeeded).
- Wanted this in ahead of the v14.1.0 cut next week so the reviews actually run.

## Test plan
- [ ] Manually trigger `release-review.yml` via `workflow_dispatch` post-merge to confirm both jobs still run correctly (unchanged path).
- [ ] Confirm on the next release branch cut (v14.1.0) that `dispatch-on-push` fires and the resulting `workflow_dispatch` run completes both review jobs successfully.