### PR TITLE
AG-17990 [CLAUDE] Emit one series-node entry per overlapping node

### DIFF
--- a/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuTypes.ts
@@ -11,7 +11,7 @@ import type {
 import type { AxisValuePick } from '../../module/axisContext';
 import type { CrossLineValuePick } from '../crossline/crossLine';
 import type { CategoryLegendDatum } from '../legend/legendDatum';
-import type { ISeries, SeriesNodeDatum } from '../series/seriesTypes';
+import type { SeriesNodeDatum } from '../series/seriesTypes';
 
 // Extract TEvent from `action?: (param: TEvent)` of the AgContextMenuItem contract:
 type InferTEvent<T extends AgContextMenuItemShowOn> =
@@ -60,10 +60,8 @@ export interface ContextShowOnMap extends ContextShowOnMapRule {
     'series-node': {
         event: InferTEvent<'series-node'>;
         callback: (param: InferTEvent<'series-node'>) => void;
-        context: {
-            pickedSeries: ISeries<any, any, any> | undefined;
-            pickedNode: SeriesNodeDatum | undefined;
-        };
+        /** Every node matched at the click point (e.g. overlapping markers), hit-test order; the first one wins. */
+        context: SeriesNodeDatum[];
     };
 }
 

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -128,6 +128,15 @@ function computeHighlightInViewport(
     return false;
 }
 
+/** Nodes without a datum index cannot be identified by a context-menu item action, so they are dropped. */
+function seriesNodeContexts(pickedNodes: readonly HighlightNodeDatum[]): SeriesNodeDatum[] {
+    const contexts: SeriesNodeDatum[] = [];
+    for (const { datumIndex, ...node } of pickedNodes) {
+        if (datumIndex != null) contexts.push({ ...node, datumIndex });
+    }
+    return contexts;
+}
+
 function computePendingViewportFocus(event: ZoomChangeCompleteEvent): PickViewportFocusInputs['where'] | undefined {
     switch (event.sourceDetail) {
         case 'keyboard-page(1)':
@@ -466,10 +475,12 @@ export class SeriesAreaManager extends BaseManager {
             return;
         }
 
-        let pickedNode: HighlightNodeDatum | undefined;
+        // Every node under the point, not just the topmost: overlapping markers each get their own context.
+        let pickedNodes: readonly HighlightNodeDatum[] = [];
         let position: { x: number; y: number } | undefined;
         if (this.focusIndicator?.isFocusVisible()) {
-            pickedNode = this.chart.ctx.highlightManager.getActiveHighlight();
+            const pickedNode = this.chart.ctx.highlightManager.getActiveHighlight();
+            if (pickedNode) pickedNodes = [pickedNode];
             if (pickedNode && this.seriesRect && pickedNode.midPoint) {
                 position = Transformable.toCanvasPoint(
                     pickedNode.series.contentGroup,
@@ -483,22 +494,20 @@ export class SeriesAreaManager extends BaseManager {
                 this.pickManager.maybeActivate(undefined, (): void => {
                     this.chart.ctx.highlightManager.updateHighlight(this.id);
                 });
-                pickedNode = pick.matches[0];
+                pickedNodes = pick.matches;
             }
         }
-
-        const pickedSeries = pickedNode?.series;
 
         this.clearAll();
         const canvasX = event.currentX + current.cssLeft();
         const canvasY = event.currentY + current.cssTop();
-        const { datumIndex } = pickedNode ?? {};
 
         const regions: AgContextMenuItemShowOn[] = ['series-area'];
         const contexts: ContextMenuRegionContexts = {};
-        if (pickedSeries && pickedNode && datumIndex != null) {
+        const nodeContexts = seriesNodeContexts(pickedNodes);
+        if (nodeContexts.length > 0) {
             regions.push('series-node');
-            contexts['series-node'] = { pickedSeries, pickedNode: { ...pickedNode, datumIndex } };
+            contexts['series-node'] = nodeContexts;
         }
 
         // Ask axis-owning modules whether an axis overlaps this point (mirrors the hover/drag handoff). They
@@ -524,7 +533,7 @@ export class SeriesAreaManager extends BaseManager {
         let primary: AgContextMenuItemShowOn = 'series-area';
         if (contexts['series-node']) {
             primary = 'series-node';
-        } else if (collectEvent.crossLine) {
+        } else if (collectEvent.crossLine.length > 0) {
             primary = 'crossline';
         } else if (collectEvent.axis) {
             primary = 'axis';

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -88,7 +88,7 @@ export class ContextMenu extends AbstractModuleInstance {
     private readonly interactionManager: _ModuleSupport.InteractionManager;
 
     // State
-    private pickedNode: PickedNode | undefined = undefined;
+    private pickedNodes?: ContextShowOnMap['series-node']['context'];
     private pickedLegendItem?: _ModuleSupport.CategoryLegendDatum;
     private pickedCaptionCtx?: ContextShowOnMap['caption']['context'];
     private pickedAxisCtx?: _ModuleSupport.AxisValuePick;
@@ -226,36 +226,45 @@ export class ContextMenu extends AbstractModuleInstance {
         }
     }
 
-    private makeGetItemsParamsSeriesNode(
-        defaultItems: AgContextMenuItem[],
-        active: ReadonlySet<AgContextMenuItemShowOn>
-    ): GetItemsParams {
-        if (this.pickedNode == null) throw new Error(`this.pickedNode is null`);
+    private seriesNodeRegion(node: PickedNode): SeriesNodeParams {
         // FIXME: Some optional keys like dataIdKey are not set. Is that a concern?
-        const itemId = getItemId(this.pickedNode, this.pickedNode.series.data?.dataIdKey);
+        const itemId = getItemId(node, node.series.data?.dataIdKey);
         const region: SeriesNodeParams = {
             showOn: 'series-node',
-            seriesId: this.pickedNode.series.id,
+            seriesId: node.series.id,
             itemId,
-            datum: this.pickedNode.datum,
-            selectionState: this.pickedNode.series.getSelectionStateString(this.pickedNode.datumIndex),
+            datum: node.datum,
+            selectionState: node.series.getSelectionStateString(node.datumIndex),
             isCollapsed: this.ctx.collapsedManager.isCollapsed(itemId),
         };
 
         for (const k of DATUM_KEYS) {
-            if (this.pickedNode[k] !== undefined) {
-                region[k] = this.pickedNode[k];
+            if (node[k] !== undefined) {
+                region[k] = node[k];
             }
         }
 
         // Histogram bins carry standardised bin metadata; binIndex is always set for histogram nodes.
-        if (this.pickedNode.binIndex !== undefined) {
-            const { datums, binIndex, binRange, aggregatedValue, frequency } = this.pickedNode;
+        if (node.binIndex !== undefined) {
+            const { datums, binIndex, binRange, aggregatedValue, frequency } = node;
             Object.assign(region, { datums, binIndex, binRange, aggregatedValue, frequency });
         }
-        const allShowOnParams: ShowOnParams[] = [...this.plotOverlapRegions(active), region];
-        const params: AgContextMenuGetItemsParamsSeriesNode = { ...region, defaultItems, allShowOnParams };
-        const callers: Caller[] = [this.pickedNode.series.properties, this.ctx.chartService];
+        return region;
+    }
+
+    private makeGetItemsParamsSeriesNode(
+        defaultItems: AgContextMenuItem[],
+        active: ReadonlySet<AgContextMenuItemShowOn>
+    ): GetItemsParams {
+        if (this.pickedNodes == null) throw new Error(`this.pickedNodes is null`);
+        const regions = this.pickedNodes.map((node) => this.seriesNodeRegion(node));
+        if (regions.length === 0) throw new Error(`this.pickedNodes is empty`);
+
+        // The topmost node (hit-test order) wins. Nodes overlapping it at this contextmenu point are broadcast in
+        // the allShowOnParams property.
+        const allShowOnParams: ShowOnParams[] = [...this.plotOverlapRegions(active), ...regions];
+        const params: AgContextMenuGetItemsParamsSeriesNode = { ...regions[0], defaultItems, allShowOnParams };
+        const callers: Caller[] = [this.pickedNodes[0].series.properties, this.ctx.chartService];
         return [params, callers];
     }
 
@@ -361,7 +370,7 @@ export class ContextMenu extends AbstractModuleInstance {
         // Regions can overlap (e.g. a datum node over a crossing axis), so populate every picked context the
         // event carries rather than a single mutually-exclusive one; item actions route by their own showOn.
         const { contexts } = event;
-        this.pickedNode = contexts['series-node']?.pickedNode;
+        this.pickedNodes = contexts['series-node'];
         this.pickedAxisCtx = contexts.axis;
         this.pickedCaptionCtx = contexts.caption;
         this.pickedLegendItem = contexts['legend-item']?.legendItem;
@@ -520,7 +529,7 @@ export class ContextMenu extends AbstractModuleInstance {
             return () => {
                 const { chartService: chart } = this.ctx;
 
-                const pickedNode = this.pickedNode;
+                const pickedNode = this.pickedNodes?.[0];
                 const callers: (Caller | undefined)[] = [pickedNode?.series.properties, chart];
                 const apiEvent = pickedNode?.series.createNodeContextMenuActionEvent(showEvent, pickedNode);
                 if (apiEvent) {

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -233,9 +233,8 @@ export interface AgContextMenuShowOnParamsLegendItem<_TDatumReserved = never, TC
  * `allShowOnParams` — the same shape a scope passes as its top-level params when it wins outright, without the
  * callback-level `defaultItems`.
  *
- * Keyed by array position rather than by scope so that a future release can surface more than one context for
- * the same scope — e.g. overlapping markers (multiple `series-node`) or an x/y crossover (multiple `axis`) —
- * without an API change. Emitting multiple entries per scope is not yet implemented.
+ * Keyed by array position rather than by scope, because one scope can match more than once at a single click
+ * point — e.g. overlapping markers each contribute their own `series-node` entry.
  */
 export type AgContextMenuShowOnParams<TDatum = DatumDefault, TContext = ContextDefault> =
     | AgContextMenuShowOnParamsAlways<TDatum, TContext>
@@ -250,8 +249,10 @@ interface GetItemsParamsMixin<TDatum, TContext> {
     /** The default menu items that would be shown without customisation. */
     defaultItems: AgContextMenuItem<TDatum, TContext>[];
     /**
-     * Every `showOn` scope that matched at the click point, including the winning scope in the root
-     * params. Scopes that did not match are absent from the array.
+     * Every `showOn` scope that matched at the click point, including the winning scope carried by these root
+     * params. Lets the callback build one combined menu when scopes overlap — for example a datum node drawn
+     * over an axis positioned with `crossAt`. Scopes that did not match are absent from the array. A scope
+     * appears more than once when several of its contexts match the same point, such as overlapping markers.
      */
     allShowOnParams: AgContextMenuShowOnParams<TDatum, TContext>[];
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17990

Allow `allShowOnParams` to carry more than one entry for the same `showOn` scope when several contexts of that scope genuinely match the click point. At most one `series-node` entry was produced before, so right-clicking the overlap of two markers (e.g. two bubbles at the same category) exposed only whichever node won hit-testing; the other node's params were unreachable from `getItems`.

The hit-test already collected every distance-0 match in `PickedNodes.matches` — only the context-menu path discarded all but the first:

-   `seriesAreaManager` forwards the whole match list instead of
    `matches[0]`. New `seriesNodeContexts()` helper drops nodes with no
    datum index, since a context-menu item action cannot identify those.
-   `ContextShowOnMap['series-node'].context` becomes `SeriesNodeDatum[]`,
    mirroring the array shape the `crossline` scope already uses. The
    `pickedSeries` field is removed — it was never read, and each node
    carries its own `series`.
-   Enterprise `ContextMenu` extracts `seriesNodeRegion()` from
    `makeGetItemsParamsSeriesNode()` and maps it over every picked node, so
    each contributes its own `series-node` entry. Root params and the
    action caller still resolve to the topmost node, leaving `showOn`
    precedence and the existing single-match behaviour unchanged.
-   `allShowOnParams` JSDoc in `ag-charts-types` no longer states that
    multiple entries per scope are unimplemented.

Scoped to the `getItems` callback; static `showOn`-item rendering is unaffected.

Also fixes an unrelated defect that this change surfaced: `primary` region selection truthy-tested `collectEvent.crossLine`, which is initialised to `[]` and therefore always truthy, so every right-click that missed a series node selected the `crossline` primary and threw
`this.pickedCrossLine is null` from `getItems`. It now guards on the crossline list being non-empty.