### PR TITLE
CRT-1185 Resize legend for diagonal placements in legend-test harness

### DIFF
--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/index.html
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/index.html
@@ -11,7 +11,7 @@
             <option value="top">top</option>
             <option value="top-right">top-right</option>
             <option value="top-left">top-left</option>
-            <option value="bottom">bottom</option>
+            <option value="bottom" selected>bottom</option>
             <option value="bottom-right">bottom-right</option>
             <option value="bottom-left">bottom-left</option>
         </select>

--- a/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/main.ts
+++ b/packages/ag-charts-website/src/content/docs/legend-test/_examples/legend-pagination/main.ts
@@ -1,4 +1,4 @@
-import { AgCartesianChartOptions, AgChartLegendPosition, AgCharts } from 'ag-charts-community';
+import { AgCartesianChartOptions, AgChartLegendPlacement, AgCharts } from 'ag-charts-community';
 
 import { getData } from './data';
 
@@ -116,16 +116,25 @@ const options: AgCartesianChartOptions = {
 
 const chart = AgCharts.create(options);
 
-function updateLegendPosition(value: AgChartLegendPosition) {
+function updateLegendPosition(value: AgChartLegendPlacement) {
     options.legend!.position = value;
+    // Placements are grouped by orientation, mirroring Legend.calculateLegendDimensions().
     switch (value) {
         case 'top':
+        case 'top-left':
+        case 'top-right':
         case 'bottom':
+        case 'bottom-left':
+        case 'bottom-right':
             options.legend!.maxHeight = 40;
             options.legend!.maxWidth = 800;
             break;
-        case 'right':
         case 'left':
+        case 'left-top':
+        case 'left-bottom':
+        case 'right':
+        case 'right-top':
+        case 'right-bottom':
             options.legend!.maxHeight = 200;
             options.legend!.maxWidth = 200;
             break;


### PR DESCRIPTION
[CRT-1185](https://ag-grid.atlassian.net/browse/CRT-1185)

## Problem

In the `legend-test` docs harness, `updateLegendPosition()` only handled the four cardinal placements. Selecting any of the eight diagonals (`top-left`, `left-top`, `right-bottom`, …) set `legend.position` but left `maxWidth`/`maxHeight` at whatever the previous placement had set, so e.g. a left-side legend kept the bottom legend's 800x40 box.

The `<select>` also opened showing `right` while the chart actually rendered the legend at the bottom.

## Change

Example-only. The library is fine — `Legend.calculateLegendDimensions()` handles all twelve placements with compiler-enforced exhaustiveness (`default: unreachable(placement)`).

- Added the eight diagonals to the switch, grouped by orientation in the same order the library groups them.
- Narrowed the parameter from `AgChartLegendPosition` to `AgChartLegendPlacement`. The object arm of that union was dead here and is what let the switch be silently non-exhaustive.
- Marked the `bottom` `<option>` as `selected` so the control matches the initial render.

## Verification

Playwright against an esbuild harness wrapping the example's real `main.ts`/`data.ts`/`index.html`, measuring legend geometry from the `.ag-charts-proxy-legend-toolbar` a11y proxies:

- all six horizontal placements → 685x16; all six vertical → 142x112, differing only in alignment offset
- the repro transition `bottom` → `left-top` now goes 685x16 → 142x112
- no console errors

Confirmed non-vacuous: the same test against the pre-fix `main.ts` fails — `bottom` → `left-top` stays 685x16. Note that stepping through all twelve placements *in order* looks correct even pre-fix, because each diagonal inherits from the cardinal before it; only the direct transition exposes the bug.

Gates: `validate-examples` (860 examples typechecked), `format:check`, `lint ag-charts-website`, `test ag-charts-website` (506 tests) — all pass.

## Not done

The position `<select>` still has no automated coverage, which is why this rotted unnoticed. `legend-test` is a manual harness by design, and CRT-1192 is the same class of defect on another one — if we want coverage here it's a decision for the `-test` pages as a group rather than this single control.
