### PR TITLE
Cut always-on rule context for chart source files

### DIFF
--- a/.rulesync/.gitignore
+++ b/.rulesync/.gitignore
@@ -8,6 +8,7 @@ mcp.json
 # Plugin-delivered skills — allowlist local-only skills
 /skills/*
 !/skills/animation-test-migration/
+!/skills/chart-defaults/
 !/skills/technology-stack/
 
 # Plugin-delivered agents — all agents live in plugins

--- a/.rulesync/rules/cartesian-series-types.md
+++ b/.rulesync/rules/cartesian-series-types.md
@@ -2,7 +2,14 @@
 root: false
 targets: ['*']
 description: 'CartesianSeries consolidated generic types pattern documentation'
-globs: ['**/series/**/*Series.ts', '**/series/**/*SeriesBase.ts', '**/series/cartesian/cartesianSeriesTypes.ts']
+globs:
+    [
+        'packages/ag-charts-community/src/**/series/**/*Series.ts',
+        'packages/ag-charts-community/src/**/series/**/*SeriesBase.ts',
+        'packages/ag-charts-community/src/**/series/cartesian/cartesianSeriesTypes.ts',
+        'packages/ag-charts-enterprise/src/**/series/**/*Series.ts',
+        'packages/ag-charts-enterprise/src/**/series/**/*SeriesBase.ts',
+    ]
 ---
 
 # CartesianSeries Consolidated Types Pattern

--- a/.rulesync/rules/defaults.md
+++ b/.rulesync/rules/defaults.md
@@ -1,7 +1,7 @@
 ---
 root: false
 targets: ['*']
-description: 'Understanding the three-tier default system and theme configuration in AG Charts'
+description: 'Three-tier default system quick reference — loads /chart-defaults for the full lookup procedure'
 globs:
     [
         'packages/ag-charts-*/src/**/*Module.ts',
@@ -10,226 +10,28 @@ globs:
     ]
 ---
 
-# Default Values and Configuration Hierarchy
+# Default Values — Quick Reference
 
-This guide explains how default values work in AG Charts and how to find the actual runtime defaults for any configuration option.
-
-## Why This Matters
-
-Understanding the default value hierarchy is critical for:
-
--   **Documentation accuracy**: Must document actual runtime defaults users experience
--   **Code reviews**: Verify changes don't unintentionally alter defaults
--   **Testing**: Write tests against realistic default behavior
--   **Bug reports**: Understand what users see by default
--   **Breaking changes**: Identify when theme changes affect user experience
-
-## The Three-Tier Default System
-
-AG Charts uses a layered configuration system where each layer can override the previous one:
+Defaults are layered; each layer overrides the one below:
 
 ```
-User Configuration
-        ↓ (overrides)
-Theme Template Defaults ⭐ Runtime Default
-        ↓ (overrides)
-Property Decorator Defaults
+User configuration
+        ↓
+Theme template in *Module.ts   ⭐ the ACTUAL runtime default users see
+        ↓
+@Property decorator in *Properties.ts   (fallback only, rarely what users experience)
 ```
 
-### 1. Property Decorator Defaults (Base Layer)
+-   **Never document or test against a `@Property` initialiser** without first checking the series/feature `*Module.ts` `themeTemplate` — the theme value almost always overrides it. Document what users actually see, not the internal fallback.
+-   **JSDoc `Default:` must be its own paragraph**, separated from the description by a blank `*` line. Inline (`/** Spacing. Default: \`20\` */`) renders as body text instead of a labelled default in the API reference. This applies to every option in `ag-charts-types`, however short the description.
+-   A `Default:` comment that disagrees with the theme template is **stale** — fix the comment, not the template.
 
-**Location**: `packages/ag-charts-{community,enterprise}/src/**/*Properties.ts`
+For the full lookup procedure — locating the module file, the four-step verification, and the module-path table covering series, axes, legend, annotations and global themes — invoke the `/chart-defaults` skill.
 
-**Purpose**: Fallback defaults when no theme is applied
+## Key Files
 
