### PR TITLE
CRT-1199 Remove stray left indent on docs pages without a left menu

### DIFF
--- a/external/ag-website-shared/src/components/page-styles/docs.module.scss
+++ b/external/ag-website-shared/src/components/page-styles/docs.module.scss
@@ -9,25 +9,10 @@
         flex-direction: row;
     }
 
+    // .docPage caps its width to leave room for the 3-12 menu column, which isn't there.
     &.noLeftMenu .docPage {
         width: 100%;
-    }
-
-    @media (min-width: $breakpoint-docs-nav-large) {
-        &.noLeftMenu .docPage {
-            width: var(--layout-width-9-12);
-            margin-left: calc(var(--layout-width-3-12) + var(--layout-gap));
-        }
-    }
-
-    @media (max-width: $breakpoint-docs-nav-extra-large) {
-        &.noLeftMenu .docPage {
-            width: var(--layout-width-6-12);
-        }
-    }
-
-    &.noLeftMenu .docPage {
-        width: 100%;
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/CRT-1199

Docs pages with `hidePageMenu: true` were indented by a full 3-12 menu
column that has nothing in it. The `.noLeftMenu` overrides had four rules
for the same selector; the last `width: 100%` cancelled the earlier width
declarations but left behind the `margin-left` that paired with the 9-12
width. Collapsed to a single rule, and opted out of the `.docPage`
max-width so the content fills the space instead of moving the slack to
the right of it.

Not Firefox-specific despite the ticket title — reproduces identically in
Chromium and WebKit. It is gated on viewport width (>= 1475px), not engine.

Fix #CRT-1199