### PR TITLE
AG-17947 [CLAUDE] Keep org-chart expander clicks out of node listeners

### DIFF
--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1154,6 +1154,10 @@ export abstract class Series<
         return false;
     }
 
+    firesUserClickListeners(_target: Node<unknown> | undefined): boolean {
+        return true;
+    }
+
     protected pickNodesInBBoxPredicate(): PickNodesInBBoxPredicate {
         // By default, pickNodesInBBox just used boxes for hit-testing because it's easier and faster. Series with more
         // complicated shapes (e.g. sectors or pie/donut, paths for maps) need to override this predicate to implement

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -869,8 +869,15 @@ export class SeriesAreaManager extends BaseManager {
 
         const distance = updated.paginationState == null ? pickedNodes.distance : 0;
 
+        // A dedicated control (e.g. the org-chart expander) owns its clicks: it still drives its own
+        // interaction via the `series-area:click` event emitted by the caller, but must not also
+        // reach the user's node click / double-click listeners (AG-17947).
+        const firesUserClickListeners = updated.active.series.firesUserClickListeners(pickedNodes.target);
+
         if (event.type === 'click') {
-            const defaultBehavior = updated.active.series.fireNodeClickEvent(event.sourceEvent, updated.active);
+            const defaultBehavior = firesUserClickListeners
+                ? updated.active.series.fireNodeClickEvent(event.sourceEvent, updated.active)
+                : true;
             if (defaultBehavior) {
                 const next = this.pickManager.nextCandidate();
                 if (next.active !== undefined) {
@@ -899,7 +906,9 @@ export class SeriesAreaManager extends BaseManager {
             // a node.
             event.preventZoomDblClick = distance === 0;
 
-            updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, updated.active);
+            if (firesUserClickListeners) {
+                updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, updated.active);
+            }
             return { node: updated.active, target: pickedNodes.target };
         }
 

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -125,6 +125,12 @@ export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesP
     hasEventListener(type: string): boolean;
     /** Whether a click on `target` triggers a built-in interaction (e.g. the org-chart expander). */
     hasBuiltinListener(target: Node<unknown> | undefined): boolean;
+    /**
+     * Whether a pointer event on `target` should reach the user's `seriesNodeClick` and
+     * `seriesNodeDoubleClick` listeners. `false` for dedicated controls that own their clicks
+     * outright, such as the org-chart expander pill.
+     */
+    firesUserClickListeners(target: Node<unknown> | undefined): boolean;
     hasData: boolean;
     update(opts: { seriesRect?: BBox }): Promise<void> | void;
     updatePlacedLabelData?(labels: PlacedLabel<TLabel>[]): void;

--- a/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/organization/organizationSeries.ts
@@ -376,13 +376,24 @@ export class OrganizationSeries extends AbstractNetworkSeries<
         }
     }
 
+    private isExpanderTarget(target: _ModuleSupport.Node<unknown> | undefined): boolean {
+        const Expander: number = OrganizationNodeTag.Expander;
+        return target?.tag === Expander;
+    }
+
     // A pointer click toggles collapse only when it lands on the expander pill; `clickToExpand`
     // widens that to the whole card. Keyboard Enter/Space activations arrive with no pointer target,
     // so they toggle exactly when `clickToExpand` is enabled — restoring the pre-Alt+Up/Down behaviour.
     override hasBuiltinListener(target: _ModuleSupport.Node<unknown> | undefined): boolean {
-        const { clickToExpand } = this.properties.node;
-        const Expander: number = OrganizationNodeTag.Expander;
-        return target?.tag === Expander || clickToExpand;
+        return this.isExpanderTarget(target) || this.properties.node.clickToExpand;
+    }
+
+    // Expanding/collapsing is a distinct interaction from activating a node, so the expander pill
+    // keeps its clicks to itself (AG-17947). Note this is deliberately independent of
+    // `clickToExpand`: a card-body click still fires the node events even when it also toggles, so
+    // consumers get a consistent event surface and can `preventDefault()` if they want.
+    override firesUserClickListeners(target: _ModuleSupport.Node<unknown> | undefined): boolean {
+        return !this.isExpanderTarget(target);
     }
 
     override pickFocus(opts: _ModuleSupport.PickFocusInputs): _ModuleSupport.PickFocusOutputs | undefined {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17947

Clicking or double-clicking an Org Chart node's expander toggled expand/collapse and also fired the node's click/double-click events. That conflates two distinct interactions - expanding a node versus activating it - which is unexpected for consumers listening on seriesNodeClick or seriesNodeDoubleClick.

SeriesAreaManager.checkSeriesNodeClick() both fired the user-facing node events and returned the picked node that drives the toggle via the series-area:click event. Add ISeries.firesUserClickListeners(target) so a series can declare that a given scene node owns its clicks outright; OrganizationSeries returns false for the expander pill. The picked node is still returned, so expand/collapse continues to work.

The existing hasBuiltinListener() could not serve as this gate: it is also true for the whole card when node.clickToExpand is enabled, which is what drives the pointer cursor and the keyboard Enter/Space toggle (the latter arrives with an undefined target). Reusing it would have suppressed node events across the entire card.

firesUserClickListeners() is therefore deliberately independent of clickToExpand - a card-body click still fires the node events even when it also toggles. The event surface does not change shape based on an unrelated option, and consumers can call preventDefault() themselves if they want to opt out.