### PR TITLE
AG-9809 [CLAUDE] Add axis click and doubleClick listeners

### DIFF
--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-base.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-base.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, NgZone, OnChanges, OnDestroy } from '@angular/core';
 
 import {
+    AgAxisListeners,
     AgBaseChartListeners,
     AgChartInstance,
     AgChartLegendListeners,
@@ -69,6 +70,15 @@ export abstract class AgChartsBase<Options extends {}> implements AfterViewInit,
                 series?.listeners ? { ...series, listeners: this.patchListeners(series.listeners) } : series
             );
         }
+        if (propsOptions.axes) {
+            // `axes` is a dictionary keyed by axis name, not an array.
+            patched.axes = Object.fromEntries(
+                Object.entries<any>(propsOptions.axes).map(([axisKey, axis]) => [
+                    axisKey,
+                    axis?.listeners ? { ...axis, listeners: this.patchListeners(axis.listeners) } : axis,
+                ])
+            );
+        }
         if (propsOptions.contextMenu) {
             patched.contextMenu = this.patchContextMenu(propsOptions.contextMenu);
         }
@@ -78,7 +88,7 @@ export abstract class AgChartsBase<Options extends {}> implements AfterViewInit,
     }
 
     private patchListeners(
-        listenerConfig: AgChartLegendListeners | AgSeriesListeners<any> | AgBaseChartListeners<any>
+        listenerConfig: AgChartLegendListeners | AgSeriesListeners<any> | AgBaseChartListeners<any> | AgAxisListeners
     ): any {
         const config: any = listenerConfig;
         const patched: any = {};

--- a/packages/ag-charts-angular/tests/zone-callback-inventory.json
+++ b/packages/ag-charts-angular/tests/zone-callback-inventory.json
@@ -7,6 +7,14 @@
         "classification": "zone-wrap",
         "reason": "Chart listener; re-entered into the zone by patchChartOptions via patchListeners(options.listeners)."
     },
