### PR TITLE
AG-17613 Add types for common point/coords objects

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -4,6 +4,7 @@ import type {
     Callback,
     CallbackParam,
     ChartAnimationPhase,
+    CurrentPoint,
     DomainWithMetadata,
     DynamicContext,
     Normalised,
@@ -1225,7 +1226,7 @@ export abstract class Axis<
         };
     }
 
-    pickValue(point: { currentX: number; currentY: number }): AxisValuePick | undefined {
+    pickValue(point: CurrentPoint): AxisValuePick | undefined {
         const position = this.isVertical() ? point.currentY : point.currentX;
 
         const value = unsafeInvert(this.scale, position);

--- a/packages/ag-charts-community/src/chart/chartCaption.ts
+++ b/packages/ag-charts-community/src/chart/chartCaption.ts
@@ -1,4 +1,9 @@
-import type { DynamicContext, NormalisedChartCaptionOptions, NormalisedTextOrSegments } from 'ag-charts-core';
+import type {
+    CanvasPoint,
+    DynamicContext,
+    NormalisedChartCaptionOptions,
+    NormalisedTextOrSegments,
+} from 'ag-charts-core';
 import {
     FONT_SIZE,
     callWithContext,
@@ -232,7 +237,7 @@ export class ChartCaption implements CaptionLike {
         moduleCtx.tooltipManager.updateTooltip(this.id, { canvasX, canvasY, showArrow: false }, [content]);
     }
 
-    private eventToCanvas(event: MouseWidgetEvent<'mousemove' | 'contextmenu'>): { canvasX: number; canvasY: number } {
+    private eventToCanvas(event: MouseWidgetEvent<'mousemove' | 'contextmenu'>): CanvasPoint {
         const bbox = Transformable.toCanvas(this.node);
         return {
             canvasX: event.sourceEvent.offsetX + bbox.x,

--- a/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
@@ -1,4 +1,13 @@
-import { BaseProperties, Property, type Scale, clampArray, createId, findMinMax, toRadians } from 'ag-charts-core';
+import {
+    BaseProperties,
+    type CanvasPoint,
+    Property,
+    type Scale,
+    clampArray,
+    createId,
+    findMinMax,
+    toRadians,
+} from 'ag-charts-core';
 import type {
     AgCartesianAxisPosition,
     AgCartesianCrossLineLabelOptions,
@@ -206,14 +215,14 @@ export class CartesianCrossLine extends BaseProperties implements CrossLine<Cart
      * node holds the geometry for both the `line` (stroke) and `range` (fill) variants; its bbox is
      * transformed into canvas space to match the pointer coordinates carried by context-menu events.
      */
-    containsPoint(canvasX: number, canvasY: number): boolean {
+    containsPoint(point: CanvasPoint): boolean {
         const group = this.type === 'range' ? this.rangeGroup : this.lineGroup;
         if (!this.enabled || this.data == null || !group.visible) {
             return false;
         }
 
         const bbox = Transformable.toCanvas(this.crossLineRange).clone().grow(CROSS_LINE_HIT_TOLERANCE);
-        return bbox.containsPoint(canvasX, canvasY);
+        return bbox.containsPoint(point.canvasX, point.canvasY);
     }
 
     private _isRange: boolean | undefined = undefined;

--- a/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/cartesianCrossLine.ts
@@ -1,13 +1,5 @@
-import {
-    BaseProperties,
-    type CanvasPoint,
-    Property,
-    type Scale,
-    clampArray,
-    createId,
-    findMinMax,
-    toRadians,
-} from 'ag-charts-core';
+import { BaseProperties, Property, clampArray, createId, findMinMax, toRadians } from 'ag-charts-core';
+import type { CanvasPoint, Scale } from 'ag-charts-core';
 import type {
     AgCartesianAxisPosition,
     AgCartesianCrossLineLabelOptions,

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.ts
@@ -1,4 +1,4 @@
-import type { ChartAxisDirection, Scale } from 'ag-charts-core';
+import type { CanvasPoint, ChartAxisDirection, Scale } from 'ag-charts-core';
 import { checkDatum } from 'ag-charts-core';
 import type {
     AgBaseCrossLineLabelOptions,
@@ -69,7 +69,7 @@ export interface CrossLine<LabelType = AgBaseCrossLineLabelOptions> {
      * Hit-tests a canvas-space point against the cross line's rendered line or fill, widened by a
      * small fixed pixel tolerance. Returns `false` when the cross line is not currently visible.
      */
-    containsPoint?(canvasX: number, canvasY: number): boolean;
+    containsPoint?(point: CanvasPoint): boolean;
     clippedRange: [number, number];
     enabled?: boolean;
     defaultColorRange: string[];

--- a/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
@@ -69,7 +69,7 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
 
     private onSeriesAreaContextMenu(event: SeriesAreaContextMenuEvent): void {
         for (const crossLine of this.instances) {
-            if (crossLine.containsPoint?.(event.canvasX, event.canvasY) !== true) continue;
+            if (crossLine.containsPoint?.(event) !== true) continue;
 
             event.crossLine.push({
                 crossLineId: crossLine.id ?? crossLine.internalId,

--- a/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
+++ b/packages/ag-charts-community/src/chart/interaction/contextMenuRegistry.ts
@@ -1,4 +1,4 @@
-import type { DynamicContext, Writeable } from 'ag-charts-core';
+import type { CanvasPoint, DynamicContext, Writeable } from 'ag-charts-core';
 import type { AgContextMenuItemLiteral, AgContextMenuItemShowOn } from 'ag-charts-types';
 
 import type { ContextMenuEvent } from '../../core/eventsHub';
@@ -34,7 +34,7 @@ export class ContextMenuRegistry {
 
     public dispatchContext<T extends AgContextMenuItemShowOn>(
         showOn: T,
-        pointerEvent: { widgetEvent: MouseWidgetEvent<'contextmenu'>; canvasX: number; canvasY: number },
+        pointerEvent: { widgetEvent: MouseWidgetEvent<'contextmenu'> } & CanvasPoint,
         context: ContextShowOnMap[T]['context'],
         position?: { x: number; y: number }
     ) {
@@ -45,7 +45,7 @@ export class ContextMenuRegistry {
         primaryShowOn: AgContextMenuItemShowOn,
         regions: readonly AgContextMenuItemShowOn[],
         contexts: ContextMenuRegionContexts,
-        pointerEvent: { widgetEvent: MouseWidgetEvent<'contextmenu'>; canvasX: number; canvasY: number },
+        pointerEvent: { widgetEvent: MouseWidgetEvent<'contextmenu'> } & CanvasPoint,
         position?: { x: number; y: number }
     ) {
         const { widgetEvent } = pointerEvent;

--- a/packages/ag-charts-community/src/chart/interaction/dragInterpreter.ts
+++ b/packages/ag-charts-community/src/chart/interaction/dragInterpreter.ts
@@ -1,4 +1,5 @@
-import { CleanupRegistry, type ClientPoint, EventEmitter } from 'ag-charts-core';
+import type { ClientPoint } from 'ag-charts-core';
+import { CleanupRegistry, EventEmitter } from 'ag-charts-core';
 
 import type { Widget } from '../../widget/widget';
 import type {

--- a/packages/ag-charts-community/src/chart/interaction/dragInterpreter.ts
+++ b/packages/ag-charts-community/src/chart/interaction/dragInterpreter.ts
@@ -1,4 +1,4 @@
-import { CleanupRegistry, EventEmitter } from 'ag-charts-core';
+import { CleanupRegistry, type ClientPoint, EventEmitter } from 'ag-charts-core';
 
 import type { Widget } from '../../widget/widget';
 import type {
@@ -45,7 +45,7 @@ function checkDragDistance(dx: number, dy: number) {
     return distanceSquared >= thresholdSquared;
 }
 
-function checkDoubleTapDistance(t1: { clientX: number; clientY: number }, t2: { clientX: number; clientY: number }) {
+function checkDoubleTapDistance(t1: ClientPoint, t2: ClientPoint) {
     const dx = t1.clientX - t2.clientX;
     const dy = t1.clientY - t2.clientY;
     const distanceSquared = dx * dx + dy * dy;
@@ -76,7 +76,7 @@ export class DragInterpreter {
 
     private dragStartEvent?: DragWidgetEvent<'drag-start'>;
     private isDragging = false;
-    private lastClick?: { time: number; clientX: number; clientY: number };
+    private lastClick?: { time: number } & ClientPoint;
     private readonly touch = { distanceTravelledX: 0, distanceTravelledY: 0, clientX: 0, clientY: 0 };
 
     constructor(widget: Widget) {

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -1,4 +1,4 @@
-import type { CallbackParamRules, DynamicContext, Point, Writeable } from 'ag-charts-core';
+import type { CallbackParamRules, CanvasPoint, CurrentPoint, DynamicContext, Point, Writeable } from 'ag-charts-core';
 import { ChartUpdateType, Vec4, clamp, createId } from 'ag-charts-core';
 import type {
     AgActiveItemState,
@@ -709,7 +709,7 @@ export class SeriesAreaManager extends BaseManager {
         }
     }
 
-    private toCanvasCoordinates(event: { currentX: number; currentY: number }): { canvasX: number; canvasY: number } {
+    private toCanvasCoordinates(event: CurrentPoint): CanvasPoint {
         return {
             canvasX: event.currentX + (this.hoverRect?.x ?? this.seriesRect?.x ?? 0),
             canvasY: event.currentY + (this.hoverRect?.y ?? this.seriesRect?.y ?? 0),

--- a/packages/ag-charts-community/src/chart/series/util.ts
+++ b/packages/ag-charts-community/src/chart/series/util.ts
@@ -1,4 +1,5 @@
-import { type BoxBounds, type CanvasPoint, Color, findMaxIndex, findMinIndex, isString } from 'ag-charts-core';
+import type { BoxBounds, CanvasPoint } from 'ag-charts-core';
+import { Color, findMaxIndex, findMinIndex, isString } from 'ag-charts-core';
 import type { AgActiveItemState, AgDrawingMode } from 'ag-charts-types';
 
 import { Transformable } from '../../scene/transformable';

--- a/packages/ag-charts-community/src/chart/series/util.ts
+++ b/packages/ag-charts-community/src/chart/series/util.ts
@@ -1,4 +1,4 @@
-import { type BoxBounds, Color, findMaxIndex, findMinIndex, isString } from 'ag-charts-core';
+import { type BoxBounds, type CanvasPoint, Color, findMaxIndex, findMinIndex, isString } from 'ag-charts-core';
 import type { AgActiveItemState, AgDrawingMode } from 'ag-charts-types';
 
 import { Transformable } from '../../scene/transformable';
@@ -100,7 +100,7 @@ export function getDatumRefPoint(
     series: ISeries<any, any, any>,
     datum: SeriesNodeDatum & Pick<ErrorBoundSeriesNodeDatum, 'yBar'>,
     movedBounds: BoxBounds | undefined
-): { canvasX: number; canvasY: number } | undefined {
+): CanvasPoint | undefined {
     if (movedBounds) {
         const { x, y, width, height } = movedBounds;
         return { canvasX: x + width / 2, canvasY: y + height / 2 };

--- a/packages/ag-charts-community/src/chart/test/utils.ts
+++ b/packages/ag-charts-community/src/chart/test/utils.ts
@@ -28,7 +28,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 
-import { fromPairs, getDocument, mapValues } from 'ag-charts-core';
+import { type OffsetPoint, fromPairs, getDocument, mapValues } from 'ag-charts-core';
 import type {
     AgCartesianChartOptions,
     AgChartInstance,
@@ -769,7 +769,7 @@ export function mouseUpAction(
 export function clickAction(
     canvasX: number,
     canvasY: number,
-    opts?: { mousedown?: { offsetX: number; offsetY: number } } & EventModifierInit
+    opts?: { mousedown?: OffsetPoint } & EventModifierInit
 ): (chart: ChartOrProxy) => Promise<void> {
     return async (chartOrProxy) => {
         const chart = deproxy(chartOrProxy);

--- a/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltip.ts
@@ -1,6 +1,7 @@
 import {
     AgDocument,
     BaseProperties,
+    type CanvasPoint,
     CleanupRegistry,
     type Placement,
     Property,
@@ -38,7 +39,7 @@ export {
 /** Default gap between tooltip and anchor; must match the theme template fallback in chartTheme.ts. */
 const DEFAULT_TOOLTIP_OFFSET = 12;
 
-type TooltipOffsets = { canvasX: number; canvasY: number; nodeCanvasX?: number; nodeCanvasY?: number };
+type TooltipOffsets = CanvasPoint & { nodeCanvasX?: number; nodeCanvasY?: number };
 export type TooltipEventType = 'pointermove' | 'click' | 'dblclick' | 'keyboard';
 export type TooltipPointerEvent<T extends TooltipEventType = TooltipEventType> = Readonly<TooltipOffsets> & {
     readonly type: T;

--- a/packages/ag-charts-community/src/chart/tooltip/tooltipBounds.ts
+++ b/packages/ag-charts-community/src/chart/tooltip/tooltipBounds.ts
@@ -1,4 +1,4 @@
-import type { Bounds } from 'ag-charts-core';
+import type { Bounds, CanvasPoint } from 'ag-charts-core';
 import type { AgTooltipAnchorTo, AgTooltipPlacement } from 'ag-charts-types';
 
 const horizontalAlignments: Record<AgTooltipPlacement, -1 | 0 | 1> = {
@@ -25,12 +25,10 @@ const verticalAlignments: Record<AgTooltipPlacement, -1 | 0 | 1> = {
     'bottom-right': 1,
 };
 
-export interface TooltipBoundsOpts {
+export interface TooltipBoundsOpts extends CanvasPoint {
     elementSize: { width: number; height: number };
     anchorTo: AgTooltipAnchorTo;
     placement: AgTooltipPlacement;
-    canvasX: number;
-    canvasY: number;
     yOffset: number;
     xOffset: number;
     offset: number;

--- a/packages/ag-charts-community/src/core/eventsHub.ts
+++ b/packages/ag-charts-community/src/core/eventsHub.ts
@@ -1,6 +1,7 @@
 import type {
     AxisID,
     BaseStyleTypeMap,
+    CanvasPoint,
     ChartAxisDirection,
     ChartUpdateType,
     DeepReadonly,
@@ -68,9 +69,7 @@ export interface UpdateOpts {
     clearCallbackCache?: boolean;
 }
 
-export interface SeriesAreaHoverEvent {
-    readonly canvasX: number;
-    readonly canvasY: number;
+export interface SeriesAreaHoverEvent extends Readonly<CanvasPoint> {
     readonly consumed: boolean;
     readonly sourceEvent: Event;
 }
@@ -87,9 +86,7 @@ export interface SeriesAreaClickEvent {
     readonly target: Node<unknown> | undefined;
 }
 
-export interface SeriesAreaContextMenuEvent {
-    readonly canvasX: number;
-    readonly canvasY: number;
+export interface SeriesAreaContextMenuEvent extends Readonly<CanvasPoint> {
     readonly widgetEvent: MouseWidgetEvent<'contextmenu'>;
     /**
      * The overlapping axis, if any, at the pointer. Modules that own axes annotate this so the series-area

--- a/packages/ag-charts-community/src/module/axisContext.ts
+++ b/packages/ag-charts-community/src/module/axisContext.ts
@@ -1,4 +1,12 @@
-import type { AxisID, BoxBounds, ChartAxisDirection, NormalisedTextOrSegments, Point, Scale } from 'ag-charts-core';
+import type {
+    AxisID,
+    BoxBounds,
+    ChartAxisDirection,
+    CurrentPoint,
+    NormalisedTextOrSegments,
+    Point,
+    Scale,
+} from 'ag-charts-core';
 import type {
     AgAxisBoundSeries,
     AgAxisDomain,
@@ -96,8 +104,8 @@ export interface AxisContext {
     attachAxisOverlay(group: Group, slot: 'low' | 'mid' | 'high'): void;
     inRange(value: number, tolerance?: number): boolean;
     getRangeOverflow(value: number): number;
-    /** Pick the scale value at a local-point (click/contextmenu events) */
-    pickValue(point: { currentX: number; currentY: number }): AxisValuePick | undefined;
+    /** Pick the scale value at a current-point (click/contextmenu events), relative to axis-dom-proxy HTML element */
+    pickValue(point: CurrentPoint): AxisValuePick | undefined;
     pickBand(point: Point): AxisBandDatum | undefined;
     measureBand(value: string): AxisBandMeasurement | undefined;
     /** Defined only on polar axes; cartesian axes leave it undefined. */

--- a/packages/ag-charts-community/src/widget/widgetEvents.ts
+++ b/packages/ag-charts-community/src/widget/widgetEvents.ts
@@ -1,4 +1,4 @@
-import type { AreExact, DeepReadonly } from 'ag-charts-core';
+import type { AreExact, ClientPoint, CurrentPoint, DeepReadonly } from 'ag-charts-core';
 
 import type { CollapseWidgetEvent, ExpandControlledWidgetEvent, ExpandWidgetEvent } from './expandableWidget';
 
@@ -382,10 +382,7 @@ export class WidgetEventUtil {
         return meta[type]?.isNative === true;
     }
 
-    static calcCurrentXY(
-        current: HTMLElement,
-        event: { clientX: number; clientY: number }
-    ): { currentX: number; currentY: number } {
+    static calcCurrentXY(current: HTMLElement, event: ClientPoint): CurrentPoint {
         const currentRect = current.getBoundingClientRect();
         // Ratio of layout size to post-transform screen size recovers ancestor CSS scale per axis.
         const clientWidth = current.clientWidth;

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -1,4 +1,11 @@
-import { type AnyFn, CleanupRegistry, attachListener, boxContains, partialAssign } from 'ag-charts-core';
+import {
+    type AnyFn,
+    CleanupRegistry,
+    type OffsetPoint,
+    attachListener,
+    boxContains,
+    partialAssign,
+} from 'ag-charts-core';
 
 import { type MouseDragCallbacks, type MouseDragger, startMouseDrag } from './mouseDragger';
 import { type TouchDragCallbacks, type TouchDragger, startOneFingerTouch } from './touchDragger';
@@ -49,7 +56,7 @@ function makeMouseDrag<K extends DragEvents>(type: K, origin: DragOrigin, source
     };
 }
 
-export function getTouchOffsets(current: Targetable, touch: Touch): { offsetX: number; offsetY: number } {
+export function getTouchOffsets(current: Targetable, touch: Touch): OffsetPoint {
     const elem = current.getElement();
     const rect = elem.getBoundingClientRect();
     // clientX/Y matches rect.x/y's coordinate space; pageX/Y would be wrong by the page scroll offset.

--- a/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
+++ b/packages/ag-charts-community/src/widget/widgetListenerInternal.ts
@@ -1,11 +1,5 @@
-import {
-    type AnyFn,
-    CleanupRegistry,
-    type OffsetPoint,
-    attachListener,
-    boxContains,
-    partialAssign,
-} from 'ag-charts-core';
+import type { AnyFn, OffsetPoint } from 'ag-charts-core';
+import { CleanupRegistry, attachListener, boxContains, partialAssign } from 'ag-charts-core';
 
 import { type MouseDragCallbacks, type MouseDragger, startMouseDrag } from './mouseDragger';
 import { type TouchDragCallbacks, type TouchDragger, startOneFingerTouch } from './touchDragger';

--- a/packages/ag-charts-core/src/types/scene.ts
+++ b/packages/ag-charts-core/src/types/scene.ts
@@ -3,9 +3,34 @@ export interface Size {
     height: number;
 }
 
+// General-purpose XY coordinates.
 export interface Point {
     x: number;
     y: number;
+}
+
+// XY coordinates relative the client (user-agent / browser) viewport.
+export interface ClientPoint {
+    clientX: number;
+    clientY: number;
+}
+
+// XY coordinates relative to the AG Charts Canvas HTML Element.
+export interface CanvasPoint {
+    canvasX: number;
+    canvasY: number;
+}
+
+// XY coordinates relative the target HTML element that is currently being listened with.
+export interface CurrentPoint {
+    currentX: number;
+    currentY: number;
+}
+
+// XY coordinates relative the deepest target HTML element that is currently being interacted with.
+export interface OffsetPoint {
+    offsetX: number;
+    offsetY: number;
 }
 
 export interface SizedPoint extends Point {

--- a/packages/ag-charts-core/src/utils/geometry/vector.ts
+++ b/packages/ag-charts-core/src/utils/geometry/vector.ts
@@ -1,4 +1,4 @@
-import type { Bounds4, Point } from '../../types/scene';
+import type { Bounds4, CurrentPoint, Point } from '../../types/scene';
 import { roundTo } from '../data/numbers';
 
 /**
@@ -155,7 +155,7 @@ export function from(x: number, y: number): Point;
 /**
  * Create a vector from a widget event.
  */
-export function from(event: { currentX: number; currentY: number }): Point;
+export function from(event: CurrentPoint): Point;
 /**
  * Create a vector from a html element's `offsetWidth` and `offsetHeight`.
  */
@@ -171,7 +171,7 @@ export function from(vec4: Bounds4): [Point, Point];
 export function from(
     a:
         | number
-        | { currentX: number; currentY: number }
+        | CurrentPoint
         | { offsetWidth: number; offsetHeight: number }
         | { x: number; y: number; width: number; height: number }
         | Bounds4,

--- a/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/annotations.ts
@@ -9,6 +9,7 @@ import {
     AbstractModuleInstance,
     ChartAxisDirection,
     ChartUpdateType,
+    type CurrentPoint,
     type DynamicContext,
     type Point,
     PropertiesArray,
@@ -959,7 +960,7 @@ export class Annotations extends AbstractModuleInstance {
         };
     }
 
-    private onHover(event: { currentX: number; currentY: number; sourceEvent: MouseEvent | TouchEvent }) {
+    private onHover(event: CurrentPoint & { sourceEvent: MouseEvent | TouchEvent }) {
         const { state } = this;
 
         const context = this.getAnnotationContext();

--- a/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
@@ -1,12 +1,6 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import {
-    AbstractModuleInstance,
-    ChartAxisDirection,
-    type DynamicContext,
-    type Point,
-    Property,
-    getIconClassNames,
-} from 'ag-charts-core';
+import type { CurrentPoint, DynamicContext, Point } from 'ag-charts-core';
+import { AbstractModuleInstance, ChartAxisDirection, Property, getIconClassNames } from 'ag-charts-core';
 
 import { convert, invert } from './utils/values';
 

--- a/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
+++ b/packages/ag-charts-enterprise/src/features/annotations/axisButton.ts
@@ -89,7 +89,7 @@ export class AxisButton extends AbstractModuleInstance {
         if (this.ctx.interactionManager.isState(InteractionState.Clickable) && e.device === 'touch') this.show(e);
     }
 
-    private show(event: { currentX: number; currentY: number; sourceEvent: MouseEvent | TouchEvent }) {
+    private show(event: CurrentPoint & { sourceEvent: MouseEvent | TouchEvent }) {
         const { sourceEvent, currentX: x, currentY: y } = event;
         if (!(this.enabled && this.ctx.widgets.seriesWidget.getElement().contains(sourceEvent.target as Node | null))) {
             this.hide();

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -1,5 +1,12 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import { AbstractModuleInstance, type AxisID, ChartAxisDirection, type DynamicContext, boxEmpty } from 'ag-charts-core';
+import {
+    AbstractModuleInstance,
+    type AxisID,
+    type CanvasPoint,
+    ChartAxisDirection,
+    type DynamicContext,
+    boxEmpty,
+} from 'ag-charts-core';
 
 type AxisHit = { axisId: AxisID; direction: ChartAxisDirection };
 
@@ -294,7 +301,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         this.ctx.contextMenuRegistry?.dispatchContext('axis', { widgetEvent, canvasX, canvasY }, pick);
     }
 
-    private pickAxisAtPoint(point: { canvasX: number; canvasY: number }): AxisHit | undefined {
+    private pickAxisAtPoint(point: Readonly<CanvasPoint>): AxisHit | undefined {
         for (const axis of this.axes) {
             if (!this.overlappingAxisIds.has(axis.axisId)) continue;
             if (axis.bounds?.containsPoint(point.canvasX, point.canvasY)) {

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -1,12 +1,6 @@
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import {
-    AbstractModuleInstance,
-    type AxisID,
-    type CanvasPoint,
-    ChartAxisDirection,
-    type DynamicContext,
-    boxEmpty,
-} from 'ag-charts-core';
+import type { AxisID, CanvasPoint, DynamicContext } from 'ag-charts-core';
+import { AbstractModuleInstance, ChartAxisDirection, boxEmpty } from 'ag-charts-core';
 
 type AxisHit = { axisId: AxisID; direction: ChartAxisDirection };
 

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -11,6 +11,7 @@ import {
     AbstractModuleInstance,
     ChartAxisDirection,
     ChartUpdateType,
+    type CurrentPoint,
     type NormalisedCrosshairOptions,
     ZIndexMap,
     coerceTextValue,
@@ -382,7 +383,7 @@ export class Crosshair
         });
     }
 
-    private getData(event: { currentX: number; currentY: number }): {
+    private getData(event: CurrentPoint): {
         [key: string]: { position: number; value: any };
     } {
         const { axisCtx } = this;

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.test.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.test.ts
@@ -34,7 +34,7 @@ import {
     waitForChartStability,
     withPreventDefault,
 } from 'ag-charts-community-test';
-import { CanvasPoint } from 'ag-charts-core';
+import type { CanvasPoint } from 'ag-charts-core';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 

--- a/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.test.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/dataSelection.test.ts
@@ -34,6 +34,7 @@ import {
     waitForChartStability,
     withPreventDefault,
 } from 'ag-charts-community-test';
+import { CanvasPoint } from 'ag-charts-core';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 
@@ -805,27 +806,26 @@ describe('DataSelection', () => {
         });
     };
 
-    type CanvasPoint = { readonly canvasX: number; readonly canvasY: number };
     type Modifiers = { altKey?: true; shiftKey?: true; ctrlKey?: true; metaKey?: true };
     const [altKey, shiftKey, ctrlKey, metaKey] = [true, true, true, true] as const;
 
-    async function mouseClick(point: CanvasPoint, modifiers?: Modifiers) {
+    async function mouseClick(point: Readonly<CanvasPoint>, modifiers?: Modifiers) {
         await clickAction(point.canvasX, point.canvasY, modifiers)(chart);
         await waitForChartStability(chart);
     }
-    async function mouseDown(point: CanvasPoint, modifiers?: Modifiers) {
+    async function mouseDown(point: Readonly<CanvasPoint>, modifiers?: Modifiers) {
         await mouseDownAction(point.canvasX, point.canvasY, modifiers)(chart);
         await waitForChartStability(chart);
     }
-    async function mouseMove(point: CanvasPoint, modifiers?: Modifiers) {
+    async function mouseMove(point: Readonly<CanvasPoint>, modifiers?: Modifiers) {
         await mouseMoveAction(point.canvasX, point.canvasY, modifiers)(chart);
         await waitForChartStability(chart);
     }
-    async function mouseUp(point: CanvasPoint, modifiers?: Modifiers) {
+    async function mouseUp(point: Readonly<CanvasPoint>, modifiers?: Modifiers) {
         await mouseUpAction(point.canvasX, point.canvasY, modifiers)(chart);
         await waitForChartStability(chart);
     }
-    async function pressEscape(point: CanvasPoint) {
+    async function pressEscape(point: Readonly<CanvasPoint>) {
         await keyDownAction(point.canvasX, point.canvasY, { key: 'Escape', code: 'Escape' })(chart);
         await waitForChartStability(chart);
     }

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomAxisDragger.ts
@@ -1,6 +1,6 @@
 import type { AgZoomAnchorPoint } from 'ag-charts-community';
 import { ChartAxisDirection, definedZoomState } from 'ag-charts-core';
-import type { BoxBounds, DefinedZoomState, ZoomMinMax, ZoomState } from 'ag-charts-core';
+import type { BoxBounds, CurrentPoint, DefinedZoomState, ZoomMinMax, ZoomState } from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
 import { constrainZoom, dx, dy, pointToRatio, scaleZoomAxisWithAnchor } from './zoomUtils';
@@ -10,7 +10,7 @@ export class ZoomAxisDragger {
     private oldZoom?: DefinedZoomState;
 
     update(
-        event: { currentX: number; currentY: number },
+        event: CurrentPoint,
         direction: ChartAxisDirection,
         anchor: AgZoomAnchorPoint,
         bbox: BoxBounds,

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
@@ -1,14 +1,6 @@
 import { _ModuleSupport } from 'ag-charts-community';
-import {
-    type BoxBounds,
-    ChartAxisDirection,
-    type CurrentPoint,
-    type DynamicContext,
-    UNIT_MAX,
-    UNIT_MIN,
-    definedZoomState,
-    entries,
-} from 'ag-charts-core';
+import type { BoxBounds, CurrentPoint, DynamicContext } from 'ag-charts-core';
+import { ChartAxisDirection, UNIT_MAX, UNIT_MIN, definedZoomState, entries } from 'ag-charts-core';
 
 import type { ZoomCoords } from './zoomTypes';
 import { constrainZoom, dx, dy, pointToRatio, translateZoom } from './zoomUtils';

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomPanner.ts
@@ -2,6 +2,7 @@ import { _ModuleSupport } from 'ag-charts-community';
 import {
     type BoxBounds,
     ChartAxisDirection,
+    type CurrentPoint,
     type DynamicContext,
     UNIT_MAX,
     UNIT_MIN,
@@ -72,7 +73,7 @@ export class ZoomPanner {
         }
     }
 
-    update(event: { currentX: number; currentY: number }) {
+    update(event: CurrentPoint) {
         this.updateCoords(event.currentX, event.currentY);
         const { x1 = 0, y1 = 0, x2 = 0, y2 = 0 } = this.coords ?? {};
         this.onUpdate?.({

--- a/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
+++ b/packages/ag-charts-enterprise/src/features/zoom/zoomSelector.ts
@@ -1,5 +1,5 @@
 import { definedZoomState } from 'ag-charts-core';
-import type { BoxBounds, DefinedZoomState, ZoomState } from 'ag-charts-core';
+import type { BoxBounds, CurrentPoint, DefinedZoomState, ZoomState } from 'ag-charts-core';
 
 import type { ZoomRect } from './scenes/zoomRect';
 import type { ZoomCoords, ZoomProperties } from './zoomTypes';
@@ -17,7 +17,7 @@ export class ZoomSelector {
         this.rect.visible = false;
     }
 
-    update(event: { currentX: number; currentY: number }, props: ZoomProperties, bbox?: BoxBounds): void {
+    update(event: CurrentPoint, props: ZoomProperties, bbox?: BoxBounds): void {
         const canvasX = event.currentX + (bbox?.x ?? 0);
         const canvasY = event.currentY + (bbox?.y ?? 0);
         this.rect.visible = true;

--- a/packages/ag-charts-website/e2e/context-menu.spec.ts
+++ b/packages/ag-charts-website/e2e/context-menu.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 
+import type { ClientPoint } from 'ag-charts-core';
 import type {
     AgAxisContextMenuActionEvent,
     AgAxisValue,
@@ -54,7 +55,7 @@ async function popGetItems(page: Page): Promise<AgContextMenuGetItemsParamsCapti
     return getItems as AgContextMenuGetItemsParamsCaption[];
 }
 
-async function contextMenu(page: Page, point: { clientX: number; clientY: number }) {
+async function contextMenu(page: Page, point: ClientPoint) {
     await page.mouse.click(point.clientX, point.clientY, { button: 'right' });
 }
 
@@ -293,7 +294,7 @@ test.describe('context-menu', () => {
             };
         };
 
-        const rightClick = (page: Page, point: { clientX: number; clientY: number }) =>
+        const rightClick = (page: Page, point: ClientPoint) =>
             page.mouse.click(point.clientX, point.clientY, { button: 'right' });
 
         const runCaptionAction = (page: Page) =>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17613

Adds four commonly used type structures:

1. `ClientPoint  = { clientX  : number; clientY  : number; }`
2. `CanvasPoint  = { canvasX  : number; canvasY  : number; }`
3. `CurrentPoint = { currentX : number; currentY : number; }`
4. `OffsetPoint  = { offsetX  : number; offsetY  : number; }`

