### PR TITLE
Fix CSS variable lookup matching Object.prototype member names

### DIFF
--- a/packages/ag-charts-community/src/module/optionsGraph.test.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.test.ts
@@ -1272,6 +1272,27 @@ describe('OptionsGraph', () => {
         });
     });
 
+    describe('css variables', () => {
+        it('should not treat `Object.prototype` member names as CSS variables', () => {
+            const themeConfig = { line: { themeValue: 'valueOf' } };
+            const userOptions = prepareOptions({
+                title: { text: 'constructor' },
+                userValue: 'toString',
+                inherited: '__proto__',
+            });
+            const options = new OptionsGraph(themeConfig, userOptions, {}, {}, {}, undefined, new Map(), {
+                'var(--brand)': '#00ff00',
+            }).resolve();
+            expect(options).toStrictEqual({
+                themeValue: 'valueOf',
+                title: { text: 'constructor' },
+                userValue: 'toString',
+                inherited: '__proto__',
+                axes: expect.any(Object),
+            });
+        });
+    });
+
     describe('public api', () => {
         describe('ref', () => {
             it('should resolve public `ref` operations', () => {

--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -1334,7 +1334,7 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
             return this.internalParams.get(value);
         }
 
-        if (typeof value === 'string' && value in this.cssVariables) {
+        if (typeof value === 'string' && Object.hasOwn(this.cssVariables, value)) {
             return this.cssVariables[value];
         }
 


### PR DESCRIPTION
`resolveValueOrSymbol` tested every resolved string against the CSS variables map with the `in` operator, which walks the prototype chain of the plain object holding them. Any option string equal to an `Object.prototype` member name was therefore treated as a declared CSS variable and replaced by that member.

Affected strings: `toString`, `valueOf`, `constructor`, `hasOwnProperty`, `isPrototypeOf`, `toLocaleString`, `propertyIsEnumerable` (each becomes a function) and `__proto__` (becomes an object).

This applies to every value passing through option resolution, from theme templates and user options alike — e.g. a chart created with `title: { text: 'constructor' }` resolved `title.text` to a function, which then flows into rendering and fails far from the cause.

Switched the lookup to `Object.hasOwn`, matching the existing pattern in `ag-charts-core/src/utils/data/value.ts`. Real CSS variable keys are `var(--x)`-shaped and can never collide with prototype names, so legitimate variables are unaffected — the existing `var(--brand)` test still passes.

Added a regression test covering both entry paths, verified to fail before the fix.