### PR TITLE
AG-17843 [CLAUDE] Add cross-line context-menu hit-testing (PoC)

### DIFF
--- a/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
@@ -12,6 +12,7 @@ import { Group } from '../../scene/group';
 import { PointerEvents } from '../../scene/node';
 import { Range } from '../../scene/shape/range';
 import { TransformableText } from '../../scene/shape/text';
+import { Transformable } from '../../scene/transformable';
 import { LabelStyle } from '../label';
 import { rangeAlignment } from '../rangeAlignment';
 import { type CrossLine, type CrossLineType, validateCrossLineValue } from './crossLine';
@@ -128,6 +129,9 @@ class CartesianCrossLineLabel extends LabelStyle implements AgCartesianCrossLine
 
 type NodeData = [number, number];
 
+/** Pointer hit tolerance in pixels, widening a cross line's line/fill so thin `line` cross lines remain targetable. */
+const CROSS_LINE_HIT_TOLERANCE = 5;
+
 export class CartesianCrossLine extends BaseProperties implements CrossLine<CartesianCrossLineLabel> {
     static readonly className = 'CrossLine';
     readonly id = createId(this);
@@ -191,6 +195,22 @@ export class CartesianCrossLine extends BaseProperties implements CrossLine<Cart
     constructor() {
         super();
         this.crossLineRange.pointerEvents = PointerEvents.None;
+    }
+
+    /**
+     * Hit-tests a canvas-space point against this cross line's rendered line/fill, widened by
+     * {@link CROSS_LINE_HIT_TOLERANCE} so thin `line` cross lines remain targetable. The `crossLineRange`
+     * node holds the geometry for both the `line` (stroke) and `range` (fill) variants; its bbox is
+     * transformed into canvas space to match the pointer coordinates carried by context-menu events.
+     */
+    containsPoint(canvasX: number, canvasY: number): boolean {
+        const group = this.type === 'range' ? this.rangeGroup : this.lineGroup;
+        if (!this.enabled || this.data == null || !group.visible) {
+            return false;
+        }
+
+        const bbox = Transformable.toCanvas(this.crossLineRange).clone().grow(CROSS_LINE_HIT_TOLERANCE);
+        return bbox.containsPoint(canvasX, canvasY);
     }
 
     private _isRange: boolean | undefined = undefined;

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.ts
@@ -48,9 +48,28 @@ export function validateCrossLineValue(crossLine: ICrossLine, scale: Scale<any, 
     }
 }
 