+    "AgBaseChartListeners.axisClick": {
+        "classification": "zone-wrap",
+        "reason": "Chart listener; re-entered into the zone by patchChartOptions via patchListeners(options.listeners)."
+    },
+    "AgBaseChartListeners.axisDoubleClick": {
+        "classification": "zone-wrap",
+        "reason": "Chart listener; re-entered into the zone by patchChartOptions via patchListeners(options.listeners)."
+    },
     "AgBaseChartListeners.collapsedChange": {
         "classification": "zone-wrap",
         "reason": "Chart listener; re-entered into the zone by patchChartOptions via patchListeners(options.listeners)."
@@ -62,6 +70,14 @@
     "AgHistogramSeriesListeners.seriesNodeDoubleClick": {
         "classification": "zone-wrap",
         "reason": "Series listener; re-entered into the zone by patchChartOptions via patchListeners(series.listeners)."
+    },
+    "AgAxisListeners.click": {
+        "classification": "zone-wrap",
+        "reason": "Axis listener; re-entered into the zone by patchChartOptions via patchListeners(axes[<key>].listeners)."
+    },
+    "AgAxisListeners.doubleClick": {
+        "classification": "zone-wrap",
+        "reason": "Axis listener; re-entered into the zone by patchChartOptions via patchListeners(axes[<key>].listeners)."
     },
     "AgContextMenuOptions.getItems": {
         "classification": "zone-wrap",

--- a/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
+++ b/packages/ag-charts-community/src/chart/axesOptionsDefs.ts
@@ -8,6 +8,7 @@ import {
     attachDescription,
     boolean,
     borderOptionsDef,
+    callback,
     callbackDefs,
     callbackOf,
     colorOrRef,
@@ -277,6 +278,10 @@ export const cartesianAxisOptionsDefs: OptionsDefs<
     position: union('top', 'right', 'bottom', 'left'),
     thickness: positiveNumber,
     maxThicknessRatio: ratio,
+    listeners: {
+        click: callback,
+        doubleClick: callback,
+    },
 };
 
 // @ts-expect-error undocumented option

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -32,6 +32,7 @@ import {
 import type {
     AgAxisBoundSeries,
     AgAxisDomain,
+    AgAxisListeners,
     AgAxisValue,
     AgBaseAxisLabelStyleOptions,
     AgContextMenuGetItemsParamsAlways,
@@ -1170,6 +1171,11 @@ export abstract class Axis<
             scale: this.scale,
             direction: this.direction,
             continuous: ContinuousScale.is(scale) || DiscreteTimeScale.is(scale),
+            // A getter, not a snapshot: `applyOptions` swaps the options reference on update, so
+            // listeners added or removed by a later `chart.update()` must be picked up.
+            get listeners() {
+                return (axis.options as { listeners?: AgAxisListeners<unknown> }).listeners;
+            },
             get mirrored() {
                 return axis.mirrored;
             },

--- a/packages/ag-charts-community/src/chart/chartService.ts
+++ b/packages/ag-charts-community/src/chart/chartService.ts
@@ -1,5 +1,11 @@
 import type { BoxBounds, CanvasPoint, RequireOptional } from 'ag-charts-core';
-import type { AgChartInstance, AgCollapsedChangeEvent, AgCoordinates, AgSelectionChangeEvent } from 'ag-charts-types';
+import type {
+    AgAxisClickEvent,
+    AgChartInstance,
+    AgCollapsedChangeEvent,
+    AgCoordinates,
+    AgSelectionChangeEvent,
+} from 'ag-charts-types';
 
 import { Group } from '../scene/group';
 import type { CaptionLike } from './captionLike';
@@ -10,7 +16,9 @@ import type { ISeries, SeriesNodeDatum } from './series/seriesTypes';
 
 export type ChartServiceEvent =
     | RequireOptional<Omit<AgSelectionChangeEvent<unknown, unknown>, 'context'>>
-    | RequireOptional<Omit<AgCollapsedChangeEvent<unknown, unknown>, 'context'>>;
+    | RequireOptional<Omit<AgCollapsedChangeEvent<unknown, unknown>, 'context'>>
+    | Omit<AgAxisClickEvent<'axisClick', unknown>, 'context'>
+    | Omit<AgAxisClickEvent<'axisDoubleClick', unknown>, 'context'>;
 export type ChartServiceEventType = ChartServiceEvent['type'];
 
 type BaseSeries = ISeries<SeriesNodeDatum, SeriesProperties<object>>;

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -23,6 +23,7 @@ export type {
 } from './chart/chartState';
 export { FormatManager } from './chart/formatter/formatManager';
 export type { TransferableResources } from './chart/chart';
+export type { ChartService } from './chart/chartService';
 export {
     angleCategoryAxisOptionsDefs,
     angleNumberAxisOptionsDefs,

--- a/packages/ag-charts-community/src/module/axisContext.ts
+++ b/packages/ag-charts-community/src/module/axisContext.ts
@@ -10,6 +10,7 @@ import type {
 import type {
     AgAxisBoundSeries,
     AgAxisDomain,
+    AgAxisListeners,
     AgAxisValue,
     AgCartesianAxisPosition,
     FormatterParams,
@@ -71,6 +72,8 @@ export interface PolarAxisLayout {
 
 export interface AxisContext {
     context?: unknown;
+    /** User-supplied `axes[].listeners`, if any. */
+    readonly listeners?: AgAxisListeners<unknown>;
     axisId: AxisID;
     /** Static axis-type identifier (matches the axis module's name, e.g. `'number'`, `'angle-category'`). */
     readonly axisType: string;

--- a/packages/ag-charts-core/src/config/chartDefaults.ts
+++ b/packages/ag-charts-core/src/config/chartDefaults.ts
@@ -491,6 +491,8 @@ export const commonChartOptionsDefs: OptionsDefs<Omit<AgBaseThemeableChartOption
     listeners: {
         seriesNodeClick: callback,
         seriesNodeDoubleClick: callback,
+        axisClick: callback,
+        axisDoubleClick: callback,
         seriesVisibilityChange: callback,
         activeChange: callback,
         selectionChange: callback,

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -1,6 +1,7 @@
+import type { AgAxisClickEvent } from 'ag-charts-community';
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { AxisID, CanvasPoint, DynamicContext } from 'ag-charts-core';
-import { AbstractModuleInstance, ChartAxisDirection, boxEmpty } from 'ag-charts-core';
+import type { AxisID, DynamicContext } from 'ag-charts-core';
+import { AbstractModuleInstance, ChartAxisDirection, boxEmpty, callWithContext } from 'ag-charts-core';
 
 type AxisHit = { axisId: AxisID; direction: ChartAxisDirection };
 
@@ -10,6 +11,11 @@ type ProxyAxis = {
     div: _Widget.AxisWidget;
     bounds?: _ModuleSupport.BBox;
 };
+
+function hasAxisClickListener(axisCtx: _ModuleSupport.AxisContext): boolean {
+    const { listeners } = axisCtx;
+    return listeners?.click != null || listeners?.doubleClick != null;
+}
 
 /**
  * The AxisDOMProxy module handles interactions with the axes. In most cases it does this via the dom events on proxy
@@ -65,6 +71,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
     private onLayoutComplete(event: _ModuleSupport.LayoutCompleteEvent) {
         this.seriesRect = event.series.rect;
+        this.refresh();
     }
 
     private onUpdate(event: _ModuleSupport.AxisDOMProxyUpdateEvent) {
@@ -76,12 +83,17 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         this.enableScrolling.set(source, enableScrolling);
         this.enableContextMenu.set(source, enableContextMenu);
 
+        this.refresh();
+    }
+
+    private refresh() {
         const isEnabled =
-            this.isEnabled() &&
-            (this.isEnabledDoubleClick() ||
-                this.isEnabledDragging() ||
-                this.isEnabledScrolling() ||
-                this.isEnabledContextMenu());
+            (this.isEnabled() &&
+                (this.isEnabledDoubleClick() ||
+                    this.isEnabledDragging() ||
+                    this.isEnabledScrolling() ||
+                    this.isEnabledContextMenu())) ||
+            this.hasClickListeners();
 
         for (const axis of this.axes) {
             axis.div.setHidden(!isEnabled);
@@ -135,6 +147,8 @@ export class AxisDOMProxy extends AbstractModuleInstance {
                 this.ctx.widgets.axisWidgets.setRegionBounds(axis.axisId, bbox);
                 axis.bounds = new _ModuleSupport.BBox(bbox.x, bbox.y, bbox.width, bbox.height);
             }
+            // Signal interactivity only on axes that actually have a click listener.
+            axis.div.setCursor(hasAxisClickListener(axisCtx) ? 'pointer' : undefined);
         }
     }
 
@@ -283,6 +297,48 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         return this.ctx.axisManager.getAxisIdContext(axisId)?.pickValue(widgetEvent);
     }
 
+    /**
+     * Fires the `axes[].listeners` callbacks and their chart-level `axisClick` / `axisDoubleClick`
+     * counterparts. The picked value is resolved exactly as it is for the axis context menu.
+     */
+    private dispatchAxisClick(axisId: AxisID, widgetEvent: _Widget.MouseWidgetEvent<'click' | 'dblclick'>) {
+        // Keyboard-synthetic clicks carry no pointer coordinates, so there is nothing to pick.
+        // Keyboard activation is out of scope for this feature (AG-9809).
+        if (widgetEvent.device === 'keyboard') return;
+
+        const axisCtx = this.ctx.axisManager.getAxisIdContext(axisId);
+        const pick = axisCtx?.pickValue(widgetEvent);
+        if (!axisCtx || !pick) return;
+
+        const isDoubleClick = widgetEvent.type === 'dblclick';
+        const { direction, boundSeries, domain, value, index } = pick;
+        const params = {
+            event: widgetEvent.sourceEvent,
+            axisId: pick.axisId,
+            direction,
+            boundSeries,
+            domain,
+            value,
+            index,
+        };
+
+        const listener = isDoubleClick ? axisCtx.listeners?.doubleClick : axisCtx.listeners?.click;
+        if (listener) {
+            // `pick.caller` is the axis, so `axes[].context` takes precedence over `chart.context`.
+            const apiEvent: Omit<AgAxisClickEvent<'click' | 'doubleClick', never>, 'context'> = {
+                type: isDoubleClick ? 'doubleClick' : 'click',
+                ...params,
+            };
+            callWithContext([pick.caller, this.ctx.chartService], listener, apiEvent);
+        }
+
+        // The chart-level listener fires alongside the axis-level one, as `seriesNodeClick` does.
+        const chartEventType = isDoubleClick ? 'axisDoubleClick' : 'axisClick';
+        if (this.ctx.chartService.hasListener(chartEventType)) {
+            this.ctx.chartService.callListener({ type: chartEventType, ...params });
+        }
+    }
+
     private dispatchAxisContextMenu(
         axisId: AxisID,
         widgetEvent: _Widget.MouseWidgetEvent<'contextmenu'>,
@@ -371,6 +427,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             this.ctx.eventsHub.emit('axis-dom-proxy:drag-end', { axisId, direction, event });
         });
         div.addListener('dblclick', (event) => {
+            if (this.hasClickListeners()) this.dispatchAxisClick(axisId, event);
             if (!this.isEnabled() || !this.isEnabledDoubleClick()) return;
             this.ctx.eventsHub.emit('axis-dom-proxy:dblclick', { axisId, direction, event });
         });
@@ -387,6 +444,10 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         div.addListener('wheel', (event) => {
             if (!this.isEnabled() || !this.isEnabledScrolling()) return;
             this.ctx.eventsHub.emit('axis-dom-proxy:wheel', { axisId, direction, event });
+        });
+        div.addListener('click', (event) => {
+            if (!this.hasClickListeners()) return;
+            this.dispatchAxisClick(axisId, event);
         });
         div.addListener('contextmenu', (event) => {
             if (!this.isEnabled() || !this.isEnabledContextMenu()) return;
@@ -412,6 +473,21 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
     private isEnabled() {
         return this.isBooleanMap(this.enabled);
+    }
+
+    /**
+     * Deliberately not named `isEnabledClick`: unlike the `isEnabled*` methods it does not read a
+     * flag requested by another module via `axis-dom-proxy:update`. Click interaction has no
+     * requester — it is implied by the presence of an `axes[].listeners` callback, or of a
+     * chart-level `axisClick` / `axisDoubleClick` listener.
+     */
+    private hasClickListeners() {
+        const { axisManager, chartService } = this.ctx;
+        if (chartService.hasListener('axisClick') || chartService.hasListener('axisDoubleClick')) return true;
+        return [
+            ...axisManager.getAxisContext(ChartAxisDirection.X),
+            ...axisManager.getAxisContext(ChartAxisDirection.Y),
+        ].some((axisCtx) => hasAxisClickListener(axisCtx));
     }
 
     private isEnabledDoubleClick() {

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -12,9 +12,13 @@ type ProxyAxis = {
     bounds?: _ModuleSupport.BBox;
 };
 
-function hasAxisClickListener(axisCtx: _ModuleSupport.AxisContext): boolean {
-    const { listeners } = axisCtx;
-    return listeners?.click != null || listeners?.doubleClick != null;
+function hasAxisClickListener(chartService: _ModuleSupport.ChartService, axisCtx: _ModuleSupport.AxisContext): boolean {
+    return (
+        chartService.hasListener('axisClick') ||
+        chartService.hasListener('axisDoubleClick') ||
+        axisCtx.listeners?.click != null ||
+        axisCtx.listeners?.doubleClick != null
+    );
 }
 
 /**
@@ -106,7 +110,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
     private processAxisDiff() {
         const {
-            ctx: { axisManager },
+            ctx: { axisManager, chartService },
         } = this;
 
         const axesCtx = [
@@ -148,7 +152,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
                 axis.bounds = new _ModuleSupport.BBox(bbox.x, bbox.y, bbox.width, bbox.height);
             }
             // Signal interactivity only on axes that actually have a click listener.
-            axis.div.setCursor(hasAxisClickListener(axisCtx) ? 'pointer' : undefined);
+            axis.div.setCursor(hasAxisClickListener(chartService, axisCtx) ? 'pointer' : undefined);
         }
     }
 
@@ -483,11 +487,10 @@ export class AxisDOMProxy extends AbstractModuleInstance {
      */
     private hasClickListeners() {
         const { axisManager, chartService } = this.ctx;
-        if (chartService.hasListener('axisClick') || chartService.hasListener('axisDoubleClick')) return true;
         return [
             ...axisManager.getAxisContext(ChartAxisDirection.X),
             ...axisManager.getAxisContext(ChartAxisDirection.Y),
-        ].some((axisCtx) => hasAxisClickListener(axisCtx));
+        ].some((axisCtx) => hasAxisClickListener(chartService, axisCtx));
     }
 
     private isEnabledDoubleClick() {

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -1,6 +1,6 @@
 import type { AgAxisClickEvent } from 'ag-charts-community';
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { AxisID, DynamicContext } from 'ag-charts-core';
+import type { AxisID, CanvasPoint, DynamicContext } from 'ag-charts-core';
 import { AbstractModuleInstance, ChartAxisDirection, boxEmpty, callWithContext } from 'ag-charts-core';
 
 type AxisHit = { axisId: AxisID; direction: ChartAxisDirection };

--- a/packages/ag-charts-enterprise/src/main.ts
+++ b/packages/ag-charts-enterprise/src/main.ts
@@ -18,6 +18,7 @@ export { RadiusNumberAxisModule } from './axes/radius-number/radiusNumberAxisMod
 export { PolarCrossLinesModule } from './axes/polar-crosslines/polarCrossLinesModule';
 export { AnimationModule } from './features/animation/animationModule';
 export { AnnotationsModule } from './features/annotations/annotationsModule';
+export { AxisDOMProxyModule as AxisInteractionModule } from './features/axis-dom-proxy/axisDomProxyModule';
 export { BandHighlightModule } from './features/band-highlight/bandHighlightModule';
 export { ChartToolbarModule } from './features/chart-toolbar/chartToolbarModule';
 export { ContextMenuModule } from './features/context-menu/contextMenuModule';

--- a/packages/ag-charts-enterprise/src/module-bundles/cartesian.ts
+++ b/packages/ag-charts-enterprise/src/module-bundles/cartesian.ts
@@ -2,6 +2,7 @@ import type { ModuleDefinition } from 'ag-charts-core';
 
 import { AnimationModule } from '../features/animation/animationModule';
 import { AnnotationsModule } from '../features/annotations/annotationsModule';
+import { AxisDOMProxyModule } from '../features/axis-dom-proxy/axisDomProxyModule';
 import { BandHighlightModule } from '../features/band-highlight/bandHighlightModule';
 import { ChartToolbarModule } from '../features/chart-toolbar/chartToolbarModule';
 import { ContextMenuModule } from '../features/context-menu/contextMenuModule';
@@ -26,6 +27,7 @@ export const AllCartesianModule: ModuleDefinition[] = [
 
     AnimationModule,
     AnnotationsModule,
+    AxisDOMProxyModule,
     BandHighlightModule,
     ChartToolbarModule,
     ContextMenuModule,

--- a/packages/ag-charts-types/src/chart/cartesianOptions.ts
+++ b/packages/ag-charts-types/src/chart/cartesianOptions.ts
@@ -28,6 +28,7 @@ import type {
 } from './crossLineOptions';
 import type { AgBaseCrosshairLabel, AgCrosshairLabel, AgCrosshairOptions } from './crosshairOptions';
 import type { AgNumericValue, AgTimeValue } from './dataValues';
+import type { AgAxisListeners } from './eventOptions';
 import type { AxisValue, ContextDefault, DatumDefault, Degree, PixelSize, Ratio, TextWrap } from './types';
 
 /** Configuration for axes in cartesian charts. */
@@ -55,6 +56,8 @@ export interface AgBaseCartesianAxisOptions<
     title?: AgCartesianAxisCaptionOptions;
     /** Configuration for the axis crosshair. */
     crosshair?: AgCrosshairOptions<CrosshairLabelType>;
+    /** A map of event names to event listeners. */
+    listeners?: AgAxisListeners<TContext>;
 }
 
 export interface AgCartesianAxisCrossAt {

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -2,7 +2,7 @@ import type { AgActiveState } from '../api/activeState';
 import type { AgStateGroupingValueType, AgStateValueType } from '../api/stateTypes';
 import type { TextOrSegments } from '../series/cartesian/commonOptions';
 import type { AgAnnotation } from './annotationsOptions';
-import type { AgAxisCoordinate, AgAxisDirection, AgAxisValue } from './axisOptions';
+import type { AgAxisBoundSeries, AgAxisCoordinate, AgAxisDirection, AgAxisDomain, AgAxisValue } from './axisOptions';
 import type { AgItemType, Listener, SelectionState } from './callbackOptions';
 import type { AgNumericValue } from './dataValues';
 import type { ContextDefault, DatumDefault, Ratio, ResolvedDatumKey } from './types';

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -214,6 +214,31 @@ export interface AgAxisContextMenuActionEvent<TContext = ContextDefault>
     axisId: string;
 }
 
+export interface AgAxisClickEvent<TEvent extends string, TContext = ContextDefault> extends AgChartEvent<
+    TEvent,
+    TContext
+> {
+    /** Axis ID, as specified in `axes` (generated if not specified). */
+    axisId: string;
+    /** The scale value of the axis at this point. */
+    value: AgAxisValue;
+    /** Direction of the clicked axis. */
+    direction: AgAxisDirection;
+    /** The index of the resolved value */
+    index: number;
+    /** Metadata about series bound to the clicked axis. */
+    boundSeries: AgAxisBoundSeries[];
+    /** Computed domain of the axis */
+    domain: AgAxisDomain;
+}
+
+export interface AgAxisListeners<TContext = ContextDefault> {
+    /** The listener to call when the axis is clicked. */
+    click?: Listener<AgAxisClickEvent<'click', TContext>>;
+    /** The listener to call when the axis is double-clicked. */
+    doubleClick?: Listener<AgAxisClickEvent<'doubleClick', TContext>>;
+}
+
 export interface AgCrossLineContextMenuActionEvent<TContext = ContextDefault>
     extends AgChartEvent<'crossLineContextMenuAction', TContext>, AgCoordinatedEvent {
     /** Cross Line ID (generated if not specified). */
@@ -262,6 +287,14 @@ export interface AgBaseChartListeners<TDatum, TContext = ContextDefault> {
     /** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is double-clicked.
      * Useful for a chart containing multiple series.*/
     seriesNodeDoubleClick?: Listener<AgNodeClickEvent<'seriesNodeDoubleClick', TDatum, TContext>>;
+    /** The listener to call when any axis in the chart is clicked.
+     *  Useful for a chart containing multiple axes.
+     */
+    axisClick?: Listener<AgAxisClickEvent<'axisClick', TContext>>;
+    /** The listener to call when any axis in the chart is double-clicked.
+     *  Useful for a chart containing multiple axes.
+     */
+    axisDoubleClick?: Listener<AgAxisClickEvent<'axisDoubleClick', TContext>>;
     /** The listener to call when a series visibility is changed. */
     seriesVisibilityChange?: Listener<AgSeriesVisibilityChange<TContext>>;
     /** The listener to call when the active state (highlight/tooltip) is changed. */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9809

Adds `axes[].listeners.click` / `.doubleClick` to Cartesian axes, plus chart-level `axisClick` / `axisDoubleClick` counterparts that fire alongside them the way `seriesNodeClick` does.

The implementation reuses the axis context-menu path rather than adding a parallel one: the interactive region is the existing axis proxy region shared with axis dragging and right-click, the callback params come from the existing `Axis.pickValue()`, and the dispatch mirrors ContextMenu's axis branch — `callWithContext([pick.caller, chartService], ...)`, so `axes[].context` takes precedence over `chart.context`.

- ag-charts-types: new `AgAxisClickEvent` and `AgAxisListeners`; `listeners` on `AgBaseCartesianAxisOptions`; `axisClick` / `axisDoubleClick` on `AgBaseChartListeners`.
- ag-charts-core / ag-charts-community: option validators for the axis-level and chart-level listeners.
- ag-charts-community: expose the axis's `listeners` on `AxisContext` as a getter, so listeners added or removed by a later `chart.update()` are picked up; widen `ChartServiceEvent` so the chart-level events can be fired through `ChartService.callListener()`.
- ag-charts-enterprise: `AxisDOMProxy` dispatches the callbacks on click and dblclick, and sets a pointer cursor on axes that have a listener. `AxisDOMProxyModule` is additionally exported as `AxisInteractionModule` and registered in the Cartesian bundle, so axis interaction no longer relies on the context-menu or zoom modules pulling it in transitively.

Known limitations, all inherited from reusing the shared axis region:

- The whole axis area is interactive, including the axis line and the axis title, since the title is a nested widget inside the region. This matches current right-click behaviour.
- On continuous axes `value` is the value under the pointer rather than the nearest tick, while `index` is the nearest tick. This is `pickValue()` unchanged.
- `crossAt` axes that overlap the series area do not fire clicks while another module has set their pointer-events to none.

Keyboard activation and polar axes are out of scope. Tests and documentation follow in a separate PR.