### PR TITLE
Fix OSS Scorecard publish failure on latest

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,16 +6,13 @@ on:
     push:
         branches: ['latest']
 
-env:
-    # Disable git's post-fetch background gc/maintenance for every git invocation
-    # (injected via git's GIT_CONFIG_* protocol). Otherwise it rewrites .git/shallow
-    # concurrently with the next chained `git fetch --depth 1`, intermittently failing
-    # job setup with "fatal: shallow file has changed since we read it".
-    GIT_CONFIG_COUNT: 2
-    GIT_CONFIG_KEY_0: gc.auto
-    GIT_CONFIG_VALUE_0: '0'
-    GIT_CONFIG_KEY_1: maintenance.auto
-    GIT_CONFIG_VALUE_1: 'false'
+# NOTE: deliberately no top-level or job-level `env`/`defaults` here. ossf/scorecard-action
+# verifies the calling workflow before it will publish results, and rejects both with
+# "workflow contains global env vars or defaults" (HTTP 400). See:
+# https://github.com/ossf/scorecard-action#workflow-restrictions
+# This means the repo-wide GIT_CONFIG_* gc/maintenance block cannot be applied to this
+# workflow; it is not needed, as the single shallow `actions/checkout` below does no
+# chained `git fetch --depth 1` for background maintenance to race with.
 
 permissions: read-all
 


### PR DESCRIPTION
`ossf/scorecard-action` verifies the calling workflow before it will publish results, and rejects top-level or job-level `env`/`defaults` with an HTTP 400: `workflow verification failed: workflow contains global env vars or defaults` ([workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)).

734d00fb662 promoted the `GIT_CONFIG_*` gc/maintenance block into every workflow's top-level `env`, including `scorecard.yml`, so the `Run analysis` step's publish has failed on every push to `latest` since 23 July — e.g. [run 30377812017](https://github.com/ag-grid/ag-charts/actions/runs/30377812017).

This drops the block from `scorecard.yml` only and records the restriction in a comment so it is not reintroduced. The workflow does not need it: its single shallow `actions/checkout` performs no chained `git fetch --depth 1` for git's background maintenance to race with. No other workflow is subject to these restrictions, so the rest of that commit is unaffected.

Worth noting separately: `post-scorecard-check.yml` stayed green throughout, because it reads the score from the public scorecard API and so has been checking the last *successfully published* result rather than detecting the publish failure.