### PR TITLE
AG-14332 Phase 1: Refactor how `Series` creates click events

### DIFF
--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -79,11 +79,11 @@ import { ChartOverlays } from './overlay/chartOverlays';
 import { getLoadingSpinner } from './overlay/loadingSpinner';
 import { getValidationOverlay } from './overlay/validationOverlay';
 import { SeriesArea } from './series-area/seriesArea';
-import { Series, SeriesGroupingChangedEvent, SeriesNodeEvent, type UnknownSeries } from './series/series';
+import { Series, SeriesGroupingChangedEvent, type UnknownSeries } from './series/series';
 import { type SeriesAreaChartDependencies, SeriesAreaManager } from './series/seriesAreaManager';
 import { SeriesLayerManager } from './series/seriesLayerManager';
 import type { SeriesProperties } from './series/seriesProperties';
-import type { DatumIndex, ISeries, ISeriesProperties, SeriesNodeDatum } from './series/seriesTypes';
+import type { DatumIndex, INodeEvent, ISeries, ISeriesProperties, SeriesNodeDatum } from './series/seriesTypes';
 import { Tooltip, type TooltipContent } from './tooltip/tooltip';
 import { DataWindowProcessor } from './update/dataWindowProcessor';
 import { OverlaysProcessor } from './update/overlaysProcessor';
@@ -1682,11 +1682,11 @@ export abstract class Chart extends Observable implements ModuleInstance, ChartS
         );
     }
 
