### PR TITLE
Fix update-versions-data silently mislabelling every version

### DIFF
--- a/packages/ag-charts-website/scripts/versions-data/updateVersionsData.ts
+++ b/packages/ag-charts-website/scripts/versions-data/updateVersionsData.ts
@@ -4,8 +4,16 @@ import * as fs from 'fs/promises';
 
 // Absolute path from the root directory
 const VERSIONS_DATA_PATH = 'packages/ag-charts-website/src/content/versions/ag-charts-versions.json';
-const WEBSITE_ARCHIVE_URLS = ['https://charts.ag-grid.com/archive', 'https://www.ag-grid.com/charts/archive'];
+// Supersedes the two URLs this previously read. The legacy charts.ag-grid.com/archive
+// listing only went up to 10.1.0, and every version it listed also appears here.
+const WEBSITE_ARCHIVE_URL = 'https://www.ag-grid.com/charts/documentation-archive/';
 const MIN_VERSION = '9.0.1';
+
+// The archive page is served behind a filter that rejects non-browser clients with
+// a 403, so identify as one. Without this every request fails and the script would
+// conclude that no version has archived docs.
+const BROWSER_USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
 
 function sortByVersionAsc(a: string, b: string) {
     const aParts = a.split('.').map(Number);
@@ -23,7 +31,7 @@ function sortByVersionDesc(a: string, b: string) {
 }
 
 function extractVersionsFromHref(html: string) {
-    const hrefRegex = /<a\s+href="(\d+\.\d+\.\d+)\/">/g;
+    const hrefRegex = /href="[^"]*\/archive\/(\d+\.\d+\.\d+)(?:\/|")/g;
 
     const versions = [];
     let match;
@@ -34,14 +42,22 @@ function extractVersionsFromHref(html: string) {
     return [...new Set(versions)].sort(sortByVersionAsc);
 }
 
-async function getWebsiteVersions(urls) {
-    const versionPromises = urls.map(async (url) => {
-        const response = await fetch(url);
-        const html = await response.text();
+async function getWebsiteVersions() {
+    const response = await fetch(WEBSITE_ARCHIVE_URL, { headers: { 'User-Agent': BROWSER_USER_AGENT } });
 
-        return extractVersionsFromHref(html);
-    });
-    const versions = (await Promise.all(versionPromises)).flat();
+    if (!response.ok) {
+        throw new Error(`Could not read ${WEBSITE_ARCHIVE_URL}: ${response.status} ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    const versions = extractVersionsFromHref(html);
+
+    // Every version is compared against this list to decide its `noDocs` flag, so an
+    // empty result is never legitimate: it would mark the entire file as having no
+    // archived docs. Treat it as a broken URL or changed page markup instead.
+    if (versions.length === 0) {
+        throw new Error(`Found no archived versions at ${WEBSITE_ARCHIVE_URL}; the URL or its markup has changed`);
+    }
 
     return versions;
 }
@@ -95,9 +111,12 @@ function logFinalReport({ versionsDataFile, allVersions, noDocsUpdated }) {
 
 function updateNoDocs({ versions, websiteVersions }) {
     let num = 0;
-    // Check website to see if version has docs
-    const updatedVersions = versions.map((versionData) => {
-        const noDocs = !websiteVersions.includes(versionData.version);
+    // Check website to see if version has docs. `versions` is sorted newest-first, and
+    // the newest entry is the live release, whose docs are served from the main site
+    // rather than the archive - so it is never in `websiteVersions`. Exempt it, or it
+    // would be flagged `noDocs` and dropped from the version selector.
+    const updatedVersions = versions.map((versionData, index) => {
+        const noDocs = index > 0 && !websiteVersions.includes(versionData.version);
 
         const newData = { ...versionData };
 
@@ -152,7 +171,7 @@ async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
                     versionParts[2] >= minVersionParts[2])
             );
         });
-    const websiteVersions = await getWebsiteVersions(WEBSITE_ARCHIVE_URLS);
+    const websiteVersions = await getWebsiteVersions();
 
     const missingNpmVersions = npmVersions.filter(({ version }) => {
         const hasVersion = agVersions.some((agVersion) => version === agVersion.version);

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -27,6 +27,14 @@
         "notesPath": "./upgrade-to-ag-charts-14-1"
     },
     {
+        "version": "14.0.2",
+        "date": "July 22nd, 2026"
+    },
+    {
+        "version": "14.0.1",
+        "date": "July 15th, 2026"
+    },
+    {
         "version": "14.0.0",
         "date": "June 24th, 2026",
         "highlights": [
@@ -49,6 +57,11 @@
         ],
         "landingPageHighlight": "Async data loading for paginated APIs, CSS variables support, and more...",
         "notesPath": "./upgrade-to-ag-charts-14"
+    },
+    {
+        "version": "13.3.1",
+        "date": "June 2nd, 2026",
+        "noDocs": true
     },
     {
         "version": "13.3.0",
@@ -325,6 +338,16 @@
         "notesPath": "./upgrade-to-ag-charts-11-3"
     },
     {
+        "version": "11.2.4",
+        "date": "April 17th, 2025",
+        "noDocs": true
+    },
+    {
+        "version": "11.2.3",
+        "date": "April 11th, 2025",
+        "noDocs": true
+    },
+    {
         "version": "11.2.2",
         "date": "April 9th, 2025"
     },
@@ -411,6 +434,26 @@
             }
         ],
         "notesPath": "./upgrade-to-ag-charts-11"
+    },
+    {
+        "version": "10.3.9",
+        "date": "August 13th, 2025",
+        "noDocs": true
+    },
+    {
+        "version": "10.3.8",
+        "date": "June 10th, 2025",
+        "noDocs": true
+    },
+    {
+        "version": "10.3.7",
+        "date": "April 28th, 2025",
+        "noDocs": true
+    },
+    {
+        "version": "10.3.6",
+        "date": "April 11th, 2025",
+        "noDocs": true
     },
     {
         "version": "10.3.5",


### PR DESCRIPTION
`nx update-versions-data ag-charts-website` is currently destructive. Both archive
URLs it read are gone: `charts.ag-grid.com/archive` is a legacy directory listing
that stops at 10.1.0, and `/charts/archive` now redirects to
`/charts/documentation-archive/`. The site also rejects non-browser clients with a
403 regardless of path.

Both failures were swallowed. `getWebsiteVersions()` returned an empty list, and
because `noDocs` is derived from "version absent from the archive", every entry
got `noDocs: true` - which filters it out of `VersionsSelector` and the archive
`MajorTable`. Running the target on `b14.1.0` today empties both.

- Read `/charts/documentation-archive/` and match the absolute hrefs it actually
  serves (`href="https://charts.ag-grid.com/archive/10.0.0/documentation"`); the
  old regex expected an Apache directory listing.
- Collapse the two URLs into that one page. It is a strict superset: it lists 46
  versions (9.0.1 - 14.0.2) against the legacy listing's 11 (9.0.1 - 10.1.0), and
  every version the legacy listing had also appears there.
- Send a browser `User-Agent` so the request is not rejected.
- Throw on a non-OK response or an empty version list rather than writing a file
  derived from nothing.
- Exempt the newest entry from the `noDocs` check: the live release is served
  from the main docs site, so it is never in the archive and must not be flagged.
  Without this, `14.1.0` itself would be dropped from the selector.

`MIN_VERSION` is unchanged at 9.0.1, which still matches the earliest archived
version.

The second commit is the resulting data refresh, adding the nine released
versions missing from the list. Every flag was cross-checked against the live
archive: 14.0.2 and 14.0.1 are archived (no `noDocs`); 13.3.1, 11.2.4, 11.2.3,
10.3.9, 10.3.8, 10.3.7 and 10.3.6 are not (flagged). Nothing lost a flag it
should have kept, and `14.1.0` is untouched.

Same fix as ag-grid and ag-studio, which have the identical script.