### PR TITLE
Make conditional theme operator branches optional

### DIFF
--- a/packages/ag-charts-community/src/chart/themes/axisThemeTemplate.ts
+++ b/packages/ag-charts-community/src/chart/themes/axisThemeTemplate.ts
@@ -33,7 +33,7 @@ export const parentLevelAxisThemeTemplate = {
             enabled: { $path: '../../label/enabled' },
             border: {
                 enabled: {
-                    $or: [{ $isUserOption: ['../border', true, false] }, { $path: '../../../label/border/enabled' }],
+                    $or: [{ $isUserOption: '../border' }, { $path: '../../../label/border/enabled' }],
                 },
                 strokeWidth: { $path: '../../../label/border/strokeWidth' },
                 stroke: { $path: '../../../label/border/stroke' },

--- a/packages/ag-charts-community/src/module/optionsGraph.test.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.test.ts
@@ -369,6 +369,52 @@ describe('OptionsGraph', () => {
             });
         });
 
+        describe('$isUserOption', () => {
+            const resolveWithMaxWidth = (themeConfig: PlainObject, maxWidth?: number) =>
+                new OptionsGraph(themeConfig, prepareOptions(maxWidth === undefined ? {} : { maxWidth })).resolve();
+
+            it('should resolve omitted branches to the check outcome', () => {
+                const themeConfig = {
+                    line: {
+                        one: { $isUserOption: './maxWidth' },
+                        two: { $isUserOption: ['./maxWidth'] },
+                        three: { $isUserOption: ['./maxWidth', 2] },
+                    },
+                };
+
+                expect(resolveWithMaxWidth(themeConfig, 10)).toMatchObject({ one: true, two: true, three: 2 });
+                expect(resolveWithMaxWidth(themeConfig)).toMatchObject({ one: false, two: false, three: false });
+            });
+
+            it('should resolve an explicit `undefined` branch to `undefined`', () => {
+                const themeConfig = { line: { one: { $isUserOption: ['./maxWidth', 2, undefined] } } };
+
+                expect(resolveWithMaxWidth(themeConfig, 10)).toMatchObject({ one: 2 });
+                expect(resolveWithMaxWidth(themeConfig)).not.toHaveProperty('one');
+            });
+
+            it('should match any path of a path list', () => {
+                const themeConfig = {
+                    line: {
+                        one: { $isUserOption: [['./minWidth', './maxWidth']] },
+                        two: { $isUserOption: [['./minWidth', './maxWidth'], 'yes'] },
+                        three: { $isUserOption: [['./minWidth', './maxWidth'], 'yes', 'no'] },
+                    },
+                };
+
+                expect(resolveWithMaxWidth(themeConfig, 10)).toMatchObject({
+                    one: true,
+                    two: 'yes',
+                    three: 'yes',
+                });
+                expect(resolveWithMaxWidth(themeConfig)).toMatchObject({
+                    one: false,
+                    two: false,
+                    three: 'no',
+                });
+            });
+        });
+
         describe('$palette', () => {
             it('should resolve `$palette` operations', () => {
                 const themeConfig = {
@@ -677,6 +723,29 @@ describe('OptionsGraph', () => {
             });
         });
 
+        it('should resolve omitted `$if` branches to the condition outcome', () => {
+            const themeConfig = {
+                line: {
+                    one: { $if: [true] },
+                    two: { $if: [false] },
+                    three: { $if: ['hello'] },
+                    four: { $if: [true, 'yes'] },
+                    five: { $if: [false, 'yes'] },
+                    six: { $if: [false, 'yes', undefined] },
+                },
+            };
+            const options = new OptionsGraph(themeConfig, prepareOptions({})).resolve();
+            expect(options).toStrictEqual({
+                one: true,
+                two: false,
+                three: true,
+                four: 'yes',
+                five: false,
+                axes: expect.any(Object),
+            });
+            expect(options).not.toHaveProperty('six');
+        });
+
         it('should resolve `$isType` operations', () => {
             const themeConfig = {
                 line: {
@@ -738,10 +807,33 @@ describe('OptionsGraph', () => {
                 twelve: 'yes',
                 thirteen: 'no',
                 fourteen: 'hello',
+                fifteen: false,
                 sixteen: { seventeen: 'yes-yes', eighteen: 'eighteen' },
                 axes: expect.any(Object),
             });
-            expect(options).not.toHaveProperty('fifteen');
+        });
+
+        it('should resolve omitted `$isType` branches to the match outcome', () => {
+            const themeConfig = {
+                line: {
+                    arrayValue: [1, 2],
+                    one: { $isType: [{ $path: './arrayValue' }, 'array'] },
+                    two: { $isType: [{ $path: './arrayValue' }, 'string'] },
+                    three: { $isType: [{ $path: './arrayValue' }, 'array', 'yes'] },
+                    four: { $isType: [{ $path: './arrayValue' }, 'string', 'yes'] },
+                    five: { $isType: [{ $path: './arrayValue' }, 'string', 'yes', undefined] },
+                },
+            };
+            const options = new OptionsGraph(themeConfig, prepareOptions({})).resolve();
+            expect(options).toStrictEqual({
+                arrayValue: expect.anything(),
+                one: true,
+                two: false,
+                three: 'yes',
+                four: false,
+                axes: expect.any(Object),
+            });
+            expect(options).not.toHaveProperty('five');
         });
 
         it('should resolve the `else` branch of `$isType` on an unrecognised type name', () => {

--- a/packages/ag-charts-community/src/module/optionsGraphOperations.ts
+++ b/packages/ag-charts-community/src/module/optionsGraphOperations.ts
@@ -535,9 +535,11 @@ function greaterThanOperation(graph: OptionsGraphInterface, vertex: VertexInterf
 function ifOperation(graph: OptionsGraphInterface, vertex: VertexInterface, values: Array<VertexInterface>) {
     const [conditionVertex, thenVertex, elseVertex] = values;
 
-    const condition = graph.resolveVertexValue(vertex, conditionVertex);
+    const condition = Boolean(graph.resolveVertexValue(vertex, conditionVertex));
+    const branchVertex = condition ? thenVertex : elseVertex;
+    if (!branchVertex) return condition;
 
-    return resolveConditionalBranch(graph, vertex, condition ? thenVertex : elseVertex);
+    return resolveConditionalBranch(graph, vertex, branchVertex);
 }
 
 // Re-parent the branch's children onto the vertex so that an object branch expands as a sub-tree.
@@ -577,7 +579,7 @@ function isTypeOperation(graph: OptionsGraphInterface, vertex: VertexInterface, 
         : isValueType(graph, vertex, value, type);
 
     const branchVertex = matched ? thenVertex : elseVertex;
-    if (!branchVertex) return;
+    if (!branchVertex) return matched;
 
     return resolveConditionalBranch(graph, vertex, branchVertex);
 }
@@ -693,19 +695,24 @@ function circularOperation(graph: OptionsGraphInterface, vertex: VertexInterface
 function isUserOptionOperation(graph: OptionsGraphInterface, vertex: VertexInterface, values: Array<VertexInterface>) {
     const [relativePathVertices, thenVertex, elseVertex] = values;
 
+    let matched = false;
     const children = graph.neighboursWithEdgeValue(relativePathVertices, PATH_EDGE);
     if (children) {
         for (const child of children) {
             const relativePathVertex = graph.findNeighbour(child, DEFAULTS_EDGE);
             if (relativePathVertex && isUserOptionCheck(graph, vertex, relativePathVertex)) {
-                return graph.resolveVertexValue(vertex, thenVertex);
+                matched = true;
+                break;
             }
         }
-    } else if (isUserOptionCheck(graph, vertex, relativePathVertices)) {
-        return graph.resolveVertexValue(vertex, thenVertex);
+    } else {
+        matched = isUserOptionCheck(graph, vertex, relativePathVertices);
     }
 
-    return graph.resolveVertexValue(vertex, elseVertex);
+    const branchVertex = matched ? thenVertex : elseVertex;
+    if (!branchVertex) return matched;
+
+    return graph.resolveVertexValue(vertex, branchVertex);
 }
 
 function isUserOptionCheck(graph: OptionsGraphInterface, vertex: VertexInterface, relativePathVertex: VertexInterface) {

--- a/packages/ag-charts-core/src/config/themeUtil.ts
+++ b/packages/ag-charts-core/src/config/themeUtil.ts
@@ -380,7 +380,7 @@ export const LABEL_BOXING_DEFAULTS: WithThemeParams<LabelBoxOptions> = {
     padding: 8,
     cornerRadius: 4,
     border: {
-        enabled: { $isUserOption: ['../border', true, false] },
+        enabled: { $isUserOption: '../border' },
         strokeWidth: 1,
         stroke: { $foregroundOpacity: 0.08 },
     },
@@ -397,7 +397,7 @@ export const LABEL_BOXING_TOP_LEVEL_DEFAULTS: WithThemeParams<LabelBoxOptions> =
     ...LABEL_BOXING_FILL_DEFAULTS,
     cornerRadius: 4,
     border: {
-        enabled: { $isUserOption: ['../border', true, false] },
+        enabled: { $isUserOption: '../border' },
         strokeWidth: 1,
         stroke: { $foregroundOpacity: 0.08 },
     },

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeriesTheme.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeriesTheme.ts
@@ -123,10 +123,10 @@ export const organizationSeriesTheme: ExtensibleTheme<'organization'> = {
                 $not: {
                     $or: [
                         { $path: ['/series/$index/selection/enabled', false] },
-                        { $isUserOption: ['/listeners/seriesNodeClick', true, false] },
-                        { $isUserOption: ['/listeners/seriesNodeDoubleClick', true, false] },
-                        { $isUserOption: ['/series/$index/listeners/seriesNodeClick', true, false] },
-                        { $isUserOption: ['/series/$index/listeners/seriesNodeDoubleClick', true, false] },
+                        { $isUserOption: '/listeners/seriesNodeClick' },
+                        { $isUserOption: '/listeners/seriesNodeDoubleClick' },
+                        { $isUserOption: '/series/$index/listeners/seriesNodeClick' },
+                        { $isUserOption: '/series/$index/listeners/seriesNodeDoubleClick' },
                     ],
                 },
             },

--- a/packages/ag-charts-types/src/chart/operationOptions.ts
+++ b/packages/ag-charts-types/src/chart/operationOptions.ts
@@ -90,15 +90,17 @@ type ColorOperation =
 
 type FontOperation = { $rem: Leaf<number> | [Leaf<number>, Leaf<ThemeParam>] }; // Ratio of base font size
 
+type UserOptionTarget = Leaf<string> | Leaf<string>[];
+
 type LocationOperation =
     | { $circular: Leaf<any> }
-    // Target vertex | Value if true (default `true`) | Value if false (default `false`)
+    // Target vertex, or list of targets matching if any is set | Value if true (default `true`) | Value if false (default `false`)
     | {
           $isUserOption:
               | Leaf<string>
-              | [Leaf<string>]
-              | [Leaf<string>, AnyLeaf | object]
-              | [Leaf<string>, AnyLeaf | object, AnyLeaf | object];
+              | [UserOptionTarget]
+              | [UserOptionTarget, AnyLeaf]
+              | [UserOptionTarget, AnyLeaf, AnyLeaf];
       }
     | { $mapPalette: PaletteParam } // Palette param
     | { $palette: PaletteParam } // Palette param

--- a/packages/ag-charts-types/src/chart/operationOptions.ts
+++ b/packages/ag-charts-types/src/chart/operationOptions.ts
@@ -92,7 +92,8 @@ type FontOperation = { $rem: Leaf<number> | [Leaf<number>, Leaf<ThemeParam>] }; 
 
 type LocationOperation =
     | { $circular: Leaf<any> }
-    | { $isUserOption: [Leaf<string>, AnyLeaf, AnyLeaf] } // Target vertex | Value if true | Value if false
+    // Target vertex | Value if true (default `true`) | Value if false (default `false`)
+    | { $isUserOption: Leaf<string> | [Leaf<string>, (AnyLeaf | object)?, (AnyLeaf | object)?] }
     | { $mapPalette: PaletteParam } // Palette param
     | { $palette: PaletteParam } // Palette param
     | { $path: Leaf<string> | [Leaf<string>, AnyLeaf] | [Leaf<string>, AnyLeaf, AnyLeaf] } // Relative path to vertex | Default if path undefined | Custom branch on which to find the path
@@ -102,12 +103,10 @@ type LocationOperation =
 type ValueTypeName = 'array' | 'boolean' | 'date' | 'function' | 'nullish' | 'number' | 'object' | 'string';
 
 type LogicOperation =
-    | { $if: [AnyLeaf, AnyLeaf | object, AnyLeaf | object] } // Condition | Value if true | Value if false
-    | {
-          $isType:
-              | [AnyLeaf, ValueTypeName | ValueTypeName[], AnyLeaf | object]
-              | [AnyLeaf, ValueTypeName | ValueTypeName[], AnyLeaf | object, AnyLeaf | object];
-      } // Value | Type name(s) | Value if matched | Value if not (omitted resolves to undefined)
+    // Condition | Value if true (default `true`) | Value if false (default `false`)
+    | { $if: [AnyLeaf, (AnyLeaf | object)?, (AnyLeaf | object)?] }
+    // Value | Type name(s) | Value if matched (default `true`) | Value if not (default `false`)
+    | { $isType: [AnyLeaf, ValueTypeName | ValueTypeName[], (AnyLeaf | object)?, (AnyLeaf | object)?] }
     | { $or: AnyLeaf[] } // Array of values that are truthy
     | { $and: AnyLeaf[] } // Array of values that are truthy
     | { $eq: AnyLeaf[] } // Array of values that are truthy

--- a/packages/ag-charts-types/src/chart/operationOptions.ts
+++ b/packages/ag-charts-types/src/chart/operationOptions.ts
@@ -93,7 +93,13 @@ type FontOperation = { $rem: Leaf<number> | [Leaf<number>, Leaf<ThemeParam>] }; 
 type LocationOperation =
     | { $circular: Leaf<any> }
     // Target vertex | Value if true (default `true`) | Value if false (default `false`)
-    | { $isUserOption: Leaf<string> | [Leaf<string>, (AnyLeaf | object)?, (AnyLeaf | object)?] }
+    | {
+          $isUserOption:
+              | Leaf<string>
+              | [Leaf<string>]
+              | [Leaf<string>, AnyLeaf | object]
+              | [Leaf<string>, AnyLeaf | object, AnyLeaf | object];
+      }
     | { $mapPalette: PaletteParam } // Palette param
     | { $palette: PaletteParam } // Palette param
     | { $path: Leaf<string> | [Leaf<string>, AnyLeaf] | [Leaf<string>, AnyLeaf, AnyLeaf] } // Relative path to vertex | Default if path undefined | Custom branch on which to find the path
@@ -104,9 +110,14 @@ type ValueTypeName = 'array' | 'boolean' | 'date' | 'function' | 'nullish' | 'nu
 
 type LogicOperation =
     // Condition | Value if true (default `true`) | Value if false (default `false`)
-    | { $if: [AnyLeaf, (AnyLeaf | object)?, (AnyLeaf | object)?] }
+    | { $if: [AnyLeaf] | [AnyLeaf, AnyLeaf | object] | [AnyLeaf, AnyLeaf | object, AnyLeaf | object] }
     // Value | Type name(s) | Value if matched (default `true`) | Value if not (default `false`)
-    | { $isType: [AnyLeaf, ValueTypeName | ValueTypeName[], (AnyLeaf | object)?, (AnyLeaf | object)?] }
+    | {
+          $isType:
+              | [AnyLeaf, ValueTypeName | ValueTypeName[]]
+              | [AnyLeaf, ValueTypeName | ValueTypeName[], AnyLeaf | object]
+              | [AnyLeaf, ValueTypeName | ValueTypeName[], AnyLeaf | object, AnyLeaf | object];
+      }
     | { $or: AnyLeaf[] } // Array of values that are truthy
     | { $and: AnyLeaf[] } // Array of values that are truthy
     | { $eq: AnyLeaf[] } // Array of values that are truthy


### PR DESCRIPTION
`$if`, `$isType` and `$isUserOption` required their true/false branches, so the predicate on its own could not be composed inside `$and` / `$or` / `$not`. That forced boilerplate like `{ $isUserOption: ['../border', true, false] }`.

An omitted branch now falls back to the check's own boolean outcome:

```
$isUserOption: './maxWidth'         ->  true | false
$isUserOption: ['./maxWidth', 2]    ->  2    | false
$if: [cond]                         ->  true | false
$if: [cond, 'a']                    ->  'a'  | false
$isType: [v, 'array']               ->  true | false
```

An explicit `undefined` branch still resolves to `undefined`, so "resolve to nothing" stays expressible. Existing 3-argument forms are unchanged apart from the note below, and the `[path, true, false]` call sites are swept down to `{ $isUserOption: path }`.

Behaviour note: the 3-argument `$isType` form now yields `false` rather than `undefined` when the type does not match. Nothing in the repo uses that form.

Verification: community and enterprise suites pass with every image and scene-graph snapshot unchanged, which is the pass criterion here since the sweep is semantics-preserving.