### PR TITLE
Fix crash when setting legend.pagination.marker.padding

### DIFF
--- a/packages/ag-charts-community/src/chart/legend/legendModule.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendModule.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from 'vitest';
+
+import { commonChartOptionsDefs } from 'ag-charts-core';
+
+import { expectSharedOptionsDefs } from '../test/sharedOptionsDefs';
+import { LegendModule } from './legendModule';
+
+describe('LegendModule', () => {
+    it('shares its options schema with commonChartOptionsDefs', () => {
+        expectSharedOptionsDefs('legend', LegendModule.options, commonChartOptionsDefs.legend);
+    });
+});

--- a/packages/ag-charts-community/src/chart/legend/legendModule.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendModule.ts
@@ -3,21 +3,7 @@ import {
     FONT_SIZE_RATIO,
     LEGEND_CONTAINER_THEME,
     type PluginModuleDefinition,
-    boolean,
-    borderOptionsDef,
-    callback,
-    colorUnion,
-    fillOptionsDef,
-    fontOptionsDef,
-    legendPositionValidator,
-    number,
-    padding,
-    positiveNumber,
-    ratio,
-    shapeValidator,
-    string,
-    strokeOptionsDef,
-    union,
+    legendOptionsDefs,
 } from 'ag-charts-core';
 import type { AgChartLegendOptions } from 'ag-charts-types';
 
@@ -33,71 +19,7 @@ export const LegendModule: PluginModuleDefinition<AgChartLegendOptions, ChartReg
     // TODO fix missing behaviour
     // removable: 'standalone-only',
 
