### PR TITLE
Check each version's archive directly for noDocs

### DIFF
--- a/packages/ag-charts-website/scripts/versions-data/updateVersionsData.ts
+++ b/packages/ag-charts-website/scripts/versions-data/updateVersionsData.ts
@@ -4,8 +4,20 @@ import * as fs from 'fs/promises';
 
 // Absolute path from the root directory
 const VERSIONS_DATA_PATH = 'packages/ag-charts-website/src/content/versions/ag-charts-versions.json';
-const WEBSITE_ARCHIVE_URLS = ['https://charts.ag-grid.com/archive', 'https://www.ag-grid.com/charts/archive'];
 const MIN_VERSION = '9.0.1';
+
+// Archived charts docs are split across two hosts: everything from 10.1.0 lives on the
+// unified site, while 9.x and 10.0.x remain on the standalone charts site.
+const PRODUCTION_CHARTS_SITE_URL = 'https://www.ag-grid.com/charts';
+const LEGACY_CHARTS_SITE_URL = 'https://charts.ag-grid.com';
+
+// The site rejects non-browser clients with a 403, so identify as one. Without this every
+// probe fails, and a failed probe must never be mistaken for a missing archive.
+const BROWSER_USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+// One request per version, so keep them spaced out to avoid being rate limited.
+const PROBE_DELAY_MS = 250;
 
 function sortByVersionAsc(a: string, b: string) {
     const aParts = a.split('.').map(Number);
@@ -22,28 +34,60 @@ function sortByVersionDesc(a: string, b: string) {
     return sortByVersionAsc(b, a);
 }
 
-function extractVersionsFromHref(html: string) {
-    const hrefRegex = /<a\s+href="(\d+\.\d+\.\d+)\/">/g;
-
-    const versions = [];
-    let match;
-    while ((match = hrefRegex.exec(html)) !== null) {
-        versions.push(match[1]);
-    }
-
-    return [...new Set(versions)].sort(sortByVersionAsc);
+function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function getWebsiteVersions(urls) {
-    const versionPromises = urls.map(async (url) => {
-        const response = await fetch(url);
-        const html = await response.text();
+/**
+ * Mirrors `getArchiveUrl` in external/ag-website-shared/src/utils/getArchiveUrl.ts, which is
+ * what the site itself uses to link to archived docs. Kept as a local copy because this
+ * script runs as a bare `tsx` entry point with no path-alias resolution.
+ */
+function getArchiveUrl(version: string) {
+    const [major, minor] = version.split('.').map(Number);
+    const baseUrl = (major === 10 && minor >= 1) || major > 10 ? PRODUCTION_CHARTS_SITE_URL : LEGACY_CHARTS_SITE_URL;
 
-        return extractVersionsFromHref(html);
+    return `${baseUrl}/archive/${version}`;
+}
+
+/**
+ * Whether archived docs are published for a version.
+ *
+ * Asks the server directly rather than reading the /documentation-archive/ page: that page
+ * is generated from this very file, so using it here would be circular - a version missing
+ * from the file could never appear on the page, which would flag it `noDocs` and then keep
+ * it flagged forever.
+ */
+async function hasArchivedDocs(version: string) {
+    // Request the trailing-slash form, which is the canonical one, so a published version
+    // answers 200 in a single request.
+    const url = `${getArchiveUrl(version)}/`;
+    // Redirects must not be followed: an unpublished version is soft-404'd to
+    // /charts/404.html, which itself answers 200 and would otherwise be indistinguishable
+    // from a real archive. This is how 9.0.0 and 9.1.1 present.
+    const response = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'manual',
+        headers: { 'User-Agent': BROWSER_USER_AGENT },
     });
-    const versions = (await Promise.all(versionPromises)).flat();
 
-    return versions;
+    if (response.status === 200) {
+        return true;
+    }
+
+    if (response.status === 404) {
+        return false;
+    }
+
+    if (response.status >= 300 && response.status < 400) {
+        // A redirect that stays within this version's archive path is a genuine relocation;
+        // anything else is the soft-404 described above.
+        return (response.headers.get('location') ?? '').includes(`/archive/${version}`);
+    }
+
+    // Typically a 403 (blocked) or 429 (rate limited). Treating either as "not archived"
+    // would silently drop the version from the selector, so stop instead of guessing.
+    throw new Error(`Unexpected ${response.status} ${response.statusText} for ${url}`);
 }
 
 function getDaySuffix(day: number) {
@@ -77,54 +121,68 @@ function getNpmLibraryVersions(library: string) {
     return JSON.parse(results.toString());
 }
 
-function logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, websiteVersions }) {
+function logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, versionsToProbe }) {
     console.log(`${agVersions.length} versions in '${versionsDataFile}'`);
     console.log(`${npmVersions.length} npm versions`);
-    console.log(`${websiteVersions.length} website versions`);
+    console.log(`${versionsToProbe.size} versions to probe for archived docs`);
     console.log(`${missingNpmVersions.length} missing npm versions${missingNpmVersions.length ? ':' : ''}`);
     if (missingNpmVersions.length) {
         console.log(missingNpmVersions);
     }
 }
 
-function logFinalReport({ versionsDataFile, allVersions, noDocsUpdated }) {
+function logFinalReport({ versionsDataFile, allVersions, noDocsUpdated, probeCount }) {
     console.log(`Wrote changes to '${versionsDataFile}'`);
+    console.log(`${probeCount} versions probed`);
     console.log(`${noDocsUpdated} noDocs values updated`);
     console.log(`${allVersions.length} versions written`);
 }
 
-function updateNoDocs({ versions, websiteVersions }) {
+async function updateNoDocs({ versions, versionsToProbe }) {
     let num = 0;
-    // Check website to see if version has docs
-    const updatedVersions = versions.map((versionData) => {
-        const noDocs = !websiteVersions.includes(versionData.version);
+    let probeCount = 0;
+    const updatedVersions = [];
+
+    for (const versionData of versions) {
+        // Each probe is a network request, so only spend one where the answer is not already
+        // recorded. Pass --recheck-all to re-probe everything.
+        if (!versionsToProbe.has(versionData.version)) {
+            updatedVersions.push(versionData);
+            continue;
+        }
+
+        if (probeCount > 0) {
+            await delay(PROBE_DELAY_MS);
+        }
+        probeCount++;
 
         const newData = { ...versionData };
 
-        if (noDocs) {
-            newData.noDocs = true;
-
-            if (!versionData.noDocs) {
-                num++;
-            }
-        } else {
+        if (await hasArchivedDocs(versionData.version)) {
             delete newData.noDocs;
 
             if (versionData.noDocs) {
                 num++;
             }
+        } else {
+            newData.noDocs = true;
+
+            if (!versionData.noDocs) {
+                num++;
+            }
         }
 
-        return newData;
-    });
+        updatedVersions.push(newData);
+    }
 
     return {
         num,
+        probeCount,
         versions: updatedVersions,
     };
 }
 
-async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
+async function updateVersionsData({ isVerbose, recheckAll }: { isVerbose: boolean; recheckAll: boolean }) {
     const versionsDataFile = VERSIONS_DATA_PATH;
     const minVersionParts = MIN_VERSION.split('.').map(Number);
     const agVersions = JSON.parse((await fs.readFile(VERSIONS_DATA_PATH)).toString());
@@ -152,21 +210,30 @@ async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
                     versionParts[2] >= minVersionParts[2])
             );
         });
-    const websiteVersions = await getWebsiteVersions(WEBSITE_ARCHIVE_URLS);
-
     const missingNpmVersions = npmVersions.filter(({ version }) => {
         const hasVersion = agVersions.some((agVersion) => version === agVersion.version);
         return !hasVersion;
     });
 
-    if (isVerbose) {
-        logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, websiteVersions });
-    }
-
     const combinedVersions = [...agVersions, ...missingNpmVersions].sort((a, b) => {
         return sortByVersionDesc(a.version, b.version);
     });
