### PR TITLE
Improve org chart docs for expander, click-to-expand, and accessibility

### DIFF
--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -220,9 +220,8 @@ interface GetItemsParamsMixin<TDatum, TContext> {
     /** The default menu items that would be shown without customisation. */
     defaultItems: AgContextMenuItem<TDatum, TContext>[];
     /**
-     * Every `showOn` scope that matched at the click point, including the winning scope carried by these root
-     * params. Lets the callback build one combined menu when scopes overlap — for example a datum node drawn
-     * over an axis positioned with `crossAt`. Scopes that did not match are absent from the array.
+     * Every `showOn` scope that matched at the click point, including the winning scope in the root
+     * params. Scopes that did not match are absent from the array.
      */
     allShowOnParams: AgContextMenuShowOnParams<TDatum, TContext>[];
 }

--- a/packages/ag-charts-website/src/content/docs/accessibility/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/accessibility/index.mdoc
@@ -33,11 +33,11 @@ The following keys are available:
 - {% kbd "←" /%}{% kbd "→" /%} moves focus between items in a series, or between legend items.
 - {% kbd "↑" /%}{% kbd "↓" /%} moves focus between series in a chart.
   Please note that datapoints and series are traversed in declared order which may not match the visual display.
-- {% kbd "Alt ↑" /%}{% kbd "Alt ↓" /%} collapses and expands nodes ([Org Chart](./org-chart) only).
 - {% kbd "PgUp" /%}{% kbd "PgDown" /%} jumps focus backward or forward by a page of data items, scrolling to keep the focused item in view.
 - {% kbd "Home" /%}{% kbd "End" /%} jumps to the first or last data item.
 - {% kbd "↵ Enter" /%} or {% kbd "␣ Space" /%} toggles legend items and triggers any click listeners for the focused item.
 - In Windows, {% kbd "⇧ Shift"/%}+{% kbd "F10"/%} or {% kbd "≡ Menu"/%} opens the context menu. On Mac this is done with {% kbd "⌃⌥⇧ M" /%} when Voiceover is enabled.
+- {% kbd "Alt" /%}+{% kbd "↑" /%} and {% kbd "Alt" /%}+{% kbd "↓" /%} collapses and expands nodes in the [Org Chart](./org-chart).
 
 {% chartExampleRunner title="Keyboard Navigation" name="keyboard-navigation" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/api-state/index.mdoc
@@ -83,6 +83,7 @@ In this example:
 - `legendPagination` - This number is the current legend page of a [paginated legend](./legend/#pagination).
 - `active` - This object contains the currently active item, which is the series node or legend item that is highlighted/showing a tooltip.
 - `annotations` - This object contains the position and style of any displayed drawings or text annotations.
+- `collapsed` - This array contains the identifiers of the currently collapsed items in an [Org Chart](./org-chart/).
 - `chartType` - This string is one of the [Chart Types](./financial-charts-configuration/#chart-types).
 
 {% note %}
@@ -150,6 +151,13 @@ In this example:
 
 - Clicking the chart freezes the current Active State. The Highlight & Tooltip remain static when the mouse moves.
 - Clicking the 'Unfreeze' button in the Tooltip restores interactivity.
+
+### Collapsed
+
+The `collapsed` state stores the identifiers of items collapsed in an [Org Chart](./org-chart/).
+
+Changes to this state can be listened to with the `collapsedChange` event. See the
+[Events API](./events/#collapsedchange) page for more details.
 
 ## API Reference
 

--- a/packages/ag-charts-website/src/content/docs/context-menu/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/context-menu/index.mdoc
@@ -60,7 +60,16 @@ The Context Menu's custom actions can be used to run arbitrary functions based o
 
 {% chartExampleRunner title="Context Menu Custom Actions" name="context-menu-actions" type="generated" /%}
 
-Use the `showOn` property to specify when the action should be shown.
+Use the `showOn` property to specify when a custom item should be shown:
+
+- `always` - shown regardless of what was clicked.
+- `axis` - shown when right-clicking an axis.
+- `caption` - shown when right-clicking a caption (title, subtitle, footnote).
+- `series-area` - shown when right-clicking anywhere within the series area bounds.
+- `series-node` - shown when right-clicking a datum node.
+- `legend-item` - shown when right-clicking a legend item.
+
+If there are multiple elements that match the `showOn` value, all of them are shown in the Context Menu.
 
 ```js format="snippet"
 {
@@ -79,14 +88,6 @@ Use the `showOn` property to specify when the action should be shown.
                 label: 'Say hello to an axis',
                 action: (ev) => console.log(`Hello in axis "${ev.axisId}":"`, ev),
             },
-            'separator',
-            {
-                showOn: 'caption',
-                label: 'Say hello in a caption',
-                action: ({ captionType, text }) =>
-                    console.log(`Hello in a ${captionType} caption: "${text}"`),
-            },
-            'separator',
             {
                 showOn: 'series-area',
                 label: 'Say hello in the series area',
@@ -98,12 +99,7 @@ Use the `showOn` property to specify when the action should be shown.
                 label: 'Say hello to a node',
                 action: ({ datum, yKey }) => console.log(`Hello ${yKey} in ${datum.month}!`),
             },
-            'separator',
-            {
-                showOn: 'legend-item',
-                label: 'Say hello to a legend item',
-                action: ({ itemId }) => console.log(`Hello ${itemId}!`),
-            },
+            //...more custom actions for legend items, captions, etc.
         ],
     },
 }
