### PR TITLE
CRT-1175 Show the example loading logo when reloading in another language

### DIFF
--- a/external/ag-website-shared/src/components/loading-logo/LoadingLogo.tsx
+++ b/external/ag-website-shared/src/components/loading-logo/LoadingLogo.tsx
@@ -1,4 +1,5 @@
 import { getLoadingIFrameId } from '@ag-website-shared/components/loading-logo/getElementId';
+import { EXAMPLE_RELOADING_MESSAGE_TYPE } from '@ag-website-shared/components/loading-logo/messages';
 import AgLoadingLogo from '@ag-website-shared/images/inline-svgs/ag-grid-logomark-not-loading.svg?react';
 import {
     type UseIntersectionObserverParams,
@@ -11,6 +12,12 @@ interface Props {
     pageName: string;
     exampleName: string;
 }
+
+/**
+ * An example only becomes visible once it reports back with an `init` message, so one that never
+ * sends it must not leave its iFrame hidden indefinitely.
+ */
+const REVEAL_FALLBACK_TIMEOUT_MS = 15_000;
 
 export const LoadingLogo: FunctionComponent<Props> = ({ pageName, exampleName }) => {
     const loadingLogoRef = useRef<HTMLDivElement>(null);
@@ -39,21 +46,56 @@ export const LoadingLogo: FunctionComponent<Props> = ({ pageName, exampleName })
     });
 
     useEffect(() => {
-        window.addEventListener('message', ({ data }) => {
+        let revealFallbackTimeout: ReturnType<typeof setTimeout> | undefined;
+
+        const eachIFrame = (callback: (iframe: HTMLIFrameElement) => void) => {
+            document.querySelectorAll<HTMLIFrameElement>('#' + loadingIFrameId).forEach(callback);
+        };
+
+        const showExample = () => {
+            clearTimeout(revealFallbackTimeout);
+            setHide(true);
+
+            eachIFrame((iframe) => {
+                iframe.style.visibility = 'visible';
+                if (document.documentElement.dataset['darkMode'] === 'true' && iframe.contentDocument) {
+                    iframe.contentDocument.documentElement.dataset['darkMode'] = 'true';
+                }
+            });
+        };
+
+        const showLoadingLogo = () => {
+            clearTimeout(revealFallbackTimeout);
+            setHide(false);
+            eachIFrame((iframe) => {
+                iframe.style.visibility = 'hidden';
+            });
+
+            revealFallbackTimeout = setTimeout(showExample, REVEAL_FALLBACK_TIMEOUT_MS);
+        };
+
+        const onMessage = ({ data }: MessageEvent) => {
+            if (data?.type === EXAMPLE_RELOADING_MESSAGE_TYPE) {
+                if (data.loadingIFrameId === loadingIFrameId) {
+                    showLoadingLogo();
+                }
+                return;
+            }
+
             const isExample = pageName === data?.pageName && exampleName === data?.exampleName;
             if (!isExample) return;
 
             if (data?.type === 'init') {
-                setHide(true);
-
-                document.querySelectorAll('#' + loadingIFrameId).forEach((iframe) => {
-                    iframe.style.visibility = 'visible';
-                    if (document.documentElement.dataset['darkMode'] === 'true') {
-                        iframe.contentDocument.documentElement.dataset.darkMode = true;
-                    }
-                });
+                showExample();
             }
-        });
+        };
+
+        window.addEventListener('message', onMessage);
+
+        return () => {
+            window.removeEventListener('message', onMessage);
+            clearTimeout(revealFallbackTimeout);
+        };
     }, []);
 
     return (

--- a/external/ag-website-shared/src/components/loading-logo/messages.ts
+++ b/external/ag-website-shared/src/components/loading-logo/messages.ts
@@ -1,0 +1,6 @@
+/**
+ * Posted on `window` by the example runner island before an example iFrame navigates, so the
+ * separate loading logo island can show itself again. Must carry the `loadingIFrameId` from
+ * `getLoadingIFrameId`, as pages contain one loading logo per example.
+ */
+export const EXAMPLE_RELOADING_MESSAGE_TYPE = 'exampleReloading';

--- a/packages/ag-charts-website/e2e/example-runner-loading.spec.ts
+++ b/packages/ag-charts-website/e2e/example-runner-loading.spec.ts
@@ -1,0 +1,65 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from './fixture';
+import { gotoUrl, toPageUrl } from './util';
+
+test.use({ viewport: { width: 1400, height: 900 } });
+
+const PAGE_NAME = 'axes-cross-lines';
+const EXAMPLE_NAME = 'axis-cross-lines-adding';
+const IFRAME_ID = `loading-frame-${PAGE_NAME}-${EXAMPLE_NAME}`;
+
+interface LoadingStatesSeen {
+    loadingLogo: boolean;
+    iframeHidden: boolean;
+}
+
+type WindowWithStates = Window & { __loadingStatesSeen: LoadingStatesSeen };
+
+/**
+ * A reload can complete faster than an assertion poll interval, so record whether the transient
+ * states were ever entered rather than trying to catch them.
+ */
+async function recordLoadingStates(page: Page, iframeId: string) {
+    await page.evaluate((id) => {
+        const iframe = document.getElementById(id) as HTMLIFrameElement;
+        const exampleOuter = iframe.closest('.example-runner-outer')!;
+        const seen: LoadingStatesSeen = { loadingLogo: false, iframeHidden: false };
+        (window as unknown as WindowWithStates).__loadingStatesSeen = seen;
+
+        new MutationObserver(() => {
+            seen.loadingLogo ||= exampleOuter.querySelector('.logomark') != null;
+            seen.iframeHidden ||= iframe.style.visibility === 'hidden';
+        }).observe(exampleOuter, { attributes: true, childList: true, subtree: true });
+    }, iframeId);
+}
+
+function getLoadingStates(page: Page) {
+    return page.evaluate(() => (window as unknown as WindowWithStates).__loadingStatesSeen);
+}
+
+test('example runner shows the loading logo when reloading an example in another language', async ({ page }) => {
+    await gotoUrl(page, toPageUrl(`javascript/${PAGE_NAME}`));
+
+    const exampleOuter = page.locator(`div#example-${EXAMPLE_NAME}`);
+    const iframe = page.locator(`#${IFRAME_ID}`);
+    const loadingLogo = exampleOuter.locator('.logomark');
+
+    await exampleOuter.scrollIntoViewIfNeeded();
+    await expect(iframe).toHaveCSS('visibility', 'visible', { timeout: 30_000 });
+    await expect(loadingLogo).toHaveCount(0);
+
+    await recordLoadingStates(page, IFRAME_ID);
+
+    await exampleOuter.getByRole('button', { name: 'Code', exact: true }).click();
+    const languageSelect = page.locator(`#example-${EXAMPLE_NAME}-typescript-style-selector`);
+    const otherLanguage = (await languageSelect.inputValue()) === 'typescript' ? 'vanilla' : 'typescript';
+    await languageSelect.selectOption(otherLanguage);
+    await exampleOuter.getByRole('button', { name: 'Preview', exact: true }).click();
+
+    await expect(iframe).toHaveAttribute('src', new RegExp(`/${otherLanguage}/`), { timeout: 30_000 });
+    await expect(iframe).toHaveCSS('visibility', 'visible', { timeout: 30_000 });
+    await expect(loadingLogo).toHaveCount(0);
+
+    expect(await getLoadingStates(page)).toEqual({ loadingLogo: true, iframeHidden: true });
+});

--- a/packages/ag-charts-website/src/components/example-runner/components/ExampleIFrame.tsx
+++ b/packages/ag-charts-website/src/components/example-runner/components/ExampleIFrame.tsx
@@ -1,3 +1,4 @@
+import { EXAMPLE_RELOADING_MESSAGE_TYPE } from '@ag-website-shared/components/loading-logo/messages';
 import { useIntersectionObserver } from '@ag-website-shared/utils/hooks/useIntersectionObserver';
 import classnames from 'classnames';
 import { type FunctionComponent, useEffect, useRef, useState } from 'react';
@@ -32,8 +33,14 @@ export const ExampleIFrame: FunctionComponent<Props> = ({ title, isHidden, url, 
             return;
         }
 
+        if (currentSrc) {
+            // Post before navigating, otherwise the stale example stays visible until the loading
+            // logo island handles the message
+            window.postMessage({ type: EXAMPLE_RELOADING_MESSAGE_TYPE, loadingIFrameId });
+        }
+
         iFrameRef.current.src = url;
-    }, [isIntersecting, url]);
+    }, [isIntersecting, url, loadingIFrameId]);
 
     return (
         <div


### PR DESCRIPTION
## Problem

Toggling an example's language (JavaScript/TypeScript) and pressing **Preview** showed the old example briefly, then a blank gap for the duration of the load with no progress indicator, then the new example.

Two pieces of state are never reset when an example reloads in place:

- `LoadingLogo`'s `hide` flag is one-shot — `setHide(true)` on `init` is never undone, so the logo never returns.
- The iFrame's `visibility` is flipped to `visible` imperatively from outside React, so React never re-applies its JSX `hidden` on the next render.

The two live in sibling Astro islands with only a one-way `init` message between them, so there was no "reloading" signal the loader could react to. Pre-existing since `7dc228e80b5` (May 2025) — not a 14.1.0 regression, despite the `[NR]` tag on the ticket.

## Change

Additive, and symmetric with the existing `init` handshake:

- `loading-logo/messages.ts` (new) — the shared `exampleReloading` message type.
- `ExampleIFrame` posts that message before reassigning `src`, and only when the iFrame already had one, so initial loads are untouched.
- `LoadingLogo` handles it by re-hiding the iFrame and showing the logo again.

Revealing the iFrame is the only code path that makes an example visible, and `PostInitMessageScript`'s 15s timeout only `console.warn`s. Re-hiding it is therefore paired with a 15s parent-side fallback that reveals it anyway if `init` never arrives — otherwise a failing example would become permanently blank, which is worse than the bug being fixed. A parent-side timer was chosen over extending the in-iFrame one because it also covers an iFrame that fails to load at all.

Gallery, hero and interactive-demo runners pass a fixed example name and framework, so their URL never changes and their behaviour is unaffected.

## Verification

- Reproduced in the browser on the dev server: iFrame → hidden, logo shown, `init` → iFrame revealed, logo removed, with the URL switching framework and the chart rendering. A slow (~8s) TypeScript compile was fully covered by the loader.
- Simulated an example that never sends `init`: the iFrame was revealed at ~15s instead of staying blank.
- New `example-runner-loading.spec.ts` records the transient states with a `MutationObserver` rather than polling, so it is not timing-sensitive. Confirmed it **fails on the unfixed code** with `{loadingLogo: false, iframeHidden: false}` and passes with the fix.
- `nx format` and `nx lint ag-charts-website` clean. The new spec plus `api-ref-page` and `localisation` pass (28 tests).

## Note for reviewers

`LoadingLogo.tsx` and `messages.ts` are in `external/ag-website-shared`, kept byte-identical across repos. Companion PRs follow for `ag-grid` and `ag-studio`. The shared change is backwards-compatible on its own — a site that never posts `exampleReloading` behaves exactly as before.
