### PR TITLE
Fix org chart spacing example label and doc typo

### DIFF
--- a/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-spacing/index.html
+++ b/packages/ag-charts-website/src/content/docs/org-chart/_examples/org-chart-spacing/index.html
@@ -27,7 +27,7 @@
             <span id="outerSpacingValue" style="display: inline-block; min-width: 3ch; text-align: right">40</span>
         </span>
         <span class="gap-left">
-            Vertical:
+            Depth:
             <input
                 type="range"
                 id="verticalSpacingInput"

--- a/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/org-chart/index.mdoc
@@ -329,7 +329,7 @@ In this example:
 
 - The subtrees under 'Lawrence Martinez' and 'Eric Jensen' will start in a collapsed state. This uses the `initialState.collapsed` property to specify which subtrees start collapsed.
 - Use `node.clickToExpand` to toggle collapsing/expanding by clicking anywhere on the card instead of the expander only.
-    - Defaults to `false` when node has a [click listener](./events/#seriesnodeclick-and-seriesnodedoubleclick) or has [Data Selection](./selection/) enabled,, otherwise defaults to `true`.
+    - Defaults to `false` when node has a [click listener](./events/#seriesnodeclick-and-seriesnodedoubleclick) or has [Data Selection](./selection/) enabled, otherwise defaults to `true`.
 - The `collapsed` array contains the identifiers of all currently collapsed nodes.
     - See the [State API](./api-state/#collapsed) page for more details.
 - Changes in the collapsed items can be listened to with the `collapsedChange` event, logged to the console here showing the `itemId` of each newly collapsed and expanded node.


### PR DESCRIPTION
- Renamed the "Vertical:" spacing control label to "Depth:" in the org-chart-spacing example so it matches what the slider actually controls.
- Removed a duplicated comma in the `clickToExpand` default-value description on the Org Chart docs page.