### PR TITLE
Surface staging deploy status on commits, deployments and JIRA tickets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1239,6 +1239,7 @@ jobs:
             contents: write
             pull-requests: write
             statuses: write
+            deployments: write
         needs:
             [
                 detect-changes,
@@ -1427,6 +1428,53 @@ jobs:
                     -f description="${description}" \
                     -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+            - name: Record staging deployment
+              # Complements the commit status above with a GitHub deployment record, giving
+              # a chronological "what is on staging, and what was before it" history at
+              # /deployments/staging rather than one status per commit to trawl.
+              #
+              # Deliberately omits environment_url: this repository is public, so the
+              # deployment record is world-readable and we do not advertise the staging
+              # hostname here. Only runs when a deploy was actually attempted -- the
+              # "CI did not pass, never tried" case stays out so the history is real deploys.
+              #
+              # continue-on-error for the same reason as the JIRA step below: `run:` blocks
+              # execute under `bash -e`, so a transient gh api failure would abort the step
+              # and redden a job whose deploy had already succeeded. The record is a
+              # convenience, never worth failing a good deploy over.
+              if: always() && job.status != 'cancelled' && github.ref == 'refs/heads/latest' && contains(fromJSON('["success", "failure"]'), steps.deploy_to_staging.outcome)
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # required_contexts:[] is mandatory: without it the API refuses to create
+                  # the deployment while any other check on this SHA is still pending. It has
+                  # no shorthand in gh's -f/-F flags, hence the JSON body on stdin.
+                  deployment_id=$(jq -n \
+                      --arg ref "${{ github.sha }}" \
+                      '{ref: $ref, environment: "staging", description: "AG Charts website", auto_merge: false, required_contexts: []}' \
+                    | gh api --method POST \
+                      -H "Accept: application/vnd.github+json" \
+                      "/repos/${{ github.repository }}/deployments" \
+                      --input - \
+                      --jq '.id')
+
+                  gh api --method POST \
+                    -H "Accept: application/vnd.github+json" \
+                    "/repos/${{ github.repository }}/deployments/${deployment_id}/statuses" \
+                    -f state="${{ steps.deploy_to_staging.outcome }}" \
+                    -f description="Staging deploy ${{ steps.deploy_to_staging.outcome }}" \
+                    -f log_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+            - name: Tag Deployed Staging Commit
+              # Moving tag so the commit currently live on staging shows as an inline chip
+              # in the commits list, with no status icon to hover.
+              if: always() && job.status != 'cancelled' && github.ref == 'refs/heads/latest' && steps.deploy_to_staging.outcome == 'success'
+              uses: EndBug/latest-tag@latest
+              with:
+                  ref: staging
+                  description: Commit currently deployed to the staging website.
+
             - name: Tag Latest Successful Commit
               if: success() && needs.init.result == 'success' && needs.init.outputs.build_type != 'pr' && steps.lastJobStatus.outputs.workflowStatus != 'failure'
               uses: EndBug/latest-tag@latest
@@ -1458,6 +1506,33 @@ jobs:
                   LIBRARY_WEBSITE_STATUS_CHANNEL: ${{ env.LIBRARY_WEBSITE_STATUS_CHANNEL }}
                   DEPLOY_TO_STAGING: 'true'
               run: node ./external/ag-shared/scripts/slack/notify-staging-deploy.mjs
+
+            - name: Comment on deployed JIRA tickets
+              # Tells each AG ticket in this deploy that it is live on staging, with the
+              # verification link, so nobody has to reconstruct it by hand. Shares
+              # find_latest_sha with the Slack notification above so both describe the
+              # same commit range.
+              #
+              # continue-on-error: a JIRA outage or a token-scope problem must never turn
+              # a successful deploy red. The script also swallows per-ticket failures, so
+              # this only trips on a total failure (e.g. missing config).
+              if: always() && job.status != 'cancelled' && github.ref == 'refs/heads/latest' && steps.deploy_to_staging.outcome == 'success'
+              continue-on-error: true
+              shell: bash
+              env:
+                  JIRA_EMAIL: ${{ secrets.JIRA_AI_BOT_EMAIL }}
+                  JIRA_API_TOKEN: ${{ secrets.JIRA_AI_BOT_API_TOKEN }}
+                  JIRA_SITE_URL: ${{ vars.JIRA_SITE_URL }}
+                  # Reads the deployed commit range from the compare API, so the shallow
+                  # checkout in this job does not matter. GITHUB_REPOSITORY is already in
+                  # the default step environment.
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  AG_PROJECT: AgCharts
+                  RUN_ID: ${{ github.run_id }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  CURRENT_SHA: ${{ github.sha }}
+                  LAST_SUCCESSFUL_SHA: ${{ steps.find_latest_sha.outputs.sha }}
+              run: node ./tools/staging/notify-jira-staging-deploy.mjs
 
             # --- CI status alert (bot token — the single notification point) ----
             # THE Slack alert for every non-PR CI state change — success and

--- a/tools/staging/notify-jira-staging-deploy.mjs
+++ b/tools/staging/notify-jira-staging-deploy.mjs
@@ -1,0 +1,220 @@
+// Comments on the JIRA tickets referenced by the commits in a staging deploy, so the
+// ticket itself says "this is live on staging, verify it here" without anyone having to
+// reconstruct the staging link by hand.
+//
+// Runs from the `report` job of ci.yml immediately after a successful staging deploy.
+// Never fails the build: a JIRA outage or a permissions problem must not turn a
+// successful deploy red, so every API failure is reported as a GHA warning and the
+// process still exits 0.
+//
+// The deployed commit range comes from GitHub's compare API rather than local git. The
+// `report` job checks out with `fetch-depth: 1`, so the last successful commit is usually
+// not a reachable object and any local `git log` range would fail outright. Comparing
+// server-side needs no history at all, and reports the truncation and divergence cases
+// explicitly instead of leaving them to be inferred from a git error.
+import { getStagingUrl, ghaError, ghaWarning } from '../../external/ag-shared/scripts/slack/_ci-notification-utils.mjs';
+
+const {
+    JIRA_EMAIL,
+    JIRA_API_TOKEN,
+    JIRA_SITE_URL,
+    AG_PROJECT,
+    CURRENT_SHA,
+    LAST_SUCCESSFUL_SHA,
+    RUN_ID,
+    RUN_URL,
+    GITHUB_REPOSITORY,
+    GITHUB_TOKEN,
+    DRY_RUN,
+} = process.env;
+
+// Only AG keys are matched. Case-insensitively on purpose: branch names in merge-commit
+// subjects use lowercase (`imoses/ag-17999`, `ghabot-ag-17992-...`), and a case-sensitive
+// pattern silently drops those commits.
+const TICKET_PATTERN = /\bAG-(\d+)\b/gi;
+
+const dryRun = DRY_RUN === 'true';
+// A dry run is expected to work without credentials, so that the commit range and the
+// rendered comment can be checked locally. Without them no JIRA call can be made at all.
+const canQueryJira = Boolean(JIRA_EMAIL && JIRA_API_TOKEN);
+
+// RUN_URL is required even though it only decorates a link: an ADF link mark with an
+// undefined href serialises to an empty `attrs`, which JIRA rejects outright, so a missing
+// value fails every comment rather than degrading one of them.
+const required = { JIRA_SITE_URL, AG_PROJECT, CURRENT_SHA, RUN_ID, RUN_URL, GITHUB_REPOSITORY, GITHUB_TOKEN };
+if (!dryRun) {
+    Object.assign(required, { JIRA_EMAIL, JIRA_API_TOKEN });
+}
+for (const [name, value] of Object.entries(required)) {
+    if (!value) {
+        ghaError(`${name} environment variable is not set.`, { title: 'JIRA deploy comment: missing config' });
+        process.exit(1);
+    }
+}
+
+const githubApi = async (path) => {
+    const response = await fetch(new URL(path, 'https://api.github.com'), {
+        headers: {
+            Authorization: `Bearer ${GITHUB_TOKEN}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+        },
+    });
+    if (!response.ok) {
+        throw new Error(`GET ${path} -> ${response.status} ${await response.text()}`);
+    }
+    return response.json();
+};
+
+const toCommit = ({ sha, commit }) => ({ shortSha: sha.slice(0, 8), subject: commit.message.split('\n')[0] });
+
+/** The deployed commit on its own — the fallback whenever a range cannot be established. */
+async function getDeployedCommit() {
+    return [toCommit(await githubApi(`/repos/${GITHUB_REPOSITORY}/commits/${CURRENT_SHA}`))];
+}
+
+/**
+ * The commits this deploy actually shipped, as `{ shortSha, subject }`.
+ *
+ * Uses GitHub's compare API so no local history is needed. `status` distinguishes the cases
+ * that matter: `identical` means this is a re-deploy of the same commit, and anything else
+ * yields the commits reachable from the deployed commit but not from the last successful
+ * one. A first build, a deleted commit, or an unrelated last-successful SHA surfaces as an
+ * error and degrades to the deployed commit alone.
+ */
+async function getDeployedCommits() {
+    if (!LAST_SUCCESSFUL_SHA || LAST_SUCCESSFUL_SHA === CURRENT_SHA) {
+        return getDeployedCommit();
+    }
+
+    try {
+        const comparison = await githubApi(
+            `/repos/${GITHUB_REPOSITORY}/compare/${LAST_SUCCESSFUL_SHA}...${CURRENT_SHA}`
+        );
+        if (comparison.status === 'identical' || comparison.commits.length === 0) {
+            return getDeployedCommit();
+        }
+        // The compare API caps `commits` at 250 while still reporting the true total, so an
+        // unusually large deploy would silently miss the oldest tickets without this.
+        if (comparison.total_commits > comparison.commits.length) {
+            ghaWarning(
+                `Deploy spans ${comparison.total_commits} commits; the compare API returned only ${comparison.commits.length}, so the oldest tickets are not covered.`,
+                { title: 'JIRA deploy comment: range truncated' }
+            );
+        }
+        return comparison.commits.map(toCommit);
+    } catch (error) {
+        ghaWarning(
+            `Could not compare ${LAST_SUCCESSFUL_SHA}..${CURRENT_SHA}; using the deployed commit only. ${error.message}`,
+            {
+                title: 'JIRA deploy comment: range unavailable',
+            }
+        );
+        return getDeployedCommit();
+    }
+}
+
+/** Groups the deployed commits by the AG ticket key(s) their subject references. */
+function groupCommitsByTicket(commits) {
+    const byTicket = new Map();
+    for (const commit of commits) {
+        for (const [, number] of commit.subject.matchAll(TICKET_PATTERN)) {
+            const key = `AG-${number}`;
+            if (!byTicket.has(key)) byTicket.set(key, []);
+            byTicket.get(key).push(commit);
+        }
+    }
+    return byTicket;
+}
+
+const jiraApi = async (path, init = {}) => {
+    const response = await fetch(new URL(`/rest/api/3${path}`, JIRA_SITE_URL), {
+        ...init,
+        headers: {
+            Authorization: `Basic ${Buffer.from(`${JIRA_EMAIL}:${JIRA_API_TOKEN}`).toString('base64')}`,
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            ...init.headers,
+        },
+    });
+    if (!response.ok) {
+        throw new Error(`${init.method ?? 'GET'} ${path} -> ${response.status} ${await response.text()}`);
+    }
+    return response.status === 204 ? undefined : response.json();
+};
+
+/**
+ * Whether the ticket should be left alone. Commits routinely reference long-closed
+ * tickets (chores citing an old key), and a deploy note on those is pure noise.
+ */
+async function isResolved(key) {
+    const { fields } = await jiraApi(`/issue/${key}?fields=resolution,status`);
+    return fields.resolution != null || fields.status?.statusCategory?.key === 'done';
+}
+
+const paragraph = (...content) => ({ type: 'paragraph', content });
+const text = (value) => ({ type: 'text', text: value });
+const link = (value, href) => ({ type: 'text', text: value, marks: [{ type: 'link', attrs: { href } }] });
+
+function buildComment(commits, stagingUrl) {
+    return {
+        type: 'doc',
+        version: 1,
+        content: [
+            paragraph(text('Deployed to staging for verification.')),
+            {
+                type: 'bulletList',
+                content: commits.map(({ shortSha, subject }) => ({
+                    type: 'listItem',
+                    content: [paragraph(text(`${shortSha} ${subject}`))],
+                })),
+            },
+            paragraph(text('Verify at: '), link(stagingUrl, stagingUrl)),
+            paragraph(
+                text('Deployed build: '),
+                link(
+                    new URL('/debug/meta.json', stagingUrl).toString(),
+                    new URL('/debug/meta.json', stagingUrl).toString()
+                ),
+                text(' · CI run: '),
+                link(`#${RUN_ID}`, RUN_URL)
+            ),
+        ],
+    };
+}
+
+(async () => {
+    const commits = await getDeployedCommits();
+    const byTicket = groupCommitsByTicket(commits);
+
+    if (byTicket.size === 0) {
+        console.log(`No AG tickets referenced by the ${commits.length} deployed commit(s); nothing to comment on.`);
+        return;
+    }
+
+    const stagingUrl = getStagingUrl(AG_PROJECT);
+    console.log(`Deployed commits: ${commits.length}. Referenced tickets: ${[...byTicket.keys()].join(', ')}`);
+
+    for (const [key, ticketCommits] of byTicket) {
+        try {
+            if (canQueryJira && (await isResolved(key))) {
+                console.log(`${key}: already resolved, skipping.`);
+                continue;
+            }
+
+            const body = buildComment(ticketCommits, stagingUrl);
+            if (dryRun) {
+                console.log(`${key}: would comment ->\n${JSON.stringify(body, null, 2)}`);
+                continue;
+            }
+
+            await jiraApi(`/issue/${key}/comment`, { method: 'POST', body: JSON.stringify({ body }) });
+            console.log(`${key}: commented.`);
+        } catch (error) {
+            // One bad ticket (deleted, moved project, no permission) must not stop the rest.
+            ghaWarning(`${key}: could not add staging deploy comment. ${error.message}`, {
+                title: 'JIRA deploy comment failed',
+            });
+        }
+    }
+})();


### PR DESCRIPTION
Answering "what is deployed to staging, and is my change in it?" without trawling commit-check statuses.

The `Deploy to Staging` commit status already existed, but it is only posted on pushed HEAD commits and needs a hover to read. The ticket-facing half was manual: pasting a staging link into JIRA to ask for verification.

### Changes

- **GitHub deployment record** against a new `staging` environment, giving a chronological history at `/deployments/staging`. `environment_url` is deliberately omitted — this repository is public, so the record is world-readable and the staging hostname stays out of it.
- **Moving `staging` tag** on each deployed commit, so the live commit renders as an inline chip in the commits list. Follows the existing `latest-success` pattern.
- **JIRA deploy comments** — `tools/staging/notify-jira-staging-deploy.mjs` works out which commits a deploy shipped, extracts `AG-NNNN` keys, skips resolved tickets, and comments with the verification link.

### Notes for review

- **The commit range comes from GitHub's compare API, not local git.** The `report` job checks out with `fetch-depth: 1`, so a local `git log <last-successful>..<current>` fails on an unreachable object — that crashed with an unhandled exception in testing. The compare API needs no local history, and reports the `identical` / truncated / missing-commit cases explicitly. The script touches git not at all.
- **Ticket matching is case-insensitive.** Branch names in merge subjects are lowercase (`imoses/ag-17999`, `ghabot-ag-17992-…`); a case-sensitive pattern silently drops those commits. Verified `DIAG-123` and `flag-123` are not false positives.
- **Both new API-calling steps are `continue-on-error`.** `run:` blocks execute under `bash -e`, so an unguarded `gh api` failure would redden a job whose deploy had already succeeded.
- Comment volume is one per ticket per deploy, by choice. There is no dedup guard, so a CI re-run of the same commit will comment again.

### Verification

Dry-run against real history — first build, `last == current`, no-tickets range, 4-merge range (11 commits → `AG-17804, AG-17947, AG-17992`), and an absent last-successful SHA (warns, degrades to the deployed commit). Confirmed independent of git by running from a non-git directory.

**Not yet verified:** the ADF comment body has never been POSTed to JIRA, and `JIRA_AI_BOT_API_TOKEN` is a scoped token whose `write:comment:jira` scope is unconfirmed. If it is missing, every ticket warns and nothing posts — visible in the run warnings, harmless to the deploy.