-    private readonly onSeriesNodeClick = (event: SeriesNodeEvent<any>) => {
+    private readonly onSeriesNodeClick = (event: INodeEvent) => {
         this.fireEvent(event);
     };
 
-    private readonly onSeriesNodeDoubleClick = (event: SeriesNodeEvent<any>) => {
+    private readonly onSeriesNodeDoubleClick = (event: INodeEvent) => {
         this.fireEvent(event);
     };
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -239,6 +239,14 @@ export class AreaSeries extends PlacedLabelCartesianSeries<AreaSeriesTypes> {
 
     override properties = new AreaSeriesProperties();
 
+    protected override createNodeParams(datum: MarkerSelectionDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
+        };
+    }
+
     override connectsToYAxis = true;
 
     private readonly aggregationManager = new AggregationManager<AreaSeriesDataAggregationFilter>();

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -329,6 +329,14 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
 
     override properties = new BarSeriesProperties();
 
+    protected override createNodeParams(datum: BarNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
+        };
+    }
+
     override connectsToYAxis = true;
 
     private readonly aggregationManager = new AggregationManager<BarSeriesDataAggregationFilter>();

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -309,6 +309,8 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
     protected override createNodeParams(datum: BubbleScatterNodeDatum) {
         return {
             ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
             sizeKey: this.properties.sizeKey,
             colorKey: this.properties.colorKey,
         };

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -39,7 +39,6 @@ import {
     type AgBubbleSeriesOptionsKeys,
     type AgBubbleSeriesStylerParams,
     type AgBubbleSeriesStylerResult,
-    type AgCoordinates,
     type AgDrawingMode,
     type AgErrorBoundSeriesTooltipRendererParams,
     type AgNumericValue,
@@ -49,7 +48,6 @@ import {
     type FillOptions,
     type FormatterPropertyType,
     type LineDashOptions,
-    type SelectionState as PublicSelectionState,
     type StrokeOptions,
 } from 'ag-charts-types';
 
@@ -103,7 +101,6 @@ import {
     type ErrorBoundSeriesNodeDatum,
     HighlightState,
     type SelectionState,
-    type SeriesNodeEventTypes,
 } from '../seriesTypes';
 import {
     type BubbleAggregation,
@@ -116,7 +113,6 @@ import {
 import { BubbleScatterSeriesProperties, BubbleSeriesProperties } from './bubbleSeriesProperties';
 import {
     CartesianSeries,
-    CartesianSeriesNodeEvent,
     DEFAULT_CARTESIAN_DIRECTION_KEYS,
     DEFAULT_CARTESIAN_DIRECTION_NAMES,
 } from './cartesianSeries';
@@ -176,27 +172,6 @@ type BubbleStylerApply = MarkerStyleApply<
     BubbleScatterNodeDatum,
     ReturnType<BubbleSeries['getStyle']>
 >;
-
-class BubbleScatterSeriesNodeEvent<
-    TEvent extends string = SeriesNodeEventTypes,
-> extends CartesianSeriesNodeEvent<TEvent> {
-    readonly sizeKey?: string;
-    readonly colorKey?: string;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: BubbleScatterNodeDatum,
-        series: BubbleSeries,
-        selectionState: PublicSelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.sizeKey = series.properties.sizeKey;
-        this.colorKey = series.properties.colorKey;
-    }
-}
 
 export interface BubbleScatterNodeDatum extends CartesianSeriesNodeDatum, ErrorBoundSeriesNodeDatum {
     readonly point: Readonly<SizedPoint>;
@@ -331,7 +306,13 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
     static override readonly className: string = 'BubbleSeries';
     static readonly type: string = 'bubble';
 
-    protected override readonly NodeEvent = BubbleScatterSeriesNodeEvent;
+    protected override createNodeParams(datum: BubbleScatterNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            sizeKey: this.properties.sizeKey,
+            colorKey: this.properties.colorKey,
+        };
+    }
 
     override properties: BubbleScatterSeriesProperties = new BubbleSeriesProperties();
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -166,14 +166,6 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         return this.contextNodeData?.nodeData;
     }
 
-    protected override createNodeParams(datum: DatumOf<TTypes>) {
-        return {
-            ...super.createNodeParams(datum),
-            xKey: this.properties.xKey,
-            yKey: this.properties.yKey,
-        };
-    }
-
     private readonly paths: SegmentedPath[];
     protected readonly dataNodeGroup = this.contentGroup.appendChild(
         new SegmentedGroup({ name: `${this.id}-series-dataNodes`, zIndex: 1 })

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeries.ts
@@ -22,7 +22,7 @@ import {
     maxValue,
     minValue,
 } from 'ag-charts-core';
-import type { AgCoordinates, AgDrawingMode, AgNumericValue, SelectionState } from 'ag-charts-types';
+import type { AgDrawingMode, AgNumericValue } from 'ag-charts-types';
 
 import type { HighlightNodeDatum } from '../../../core/eventsHub';
 import type { AnimationValue } from '../../../motion/animation';
@@ -52,9 +52,8 @@ import type {
     SeriesDirectionKeysMapping,
     SeriesNodePickMatch,
 } from '../series';
-import { SeriesNodeEvent } from '../series';
 import { Segmentation, SeriesProperties } from '../seriesProperties';
-import type { ISeries, ISeriesProperties, SeriesNodeDatum, SeriesNodeEventTypes } from '../seriesTypes';
+import type { SeriesNodeDatum } from '../seriesTypes';
 import { type ShapeFillBBox } from '../shapeUtil';
 import { countExpandingSearch, visibleRangeIndices } from '../util';
 import type {
@@ -100,27 +99,6 @@ export const DEFAULT_CARTESIAN_DIRECTION_NAMES = {
     [ChartAxisDirection.X]: ['xName' as const],
     [ChartAxisDirection.Y]: ['yName' as const],
 };
-
-export class CartesianSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeEvent<
-    SeriesNodeDatum,
-    TEvent
-> {
-    readonly xKey?: string;
-    readonly yKey?: string;
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: SeriesNodeDatum,
-        series: ISeries<SeriesNodeDatum, ISeriesProperties & { xKey?: string; yKey?: string }>,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.xKey = series.properties.xKey;
-        this.yKey = series.properties.yKey;
-    }
-}
 
 type CartesianAnimationState = 'empty' | 'ready' | 'waiting' | 'clearing' | 'disabled';
 type CartesianAnimationEvent<TTypes extends CartesianSeriesTypes> = {
@@ -188,7 +166,13 @@ export abstract class CartesianSeries<TTypes extends CartesianSeriesTypes> exten
         return this.contextNodeData?.nodeData;
     }
 
-    protected override readonly NodeEvent = CartesianSeriesNodeEvent;
+    protected override createNodeParams(datum: DatumOf<TTypes>) {
+        return {
+            ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
+        };
+    }
 
     private readonly paths: SegmentedPath[];
     protected readonly dataNodeGroup = this.contentGroup.appendChild(

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts
@@ -120,8 +120,6 @@ export interface CartesianMarkerLikeContext<
  * CartesianSeriesProperties class implements this interface.
  */
 export interface CartesianSeriesPropertiesBase<T extends object> extends SeriesProperties<T> {
-    xKey?: string;
-    yKey?: string; // optional, because some series like range-area, range-bar, boxplot use different Y keys
     xKeyAxis: string;
     yKeyAxis: string;
     legendItemName?: string;

--- a/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/cartesianSeriesTypes.ts
@@ -120,6 +120,8 @@ export interface CartesianMarkerLikeContext<
  * CartesianSeriesProperties class implements this interface.
  */
 export interface CartesianSeriesPropertiesBase<T extends object> extends SeriesProperties<T> {
+    xKey?: string;
+    yKey?: string; // optional, because some series like range-area, range-bar, boxplot use different Y keys
     xKeyAxis: string;
     yKeyAxis: string;
     legendItemName?: string;

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -190,6 +190,8 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
     protected override createNodeParams(datum: HistogramNodeDatum) {
         return {
             ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
             binIndex: datum.binIndex,
             binRange: datum.binRange,
             aggregatedValue: datum.aggregatedValue,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -44,14 +44,12 @@ import {
     toNumber,
 } from 'ag-charts-core';
 import type {
-    AgCoordinates,
     AgHistogramSeriesBinParams,
     AgHistogramSeriesItemStylerParams,
     AgHistogramSeriesLabelFormatterParams,
     AgHistogramSeriesOptions,
     AgHistogramSeriesStylerParams,
     AgNumericValue,
-    SelectionState as PublicSelectionState,
 } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../../module/moduleContext';
@@ -106,7 +104,7 @@ import {
 } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation } from '../seriesLabelUtil';
 import { toHighlightString } from '../seriesProperties';
-import { HighlightState, type SeriesNodeEventTypes } from '../seriesTypes';
+import { HighlightState } from '../seriesTypes';
 import { getItemStyles } from '../util';
 import {
     collapsedStartingBarPosition,
@@ -117,7 +115,6 @@ import {
 } from './barUtil';
 import {
     CartesianSeries,
-    CartesianSeriesNodeEvent,
     DEFAULT_CARTESIAN_DIRECTION_KEYS,
     DEFAULT_CARTESIAN_DIRECTION_NAMES,
 } from './cartesianSeries';
@@ -184,36 +181,21 @@ interface HistogramSeriesNodeDatumContext extends CartesianCreateNodeDataContext
     readonly labelFit: LabelFit | undefined;
 }
 
-class HistogramSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends CartesianSeriesNodeEvent<TEvent> {
-    readonly binIndex: number;
-    readonly binRange: [AgNumericValue, AgNumericValue];
-    readonly aggregatedValue: AgNumericValue;
-    readonly frequency: number;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: HistogramNodeDatum,
-        series: HistogramSeries,
-        selectionState: PublicSelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.binIndex = datum.binIndex;
-        this.binRange = datum.binRange;
-        this.aggregatedValue = datum.aggregatedValue;
-        this.frequency = datum.frequency;
-    }
-}
-
 export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
     static override readonly className = 'HistogramSeries';
     static readonly type = 'histogram' as const;
 
     override properties = new HistogramSeriesProperties();
 
-    protected override readonly NodeEvent = HistogramSeriesNodeEvent;
+    protected override createNodeParams(datum: HistogramNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            binIndex: datum.binIndex,
+            binRange: datum.binRange,
+            aggregatedValue: datum.aggregatedValue,
+            frequency: datum.frequency,
+        };
+    }
 
     constructor(moduleCtx: DynamicContext<ChartRegistry>) {
         super({

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -170,6 +170,14 @@ export class LineSeries extends PlacedLabelCartesianSeries<LineSeriesTypes> {
 
     override properties = new LineSeriesProperties();
 
+    protected override createNodeParams(datum: LineNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
+        };
+    }
+
     private readonly aggregationManager = new AggregationManager<LineSeriesDataAggregationFilter>();
     private hideWithSize0 = false;
 

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -34,7 +34,6 @@ import {
     wrapTextOrSegments,
 } from 'ag-charts-core';
 import type {
-    AgCoordinates,
     AgDonutCalloutLineItemStylerParams,
     AgDonutCalloutLineItemStylerResult,
     AgDonutSeriesCalloutOptions,
@@ -46,7 +45,6 @@ import type {
     AgPieSeriesItemStylerParams,
     AgPieSeriesLabelFormatterParams,
     NormalisedCallbackParams,
-    SelectionState,
 } from 'ag-charts-types';
 
 import type { ChartRegistry } from '../../../module/moduleContext';
@@ -80,10 +78,10 @@ import type { LegendSymbolOptions } from '../../legend/legendSymbol';
 import { Marker } from '../../marker/marker';
 import { type TooltipContent } from '../../tooltip/tooltip';
 import type { DataModelSeriesNodeDatum } from '../dataModelSeries';
-import { SeriesNodeEvent, type SeriesNodePickMatch, SeriesNodePickMode } from '../series';
+import { type SeriesNodePickMatch, SeriesNodePickMode } from '../series';
 import { resetLabelFn, seriesLabelFadeInAnimation, seriesLabelFadeOutAnimation } from '../seriesLabelUtil';
 import { isUnselected } from '../seriesProperties';
-import type { HighlightState, SeriesNodeEventTypes } from '../seriesTypes';
+import type { HighlightState } from '../seriesTypes';
 import type { DonutInnerLabel, DonutTitle } from './donutSeriesProperties';
 import { DonutSeriesProperties } from './donutSeriesProperties';
 import {
@@ -98,31 +96,6 @@ import {
     type PolarAnimationData,
     PolarSeries,
 } from './polarSeries';
-
-class PieDonutSeriesNodeEvent<TEvent extends string = SeriesNodeEventTypes> extends SeriesNodeEvent<
-    PieDonutNodeDatum,
-    TEvent
-> {
-    readonly angleKey: string;
-    readonly radiusKey?: string;
-    readonly calloutLabelKey?: string;
-    readonly sectorLabelKey?: string;
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: PieDonutNodeDatum,
-        series: DonutSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.angleKey = series.properties.angleKey;
-        this.radiusKey = series.properties.radiusKey;
-        this.calloutLabelKey = series.properties.calloutLabelKey;
-        this.sectorLabelKey = series.properties.sectorLabelKey;
-    }
-}
 
 interface PieDonutLabelDatum {
     readonly text: NormalisedTextOrSegments;
@@ -1721,7 +1694,15 @@ export class DonutSeries extends PolarSeries<
         this.zerosumInnerRing.size = this.getInnerRadius() * 2;
     }
 
-    protected override readonly NodeEvent = PieDonutSeriesNodeEvent;
+    protected override createNodeParams(datum: PieDonutNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            angleKey: this.properties.angleKey,
+            radiusKey: this.properties.radiusKey,
+            calloutLabelKey: this.properties.calloutLabelKey,
+            sectorLabelKey: this.properties.sectorLabelKey,
+        };
+    }
 
     protected override pickNodeClosestDatum(point: Point): SeriesNodePickMatch | undefined {
         return pickByMatchingAngle(this, point);

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -43,7 +43,7 @@ import type {
     AgCoordinates,
     AgDrawingMode,
     AgInitialStateLegendOptions,
-    AgNumericValue,
+    AgNodeParams,
     AgSeriesTooltipRendererParams,
     AgSeriesVisibilityChange,
     FormatterParams,
@@ -92,7 +92,6 @@ import {
     type INodeEvent,
     type ISeries,
     type ISeriesAriaMeta,
-    type ISeriesProperties,
     type NodeDataDependencies,
     SelectionState,
     type SeriesNodeDatum,
@@ -161,62 +160,8 @@ export type PickResult = {
 
 export type PickNodesInBBoxPredicate = (selectionBox: BoxBounds, node: Node<unknown>) => boolean;
 
-export type INodeEventConstructor<
-    TDatum extends SeriesNodeDatum,
-    TSeries extends Series<TDatum, object, any>,
-    TEvent extends string = SeriesNodeEventTypes,
-> = new <T extends TEvent>(
-    type: T,
-    event: Event,
-    nodeDatum: TDatum,
-    series: TSeries,
-    selectionState: PublicSelectionState | undefined,
-    isCollapsed: boolean | undefined,
-    coordinates: AgCoordinates | undefined
-) => INodeEvent<T>;
-
 const CROSS_FILTER_MARKER_FILL_OPACITY_FACTOR = 0.25;
 const CROSS_FILTER_MARKER_STROKE_OPACITY_FACTOR = 0.125;
-
-export class SeriesNodeEvent<
-    TDatum extends SeriesNodeDatum,
-    TEvent extends string = SeriesNodeEventTypes,
-> implements INodeEvent<TEvent> {
-    readonly datum: unknown;
-    readonly datums?: unknown[];
-    readonly totalValue?: AgNumericValue;
-    readonly seriesId: string;
-    readonly itemId: string | number;
-    readonly dataIdKey: string | undefined;
-    readonly selectionState: PublicSelectionState | undefined;
-    readonly isCollapsed: boolean | undefined;
-    readonly coordinates: AgCoordinates | undefined;
-    defaultPrevented = false;
-
-    constructor(
-        readonly type: TEvent,
-        readonly event: Event,
-        nodeDatum: TDatum,
-        series: ISeries<TDatum, ISeriesProperties, unknown>,
-        selectionState: PublicSelectionState | undefined,
-        isCollapsed: boolean | undefined = undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        this.datum = nodeDatum.datum;
-        this.datums = nodeDatum.datums;
-        this.totalValue = nodeDatum.totalValue;
-        this.seriesId = series.id;
-        this.dataIdKey = series.data?.dataIdKey;
-        this.itemId = getItemId(nodeDatum, this.dataIdKey);
-        this.selectionState = selectionState;
-        this.isCollapsed = isCollapsed;
-        this.coordinates = coordinates;
-    }
-
-    public preventDefault() {
-        this.defaultPrevented = true;
-    }
-}
 
 export type SeriesNodeDataContext<S = SeriesNodeDatum, L = S> = {
     itemId: string;
@@ -342,8 +287,6 @@ export abstract class Series<
         },
     })
     seriesGrouping: SeriesGrouping | undefined = undefined;
-
-    protected readonly NodeEvent: INodeEventConstructor<TDatum, any> = SeriesNodeEvent;
 
     readonly internalId = createId(this);
 
@@ -639,16 +582,16 @@ export abstract class Series<
     }>();
 
     override addEventListener(type: 'seriesVisibilityChange', listener: (e: AgSeriesVisibilityChange) => void): void;
-    override addEventListener(type: 'seriesNodeClick', listener: (e: SeriesNodeEvent<any>) => void): void;
-    override addEventListener(type: 'seriesNodeDoubleClick', listener: (e: SeriesNodeEvent<any>) => void): void;
+    override addEventListener(type: 'seriesNodeClick', listener: (e: INodeEvent) => void): void;
+    override addEventListener(type: 'seriesNodeDoubleClick', listener: (e: INodeEvent) => void): void;
     override addEventListener(type: string, listener: TypedEventListener): void;
     override addEventListener(type: string, listener: TypedEventListener | ((e: unknown) => void)): void {
         return super.addEventListener(type, listener);
     }
 
     override removeEventListener(type: 'seriesVisibilityChange', listener: (e: AgSeriesVisibilityChange) => void): void;
-    override removeEventListener(type: 'seriesNodeClick', listener: (e: SeriesNodeEvent<any>) => void): void;
-    override removeEventListener(type: 'seriesNodeDoubleClick', listener: (e: SeriesNodeEvent<any>) => void): void;
+    override removeEventListener(type: 'seriesNodeClick', listener: (e: INodeEvent) => void): void;
+    override removeEventListener(type: 'seriesNodeDoubleClick', listener: (e: INodeEvent) => void): void;
     override removeEventListener(type: string, listener: TypedEventListener): void;
     override removeEventListener(type: string, listener: TypedEventListener | ((e: unknown) => void)): void {
         return super.removeEventListener(type, listener);
@@ -1261,33 +1204,13 @@ export abstract class Series<
     }
 
     fireNodeClickEvent(event: Event, datum: TDatum, coordinates: AgCoordinates | undefined): boolean {
-        const selectionState = this.getSelectionStateString(datum.datumIndex);
-        const isCollapsed = datum.itemId == null ? undefined : this.getCollapsedState(datum.itemId);
-        const clickEvent = new this.NodeEvent(
-            'seriesNodeClick',
-            event,
-            datum,
-            this,
-            selectionState,
-            isCollapsed,
-            coordinates
-        );
+        const clickEvent = this.createNodeEvent('seriesNodeClick', event, datum, coordinates);
         this.fireEvent(clickEvent);
         return !clickEvent.defaultPrevented;
     }
 
     fireNodeDoubleClickEvent(event: Event, datum: TDatum, coordinates: AgCoordinates | undefined): boolean {
-        const selectionState = this.getSelectionStateString(datum.datumIndex);
-        const isCollapsed = datum.itemId == null ? undefined : this.getCollapsedState(datum.itemId);
-        const clickEvent = new this.NodeEvent(
-            'seriesNodeDoubleClick',
-            event,
-            datum,
-            this,
-            selectionState,
-            isCollapsed,
-            coordinates
-        );
+        const clickEvent = this.createNodeEvent('seriesNodeDoubleClick', event, datum, coordinates);
         this.fireEvent(clickEvent);
         return !clickEvent.defaultPrevented;
     }
@@ -1297,17 +1220,43 @@ export abstract class Series<
         datum: TDatum,
         coordinates: AgCoordinates | undefined
     ): INodeEvent<'nodeContextMenuAction'> {
-        const selectionState = this.getSelectionStateString(datum.datumIndex);
-        const isCollapsed = datum.itemId == null ? undefined : this.getCollapsedState(datum.itemId);
-        return new this.NodeEvent(
-            'nodeContextMenuAction',
+        return this.createNodeEvent('nodeContextMenuAction', event, datum, coordinates);
+    }
+
+    // Do not override. Override createNodeParams instead.
+    private createNodeEvent<T extends SeriesNodeEventTypes>(
+        type: T,
+        event: Event,
+        datum: TDatum,
+        coordinates: AgCoordinates | undefined
+    ): INodeEvent<T> {
+        let defaultPrevented = false;
+        return {
+            ...this.createNodeParams(datum),
+            type,
             event,
-            datum,
-            this,
-            selectionState,
-            isCollapsed,
-            coordinates
-        );
+            coordinates,
+            get defaultPrevented() {
+                return defaultPrevented;
+            },
+            preventDefault: () => {
+                defaultPrevented = true;
+            },
+        };
+    }
+
+    protected createNodeParams(datum: TDatum): AgNodeParams<unknown> {
+        const dataIdKey = this.data?.dataIdKey;
+        return {
+            datum: datum.datum,
+            datums: datum.datums,
+            totalValue: datum.totalValue,
+            seriesId: this.id,
+            dataIdKey,
+            itemId: getItemId(datum, dataIdKey),
+            selectionState: this.getSelectionStateString(datum.datumIndex),
+            isCollapsed: datum.itemId == null ? undefined : this.getCollapsedState(datum.itemId),
+        };
     }
 
     onLegendInitialState(legendType: ChartLegendType, initialState: AgInitialStateLegendOptions | undefined) {

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -13,6 +13,7 @@ import type {
 import type {
     AgActiveItemState,
     AgCoordinates,
+    AgNodeParams,
     AgNumericValue,
     SelectionState as PublicSelectionState,
 } from 'ag-charts-types';
@@ -99,20 +100,14 @@ export interface ISeriesAriaMeta {
     readonly instructions?: string[];
 }
 
-export interface INodeEvent<TEvent extends string = SeriesNodeEventTypes> extends TypedEvent {
+export interface INodeEvent<TEvent extends string = SeriesNodeEventTypes>
+    extends TypedEvent, Readonly<AgNodeParams<unknown>> {
     readonly type: TEvent;
     // Note: this is typically a MouseEvent, but it can be a TouchEvent or KeyboardEvent too.
     readonly event: Event;
-    readonly datum: unknown;
-    readonly datums?: unknown[];
-    readonly totalValue?: AgNumericValue;
-    readonly seriesId: string;
-    readonly itemId: string | number;
-    readonly dataIdKey: string | undefined;
-    readonly defaultPrevented: boolean;
-    readonly selectionState: PublicSelectionState | undefined;
-    readonly isCollapsed: boolean | undefined;
     readonly coordinates: AgCoordinates | undefined;
+    readonly defaultPrevented: boolean;
+    preventDefault(): void;
 }
 
 export interface ISeriesProperties {

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -228,7 +228,7 @@ export {
 export type { CoreZoomState, CoreZoomStateSafeRetrieval, UpdateZoomChanges } from './chart/interaction/zoomManager';
 export { PanToBBoxScalingModeEnum } from './util/panToBBox';
 export { getItemId } from './chart/series/pickManager';
-export { Series, SeriesNodeEvent, SeriesNodePickMode } from './chart/series/series';
+export { Series, SeriesNodePickMode } from './chart/series/series';
 export type {
     MarkerStyleApply,
     MarkerStyleCompute,
@@ -274,7 +274,6 @@ export type {
 } from './chart/series/cartesian/abstractBarSeries';
 export {
     CartesianSeries,
-    CartesianSeriesNodeEvent,
     CartesianSeriesProperties,
     DEFAULT_CARTESIAN_DIRECTION_KEYS,
     DEFAULT_CARTESIAN_DIRECTION_NAMES,

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -5,7 +5,6 @@ import {
     type AgBoxPlotSeriesStyle,
     type AgBoxPlotSeriesStylerParams,
     type AgBoxPlotWhiskerOptions,
-    type SelectionState,
     _ModuleSupport,
 } from 'ag-charts-community';
 import type {
@@ -18,7 +17,7 @@ import type {
     RequireOptional,
 } from 'ag-charts-core';
 import { ChartAxisDirection, deepClone, isNumericValue, mergeDefaults, toNumber } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue } from 'ag-charts-types';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import { prepareBoxPlotFromTo, resetBoxPlotSelectionsScalingCenterFn } from './blotPlotUtil';
 import { BoxPlotNode } from './boxPlotNode';
@@ -117,42 +116,22 @@ interface BoxPlotNodeDatumParams {
     scaledValues: ScaledBoxPlotValues;
 }
 
-class BoxPlotSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<BoxPlotNodeDatum, TEvent> {
-    readonly xKey?: string;
-    readonly minKey?: string;
-    readonly q1Key?: string;
-    readonly medianKey?: string;
-    readonly q3Key?: string;
-    readonly maxKey?: string;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: BoxPlotNodeDatum,
-        series: BoxPlotSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.xKey = series.properties.xKey;
-        this.minKey = series.properties.minKey;
-        this.q1Key = series.properties.q1Key;
-        this.medianKey = series.properties.medianKey;
-        this.q3Key = series.properties.q3Key;
-        this.maxKey = series.properties.maxKey;
-    }
-}
-
 export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSeriesTypes> {
     static override readonly className = 'BoxPlotSeries';
     static readonly type = 'box-plot' as const;
 
     override properties = new BoxPlotSeriesProperties();
 
-    protected override readonly NodeEvent = BoxPlotSeriesNodeEvent;
+    protected override createNodeParams(datum: BoxPlotNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            minKey: this.properties.minKey,
+            q1Key: this.properties.q1Key,
+            medianKey: this.properties.medianKey,
+            q3Key: this.properties.q3Key,
+            maxKey: this.properties.maxKey,
+        };
+    }
 
     constructor(moduleCtx: DynamicContext<_ModuleSupport.ChartRegistry>) {
         super({

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -125,6 +125,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
     protected override createNodeParams(datum: BoxPlotNodeDatum) {
         return {
             ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
             minKey: this.properties.minKey,
             q1Key: this.properties.q1Key,
             medianKey: this.properties.medianKey,

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -1,9 +1,7 @@
 import {
     type AgActiveItemState,
-    type AgCoordinates,
     type FillOptions,
     type LineDashOptions,
-    type SelectionState,
     type StrokeOptions,
     _ModuleSupport,
 } from 'ag-charts-community';
@@ -94,34 +92,6 @@ type TDatum<
     TLinkDatum extends FlowProportionLinkDatum<TNodeDatum, TLinkDatum>,
 > = TLinkDatum | TNodeDatum;
 
-export class FlowProportionSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<_ModuleSupport.SeriesNodeDatum, TEvent> {
-    readonly size?: number;
-    readonly label?: string;
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: _ModuleSupport.SeriesNodeDatum & { type?: FlowProportionDatumType },
-        series: _ModuleSupport.ISeries<_ModuleSupport.SeriesNodeDatum, _ModuleSupport.ISeriesProperties, unknown> & {
-            contextNodeData?: _ModuleSupport.SeriesNodeDataContext<
-                TDatum<FlowProportionNodeDatum<any, any>, FlowProportionLinkDatum<any, any>>,
-                _ModuleSupport.ISeriesProperties
-            >;
-        },
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        const nodeDatum = series.contextNodeData?.nodeData.find(
-            (d) => d.type === datum.type && d.datumIndex === datum.datumIndex
-        );
-        this.size = nodeDatum?.size;
-        this.label = nodeDatum?.type === FlowProportionDatumType.Node ? nodeDatum?.label : undefined;
-    }
-}
-
 export abstract class FlowProportionSeries<
     TNodeDatum extends FlowProportionNodeDatum<TNodeDatum, TLinkDatum>,
     TLinkDatum extends FlowProportionLinkDatum<TNodeDatum, TLinkDatum>,
@@ -137,7 +107,17 @@ export abstract class FlowProportionSeries<
     TLabel,
     _ModuleSupport.SeriesNodeDataContext<TDatum<TNodeDatum, TLinkDatum>, TLabel>
 > {
-    protected override readonly NodeEvent = FlowProportionSeriesNodeEvent;
+    // `size`/`label` live on the context node data rather than on the picked datum, so they need a lookup.
+    protected override createNodeParams(datum: TDatum<TNodeDatum, TLinkDatum>) {
+        const nodeDatum = this.contextNodeData?.nodeData.find(
+            (d) => d.type === datum.type && d.datumIndex === datum.datumIndex
+        );
+        return {
+            ...super.createNodeParams(datum),
+            size: nodeDatum?.size,
+            label: nodeDatum?.type === FlowProportionDatumType.Node ? nodeDatum?.label : undefined,
+        };
+    }
 
     abstract override properties: TProps;
 

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -1,9 +1,4 @@
-import {
-    type AgFunnelSeriesLabelFormatterParams,
-    type AgFunnelSeriesStyle,
-    type SelectionState,
-    _ModuleSupport,
-} from 'ag-charts-community';
+import { type AgFunnelSeriesLabelFormatterParams, type AgFunnelSeriesStyle, _ModuleSupport } from 'ag-charts-community';
 import type {
     DomainWithMetadata,
     DynamicContext,
@@ -14,7 +9,7 @@ import type {
     RequireOptional,
 } from 'ag-charts-core';
 import { ChartAxisDirection, SeriesZIndexMap, maxValue } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue } from 'ag-charts-types';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { BaseFunnelProperties } from './baseFunnelSeriesProperties';
 import { FunnelConnector } from './funnelConnector';
@@ -109,31 +104,16 @@ export interface FunnelAnimationData<
     TNode extends _ModuleSupport.QuadtreeCompatibleNode<FunnelNodeDatum>,
 > extends _ModuleSupport.CartesianAnimationData<FunnelNodeDatum, TNode, FunnelNodeLabelDatum, FunnelContext> {}
 
-class FunnelSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<FunnelNodeDatum, TEvent> {
-    readonly xKey?: string;
-    readonly yKey?: string;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: FunnelNodeDatum,
-        series: BaseFunnelSeries<BaseFunnelSeriesTypes>,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.xKey = series.properties.stageKey;
-        this.yKey = series.properties.valueKey;
-    }
-}
-
 export abstract class BaseFunnelSeries<
     TTypes extends BaseFunnelSeriesTypes,
 > extends _ModuleSupport.AbstractBarSeries<TTypes> {
-    protected override readonly NodeEvent = FunnelSeriesNodeEvent;
+    protected override createNodeParams(datum: FunnelNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            xKey: this.properties.stageKey,
+            yKey: this.properties.valueKey,
+        };
+    }
 
     protected readonly connectorNodeGroup = this.contentGroup.appendChild(
         new Group({

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -152,7 +152,12 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
     override properties = new HeatmapSeriesProperties();
 
     protected override createNodeParams(datum: HeatmapNodeDatum) {
-        return { ...super.createNodeParams(datum), colorKey: this.properties.colorKey };
+        return {
+            ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
+            colorKey: this.properties.colorKey,
+        };
     }
 
     readonly colorScale = new ColorScale();

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -1,12 +1,10 @@
 import type {
-    AgCoordinates,
     AgHeatmapSeriesItemStylerParams,
     AgHeatmapSeriesLabelFormatterParams,
     AgHeatmapSeriesOptions,
     AgHeatmapSeriesStyle,
     FontStyle,
     FontWeight,
-    SelectionState,
     TextAlign,
     VerticalAlign,
 } from 'ag-charts-community';
@@ -120,25 +118,6 @@ interface HeatmapSeriesNodeDatumContext extends _ModuleSupport.CartesianCreateNo
     readonly itemStyleContext: HeatmapItemStyleContext;
 }
 
-class HeatmapSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.CartesianSeriesNodeEvent<TEvent> {
-    readonly colorKey?: string;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: HeatmapNodeDatum,
-        series: HeatmapSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.colorKey = series.properties.colorKey;
-    }
-}
-
 const textAlignFactors: Record<TextAlign, number> = {
     left: -0.5,
     center: 0,
@@ -172,7 +151,9 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
 
     override properties = new HeatmapSeriesProperties();
 
-    protected override readonly NodeEvent = HeatmapSeriesNodeEvent;
+    protected override createNodeParams(datum: HeatmapNodeDatum) {
+        return { ...super.createNodeParams(datum), colorKey: this.properties.colorKey };
+    }
 
     readonly colorScale = new ColorScale();
 

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -7,7 +7,7 @@ import {
     type StrokeOptions,
     _ModuleSupport,
 } from 'ag-charts-community';
-import type { AgOhlcSeriesBaseOptions, AgOhlcSeriesItemStylerParams, SelectionState } from 'ag-charts-community';
+import type { AgOhlcSeriesBaseOptions, AgOhlcSeriesItemStylerParams } from 'ag-charts-community';
 import {
     AGGREGATION_INDEX_X_MAX,
     AGGREGATION_INDEX_X_MIN,
@@ -27,7 +27,7 @@ import {
     mergeDefaults,
     toNumber,
 } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue, CssColor } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import {
     type OhlcSeriesDataAggregationFilter,
@@ -88,33 +88,6 @@ export interface OhlcNodeDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDa
     readonly crisp: boolean;
 
     style?: Required<NormalisedOhlcCandleStickSeriesStyle>;
-}
-
-class OhlcSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<OhlcNodeDatum, TEvent> {
-    readonly xKey?: string;
-    readonly openKey?: string;
-    readonly closeKey?: string;
-    readonly highKey?: string;
-    readonly lowKey?: string;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: OhlcNodeDatum,
-        series: OhlcSeriesBase<OhlcSeriesBaseTypes>,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.xKey = series.properties.xKey;
-        this.openKey = series.properties.openKey;
-        this.closeKey = series.properties.closeKey;
-        this.highKey = series.properties.highKey;
-        this.lowKey = series.properties.lowKey;
-    }
 }
 
 /**
@@ -237,7 +210,15 @@ function resetOhlcSelectionsDirect<D extends OhlcNodeDatum>(
 export abstract class OhlcSeriesBase<
     TTypes extends OhlcSeriesBaseTypes,
 > extends _ModuleSupport.AbstractBarSeries<TTypes> {
-    protected override readonly NodeEvent = OhlcSeriesNodeEvent;
+    protected override createNodeParams(datum: OhlcNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            openKey: this.properties.openKey,
+            closeKey: this.properties.closeKey,
+            highKey: this.properties.highKey,
+            lowKey: this.properties.lowKey,
+        };
+    }
 
     private readonly aggregationManager = new AggregationManager<OhlcSeriesDataAggregationFilter>();
 

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -213,6 +213,7 @@ export abstract class OhlcSeriesBase<
     protected override createNodeParams(datum: OhlcNodeDatum) {
         return {
             ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
             openKey: this.properties.openKey,
             closeKey: this.properties.closeKey,
             highKey: this.properties.highKey,

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -1,6 +1,5 @@
 import {
     type AgBaseRadarSeriesOptions,
-    type AgCoordinates,
     type AgDrawingMode,
     type AgRadarSeriesLabelFormatterParams,
     type AgRadarSeriesStyle,
@@ -8,7 +7,6 @@ import {
     type ContextDefault,
     type CssColor,
     type DatumDefault,
-    type SelectionState,
     _ModuleSupport,
 } from 'ag-charts-community';
 import {
@@ -99,40 +97,11 @@ type StylerResult<TStyle extends AgRadarSeriesStyle> = Omit<TStyle, 'stroke' | '
     marker?: NormalisedSeriesMarkerStyle & { enabled?: boolean };
 };
 
-type BaseRadarSeries = RadarSeries<
-    AgRadarSeriesStyle,
-    AgBaseRadarSeriesOptions<DatumDefault, ContextDefault, AgRadarSeriesStyle>,
-    RadarSeriesProperties<
-        AgRadarSeriesStyle,
-        AgBaseRadarSeriesOptions<DatumDefault, ContextDefault, AgRadarSeriesStyle>
-    >
->;
-
 export type ResolvedRadarStyle<TStyle extends AgRadarSeriesStyle> = {
     [K in keyof TStyle]-?: K extends 'stroke' ? CssColor : Exclude<TStyle[K], undefined>;
 } & {
     marker: Required<NormalisedSeriesMarkerStyle> & { enabled: boolean };
 };
-
-class RadarSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<RadarNodeDatum, TEvent> {
-    readonly angleKey?: string;
-    readonly radiusKey?: string;
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: RadarNodeDatum,
-        series: BaseRadarSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.angleKey = series.properties.angleKey;
-        this.radiusKey = series.properties.radiusKey;
-    }
-}
 
 export abstract class RadarSeries<
     TStyle extends AgRadarSeriesStyle,
@@ -141,7 +110,13 @@ export abstract class RadarSeries<
 > extends _ModuleSupport.PolarSeries<RadarNodeDatum, TOpts, TProps, _ModuleSupport.Marker<RadarNodeDatum>> {
     static override readonly className: string = 'RadarSeries';
 
-    protected override readonly NodeEvent = RadarSeriesNodeEvent;
+    protected override createNodeParams(datum: RadarNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            angleKey: this.properties.angleKey,
+            radiusKey: this.properties.radiusKey,
+        };
+    }
 
     private readonly lineGroup = this.contentGroup.appendChild(new Group<boolean>({ name: 'radar-line' }));
     protected lineSelection = Selection.select<_ModuleSupport.Path<boolean>>(this.lineGroup, Path<boolean>);

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -2,7 +2,6 @@ import {
     type AgRadialBarSeriesOptions,
     type AgRadialSeriesLabelFormatterParams,
     type AgRadialSeriesStyle,
-    type SelectionState,
     _ModuleSupport,
 } from 'ag-charts-community';
 import {
@@ -20,7 +19,7 @@ import {
     minValue,
     zeroLike,
 } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue, CssColor } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import { RadiusCategoryAxis } from '../../axes/radius-category/radiusCategoryAxis';
 import { readDatum } from '../../utils/datum';
@@ -53,26 +52,6 @@ const {
 } = _ModuleSupport;
 
 type NormalisedRadialSeriesStyle = Normalised<AgRadialSeriesStyle, never, FillStrokeMorph>;
-
-class RadialBarSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<RadialBarNodeDatum, TEvent> {
-    readonly angleKey?: string;
-    readonly radiusKey?: string;
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: RadialBarNodeDatum,
-        series: RadialBarSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.angleKey = series.properties.angleKey;
-        this.radiusKey = series.properties.radiusKey;
-    }
-}
 
 interface RadialBarLabelNodeDatum {
     text: NormalisedTextOrSegments;
@@ -116,7 +95,13 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
 
     override properties = new RadialBarSeriesProperties();
 
-    protected override readonly NodeEvent = RadialBarSeriesNodeEvent;
+    protected override createNodeParams(datum: RadialBarNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            angleKey: this.properties.angleKey,
+            radiusKey: this.properties.radiusKey,
+        };
+    }
 
     private readonly groupScale = new CategoryScale<string>();
 

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -2,7 +2,6 @@ import type {
     AgBaseRadialColumnSeriesOptions,
     AgRadialSeriesLabelFormatterParams,
     AgRadialSeriesStyle,
-    SelectionState,
 } from 'ag-charts-community';
 import { _ModuleSupport } from 'ag-charts-community';
 import {
@@ -20,7 +19,7 @@ import {
     normalizeAngle360,
     zeroLike,
 } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue, CssColor } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import { AngleCategoryAxis } from '../../axes/angle-category/angleCategoryAxis';
 import { type RadialSeriesStyleResult, getItemStyle, getStyle } from '../util/radialUtil';
@@ -49,26 +48,6 @@ const {
 } = _ModuleSupport;
 
 type NormalisedRadialSeriesStyle = Normalised<AgRadialSeriesStyle, never, FillStrokeMorph>;
-
-class RadialColumnSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<RadialColumnNodeDatum, TEvent> {
-    readonly angleKey?: string;
-    readonly radiusKey?: string;
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: RadialColumnNodeDatum,
-        series: RadialColumnSeriesBase<any>,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.angleKey = series.properties.angleKey;
-        this.radiusKey = series.properties.radiusKey;
-    }
-}
 
 interface RadialColumnLabelNodeDatum {
     x: number;
@@ -116,7 +95,13 @@ export abstract class RadialColumnSeriesBase<
     RadialColumnNodeDatum,
     RadialColumnSeriesNodeDataContext
 > {
-    protected override readonly NodeEvent = RadialColumnSeriesNodeEvent;
+    protected override createNodeParams(datum: RadialColumnNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            angleKey: this.properties.angleKey,
+            radiusKey: this.properties.radiusKey,
+        };
+    }
 
     private readonly groupScale = new CategoryScale<string>();
 

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -8,7 +8,6 @@ import {
     type AgRangeAreaSeriesStyle,
     type AgRangeAreaSeriesStylerParams,
     type AgSeriesMarkerStyle,
-    type SelectionState,
     _ModuleSupport,
 } from 'ag-charts-community';
 import {
@@ -47,7 +46,7 @@ import {
     toArray,
     toNumber,
 } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue, CssColor } from 'ag-charts-types';
+import type { AgNumericValue, CssColor } from 'ag-charts-types';
 
 import {
     type RangeAreaSeriesDataAggregationFilter,
@@ -223,29 +222,6 @@ interface RangeAreaNodeDatumScratch {
     inverted: boolean;
 }
 
-class RangeAreaSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<RangeAreaMarkerDatum, TEvent> {
-    readonly xKey?: string;
-    readonly yLowKey?: string;
-    readonly yHighKey?: string;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: RangeAreaMarkerDatum,
-        series: RangeAreaSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.xKey = series.properties.xKey;
-        this.yLowKey = series.properties.yLowKey;
-        this.yHighKey = series.properties.yHighKey;
-    }
-}
-
 interface RangeAreaSpanPointDatum {
     high: _ModuleSupport.LineSpanPointDatum;
     low: _ModuleSupport.LineSpanPointDatum;
@@ -300,7 +276,13 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
 
     override properties = new RangeAreaProperties();
 
-    protected override readonly NodeEvent = RangeAreaSeriesNodeEvent;
+    protected override createNodeParams(datum: RangeAreaMarkerDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            yLowKey: this.properties.yLowKey,
+            yHighKey: this.properties.yHighKey,
+        };
+    }
 
     private readonly aggregationManager = new AggregationManager<RangeAreaSeriesDataAggregationFilter>();
     private hideWithSize0 = false;

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -279,6 +279,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
     protected override createNodeParams(datum: RangeAreaMarkerDatum) {
         return {
             ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
             yLowKey: this.properties.yLowKey,
             yHighKey: this.properties.yHighKey,
         };

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -300,6 +300,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
     protected override createNodeParams(datum: RangeBarNodeDatum) {
         return {
             ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
             yLowKey: this.properties.yLowKey,
             yHighKey: this.properties.yHighKey,
         };

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -4,7 +4,6 @@ import {
     type AgRangeBarSeriesOptions,
     type AgRangeBarSeriesStyle,
     type AgRangeBarSeriesStylerParams,
-    type SelectionState,
     _ModuleSupport,
 } from 'ag-charts-community';
 import {
@@ -53,7 +52,7 @@ import {
     toArray,
     toNumber,
 } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue, PaddingOptions } from 'ag-charts-types';
+import type { AgNumericValue, PaddingOptions } from 'ag-charts-types';
 
 import {
     type RangeBarSeriesDataAggregationFilter,
@@ -246,29 +245,6 @@ interface RangeBarNodeDatum extends Omit<_ModuleSupport.CartesianSeriesNodeDatum
 
 type RangeBarAnimationData = _ModuleSupport.AbstractBarSeriesAnimationData<RangeBarSeriesTypes>;
 
-class RangeBarSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.SeriesNodeEvent<RangeBarNodeDatum, TEvent> {
-    readonly xKey?: string;
-    readonly yLowKey?: string;
-    readonly yHighKey?: string;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: RangeBarNodeDatum,
-        series: RangeBarSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.xKey = series.properties.xKey;
-        this.yLowKey = series.properties.yLowKey;
-        this.yHighKey = series.properties.yHighKey;
-    }
-}
-
 interface RangeBarSeriesNodeDataContext extends _ModuleSupport.AbstractBarSeriesNodeDataContext<
     RangeBarNodeDatum,
     RangeBarNodeLabelDatum
@@ -321,7 +297,13 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
 
     private readonly aggregationManager = new AggregationManager<RangeBarSeriesDataAggregationFilter>();
 
-    protected override readonly NodeEvent = RangeBarSeriesNodeEvent;
+    protected override createNodeParams(datum: RangeBarNodeDatum) {
+        return {
+            ...super.createNodeParams(datum),
+            yLowKey: this.properties.yLowKey,
+            yHighKey: this.properties.yHighKey,
+        };
+    }
 
     constructor(moduleCtx: DynamicContext<_ModuleSupport.ChartRegistry>) {
         super({

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -206,7 +206,12 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
     override properties = new WaterfallSeriesProperties();
 
     protected override createNodeParams(datum: WaterfallNodeDatum) {
-        return { ...super.createNodeParams(datum), itemType: datum.itemType };
+        return {
+            ...super.createNodeParams(datum),
+            xKey: this.properties.xKey,
+            yKey: this.properties.yKey,
+            itemType: datum.itemType,
+        };
     }
 
     constructor(moduleCtx: DynamicContext<_ModuleSupport.ChartRegistry>) {

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -46,7 +46,7 @@ import {
     toArray,
     zeroLike,
 } from 'ag-charts-core';
-import type { AgCoordinates, AgNumericValue, SelectionState } from 'ag-charts-types';
+import type { AgNumericValue } from 'ag-charts-types';
 
 import type { WaterfallSeriesItem, WaterfallSeriesTotal } from './waterfallSeriesProperties';
 import { WaterfallSeriesProperties } from './waterfallSeriesProperties';
@@ -199,32 +199,15 @@ interface WaterfallSeriesTypes extends _ModuleSupport.AbstractBarSeriesTypes {
 
 type WaterfallAnimationData = _ModuleSupport.AbstractBarSeriesAnimationData<WaterfallSeriesTypes>;
 
-class WaterfallSeriesNodeEvent<
-    TEvent extends string = _ModuleSupport.SeriesNodeEventTypes,
-> extends _ModuleSupport.CartesianSeriesNodeEvent<TEvent> {
-    readonly itemType: AgWaterfallSeriesItemType;
-
-    constructor(
-        type: TEvent,
-        nativeEvent: Event,
-        datum: WaterfallNodeDatum,
-        series: WaterfallSeries,
-        selectionState: SelectionState | undefined,
-        isCollapsed: boolean | undefined,
-        coordinates: AgCoordinates | undefined
-    ) {
-        super(type, nativeEvent, datum, series, selectionState, isCollapsed, coordinates);
-        this.itemType = datum.itemType;
-    }
-}
-
 export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallSeriesTypes> {
     static override readonly className = 'WaterfallSeries';
     static readonly type = 'waterfall' as const;
 
     override properties = new WaterfallSeriesProperties();
 
-    protected override readonly NodeEvent = WaterfallSeriesNodeEvent;
+    protected override createNodeParams(datum: WaterfallNodeDatum) {
+        return { ...super.createNodeParams(datum), itemType: datum.itemType };
+    }
 
     constructor(moduleCtx: DynamicContext<_ModuleSupport.ChartRegistry>) {
         super({

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -26,9 +26,16 @@ interface AgCoordinatedEvent {
 }
 
 export interface AgNodeClickEvent<TEvent extends string, TDatum, TContext = ContextDefault>
-    extends AgChartEvent<TEvent, TContext>, AgCoordinatedEvent {
+    extends AgChartEvent<TEvent, TContext>, AgCoordinatedEvent, AgNodeParams<TDatum> {
     /** Event type. */
     type: TEvent;
+}
+
+/**
+ * Everything a node event reports about the picked datum itself, i.e. an {@link AgNodeClickEvent} minus the
+ * event-delivery fields. Most fields are optional, because each series type only sets the properties applicable to it.
+ */
+export interface AgNodeParams<TDatum> {
     /** Series ID, as specified in `series.id` (or generated if not specified) */
     seriesId: string;
     /** The unique identifier of the picked datum. */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14332

Refactor `seriesNodeClick` / `seriesNodeDoubleClick` in preparation for the `allNodeParams` implementation.

Currently, each concrete/derived series class is responsible for allocating the event-object for clicks. This isn't going to work well on multi-node clicks. You could for example be clicking a marker (line-series) & bar (range-bar series) on a combo chart.

Therefore, each derived series is now only responsible for allocating the datum "parameters", whereas the base `Series` class owns event-object allocations:

- `Series.createNodeParams` - abstract: implemented by concrete/derived series classes.
- `Series.createNodeEvent` - final/non-overridable: allocates event by calling `createNodeParams`.

Phase 2 will call `createNodeParams` in a loop to implement `allNodeParams`.