### PR TITLE
Refine 14.1 What's New highlights

### DIFF
--- a/packages/ag-charts-website/src/content/docs/high-frequency-data/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/high-frequency-data/index.mdoc
@@ -4,7 +4,7 @@ description: 'High-performance $framework charts with real-time updates running 
 enterprise: true
 ---
 
-AG Charts is optimised for **high-frequency data updates**, maintaining smooth performance with rapid data updates on large datasets, while maintaining full functionality.
+AG Charts is optimised for **high-frequency data updates**, maintaining smooth performance with rapid or real-time data updates on large datasets, while maintaining full functionality.
 
 {% chartExampleRunner title="High-Frequency Updates" name="high-frequency-showcase" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -4,15 +4,20 @@
         "date": "August 5th, 2026",
         "highlights": [
             {
-                "text": "Series Label Collisions"
+                "text": "Additional Label Placement Options",
+                "path": "./series-labels/"
             },
             {
-                "text": "Org Chart Improvements",
+                "text": "Label Collision Avoidance",
+                "path": "./series-labels/#collision-avoidance"
+            },
+            {
+                "text": "Extended Context Menu Scopes",
+                "path": "./context-menu/#custom-actions"
+            },
+            {
+                "text": "Org Chart Interactivity Improvements",
                 "path": "./org-chart/"
-            },
-            {
-                "text": "Context Menu Improvements",
-                "path": "./context-menu/"
             }
         ],
         "notesPath": "./upgrade-to-ag-charts-14-1"

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -4,12 +4,10 @@
         "date": "August 5th, 2026",
         "highlights": [
             {
-                "text": "Additional Label Placement Options",
-                "path": "./series-labels/"
+                "text": "Additional Label Placement Options"
             },
             {
-                "text": "Label Collision Avoidance",
-                "path": "./series-labels/#collision-avoidance"
+                "text": "Label Collision Avoidance"
             },
             {
                 "text": "Extended Context Menu Scopes",

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
@@ -44,15 +44,6 @@ describe('buildHomepageMarkdown', () => {
         expect(output).toContain('### Markers & POIs');
     });
 
-    it('lists the latest releases with blog links and highlights', () => {
-        expect(output).toContain(
-            '### [14.1.0 — August 5th, 2026](https://blog.ag-grid.com/whats-new-in-ag-charts-14-1/)'
-        );
-        expect(output).toContain('- Series Label Collisions');
-        // A .0 minor release links to the major-only blog URL.
-        expect(output).toContain('](https://blog.ag-grid.com/whats-new-in-ag-charts-14/)');
-    });
-
     it('renders each FAQ question as an H3', () => {
         expect(output).toContain('### What are AG Charts JavaScript charts?');
     });


### PR DESCRIPTION
## Summary
- Splits the single "Series Label Collisions" highlight into **Additional Label Placement Options** and **Label Collision Avoidance**, each linking to the relevant `series-labels` section.
- Retitles the context menu highlight to **Extended Context Menu Scopes**, linking to the new axis/caption `showOn` scopes.
- Reframes the org chart highlight as **Org Chart Interactivity Improvements**, matching the shipped work (expander-only collapse/expand, `collapsedItemChange` event, data-point selection).

## Test plan
- [ ] Verify `packages/ag-charts-website/src/content/versions/ag-charts-versions.json` renders correctly on the What's New page in dev server
- [ ] Confirm each highlight link resolves to the correct section