-    const { versions: allVersions, num: noDocsUpdated } = updateNoDocs({ versions: combinedVersions, websiteVersions });
+
+    // Versions already in the file have had their `noDocs` flag determined by an earlier run,
+    // so by default only the newly discovered ones need a probe.
+    const versionsToProbe = new Set(
+        recheckAll ? combinedVersions.map(({ version }) => version) : missingNpmVersions.map(({ version }) => version)
+    );
+
+    if (isVerbose) {
+        logInitialReport({ versionsDataFile, agVersions, npmVersions, missingNpmVersions, versionsToProbe });
+    }
+
+    const {
+        versions: allVersions,
+        num: noDocsUpdated,
+        probeCount,
+    } = await updateNoDocs({ versions: combinedVersions, versionsToProbe });
 
     if (missingNpmVersions.length || noDocsUpdated > 0) {
         const updatedVersions = JSON.stringify(allVersions, null, 4) + '\n';
@@ -175,7 +242,7 @@ async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
         await fs.writeFile(VERSIONS_DATA_PATH, updatedVersions);
 
         if (isVerbose) {
-            logFinalReport({ versionsDataFile, allVersions, noDocsUpdated });
+            logFinalReport({ versionsDataFile, allVersions, noDocsUpdated, probeCount });
         }
     } else if (isVerbose) {
         console.log('No changes needed');
@@ -183,5 +250,6 @@ async function updateVersionsData({ isVerbose }: { isVerbose: boolean }) {
 }
 
 const isVerbose = process.argv.includes('--verbose');
+const recheckAll = process.argv.includes('--recheck-all');
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-updateVersionsData({ isVerbose });
+updateVersionsData({ isVerbose, recheckAll });

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -27,6 +27,14 @@
         "notesPath": "./upgrade-to-ag-charts-14-1"
     },
     {
+        "version": "14.0.2",
+        "date": "July 22nd, 2026"
+    },
+    {
+        "version": "14.0.1",
+        "date": "July 15th, 2026"
+    },
+    {
         "version": "14.0.0",
         "date": "June 24th, 2026",
         "highlights": [
@@ -49,6 +57,10 @@
         ],
         "landingPageHighlight": "Async data loading for paginated APIs, CSS variables support, and more...",
         "notesPath": "./upgrade-to-ag-charts-14"
+    },
+    {
+        "version": "13.3.1",
+        "date": "June 2nd, 2026"
     },
     {
         "version": "13.3.0",
@@ -325,6 +337,14 @@
         "notesPath": "./upgrade-to-ag-charts-11-3"
     },
     {
+        "version": "11.2.4",
+        "date": "April 17th, 2025"
+    },
+    {
+        "version": "11.2.3",
+        "date": "April 11th, 2025"
+    },
+    {
         "version": "11.2.2",
         "date": "April 9th, 2025"
     },
