### PR TITLE
Fix series-labels example interactivity and layout bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,6 @@ env:
     BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     AG_LIBRARY: charts
     AG_SKIP_NATIVE_DEP_VERSION_CHECK: 1
-    # PR runs sweep only the vanilla example variant (see AG_E2E_FRAMEWORKS), so each shard
-    # carries roughly a third of the work and fewer, fuller shards waste less on the ~45s of
-    # fixed per-shard setup. Pushes still run all six variants and keep the wider fan-out.
-    AG_E2E_SHARD_COUNT: ${{ github.event_name == 'pull_request' && '16' || '32' }}
     LIBRARY_WEBSITE_STATUS_CHANNEL: '#charts-website-status'
 
 permissions:
@@ -225,15 +221,43 @@ jobs:
 
                   # Duration-balanced shard assignment (falls back to Playwright count-based
                   # --shard sharding if the committed timings file is missing or stale).
-                  # One timings file per event type: pushes sweep all six framework variants with
-                  # AG_SCENE_SNAPSHOTS=all, so their docs-example specs cost ~10x what the same
-                  # specs cost on a vanilla-only PR run. Planning either run type from the other's
-                  # timings mis-weights those specs badly enough to overflow the 15-minute job
-                  # timeout, so each file must be regenerated from a run of its own event type.
+                  #
+                  # The plan is sized by the workload's *shape*, not by the event type. A PR run
+                  # normally sweeps only the vanilla example variant (see AG_E2E_FRAMEWORKS), so it
+                  # is planned from the PR timings, and its lighter shards are packed into a
+                  # narrower fan-out — fewer, fuller shards waste less on the ~45s of fixed
+                  # per-shard setup. Pushes sweep all six variants with AG_SCENE_SNAPSHOTS=all,
+                  # making their docs-example specs cost ~10x as much, so they need both the push
+                  # timings and the wider fan-out.
+                  #
+                  # A change under the example generator plugin invalidates the output of every
+                  # example, so the runtime sweeps escalate all of them to the full six-variant
+                  # matrix even on a PR (see e2e/changed-examples.ts). Such a run is push-shaped
+                  # and must be planned as one: the PR timings under-weight those specs ~3x, which
+                  # packs them together until the bins overflow the 15-minute job timeout. The push
+                  # timings over-weight them instead, by the snapshot capture a PR does not pay —
+                  # the safe direction, since shards then finish early rather than time out.
+                  e2e_full_sweep=1
+                  if [[ "${{ github.event_name }}" == "pull_request" ]] ; then
+                    if git diff --quiet ${{ steps.setup.outputs.base }} -- plugins/ag-charts-generate-example-files/ ; then
+                      e2e_full_sweep=0
+                    else
+                      echo "Example generator changed - every example escalates to the full framework sweep; planning this PR run as push-shaped."
+                    fi
+                  fi
+
+                  if [[ ${e2e_full_sweep} -eq 1 ]] ; then
+                    e2e_timings=shard-timings.json
+                    e2e_shards=32
+                  else
+                    e2e_timings=shard-timings.pr.json
+                    e2e_shards=16
+                  fi
+
                   e2e_matrix=$(node ./external/ag-shared/scripts/shard/assign-e2e-shards.js \
-                    --max ${{ env.AG_E2E_SHARD_COUNT }} \
+                    --max ${e2e_shards} \
                     --count ${e2e_count} \
-                    --timings packages/ag-charts-website/e2e/shard-timings${{ github.event_name == 'pull_request' && '.pr' || '' }}.json \
+                    --timings packages/ag-charts-website/e2e/${e2e_timings} \
                     --test-dir packages/ag-charts-website/e2e)
                   echo "e2e_matrix=${e2e_matrix}" >> $GITHUB_OUTPUT
                   echo "e2e_count=${e2e_count}" >> $GITHUB_OUTPUT

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/data.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/data.ts
@@ -1,15 +1,16 @@
 export interface DataType {
     quarter: string;
     profitChange: number;
+    note?: string;
 }
 
 export const data: DataType[] = [
     { quarter: 'Q1 2024', profitChange: 12 },
     { quarter: 'Q2 2024', profitChange: 8 },
     { quarter: 'Q3 2024', profitChange: 15 },
-    { quarter: 'Q4 2024', profitChange: 6 },
+    { quarter: 'Q4 2024', profitChange: 2 },
     { quarter: 'Q1 2025', profitChange: 11 },
-    { quarter: 'Q2 2025', profitChange: 9 },
+    { quarter: 'Q2 2025', profitChange: 9, note: 'best quarter on record' },
     { quarter: 'Q3 2025', profitChange: 14 },
     { quarter: 'Q4 2025', profitChange: 7 },
 ];

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/index.html
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/index.html
@@ -2,11 +2,11 @@
     <div class="controls-row">
         <span>Orientation:</span>
         <select class="gap-right" onchange="setOrientation(event.target.value)">
