### PR TITLE
ci(jira-agent): enable the in-flight-agent interlock (AG-17369)

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -327,7 +327,11 @@ jobs:
             (github.event.workflow_run.conclusion == 'success' ||
              github.event.workflow_run.conclusion == 'cancelled')
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        # Must be >= agent_interlock_wait_minutes + 5 (below). The interlock
+        # WAITS for an in-flight agent run before promoting; a wait longer than
+        # this job budget would be killed mid-wait and the ticket would never be
+        # promoted at all — a strand worse than the early handback it prevents.
+        timeout-minutes: 25
         permissions:
             contents: read
             # actions: read — the handler reads this CI run's own jobs
@@ -364,6 +368,13 @@ jobs:
             - id: handler
               uses: ./.ag-dev-prompts/node_modules/@ag-grid/dev-prompts/.github/actions/jira-ci-success-handler
               with:
+                  # In-flight-agent interlock (AG-17369). A pr-iterate agent pushes
+                  # mid-run, that push fires CI, CI goes green — and without this the
+                  # handback lands while the agent is still working (AG-17369: 28 min
+                  # early; its later edits hit an already-`done` ticket). Wait for the
+                  # run named by `AI run url` first. Fail-open: an exhausted wait
+                  # promotes anyway. Paired with timeout-minutes above.
+                  agent_interlock_wait_minutes: 20
                   head_branch: ${{ github.event.workflow_run.head_branch }}
                   head_sha: ${{ github.event.workflow_run.head_sha }}
                   run_url: ${{ github.event.workflow_run.html_url }}


### PR DESCRIPTION
Activates the **in-flight-agent interlock** on this repo's `jira-agent-pipeline.yml` stub. Two lines in the `ci-success-handler` job; everything else is untouched.

## What it fixes

A `pr-iterate` agent pushes mid-run → that push fires `pull_request` CI → CI goes green → the green-CI handler promotes the ticket to `Needs Review` **while the agent is still working**.

On [AG-17369](https://github.com/ag-grid/ag-grid/actions/runs/30992989322) the agent pushed at minute 24, CI went green at minute 34, the handler promoted at 10:01:57Z — and the agent carried on until 10:29Z. So the reviewer was pinged **28 minutes early**, the agent's later edits landed on a ticket already marked `AI status=done`, and its final PR-body edit was lost.

Nothing in the gate could catch it. Its own log line reads `eligible=true stale=false pr=open aiStatus=pr-iterating headSha=75f560923 prHeadSha=75f560923` — `pr-iterating` *is* eligible, and the SHAs match because **the SHA the agent pushed is the one CI ran against**.

Root cause of the concurrency: this workflow's `concurrency.group` resolves to `claude-<ISSUE_KEY>` for a `repository_dispatch` but `claude-<head_branch>` for a `workflow_run`, so GitHub never serialised the two runs.

## The change

```yaml
    ci-success-handler:
-       timeout-minutes: 5
+       timeout-minutes: 25
        # …
            - id: handler
              with:
+                 agent_interlock_wait_minutes: 20
```

The handler now waits for the run named by `AI run url` (live `actions/runs/{id}` status poll, every 30s) before promoting, then re-reads every gate input — so an agent that pushed *again* during the wait is caught by the existing stale-SHA guard and the newer CI's own handler promotes.

> [!IMPORTANT]
> **Both lines must land together.** `agent_interlock_wait_minutes` without the raised `timeout-minutes` is the one unsafe combination: the job would be SIGKILLed mid-wait and the ticket would **never be promoted at all** — a strand strictly worse than the early handback. The invariant is `timeout-minutes >= wait + 5`.

Fail-open throughout — an unreadable `AI run url`, a malformed URL, a failed run lookup or an exhausted wait all promote exactly as before. The handler also refuses to wait on its own `GITHUB_RUN_ID`. Values clamp at 45 minutes.

## Cost

An extra idle `ubuntu-latest` job-minute only when an agent is genuinely still running for that ticket — and only up to 20. In the common case (agent already exited) the run lookup returns `completed` and the handler proceeds immediately, with one extra API call.

## Verification

Semantic diff of the parsed YAML confirms: `ci-success-handler.timeout-minutes` 5 → 25, exactly one new `with` key, no existing key changed or removed, and **every other job byte-identical** after parse.

## Merge ordering — DRAFT until the shared action ships

The `agent_interlock_wait_minutes` input is added by **ag-dev-prompts [PR #715](https://github.com/ag-grid/ag-dev-prompts/pull/715)**. This repo installs `@ag-grid/dev-prompts` from the **`canary`** channel, so this PR can be marked ready and merged **as soon as #715 merges to `canary`** and the auto-bump publishes.

Merging earlier is not dangerous — an undeclared composite-action input is a warning, not an error, so the handler would simply behave as it does today — but the raised `timeout-minutes` would be doing nothing until the input exists.
