### PR TITLE
AG-17843 [CLAUDE] Add `crossline` context-menu scope

### DIFF
--- a/packages/ag-charts-angular/tests/zone-callback-inventory.json
+++ b/packages/ag-charts-angular/tests/zone-callback-inventory.json
@@ -79,6 +79,10 @@
         "classification": "zone-wrap",
         "reason": "Context-menu action dispatched from out-of-zone DOM listeners; re-entered into the zone by patchContextMenu."
     },
+    "AgContextMenuItemCrossLine.action": {
+        "classification": "zone-wrap",
+        "reason": "Context-menu action dispatched from out-of-zone DOM listeners; re-entered into the zone by patchContextMenu."
+    },
     "AgContextMenuItemSeriesArea.action": {
         "classification": "zone-wrap",
         "reason": "Context-menu action dispatched from out-of-zone DOM listeners; re-entered into the zone by patchContextMenu."

--- a/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
@@ -60,8 +60,8 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
         this.axisCtx.attachAxisOverlay(this.labelGroup, 'high');
 
         // Annotate the series-area context-menu handoff when the pointer hits one of this axis's cross
-        // lines — mirrors how axis-owning modules annotate `event.axis` (see axisDomProxy). Phase 3b
-        // consumes the annotation to build the `crossline` context-menu region.
+        // lines — mirrors how axis-owning modules annotate `event.axis` (see axisDomProxy). The
+        // series-area dispatch turns the annotation into a `crossline` context-menu region.
         this.removeContextMenuListener = this.ctx.eventsHub.on('series-area:contextmenu', (event) =>
             this.onSeriesAreaContextMenu(event)
         );
@@ -82,10 +82,6 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
                 value: crossLine.value,
                 range: crossLine.range,
             };
-
-            // Phase 3a PoC: observable stub broadcast into the context-menu flow. Replaced in Phase 3b
-            // by wiring the annotation through to a rendered `crossline` menu region.
-            this.ctx.logger.log('AG Charts - [PoC] cross-line context-menu hit', event.crossLine);
             return;
         }
     }

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
@@ -9,6 +9,7 @@ import type {
 } from 'ag-charts-types';
 
 import type { AxisValuePick } from '../../module/axisContext';
+import type { CrossLineValuePick } from '../crossline/crossLine';
 import type { CategoryLegendDatum } from '../legend/legendDatum';
 import type { ISeries, SeriesNodeDatum } from '../series/seriesTypes';
 