-            <option value="horizontal">Horizontal</option>
+            <option value="horizontal" selected>Horizontal</option>
             <option value="vertical">Vertical</option>
             <option value="vertical-reversed">Vertical Reversed</option>
             <hr />
-            <option value="horizontal, vertical" selected>Horizontal, Vertical fallback</option>
+            <option value="horizontal, vertical">Horizontal, Vertical fallback</option>
             <option value="vertical, horizontal">Vertical, Horizontal fallback</option>
         </select>
     </div>

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
@@ -18,9 +18,9 @@ const options: AgCartesianChartOptions<DataType> = {
             label: {
                 enabled: true,
                 placement: 'inside-end',
-                orientation: ['horizontal', 'vertical'],
+                orientation: 'horizontal',
                 wrapping: 'never',
-                formatter: (params) => `$${params.value}m profit`,
+                formatter: (params) => `$${params.value}m profit${params.datum.note ? ` (${params.datum.note})` : ''}`,
             },
         },
     ],

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/index.html
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/index.html
@@ -8,7 +8,7 @@
     <div class="controls-row">
         <span>Placement:</span>
         <span id="bubblePlacementRow">
-            <select class="gap-right" onchange="setPlacement(event.target.value)">
+            <select id="bubblePlacementSelect" class="gap-right" onchange="setPlacement(event.target.value)">
                 <option value="top" selected>Top</option>
                 <option value="top-right">Top Right</option>
                 <option value="right">Right</option>
@@ -24,7 +24,7 @@
             </select>
         </span>
         <span id="barPlacementRow" style="display: none">