@@ -112,7 +108,7 @@ Use the `showOn` property to specify when the action should be shown.
 In this configuration:
 
 - A single custom action is added for the entire chart, the captions, the series area, the series node and the legend items.
-  Multiple actions per item can be specified within the array if required.
+- Multiple entries per `showOn` element can be specified within the array if required.
 - Right clicking on one of these areas will show these additional actions in the Context Menu.
 - Clicking these extra actions will display information in the console, demonstrating that the action is aware of details about the right-clicked item.
 
@@ -216,8 +212,9 @@ The `getItems` callback can be used to implement Dynamic Context Menus. This is 
 
 In this example:
 
-- The Context Menu on Bar Nodes includes a console `Log Datum` Menu Item,
-  whose text is dynamically derived from the Context Menu Event parameters.
+- The Context Menu on Bar Nodes includes a console `Log Datum` Menu Item, whose text is dynamically derived from the Context Menu Event parameters.
+- The `getItems` params includes a `showOn` property which indicates which element type was right-clicked, alongside relevant information about the clicked element.
+- If there are multiple elements at the same click point, the `allShowOnParams` array on the `getItems` params provides the parameters for every element, not just the winning one.
 
 ### Example: Interactive Customisation
 

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expand-collapse/index.html
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expand-collapse/index.html
@@ -3,6 +3,14 @@
         <button onclick="expandAll()">Expand All</button>
         <button onclick="collapseAll()">Collapse All</button>
         <button onclick="toggleCTO()">Toggle CTO</button>
+        <input
+            type="checkbox"
+            id="clickToExpand"
+            checked
+            class="gap-left"
+            onchange="setClickToExpand(event.target.checked)"
+        />
+        <label for="clickToExpand">Click node to expand</label>
     </div>
 </div>
 <div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expand-collapse/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expand-collapse/main.ts
@@ -1,5 +1,6 @@
 import {
     AgCharts,
+    AgOrganizationSeriesOptions,
     AgStandaloneChartOptions,
     ContextMenuModule,
     ModuleRegistry,
@@ -27,12 +28,28 @@ const options: AgStandaloneChartOptions = {
                 title: { key: 'name' },
                 subtitle: { key: 'job' },
                 labels: [{ key: 'location' }],
+                clickToExpand: true,
             },
         },
     ],
+    listeners: {
+        collapsedChange: ({ collapsed, expanded }) => {
+            console.log(
+                'collapsed:',
+                collapsed.map((item) => item.itemId),
+                'expanded:',
+                expanded.map((item) => item.itemId)
+            );
+        },
+    },
 };
 
 const chart = AgCharts.create(options);
