### PR TITLE
Resolve low-risk SonarCloud code smells

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axisLabelUtil.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisLabelUtil.ts
@@ -43,7 +43,7 @@ export function formatAxisLabelValue(
         | (Pick<AgBaseAxisLabelStyleOptions, never> & {
               formatter?: AgAxisLabelFormatterParams extends never
                   ? never
-                  : ((params: AgAxisLabelFormatterParams) => NormalisedTextOrSegments | undefined) | undefined;
+                  : (params: AgAxisLabelFormatterParams) => NormalisedTextOrSegments | undefined;
               format?: string | Record<string, string>;
           })
         | undefined,

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -150,7 +150,7 @@ function deriveMiniChartInterval(
     intervalOverride: Record<string, unknown> | undefined,
     sourceInterval: object | undefined
 ): Record<string, unknown> {
-    const merged: Record<string, unknown> = { ...(sourceInterval as object), ...(intervalOverride ?? {}) };
+    const merged: Record<string, unknown> = { ...(sourceInterval as object), ...intervalOverride };
     for (const key of MINI_CHART_INTERVAL_DENSITY_KEYS) {
         merged[key] = intervalOverride?.[key];
     }

--- a/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
+++ b/packages/ag-charts-community/src/chart/data/data-model/utils/helpers.ts
@@ -51,7 +51,7 @@ function isBigIntArray(values: ReadonlyArray<number | Date | bigint>): values is
 export function fixNumericExtent(extent: ReadonlyArray<number | Date | bigint> | null): number[] | bigint[] {
     if (extent == null) return [];
     if (isBigIntArray(extent)) return [...extent];
-    const mapped = extent.map((v) => Number(v));
+    const mapped = extent.map(Number);
     return mapped.every(Number.isFinite) ? mapped : [];
 }
 

--- a/packages/ag-charts-community/src/chart/data/dataModel.ts
+++ b/packages/ag-charts-community/src/chart/data/dataModel.ts
@@ -742,10 +742,10 @@ export class DataModel<
             if (this.aggregates.length > 0) {
                 reasons.push('has aggregates');
             }
-            if (this.reducers.filter((r) => !r.supportsBanding).length > 0) {
+            if (this.reducers.some((r) => !r.supportsBanding)) {
                 reasons.push('has reducers');
             }
-            if (this.processors.filter((p) => p.incrementalCalculate === undefined).length > 0) {
+            if (this.processors.some((p) => p.incrementalCalculate === undefined)) {
                 reasons.push('has processors');
             }
             if (this.propertyProcessors.length > 0) {

--- a/packages/ag-charts-community/src/chart/interaction/activeManager.ts
+++ b/packages/ag-charts-community/src/chart/interaction/activeManager.ts
@@ -17,7 +17,7 @@ export class ActiveManager implements MementoOriginator<AgActiveState> {
     mementoOriginatorKey: string = 'active';
 
     private readonly ctx: DynamicContext<ChartRegistry>;
-    private currentItem?: ActiveItem;
+    private currentItem: ActiveItem;
     private updateable: boolean = true;
 
     // FIXME: same pattern as `ZoomManager`. Perhaps an architectural rewrite is warranted.

--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -1481,11 +1481,11 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
         className = className ? `:::${className}` : '';
 
         if (typeof vertex.value === 'symbol') {
-            return `${diagramKey}[/"[symbol]"\\]${className}`;
+            return String.raw`${diagramKey}[/"[symbol]"\]${className}`;
         } else if (Array.isArray(vertex.value)) {
-            return `${diagramKey}[/"[array]"\\]${className}`;
+            return String.raw`${diagramKey}[/"[array]"\]${className}`;
         } else if (typeof vertex.value === 'object') {
-            return `${diagramKey}[/"[object]"\\]${className}`;
+            return String.raw`${diagramKey}[/"[object]"\]${className}`;
         } else if (edge === DEFAULTS_EDGE || edge === USER_OPTIONS_EDGE || edge === OVERRIDES_EDGE) {
             return `${diagramKey}("${vertex.value as any}")${className}`;
         } else {

--- a/packages/ag-charts-community/src/module/optionsGraphOperations.ts
+++ b/packages/ag-charts-community/src/module/optionsGraphOperations.ts
@@ -489,7 +489,7 @@ function andOperation(graph: OptionsGraphInterface, vertex: VertexInterface, val
     for (const valueVertex of values) {
         const value = graph.resolveVertexValue(vertex, valueVertex);
         if (values.length === 1 && Array.isArray(value)) {
-            return value.every((v) => Boolean(v));
+            return value.every(Boolean);
         }
         if (!value) return false;
     }
@@ -614,7 +614,7 @@ function orOperation(graph: OptionsGraphInterface, vertex: VertexInterface, valu
     for (const valueVertex of values) {
         const value = graph.resolveVertexValue(vertex, valueVertex);
         if (values.length === 1 && Array.isArray(value)) {
-            return value.some((v) => Boolean(v));
+            return value.some(Boolean);
         }
         if (value) return true;
     }

--- a/packages/ag-charts-community/src/scale/colorScale.ts
+++ b/packages/ag-charts-community/src/scale/colorScale.ts
@@ -104,7 +104,7 @@ export class ColorScale extends AbstractScale<number, string> {
     }
 
     override normalizeDomains(...domains: DomainWithMetadata<number>[]): NormalizedDomain<number> {
-        return { domain: domains.map((d) => d.domain).flat(), animatable: true };
+        return { domain: domains.flatMap((d) => d.domain), animatable: true };
     }
 
     override toDomain(): number | undefined {

--- a/packages/ag-charts-community/src/scale/ordinalTimeScale.ts
+++ b/packages/ag-charts-community/src/scale/ordinalTimeScale.ts
@@ -129,7 +129,7 @@ export class OrdinalTimeScale extends DiscreteTimeScale {
 
         // Multiple domains - must merge and sort, metadata not applicable
         return {
-            domain: sortAndUniqueDates(nonEmptyDomains.map((d) => d.domain).flat()),
+            domain: sortAndUniqueDates(nonEmptyDomains.flatMap((d) => d.domain)),
             animatable: true,
         };
     }

--- a/packages/ag-charts-community/src/util/render.ts
+++ b/packages/ag-charts-community/src/util/render.ts
@@ -3,21 +3,13 @@
 // profiler, whereas anonymous arrow functions get grouped together making profiling difficult.
 import { AgDocument } from 'ag-charts-core';
 
-type VoidCallback = {
-    (): void;
-};
+type VoidCallback = () => void;
 
-type SchedulerFunction = {
-    (cb: VoidCallback, delayMs?: number): number | void;
-};
+type SchedulerFunction = (cb: VoidCallback, delayMs?: number) => number | void;
 
-type CancelFunction = {
-    (id: number | void): void;
-};
+type CancelFunction = (id: number | void) => void;
 
-type Callback = {
-    (params: { count: number }): Promise<void> | void;
-};
+type Callback = (params: { count: number }) => Promise<void> | void;
 
 /**
  * Wrap a function in debouncing trigger function. A requestAnimationFrame() is scheduled

--- a/packages/ag-charts-core/src/utils/time/time/range.ts
+++ b/packages/ag-charts-core/src/utils/time/time/range.ts
@@ -322,7 +322,7 @@ const unitRanger: Record<AgTimeIntervalUnit, IntervalRanger> = {
     },
     second: {
         adjust(date: Date, step: number, utc: boolean) {
-            const adjusted = new Date(date.getTime());
+            const adjusted = new Date(date);
             if (utc) {
                 adjusted.setUTCSeconds(date.getUTCSeconds() + step);
             } else {
@@ -333,7 +333,7 @@ const unitRanger: Record<AgTimeIntervalUnit, IntervalRanger> = {
     },
     minute: {
         adjust(date: Date, step: number, utc: boolean) {
-            const adjusted = new Date(date.getTime());
+            const adjusted = new Date(date);
             if (utc) {
                 adjusted.setUTCMinutes(date.getUTCMinutes() + step);
             } else {
@@ -344,7 +344,7 @@ const unitRanger: Record<AgTimeIntervalUnit, IntervalRanger> = {
     },
     hour: {
         adjust(date: Date, step: number, utc: boolean) {
-            const adjusted = new Date(date.getTime());
+            const adjusted = new Date(date);
             if (utc) {
                 adjusted.setUTCHours(date.getUTCHours() + step);
             } else {
@@ -355,7 +355,7 @@ const unitRanger: Record<AgTimeIntervalUnit, IntervalRanger> = {
     },
     day: {
         adjust(date: Date, step: number, utc: boolean) {
-            const adjusted = new Date(date.getTime());
+            const adjusted = new Date(date);
             if (utc) {
                 adjusted.setUTCDate(date.getUTCDate() + step);
             } else {
@@ -366,7 +366,7 @@ const unitRanger: Record<AgTimeIntervalUnit, IntervalRanger> = {
     },
     month: {
         adjust(date: Date, step: number, utc: boolean) {
-            const adjusted = new Date(date.getTime());
+            const adjusted = new Date(date);
             if (utc) {
                 adjusted.setUTCMonth(date.getUTCMonth() + step);
 
@@ -393,7 +393,7 @@ const unitRanger: Record<AgTimeIntervalUnit, IntervalRanger> = {
     },
     year: {
         adjust(date: Date, step: number, utc: boolean) {
-            const adjusted = new Date(date.getTime());
+            const adjusted = new Date(date);
             if (utc) {
                 adjusted.setUTCFullYear(date.getUTCFullYear() + step);
             } else {

--- a/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
+++ b/packages/ag-charts-enterprise/src/features/crosshair/crosshair.ts
@@ -75,7 +75,7 @@ export class Crosshair
     );
     protected lineGroupSelection = _ModuleSupport.Selection.select(this.lineGroup, Line<string>, false);
 
-    private activeHighlight?: _ModuleSupport.HighlightChangeEvent['currentHighlight'] = undefined;
+    private activeHighlight: _ModuleSupport.HighlightChangeEvent['currentHighlight'] = undefined;
     private activeHighlightInViewport: boolean = false;
 
     constructor(private readonly ctx: _ModuleSupport.ChartAxisRegistry<_ModuleSupport.AxisContext>) {

--- a/packages/ag-charts-enterprise/src/features/data-selection/intervalSet.ts
+++ b/packages/ag-charts-enterprise/src/features/data-selection/intervalSet.ts
@@ -27,7 +27,7 @@ export class IntervalSet {
         }
 
         // FAST PATH: extend / merge last interval (most common case)
-        const last = intervals.at(intervals.length - 1)!;
+        const last = intervals.at(-1)!;
 
         if (end + 1 < last.start) {
             // New interval is completely after last → append

--- a/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
+++ b/packages/ag-charts-enterprise/src/features/ranges/ranges.ts
@@ -63,7 +63,7 @@ const EMPTY_STYLES: ResolvedStyles = {
 };
 
 function resolveStyles(styles: AgRangesStyles | undefined): ResolvedStyles {
-    return { ...EMPTY_STYLES, ...(styles ?? {}) } as ResolvedStyles;
+    return { ...EMPTY_STYLES, ...styles } as ResolvedStyles;
 }
 
 export class Ranges extends AbstractModuleInstance {


### PR DESCRIPTION
Clears 26 open SonarCloud issues across `ag-charts-core`, `ag-charts-community` and `ag-charts-enterprise`. Every change is behaviour-preserving; no JIRA ticket, this is post-release static-analysis cleanup from the 14.1.0 report.

Rules addressed:

| Rule | Count | Change |
|---|---|---|
| S7719 | 6 | clone dates via `new Date(date)` rather than `.getTime()` |
| S6598 | 4 | call-signature type literals to function types |
| S7780 | 3 | `String.raw` for the mermaid diagram templates |
| S7770 | 3 | pass `Number` / `Boolean` directly instead of wrapping in an arrow |
| S4782 | 3 | drop redundant `?` + `\| undefined` |
| S7752 | 2 | `flatMap` instead of `map().flat()` |
| S7754 | 2 | `some` instead of `filter().length > 0` |
| S7744 | 2 | drop no-op `?? {}` in spreads |
| S7771 | 1 | `at(-1)` instead of `at(length - 1)` |

Deliberately **not** included, having been assessed as false positives or conflicts with existing project decisions:

- **S3863** (58, duplicate imports) — every hit is a value import plus a separate `import type` from the same module, which `eslint.config.mjs` explicitly permits via `no-duplicate-imports: [error, { allowSeparateTypeImports: true }]`. Sonar flags 58 of ~242 identical instances repo-wide, so fixing the flagged subset would be inconsistent churn.
- **S6564** (15, redundant type aliases) — all intentional: semantic aliases over primitives (`ScopeId = string`), public API naming indirection, and function-local shorthand for long generic types.
- **S7741** (3, `typeof` vs `undefined`) — the flagged guards are environment checks on `globalThis.window` / `globalThis.global`. TypeScript types these as always-defined, so `!== undefined` is statically always-true and trades the Sonar issue for a new `sonarjs/different-types-comparison` lint warning.
- **S6679** (1, `Number.isNaN`) — `aggregation.ts` documents `x !== x` as a deliberate hot-loop idiom at lines 442 and 587.
- **S7758** (1, `codePointAt`) — the function parses fixed-width ASCII digits, where `charCodeAt` is correct and faster.
- **S4782** (12 of 15) — the remaining sites inherit `undefined` indirectly through public type aliases; changing them needs either an API-visible `?` removal or `NonNullable<>` noise.

Verification: `nx format`, `build:types` for all three packages, `lint` with no net-new warnings against the 691-warning baseline, and the full community (4164 tests) and enterprise (2729 tests) suites passing.