### PR TITLE
Add missing release date for 11.3.2

### DIFF
--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -303,7 +303,8 @@
         "notesPath": "./upgrade-to-ag-charts-12"
     },
     {
-        "version": "11.3.2"
+        "version": "11.3.2",
+        "date": "June 4th, 2025"
     },
     {
         "version": "11.3.1",


### PR DESCRIPTION
The `11.3.2` entry in `ag-charts-versions.json` was missing its `date` field, unlike the surrounding entries. Adds `June 4th, 2025`, matching the package's npm publish date and the existing date format.