-    options: {
-        enabled: boolean,
-        position: legendPositionValidator,
-        orientation: union('horizontal', 'vertical'),
-        maxWidth: positiveNumber,
-        maxHeight: positiveNumber,
-        spacing: positiveNumber,
-        border: borderOptionsDef,
-        cornerRadius: number,
-        padding: padding,
-        fill: colorUnion,
-        fillOpacity: ratio,
-        preventHidingAll: boolean,
-        reverseOrder: boolean,
-        toggleSeries: boolean,
-        item: {
-            marker: {
-                size: positiveNumber,
-                shape: shapeValidator,
-                padding: padding,
-                strokeWidth: positiveNumber,
-            },
-            line: {
-                length: positiveNumber,
-                strokeWidth: positiveNumber,
-            },
-            label: {
-                maxLength: positiveNumber,
-                formatter: callback,
-                ...fontOptionsDef,
-            },
-            tooltip: {
-                visible: union('auto', 'always', 'never'),
-                text: string,
-                renderer: callback,
-            },
-            maxWidth: positiveNumber,
-            padding: padding,
-            showSeriesStroke: boolean,
-        },
-        pagination: {
-            marker: {
-                size: positiveNumber,
-                shape: shapeValidator,
-                padding: padding,
-            },
-            activeStyle: {
-                ...fillOptionsDef,
-                ...strokeOptionsDef,
-            },
-            inactiveStyle: {
-                ...fillOptionsDef,
-                ...strokeOptionsDef,
-            },
-            highlightStyle: {
-                ...fillOptionsDef,
-                ...strokeOptionsDef,
-            },
-            label: fontOptionsDef,
-        },
-        listeners: {
-            legendItemClick: callback,
-            legendItemDoubleClick: callback,
-        },
-    },
+    options: legendOptionsDefs,
     themeTemplate: {
         ...LEGEND_CONTAINER_THEME,
         enabled: {

--- a/packages/ag-charts-community/src/chart/legend/legendPagination.test.ts
+++ b/packages/ag-charts-community/src/chart/legend/legendPagination.test.ts
@@ -97,6 +97,23 @@ describe('Legend pagination state (AG-13436)', () => {
         expect(chart.getState().legendPagination).toBeUndefined();
     });
 
+    it.each([
+        { name: 'a partial object', padding: { top: 4, left: 8 }, expected: { top: 4, right: 8, bottom: 8, left: 8 } },
+        { name: 'a number', padding: 6, expected: { top: 6, right: 6, bottom: 6, left: 6 } },
+    ])('accepts $name for pagination.marker.padding', async ({ padding, expected }) => {
+        const options: AgChartOptions = {
+            legend: { position: 'right', pagination: { marker: { padding } } },
+            series: buildPaginatingSeries(100),
+        };
+        prepareTestOptions(options, container);
+        chart = AgCharts.create(options);
+        await waitForChartStability(chart);
+
+        expectWarningsCalls().toEqual([]);
+        const { processedOptions } = deproxy(chart).chartOptions;
+        expect(processedOptions.legend?.pagination?.marker?.padding).toEqual(expected);
+    });
+
     it('restores the legend pagination page via setState on a like-sized chart', async () => {
         const optionsA = paginatingOptions();
         const containerA = document.createElement('div');

--- a/packages/ag-charts-community/src/chart/test/sharedOptionsDefs.ts
+++ b/packages/ag-charts-community/src/chart/test/sharedOptionsDefs.ts
@@ -1,0 +1,17 @@
+import { expect } from 'vitest';
+
+// Plugin option schemas are validated twice — once against `commonChartOptionsDefs` in the chart pass,
+// then again against the plugin module's own `options` in the plugin pass. Both must resolve to the same
+// object: while they were separate copies they drifted, and the stricter copy cleared values the other
+// accepted. Reference the shared const rather than inlining a second literal.
+export function expectSharedOptionsDefs(name: string, pluginOptions: unknown, commonOptions: unknown) {
+    // Guard against a vacuous pass: two `undefined` reads would otherwise satisfy the identity check.
+    expect(pluginOptions, `\`${name}\` plugin options must be a populated schema`).toEqual(expect.any(Object));
+    expect(Object.keys(pluginOptions as object).length).toBeGreaterThan(0);
+
+    expect(
+        pluginOptions === commonOptions,
+        `\`${name}\` options must be the same object in the plugin module and in commonChartOptionsDefs, ` +
+            `so the two validation passes cannot disagree`
+    ).toBe(true);
+}

--- a/packages/ag-charts-community/src/main-test.ts
+++ b/packages/ag-charts-community/src/main-test.ts
@@ -9,3 +9,4 @@ export * from './chart/series/test/examples';
 export * from './chart/test/findTarget';
 export * from './chart/test/freezableMock';
 export * from './chart/test/legendItemName';
+export * from './chart/test/sharedOptionsDefs';

--- a/packages/ag-charts-core/src/config/chartDefaults.ts
+++ b/packages/ag-charts-core/src/config/chartDefaults.ts
@@ -10,6 +10,7 @@ import {
     type AgChartLabelOptions,
     type AgChartLabelPlacementStyleOptions,
     type AgChartLabelStyleOptions,
+    type AgChartLegendOptions,
     type AgChartLegendPlacement,
     type AgChartLegendPositionOptions,
     type AgChartOverlayOptions,
@@ -20,6 +21,7 @@ import {
     type AgDropShadowOptions,
     type AgErrorBarOptions,
     type AgErrorBarThemeableOptions,
+    type AgGradientLegendOptions,
     type AgInitialFocus,
     type AgInterpolationType,
     type AgLineSeriesLabelOptions,
@@ -377,6 +379,105 @@ timeIntervalDefs.every = callback;
 
 export const timeInterval = optionsDefs<AgTimeInterval>(timeIntervalDefs, 'a time interval object');
 
+// The `legend` plugin module re-validates these options on a second pass; both passes must share one definition.
+export const legendOptionsDefs: OptionsDefs<AgChartLegendOptions> = {
+    enabled: boolean,
+    position: legendPositionValidator,
+    orientation: union('horizontal', 'vertical'),
+    maxWidth: positiveNumber,
+    maxHeight: positiveNumber,
+    spacing: positiveNumber,
+    border: borderOptionsDef,
+    cornerRadius: number,
+    padding: padding,
+    fill: colorUnion,
+    fillOpacity: ratio,
+    preventHidingAll: boolean,
+    reverseOrder: boolean,
+    toggleSeries: boolean,
+    item: {
+        marker: {
+            size: positiveNumber,
+            shape: shapeValidator,
+            padding: padding,
+            strokeWidth: positiveNumber,
+        },
+        line: {
+            length: positiveNumber,
+            strokeWidth: positiveNumber,
+        },
+        label: {
+            maxLength: positiveNumber,
+            formatter: callback,
+            ...fontOptionsDef,
+        },
+        tooltip: {
+            visible: union('auto', 'always', 'never'),
+            text: string,
+            renderer: callback,
+        },
+        maxWidth: positiveNumber,
+        padding: padding,
+        showSeriesStroke: boolean,
+    },
+    pagination: {
+        marker: {
+            size: positiveNumber,
+            shape: shapeValidator,
+            padding: padding,
+        },
+        activeStyle: {
+            ...fillOptionsDef,
+            ...strokeOptionsDef,
+        },
+        inactiveStyle: {
+            ...fillOptionsDef,
+            ...strokeOptionsDef,
+        },
+        highlightStyle: {
+            ...fillOptionsDef,
+            ...strokeOptionsDef,
+        },
+        label: fontOptionsDef,
+    },
+    listeners: {
+        legendItemClick: callback,
+        legendItemDoubleClick: callback,
+    },
+};
+
+// The `gradientLegend` plugin module re-validates these options on a second pass; both passes must share one definition.
+export const gradientLegendOptionsDefs: OptionsDefs<AgGradientLegendOptions> = {
+    enabled: boolean,
+    position: legendPositionValidator,
+    spacing: positiveNumber,
+    reverseOrder: boolean,
+    border: borderOptionsDef,
+    cornerRadius: number,
+    padding: padding,
+    fill: colorUnion,
+    fillOpacity: ratio,
+    gradient: {
+        preferredLength: positiveNumber,
+        thickness: positiveNumber,
+    },
+    scale: {
+        label: {
+            ...fontOptionsDef,
+            minSpacing: positiveNumber,
+            format: numberFormatValidator,
+            formatter: callback,
+        },
+        padding: positiveNumber,
+        interval: {
+            step: number,
+            values: array,
+            minSpacing: and(positiveNumber, lessThan('maxSpacing')),
+            maxSpacing: and(positiveNumber, greaterThan('minSpacing')),
+        },
+    },
+};
+
 export const commonChartOptionsDefs: OptionsDefs<Omit<AgBaseThemeableChartOptions, 'navigator'>> = {
     width: positiveNumber,
     height: positiveNumber,
@@ -393,101 +494,8 @@ export const commonChartOptionsDefs: OptionsDefs<Omit<AgBaseThemeableChartOption
         cornerRadius: number,
         padding: or(themeOperator, padding),
     },
-    legend: {
-        enabled: boolean,
-        position: legendPositionValidator,
-        orientation: union('horizontal', 'vertical'),
-        maxWidth: positiveNumber,
-        maxHeight: positiveNumber,
-        spacing: positiveNumber,
-        border: borderOptionsDef,
-        cornerRadius: number,
-        padding: padding,
-        fill: colorUnion,
-        fillOpacity: ratio,
-        preventHidingAll: boolean,
-        reverseOrder: boolean,
-        toggleSeries: boolean,
-        item: {
-            marker: {
-                size: positiveNumber,
-                shape: shapeValidator,
-                padding: padding,
-                strokeWidth: positiveNumber,
-            },
-            line: {
-                length: positiveNumber,
-                strokeWidth: positiveNumber,
-            },
-            label: {
-                maxLength: positiveNumber,
-                formatter: callback,
-                ...fontOptionsDef,
-            },
-            tooltip: {
-                visible: union('auto', 'always', 'never'),
-                text: string,
-                renderer: callback,
-            },
-            maxWidth: positiveNumber,
-            padding: padding,
-            showSeriesStroke: boolean,
-        },
-        pagination: {
-            marker: {
-                size: positiveNumber,
-                shape: shapeValidator,
-                padding: positiveNumber,
-            },
-            activeStyle: {
-                ...fillOptionsDef,
-                ...strokeOptionsDef,
-            },
-            inactiveStyle: {
-                ...fillOptionsDef,
-                ...strokeOptionsDef,
-            },
-            highlightStyle: {
-                ...fillOptionsDef,
-                ...strokeOptionsDef,
-            },
-            label: fontOptionsDef,
-        },
-        listeners: {
-            legendItemClick: callback,
-            legendItemDoubleClick: callback,
-        },
-    },
-    gradientLegend: {
-        enabled: boolean,
-        position: legendPositionValidator,
-        spacing: positiveNumber,
-        reverseOrder: boolean,
-        border: borderOptionsDef,
-        cornerRadius: number,
-        padding: padding,
-        fill: colorUnion,
-        fillOpacity: ratio,
-        gradient: {
-            preferredLength: positiveNumber,
-            thickness: positiveNumber,
-        },
-        scale: {
-            label: {
-                ...fontOptionsDef,
-                minSpacing: positiveNumber,
-                format: numberFormatValidator,
-                formatter: callback,
-            },
-            padding: positiveNumber,
-            interval: {
-                step: number,
-                values: array,
-                minSpacing: and(positiveNumber, lessThan('maxSpacing')),
-                maxSpacing: and(positiveNumber, greaterThan('minSpacing')),
-            },
-        },
-    },
+    legend: legendOptionsDefs,
+    gradientLegend: gradientLegendOptionsDefs,
     listeners: {
         seriesNodeClick: callback,
         seriesNodeDoubleClick: callback,

--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegendModule.test.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegendModule.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from 'vitest';
+
+import { expectSharedOptionsDefs } from 'ag-charts-community-test';
+import { commonChartOptionsDefs } from 'ag-charts-core';
+
+import { GradientLegendModule } from './gradientLegendModule';
+
+describe('GradientLegendModule', () => {
+    it('shares its options schema with commonChartOptionsDefs', () => {
+        expectSharedOptionsDefs('gradientLegend', GradientLegendModule.options, commonChartOptionsDefs.gradientLegend);
+    });
+});

--- a/packages/ag-charts-enterprise/src/gradient-legend/gradientLegendModule.ts
+++ b/packages/ag-charts-enterprise/src/gradient-legend/gradientLegendModule.ts
@@ -5,21 +5,7 @@ import {
     FILL_PATTERN_BLANK_DEFAULTS,
     LEGEND_CONTAINER_THEME,
     type PluginModuleDefinition,
-    and,
-    array,
-    boolean,
-    borderOptionsDef,
-    callback,
-    colorUnion,
-    fontOptionsDef,
-    greaterThan,
-    legendPositionValidator,
-    lessThan,
-    number,
-    numberFormatValidator,
-    padding,
-    positiveNumber,
-    ratio,
+    gradientLegendOptionsDefs,
 } from 'ag-charts-core';
 
 import { GradientLegend } from './gradientLegend';
@@ -31,36 +17,7 @@ export const GradientLegendModule: PluginModuleDefinition<AgGradientLegendOption
     version: VERSION,
     // removable: 'standalone-only',
 
-    options: {
-        enabled: boolean,
-        position: legendPositionValidator,
-        spacing: positiveNumber,
-        reverseOrder: boolean,
-        border: borderOptionsDef,
-        cornerRadius: number,
-        padding: padding,
-        fill: colorUnion,
-        fillOpacity: ratio,
-        gradient: {
-            preferredLength: positiveNumber,
-            thickness: positiveNumber,
-        },
-        scale: {
-            label: {
-                ...fontOptionsDef,
-                minSpacing: positiveNumber,
-                format: numberFormatValidator,
-                formatter: callback,
-            },
-            padding: positiveNumber,
-            interval: {
-                step: number,
-                values: array,
-                minSpacing: and(positiveNumber, lessThan('maxSpacing')),
-                maxSpacing: and(positiveNumber, greaterThan('minSpacing')),
-            },
-        },
-    },
+    options: gradientLegendOptionsDefs,
     themeTemplate: {
         ...LEGEND_CONTAINER_THEME,
         enabled: false,


### PR DESCRIPTION
`legend.pagination.marker.padding` was validated by two separate schemas that had drifted: the copy in `commonChartOptionsDefs` (`ag-charts-core`) used `positiveNumber`, while the `legend` plugin module used `padding`. Both passes run — `validateChart` first, then `validatePluginOptions` — so the stricter copy won and cleared the value, leaving the option `undefined`. `Pagination.updateLabelPosition` then threw `TypeError: Cannot read properties of undefined (reading 'right')` once the legend paginated.

Both documented forms were affected, not just the object form: `OptionsGraph` forces `$applyPadding` on any key named `padding` even when a user option is present, and grafts the expanded object back for re-validation, so a scalar `padding: 6` was rejected too. The option was effectively unusable, despite `ag-charts-types` declaring `padding?: Padding` and documenting both forms.

**Changes**

- Extract `legendOptionsDefs` and `gradientLegendOptionsDefs` as shared consts in `ag-charts-core/src/config/chartDefaults.ts`, referenced by both `commonChartOptionsDefs` and the two plugin modules, so one definition backs both validation passes.
- Resolve the drifted line to `padding` — the form the runtime consumer (`pagination.ts`) requires and the public type documents. The `gradientLegend` half is a pure dedupe (the two copies were byte-identical) with no behaviour change.
- Regression coverage for both the partial-object and scalar forms, verified to fail when the old validator is restored.
- Identity guards on both schema pairs, so re-inlining a copy fails rather than silently drifting again. The shared helper lives in community test space since enterprise can import community but not the reverse.

Net −54 lines.

**Not included**

`ranges` has the same duplicated-schema hazard, but has diverged structurally rather than by one line — the enterprise `rangesOptionsDefs` has `gap`, `buttons` and `...stylesOptions` that core's block lacks. Unifying it means deciding where enterprise-only option shapes should live, so it's left for a follow-up.