@@ -40,6 +41,11 @@ export interface ContextShowOnMap extends ContextShowOnMapRule {
         event: InferTEvent<'caption'>;
         callback: (param: InferTEvent<'caption'>) => void;
         context: Pick<AgContextMenuGetItemsParamsCaption, 'captionType' | 'text'>;
+    };
+    crossline: {
+        event: InferTEvent<'crossline'>;
+        callback: (param: InferTEvent<'crossline'>) => void;
+        context: CrossLineValuePick;
     };
     'legend-item': {
         event: InferTEvent<'legend-item'>;

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -509,12 +509,18 @@ export class SeriesAreaManager extends BaseManager {
             regions.push('axis');
             contexts.axis = collectEvent.axis;
         }
+        if (collectEvent.crossLine) {
+            regions.push('crossline');
+            contexts.crossline = collectEvent.crossLine;
+        }
 
-        // Primary region for backwards-compatible `showOn`: a node wins over an overlapping axis, which wins
-        // over the bare series area (matches the pre-multi-region dispatch precedence).
+        // Primary region for backwards-compatible `showOn`: a node wins over a cross line, which wins over an
+        // overlapping axis, which wins over the bare series area (matches the pre-multi-region dispatch precedence).
         let primary: AgContextMenuItemShowOn = 'series-area';
         if (contexts['series-node']) {
             primary = 'series-node';
+        } else if (collectEvent.crossLine) {
+            primary = 'crossline';
         } else if (collectEvent.axis) {
             primary = 'axis';
         }

--- a/packages/ag-charts-core/src/config/chartDefaults.ts
+++ b/packages/ag-charts-core/src/config/chartDefaults.ts
@@ -239,6 +239,7 @@ const contextMenuItemObjectDef: OptionsDefs<Extract<AgContextMenuItem, object>> 
         'always',
         'axis',
         'caption',
+        'crossline',
         'series-area',
         'series-node',
         'legend-item'

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -4,11 +4,13 @@ import type {
     AgContextMenuGetItemsParams,
     AgContextMenuGetItemsParamsAxis,
     AgContextMenuGetItemsParamsCaption,
+    AgContextMenuGetItemsParamsCrossLine,
     AgContextMenuGetItemsParamsLegendItem,
     AgContextMenuGetItemsParamsSeriesNode,
     AgContextMenuItem,
     AgContextMenuItemShowOn,
     AgContextMenuShowOnParams,
+    AgCrossLineContextMenuActionEvent,
     ContextDefault,
     DatumDefault,
 } from 'ag-charts-community';
@@ -72,6 +74,7 @@ type PickedNode = _ModuleSupport.SeriesNodeDatum & {
 type ShowOnParams = AgContextMenuShowOnParams<DatumDefault, ContextDefault>;
 type SeriesNodeParams = Extract<ShowOnParams, { showOn: 'series-node' }>;
 type AxisParams = Extract<ShowOnParams, { showOn: 'axis' }>;
+type CrossLineParams = Extract<ShowOnParams, { showOn: 'crossline' }>;
 type CaptionParams = Extract<ShowOnParams, { showOn: 'caption' }>;
 type LegendItemParams = Extract<ShowOnParams, { showOn: 'legend-item' }>;
 type GetItemsParams = [AgContextMenuGetItemsParams, Caller[]];
@@ -89,6 +92,7 @@ export class ContextMenu extends AbstractModuleInstance {
     private pickedLegendItem?: _ModuleSupport.CategoryLegendDatum;
     private pickedCaptionCtx?: ContextShowOnMap['caption']['context'];
     private pickedAxisCtx?: _ModuleSupport.AxisValuePick;
+    private pickedCrossLine?: ContextShowOnMap['crossline']['context'];
     private x: number = 0;
     private y: number = 0;
     private collapsingSubMenus = 0;
@@ -169,12 +173,28 @@ export class ContextMenu extends AbstractModuleInstance {
         return { showOn: 'axis', axisId, boundSeries, direction, domain, value, index };
     }
 
-    // Scopes that can overlap the series area: the area itself, and an axis positioned inside it (e.g. `crossAt`).
-    // `axis` is the only scope that appears both as a primary and as a non-primary overlap, so it lives here.
+    private crossLineRegion(pick: ContextShowOnMap['crossline']['context']): CrossLineParams {
+        const { crossLineId, axisId, direction, type, value, range } = pick;
+        return {
+            showOn: 'crossline',
+            crossLineId,
+            axisId,
+            direction,
+            crossLineType: type,
+            value: value as CrossLineParams['value'],
+            range: range as CrossLineParams['range'],
+        };
+    }
+
+    // Scopes that can overlap the series area: the area itself, an axis positioned inside it (e.g. `crossAt`),
+    // and a cross line. These appear both as a primary and as a non-primary overlap, so they live here.
     private plotOverlapRegions(active: ReadonlySet<AgContextMenuItemShowOn>): ShowOnParams[] {
         const params: ShowOnParams[] = [];
         if (active.has('series-area')) params.push({ showOn: 'series-area' });
         if (active.has('axis') && this.pickedAxisCtx != null) params.push(this.axisRegion(this.pickedAxisCtx));
+        if (active.has('crossline') && this.pickedCrossLine != null) {
+            params.push(this.crossLineRegion(this.pickedCrossLine));
+        }
         return params;
     }
 
@@ -191,6 +211,8 @@ export class ContextMenu extends AbstractModuleInstance {
                 return this.makeGetItemsParamsSeriesNode(defaultItems, active);
             case 'axis':
                 return this.makeGetItemsParamsAxis(defaultItems, active);
+            case 'crossline':
+                return this.makeGetItemsParamsCrossLine(defaultItems, active);
             case 'caption':
                 return this.makeGetItemsParamsCaption(defaultItems);
             case 'legend-item':
@@ -241,12 +263,33 @@ export class ContextMenu extends AbstractModuleInstance {
         const region = this.axisRegion(this.pickedAxisCtx);
         const allShowOnParams: ShowOnParams[] = [region];
         if (active.has('series-area')) allShowOnParams.push({ showOn: 'series-area' });
+        if (active.has('crossline') && this.pickedCrossLine != null) {
+            allShowOnParams.push(this.crossLineRegion(this.pickedCrossLine));
+        }
         const params: AgContextMenuGetItemsParamsAxis<DatumDefault, ContextDefault> = {
             ...region,
             defaultItems,
             allShowOnParams,
         };
         const callers: Caller[] = [this.pickedAxisCtx.caller, this.ctx.chartService];
+        return [params, callers];
+    }
+
+    private makeGetItemsParamsCrossLine(
+        defaultItems: AgContextMenuItem[],
+        active: ReadonlySet<AgContextMenuItemShowOn>
+    ): GetItemsParams {
+        if (this.pickedCrossLine == null) throw new Error(`this.pickedCrossLine is null`);
+        const region = this.crossLineRegion(this.pickedCrossLine);
+        const allShowOnParams: ShowOnParams[] = [region];
+        if (active.has('series-area')) allShowOnParams.push({ showOn: 'series-area' });
+        if (active.has('axis') && this.pickedAxisCtx != null) allShowOnParams.push(this.axisRegion(this.pickedAxisCtx));
+        const params: AgContextMenuGetItemsParamsCrossLine<DatumDefault, ContextDefault> = {
+            ...region,
+            defaultItems,
+            allShowOnParams,
+        };
+        const callers: Caller[] = [this.ctx.chartService];
         return [params, callers];
     }
 
@@ -314,6 +357,7 @@ export class ContextMenu extends AbstractModuleInstance {
         this.pickedAxisCtx = contexts.axis;
         this.pickedCaptionCtx = contexts.caption;
         this.pickedLegendItem = contexts['legend-item']?.legendItem;
+        this.pickedCrossLine = contexts.crossline;
 
         const expandedItems = this.expandItemsOptions(event);
         if (expandedItems.length === 0) return;
@@ -496,6 +540,27 @@ export class ContextMenu extends AbstractModuleInstance {
                     callWithContext(callers, callback, apiEvent);
                 } else {
                     this.ctx.logger.error('axis item not found');
+                }
+                this.hide();
+            };
+        } else if (ContextMenuRegistry.checkCallback('crossline', showOn, callback)) {
+            return () => {
+                if (this.pickedCrossLine) {
+                    const { crossLineId, axisId, direction, type, value, range } = this.pickedCrossLine;
+                    const callers: Caller = this.ctx.chartService;
+                    const apiEvent: Omit<AgCrossLineContextMenuActionEvent<never>, 'context'> = {
+                        type: 'crossLineContextMenuAction',
+                        event: showEvent,
+                        crossLineId,
+                        axisId,
+                        direction,
+                        crossLineType: type,
+                        value: value as AgCrossLineContextMenuActionEvent<never>['value'],
+                        range: range as AgCrossLineContextMenuActionEvent<never>['range'],
+                    };
+                    callWithContext(callers, callback, apiEvent);
+                } else {
+                    this.ctx.logger.error('cross line item not found');
                 }
                 this.hide();
             };

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -3,6 +3,7 @@ import type {
     AgAxisContextMenuActionEvent,
     AgCaptionContextMenuActionEvent,
     AgChartContextMenuEvent,
+    AgCrossLineContextMenuActionEvent,
     AgNodeContextMenuActionEvent,
     AgSeriesAreaContextMenuActionEvent,
 } from './eventOptions';
@@ -19,7 +20,14 @@ export type AgContextMenuItemLiteral =
     | 'toggle-other-series'
     | 'separator';
 
-export type AgContextMenuItemShowOn = 'always' | 'axis' | 'caption' | 'series-area' | 'series-node' | 'legend-item';
+export type AgContextMenuItemShowOn =
+    | 'always'
+    | 'axis'
+    | 'caption'
+    | 'crossline'
+    | 'series-area'
+    | 'series-node'
+    | 'legend-item';
 
 export type AgContextMenuItemType = 'action' | 'separator';
 
@@ -73,6 +81,18 @@ export interface AgContextMenuItemAxis<TDatum = DatumDefault, TContext = Context
     showOn: 'axis';
     /** Function called when clicking on this menu item. */
     action?: (event: AgAxisContextMenuActionEvent<TContext>) => void;
+}
+
+export interface AgContextMenuItemCrossLine<TDatum = DatumDefault, TContext = ContextDefault> extends ItemMixin<
+    TDatum,
+    TContext
+> {
+    /**
+     * Which clicked element this menu item should be shown for. `'crossline'` menu items are shown when right-clicking a cross line's line or fill.
+     */
+    showOn: 'crossline';
+    /** Function called when clicking on this menu item. */
+    action?: (event: AgCrossLineContextMenuActionEvent<TContext>) => void;
 }
 
 export interface AgContextMenuItemCaption<TDatum = DatumDefault, TContext = ContextDefault> extends ItemMixin<
@@ -130,6 +150,7 @@ export type AgContextMenuItem<TDatum = DatumDefault, TContext = ContextDefault> 
     | AgContextMenuItemAlways<TDatum, TContext>
     | AgContextMenuItemAxis<TDatum, TContext>
     | AgContextMenuItemCaption<TDatum, TContext>
+    | AgContextMenuItemCrossLine<TDatum, TContext>
     | AgContextMenuItemSeriesArea<TDatum, TContext>
     | AgContextMenuItemSeriesNode<TDatum, TContext>
     | AgContextMenuItemLegendItem<TDatum, TContext>;
@@ -159,6 +180,14 @@ export interface AgContextMenuShowOnParamsAxis<_TDatumReserved = never, TContext
 > {
     /** Which clicked element this menu item should be shown for. */
     showOn: 'axis';
+}
+
+export interface AgContextMenuShowOnParamsCrossLine<_TDatumReserved = never, TContext = ContextDefault> extends Omit<
+    AgCrossLineContextMenuActionEvent<TContext>,
+    GetItemsParamsOmissions
+> {
+    /** Which clicked element this menu item should be shown for. */
+    showOn: 'crossline';
 }
 
 export interface AgContextMenuShowOnParamsCaption<_TDatumReserved = never, TContext = ContextDefault> extends Omit<
@@ -212,6 +241,7 @@ export type AgContextMenuShowOnParams<TDatum = DatumDefault, TContext = ContextD
     | AgContextMenuShowOnParamsAlways<TDatum, TContext>
     | AgContextMenuShowOnParamsAxis<TDatum, TContext>
     | AgContextMenuShowOnParamsCaption<TDatum, TContext>
+    | AgContextMenuShowOnParamsCrossLine<TDatum, TContext>
     | AgContextMenuShowOnParamsSeriesArea<TDatum, TContext>
     | AgContextMenuShowOnParamsSeriesNode<TDatum, TContext>
     | AgContextMenuShowOnParamsLegendItem<TDatum, TContext>;
@@ -235,6 +265,11 @@ export interface AgContextMenuGetItemsParamsAlways<_TDatumReserved = never, TCon
 export interface AgContextMenuGetItemsParamsAxis<_TDatumReserved = never, TContext = ContextDefault>
     extends AgContextMenuShowOnParamsAxis<_TDatumReserved, TContext>, GetItemsParamsMixin<_TDatumReserved, TContext> {}
 
+export interface AgContextMenuGetItemsParamsCrossLine<_TDatumReserved = never, TContext = ContextDefault>
+    extends
+        AgContextMenuShowOnParamsCrossLine<_TDatumReserved, TContext>,
+        GetItemsParamsMixin<_TDatumReserved, TContext> {}
+
 export interface AgContextMenuGetItemsParamsCaption<_TDatumReserved = never, TContext = ContextDefault>
     extends
         AgContextMenuShowOnParamsCaption<_TDatumReserved, TContext>,
@@ -257,6 +292,7 @@ export type AgContextMenuGetItemsParams<TDatum = DatumDefault, TContext = Contex
     | AgContextMenuGetItemsParamsAlways<TDatum, TContext>
     | AgContextMenuGetItemsParamsAxis<TDatum, TContext>
     | AgContextMenuGetItemsParamsCaption<TDatum, TContext>
+    | AgContextMenuGetItemsParamsCrossLine<TDatum, TContext>
     | AgContextMenuGetItemsParamsSeriesArea<TDatum, TContext>
     | AgContextMenuGetItemsParamsSeriesNode<TDatum, TContext>
     | AgContextMenuGetItemsParamsLegendItem<TDatum, TContext>;

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -212,6 +212,24 @@ export interface AgAxisContextMenuActionEvent<TContext = ContextDefault> extends
     domain: AgAxisDomain;
 }
 
+export interface AgCrossLineContextMenuActionEvent<TContext = ContextDefault> extends AgChartEvent<
+    'crossLineContextMenuAction',
+    TContext
+> {
+    /** Cross Line ID (generated if not specified). */
+    crossLineId: string;
+    /** ID of the axis the Cross Line belongs to, as specified in `axes`. */
+    axisId: string;
+    /** Direction of the axis the Cross Line belongs to. */
+    direction: AgAxisDirection;
+    /** Whether the Cross Line is a single `line` or a `range` band. */
+    crossLineType: 'line' | 'range';
+    /** The data value of a `line` Cross Line. Undefined for `range` Cross Lines. */
+    value?: AgAxisValue;
+    /** The `[start, end]` data values of a `range` Cross Line. Undefined for `line` Cross Lines. */
+    range?: [AgAxisValue, AgAxisValue];
+}
+
 export interface AgCaptionContextMenuActionEvent<TContext = ContextDefault> extends AgChartEvent<
     'captionContextMenuAction',
     TContext

--- a/packages/ag-charts-website/e2e/context-menu.spec.ts
+++ b/packages/ag-charts-website/e2e/context-menu.spec.ts
@@ -210,7 +210,7 @@ test.describe('context-menu', () => {
             await gotoExample(page, toExamplePageUrl('context-menu-e2e', 'ag-17637-overlap', 'vanilla').url);
         });
 
-        test('right-clicking Mar tick label shows axis and series-node contexts', async ({ page }) => {
+        test('right-clicking Mar tick label shows axis and series contexts', async ({ page }) => {
             await page.mouse.click(283, 336, { button: 'right' });
             expect(await popContextMenuText(page)).toEqual('always,axis,series-area,series-node,');
         });
@@ -220,11 +220,14 @@ test.describe('context-menu', () => {
             expect(await popContextMenuText(page)).toEqual('always,series-area,series-node,');
         });
 
-        test('right-clicking Apr bar on crossline shows crossline, series-area and series-node contexts', async ({
-            page,
-        }) => {
+        test('right-clicking Apr bar on crossline shows crossline and series contexts', async ({ page }) => {
             await page.mouse.click(371, 224, { button: 'right' });
             expect(await popContextMenuText(page)).toEqual('always,crossline,series-area,series-node,');
+        });
+
+        test('right-clicking May tick label shows axis, crossline and series contexts', async ({ page }) => {
+            await page.mouse.click(459, 336, { button: 'right' });
+            expect(await popContextMenuText(page)).toEqual('always,axis,crossline,series-area,series-node,');
         });
     });
 

--- a/packages/ag-charts-website/e2e/context-menu.spec.ts
+++ b/packages/ag-charts-website/e2e/context-menu.spec.ts
@@ -220,7 +220,7 @@ test.describe('context-menu', () => {
             expect(await popContextMenuText(page)).toEqual('always,series-area,series-node,');
         });
 
-        test.skip('right-clicking Apr bar on crossline shows only crossline and series-node contexts', async ({
+        test('right-clicking Apr bar on crossline shows crossline, series-area and series-node contexts', async ({
             page,
         }) => {
             await page.mouse.click(371, 224, { button: 'right' });

--- a/packages/ag-charts-website/src/content/docs/context-menu-e2e/_examples/ag-17637-overlap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu-e2e/_examples/ag-17637-overlap/main.ts
@@ -39,6 +39,7 @@ const options: AgCartesianChartOptions = {
         items: [
             { showOn: 'always', label: 'always,', action: () => {} },
             { showOn: 'axis', label: 'axis,', action: () => {} },
+            { showOn: 'crossline', label: 'crossline,', action: () => {} },
             { showOn: 'series-area', label: 'series-area,', action: () => {} },
             { showOn: 'series-node', label: 'series-node,', action: () => {} },
         ],

--- a/packages/ag-charts-website/src/content/docs/context-menu-e2e/_examples/ag-17637-overlap/main.ts
+++ b/packages/ag-charts-website/src/content/docs/context-menu-e2e/_examples/ag-17637-overlap/main.ts
@@ -28,6 +28,7 @@ const options: AgCartesianChartOptions = {
         x: {
             type: 'category',
             crossAt: { value: 0 },
+            crossLines: [{ type: 'line', value: 'May', stroke: 'blue', strokeWidth: 2 }],
         },
         y: {
             type: 'number',


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17843

Introduce a new `showOn: 'crossline'` context-menu scope so right-clicking an axis cross line (`axes[].crossLines[]`) opens the context menu with items scoped to that cross line. Builds on the Phase-3a hit-testing: the cross-lines plugin already annotates the `series-area:contextmenu` handoff with the hit cross line; this wires that annotation through to a rendered menu region. Additive, non-breaking — with no crossline-scoped item registered, behaviour is unchanged.

Types (ag-charts-types):
- contextMenuOptions.ts: add `'crossline'` to `AgContextMenuItemShowOn`, plus `AgContextMenuItemCrossLine`, `AgContextMenuShowOnParamsCrossLine` and `AgContextMenuGetItemsParamsCrossLine` (each added to its union).
- eventOptions.ts: add `AgCrossLineContextMenuActionEvent` (crossLineId, axisId, direction, crossLineType, value/range). The line/range field is named `crossLineType` because `type` is reserved by the base event discriminator.

Core:
- chartDefaults.ts: add `'crossline'` to the exhaustive `showOn` options validator.

Community:
- contextMenuTypes.ts: add the `crossline` entry to `ContextShowOnMap` (context = `CrossLineValuePick`).
- seriesAreaManager.ts: push a `crossline` region and context when the handoff is annotated, and slot it into the primary precedence (series-node > crossline > axis > series-area).
- crossLinesPlugin.ts: drop the Phase-3a placeholder log; the annotation is now consumed to build the menu region.

Enterprise:
- contextMenu.ts: build the cross-line region params, include it in the overlap params so it shows alongside series-area/series-node, handle the `crossline` case in `makeGetItemsParams`, and route item actions to a `crossLineContextMenuAction` event.

Testing (reused existing example, no new example):
- ag-17637-overlap example: add a `showOn: 'crossline'` menu item.
- context-menu.spec.ts: un-skip the pre-scaffolded crossline e2e assertion.