### PR TITLE
Fix ag-charts-types deprecation tag and undocumented barrel export

### DIFF
--- a/packages/ag-charts-community/src/chart/label.ts
+++ b/packages/ag-charts-community/src/chart/label.ts
@@ -8,7 +8,6 @@ import {
     mergeDefaults,
 } from 'ag-charts-core';
 import type {
-    AgChartLabelCollideWithOptions,
     AgChartLabelCollisionOptions,
     AgChartLabelCollisionPlacement,
     AgChartLabelFormatterParams,
@@ -62,7 +61,8 @@ export class LabelPlacementBorder {
     strokeOpacity?: number;
 }
 
-class LabelCollideWith extends BaseProperties implements AgChartLabelCollideWithOptions {
+/** Undocumented per-category toggle for the obstacles a label avoids. */
+class LabelCollideWith extends BaseProperties {
     @Property
     markers?: boolean;
 

--- a/packages/ag-charts-types/src/chart/collisionAvoidanceOptions.ts
+++ b/packages/ag-charts-types/src/chart/collisionAvoidanceOptions.ts
@@ -58,6 +58,4 @@ export interface AgChartLabelCollisionOptions {
      * Whether to keep a colliding label visible when a collision remains after every avoidance strategy has been applied. When `true` the label stays at the best available position; when `false` it is hidden instead.
      */
     alwaysShow?: boolean;
-    // Undocumented `collideWith` (markers/labels/seriesItems/seriesArea) is accepted by the runtime
-    // validator but deliberately kept off the public type contract.
 }

--- a/packages/ag-charts-types/src/chart/collisionAvoidanceOptions.ts
+++ b/packages/ag-charts-types/src/chart/collisionAvoidanceOptions.ts
@@ -48,18 +48,6 @@ export type AgBarSeriesLabelPlacement =
     | 'beside-after-center'
     | 'beside-after-end';
 
-/** Per-category toggle for the obstacles a label avoids. */
-export interface AgChartLabelCollideWithOptions {
-    /** Whether labels avoid series markers. */
-    markers?: boolean;
-    /** Whether labels avoid other labels. */
-    labels?: boolean;
-    /** Whether labels avoid rendered series geometry contributed by other series, such as bars. */
-    seriesItems?: boolean;
-    /** Whether labels must stay inside the series plotting area, treating an overflow past it as a collision. */
-    seriesArea?: boolean;
-}
-
 /** Configuration controlling how a label behaves when it cannot be placed clear of every obstacle. */
 export interface AgChartLabelCollisionOptions {
     /**
@@ -70,7 +58,6 @@ export interface AgChartLabelCollisionOptions {
      * Whether to keep a colliding label visible when a collision remains after every avoidance strategy has been applied. When `true` the label stays at the best available position; when `false` it is hidden instead.
      */
     alwaysShow?: boolean;
-    // Undocumented: per-category toggle for the obstacles the label avoids. Accepted at runtime via
-    // the `collideWith` validator but kept off the public type contract.
-    // collideWith?: AgChartLabelCollideWithOptions;
+    // Undocumented `collideWith` (markers/labels/seriesItems/seriesArea) is accepted by the runtime
+    // validator but deliberately kept off the public type contract.
 }

--- a/packages/ag-charts-types/src/series/standalone/networkOptions.ts
+++ b/packages/ag-charts-types/src/series/standalone/networkOptions.ts
@@ -34,6 +34,8 @@ export interface AgNetworkSeriesTreeLayout {
      * Vertical gap in pixels between parent and child rows.
      *
      * Default: `52`
+     *
+     * @deprecated v14.1.0 Use `depthSpacing` instead.
      */
     verticalSpacing?: PixelSize;
 }


### PR DESCRIPTION
Two API-surface fixes found while reviewing the 14.1 types diff against the release notes.

**Missing deprecation tag.** The 14.1 upgrade guide deprecates organization `verticalSpacing` in favour of `depthSpacing`, but `AgNetworkSeriesTreeLayout.verticalSpacing` carried no `@deprecated` tag — so the deprecation was invisible in IDE autocomplete and the generated API reference. Tagged `@deprecated v14.1.0`, matching the convention used for the v13.3.0 `colorRange` deprecations.

**Undocumented option in the public contract.** `AgChartLabelCollideWithOptions` described the undocumented `collideWith` label option, which per our API-contract convention should not live in `ag-charts-types`. Its only reference was the `implements` clause on `LabelCollideWith` in community, which already declares the same four properties, so the type is removed and the class keeps the shape. `collideWith` is unaffected at runtime — its validator is untouched.

Verified with `build:types` and `lint` across `ag-charts-types`, `ag-charts-community` and `ag-charts-enterprise`, plus `label.test.ts` and `labelCollisionAvoidance.test.ts` (123 tests).

Two related findings from the same review are deliberately **not** in scope:

- `AgNetworkSeriesTreeLayout` / `AgNetworkSeriesTreeLayoutDirection` are exported publicly with no public network series type yet. Community and enterprise import them from `ag-charts-types`, so relocating them is a design decision rather than a cleanup.
- Nine exported types in `ag-charts-types` are referenced nowhere in the repo (`AgBaseFlowProportionThemeOptions`, `AgBaseHierarchyThemeOptions`, `AgConeFunnelSeriesItemStylerParams`, `AgPolarAxisType`, `AgRadarLineHighlightStyleOptions`, `AgScrollbarThemeableOptions`, `ChartFormatterParams`, `_DatumKeyChecks`, `_ResolvedDatumKeyChecks`). All predate 14.0.2, so removing them would be a breaking change for anyone importing them.