### PR TITLE
RTI-3421: keep the framework name in the docs page h1, version out

### DIFF
--- a/packages/ag-charts-website/src/components/docs/components/Header.module.scss
+++ b/packages/ag-charts-website/src/components/docs/components/Header.module.scss
@@ -10,9 +10,12 @@
     }
 }
 
+// `display: contents` drops the h1's box so its children are laid out in
+// .pageTitleContainer's grid directly, which is what lets the version share the eyebrow
+// line from outside the heading. Inherited properties still reach the children, so the
+// line height below applies to the title.
 .docsPageTitle {
-    grid-area: title;
-    margin-bottom: $spacing-size-4;
+    display: contents;
     color: var(--color-fg-primary);
 
     @media screen and (min-width: $breakpoint-docs-nav-medium) {
@@ -20,46 +23,52 @@
     }
 }
 
-// Narrow screens stack the metadata, then the controls, then the title. From the
+// Carries the grid placement and trailing space the h1's dropped box would have applied.
+.titleText {
+    grid-area: title;
+    margin-bottom: $spacing-size-4;
+}
+
+// Narrow screens stack the eyebrow, then the controls, then the title. From the
 // docs-search breakpoint up, the controls move to the top right: they span both
-// rows so they sit level with the metadata without pushing the title down.
+// rows so they sit level with the eyebrow without pushing the title down.
 .pageTitleContainer {
     display: grid;
     width: 100%;
-    grid-template-columns: 1fr;
+    grid-template-columns: auto 1fr;
     grid-template-areas:
-        'meta'
-        'actions'
-        'title';
+        'meta version'
+        'actions actions'
+        'title title';
     row-gap: $spacing-size-3;
+    column-gap: $spacing-size-3;
 
     @media screen and (min-width: $breakpoint-docs-search-medium) {
-        grid-template-columns: 1fr auto;
+        grid-template-columns: auto 1fr auto;
         grid-template-areas:
-            'meta actions'
-            'title actions';
-        column-gap: $spacing-size-4;
+            'meta version actions'
+            'title title actions';
     }
 }
 
-// Eyebrow line above the page title, holding the framework name and version.
-.titleMeta {
-    grid-area: meta;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: $spacing-size-3;
-}
-
+// Framework name, inside the h1, so it opts back out of the heading type it inherits.
 .headerFramework {
+    grid-area: meta;
+    align-self: baseline;
     font-size: var(--text-fs-base);
     font-weight: var(--text-semibold);
+    line-height: var(--text-lh-base);
     color: var(--color-text-brand-primary);
 }
 
+// Outside the h1, so it does not read as part of the heading.
 .version {
+    grid-area: version;
+    align-self: baseline;
+    justify-self: start;
     font-size: var(--text-fs-sm);
     font-weight: var(--text-regular);
+    line-height: var(--text-lh-base);
     color: var(--color-text-tertiary);
 }
 

--- a/packages/ag-charts-website/src/components/docs/components/Header.test.tsx
+++ b/packages/ag-charts-website/src/components/docs/components/Header.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { Header } from './Header';
+
+type HeaderProps = Parameters<typeof Header>[0];
+
+const defaultProps: HeaderProps = {
+    title: 'Quick Start',
+    framework: 'react',
+    path: '/react/quick-start/',
+    menuItems: [],
+};
+
+function renderHeader(props: Partial<HeaderProps> = {}) {
+    return renderToStaticMarkup(<Header {...defaultProps} {...props} />);
+}
+
+function getHeadingHtml(props: Partial<HeaderProps> = {}) {
+    const html = renderHeader(props);
+    const heading = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/);
+    if (!heading) {
+        throw new Error(`No <h1> rendered in:\n${html}`);
+    }
+    return heading[1];
+}
+
+describe('Header', () => {
+    it('renders the framework name inside the h1, as search engines index the heading', () => {
+        expect(getHeadingHtml()).toContain('React Charts');
+    });
+
+    it('omits the framework name from the h1 when it is suppressed', () => {
+        const headingHtml = getHeadingHtml({ suppressFrameworkHeader: true });
+
+        expect(headingHtml).not.toContain('React Charts');
+        expect(headingHtml).toContain('Quick Start');
+    });
+
+    it('renders the version outside the h1, so it does not read as part of the heading', () => {
+        const html = renderHeader({ version: '14.1.0' });
+
+        expect(html).toContain('Version 14.1.0');
+        expect(getHeadingHtml({ version: '14.1.0' })).not.toContain('Version 14.1.0');
+    });
+
+    it('marks the page title within the h1, as that is how the Algolia indexer finds it', () => {
+        expect(getHeadingHtml()).toMatch(/<span[^>]*data-page-title[^>]*>Quick Start<\/span>/);
+    });
+});

