### PR TITLE
Fix documentation defects found by b14.1.0 release docs review

### DIFF
--- a/packages/ag-charts-website/src/content/docs/accessibility/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/accessibility/index.mdoc
@@ -37,7 +37,7 @@ The following keys are available:
 - {% kbd "Home" /%}{% kbd "End" /%} jumps to the first or last data item.
 - {% kbd "↵ Enter" /%} or {% kbd "␣ Space" /%} toggles legend items and triggers any click listeners for the focused item.
 - In Windows, {% kbd "⇧ Shift"/%}+{% kbd "F10"/%} or {% kbd "≡ Menu"/%} opens the context menu. On Mac this is done with {% kbd "⌃⌥⇧ M" /%} when Voiceover is enabled.
-- {% kbd "Alt" /%}+{% kbd "↑" /%} and {% kbd "Alt" /%}+{% kbd "↓" /%} collapses and expands nodes in the [Org Chart](./org-chart).
+- {% kbd "Alt" /%}+{% kbd "↑" /%} and {% kbd "Alt" /%}+{% kbd "↓" /%} collapse and expand nodes in the [Org Chart](./org-chart/).
 
 {% chartExampleRunner title="Keyboard Navigation" name="keyboard-navigation" type="generated" /%}
 

--- a/packages/ag-charts-website/src/content/docs/axes-configuration/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/axes-configuration/index.mdoc
@@ -44,12 +44,10 @@ In this example:
 
 ## Axis Title Orientation
 
-The `title.orientation` option controls how an axis title is rendered:
+The axis title aligns with the axis line. Use the `title.orientation` option to customise this
 
 - `'horizontal'` renders the title in the normal left-to-right reading direction.
 - `'vertical'` and `'vertical-reversed'` rotate it a quarter-turn in opposite directions, which is useful for flipping a secondary axis title.
-
-When unset, the title aligns with the axis line — horizontal on the x-axis and vertical on the y-axis.
 
 ```js format="snippet"
 {

--- a/packages/ag-charts-website/src/content/docs/community-vs-enterprise/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/community-vs-enterprise/index.mdoc
@@ -79,7 +79,7 @@ AG Charts Community relies on community-driven support through GitHub and public
 
 AG Charts Enterprise provides dedicated support via [Zendesk](https://ag-grid.zendesk.com/hc/en-us) with guaranteed response times, bug fixes, and direct access to the AG Charts developers, who handle all support tickets. Support is also available during your free trial period.
 
-## Licencing
+## Licensing
 
 Both AG Charts Community and Enterprise are open source, however, **AG Charts Community is available under the MIT licence** and **AG Charts Enterprise requires a commercial, EULA licence**.
 

--- a/packages/ag-charts-website/src/content/docs/context-menu/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/context-menu/index.mdoc
@@ -108,7 +108,7 @@ If there are multiple elements that match the `showOn` value, all of them are sh
 
 In this configuration:
 
-- A single custom action is added for the entire chart, the captions, the series area, the series node and the legend items.
+- A single custom action is added for the entire chart, the captions, the axes, the series area, the series node and the legend items.
 - Multiple entries per `showOn` element can be specified within the array if required.
 - Right clicking on one of these areas will show these additional actions in the Context Menu.
 - Clicking these extra actions will display information in the console, demonstrating that the action is aware of details about the right-clicked item.

--- a/packages/ag-charts-website/src/content/docs/events/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/events/index.mdoc
@@ -110,12 +110,19 @@ This is fired when an item in an [Org Chart](./org-chart/) is expanded or collap
 
 The event contains:
 
-- `collapsed` - array of collapsed items each with `itemId` and `datum`:
+- `collapsed` - array of the items newly collapsed by this change, each with `itemId` and `datum`:
     - `itemId` - the unique identifier of the datum.
     - `datum` - the data from the chart data array for the collapsed item.
+- `expanded` - array of the items newly expanded by this change, each with `itemId` and `datum`:
+    - `itemId` - the unique identifier of the datum.
+    - `datum` - the data from the chart data array for the expanded item.
 - `source` - the source of the event, either `'user-interaction'` or `'api-call'`.
 
-{% chartExampleRunner title="Annotations" name="collapsed-change-event" type="generated" /%}
+{% note %}
+`collapsed` and `expanded` contain only the items changed by this event, not the full set of collapsed or expanded items.
+{% /note %}
+
+{% chartExampleRunner title="Collapsed Change Event" name="collapsed-change-event" type="generated" /%}
 
 In this example:
 

--- a/packages/ag-charts-website/src/content/docs/events/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/events/index.mdoc
@@ -119,7 +119,7 @@ The event contains:
 - `source` - the source of the event, either `'user-interaction'` or `'api-call'`.
 
 {% note %}
-`collapsed` and `expanded` contain only the items changed by this event, not the full set of collapsed or expanded items.
+`collapsed` and `expanded` contain only the items changed by this event, not the full set of collapsed or expanded items. Use `chart.getState()` to get the current state of all items.
 {% /note %}
 
 {% chartExampleRunner title="Collapsed Change Event" name="collapsed-change-event" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/fills-borders/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/fills-borders/index.mdoc
@@ -9,7 +9,7 @@ This section describes how to change the fills and borders of chart elements.
 In the above example:
 
 - A border is drawn around the series area with a corner radius and no padding.
-- A fill, border and corner radius are applied to the chart title and subtitle.
+- A fill and corner radius are applied to the chart title and subtitle, with a border on the title only.
 - A border, fill and corner radius are applied to the [Legend](./legend), with padding between the border and items provided as a single number.
 - A border, fill and corner radius are applied to the series labels and [axis labels](./axes-labels) with padding defined for each of the top, right, bottom and left.
 - An [item styler](./stylers/#item-stylers) is used to override the styling of series labels for names starting with the letter 'D' and 'E'.

--- a/packages/ag-charts-website/src/content/docs/fills-borders/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/fills-borders/index.mdoc
@@ -9,7 +9,7 @@ This section describes how to change the fills and borders of chart elements.
 In the above example:
 
 - A border is drawn around the series area with a corner radius and no padding.
-- A fill and corner radius are applied to the chart title and subtitle, with a border on the title only.
+- A fill and corner radius are applied to the chart title and subtitle, with a border applied to the title only.
 - A border, fill and corner radius are applied to the [Legend](./legend), with padding between the border and items provided as a single number.
 - A border, fill and corner radius are applied to the series labels and [axis labels](./axes-labels) with padding defined for each of the top, right, bottom and left.
 - An [item styler](./stylers/#item-stylers) is used to override the styling of series labels for names starting with the letter 'D' and 'E'.

--- a/packages/ag-charts-website/src/content/docs/installation/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/installation/index.mdoc
@@ -154,7 +154,7 @@ ModuleRegistry.registerModules([AllEnterpriseModule]);
 ```
 
 {% note %}
