### PR TITLE
CRT-1192 Fix "Remove Random Point" in the error-bars test example

### DIFF
--- a/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/main.ts
+++ b/packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/main.ts
@@ -135,16 +135,33 @@ function randomiseErrors() {
 
 function removeRandomElem() {
     const { series } = options;
-    if (series !== undefined) {
-        const meta: { seriesIndex: number; datumIndex: number }[] = [];
-        for (let seriesIndex = 0; seriesIndex < series.length; seriesIndex++) {
-            const { data } = series[seriesIndex];
-            for (let datumIndex = 0; datumIndex < (data?.length ?? 0); datumIndex++) {
-                meta.push({ seriesIndex, datumIndex });
-            }
-        }
-        const { seriesIndex, datumIndex } = meta[randomIndex(meta.length)];
-        series[seriesIndex].data?.splice(datumIndex, 1);
+    if (series === undefined) {
+        return;
     }
+
+    const meta: { seriesIndex: number; datumIndex: number }[] = [];
+    for (let seriesIndex = 0; seriesIndex < series.length; seriesIndex++) {
+        const { data } = series[seriesIndex];
+        for (let datumIndex = 0; datumIndex < (data?.length ?? 0); datumIndex++) {
+            meta.push({ seriesIndex, datumIndex });
+        }
+    }
+
+    // Nothing left to remove - bail out rather than indexing an empty array.
+    if (meta.length === 0) {
+        return;
+    }
+
+    const { seriesIndex, datumIndex } = meta[randomIndex(meta.length)];
+    const data = series[seriesIndex].data;
+    if (data === undefined) {
+        return;
+    }
+
+    // Assign a new array rather than splicing in place: `update()` diffs data arrays by
+    // reference, so an in-place mutation of the array the chart already holds is not
+    // detected as a change and nothing would re-render.
+    series[seriesIndex].data = data.filter((_, index) => index !== datumIndex);
+
     chart.update(options);
 }


### PR DESCRIPTION
Fixes [CRT-1192](https://ag-grid.atlassian.net/browse/CRT-1192).

## Problem

On the internal `error-bars-test` page (Boyle's Law section), pressing **Remove Random Point** did nothing, and after enough clicks it threw `TypeError: Cannot destructure property 'seriesIndex' of undefined`.

## Root cause

`removeRandomElem` spliced the series `data` array **in place** and then called `chart.update(options)` with the same `options` object:

- `Chart.applyOptions` diffs against `chartOptions.processedOptions`, which **aliases** the user's data arrays by reference (`mergeDefaults` does not clone arrays).
- `jsonDiff` short-circuits on reference equality (`if (source[key] === target[key]) continue;`), so the mutated array's changed length was never examined.
- The series diff therefore had no `data` key, `dataChanged` stayed `false`, and the change was classified `'no-op'` - hence "nothing happens".

The splice itself did succeed, so the arrays really shrank on every click while the chart never re-rendered. Once all three were empty, `meta` was empty and `randomIndex(0)` produced a negative index, so destructuring `meta[-1]` threw. Both reported symptoms come from the one defect.

This is example-side only. The reference-based diff is deliberate (the "Cheap-and-easy equality check" short-circuit exists for large datasets), and the three sibling buttons that assign fresh arrays - `randomiseData`, `randomiseErrors`, `resetData` - all work. `removeRandomElem` was the only in-place mutator and the only control reported broken.

Pre-existing since `bff7fd6` (2023-11-15, AG-9018); not a regression in this cycle, matching the reporter's `[NR]`.

## Fix

`packages/ag-charts-website/src/content/docs/error-bars-test/_examples/boyles/main.ts` only:

- Assign a **new** array (`data.filter(...)`) rather than splicing in place, matching the pattern the working sibling buttons already use, with a comment recording the reference-diff contract so it is not reintroduced.
- Return early once there is nothing left to remove (mirrors `simple-apply-transaction`'s `if (data.length === 0) return;`), which removes the console error.

## Scope / risk

- One unpublished example file. No library code, no test or image-snapshot changes.
- `error-bars-test` is internal-only - excluded from the sitemap, from search engines and from docs nav - so there is no customer-facing surface and this is decoupled from the NPM release.

## Verification

- `jsonDiff` / `dataChanged` mechanism re-verified in source: a new array reference makes lengths differ, `jsonDiff` returns the target array, so `change.diff?.data != null` and the data is reprocessed.
- The new handler logic was simulated over 60 clicks against 27 datums: exactly 27 removals, exactly one new array reference per removal, and 33 further clicks past exhaustion with no throw and no spurious `update()`.
- Prettier clean. (The example files are outside the TS project service, so `eslint` cannot be run on them directly.)

## Deliberately out of scope

- Warning from the library when an aliased data array is mutated - would need an O(n) content check on every update, defeating the short-circuit the code calls out as a performance decision. Worth a separate enhancement ticket if wanted.
- The inconsistent `ModuleRegistry.registerModules(...)` practice across `-test` examples - cosmetic, and the example demonstrably renders.
- `temperatures/main.ts` on the same page was inspected; all of its controls already assign fresh arrays.

## Docs - manual curation needed

None - no prose-docs curation needed (the change is example code on an internal test page).