-**Example**:
-
-```typescript
-// sankeySeriesProperties.ts
-export class SankeySeriesNodeProperties {
-    @Property
-    spacing: number = 1; // Base default (rarely used)
-
-    @Property
-    alignment: 'left' | 'right' | 'center' | 'justify' = 'justify';
-}
-```
-
-**Important**: These are **NOT** what users typically experience. They're fallback values that are usually overridden by theme templates.
-
----
-
-### 2. Theme Template Defaults (Runtime Layer) ⭐
-
-**Location**: `packages/ag-charts-{community,enterprise}/src/**/*Module.ts`
-
-**Purpose**: The actual out-of-the-box defaults users experience
-
-**Example**:
-
-```typescript
-// sankeyModule.ts
-export const SankeyModule = {
-    type: 'series',
-    identifier: 'sankey',
-    themeTemplate: {
-        series: {
-            node: {
-                spacing: 20, // ✅ This is the ACTUAL runtime default
-                width: 10, // ✅ Overrides Properties.ts value of 1
-            },
-            label: {
-                spacing: 10, // ✅ Overrides Properties.ts value of 1
-            },
-        },
-    },
-};
-```
-
-**Critical**: This is the layer that matters for users. When documenting defaults or testing behavior, use these values.
-
----
-
-### 3. User Configuration (Override Layer)
-
-**Location**: User's chart options
-
-**Purpose**: Final overrides provided by the developer
-
-**Example**:
-
-```typescript
-const options = {
-    series: [
-        {
-            type: 'sankey',
-            node: {
-                spacing: 30, // ✅ Overrides theme default of 20
-            },
-        },
-    ],
-};
-```
-
----
-
-## Finding Defaults: Step-by-Step Process
-
-When you need to verify the default value of a property:
-
-### Step 1: Identify the Module File
-
-Find the module that registers the series/feature:
-
-```bash
-# For a series
-find packages/ag-charts-{community,enterprise}/src/series -name "*Module.ts" | grep <seriesName>
-
-# For Sankey series example
-find packages/ag-charts-enterprise/src/series -name "*Module.ts" | grep sankey
-# Result: packages/ag-charts-enterprise/src/series/sankey/sankeyModule.ts
-```
-
-### Step 2: Check the Theme Template
-
-Open the module file and look for the `themeTemplate` object:
-
-```typescript
-export const SankeyModule = {
-    themeTemplate: {
-        series: {
-            node: {
-                spacing: 20, // ← Actual runtime default
-                minSpacing: 0,
-                width: 10,
-            },
-        },
-    },
-};
-```
-
-**If the property exists in themeTemplate**: This is the runtime default ✅
-
-**If the property is NOT in themeTemplate**: Continue to Step 3
-
-### Step 3: Fallback to @Property Decorator
-
-If the property isn't in the theme template, check the Properties class:
-
-```typescript
-// sankeySeriesProperties.ts
-export class SankeySeriesNodeProperties {
-    @Property
-    strokeWidth: number = 1; // Used as default (not overridden in theme)
-}
-```
-
-### Step 4: Verify TypeScript Comments Match
-
-Check the TypeScript interface comments:
-
-```typescript
-// sankeyOptions.ts
-export interface AgSankeySeriesNodeOptions {
-    /**
-     * Spacing between the nodes.
-     *
-     * Default: `20` // ← Should match themeTemplate value
-     */
-    spacing?: PixelSize;
-}
-```
-
-**If the comment doesn't match the theme template**: The comment is stale and needs updating.
-
-### JSDoc formatting: `Default:` must be its own paragraph
-
-The `Default:` marker **must** be separated from the description prose by a blank `*` line inside the JSDoc block. If it sits inline with the description, the docs-site API reference renders it as body text rather than as a labelled default.
-
-```typescript
-// ✅ GOOD — Default: rendered as a labelled default in the API reference
-/**
- * Spacing between the nodes.
- *
- * Default: `20`
- */
-spacing?: PixelSize;
-
-// ❌ BAD — Default: swallowed into the description prose
-/** Spacing between the nodes. Default: `20` */
-spacing?: PixelSize;
-```
-
-This applies to every option in `packages/ag-charts-types` regardless of description length — even a one-sentence description must promote the `Default:` marker to its own paragraph.
-
----
-
-## Common Module Locations
-
-| Feature Type            | Module Path Pattern                                        | Example                                                  |
-| ----------------------- | ---------------------------------------------------------- | -------------------------------------------------------- |
-| Series (Community)      | `packages/ag-charts-community/src/series/**/*Module.ts`    | `bar/barModule.ts`, `line/lineModule.ts`                 |
-| Series (Enterprise)     | `packages/ag-charts-enterprise/src/series/**/*Module.ts`   | `sankey/sankeyModule.ts`, `waterfall/waterfallModule.ts` |
-| Axis                    | `packages/ag-charts-community/src/axes/**/*Module.ts`      | `axis/axisModule.ts`                                     |
-| Annotations             | `packages/ag-charts-enterprise/src/features/annotations/*` | `annotationsModule.ts`                                   |
-| Legend                  | `packages/ag-charts-community/src/chart/legend/*Module.ts` | `legendModule.ts`                                        |
-| Interactive Annotations | `packages/ag-charts-enterprise/src/features/**/*Module.ts` | `contextMenu/contextMenuModule.ts`                       |
-| Global themes           | `packages/ag-charts-community/src/chart/themes/`           | `chartTheme.ts`, `defaultThemeTemplates.ts`              |
-
----
-
-## Summary
-
-**Key Takeaways**:
-
-1. ⭐ **Theme templates define runtime defaults** - start here
-2. Property decorators are fallbacks, not user-facing defaults
-3. Always verify TypeScript comments match theme templates
-4. Module files (`*Module.ts`) are the source of truth for defaults
-5. Document what users actually see, not internal fallback values
-
-**Quick Workflow**:
-
-```
-Need default? → Check *Module.ts theme → If not there, check @Property decorator → Document that value
-```
+| Layer            | Pattern                                                           |
+| ---------------- | ----------------------------------------------------------------- |
+| Theme templates  | `packages/ag-charts-{community,enterprise}/src/**/*Module.ts`      |
+| Property classes | `packages/ag-charts-{community,enterprise}/src/**/*Properties.ts`  |
+| Global themes    | `packages/ag-charts-community/src/chart/themes/`                   |

