### PR TITLE
Use Java 21 for the release Sonar scan

### DIFF
--- a/.github/workflows/sonar-scanner-release.yml
+++ b/.github/workflows/sonar-scanner-release.yml
@@ -44,7 +44,7 @@ jobs:
             - uses: actions/setup-java@v4
               with:
                   distribution: 'oracle'
-                  java-version: '17'
+                  java-version: '21'
 
             - name: Run Scan
               run: |


### PR DESCRIPTION
SonarCloud has dropped support for Java 17 analysis. The `Sonar Scanner (Release)` workflow pins `setup-java` to 17, so the post-release scan aborts immediately:

> The version of Java (17) used to run this analysis is deprecated, and SonarQube Cloud no longer supports it. Please upgrade to Java 21 or later.

Bumping to Java 21 unblocks it. Verified by dispatching the fixed workflow against `b14.1.0` to produce that release's Sonar report.

The dev-branch scan in `ci.yml` is unaffected — `sonarsource/sonarqube-scan-action` bundles its own JRE.