--- a/packages/ag-charts-website/src/components/docs/components/Header.tsx
+++ b/packages/ag-charts-website/src/components/docs/components/Header.tsx
@@ -35,13 +35,22 @@ export const Header: FunctionComponent<Props> = ({
 
     return (
         <header className={styles.docsPageHeader}>
-            <div className={styles.pageTitleContainer}>
-                <div className={styles.titleMeta}>
+            {/* `#top` is the side navigation's scroll target, so it sits on the container rather than
+                the h1: the h1 is `display: contents` and so has no box to scroll to. */}
+            <div id="top" className={styles.pageTitleContainer}>
+                {/* The framework name must stay inside the h1 to count towards it for SEO; the version
+                    must stay outside it, or it would read as part of the heading. `data-page-title` is
+                    how the Algolia indexer finds the page title within the heading. */}
+                <h1 className={styles.docsPageTitle}>
                     {!suppressFrameworkHeader && (
                         <span className={styles.headerFramework}>{`${getFrameworkDisplayText(framework)} Charts`}</span>
                     )}
-                    {version != null && <span className={styles.version}>{`Version ${version}`}</span>}
-                </div>
+                    <span className={styles.titleText} data-page-title>
+                        {title}
+                    </span>
+                </h1>
+
+                {version != null && <span className={styles.version}>{`Version ${version}`}</span>}
 
                 <div className={styles.headerActions}>
                     {markdownHref != null && <MarkdownActions markdownHref={markdownHref} />}
@@ -49,10 +58,6 @@ export const Header: FunctionComponent<Props> = ({
                         <FrameworkSelectorInsideDocs path={path} currentFramework={framework} menuItems={menuItems} />
                     </div>
                 </div>
-
-                <h1 id="top" className={styles.docsPageTitle}>
-                    <span>{title}</span>
-                </h1>
             </div>
 
             {isEnterprise && (

--- a/packages/ag-charts-website/update-algolia.js
+++ b/packages/ag-charts-website/update-algolia.js
@@ -77,6 +77,13 @@ const cleanContents = (contents) => {
 };
 
 const extractTitle = (titleTag) => {
+    // The h1 also holds the framework name ('React Charts'), which is part of the heading
+    // for SEO but not part of the page title, so the title is marked up explicitly.
+    const pageTitle = titleTag.querySelector('[data-page-title]');
+    if (pageTitle) {
+        return pageTitle.textContent?.trim() ?? '';
+    }
+
     let title = titleTag.firstChild.textContent;
 
     let sibling = titleTag.firstChild.nextSibling;

--- a/packages/ag-charts-website/vitest.config.mjs
+++ b/packages/ag-charts-website/vitest.config.mjs
@@ -20,6 +20,7 @@ export default getViteConfig({
     resolve: {
         alias: {
             // Matches `tsconfig.json`
+            '@ag-website-shared': resolvePath('../../external/ag-website-shared/src'),
             '@astro': resolvePath('src/astro'),
             '@components': resolvePath('src/components'),
             '@design-system': resolvePath('src/design-system'),


### PR DESCRIPTION
Restores the framework name to the docs page `<h1>`, which AG-17860 moved out into a sibling `div` when it restructured the header into a CSS grid. Search engines only index the heading, so the framework name had stopped counting towards it.

The framework name now sits inside the `<h1>`; `Version X.Y.Z` stays outside it, so it doesn't read as part of the heading. They still share the eyebrow line because the `<h1>` is `display: contents`, which places its children in the header grid directly. The page title is now a marked-up element (`data-page-title`) rather than a bare text node, so it can be given a grid area — the Algolia indexer reads that marker, falling back to the h1's text with the framework name stripped.

Header layout is unchanged at every breakpoint — verified by compiling the real SCSS before and after and measuring the rendered header at 420/700/1000/1400px.

Two details specific to this site's header:

- `#top` moves from the h1 to the container. It's the side navigation's scroll target, and a `display: contents` element has no box to scroll to.
- The `line-height` override stays on the h1 rather than moving to the title element. `--line-height-ultra-tight` isn't defined anywhere, so the declaration is invalid at computed-value time and falls back to inheritance; leaving it on the h1 keeps it inheriting from the container, as it does today. (That dead token is pre-existing and left alone.)

`vitest.config.mjs` gains the `@ag-website-shared` alias its own `tsconfig.json` already has, so the new `Header.test.tsx` can resolve the component's imports.

Ported from ag-grid#14696.

RTI-3421