-To minimize bundle size, only register the modules you want to use. See the [Selecting Modules](./module-registry/#selecting-modules) docs for more information.
+To minimise bundle size, only register the modules you want to use. See the [Selecting Modules](./module-registry/#selecting-modules) docs for more information.
 {% /note %}
 
 {% if isFramework("react", "angular", "vue") %}

--- a/packages/ag-charts-website/src/content/docs/key-features/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/key-features/index.mdoc
@@ -255,7 +255,7 @@ Use the `theme` property to set the theme:
 
 ```js format="snippet"
 {
-    theme: 'ag-default', // or 'ag-sheets', 'ag-polychrome', 'ag-material', 'ag-vivid'
+    theme: 'ag-default', // or 'ag-sheets', 'ag-polychroma', 'ag-material', 'ag-vivid'
 }
 ```
 

--- a/packages/ag-charts-website/src/content/docs/scrollbar/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/scrollbar/index.mdoc
@@ -5,7 +5,7 @@ enterprise: true
 ---
 
 The Scrollbar provides an intuitive control for panning when [fixed width bars](./bars/#fixed-width) require more space than
-the series area, or when zoom is applied with the [State API](./api-state/) or [Zoom](./zoom) functionality.
+the series area, or when zoom is applied with the [State API](./api-state/) or [Zoom](./zoom/) functionality.
 
 ## Simple Scrollbar
 
@@ -142,7 +142,7 @@ In this example:
 
 - `enableAxisScrolling` controls whether scrolling over the axis pans in that direction.
 - `enableSeriesAreaScrolling` controls whether scrolling within the series area pans the chart.
-- If [Zoom](./zoom) is also enabled, its scroll interactions take precedence.
+- If [Zoom](./zoom/) is also enabled, its scroll interactions take precedence.
 
 ## Visibility
 

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-threshold/data.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-threshold/data.ts
@@ -16,7 +16,7 @@ export const data: DataType[] = [
     { station: 'Hexham', temperature: 20.2, humidity: 62, windSpeed: 10 },
     { station: 'Ilkley', temperature: 19.7, humidity: 60, windSpeed: 15 },
     { station: 'Jarrow', temperature: 19.3, humidity: 63, windSpeed: 9 },
-    { station: 'Kendal', temperature: 20.1, humidity: 65, windSpeed: 12 },
+    { station: 'Kendal', temperature: 20.055, humidity: 65, windSpeed: 12 },
     { station: 'Looe', temperature: 19.6, humidity: 62, windSpeed: 10 },
     { station: 'Marlow', temperature: 20.3, humidity: 59, windSpeed: 11 },
     { station: 'Napton', temperature: 19.4, humidity: 63, windSpeed: 14 },

--- a/packages/ag-charts-website/src/content/docs/series-labels/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/series-labels/index.mdoc
@@ -29,7 +29,7 @@ Enable labels with `label.enabled`, then style them with the following options.
 In this example:
 
 - Text is styled with `color`, `fontSize`, `fontWeight`, `fontStyle` and `fontFamily`.
-- The label itself has a fill and border using with `fill`, `fillOpacity`, `cornerRadius`, `padding` and `border` properties. See [Fills & Borders](./fills-borders/) for more details.
+- The label itself has a fill and border, configured with the `fill`, `fillOpacity`, `cornerRadius`, `padding` and `border` properties. See [Fills & Borders](./fills-borders/) for more details.
 - The `insideStyle` and `outsideStyle` properties provide overrides for when the resolved label placement sits inside or outside the series node.
 - Bar-family labels can additionally be rotated with `orientation`. See [Orientation](#orientation) for more details.
 - Providing `placement` as an ordered array lets a label fall back to an alternative position. See [Placement](#placement) for more details.
@@ -128,7 +128,7 @@ Series label collision avoidance is separate from [axis label collision avoidanc
 
 When any of these strategies are used but fail to find a satisfactory resolution, the label is hidden by default.
 
-Use `collision.alwaysShow: true` to force the label to remain visible, or use `collision.alwaysShow: false` to enable the hiding the labels if other strategies are not enabled.
+Use `collision.alwaysShow: true` to force the label to remain visible, or `collision.alwaysShow: false` to allow labels to be hidden even when no other strategies are enabled.
 
 {% chartExampleRunner title="Label Collision Threshold" name="label-threshold" type="generated" /%}
 
@@ -150,7 +150,7 @@ Use `collision.alwaysShow: true` to force the label to remain visible, or use `c
 
 ### Threshold
 
-Collisions are defined as the edge of one label hitting another the edge of another element.
+Collisions are defined as the edge of one label hitting the edge of another element.
 
 Use a `collision.threshold` value to ensure labels are a minimum pixel distance from obstacles, or a negative value to allow labels to overlap somewhat.
 

--- a/packages/ag-charts-website/src/content/docs/series-labels/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/series-labels/index.mdoc
@@ -28,9 +28,9 @@ Enable labels with `label.enabled`, then style them with the following options.
 
 In this example:
 
-- Text is styled with `color`, `fontSize`, `fontWeight`, `fontStyle` and `fontFamily`.
-- The label itself has a fill and border, configured with the `fill`, `fillOpacity`, `cornerRadius`, `padding` and `border` properties. See [Fills & Borders](./fills-borders/) for more details.
-- The `insideStyle` and `outsideStyle` properties provide overrides for when the resolved label placement sits inside or outside the series node.
+- The label text is styled with properties such as `color` and `fontWeight`. Other available options include `fontSize`, `fontStyle` and `fontFamily`.
+- The label itself has a fill and border, configured with properties such as `fill` and `border`. Other available options include `fillOpacity`, `cornerRadius` and `padding`. See [Fills & Borders](./fills-borders/) for more details.
+- The `insideStyle` and `outsideStyle` properties override these text and box styles for when the resolved label placement sits inside or outside the series node — used here to swap between a dark-on-light and light-on-dark treatment.
 - Bar-family labels can additionally be rotated with `orientation`. See [Orientation](#orientation) for more details.
 - Providing `placement` as an ordered array lets a label fall back to an alternative position. See [Placement](#placement) for more details.
 


### PR DESCRIPTION
Applies the fixes from the automated b14.1.0 release docs review ([run 30432526195](https://github.com/ag-grid/ag-charts/actions/runs/30432526195)). Raised as a starting point to iterate on — the mechanical fixes are done, the judgement calls are listed below and deliberately left out.

Every finding below was re-verified against the source before changing anything.

## Applied — correctness

| Page | Fix | Verified against |
| --- | --- | --- |
| `key-features:258` | Invalid theme keyword `'ag-polychrome'` → `'ag-polychroma'`. Copy-pasting the snippet warned and silently fell back to `ag-default`. | `ag-charts-types/src/chart/themeOptions.ts:59` |
| `events:111-116` | `collapsedChange` documented only `collapsed` and `source`; added the missing `expanded` field. It is a primary payload field of a **newly added** event, and the page's own example logs `event.expanded.map(...)`. | `ag-charts-types/src/chart/eventOptions.ts:139-150` |
| `events:113` | Added a note that `collapsed`/`expanded` are the delta of this change, not the full collapsed/expanded set — matching the type's own doc comments. | as above |
| `fills-borders:12` | Prose claimed a border on the title *and* subtitle; the example gives the subtitle only `fill` + `cornerRadius`. | `_examples/fills-borders/main.ts:12-25` |
| `context-menu:111` | Prose listed every `showOn` target except `axis`, which the example does use. | `_examples/context-menu-actions/main.ts:50` |

## Applied — prose and conventions

- `series-labels`: three grammar defects — `:32` "using with", `:131` "to enable the hiding the labels", `:153` duplicated "another the edge of another".
- `events:118`: example runner mislabelled `title="Annotations"` (copy-paste from the adjacent runner) → `"Collapsed Change Event"`.
- `installation:157`: "minimize" → "minimise" (UK English convention).
- `community-vs-enterprise:82`: heading "Licencing" → "Licensing".
- `accessibility:40`: subject-verb agreement ("collapses and expands" → "collapse and expand", subject is two key combinations), plus trailing slash on the Org Chart link.
- `scrollbar:8,145`: trailing slash on two Zoom cross-references (repo is 12 × `./zoom/` vs 3 × `./zoom`).

## Not applied — needs a decision from us

1. **Mac (⌘) shortcuts were stripped from the docs but still work at runtime** — `financial-charts-toolbar:88-91` (Medium) and `annotations:65-68`. The b14.1.0 diff removed the ⌘ variants of undo/redo/copy/paste leaving Ctrl only, but the implementation still binds both (`keyBindings.ts:28-52` via `ctrlOrMeta`; `annotations.ts:1125` `ctrlKey || metaKey`). So macOS users are told only Ctrl works when ⌘ is fully functional. **Was the Ctrl-only simplification intentional?** If not, the ⌘ variants should go back on both pages. Not guessing at this one.
2. **`overlays` — AG-17732 is shipped but undocumented** (Medium). The "overlay text inherits theme `textColor`" behaviour has an example (`no-data-themed-text`) that is generated across all frameworks but never referenced from the page, and the behaviour itself has no prose. Needs new content, not a mechanical fix. The same example also has its x/y axis titles swapped.
3. **Four more orphaned `_examples/` folders** — `context-menu/context-menu-icons`, `bar-series/bar-no-labels`, `selection/per-series-selection`, `selection/selection-with-highlight`. Each is built for every framework but never surfaces. Wire in or delete — needs a per-example call.
4. **`bars` examples register the wrong modules** (Low) — `band-alignment` and `skip-null-bars` import from enterprise but register only community modules. This is example code rather than prose, so I left it for someone to run.
5. **`bars` Fixed Width prose** (Low) cites Scrollbar/Navigator/Zoom recovery, but the example was downgraded this release to a community category axis with no scrollbar. Fix the prose or restore the example — depends on which was intended.

## Two review findings I checked and rejected

Worth recording so they don't get re-raised:

- The review flagged `context-menu/technical-review-plan.md` as a stray file to delete. **It isn't stray** — 117 of 181 docs pages carry one. Deleting a single page's copy would just make things inconsistent. Whether these belong in `src/content/docs` at all is a real question, but it's a repo-wide cleanup, not a release fix.
- It also flagged `context-menu` and `fills-borders` for missing `description` frontmatter. Only 67 of 181 pages have it, so it isn't the prevailing pattern, and the field is authored copy rather than something to generate. Left alone.

## Review coverage caveat

The review ran headless under `claude-code-action`, where browser tooling is unavailable, so **all 25 pages were static-analysis only**. Findings are validated against the types and implementation but nothing was confirmed in a browser — notably the AG-17732 overlay text-colour visual claim.