### PR TITLE
AG-16226: Add dev tools option to copy links as the framework-agnostic redirect

### DIFF
--- a/external/ag-website-shared/src/components/dev-tools/DevTools.tsx
+++ b/external/ag-website-shared/src/components/dev-tools/DevTools.tsx
@@ -1,8 +1,10 @@
 import {
+    $copyFrameworkAgnosticLinks,
     $devTools,
     $exampleDevToolbar,
     $fpsMonitor,
     $openLinksInNewTab,
+    toggleCopyFrameworkAgnosticLinks,
     toggleDevTools,
     toggleExampleDevToolbar,
     toggleFpsMonitor,
@@ -51,6 +53,7 @@ export const DevTools: FunctionComponent = () => {
     const devTools = useStoreSsr($devTools, false);
     const exampleDevToolbar = useStoreSsr($exampleDevToolbar, false);
     const openLinksInNewTab = useStoreSsr($openLinksInNewTab, false);
+    const copyFrameworkAgnosticLinks = useStoreSsr($copyFrameworkAgnosticLinks, false);
     const fpsMonitor = useStoreSsr($fpsMonitor, false);
 
     useEffect(() => {
@@ -90,6 +93,16 @@ export const DevTools: FunctionComponent = () => {
                         defaultChecked={openLinksInNewTab}
                         onClick={() => {
                             toggleOpenLinksInNewTab();
+                        }}
+                    />
+                </div>
+                <div>
+                    <label>Copy Framework Agnostic Links:</label>
+                    <input
+                        type="checkbox"
+                        defaultChecked={copyFrameworkAgnosticLinks}
+                        onClick={() => {
+                            toggleCopyFrameworkAgnosticLinks();
                         }}
                     />
                 </div>

--- a/external/ag-website-shared/src/components/dev-tools/stores/devToolsStore.ts
+++ b/external/ag-website-shared/src/components/dev-tools/stores/devToolsStore.ts
@@ -31,5 +31,12 @@ export const $openLinksInNewTab = persistentAtom<boolean>(
 );
 export const toggleOpenLinksInNewTab = createToggleBoolean($openLinksInNewTab);
 
+export const $copyFrameworkAgnosticLinks = persistentAtom<boolean>(
+    `${LOCALSTORAGE_PREFIX}:copyFrameworkAgnosticLinks`,
+    false,
+    parseBoolean
+);
+export const toggleCopyFrameworkAgnosticLinks = createToggleBoolean($copyFrameworkAgnosticLinks);
+
 export const $fpsMonitor = persistentAtom<boolean>(`${LOCALSTORAGE_PREFIX}:fpsMonitor`, false, parseBoolean);
 export const toggleFpsMonitor = createToggleBoolean($fpsMonitor);

--- a/external/ag-website-shared/src/components/link-icon/LinkIcon.tsx
+++ b/external/ag-website-shared/src/components/link-icon/LinkIcon.tsx
@@ -1,4 +1,7 @@
+import { $copyFrameworkAgnosticLinks } from '@ag-website-shared/components/dev-tools/stores/devToolsStore';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
+import { getFrameworkRedirectUrl } from '@ag-website-shared/utils/getFrameworkRedirectUrl';
+import { useStoreSsr } from '@utils/hooks/useStoreSsr';
 import classnames from 'classnames';
 import { type AllHTMLAttributes, useEffect, useRef, useState } from 'react';
 
@@ -14,14 +17,15 @@ export function LinkIcon({
     const [linkActive, setlinkActive] = useState(false);
     const copiedTimeoutRef = useRef(null);
     const activeTimeoutRef = useRef(null);
+    const copyFrameworkAgnosticLinks = useStoreSsr($copyFrameworkAgnosticLinks, false);
 
     const onClick = (event) => {
         event.preventDefault();
 
-        const href = event.target.href;
-        const hash = event.target.hash;
+        const { href, hash } = event.currentTarget;
+        const redirectUrl = copyFrameworkAgnosticLinks ? getFrameworkRedirectUrl(href) : undefined;
 
-        navigator.clipboard.writeText(href);
+        navigator.clipboard.writeText(redirectUrl ?? href);
 
         history.replaceState({}, '', hash);
 
@@ -49,6 +53,7 @@ export function LinkIcon({
 
     const aStyles = exampleLink ? ctaStyles.cta : [linkStyles.docsHeaderIcon, 'button-secondary'];
     const tooltipStyles = exampleLink ? ctaStyles.tooltip : linkStyles.tooltip;
+    const copyLabel = copyFrameworkAgnosticLinks ? 'Copy Redirect Link' : 'Copy Link';
 
     return (
         <a
@@ -57,7 +62,7 @@ export function LinkIcon({
             className={classnames(linkStyles.linkIcon, aStyles, { [linkStyles.active]: linkActive }, className)}
             onClick={onClick}
         >
-            <span className={tooltipStyles}>{linkCopied ? 'Link copied!' : 'Copy Link'}</span>
+            <span className={tooltipStyles}>{linkCopied ? 'Link copied!' : copyLabel}</span>
             <Icon name="link" />
         </a>
     );

--- a/external/ag-website-shared/src/utils/getFrameworkRedirectUrl.test.ts
+++ b/external/ag-website-shared/src/utils/getFrameworkRedirectUrl.test.ts
@@ -1,0 +1,70 @@
+import { getFrameworkRedirectUrl } from '@ag-website-shared/utils/getFrameworkRedirectUrl';
+
+const FRAMEWORKS = ['react', 'angular', 'vue', 'javascript'];
+
+// Charts: `https://charts-staging.ag-grid.com/javascript/bar-series/`
+const CHARTS_URL_SHAPE = {
+    frameworkPathIndex: 1,
+    pageNamePathIndex: 2,
+    frameworkPaths: FRAMEWORKS,
+    redirectPath: 'r',
+};
+
+// Charts on production, which is served under a `/charts` base url
+const CHARTS_BASE_URL_SHAPE = {
+    ...CHARTS_URL_SHAPE,
+    frameworkPathIndex: 2,
+    pageNamePathIndex: 3,
+};
+
+// Grid: `https://www.ag-grid.com/react-data-grid/getting-started/`
+const GRID_URL_SHAPE = {
+    frameworkPathIndex: 1,
+    pageNamePathIndex: 2,
+    frameworkPaths: FRAMEWORKS.map((framework) => `${framework}-data-grid`),
+    redirectPath: 'data-grid',
+};
+
+describe('getFrameworkRedirectUrl', () => {
+    test.each`
+        url                                                                | expected
+        ${'https://charts-staging.ag-grid.com/javascript/bar-series/'}     | ${'https://charts-staging.ag-grid.com/r/bar-series/'}
+        ${'https://charts-staging.ag-grid.com/react/bar-series'}           | ${'https://charts-staging.ag-grid.com/r/bar-series'}
+        ${'https://charts-staging.ag-grid.com/vue/overview/#formatter'}    | ${'https://charts-staging.ag-grid.com/r/overview/#formatter'}
+        ${'https://charts-staging.ag-grid.com/angular/themes/?debug=true'} | ${'https://charts-staging.ag-grid.com/r/themes/?debug=true'}
+        ${'http://localhost:4600/javascript/bar-series/'}                  | ${'http://localhost:4600/r/bar-series/'}
+    `('charts url shape: $url -> $expected', ({ url, expected }) => {
+        expect(getFrameworkRedirectUrl(url, CHARTS_URL_SHAPE)).toBe(expected);
+    });
+
+    test.each`
+        url                                                                            | reason
+        ${'https://charts-staging.ag-grid.com/gallery/simple-bar/'}                    | ${'not a framework page'}
+        ${'https://charts-staging.ag-grid.com/javascript/'}                            | ${'no page name'}
+        ${'https://charts-staging.ag-grid.com/'}                                       | ${'site root'}
+        ${'https://charts-staging.ag-grid.com/javascript/bar-series/examples/simple/'} | ${'nested below the page name'}
+        ${'https://charts-staging.ag-grid.com/javascript-charts/'}                     | ${'framework page name, not a framework path'}
+        ${'#formatter'}                                                                | ${'not an absolute url'}
+    `('returns undefined for $url ($reason)', ({ url }) => {
+        expect(getFrameworkRedirectUrl(url, CHARTS_URL_SHAPE)).toBeUndefined();
+    });
+
+    test('handles a site base url', () => {
+        expect(getFrameworkRedirectUrl('https://www.ag-grid.com/charts/react/bar-series/', CHARTS_BASE_URL_SHAPE)).toBe(
+            'https://www.ag-grid.com/charts/r/bar-series/'
+        );
+        expect(
+            getFrameworkRedirectUrl('https://www.ag-grid.com/react/bar-series/', CHARTS_BASE_URL_SHAPE)
+        ).toBeUndefined();
+    });
+
+    test.each`
+        url                                                           | expected
+        ${'https://www.ag-grid.com/react-data-grid/getting-started/'} | ${'https://www.ag-grid.com/data-grid/getting-started/'}
+        ${'https://www.ag-grid.com/vue-data-grid/filter-text/#api'}   | ${'https://www.ag-grid.com/data-grid/filter-text/#api'}
+        ${'https://www.ag-grid.com/data-grid/getting-started/'}       | ${undefined}
+        ${'https://www.ag-grid.com/license-pricing/'}                 | ${undefined}
+    `('grid url shape: $url -> $expected', ({ url, expected }) => {
+        expect(getFrameworkRedirectUrl(url, GRID_URL_SHAPE)).toBe(expected);
+    });
+});

--- a/external/ag-website-shared/src/utils/getFrameworkRedirectUrl.ts
+++ b/external/ag-website-shared/src/utils/getFrameworkRedirectUrl.ts
@@ -1,0 +1,55 @@
+import { DOCS_FRAMEWORK_PATH_INDEX, DOCS_PAGE_NAME_PATH_INDEX } from '@components/docs/constants';
+import { getFrameworkPath } from '@components/docs/utils/urlPaths';
+import { FRAMEWORKS, FRAMEWORK_REDIRECT_PATH } from '@constants';
+
+/**
+ * Shape of the docs urls on the site, ie the parts that differ between
+ * Grid (`/react-data-grid/getting-started/`) and Charts (`/javascript/bar-series/`)
+ */
+interface DocsUrlShape {
+    frameworkPathIndex: number;
+    pageNamePathIndex: number;
+    frameworkPaths: string[];
+    redirectPath: string;
+}
+
+const SITE_DOCS_URL_SHAPE: DocsUrlShape = {
+    frameworkPathIndex: DOCS_FRAMEWORK_PATH_INDEX,
+    pageNamePathIndex: DOCS_PAGE_NAME_PATH_INDEX,
+    frameworkPaths: FRAMEWORKS.map(getFrameworkPath),
+    redirectPath: FRAMEWORK_REDIRECT_PATH,
+};
+
+/**
+ * A docs page url as its framework agnostic equivalent, which redirects the visitor
+ * on to whichever framework they last used, ie
+ * `https://charts-staging.ag-grid.com/javascript/bar-series/#formatter`
+ *   -> `https://charts-staging.ag-grid.com/r/bar-series/#formatter`
+ *
+ * `undefined` if the url is not a framework specific docs page, as only those have
+ * a redirect equivalent.
+ */
+export function getFrameworkRedirectUrl(url: string, urlShape: DocsUrlShape = SITE_DOCS_URL_SHAPE): string | undefined {
+    const { frameworkPathIndex, pageNamePathIndex, frameworkPaths, redirectPath } = urlShape;
+    let redirectUrl: URL;
+    try {
+        redirectUrl = new URL(url);
+    } catch {
+        return undefined;
+    }
+
+    const pathSegments = redirectUrl.pathname.split('/');
+    const isFrameworkPath = frameworkPaths.includes(pathSegments[frameworkPathIndex]);
+    // The redirect pages only cover `/{framework}/{pageName}`, so anything nested
+    // deeper (eg, an example url) has no equivalent
+    const isDocsPage =
+        Boolean(pathSegments[pageNamePathIndex]) && !pathSegments.slice(pageNamePathIndex + 1).some(Boolean);
+    if (!isFrameworkPath || !isDocsPage) {
+        return undefined;
+    }
+
+    pathSegments[frameworkPathIndex] = redirectPath;
+    redirectUrl.pathname = pathSegments.join('/');
+
+    return redirectUrl.toString();
+}


### PR DESCRIPTION
[AG-16226](https://ag-grid.atlassian.net/browse/AG-16226)

Adds a `Copy Framework Agnostic Links` dev tools toggle. With it enabled, the 'copy link' buttons copy the framework agnostic redirect url for the page — `/charts/r/bar-series/#formatter` instead of `/charts/javascript/bar-series/#formatter` — so the recipient lands on whichever framework they last used. Useful for support and other client communication.

The tooltip reads "Copy Redirect Link" while the option is on, and pages with no redirect equivalent (gallery, framework index, example urls) fall back to copying their own url. Default is off, so copy-link behaviour is unchanged for visitors.

The url derivation is shared and composes the per-site constants that already exist in both websites, so Grid gets `/data-grid/getting-started/` from the same code once the `ag-website-shared` subrepo is synced.

### Testing

- `Copy Framework Agnostic Links` off (default): copy link on a docs heading copies the current framework url, as before
- On: same button copies the `/r/<page>/` redirect url with the heading hash intact, and that link resolves to your last used framework
- Unit tests cover both the Charts and Grid url shapes, including the fallback cases