### PR TITLE
Accept space-separated rgb() colours and reject malformed ones

### DIFF
--- a/packages/ag-charts-core/src/utils/format/color.test.ts
+++ b/packages/ag-charts-core/src/utils/format/color.test.ts
@@ -180,6 +180,53 @@ describe('Color', () => {
         }
     });
 
+    test('fromRgbaString accepts the space-separated syntax', () => {
+        {
+            const color = Color.fromRgbaString('rgb(120 240 100)');
+            expect(color.r).toBe(120 / 255);
+            expect(color.g).toBe(240 / 255);
+            expect(color.b).toBe(100 / 255);
+            expect(color.a).toBe(1);
+        }
+        {
+            const color = Color.fromRgbaString('rgb(120 240 100 / 0.4)');
+            expect(color.r).toBe(120 / 255);
+            expect(color.g).toBe(240 / 255);
+            expect(color.b).toBe(100 / 255);
+            expect(color.a).toBe(0.4);
+        }
+        {
+            const color = Color.fromRgbaString('rgb(50% 25% 75% / 50%)');
+            expect(color.r).toBe(0.5);
+            expect(color.g).toBe(0.25);
+            expect(color.b).toBe(0.75);
+            expect(color.a).toBe(0.5);
+        }
+        {
+            // The comma-separated syntax also accepts a slash-separated alpha.
+            const color = Color.fromRgbaString('rgb(120, 240, 100 / 0.4)');
+            expect(color.a).toBe(0.4);
+        }
+    });
+
+    test('validColorString agrees with fromString for rgb', () => {
+        for (const str of [
+            'rgb(120, 240, 100)',
+            'rgb(120 240 100)',
+            'rgba(120, 240, 100, 0.4)',
+            'rgb(120 240 100 / 0.4)',
+        ]) {
+            expect(Color.validColorString(str)).toBe(true);
+            expect(() => Color.fromString(str)).not.toThrow();
+        }
+
+        // Malformed component counts must be rejected by the validator, not left to throw at render time.
+        for (const str of ['rgb()', 'rgb(120)', 'rgb(120, 240)', 'rgb(120, 240, 100, 0.4, 5)', 'rgb(blah, 240, 100)']) {
+            expect(Color.validColorString(str)).toBe(false);
+            expect(() => Color.fromString(str)).toThrow();
+        }
+    });
+
     test('fromString', () => {
         {
             const color = Color.fromString('#abc');

--- a/packages/ag-charts-core/src/utils/format/color.ts
+++ b/packages/ag-charts-core/src/utils/format/color.ts
@@ -171,45 +171,46 @@ export class Color implements IColor {
         throw new Error(`Malformed hexadecimal color string: '${str}'`);
     }
 
-    private static stringToRgba(str: string): number[] | undefined {
-        // Find positions of opening and closing parentheses.
-        let po = -1;
-        let pc = -1;
-        for (let i = 0; i < str.length; i++) {
-            const c = str[i];
-            if (po === -1 && c === '(') {
-                po = i;
-            } else if (c === ')') {
-                pc = i;
-                break;
-            }
+    // An r, g or b component: a percentage is relative to 100%, a bare number to 255 — clamped to [0, 1].
+    private static parseRgbComponent(part: string): number | undefined {
+        const value = Number.parseFloat(part);
+        if (!Number.isFinite(value)) {
+            return;
         }
+        return part.includes('%') ? clamp(0, value / 100, 1) : clamp(0, value / 255, 1);
+    }
 
-        if (po === -1 || pc === -1) return;
+    private static stringToRgba(str: string): number[] | undefined {
+        const po = str.indexOf('(');
+        const pc = str.indexOf(')');
+
+        if (po === -1 || pc === -1 || pc < po) return;
 
         const contents = str.substring(po + 1, pc);
-        const parts = contents.split(',');
-        const rgba: number[] = [];
 
-        for (let i = 0; i < parts.length; i++) {
-            const part = parts[i];
-            let value = Number.parseFloat(part);
-            if (!Number.isFinite(value)) {
-                return;
-            }
-            if (part.includes('%')) {
-                // percentage r, g, or b value
-                value = clamp(0, value, 100);
-                value /= 100;
-            } else if (i === 3) {
-                // alpha component
-                value = clamp(0, value, 1);
-            } else {
-                // absolute r, g, or b value
-                value = clamp(0, value, 255);
-                value /= 255;
-            }
-            rgba.push(value);
+        // The `/ alpha` form separates the alpha component with a slash; otherwise
+        // components are split on whitespace and/or commas, covering both the
+        // comma-separated and space-separated syntaxes.
+        const slash = contents.indexOf('/');
+        const head = slash === -1 ? contents : contents.substring(0, slash);
+        const parts = head.trim().split(/[\s,]+/);
+        if (slash !== -1) {
+            parts.push(contents.substring(slash + 1).trim());
+        }
+
+        if (parts.length < 3 || parts.length > 4) return;
+
+        const r = Color.parseRgbComponent(parts[0]);
+        const g = Color.parseRgbComponent(parts[1]);
+        const b = Color.parseRgbComponent(parts[2]);
+        if (r === undefined || g === undefined || b === undefined) return;
+
+        const rgba = [r, g, b];
+
+        if (parts.length === 4) {
+            const a = Color.parseUnitInterval(parts[3]);
+            if (a === undefined) return;
+            rgba.push(a);
         }
 
         return rgba;

--- a/packages/ag-charts-core/src/utils/format/color.ts
+++ b/packages/ag-charts-core/src/utils/format/color.ts
@@ -180,17 +180,20 @@ export class Color implements IColor {
         return part.includes('%') ? clamp(0, value / 100, 1) : clamp(0, value / 255, 1);
     }
 
-    private static stringToRgba(str: string): number[] | undefined {
+    /**
+     * Splits the argument list out of a `name(...)` colour function into its three components plus an
+     * optional alpha, or `undefined` if the string isn't a colour function of that shape.
+     *
+     * The `/ alpha` form separates the alpha component with a slash; otherwise components are split on
+     * whitespace and/or commas, covering both the comma-separated and space-separated syntaxes.
+     */
+    private static parseColorFunctionParts(str: string): string[] | undefined {
         const po = str.indexOf('(');
         const pc = str.indexOf(')');
 
         if (po === -1 || pc === -1 || pc < po) return;
 
         const contents = str.substring(po + 1, pc);
-
-        // The `/ alpha` form separates the alpha component with a slash; otherwise
-        // components are split on whitespace and/or commas, covering both the
-        // comma-separated and space-separated syntaxes.
         const slash = contents.indexOf('/');
         const head = slash === -1 ? contents : contents.substring(0, slash);
         const parts = head.trim().split(/[\s,]+/);
@@ -198,7 +201,12 @@ export class Color implements IColor {
             parts.push(contents.substring(slash + 1).trim());
         }
 
-        if (parts.length < 3 || parts.length > 4) return;
+        return parts.length === 3 || parts.length === 4 ? parts : undefined;
+    }
+
+    private static stringToRgba(str: string): number[] | undefined {
+        const parts = Color.parseColorFunctionParts(str);
+        if (parts === undefined) return;
 
         const r = Color.parseRgbComponent(parts[0]);
         const g = Color.parseRgbComponent(parts[1]);
@@ -278,24 +286,8 @@ export class Color implements IColor {
     }
 
     private static stringToHsla(str: string): number[] | undefined {
-        const po = str.indexOf('(');
-        const pc = str.indexOf(')');
-
-        if (po === -1 || pc === -1 || pc < po) return;
-
-        const contents = str.substring(po + 1, pc);
-
-        // The `/ alpha` form separates the alpha component with a slash; otherwise
-        // components are split on whitespace and/or commas, covering both the
-        // comma-separated and space-separated syntaxes.
-        const slash = contents.indexOf('/');
-        const head = slash === -1 ? contents : contents.substring(0, slash);
-        const parts = head.trim().split(/[\s,]+/);
-        if (slash !== -1) {
-            parts.push(contents.substring(slash + 1).trim());
-        }
-
-        if (parts.length < 3 || parts.length > 4) return;
+        const parts = Color.parseColorFunctionParts(str);
+        if (parts === undefined) return;
 
         const h = Color.parseHueDegrees(parts[0]);
         const s = Color.parsePercentage(parts[1]);
@@ -325,24 +317,8 @@ export class Color implements IColor {
     }
 
     private static stringToOklcha(str: string): number[] | undefined {
-        const po = str.indexOf('(');
-        const pc = str.indexOf(')');
-
-        if (po === -1 || pc === -1 || pc < po) return;
-
-        const contents = str.substring(po + 1, pc);
-
-        // The `/ alpha` form separates the alpha component with a slash; otherwise
-        // components are split on whitespace and/or commas, covering both the
-        // comma-separated and space-separated syntaxes.
-        const slash = contents.indexOf('/');
-        const head = slash === -1 ? contents : contents.substring(0, slash);
-        const parts = head.trim().split(/[\s,]+/);
-        if (slash !== -1) {
-            parts.push(contents.substring(slash + 1).trim());
-        }
-
-        if (parts.length < 3 || parts.length > 4) return;
+        const parts = Color.parseColorFunctionParts(str);
+        if (parts === undefined) return;
 
         const l = Color.parseUnitInterval(parts[0]);
         const c = Color.parseOklchChroma(parts[1]);


### PR DESCRIPTION
## The bug

`Color.stringToRgba` split components on commas only, and never checked how many components it ended up with. Two consequences:

1. **The modern CSS syntax does not parse.** `rgb(255 0 0)` splits into a single part, `Number.parseFloat` reads `255` off the front, and the result is a one-element array. The slash-separated alpha form, `rgb(255 0 0 / 0.4)`, fails the same way. The sibling parsers `stringToHsla` and `stringToOklcha` already handle both syntaxes — `rgb()` was left behind.

2. **`validColorString` disagrees with `fromString`.** Because any arity was returned unchecked, `validColorString('rgb(255 0 0)')` returned `true` while `Color.fromString('rgb(255 0 0)')` threw `Malformed rgb/rgba color string`. `validColorString` backs option validation (`optionsDefaults.ts`, `optionsModule.ts`), so a chart configured with `fill: 'rgb(255 0 0)'` passed validation and then threw when the colour was resolved for rendering. Short arities like `rgb(120, 240)` behaved identically.

## The fix

`stringToRgba` now mirrors `stringToHsla` / `stringToOklcha`: split the optional `/ alpha` off first, split the head on whitespace and/or commas, and require exactly three or four components — anything else returns `undefined`, so the validator rejects it instead of leaving it to throw at render time.

Component coercion is factored out into `parseRgbComponent` (percentage relative to 100%, bare number relative to 255, clamped to `[0, 1]`), and alpha reuses the existing shared `parseUnitInterval`. Clamping behaviour for the comma-separated form is unchanged — `rgb(-23, 255, 300)` still yields `0, 1, 1`, and `rgb(100, 25%, 200, 50%)` still yields alpha `0.5`.

## Testing

Two tests added to `color.test.ts`: one covering the space-separated and slash-alpha forms, one asserting `validColorString` and `fromString` agree on both well-formed and malformed `rgb()` strings.

- `yarn nx format`, `yarn nx build:types ag-charts-core`, `yarn nx lint ag-charts-core` — clean
- `yarn nx test ag-charts-core` — 856 passed
- `yarn nx test ag-charts-community` — 4167 passed
- `yarn nx test ag-charts-enterprise` — 2732 passed

No existing test needed changing.

---
_Generated by [Claude Code](https://claude.ai/code/session_012VfCBX5cuzDCMg6utKhQ84)_