+
+function setClickToExpand(clickToExpand: boolean) {
+    (options.series![0] as AgOrganizationSeriesOptions).node!.clickToExpand = clickToExpand;
+    chart.update(options);
+}
 
 function expandAll() {
     const { version } = chart.getState();

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-child-counts/data.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-child-counts/data.ts
@@ -1,0 +1,58 @@
+export function getData() {
+    return [
+        {
+            id: 'Ashley Rivers',
+            parentId: null,
+            name: 'Ashley Rivers',
+            job: 'CEO',
+        },
+        {
+            id: 'Joseph Howe',
+            parentId: 'Ashley Rivers',
+            name: 'Joseph Howe',
+            job: 'CTO',
+        },
+        {
+            id: 'Nicole Jones',
+            parentId: 'Joseph Howe',
+            name: 'Nicole Jones',
+            job: 'Exec. Vice President',
+        },
+        {
+            id: 'James Long',
+            parentId: 'Nicole Jones',
+            name: 'James Long',
+            job: 'Design',
+        },
+        {
+            id: 'Susan Hernandez',
+            parentId: 'Nicole Jones',
+            name: 'Susan Hernandez',
+            job: 'Design',
+        },
+        {
+            id: 'Justin Contreras',
+            parentId: 'Joseph Howe',
+            name: 'Justin Contreras',
+            job: 'Design',
+        },
+        {
+            id: 'Gary Garcia',
+            parentId: 'Ashley Rivers',
+            name: 'Gary Garcia',
+            job: 'Head of Department',
+        },
+        {
+            id: 'Lawrence Martinez',
+            parentId: 'Gary Garcia',
+            name: 'Lawrence Martinez',
+            job: 'Design',
+        },
+        {
+            id: 'Eric Jensen',
+            parentId: 'Gary Garcia',
+            name: 'Eric Jensen',
+            job: 'Design',
+        },
+    ];
+}

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-child-counts/index.html
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-child-counts/index.html
@@ -1,0 +1,15 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <input type="checkbox" id="showAllChildren" checked onchange="setShowAllChildren(event.target.checked)" />
+        <label for="showAllChildren">showAllChildren</label>
+        <input
+            type="checkbox"
+            id="showDirectChildren"
+            checked
+            class="gap-left"
+            onchange="setShowDirectChildren(event.target.checked)"
+        />
+        <label for="showDirectChildren">showDirectChildren</label>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-child-counts/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-child-counts/main.ts
@@ -1,0 +1,46 @@
+import {
+    AgCharts,
+    AgOrganizationSeriesOptions,
+    AgStandaloneChartOptions,
+    ModuleRegistry,
+    OrganizationSeriesModule,
+} from 'ag-charts-enterprise';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([OrganizationSeriesModule]);
+
+const options: AgStandaloneChartOptions = {
+    container: document.getElementById('myChart'),
+    title: { text: 'Company Organisation' },
+    data: getData(),
+    series: [
+        {
+            type: 'organization',
+            idKey: 'id',
+            parentIdKey: 'parentId',
+            node: {
+                title: { key: 'name' },
+                subtitle: { key: 'job' },
+            },
+            expander: {
+                text: {
+                    showAllChildren: true,
+                    showDirectChildren: true,
+                },
+            },
+        },
+    ],
+};
+
+const chart = AgCharts.create(options);
+
+function setShowAllChildren(showAllChildren: boolean) {
+    (options.series![0] as AgOrganizationSeriesOptions).expander!.text!.showAllChildren = showAllChildren;
+    chart.update(options);
+}
+
+function setShowDirectChildren(showDirectChildren: boolean) {
+    (options.series![0] as AgOrganizationSeriesOptions).expander!.text!.showDirectChildren = showDirectChildren;
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-expander-styling/main.ts
@@ -26,13 +26,6 @@ const options: AgChartOptions = {
                 cornerRadius: 25,
                 strokeWidth: 2,
                 padding: 15,
-                text: {
-                    fontSize: 18,
-                    fontWeight: 'bold',
-                    color: 'red',
-                    showAllChildren: true,
-                    showDirectChildren: true,
-                },
                 itemStyler: ({ datum }) => {
                     if (datum.department === 'Technology') return { fill: '#e8f5e9', stroke: '#2e7d32' };
                     if (datum.department === 'Operations') return { fill: '#fff3e0', stroke: '#e65100' };

--- a/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
@@ -131,6 +131,36 @@ In this configuration:
 }
 ```
 
+## Expander
+
+The expander is displayed on nodes with children and is used to [collapse and expand](#collapse-and-expand) subtrees.
+
+{% chartExampleRunner title="Expander Child Counts" name="org-chart-expander-child-counts" type="generated" /%}
+
+```js format="snippet"
+{
+    series: [
+        {
+            type: 'organization',
+            expander: {
+                text: {
+                    showAllChildren: true,
+                    showDirectChildren: true,
+                },
+            },
+        },
+    ],
+}
+```
+
+In this example:
+
+- `showAllChildren` includes the total count of all descendants in the expander text.
+- `showDirectChildren` includes the count of direct children in the expander text.
+- A `formatter` can be used instead, for full control over the expander text. The params include `allChildren`, `directChildren`, `depth` and `isCollapsed` alongside the datum.
+
+See the [API Reference](#reference-AgOrganizationSeriesOptions-expander-text) for more details.
+
 ## Customisation
 
 ### Node Styling
@@ -204,9 +234,8 @@ In this configuration:
 
 ### Expander
 
-The expander is the button displayed on nodes with children, used to
-[collapse and expand](#collapse-and-expand) subtrees. Its appearance can be customised via the
-`expander` property.
+The expander's appearance can be customised via the `expander` property. See [Expander](#expander) above for
+text-content options like child counts and `formatter`.
 
 {% chartExampleRunner title="Expander Styling" name="org-chart-expander-styling" type="generated" /%}
 
@@ -219,13 +248,6 @@ The expander is the button displayed on nodes with children, used to
                 cornerRadius: 25,
                 strokeWidth: 2,
                 padding: 15,
-                text: {
-                    fontSize: 18,
-                    fontWeight: 'bold',
-                    color: 'red',
-                    showAllChildren: true,
-                    showDirectChildren: true,
-                },
                 itemStyler: ({ datum }) => {
                     if (datum.department === 'Technology') return { fill: '#e8f5e9', stroke: '#2e7d32' };
                     if (datum.department === 'Operations') return { fill: '#fff3e0', stroke: '#e65100' };
@@ -239,7 +261,6 @@ The expander is the button displayed on nodes with children, used to
 In this configuration:
 
 - `cornerRadius`, `strokeWidth`, and `padding` control the button shape and border.
-- `text` options control the text appearance.
 - `expander.itemStyler` provides per-node styling based on the department.
 
 ### Node Spacing
@@ -290,11 +311,9 @@ Nodes with children can be collapsed and expanded by clicking the expander butto
 In this example:
 
 - The subtrees under 'Lawrence Martinez' and 'Eric Jensen' will start in a collapsed state. This uses the `initialState.collapsed` property to specify which subtrees start collapsed.
-- To read or update the collapsed state at runtime, use `getState()` and `setState()`. The `collapsed` array contains the identifiers of all currently collapsed nodes.
-
-See the [State](./api-state/) page for the full state management API.
-
-Changes in the collapsed items can be listened to with the `collapsedChange` event. See the [Events API](./events#collapsedchange) page for more details.
+- To read or update the collapsed state at runtime, use `getState()` and `setState()`. The `collapsed` array contains the identifiers of all currently collapsed nodes. See the [State API](./api-state/#collapsed) page for more details.
+- Set `node.clickToExpand` to `false` to disable collapsing/expanding by clicking anywhere on the card, restricting the interaction to the expander button only. Defaults to `false` when clicking a node is used for something else (e.g. [Data Selection](./selection/)), otherwise defaults to `true`. Toggle the checkbox above to compare both behaviours.
+- Changes in the collapsed items can be listened to with the `collapsedChange` event, logged to the console here showing the `itemId` of each newly collapsed and expanded node. See the [Events API](./events/#collapsedchange) page for more details.
 
 ### Zoom
 
@@ -306,12 +325,15 @@ zoom options.
 
 ## Accessibility
 
-Organisation Charts support full keyboard navigation and screen readers. Use the arrow keys to move
-focus between nodes, {% kbd "Alt ↓" /%} and {% kbd "Alt ↑" /%} to expand and collapse the focused
-node, and—when `clickToExpand` is enabled (the default)—{% kbd "↵ Enter" /%} or
-{% kbd "␣ Space" /%} to toggle it.
+Organisation Charts support full keyboard navigation and screen readers.
 
-See [Accessibility](./accessibility/) for details.
+The following keys are available:
+
+- {% kbd "←" /%}{% kbd "→" /%}{% kbd "↑" /%}{% kbd "↓" /%} moves focus between nodes.
+- {% kbd "Alt" /%}+{% kbd "↓" /%} and {% kbd "Alt" /%}+{% kbd "↑" /%} expand and collapse the focused node.
+- {% kbd "↵ Enter" /%} or {% kbd "␣ Space" /%} trigger any click listeners, and also toggle the focused node when `clickToExpand` is enabled.
+
+See [Accessibility](./accessibility/) for more details.
 
 ## API Reference
 

--- a/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
@@ -328,11 +328,11 @@ Nodes with children can be collapsed and expanded by clicking the expander. They
 In this example:
 
 - The subtrees under 'Lawrence Martinez' and 'Eric Jensen' will start in a collapsed state. This uses the `initialState.collapsed` property to specify which subtrees start collapsed.
-- Use `node.clickToExpand` to toggle collapsing/expanding by clicking anywhere on the card instead of the expander only. 
-    - Defaults to `false` when node has a [click listener](./events/#seriesnodeclick-and-seriesnodedoubleclick) or has [Data Selection](./selection/) enabled,, otherwise defaults to `true`. 
-- The `collapsed` array contains the identifiers of all currently collapsed nodes. 
+- Use `node.clickToExpand` to toggle collapsing/expanding by clicking anywhere on the card instead of the expander only.
+    - Defaults to `false` when node has a [click listener](./events/#seriesnodeclick-and-seriesnodedoubleclick) or has [Data Selection](./selection/) enabled,, otherwise defaults to `true`.
+- The `collapsed` array contains the identifiers of all currently collapsed nodes.
     - See the [State API](./api-state/#collapsed) page for more details.
-- Changes in the collapsed items can be listened to with the `collapsedChange` event, logged to the console here showing the `itemId` of each newly collapsed and expanded node. 
+- Changes in the collapsed items can be listened to with the `collapsedChange` event, logged to the console here showing the `itemId` of each newly collapsed and expanded node.
     - See the [Events API](./events/#collapsedchange) page for more details.
 
 ### Zoom

--- a/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
@@ -295,7 +295,7 @@ In this configuration:
 
 ### Collapse and Expand
 
-Nodes with children can be collapsed and expanded by clicking the expander button. They can also be controlled programmatically.
+Nodes with children can be collapsed and expanded by clicking the expander. They can also be controlled programmatically.
 
 {% chartExampleRunner title="Collapse and Expand" name="org-chart-expand-collapse" type="generated" /%}
 
@@ -304,16 +304,36 @@ Nodes with children can be collapsed and expanded by clicking the expander butto
     initialState: {
         collapsed: ['Lawrence Martinez', 'Eric Jensen'],
     },
-    series: [{ type: 'organization' }],
+    series: [
+        {
+            type: 'organization',
+            node: {
+                clickToExpand: true,
+            },
+        },
+    ],
+    listeners: {
+        collapsedChange: ({ collapsed, expanded }) => {
+            console.log(
+                'collapsed:',
+                collapsed.map((item) => item.itemId),
+                'expanded:',
+                expanded.map((item) => item.itemId)
+            );
+        },
+    },
 }
 ```
 
 In this example:
 
 - The subtrees under 'Lawrence Martinez' and 'Eric Jensen' will start in a collapsed state. This uses the `initialState.collapsed` property to specify which subtrees start collapsed.
-- To read or update the collapsed state at runtime, use `getState()` and `setState()`. The `collapsed` array contains the identifiers of all currently collapsed nodes. See the [State API](./api-state/#collapsed) page for more details.
-- Set `node.clickToExpand` to `false` to disable collapsing/expanding by clicking anywhere on the card, restricting the interaction to the expander button only. Defaults to `false` when clicking a node is used for something else (e.g. [Data Selection](./selection/)), otherwise defaults to `true`. Toggle the checkbox above to compare both behaviours.
-- Changes in the collapsed items can be listened to with the `collapsedChange` event, logged to the console here showing the `itemId` of each newly collapsed and expanded node. See the [Events API](./events/#collapsedchange) page for more details.
+- Use `node.clickToExpand` to toggle collapsing/expanding by clicking anywhere on the card instead of the expander only. 
+    - Defaults to `false` when node has a [click listener](./events/#seriesnodeclick-and-seriesnodedoubleclick) or has [Data Selection](./selection/) enabled,, otherwise defaults to `true`. 
+- The `collapsed` array contains the identifiers of all currently collapsed nodes. 
+    - See the [State API](./api-state/#collapsed) page for more details.
+- Changes in the collapsed items can be listened to with the `collapsedChange` event, logged to the console here showing the `itemId` of each newly collapsed and expanded node. 
+    - See the [Events API](./events/#collapsedchange) page for more details.
 
 ### Zoom
 

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14-1/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14-1/index.mdoc
@@ -80,20 +80,11 @@ The following APIs have been deprecated since version !PREV_x.x! and have now be
 
 ## Deprecations
 
-<!-- If there are *no* deprecations, add the following: -->
-
-There are no deprecations in AG Charts version {% migrationVersion() %}.
-
-<!-- Otherwise: -->
-<!--
 {% expandingSection headerText="Deprecations" %}
 
-### Deprecation section Name
-
-- item...
+- Organization series `verticalSpacing` is deprecated. Use `depthSpacing` instead.
 
 {% /expandingSection %}
--->
 
 <!-- Changelog for the `migrationVersion` property DO NOT TOUCH -->
 


### PR DESCRIPTION
## Summary
- Adds a dedicated **Expander** section to the org chart docs covering `expander.text` child-count options (`showAllChildren`, `showDirectChildren`) and a new example.
- Documents `node.clickToExpand` behaviour and defaults, with an interactive comparison in the collapse/expand example.
- Expands the accessibility keyboard shortcut list (arrow keys, Alt+↓/↑, Enter/Space) and links out to the state and events API pages.
- Minor tidy-ups to context menu and API state docs, and a small JSDoc simplification on `AgContextMenuShowOnParams`.