### PR TITLE
AG-17912 Expand nested API members in markdown docs pages

### DIFF
--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
@@ -364,6 +364,14 @@ describe('buildTypeArguments', () => {
         expect(buildTypeArguments(member({ kind: 'typeRef', type: 'Selection' }) as any, {})).toBeUndefined();
     });
 
+    // getMemberType unwraps `Foo<Bar>[]` to `Foo`, so the arguments must be read from the element
+    // type too — otherwise the resolved interface falls back to its type-param defaults.
+    it('unwraps an array member to read its element type arguments', () => {
+        const type = { kind: 'array', type: { kind: 'typeRef', type: 'CrossLine', typeArguments: ['NumericValue'] } };
+
+        expect(buildTypeArguments(member(type) as any, {})).toEqual(['NumericValue']);
+    });
+
     it('returns undefined for a member that is not a typeRef', () => {
         expect(buildTypeArguments(member('boolean') as any, {})).toBeUndefined();
     });

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    buildTypeArguments,
     extractSearchData,
     formatTypeToCode,
     formatUnionSignature,
@@ -8,6 +9,7 @@ import {
     getMemberType,
     normalizeType,
     processMembers,
+    resolveReferenceType,
 } from './apiReferenceHelpers';
 
 const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
@@ -310,5 +312,59 @@ describe('extractSearchData', () => {
         expect(run).not.toThrow();
         // Root(1) + Wide members(breadth) + Leaf members per Wide member(breadth^2).
         expect(run()).toHaveLength(1 + breadth + breadth * breadth);
+    });
+});
+
+describe('resolveReferenceType', () => {
+    const reference = new Map<string, any>(
+        Object.entries({
+            LabelOptions: { kind: 'interface', name: 'LabelOptions', members: [] },
+            Label: alias('Label', 'LabelOptions'),
+            Dangling: alias('Dangling', 'NotInReference'),
+            CssColor: alias('CssColor', union('string')),
+        })
+    );
+
+    it('resolves a plain interface to its node', () => {
+        expect(resolveReferenceType(reference as any, 'LabelOptions')).toBe(reference.get('LabelOptions'));
+    });
+
+    it('resolves an alias to a known type as the alias and its target', () => {
+        expect(resolveReferenceType(reference as any, 'Label')).toEqual([
+            reference.get('Label'),
+            reference.get('LabelOptions'),
+        ]);
+    });
+
+    it('resolves an alias to an unknown type as the alias alone', () => {
+        expect(resolveReferenceType(reference as any, 'Dangling')).toBe(reference.get('Dangling'));
+    });
+
+    it.each([
+        ['a name hidden from the docs', 'CssColor'],
+        ['a name absent from the reference', 'Missing'],
+    ])('returns undefined for %s', (_label, typeName) => {
+        expect(resolveReferenceType(reference as any, typeName)).toBeUndefined();
+    });
+});
+
+describe('buildTypeArguments', () => {
+    const member = (type: any) => ({ kind: 'member' as const, name: 'selection', type });
+
+    it('resolves a type-param argument through the generics map', () => {
+        const type = { kind: 'typeRef', type: 'Selection', typeArguments: ['ItemStyle', 'Explicit'] };
+
+        expect(buildTypeArguments(member(type) as any, { ItemStyle: 'StyleOptions' })).toEqual([
+            'StyleOptions',
+            'Explicit',
+        ]);
+    });
+
+    it('returns undefined for a typeRef without arguments', () => {
+        expect(buildTypeArguments(member({ kind: 'typeRef', type: 'Selection' }) as any, {})).toBeUndefined();
+    });
+
+    it('returns undefined for a member that is not a typeRef', () => {
+        expect(buildTypeArguments(member('boolean') as any, {})).toBeUndefined();
     });
 });

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -910,10 +910,17 @@ export function buildTypeArgumentsFromGenericsMap(
  * Builds positional type arguments from a member's own `typeRef`, resolving each against the
  * declaring interface's generics map. Counterpart to buildTypeArgumentsFromGenericsMap, which
  * reads the target's type-params rather than the member's arguments.
+ *
+ * Array members unwrap to their element type, so the arguments read here line up with the type
+ * `getMemberType` resolves for the same member (e.g. `AgAngleCrossLineOptions<AgNumericValue>[]`).
  */
 export function buildTypeArguments(member: MemberNode, genericsMap?: Record<string, TypeNode>) {
-    if (typeof member.type === 'object' && member.type.kind === 'typeRef') {
-        return member.type.typeArguments?.map((genericType) =>
+    let memberType = member.type;
+    while (isArrayNode(memberType)) {
+        memberType = memberType.type;
+    }
+    if (typeof memberType === 'object' && memberType.kind === 'typeRef') {
+        return memberType.typeArguments?.map((genericType) =>
             typeof genericType === 'string'
                 ? normalizeType(genericsMap?.[genericType] ?? genericType)
                 : normalizeType(genericType)

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceHelpers.ts
@@ -20,7 +20,7 @@ import { entries } from 'ag-charts-core';
 
 import { getIsBenchmarkOnlyBuild } from '../../utils/env';
 
-type ApiReferenceType = Map<string, NodeTypes>;
+export type ApiReferenceType = Map<string, NodeTypes>;
 type PossibleTypeNode = NodeTypes | undefined | PossibleTypeNode[];
 
 export type SearchDatum = { label: string; searchable: string; navPath: NavigationPath[] };
@@ -904,6 +904,41 @@ export function buildTypeArgumentsFromGenericsMap(
     return typeParams.map((typeParam) =>
         normalizeType(genericsMap[typeParam.name] ?? typeParam.default ?? typeParam.name)
     );
+}
+
+/**
+ * Builds positional type arguments from a member's own `typeRef`, resolving each against the
+ * declaring interface's generics map. Counterpart to buildTypeArgumentsFromGenericsMap, which
+ * reads the target's type-params rather than the member's arguments.
+ */
+export function buildTypeArguments(member: MemberNode, genericsMap?: Record<string, TypeNode>) {
+    if (typeof member.type === 'object' && member.type.kind === 'typeRef') {
+        return member.type.typeArguments?.map((genericType) =>
+            typeof genericType === 'string'
+                ? normalizeType(genericsMap?.[genericType] ?? genericType)
+                : normalizeType(genericType)
+        );
+    }
+    return undefined;
+}
+
+/**
+ * Resolves a type name to its reference node, dropping interfaces hidden from the docs. A type
+ * alias pointing at another known type resolves to both nodes, so renderers can show the alias
+ * alongside what it expands to.
+ */
+export function resolveReferenceType(
+    reference: ApiReferenceType | undefined,
+    typeName: string
+): NodeTypes | NodeTypes[] | undefined {
+    if (!reference?.has(typeName) || isInterfaceHidden(typeName)) {
+        return undefined;
+    }
+    const ref = reference.get(typeName)!;
+    if (ref.kind === 'typeAlias' && typeof ref.type === 'string' && reference.has(ref.type)) {
+        return [ref, reference.get(ref.type)!];
+    }
+    return ref;
 }
 
 function collectInterfaceSearchData(

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
@@ -29,6 +29,7 @@ import remarkBreaks from 'remark-breaks';
 
 import {
     type SpecialTypesMap,
+    buildTypeArguments,
     buildTypeArgumentsFromGenericsMap,
     cleanupName,
     formatTypeToCode,
@@ -44,6 +45,7 @@ import {
     parseJsDocs,
     processMembers,
     resolveAliasedUnion,
+    resolveReferenceType,
 } from '../apiReferenceHelpers';
 import { SelectionContext } from './OptionsNavigation';
 import { type CollapsibleType, PropertyTitle, PropertyType } from './Properties';
@@ -679,31 +681,6 @@ function isUnionTypesDetails(node?: MemberAdditionalDetails): node is UnionTypes
 
 function isInterfaceNode(node?: MemberAdditionalDetails): node is InterfaceNode {
     return Boolean(node && !Array.isArray(node) && 'kind' in node && node.kind === 'interface');
-}
-
-function buildTypeArguments(member: MemberNode, genericsMap?: Record<string, TypeNode>) {
-    if (typeof member.type === 'object' && member.type.kind === 'typeRef') {
-        return member.type.typeArguments?.map((genericType) =>
-            typeof genericType === 'string'
-                ? normalizeType(genericsMap?.[genericType] ?? genericType)
-                : normalizeType(genericType)
-        );
-    }
-    return undefined;
-}
-
-function resolveReferenceType(
-    reference: ReferenceMap | undefined,
-    typeName: string
-): NodeTypes | NodeTypes[] | undefined {
-    if (!reference?.has(typeName) || isInterfaceHidden(typeName)) {
-        return undefined;
-    }
-    const ref = reference.get(typeName)!;
-    if (ref.kind === 'typeAlias' && typeof ref.type === 'string' && reference.has(ref.type)) {
-        return [ref, reference.get(ref.type)!];
-    }
-    return ref;
 }
 
 function scrollToAndHighlightById(id: string) {

--- a/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.test.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildApiReferenceTable } from './renderApiReferenceTable';
+
+const member = (name: string, type: any, extra: Record<string, unknown> = {}) => ({
+    kind: 'member' as const,
+    name,
+    type,
+    optional: true,
+    ...extra,
+});
+const iface = (name: string, members: any[], extra: Record<string, unknown> = {}) => ({
+    kind: 'interface' as const,
+    name,
+    members,
+    ...extra,
+});
+const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
+const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
+const typeRef = (type: string, typeArguments?: string[]) => ({ kind: 'typeRef' as const, type, typeArguments });
+
+const makeReference = (nodes: Record<string, unknown>) => new Map<string, any>(Object.entries(nodes)) as any;
+
+/** Body rows as `[property, type, default, description]`, with markdownTable's pipe escaping undone. */
+function bodyRows(table: string): string[][] {
+    return table
+        .split('\n')
+        .slice(2)
+        .map((line) =>
+            line
+                .split(/(?<!\\)\|/)
+                .slice(1, -1)
+                .map((cell) => cell.trim().replaceAll('\\|', '|'))
+        );
+}
+
+/** The `Property` column of each body row, which is what carries the nesting. */
+function propertyPaths(table: string): string[] {
+    return bodyRows(table).map(([property]) => property);
+}
+
+function row(table: string, property: string): string[] | undefined {
+    return bodyRows(table).find((cells) => cells[0] === property);
+}
+
+describe('buildApiReferenceTable', () => {
+    it('renders a flat interface of primitives', () => {
+        const reference = makeReference({
+            Root: iface('Root', [
+                member('enabled', 'boolean', { docs: ['Whether it is on.'] }),
+                member('name', 'string', { optional: false }),
+            ]),
+        });
+
+        expect(buildApiReferenceTable(reference, { id: 'Root' })).toBe(
+            [
+                '| Property | Type | Default | Description |',
+                '| --- | --- | --- | --- |',
+                '| enabled | boolean |  | Whether it is on. |',
+                '| name (required) | string |  |  |',
+            ].join('\n')
+        );
+    });
+
+    it('expands a nested interface as dotted-path rows directly after its parent', () => {
+        const reference = makeReference({
+            Root: iface('Root', [member('selection', typeRef('Selection')), member('width', 'number')]),
+            Selection: iface('Selection', [member('enabled', 'boolean'), member('containment', 'string')]),
+        });
+
+        const table = buildApiReferenceTable(reference, { id: 'Root' });
+
+        expect(propertyPaths(table)).toEqual(['selection', 'selection.enabled', 'selection.containment', 'width']);
+        // The parent keeps its own docs and interface name; the name is what ties the dotted rows to it.
+        expect(row(table, 'selection')).toEqual(['selection', 'Selection', '', '']);
+    });
+
+    it('composes paths across three levels', () => {
+        const reference = makeReference({
+            A: iface('A', [member('b', typeRef('B'))]),
+            B: iface('B', [member('c', typeRef('C'))]),
+            C: iface('C', [member('leaf', 'string')]),
+        });
+
+        expect(propertyPaths(buildApiReferenceTable(reference, { id: 'A' }))).toEqual(['b', 'b.c', 'b.c.leaf']);
+    });
+
+    it('emits a member default in the Default column', () => {
+        const reference = makeReference({
+            Root: iface('Root', [member('containment', 'string', { defaultValue: 'chart.selection.containment' })]),
+        });
+
+        expect(row(buildApiReferenceTable(reference, { id: 'Root' }), 'containment')).toEqual([
+            'containment',
+            'string',
+            'chart.selection.containment',
+            '',
+        ]);
+    });
+
+    describe('cycles', () => {
+        it('stops a mutual cycle without dropping the row that closes it', () => {
+            const reference = makeReference({
+                A: iface('A', [member('b', typeRef('B'))]),
+                B: iface('B', [member('a', typeRef('A'))]),
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'A' }))).toEqual(['b', 'b.a']);
+        });
+
+        it('stops a self-reference', () => {
+            const reference = makeReference({
+                A: iface('A', [member('a', typeRef('A')), member('name', 'string')]),
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'A' }))).toEqual(['a', 'name']);
+        });
+
+        it('expands a shared type under each parent that references it', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('start', typeRef('Point')), member('end', typeRef('Point'))]),
+                Point: iface('Point', [member('x', 'number')]),
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root' }))).toEqual([
+                'start',
+                'start.x',
+                'end',
+                'end.x',
+            ]);
+        });
+    });
+
+    // Mirrors `AgBarSeriesOptions.selection`, which is
+    // `AgSelectionOptions<AgSelectionStyleOptions, AgSelectionStyleOptions>` — without the member's
+    // own type arguments the children render the type-param names and dead-end there.
+    it('substitutes generics so nested members resolve and keep expanding', () => {
+        const reference = makeReference({
+            Root: iface('Root', [member('selection', typeRef('Selection', ['StyleOptions', 'StyleOptions']))]),
+            Selection: iface(
+                'Selection',
+                [member('selectedItem', 'ItemStyle'), member('unselectedItem', 'SeriesStyle')],
+                {
+                    typeParams: [
+                        { kind: 'typeParam', name: 'ItemStyle', default: 'StyleOptions' },
+                        { kind: 'typeParam', name: 'SeriesStyle', default: 'ItemStyle' },
+                    ],
+                }
+            ),
+            StyleOptions: iface('StyleOptions', [member('fill', 'string')]),
+        });
+
+        const table = buildApiReferenceTable(reference, { id: 'Root' });
+
+        expect(propertyPaths(table)).toEqual([
+            'selection',
+            'selection.selectedItem',
+            'selection.selectedItem.fill',
+            'selection.unselectedItem',
+            'selection.unselectedItem.fill',
+        ]);
+        expect(row(table, 'selection.selectedItem')?.[1]).toBe('StyleOptions');
+    });
+
+    describe('config attributes', () => {
+        const reference = makeReference({
+            Root: iface('Root', [
+                member('a', typeRef('Child')),
+                member('b', 'string'),
+                member('c', 'string', { optional: false }),
+            ]),
+            Child: iface('Child', [member('b', 'number'), member('c', 'number', { optional: false })]),
+        });
+
+        it('scopes exclude to the top level so a nested member of the same name survives', () => {
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root', exclude: ['b'] }))).toEqual([
+                'a',
+                'a.b',
+                'a.c (required)',
+                'c (required)',
+            ]);
+        });
+
+        it('scopes include to the top level', () => {
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root', include: ['a'] }))).toEqual([
+                'a',
+                'a.b',
+                'a.c (required)',
+            ]);
+        });
+
+        it('hides the required marker at every depth', () => {
+            const paths = propertyPaths(buildApiReferenceTable(reference, { id: 'Root', hideRequired: true }));
+
+            expect(paths).toEqual(['a', 'a.b', 'a.c', 'b', 'c']);
+        });
+    });
+
+    describe('type cell', () => {
+        it('expands a union alias so its variants survive', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('fill', typeRef('FillOptions'))]),
+                FillOptions: alias('FillOptions', union('string', 'GradientFill')),
+                GradientFill: iface('GradientFill', [member('stops', 'string')]),
+            });
+
+            expect(row(buildApiReferenceTable(reference, { id: 'Root' }), 'fill')?.[1]).toBe('string | GradientFill');
+        });
+
+        it('keeps arrayness when expanding a union alias', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('annotations', { kind: 'array', type: typeRef('Annotation') })]),
+                Annotation: alias('Annotation', union('LineAnnotation', 'BoxAnnotation')),
+                LineAnnotation: iface('LineAnnotation', [member('type', 'line')]),
+                BoxAnnotation: iface('BoxAnnotation', [member('type', 'box')]),
+            });
+
+            expect(row(buildApiReferenceTable(reference, { id: 'Root' }), 'annotations')?.[1]).toBe(
+                'Array<LineAnnotation | BoxAnnotation>'
+            );
+        });
+
+        it('keeps the alias name when the expansion is too long to read', () => {
+            const variants = Array.from({ length: 40 }, (_, i) => `'icon-name-${i}'`);
+            const reference = makeReference({
+                Root: iface('Root', [member('icon', typeRef('IconName'))]),
+                IconName: alias('IconName', union(...variants)),
+            });
+
+            expect(row(buildApiReferenceTable(reference, { id: 'Root' }), 'icon')?.[1]).toBe('IconName');
+        });
+
+        it('leaves an inline union alone', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('position', union("'top'", "'bottom'"))]),
+            });
+
+            expect(row(buildApiReferenceTable(reference, { id: 'Root' }), 'position')?.[1]).toBe("'top' | 'bottom'");
+        });
+    });
+
+    describe('members that must not expand', () => {
+        it('leaves a union of interfaces flat', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('fill', typeRef('FillOptions'))]),
+                FillOptions: alias('FillOptions', union('SolidFill', 'GradientFill')),
+                SolidFill: iface('SolidFill', [member('colour', 'string')]),
+                GradientFill: iface('GradientFill', [member('stops', 'string')]),
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root' }))).toEqual(['fill']);
+        });
+
+        it('leaves a hidden interface flat', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('colour', typeRef('CssColor'))]),
+                CssColor: iface('CssColor', [member('internal', 'string')]),
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root' }))).toEqual(['colour']);
+        });
+
+        it('leaves an alias to an interface flat', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('label', typeRef('Label'))]),
+                Label: alias('Label', 'LabelOptions'),
+                LabelOptions: iface('LabelOptions', [member('text', 'string')]),
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root' }))).toEqual(['label']);
+        });
+
+        it('leaves an enum flat', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('mode', typeRef('Mode'))]),
+                Mode: { kind: 'enum', name: 'Mode', members: { A: 'a', B: 'b' } },
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root' }))).toEqual(['mode']);
+        });
+
+        it('leaves an empty interface flat', () => {
+            const reference = makeReference({
+                Root: iface('Root', [member('empty', typeRef('Empty'))]),
+                Empty: iface('Empty', []),
+            });
+
+            expect(propertyPaths(buildApiReferenceTable(reference, { id: 'Root' }))).toEqual(['empty']);
+        });
+    });
+
+    it('warns and clamps rather than emitting an unbounded table', () => {
+        // A chain long enough to trip the depth cap: each level nests one further interface.
+        const nodes: Record<string, unknown> = {};
+        for (let i = 0; i < 20; i++) {
+            nodes[`N${i}`] = iface(`N${i}`, [member('next', typeRef(`N${i + 1}`))]);
+        }
+        nodes.N20 = iface('N20', [member('leaf', 'string')]);
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const paths = propertyPaths(buildApiReferenceTable(makeReference(nodes), { id: 'N0' }));
+
+        expect(paths.length).toBe(8);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('apiReference "N0"'));
+        warn.mockRestore();
+    });
+
+    describe('degrades to an empty string', () => {
+        const reference = makeReference({
+            Root: iface('Root', [member('a', 'string')]),
+            NotAnInterface: alias('NotAnInterface', 'string'),
+        });
+
+        it.each([
+            ['no id attribute', {}],
+            ['an unknown id', { id: 'Missing' }],
+            ['an id that is not an interface', { id: 'NotAnInterface' }],
+            ['an interface with no members', { id: 'Root', exclude: ['a'] }],
+        ])('for %s', (_label, attributes) => {
+            expect(buildApiReferenceTable(reference, attributes)).toBe('');
+        });
+    });
+});