-            <select class="gap-right" onchange="setPlacement(event.target.value)">
+            <select id="barPlacementSelect" class="gap-right" onchange="setPlacement(event.target.value)">
                 <option value="outside-end" selected>Outside End</option>
                 <option value="outside-start">Outside Start</option>
                 <option value="inside-end">Inside End</option>

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
@@ -53,6 +53,15 @@ const options: AgCartesianChartOptions<BubbleDataType | BarDataType> = {
 
 const chart = AgCharts.create(options);
 
+function parsePlacement(value: string) {
+    const placements = value.split(/,\s*/g);
+    return (placements.length > 1 ? placements : placements[0]) as
+        | AgChartLabelCollisionPlacement
+        | AgChartLabelCollisionPlacement[]
+        | AgBarSeriesLabelPlacement
+        | AgBarSeriesLabelPlacement[];
+}
+
 function setSeriesType(seriesType: SeriesType) {
     document.getElementById('bubblePlacementRow')!.style.display = seriesType === 'bubble' ? '' : 'none';
     document.getElementById('barPlacementRow')!.style.display = seriesType === 'bubble' ? 'none' : '';
@@ -64,6 +73,7 @@ function setSeriesType(seriesType: SeriesType) {
             x: { type: 'number', title: { text: 'Temperature (°C)' } },
             y: { type: 'number', title: { text: 'Humidity (%)' } },
         };
+        const bubblePlacementSelect = document.getElementById('bubblePlacementSelect') as HTMLSelectElement;
         options.series = [
             {
                 type: 'bubble',
@@ -72,7 +82,13 @@ function setSeriesType(seriesType: SeriesType) {
                 sizeKey: 'windSpeed',
                 labelKey: 'station',
                 maxSize: 60,
-                label: { enabled: true, placement: 'top', spacing: 6 },
+                label: {
+                    enabled: true,
+                    placement: parsePlacement(bubblePlacementSelect.value) as
+                        | AgChartLabelCollisionPlacement
+                        | AgChartLabelCollisionPlacement[],
+                    spacing: 6,
+                },
             },
         ];
     } else {
@@ -89,6 +105,7 @@ function setSeriesType(seriesType: SeriesType) {
                       x: { type: 'category' },
                       y: { type: 'number', title: { text: 'Profit Change ($m)' } },
                   };
+        const barPlacementSelect = document.getElementById('barPlacementSelect') as HTMLSelectElement;
         options.series = [
             {
                 type: 'bar',
@@ -97,7 +114,9 @@ function setSeriesType(seriesType: SeriesType) {
                 yKey: 'profitChange',
                 label: {
                     enabled: true,
-                    placement: 'outside-end',
+                    placement: parsePlacement(barPlacementSelect.value) as
+                        | AgBarSeriesLabelPlacement
+                        | AgBarSeriesLabelPlacement[],
                     spacing: 6,
                     truncate: false,
                     formatter: (params) => `$${params.value}m`,
@@ -112,12 +131,7 @@ function setSeriesType(seriesType: SeriesType) {
 
 function setPlacement(placement: string) {
     const series = options.series![0] as AgBubbleSeriesOptions<BubbleDataType> | AgBarSeriesOptions<BarDataType>;
-    const placements = placement.split(/,\s*/g);
-    series.label!.placement = (placements.length > 1 ? placements : placements[0]) as
-        | AgChartLabelCollisionPlacement
-        | AgChartLabelCollisionPlacement[]
-        | AgBarSeriesLabelPlacement
-        | AgBarSeriesLabelPlacement[];
+    series.label!.placement = parsePlacement(placement);
     chart.update(options);
     updateSpacingSlider();
 }
@@ -130,6 +144,7 @@ function setSpacing(event: Event) {
     chart.update(options);
 }
 
+/** inScope */
 function updateSpacingSlider() {
     const series = options.series![0] as AgBubbleSeriesOptions<BubbleDataType> | AgBarSeriesOptions<BarDataType>;
     const placement = series.label!.placement;

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-showcase/data.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-showcase/data.ts
@@ -1,12 +1,13 @@
 export interface DataType {
     quarter: string;
-    profitChange: number;
+    hardware: number;
+    software: number;
+    services: number;
 }
 
 export const data: DataType[] = [
-    { quarter: 'Q1', profitChange: 12 },
-    { quarter: 'Q2', profitChange: 8 },
-    { quarter: 'Q3', profitChange: -5 },
-    { quarter: 'Q4', profitChange: 1 },
-    { quarter: 'Q5', profitChange: -9 },
+    { quarter: 'Q1', hardware: 42, software: 26, services: 3 },
+    { quarter: 'Q2', hardware: 35, software: 31, services: 9 },
+    { quarter: 'Q3', hardware: 29, software: 33, services: 2 },
+    { quarter: 'Q4', hardware: 46, software: 21, services: 6 },
 ];

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-showcase/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-showcase/main.ts
@@ -1,43 +1,44 @@
-import { AgCartesianChartOptions, AgCharts, LegendModule } from 'ag-charts-community';
+import { AgBarSeriesOptions, AgCartesianChartOptions, AgCharts, LegendModule } from 'ag-charts-community';
 import { BarSeriesModule, CategoryAxisModule, ModuleRegistry, NumberAxisModule } from 'ag-charts-community';
 
 import { DataType, data } from './data';
 
 ModuleRegistry.registerModules([BarSeriesModule, LegendModule, CategoryAxisModule, NumberAxisModule]);
 
+function seriesLabel(): AgBarSeriesOptions<DataType>['label'] {
+    return {
+        enabled: true,
+        fontWeight: 'bold',
+        placement: ['inside-center', 'beside-after-center', 'beside-before-center'],
+        orientation: 'horizontal',
+        border: { enabled: true, strokeWidth: 1 },
+        insideStyle: {
+            color: 'white',
+            fill: 'black',
+            fillOpacity: 0.6,
+            border: { stroke: 'white' },
+        },
+        outsideStyle: {
+            color: 'black',
+            fill: 'white',
+            fillOpacity: 0.8,
+            border: { stroke: 'black' },
+        },
+    };
+}
+
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),
-    title: { text: 'Quarterly Profit Change ($m)' },
+    title: { text: 'Quarterly Revenue by Product Line ($m)' },
     data,
     series: [
-        {
-            type: 'bar',
-            xKey: 'quarter',
-            yKey: 'profitChange',
-            label: {
-                enabled: true,
-                fontWeight: 'bold',
-                placement: ['outside-end', 'inside-end'],
-                orientation: 'horizontal',
-                border: { enabled: true, strokeWidth: 1 },
-                insideStyle: {
-                    color: 'white',
-                    fill: 'black',
-                    fillOpacity: 0.6,
-                    border: { stroke: 'white' },
-                },
-                outsideStyle: {
-                    color: 'black',
-                    fill: 'white',
-                    fillOpacity: 0.8,
-                    border: { stroke: 'black' },
-                },
-            },
-        },
+        { type: 'bar', xKey: 'quarter', yKey: 'hardware', yName: 'Hardware', stacked: true, label: seriesLabel() },
+        { type: 'bar', xKey: 'quarter', yKey: 'services', yName: 'Services', stacked: true, label: seriesLabel() },
+        { type: 'bar', xKey: 'quarter', yKey: 'software', yName: 'Software', stacked: true, label: seriesLabel() },
     ],
     axes: {
         x: { type: 'category' },
-        y: { type: 'number', title: { text: 'Profit Change ($m)' } },
+        y: { type: 'number', title: { text: 'Revenue ($m)' } },
     },
 };
 

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-threshold/index.html
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-threshold/index.html
@@ -4,7 +4,7 @@
         <input
             type="range"
             id="thresholdSlider"
-            min="-5"
+            min="-10"
             max="5"
             value="4"
             oninput="setThreshold(event)"

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-threshold/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-threshold/main.ts
@@ -38,6 +38,8 @@ const options: AgCartesianChartOptions<DataType> = {
 
 const chart = AgCharts.create(options);
 
+updateThresholdSlider();
+
 function setThreshold(event: Event) {
     const value = Number((event.target as HTMLInputElement).value);
     document.getElementById('thresholdValue')!.textContent = String(value);
@@ -48,4 +50,13 @@ function setThreshold(event: Event) {
 function setAlwaysShow(value: string) {
     (options.series![0] as AgBubbleSeriesOptions<DataType>).label!.collision!.alwaysShow = value === 'show';
     chart.update(options);
+    updateThresholdSlider();
+}
+
+/** inScope */
+function updateThresholdSlider() {
+    const series = options.series![0] as AgBubbleSeriesOptions<DataType>;
+    (document.getElementById('thresholdSlider') as HTMLInputElement).disabled = Boolean(
+        series.label!.collision!.alwaysShow
+    );
 }

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/chart-vanilla-to-angular.ts
@@ -262,7 +262,7 @@ export async function vanillaToAngular(
                 bindings.init.length !== 0
                     ? `
             ngOnInit() {
-                ${bindings.init.join(';\n    ')}
+                ${prefixInstanceMethodCalls(bindings.init.join(';\n    '), methodNames)}
             }
             `
                     : ''

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/preserve-type-declarations.test.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/transformation-scripts/preserve-type-declarations.test.ts
@@ -122,6 +122,34 @@ function refresh(): boolean | undefined {
         expect(reactOutput).toMatch(/const refresh = \(\): boolean \| undefined => \{/);
     });
 
+    test('angular output prefixes inScope function calls in top-level init code with this.', async () => {
+        const src = `
+import { AgChartOptions, AgCharts } from 'ag-charts-community';
+
+const options: AgChartOptions = {
+    container: document.getElementById('myChart'),
+    data: [{ quarter: 'Q1', value: 1 }],
+    series: [{ type: 'bar', xKey: 'quarter', yKey: 'value' }],
+};
+
+const chart = AgCharts.create(options);
+
+refresh();
+
+/** inScope */
+function refresh() {
+    options.data = [{ quarter: 'Q1', value: 2 }];
+    chart.update(options);
+}
+`;
+        const { typedBindings } = parse(src);
+        const output = await vanillaToAngular(typedBindings, [], false);
+
+        // Top-level statements land in ngOnInit, where the function is a component member.
+        expect(output).toContain('this.refresh()');
+        expect(output).not.toMatch(/(?<!\.)\brefresh\(\)/);
+    });
+
     test('angular output expands object shorthand references to inScope functions', async () => {
         const src = `
 import { AgChartOptions, AgCharts } from 'ag-charts-community';


### PR DESCRIPTION
Fixes interactivity and layout bugs found in the series-labels documentation examples (packages/ag-charts-website/src/content/docs/series-labels/):

- label-position: switching between bar/bar-horizontal/bubble no longer resets the placement to a hardcoded default when the dropdown already reflects a different choice
- label-orientation: defaults to plain `horizontal` (matching label-position's pattern) instead of a fallback array; data tuned so both fallback directions are demonstrable via the dropdown
- label-showcase: narrow stacked segment now sits between the other two; added a third placement fallback so its label doesn't hide at the container width used on the actual docs page
- label-threshold: widened the collision threshold slider range

https://ag-grid.atlassian.net/browse/CRT-1188