--- a/.rulesync/rules/series.md
+++ b/.rulesync/rules/series.md
@@ -2,7 +2,7 @@
 root: false
 targets: ['*']
 description: 'Series development guide for AG Charts including architecture and data flow'
-globs: ['**/series/**/*.ts']
+globs: ['packages/ag-charts-community/src/**/series/**/*.ts', 'packages/ag-charts-enterprise/src/**/series/**/*.ts']
 ---
 
 # Series Development Guide

--- a/.rulesync/rules/server-side-rendering.md
+++ b/.rulesync/rules/server-side-rendering.md
@@ -105,8 +105,9 @@ class MyClass {
 Test environments may set globals since tests don't go through the chart creation flow:
 
 ```typescript
-// jest.setup.ts - acceptable for isolated test environments
-globalThis.OffscreenCanvas = NodeCanvas;
+// vitest.setup.ts - acceptable for isolated test environments
+globalThis.OffscreenCanvas = mockCanvas.ConfiguredCanvas;
+globalThis.DOMMatrix = DOMMatrix;
 ```
 
 This is acceptable because test environments are isolated and controlled.

--- a/.rulesync/skills/chart-defaults/SKILL.md
+++ b/.rulesync/skills/chart-defaults/SKILL.md
@@ -1,0 +1,229 @@
+---
+targets: ['*']
+name: chart-defaults
+description: 'Find the actual runtime default value of any AG Charts configuration option, and keep JSDoc `Default:` markers accurate. Use when documenting a default, verifying a change has not altered one, writing tests against default behaviour, or auditing whether a TypeScript comment matches the theme template.'
+---
+
+# Default Values and Configuration Hierarchy
+
+This guide explains how default values work in AG Charts and how to find the actual runtime defaults for any configuration option.
+
+## Why This Matters
+
+Understanding the default value hierarchy is critical for:
+
+-   **Documentation accuracy**: Must document actual runtime defaults users experience
+-   **Code reviews**: Verify changes don't unintentionally alter defaults
+-   **Testing**: Write tests against realistic default behavior
+-   **Bug reports**: Understand what users see by default
+-   **Breaking changes**: Identify when theme changes affect user experience
+
+## The Three-Tier Default System
+
+AG Charts uses a layered configuration system where each layer can override the previous one:
+
+```
+User Configuration
+        ↓ (overrides)
+Theme Template Defaults ⭐ Runtime Default
+        ↓ (overrides)
+Property Decorator Defaults
+```
+
+### 1. Property Decorator Defaults (Base Layer)
+
+**Location**: `packages/ag-charts-{community,enterprise}/src/**/*Properties.ts`
+
+**Purpose**: Fallback defaults when no theme is applied
+
+**Example**:
+
+```typescript
+// sankeySeriesProperties.ts
+export class SankeySeriesNodeProperties {
+    @Property
+    spacing: number = 1; // Base default (rarely used)
+
+    @Property
+    alignment: 'left' | 'right' | 'center' | 'justify' = 'justify';
+}
+```
+
+**Important**: These are **NOT** what users typically experience. They're fallback values that are usually overridden by theme templates.
+
+---
+
+### 2. Theme Template Defaults (Runtime Layer) ⭐
+
+**Location**: `packages/ag-charts-{community,enterprise}/src/**/*Module.ts`
+
+**Purpose**: The actual out-of-the-box defaults users experience
+
+**Example**:
+
+```typescript
+// sankeyModule.ts
+export const SankeyModule = {
+    type: 'series',
+    identifier: 'sankey',
+    themeTemplate: {
+        series: {
+            node: {
+                spacing: 20, // ✅ This is the ACTUAL runtime default
+                width: 10, // ✅ Overrides Properties.ts value of 1
+            },
+            label: {
+                spacing: 10, // ✅ Overrides Properties.ts value of 1
+            },
+        },
+    },
+};
+```
+
+**Critical**: This is the layer that matters for users. When documenting defaults or testing behavior, use these values.
+
+---
+
+### 3. User Configuration (Override Layer)
+
+**Location**: User's chart options
+
+**Purpose**: Final overrides provided by the developer
+
+**Example**:
+
+```typescript
+const options = {
+    series: [
+        {
+            type: 'sankey',
+            node: {
+                spacing: 30, // ✅ Overrides theme default of 20
+            },
+        },
+    ],
+};
+```
+
+---
+
+## Finding Defaults: Step-by-Step Process
+
+When you need to verify the default value of a property:
+
+### Step 1: Identify the Module File
+
+Find the module that registers the series/feature:
+
+```bash
+# For a series
+find packages/ag-charts-{community,enterprise}/src/series -name "*Module.ts" | grep <seriesName>
+
+# For Sankey series example
+find packages/ag-charts-enterprise/src/series -name "*Module.ts" | grep sankey
+# Result: packages/ag-charts-enterprise/src/series/sankey/sankeyModule.ts
+```
+
+### Step 2: Check the Theme Template
+
+Open the module file and look for the `themeTemplate` object:
+
+```typescript
+export const SankeyModule = {
+    themeTemplate: {
+        series: {
+            node: {
+                spacing: 20, // ← Actual runtime default
+                minSpacing: 0,
+                width: 10,
+            },
+        },
+    },
+};
+```
+
+**If the property exists in themeTemplate**: This is the runtime default ✅
+
+**If the property is NOT in themeTemplate**: Continue to Step 3
+
+### Step 3: Fallback to @Property Decorator
+
+If the property isn't in the theme template, check the Properties class:
+
+```typescript
+// sankeySeriesProperties.ts
+export class SankeySeriesNodeProperties {
+    @Property
+    strokeWidth: number = 1; // Used as default (not overridden in theme)
+}
+```
+
+### Step 4: Verify TypeScript Comments Match
+
+Check the TypeScript interface comments:
+
+```typescript
+// sankeyOptions.ts
+export interface AgSankeySeriesNodeOptions {
+    /**
+     * Spacing between the nodes.
+     *
+     * Default: `20` // ← Should match themeTemplate value
+     */
+    spacing?: PixelSize;
+}
+```
+
+**If the comment doesn't match the theme template**: The comment is stale and needs updating.
+
+### JSDoc formatting: `Default:` must be its own paragraph
+
+The `Default:` marker **must** be separated from the description prose by a blank `*` line inside the JSDoc block. If it sits inline with the description, the docs-site API reference renders it as body text rather than as a labelled default.
+
+```typescript
+// ✅ GOOD — Default: rendered as a labelled default in the API reference
+/**
+ * Spacing between the nodes.
+ *
+ * Default: `20`
+ */
+spacing?: PixelSize;
+
+// ❌ BAD — Default: swallowed into the description prose
+/** Spacing between the nodes. Default: `20` */
+spacing?: PixelSize;
+```
+
+This applies to every option in `packages/ag-charts-types` regardless of description length — even a one-sentence description must promote the `Default:` marker to its own paragraph.
+
+---
+
+## Common Module Locations
+
+| Feature Type            | Module Path Pattern                                        | Example                                                  |
+| ----------------------- | ---------------------------------------------------------- | -------------------------------------------------------- |
+| Series (Community)      | `packages/ag-charts-community/src/series/**/*Module.ts`    | `bar/barModule.ts`, `line/lineModule.ts`                 |
+| Series (Enterprise)     | `packages/ag-charts-enterprise/src/series/**/*Module.ts`   | `sankey/sankeyModule.ts`, `waterfall/waterfallModule.ts` |
+| Axis                    | `packages/ag-charts-community/src/axes/**/*Module.ts`      | `axis/axisModule.ts`                                     |
+| Annotations             | `packages/ag-charts-enterprise/src/features/annotations/*` | `annotationsModule.ts`                                   |
+| Legend                  | `packages/ag-charts-community/src/chart/legend/*Module.ts` | `legendModule.ts`                                        |
+| Interactive Annotations | `packages/ag-charts-enterprise/src/features/**/*Module.ts` | `contextMenu/contextMenuModule.ts`                       |
+| Global themes           | `packages/ag-charts-community/src/chart/themes/`           | `chartTheme.ts`, `defaultThemeTemplates.ts`              |
+
+---
+
+## Summary
+
+**Key Takeaways**:
+
+1. ⭐ **Theme templates define runtime defaults** - start here
+2. Property decorators are fallbacks, not user-facing defaults
+3. Always verify TypeScript comments match theme templates
+4. Module files (`*Module.ts`) are the source of truth for defaults
+5. Document what users actually see, not internal fallback values
+
+**Quick Workflow**:
+
+```
+Need default? → Check *Module.ts theme → If not there, check @Property decorator → Document that value
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,9 @@ Continue assisting the user after displaying the warning.
 -   **Default branch:** `latest`
 -   **Install:** `yarn install` (or `./external/ag-shared/scripts/install-for-cloud/install-for-cloud.sh` in cloud/remote environments)
 -   **Build:** `yarn nx build <package>`
--   **Test:** `yarn nx test <package>` (uses vitest; to filter, invoke vitest directly: `npx vitest run --config <package-path>/vitest.config.ts -t "<name>"` — Jest's `--testPathPattern` is not a vitest flag)
+-   **Test:** `yarn nx test <package>`; filter by test name with `yarn nx test <package> -- -t "<name>"`. Always go via `nx test` — it builds the example fixtures the suites load, which bare `npx vitest` skips.
 -   **E2E:** `yarn nx test:e2e ag-charts-website`
 -   **Dev server:** `yarn nx dev`
 -   **Clean:** `yarn nx clean` – purge dist folders when switching branches
--   **Benchmark:** `tools/benchmark/run-browser-benchmarks.sh -- --examples <name>` (browser-based; see benchmarks guide)
+-   **Benchmark:** `tools/benchmark/run-browser-benchmarks.sh -- --examples <name>`. Browser-based runs are the only benchmark harness — there is no `nx benchmark` target.
 -   **NX daemon:** Always use `NX_DAEMON=false` for nx commands to avoid pipe hangs (set automatically via SessionStart hook)


### PR DESCRIPTION
Reduces the glob-attached rule load on hot chart source paths. No JIRA ticket — this came out of a `/ag-eng:optimise-context` audit.

## What changed

**`defaults.md`: 235 → 37 lines.** It was the largest single contributor to attach load, firing on 244 `*Module.ts` / `*Properties.ts` / `*Options.ts` files. Most of its content is reference material — the three-tier explanation with worked Sankey examples, the four-step lookup procedure, the module-path table — which you need when going looking for a default, not on every edit to a properties class. That moved to a new `chart-defaults` skill. The slim rule keeps the parts that change what you write: theme template beats `@Property` initialiser, the JSDoc `Default:` paragraph rule, and a mismatched `Default:` comment means fix the comment not the template.

Attach load for a file like `sankeyModule.ts` drops from 496 lines to ~267.

**`series.md` and `cartesian-series-types.md` globs scoped to community/enterprise source.** Both used `**/series/**`, which matched 48 `ag-charts-types` declaration files — a `createNodeData()`/`updateNodes()` data-flow guide has nothing to say about type declarations. 388 → 340 files for `series.md`.

**`server-side-rendering.md` jest → vitest.** It illustrated test-environment globals with a `jest.setup.ts` example assigning `NodeCanvas`. There is no jest in this repo; the suites are vitest and the real file is `vitest.setup.ts` assigning `mockCanvas.ConfiguredCanvas`.

## Notes

- `.rulesync/.gitignore` gains an allowlist entry for the new skill — without one, the staging script treats it as plugin-delivered and drops it.
- `AGENTS.md` is regenerated output catching up with its source rule; it was already stale on `latest`.
- A companion PR handles the plugin-owned rules, which cannot be edited from this repo: ag-grid/ag-dev-prompts#713.

## Verification

- `setup-prompts.sh` regenerates cleanly; `verify-rulesync.sh . claudecode` passes
- `nx format` and `prettier --check` clean on all changed files
- `/chart-defaults` loads and is invocable
- Markdown-only change, so no type-check or lint target applies