+/**
+ * Identifies a cross line hit by a pointer interaction, assembled by the cross-lines plugin from the
+ * hit {@link CrossLine} instance plus its owning axis. Mirrors {@link AxisValuePick}; consumed by the
+ * context-menu `crossline` scope.
+ */
+export interface CrossLineValuePick {
+    readonly crossLineId: string;
+    readonly axisId: string;
+    readonly direction: ChartAxisDirection;
+    readonly type: CrossLineType;
+    readonly value?: unknown;
+    readonly range?: [unknown, unknown];
+}
+
 export interface CrossLine<LabelType = AgBaseCrossLineLabelOptions> {
     calculateLayout?(visible: boolean, reversedAxis?: boolean): void;
     calculatePadding?(padding: Partial<Record<AgCrossLineLabelPosition, number>>): void;
+    /**
+     * Hit-tests a canvas-space point against the cross line's rendered line or fill, widened by a
+     * small fixed pixel tolerance. Returns `false` when the cross line is not currently visible.
+     */
+    containsPoint?(canvasX: number, canvasY: number): boolean;
     clippedRange: [number, number];
     enabled?: boolean;
     defaultColorRange: string[];

--- a/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
@@ -6,6 +6,7 @@ import {
     jsonDiff,
 } from 'ag-charts-core';
 
+import type { SeriesAreaContextMenuEvent } from '../../core/eventsHub';
 import type { AxisContext } from '../../module/axisContext';
 import type { ChartAxisRegistry } from '../../module/moduleContext';
 import { Group } from '../../scene/group';
@@ -48,6 +49,7 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
     private readonly labelGroup = new Group({ name: 'CrossLines-Label' });
     private instances: CrossLine[] = [];
     private lastOptions: NormalisedAxisCrossLineOptions[] | undefined;
+    private readonly removeContextMenuListener: () => void;
 
     constructor(ctx: DynamicContext<ChartAxisRegistry<AxisContext>>) {
         super();
@@ -56,6 +58,36 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
         this.axisCtx.attachAxisOverlay(this.rangeGroup, 'low');
         this.axisCtx.attachAxisOverlay(this.lineGroup, 'mid');
         this.axisCtx.attachAxisOverlay(this.labelGroup, 'high');
+
+        // Annotate the series-area context-menu handoff when the pointer hits one of this axis's cross
+        // lines — mirrors how axis-owning modules annotate `event.axis` (see axisDomProxy). Phase 3b
+        // consumes the annotation to build the `crossline` context-menu region.
+        this.removeContextMenuListener = this.ctx.eventsHub.on('series-area:contextmenu', (event) =>
+            this.onSeriesAreaContextMenu(event)
+        );
+    }
+
+    private onSeriesAreaContextMenu(event: SeriesAreaContextMenuEvent): void {
+        // Another axis's cross line already claimed the hit.
+        if (event.crossLine != null) return;
+
+        for (const crossLine of this.instances) {
+            if (crossLine.containsPoint?.(event.canvasX, event.canvasY) !== true) continue;
+
+            event.crossLine = {
+                crossLineId: crossLine.id,
+                axisId: this.axisCtx.axisId,
+                direction: this.axisCtx.direction,
+                type: crossLine.type,
+                value: crossLine.value,
+                range: crossLine.range,
+            };
+
+            // Phase 3a PoC: observable stub broadcast into the context-menu flow. Replaced in Phase 3b
+            // by wiring the annotation through to a rendered `crossline` menu region.
+            this.ctx.logger.log('AG Charts - [PoC] cross-line context-menu hit', event.crossLine);
+            return;
+        }
     }
 
     applyOptions(options: NormalisedAxisCrossLineOptions[] | undefined): void {
@@ -138,6 +170,7 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
     }
 
     override destroy(): void {
+        this.removeContextMenuListener();
         for (const crossLine of this.instances) {
             this.detachInstance(crossLine);
         }

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -26,6 +26,7 @@ import type {
     AgZoomEventSource,
 } from 'ag-charts-types';
 
+import type { CrossLineValuePick } from '../chart/crossline/crossLine';
 import { DataSet } from '../chart/data/dataSet';
 import type { ContextMenuRegionContexts, ContextShowOnMap } from '../chart/interaction/contextMenuTypes';
 import type { ChartLegendType } from '../chart/legend/legendDatum';
@@ -95,6 +96,11 @@ export interface SeriesAreaContextMenuEvent {
      * dispatch can offer the axis region alongside the series region rather than dispatching a competing menu.
      */
     axis?: AxisValuePick;
+    /**
+     * The cross line, if any, at the pointer. The cross-lines plugin annotates this (mirroring `axis`) so the
+     * series-area dispatch can offer the cross-line region alongside the series region.
+     */
+    crossLine?: CrossLineValuePick;
 }
 
 export interface DataModelSeriesDiff {


### PR DESCRIPTION
Make axis cross lines respond to context-menu (right-click) interactions, which were previously non-interactive. This is Phase 3a: the hit-testing plus a stub broadcast; wiring the hit through to a rendered `crossline` menu region follows in Phase 3b.

- cartesianCrossLine.ts: add `containsPoint(canvasX, canvasY)` that hit-tests the pointer against the rendered `Range` node's canvas-space bbox (via `Transformable.toCanvas`), widened by a fixed `CROSS_LINE_HIT_TOLERANCE` (5px) so thin `line` cross lines remain targetable. The tolerance is hard-coded rather than a public option, per product feedback.
- crossLine.ts: add optional `containsPoint` to the `CrossLine` interface and a `CrossLineValuePick` type (crossLineId, axisId, direction, type, value/range), mirroring `AxisValuePick`.
- crossLinesPlugin.ts: subscribe to `series-area:contextmenu`, hit-test the axis's cross-line instances, and annotate `event.crossLine` on the first hit — mirroring how axis-owning modules annotate `event.axis`. Emits a temporary PoC log; the listener is removed on destroy.
- eventsHub.ts: add the `crossLine?` annotation field to `SeriesAreaContextMenuEvent`.

No public API changes and no rendering changes; existing behaviour is unaffected when nothing consumes the annotation.