### PR TITLE
Always run agent prompt setup on postinstall, including CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postinstall:plugin-build": "[ \"$AG_WORKTREE_FAST_PATH\" = \"1\" ] || [ -n \"$AG_SKIP_PLUGIN_BUILD\" ] || nx run-many -p tag:plugin -t build",
     "postinstall:nx-daemon-restart": "[ \"$AG_WORKTREE_FAST_PATH\" = \"1\" ] || (test -e .nx/workspace-data/d/server-process.json && nx daemon --stop) || echo \"Nx Daemon not running\"",
     "postinstall:setup-git-hooks": "[ -n \"$CI\" ] || ./external/ag-shared/scripts/git-hooks/setup-hooks.sh",
-    "postinstall:setup-prompts": "[ -n \"$CI\" ] || AG_DEV_PROMPTS_REF=canary ./external/ag-shared/scripts/setup-prompts/setup-prompts.sh --postinstall"
+    "postinstall:setup-prompts": "AG_DEV_PROMPTS_REF=canary ./external/ag-shared/scripts/setup-prompts/setup-prompts.sh --postinstall"
   },
   "private": true,
   "engines": {


### PR DESCRIPTION
The `[ -n "$CI" ]` guard added to `postinstall:setup-prompts` in b27d67efdf8 stopped `.claude/settings.json` (and the rulesync-generated skills/rules) from being rendered in CI.

`jira-agent-pipeline.yml` and `release-review.yml` both depend on setup-nx's postinstall performing that render — its step is named "Setup Nx (renders .claude/settings.json)" — so from the moment that guard landed on `latest` (15:14 UTC, 27 Jul) every agent job failed its `setup-jira-agent` precondition before Claude was invoked:

```
[setup-jira-agent] .claude/settings.json not found in workspace.
```

Five runs died this way (AG-17992 ×3, AG-17922, AG-17974) and the pipeline has been fully down since. The step costs ~1.4s per CI job, so guarding it saved nothing material.

The `setup-git-hooks` guard from the same commit is left in place — hooks genuinely are pointless in CI.