@@ -411,6 +431,22 @@
             }
         ],
         "notesPath": "./upgrade-to-ag-charts-11"
+    },
+    {
+        "version": "10.3.9",
+        "date": "August 13th, 2025"
+    },
+    {
+        "version": "10.3.8",
+        "date": "June 10th, 2025"
+    },
+    {
+        "version": "10.3.7",
+        "date": "April 28th, 2025"
+    },
+    {
+        "version": "10.3.6",
+        "date": "April 11th, 2025"
     },
     {
         "version": "10.3.5",


### PR DESCRIPTION
Replaces #7672, which fixed how the archive pages were fetched but kept the underlying
mistake: `/charts/documentation-archive/` is **generated from the very file this script
writes**. `MajorTable` renders `versionsData.filter((entry) => … && !entry.noDocs)`
(`external/ag-website-shared/src/markdoc/buildMajorTable.ts`), so deriving `noDocs`
from it is circular, and self-reinforcing:

- a version missing from the JSON can never appear on the page, so it is flagged
- once flagged it is filtered off the page, so the next run re-flags it

A flag could therefore never be cleared, and every newly added version acquired one
permanently. The other URL, the `charts.ag-grid.com/archive` listing, is a plain
directory listing that no longer reflects what is published.

Ask the server instead - `HEAD …/archive/<version>/`, **without following redirects**:

| Response | Meaning |
|---|---|
| 200 | archived |
| 404 | not archived |
| 3xx | archived only if `location` stays within `/archive/<version>` |
| anything else (403 bot filter, 429) | unknown -> throw |

The redirect row is load-bearing for charts specifically. An unpublished version is
soft-404'd: `…/archive/9.1.1/` returns `301 -> https://www.ag-grid.com/charts/404.html`,
and that page itself answers **200**. Following redirects therefore reports every
missing archive as present. `9.0.0` and `9.1.1` both present this way.

The last row is the other half: a blocked or rate-limited request must never be
recorded as "no archived docs", because that is what silently strips versions from
`VersionsSelector` and the archive table.

Archived charts docs are split across two hosts, so the per-version URL mirrors
`getArchiveUrl` in `ag-website-shared`: 9.x and 10.0.x on the standalone charts site,
10.1.0 onwards on the unified site. The split is load-bearing - 10.0.2 returns 200 on
the standalone site and 404 on the unified one, so routing it wrongly would flag it.

**Request volume.** Only versions whose flag is not already recorded get probed, so a
normal run makes zero archive requests. `--recheck-all` re-probes everything,
sequentially and spaced by `PROBE_DELAY_MS`.

**Second commit: data.** A full re-probe of all 56 versions left every existing
`noDocs` flag unchanged - including 9.0.0 and 9.1.1, which stay flagged because they
are genuinely not published. It only surfaced nine released versions that were never
added, all of which are archived. Verified independently with `curl -I`: 9.0.1, 9.1.0,
9.2.0, 10.0.0, 10.0.2, 10.1.0, 11.2.2 and 14.0.2 all return a direct 200, while 9.0.0
and 9.1.1 return the 301 to `/charts/404.html`.

Same fix in ag-grid (#14705) and ag-studio (#2292), which share this script.
