### PR TITLE
Fetch the branch's own success tag in the report job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1299,6 +1299,10 @@ jobs:
               run: |
                   git fetch origin --depth 1 latest next
                   git fetch origin --depth 1 tag latest-success
+                  # Commit History below diffs against init's nx_base, which on a release branch is
+                  # <branch>-success rather than latest-success. Tolerate its absence: a release
+                  # branch has no success tag until its first green build.
+                  git fetch origin --depth 1 tag "${BRANCH_NAME}-success" || true
 
             - uses: actions/download-artifact@v4
               with:
@@ -1403,7 +1407,19 @@ jobs:
               id: commits
               if: always() && job.status != 'cancelled' && needs.init.result == 'success' && needs.init.outputs.build_type != 'pr' && steps.lastJobStatus.outputs.changedState == 'true'
               run: |
-                  GIT_LOG=$(git log HEAD ^${{ needs.init.outputs.nx_base }} --format="%an (%h) %s")
+                  # Fall back through the bases that may not exist in this shallow checkout, so a
+                  # missing success tag degrades the Slack commit list rather than failing the job.
+                  GIT_LOG=""
+                  for base in "${{ needs.init.outputs.nx_base }}" latest-success ; do
+                    if git rev-parse --verify --quiet "${base}^{commit}" > /dev/null ; then
+                      GIT_LOG=$(git log HEAD "^${base}" --format="%an (%h) %s")
+                      break
+                    fi
+                    echo "Base '${base}' not resolvable in this checkout, trying next."
+                  done
+                  if [[ -z "$GIT_LOG" ]] ; then
+                    GIT_LOG=$(git log HEAD -1 --format="%an (%h) %s")
+                  fi
                   echo "GIT_LOG<<EOF" >> $GITHUB_ENV
                   echo "$GIT_LOG" >> $GITHUB_ENV
                   echo "EOF" >> $GITHUB_ENV


### PR DESCRIPTION
The `report` job's Commit History step has been failing on `b14.1.0` pushes with:

```
fatal: bad revision '^b14.1.0-success'
```

The job checks out at `fetch-depth: 1` and its Fetch Refs step fetched only the `latest-success` tag, but Commit History diffs against `needs.init.outputs.nx_base` — which on a release branch resolves to `<branch>-success`. That tag does exist on origin; it was simply never fetched into the shallow checkout. On `latest` the two coincide, which is why this only bites release branches.

It surfaced now rather than earlier because the step is gated on `changedState == 'true'` — earlier `b14.1.0` pushes skipped it rather than passing it.

Changes:

- Fetch `${BRANCH_NAME}-success` alongside `latest-success`, tolerating its absence (a release branch has no success tag until its first green build).
- Have Commit History fall back through the candidate bases and finally to `HEAD -1`, so an unresolvable base degrades the Slack commit list instead of failing the job.

Verified the fallback logic under `bash -e` for all three paths (real tag → 95 commits; missing branch tag → falls back to `latest-success`; neither present → last commit), each exiting 0, and confirmed the workflow YAML still parses.