--- a/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.test.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.test.ts
@@ -162,6 +162,25 @@ describe('buildApiReferenceTable', () => {
         expect(row(table, 'selection.selectedItem')?.[1]).toBe('StyleOptions');
     });
 
+    // Shaped like `crossLines?: AgAngleCrossLineOptions<AgNumericValue>[]`, where the supplied
+    // argument differs from the type-param default. The member resolves through the array, so the
+    // type arguments have to as well or the children fall back to the default.
+    it('substitutes generics through an array member', () => {
+        const reference = makeReference({
+            Root: iface('Root', [
+                member('crossLines', { kind: 'array', type: typeRef('CrossLine', ['NumericValue']) }),
+            ]),
+            CrossLine: iface('CrossLine', [member('value', 'TValue')], {
+                typeParams: [{ kind: 'typeParam', name: 'TValue', default: 'AxisValue' }],
+            }),
+        });
+
+        const table = buildApiReferenceTable(reference, { id: 'Root' });
+
+        expect(row(table, 'crossLines')?.[1]).toBe('CrossLine[]');
+        expect(row(table, 'crossLines.value')?.[1]).toBe('NumericValue');
+    });
+
     describe('config attributes', () => {
         const reference = makeReference({
             Root: iface('Root', [

--- a/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.ts
@@ -1,17 +1,87 @@
 import { markdownTable } from '@ag-website-shared/markdoc/markdownTable';
 import type { MarkdownFramework } from '@ag-website-shared/markdoc/renderMarkdocToMarkdown';
 import {
+    type ApiReferenceType,
+    buildTypeArguments,
     cleanupName,
+    getMemberType,
+    isArrayNode,
     normalizeType,
     parseJsDocs,
     processMembers,
+    resolveAliasedUnion,
+    resolveReferenceType,
 } from '@components/api-documentation/apiReferenceHelpers';
 import type { ApiReferenceConfig } from '@components/api-documentation/components/ApiReference';
+import type {
+    InterfaceNode,
+    MemberNode,
+    NodeTypes,
+    TypeLiteralNode,
+} from '@generate-code-reference-plugin/doc-interfaces/types';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// The deepest real nesting in the generated reference is 5 levels and the widest table 579 rows.
+// These caps only stop a cycle the ancestor guard misses from producing an unbounded table.
+const MAX_DEPTH = 8;
+const MAX_ROWS = 1500;
+
+// A union alias with dozens of variants (e.g. AgIconName, 53 string literals) makes an unreadable
+// cell; past this budget the alias name is left in place, still resolvable from the docs site.
+const MAX_UNION_SIGNATURE_CHARS = 120;
 
 /** Read a Markdoc attribute as a list of member names, ignoring non-string entries. */
 function asNameList(value: unknown): string[] | undefined {
     return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : undefined;
+}
+
+function interfaceId(attributes: Record<string, unknown>): string | undefined {
+    return typeof attributes.id === 'string' ? attributes.id : undefined;
+}
+
+function isMembersNode(node: NodeTypes): node is InterfaceNode | TypeLiteralNode {
+    return node.kind === 'interface' || node.kind === 'typeLiteral';
+}
+
+/**
+ * The interface a member expands into, mirroring the `hasMembers` branch of ApiReference's
+ * NodeFactory. Union variants — which the on-page tree expands behind "See available interfaces" —
+ * resolve to a type alias here and so stay flat; expanding them as rows is combinatorial.
+ */
+function resolveNestedInterface(reference: ApiReferenceType, member: MemberNode) {
+    const typeName = getMemberType(member);
+    const resolved = resolveReferenceType(reference, typeName);
+    if (!resolved || Array.isArray(resolved) || !isMembersNode(resolved) || !resolved.members.length) {
+        return undefined;
+    }
+    return { node: resolved, typeName };
+}
+
+/**
+ * The Type cell for a member. A member typed as a union alias renders as the bare alias name,
+ * which tells the reader nothing; expand it to the union itself so the variants survive in a
+ * surface that has no "See available interfaces" affordance.
+ */
+function formatMemberType(reference: ApiReferenceType, member: MemberNode): string {
+    const type = normalizeType(member.type);
+    const typeName = getMemberType(member);
+    // Anything that did not collapse to the bare name already spells out its members.
+    if (type !== typeName && type !== `${typeName}[]`) {
+        return type;
+    }
+
+    const resolved = resolveReferenceType(reference, typeName);
+    const aliasedUnion = resolveAliasedUnion(resolved && !Array.isArray(resolved) ? resolved : undefined, reference);
+    if (!aliasedUnion) {
+        return type;
+    }
+
+    const signature = normalizeType(aliasedUnion.unionType);
+    if (signature.length > MAX_UNION_SIGNATURE_CHARS) {
+        return type;
+    }
+    // Array<> rather than [] for the same reason normalizeType uses it: `A | B[]` would misread.
+    return isArrayNode(member.type) ? `Array<${signature}>` : signature;
 }
 
 /**
@@ -19,55 +89,119 @@ function asNameList(value: unknown): string[] | undefined {
  * component's member pipeline (same `processMembers`/`normalizeType`/`parseJsDocs`) so the
  * table stays in step with the rendered docs.
  *
- * Never throws: a build without generated types (missing resolved-interfaces file) or an
- * unresolvable interface degrades to an empty string so the surrounding page still renders.
+ * Nested object members are expanded in place as dotted-path rows (`selection.enabled`), since a
+ * static page has no equivalent of the on-page "See child properties" toggle.
+ *
+ * Pure (no filesystem access) so it is unit-testable; the entry point loads the reference.
  */
-function buildApiReferenceTable(attributes: Record<string, unknown>): string {
-    const id = typeof attributes.id === 'string' ? attributes.id : undefined;
+export function buildApiReferenceTable(reference: ApiReferenceType, attributes: Record<string, unknown>): string {
+    const id = interfaceId(attributes);
     if (!id) {
         return '';
     }
 
-    try {
-        const interfaceRef = getInterfacesReference().get(id);
-        if (interfaceRef?.kind !== 'interface') {
-            return '';
-        }
-
-        const config: ApiReferenceConfig = {
-            include: asNameList(attributes.include),
-            exclude: asNameList(attributes.exclude),
-            prioritise: asNameList(attributes.prioritise),
-        };
-
-        const hideRequired = attributes.hideRequired === true;
-        // markdownTable's cell escaping already collapses newlines and escapes pipes, so the
-        // markdown from parseJsDocs can be passed through as-is.
-        const rows = processMembers(interfaceRef, config).map((member) => {
-            const required = !hideRequired && !member.optional ? ' (required)' : '';
-            return [cleanupName(member.name) + required, normalizeType(member.type), parseJsDocs(member.docs) ?? ''];
-        });
-
-        if (!rows.length) {
-            return '';
-        }
-
-        return markdownTable(['Property', 'Type', 'Description'], rows);
-    } catch (error) {
-        // eslint-disable-next-line no-console
-        console.warn(`Unable to render apiReference table for "${id}":`, error);
+    const interfaceRef = reference.get(id);
+    if (interfaceRef?.kind !== 'interface') {
         return '';
     }
+
+    const config: ApiReferenceConfig = {
+        include: asNameList(attributes.include),
+        exclude: asNameList(attributes.exclude),
+        prioritise: asNameList(attributes.prioritise),
+    };
+    // include/exclude/prioritise scope the top-level interface only; nested interfaces must render
+    // their full member set, matching ApiReference's nestedConfig.
+    const nestedConfig: ApiReferenceConfig = {
+        ...config,
+        include: undefined,
+        exclude: undefined,
+        prioritise: undefined,
+    };
+
+    const hideRequired = attributes.hideRequired === true;
+    const rows: string[][] = [];
+    let capped = false;
+
+    function collectRows(
+        node: InterfaceNode | TypeLiteralNode,
+        memberConfig: ApiReferenceConfig,
+        prefix: string,
+        depth: number,
+        // The on-page tree needs no cycle guard, as each expansion is a fresh component reacting to
+        // a click. A single pre-order pass does — tracked per branch, so a type shared between two
+        // parents still expands under each of them.
+        ancestors: ReadonlySet<string>,
+        typeArguments?: string[]
+    ): void {
+        for (const member of processMembers(node, memberConfig, typeArguments)) {
+            if (rows.length >= MAX_ROWS) {
+                capped = true;
+                return;
+            }
+
+            const path = prefix ? `${prefix}.${cleanupName(member.name)}` : cleanupName(member.name);
+            const required = !hideRequired && !member.optional ? ' (required)' : '';
+            // markdownTable's cell escaping collapses newlines and escapes pipes, so the markdown
+            // from parseJsDocs can be passed through as-is.
+            rows.push([
+                path + required,
+                formatMemberType(reference, member),
+                member.defaultValue ?? '',
+                parseJsDocs(member.docs) ?? '',
+            ]);
+
+            const nested = resolveNestedInterface(reference, member);
+            if (!nested || ancestors.has(nested.typeName)) {
+                continue;
+            }
+            if (depth >= MAX_DEPTH) {
+                capped = true;
+                continue;
+            }
+
+            collectRows(
+                nested.node,
+                nestedConfig,
+                path,
+                depth + 1,
+                new Set(ancestors).add(nested.typeName),
+                // Type arguments come from the member's own typeRef resolved through the declaring
+                // node's generics map, then apply to the target's members — as in NodeFactory.
+                buildTypeArguments(member, node.kind === 'interface' ? node.genericsMap : undefined)
+            );
+        }
+    }
+
+    collectRows(interfaceRef, config, '', 1, new Set([id]));
+
+    if (capped) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `apiReference "${id}": nested expansion hit the ${MAX_ROWS}-row/${MAX_DEPTH}-level cap; table truncated.`
+        );
+    }
+
+    return markdownTable(['Property', 'Type', 'Default', 'Description'], rows);
 }
 
 /**
  * Renders an `apiReference` Markdoc tag as a GitHub-flavoured Markdown table for the
  * LLM-facing docs. The table is framework-agnostic — the member set and its types are
  * identical across frameworks — so `framework` is accepted for contract parity only.
+ *
+ * Never throws: a build without generated types (missing resolved-interfaces file) or an
+ * unresolvable interface degrades to an empty string so the surrounding page still renders.
  */
 export function renderApiReferenceTable(params: {
     attributes: Record<string, unknown>;
     framework: MarkdownFramework;
 }): Promise<string> {
-    return Promise.resolve(buildApiReferenceTable(params.attributes));
+    try {
+        return Promise.resolve(buildApiReferenceTable(getInterfacesReference(), params.attributes));
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(`Unable to render apiReference table for "${interfaceId(params.attributes)}":`, error);
+        return Promise.resolve('');
+    }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17912

## What

The `apiReference` Markdoc tag rendered a flat, one-level table in the LLM-facing `.md` pages, so nested object members were unreachable. QA flagged it against `AgBarSeriesOptions.selection` — the HTML reference exposes those members behind "See child properties", but a static page has no equivalent affordance.

Nested interfaces now expand in place as dotted-path rows:

```
| selection | AgSelectionOptions |  | Configuration for data selection. |
| selection.enabled | boolean |  | Set to `true` to enable the data-selection on this series. |
| selection.containment | 'any' \| 'all' | chart.selection.containment | Override the drag-to-select containment rule. |
| selection.selectedItem | AgSelectionStyleOptions |  | Styling options for selected items. |
| selection.selectedItem.opacity | Opacity |  | The opacity of the whole series … |
```

Also in scope:

- **Default column** — present in the HTML, previously dropped by the markdown.
- **Union-alias signatures** — a member typed as a union alias showed only the bare alias name; it now shows the union itself (`'any' | 'all'`), capped at 120 characters so a 53-variant alias like `AgIconName` keeps its name.

## Approach

`buildTypeArguments` and `resolveReferenceType` move from `ApiReference.tsx` into `apiReferenceHelpers.ts` so both surfaces share the resolution rules that must not drift. The generics substitution is load-bearing: `selection` is `AgSelectionOptions<AgSelectionStyleOptions, ...>`, and without the member's own type arguments the children render the type-param names and dead-end there. The union-variant machinery stays local to the React tree, which is still its only consumer.

`buildApiReferenceTable` now takes the reference map as an argument so it is unit-testable without mocking the filesystem, matching its siblings `renderModuleMappings` / `renderMajorTable`.

**Union variants are deliberately left flat.** Expanding them as rows is combinatorial — `AgFinancialChartOptions` reaches ~154k rows, ~482k total across the site — and would need an arbitrary depth cap. Recursing plain interfaces instead converges on its own: 594 rows in the widest table, 5 levels at the deepest. `MAX_DEPTH`/`MAX_ROWS` are safety rails for a cycle the ancestor guard misses; they never fire on current data and `console.warn` rather than truncate silently.

## Size impact — worth a reviewer's opinion

Measured against a live dev server, before vs after:

| Page | Before | After |
| --- | --- | --- |
| `bar-series.md` | 31 KB | 54 KB |
| `sparklines.md` | 35 KB | 98 KB |
| `axes-types.md` | 32 KB | **125 KB** |

`axes-types.md` at 125 KB is roughly 31k tokens for a single page. If that is too much for the LLM budget, the lever is a product-level depth cap (depth 2 still covers the reported `selection` case), not the safety rails above. Happy to add one if you would prefer it.

## Testing

- New `renderApiReferenceTable.test.ts` — 25 cases: path composition, pre-order, cycles/self-reference, generics substitution, top-level-only `include`/`exclude`/`prioritise`, `(required)` at depth, `hideRequired`, union-alias expansion and its length guard, non-expanding members (hidden interface, alias-to-interface, enum, empty interface, interface unions), the cap warning, and empty-string degradation.
- `apiReferenceHelpers.test.ts` — 8 cases covering the two newly shared exports.
- `yarn nx format`, `yarn nx lint ag-charts-website` (0 errors), `yarn nx test ag-charts-website` (505 passed).
- End-to-end against `yarn nx dev`: `/charts/react/bar-series.md` returns 200 with the nested rows; no cap warnings or render failures across the pages sampled.

`yarn nx test:e2e ag-charts-website` could **not** be run locally — it fails in a prerequisite `generate-example` task with `Cannot find module .../ag-charts-locale/dist/package/main.cjs.js`, which reproduces with these changes stashed, so it is a pre-existing build-state issue in my working copy rather than a regression. `e2e/api-ref-page.spec.ts` is the check that would independently confirm the `ApiReference.tsx` extraction is behaviour-preserving, so please keep an eye on it in CI. The move itself is verbatim function bodies with only a structurally-identical parameter type change (`ReferenceMap` → `ApiReferenceType`, both `Map<string, NodeTypes>`).

## Noted, not fixed here

- `member.omit` is ignored, matching `ApiReference.tsx`; only `OptionsNavigation.tsx` consumes it. Filtering omitted keys would be a separate change fixing both surfaces.
- `getInterfacesReference()` re-reads and re-parses the 3.7 MB JSON per tag render. Not worsened by this change; a memo risks stale data in the dev server, so it belongs in its own commit.
- `options.astro` and `themes-api.astro` have no `.md` twins at all, so the full options browser is invisible to LLMs. Separate gap.