### PR TITLE
AG-17637 [CLAUDE] Resolve crosshair label formatter index to nearest tick

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1062,11 +1062,22 @@ export abstract class Axis<
         );
         const { type, value } = formatParams;
 
+        // A crosshair sits at an interpolated position rather than on a tick, so resolve the nearest tick to
+        // give the label formatter the same index it reports for that tick (and the context menu at that point).
+        // Other sources have no meaningful tick index and keep NaN.
+        let labelIndex = Number.NaN;
+        if (source === 'crosshair') {
+            const position = this.scale.convert(input);
+            if (typeof position === 'number' && Number.isFinite(position)) {
+                labelIndex = this.resolveTickIndex(position);
+            }
+        }
+
         const f = this.createCallWithContext(contextProvider);
         const result =
             label?.formatValue(f, type, value, params ?? formatParams) ??
             formatManager.format(f, formatParams, { allowNull }) ??
-            formatAxisLabelValue(this.options.label, this.formatterCache, f, formatParams, Number.NaN) ??
+            formatAxisLabelValue(this.options.label, this.formatterCache, f, formatParams, labelIndex) ??
             formatManager.defaultFormat(formatParams);
 
         return isArray(result) ? result : String(result);


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17637

A crosshair sits at an interpolated position rather than on a tick, so `Axis.formatDatum` passed `NaN` as the index to the axis label formatter. Any `label.formatter` reading `params.index` therefore received `NaN` on hover.

For the crosshair source, resolve the value to the nearest tick via `resolveTickIndex`, so the formatter receives the same index it reports for that tick (and that the `showOn: 'axis'` context menu reports at that point). Non-finite conversions fall back to `NaN`, and all other formatter sources (tooltip, series-label, annotation-label, legend-label) are unchanged.

Builds on the reversed-axis picked-index fix, so the resolved crosshair index is consistent with both the axis labels and the context menu.