### PR TITLE
CRT-1197 Retain search dropdown horizontal scroll position

### DIFF
--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -9,6 +9,7 @@ const NAV_TREE_SELECTOR = 'pre code';
 const PROPERTY_NAME_SELECTOR = '[class*="propertyName"]';
 const PROPERTY_EXPANDER_SELECTOR = '[class*="propertyExpander"]';
 const SEARCH_OPTION_SELECTOR = '[class*="searchOption"]';
+const SEARCH_DROPDOWN_SELECTOR = '[class*="searchDropdown"]';
 
 function getSearchInput(page: Page) {
     return page.getByPlaceholder('Search properties...');
@@ -199,6 +200,67 @@ test.describe('api-ref-page', () => {
         await page.keyboard.press('Enter');
 
         await expect(getSearchInput(page)).toHaveValue('');
+    });
+
+    // Property paths are wider than the search box, so the dropdown scrolls on both axes. Wheeling
+    // vertically moves the pointer onto a new option, selecting it, and that selection must leave
+    // the horizontal scroll position alone.
+    test('keeps the horizontal scroll position when scrolling the results vertically', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/'));
+        await waitForApiReady(page);
+
+        const searchInput = getSearchInput(page);
+        await searchInput.click();
+        await searchInput.fill('label');
+
+        const dropdown = page.locator(SEARCH_DROPDOWN_SELECTOR);
+        await expect(dropdown).toBeVisible();
+        await expect(page.locator(SEARCH_OPTION_SELECTOR)).not.toHaveCount(0);
+
+        // The results have to overflow on both axes for the interaction to mean anything.
+        const overflow = await dropdown.evaluate((element) => ({
+            horizontal: element.scrollWidth - element.clientWidth,
+            vertical: element.scrollHeight - element.clientHeight,
+        }));
+        expect(overflow.horizontal).toBeGreaterThan(0);
+        expect(overflow.vertical).toBeGreaterThan(0);
+
+        await dropdown.hover();
+        await page.mouse.wheel(60, 0);
+        await expect.poll(() => dropdown.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
+        const scrollLeft = await dropdown.evaluate((element) => element.scrollLeft);
+
+        await page.mouse.wheel(0, 60);
+        await expect.poll(() => dropdown.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+        expect(await dropdown.evaluate((element) => element.scrollLeft)).toBe(scrollLeft);
+    });
+
+    // Keyboard navigation, unlike the pointer, must still bring the selection into view.
+    test('scrolls the keyboard-selected option into view', async ({ page }) => {
+        await gotoUrl(page, toPageUrl('options/'));
+        await waitForApiReady(page);
+
+        const searchInput = getSearchInput(page);
+        await searchInput.click();
+        await searchInput.fill('label');
+        await expect(page.locator(SEARCH_OPTION_SELECTOR)).not.toHaveCount(0);
+
+        const dropdown = page.locator(SEARCH_DROPDOWN_SELECTOR);
+        for (let i = 0; i < 10; i++) {
+            await page.keyboard.press('ArrowDown');
+        }
+
+        await expect.poll(() => dropdown.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+
+        const selectedIsVisible = await page
+            .locator(`${SEARCH_OPTION_SELECTOR}[class*="selected"]`)
+            .evaluate((element, dropdownSelector) => {
+                const container = element.closest(dropdownSelector)!;
+                const optionRect = element.getBoundingClientRect();
+                const containerRect = container.getBoundingClientRect();
+                return optionRect.top >= containerRect.top && optionRect.bottom <= containerRect.bottom;
+            }, SEARCH_DROPDOWN_SELECTOR);
+        expect(selectedIsVisible).toBe(true);
     });
 
     test('direct bar series hash loads and highlights typed union entry', async ({ page }) => {

--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -258,7 +258,11 @@ test.describe('api-ref-page', () => {
                 const container = element.closest(dropdownSelector)!;
                 const optionRect = element.getBoundingClientRect();
                 const containerRect = container.getBoundingClientRect();
-                return optionRect.top >= containerRect.top && optionRect.bottom <= containerRect.bottom;
+                // The visible area excludes the container's borders and scrollbar gutter. A pixel of
+                // slack absorbs the sub-pixel rounding of a fractional scroll offset.
+                const visibleTop = containerRect.top + container.clientTop;
+                const visibleBottom = visibleTop + container.clientHeight;
+                return optionRect.top >= visibleTop - 1 && optionRect.bottom <= visibleBottom + 1;
             }, SEARCH_DROPDOWN_SELECTOR);
         expect(selectedIsVisible).toBe(true);
     });

--- a/packages/ag-charts-website/src/components/api-documentation/components/SearchBox.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/SearchBox.tsx
@@ -191,10 +191,14 @@ function scrollVerticallyIntoView(element: HTMLElement, container: HTMLElement |
 
     const elementRect = element.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
+    // clientTop and clientHeight exclude the container's borders and scrollbar gutter, which the
+    // bounding rect includes — aligning to the bounding rect leaves the option clipped by them.
+    const visibleTop = containerRect.top + container.clientTop;
+    const visibleBottom = visibleTop + container.clientHeight;
 
-    if (elementRect.top < containerRect.top) {
-        container.scrollTop -= containerRect.top - elementRect.top;
-    } else if (elementRect.bottom > containerRect.bottom) {
-        container.scrollTop += elementRect.bottom - containerRect.bottom;
+    if (elementRect.top < visibleTop) {
+        container.scrollTop -= visibleTop - elementRect.top;
+    } else if (elementRect.bottom > visibleBottom) {
+        container.scrollTop += elementRect.bottom - visibleBottom;
     }
 }

--- a/packages/ag-charts-website/src/components/api-documentation/components/SearchBox.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/SearchBox.tsx
@@ -63,7 +63,9 @@ export function SearchBox({
                         {data.length ? (
                             data.map((innerData, index) => (
                                 <div
-                                    key={innerData.label}
+                                    // Sibling union variants can collapse to the same label, so the
+                                    // label alone is not unique.
+                                    key={`${index}-${innerData.label}`}
                                     ref={index === selectedIndex ? selectedOptionRef : null}
                                     className={classnames(styles.searchOption, {
                                         [styles.selected]: index === selectedIndex,

--- a/packages/ag-charts-website/src/components/api-documentation/components/SearchBox.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/SearchBox.tsx
@@ -26,16 +26,22 @@ export function SearchBox({
 }) {
     const inputRef = useRef<HTMLInputElement>(null);
     const [inFocus, setInFocus] = useState(false);
-    const { data, searchQuery, selectedIndex, handleInput, handleClick, handleKeyDown, setSelectedIndex } = useSearch(
-        searchData,
-        searchDataIndex,
-        (d) => {
-            onItemClick(d);
-            if (inputRef.current) {
-                inputRef.current.value = '';
-            }
+    const {
+        data,
+        searchQuery,
+        selectedIndex,
+        dropdownRef,
+        selectedOptionRef,
+        handleInput,
+        handleClick,
+        handleKeyDown,
+        selectFromPointer,
+    } = useSearch(searchData, searchDataIndex, (d) => {
+        onItemClick(d);
+        if (inputRef.current) {
+            inputRef.current.value = '';
         }
-    );
+    });
 
     return (
         <div className={classnames(styles.searchOuter, className)} {...props}>
@@ -52,22 +58,18 @@ export function SearchBox({
             <Icon svgClasses={styles.searchIcon} name={iconName} />
 
             {searchQuery.length > 0 && inFocus && (
-                <div className={styles.searchDropdown} onMouseDown={(e) => e.preventDefault()}>
+                <div ref={dropdownRef} className={styles.searchDropdown} onMouseDown={(e) => e.preventDefault()}>
                     <div className={styles.searchOptions}>
                         {data.length ? (
                             data.map((innerData, index) => (
                                 <div
                                     key={innerData.label}
-                                    ref={
-                                        index === selectedIndex
-                                            ? (ref) => ref?.scrollIntoView({ block: 'nearest', inline: 'start' })
-                                            : null
-                                    }
+                                    ref={index === selectedIndex ? selectedOptionRef : null}
                                     className={classnames(styles.searchOption, {
                                         [styles.selected]: index === selectedIndex,
                                     })}
                                     onClick={() => handleClick(innerData)}
-                                    onMouseEnter={() => setSelectedIndex(index)}
+                                    onMouseEnter={() => selectFromPointer(index)}
                                 >
                                     {markResults && searchQuery ? (
                                         <HighlightText text={innerData.label} searchTerm={searchQuery} />
@@ -99,6 +101,23 @@ function useSearch(
     const [data, setFilteredData] = useState(searchData);
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [searchQuery, setSearchQuery] = useState(initialValue);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    const shouldScrollToSelection = useRef(false);
+
+    // An option selected by the pointer is already under the cursor, so scrolling to it would fight
+    // the scroll the user is performing.
+    const selectFromPointer = (index: number) => {
+        shouldScrollToSelection.current = false;
+        setSelectedIndex(index);
+    };
+
+    const selectedOptionRef = (element: HTMLDivElement | null) => {
+        if (!element || !shouldScrollToSelection.current) {
+            return;
+        }
+        shouldScrollToSelection.current = false;
+        scrollVerticallyIntoView(element, dropdownRef.current);
+    };
 
     const handleInput: FormEventHandler<HTMLInputElement> = (event) => {
         const inputSearchQuery = event.currentTarget.value.trim().toLowerCase();
@@ -115,6 +134,7 @@ function useSearch(
         setFilteredData(dataResults);
 
         setSearchQuery(inputSearchQuery);
+        shouldScrollToSelection.current = true;
         setSelectedIndex(0);
     };
 
@@ -131,9 +151,11 @@ function useSearch(
         }
         switch (event.key) {
             case 'ArrowUp':
+                shouldScrollToSelection.current = true;
                 setSelectedIndex(selectedIndex === 0 ? data.length - 1 : selectedIndex - 1);
                 break;
             case 'ArrowDown':
+                shouldScrollToSelection.current = true;
                 setSelectedIndex(selectedIndex === data.length - 1 ? 0 : selectedIndex + 1);
                 break;
             case 'Enter':
@@ -148,10 +170,29 @@ function useSearch(
         data,
         searchQuery,
         selectedIndex,
+        dropdownRef,
+        selectedOptionRef,
         setSearchQuery,
-        setSelectedIndex,
+        selectFromPointer,
         handleInput,
         handleClick,
         handleKeyDown,
     };
+}
+
+// Element.scrollIntoView() cannot be constrained to one axis, so the scroll is applied by hand to
+// leave the horizontal position the user has scrolled to untouched.
+function scrollVerticallyIntoView(element: HTMLElement, container: HTMLElement | null) {
+    if (!container) {
+        return;
+    }
+
+    const elementRect = element.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+
+    if (elementRect.top < containerRect.top) {
+        container.scrollTop -= containerRect.top - elementRect.top;
+    } else if (elementRect.bottom > containerRect.bottom) {
+        container.scrollTop += elementRect.bottom - containerRect.bottom;
+    }
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1197

The selected option's ref callback ran `scrollIntoView({ inline: 'start' })` on every render. Wheel-scrolling the API search dropdown vertically moves the pointer onto a new option, which selects it and re-renders — so `inline: 'start'` reset the horizontal scroll to the left.

Selection now only scrolls the dropdown for keyboard navigation and new results, and does so vertically, leaving the user's horizontal scroll position untouched.

Second commit is a pre-existing fix pulled in because it blocks the new tests: search options were keyed by label, but sibling union variants can collapse to the same label, so the list emitted React duplicate-key warnings. Reproducible on b14.1.0 by searching `label`.

Fix #CRT-1197