### PR TITLE
AG-14332 Phase 2: Draft implementation of allNodeParams

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/areaSeries.ts
@@ -239,7 +239,7 @@ export class AreaSeries extends PlacedLabelCartesianSeries<AreaSeriesTypes> {
 
     override properties = new AreaSeriesProperties();
 
-    protected override createNodeParams(datum: MarkerSelectionDatum) {
+    override createNodeParams(datum: MarkerSelectionDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -329,7 +329,7 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
 
     override properties = new BarSeriesProperties();
 
-    protected override createNodeParams(datum: BarNodeDatum) {
+    override createNodeParams(datum: BarNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -306,7 +306,7 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
     static override readonly className: string = 'BubbleSeries';
     static readonly type: string = 'bubble';
 
-    protected override createNodeParams(datum: BubbleScatterNodeDatum) {
+    override createNodeParams(datum: BubbleScatterNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -187,7 +187,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
 
     override properties = new HistogramSeriesProperties();
 
-    protected override createNodeParams(datum: HistogramNodeDatum) {
+    override createNodeParams(datum: HistogramNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/lineSeries.ts
@@ -170,7 +170,7 @@ export class LineSeries extends PlacedLabelCartesianSeries<LineSeriesTypes> {
 
     override properties = new LineSeriesProperties();
 
-    protected override createNodeParams(datum: LineNodeDatum) {
+    override createNodeParams(datum: LineNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/polar/donutSeries.ts
@@ -1694,7 +1694,7 @@ export class DonutSeries extends PolarSeries<
         this.zerosumInnerRing.size = this.getInnerRadius() * 2;
     }
 
-    protected override createNodeParams(datum: PieDonutNodeDatum) {
+    override createNodeParams(datum: PieDonutNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             angleKey: this.properties.angleKey,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1,5 +1,4 @@
 import type {
-    AreExact,
     BoxBounds,
     Callback,
     CallbackParam,
@@ -96,7 +95,6 @@ import {
     type NodeDataDependencies,
     SelectionState,
     type SeriesNodeDatum,
-    type SeriesNodeEventTypes,
 } from './seriesTypes';
 import { type ShapeFillBBox } from './shapeUtil';
 import { hasDimmedOpacity, resolveMarkerDrawingMode } from './util';
@@ -1238,7 +1236,7 @@ export abstract class Series<
         datums: TDatum[],
         coordinates: AgCoordinates | undefined
     ) {
-        const allNodeParams: AgNodeParams<unknown>[] = datums.map(d => d.series.createNodeParams(d));
+        const allNodeParams: AgNodeParams<unknown>[] = datums.map((d) => d.series.createNodeParams(d));
 
         // datums[0] is the "winner" for backward compatibility.
         const datum = datums[0];
@@ -1258,7 +1256,7 @@ export abstract class Series<
         };
     }
 
-    protected createNodeParams(datum: TDatum): AgNodeParams<unknown> {
+    createNodeParams(datum: TDatum): AgNodeParams<unknown> {
         const dataIdKey = this.data?.dataIdKey;
         return {
             datum: datum.datum,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1,4 +1,5 @@
 import type {
+    AreExact,
     BoxBounds,
     Callback,
     CallbackParam,
@@ -1203,39 +1204,51 @@ export abstract class Series<
         callWithContext([this.properties, this.ctx.chartService], this.fireEventWrapper, event);
     }
 
-    fireNodeClickEvent(event: Event, datum: TDatum, coordinates: AgCoordinates | undefined): boolean {
-        const clickEvent = this.createNodeEvent('seriesNodeClick', event, datum, coordinates);
-        this.fireEvent(clickEvent);
-        return !clickEvent.defaultPrevented;
+    fireNodeClickEvent(event: Event, datums: TDatum[], coordinates: AgCoordinates | undefined): boolean {
+        return this.fireNodeEvent('seriesNodeClick', event, datums, coordinates);
     }
 
-    fireNodeDoubleClickEvent(event: Event, datum: TDatum, coordinates: AgCoordinates | undefined): boolean {
-        const clickEvent = this.createNodeEvent('seriesNodeDoubleClick', event, datum, coordinates);
+    fireNodeDoubleClickEvent(event: Event, datums: TDatum[], coordinates: AgCoordinates | undefined): boolean {
+        return this.fireNodeEvent('seriesNodeDoubleClick', event, datums, coordinates);
+    }
+
+    private fireNodeEvent<T extends 'seriesNodeClick' | 'seriesNodeDoubleClick'>(
+        type: T,
+        event: Event,
+        datums: TDatum[],
+        coordinates: AgCoordinates | undefined
+    ) {
+        const clickEvent = this.createNodeEvent(type, event, datums, coordinates);
         this.fireEvent(clickEvent);
         return !clickEvent.defaultPrevented;
     }
 
     createNodeContextMenuActionEvent(
         event: Event,
-        datum: TDatum,
+        datums: TDatum[],
         coordinates: AgCoordinates | undefined
     ): INodeEvent<'nodeContextMenuAction'> {
-        return this.createNodeEvent('nodeContextMenuAction', event, datum, coordinates);
+        return this.createNodeEvent('nodeContextMenuAction', event, datums, coordinates);
     }
 
     // Do not override. Override createNodeParams instead.
-    private createNodeEvent<T extends SeriesNodeEventTypes>(
+    private createNodeEvent<T extends 'seriesNodeClick' | 'seriesNodeDoubleClick' | 'nodeContextMenuAction'>(
         type: T,
         event: Event,
-        datum: TDatum,
+        datums: TDatum[],
         coordinates: AgCoordinates | undefined
-    ): INodeEvent<T> {
+    ) {
+        const allNodeParams: AgNodeParams<unknown>[] = datums.map(d => d.series.createNodeParams(d));
+
+        // datums[0] is the "winner" for backward compatibility.
+        const datum = datums[0];
         let defaultPrevented = false;
         return {
             ...this.createNodeParams(datum),
             type,
             event,
             coordinates,
+            allNodeParams,
             get defaultPrevented() {
                 return defaultPrevented;
             },

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -841,7 +841,7 @@ export class SeriesAreaManager extends BaseManager {
                 this.chart.ctx.chartService,
                 datum
             );
-            const defaultBehavior = series.fireNodeClickEvent(sourceEvent, datum, coordinates);
+            const defaultBehavior = series.fireNodeClickEvent(sourceEvent, [datum], coordinates);
             if (defaultBehavior) {
                 const syntheticEvent: KeyboardSyntheticMouseWidgetEvent = {
                     type: 'click',
@@ -888,7 +888,7 @@ export class SeriesAreaManager extends BaseManager {
         const firesUserClickListeners = updated.active.series.firesUserClickListeners(pickedNodes.target);
         if (event.type === 'click') {
             const defaultBehavior = firesUserClickListeners
-                ? updated.active.series.fireNodeClickEvent(event.sourceEvent, updated.active, coordinates)
+                ? updated.active.series.fireNodeClickEvent(event.sourceEvent, [updated.active], coordinates)
                 : true;
             if (defaultBehavior) {
                 const next = this.pickManager.nextCandidate();
@@ -917,7 +917,7 @@ export class SeriesAreaManager extends BaseManager {
             event.preventZoomDblClick = distance === 0;
 
             if (firesUserClickListeners) {
-                updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, updated.active, coordinates);
+                updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, [updated.active], coordinates);
             }
             return { node: updated.active, target: pickedNodes.target };
         } else {

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -136,8 +136,8 @@ export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesP
     hasData: boolean;
     update(opts: { seriesRect?: BBox }): Promise<void> | void;
     updatePlacedLabelData?(labels: PlacedLabel<TLabel>[]): void;
-    fireNodeClickEvent(event: Event, datum: SeriesNodeDatum, coordinates: AgCoordinates | undefined): boolean;
-    fireNodeDoubleClickEvent(event: Event, datum: SeriesNodeDatum, coordinates: AgCoordinates | undefined): void;
+    fireNodeClickEvent(event: Event, datums: SeriesNodeDatum[], coordinates: AgCoordinates | undefined): boolean;
+    fireNodeDoubleClickEvent(event: Event, datums: SeriesNodeDatum[], coordinates: AgCoordinates | undefined): void;
     createNodeContextMenuActionEvent(
         event: Event,
         datums: TDatum[],

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -140,9 +140,10 @@ export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesP
     fireNodeDoubleClickEvent(event: Event, datum: SeriesNodeDatum, coordinates: AgCoordinates | undefined): void;
     createNodeContextMenuActionEvent(
         event: Event,
-        datum: TDatum,
+        datums: TDatum[],
         coordinates: AgCoordinates | undefined
     ): INodeEvent<'nodeContextMenuAction'>;
+    createNodeParams(datum: TDatum): AgNodeParams<unknown>;
     getLegendData<T extends ChartLegendType>(legendType: T): ChartLegendDatum<T>[];
     getLegendData(legendType: ChartLegendType): ChartLegendDatum<ChartLegendType>[];
     getLabelData(): PointLabelDatum[];

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -590,7 +590,7 @@ export class ContextMenu extends AbstractModuleInstance {
             return () => {
                 const { chartService: chart } = this.ctx;
                 const pickedNodes = this.pickedNodes;
-                if (!pickedNodes || !pickedNodes[0]) return;
+                if (!pickedNodes?.[0]) return;
 
                 const coordinates: AgCoordinates | undefined = this.ctx.chartService.toAgCoordinates(event);
                 const callers: (Caller | undefined)[] = [pickedNodes[0].series.properties, chart];

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -589,13 +589,14 @@ export class ContextMenu extends AbstractModuleInstance {
         } else if (ContextMenuRegistry.checkCallback('series-node', showOn, callback)) {
             return () => {
                 const { chartService: chart } = this.ctx;
+                const pickedNodes = this.pickedNodes;
+                if (!pickedNodes || !pickedNodes[0]) return;
 
-                const pickedNode = this.pickedNodes?.[0];
                 const coordinates: AgCoordinates | undefined = this.ctx.chartService.toAgCoordinates(event);
-                const callers: (Caller | undefined)[] = [pickedNode?.series.properties, chart];
+                const callers: (Caller | undefined)[] = [pickedNodes[0].series.properties, chart];
                 // FIXME: apiEvent should be of type CallbackParamRules<AgNodeContextMenuActionEvent>
                 const apiEvent: AgNodeContextMenuActionEvent | undefined =
-                    pickedNode?.series.createNodeContextMenuActionEvent(showEvent, pickedNode, coordinates);
+                    pickedNode?.series.createNodeContextMenuActionEvent(showEvent, pickedNodes, coordinates);
                 if (apiEvent) {
                     callWithContext(callers, callback, apiEvent);
                 } else {

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -596,7 +596,7 @@ export class ContextMenu extends AbstractModuleInstance {
                 const callers: (Caller | undefined)[] = [pickedNodes[0].series.properties, chart];
                 // FIXME: apiEvent should be of type CallbackParamRules<AgNodeContextMenuActionEvent>
                 const apiEvent: AgNodeContextMenuActionEvent | undefined =
-                    pickedNode?.series.createNodeContextMenuActionEvent(showEvent, pickedNodes, coordinates);
+                    pickedNodes[0]?.series.createNodeContextMenuActionEvent(showEvent, pickedNodes, coordinates);
                 if (apiEvent) {
                     callWithContext(callers, callback, apiEvent);
                 } else {

--- a/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/box-plot/boxPlotSeries.ts
@@ -122,7 +122,7 @@ export class BoxPlotSeries extends _ModuleSupport.AbstractBarSeries<BoxPlotSerie
 
     override properties = new BoxPlotSeriesProperties();
 
-    protected override createNodeParams(datum: BoxPlotNodeDatum) {
+    override createNodeParams(datum: BoxPlotNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/flow-proportion/flowProportionSeries.ts
@@ -108,7 +108,7 @@ export abstract class FlowProportionSeries<
     _ModuleSupport.SeriesNodeDataContext<TDatum<TNodeDatum, TLinkDatum>, TLabel>
 > {
     // `size`/`label` live on the context node data rather than on the picked datum, so they need a lookup.
-    protected override createNodeParams(datum: TDatum<TNodeDatum, TLinkDatum>) {
+    override createNodeParams(datum: TDatum<TNodeDatum, TLinkDatum>) {
         const nodeDatum = this.contextNodeData?.nodeData.find(
             (d) => d.type === datum.type && d.datumIndex === datum.datumIndex
         );

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -107,7 +107,7 @@ export interface FunnelAnimationData<
 export abstract class BaseFunnelSeries<
     TTypes extends BaseFunnelSeriesTypes,
 > extends _ModuleSupport.AbstractBarSeries<TTypes> {
-    protected override createNodeParams(datum: FunnelNodeDatum) {
+    override createNodeParams(datum: FunnelNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.stageKey,

--- a/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/heatmap/heatmapSeries.ts
@@ -151,7 +151,7 @@ export class HeatmapSeries extends _ModuleSupport.CartesianSeries<HeatmapSeriesT
 
     override properties = new HeatmapSeriesProperties();
 
-    protected override createNodeParams(datum: HeatmapNodeDatum) {
+    override createNodeParams(datum: HeatmapNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/ohlc/ohlcSeriesBase.ts
@@ -210,7 +210,7 @@ function resetOhlcSelectionsDirect<D extends OhlcNodeDatum>(
 export abstract class OhlcSeriesBase<
     TTypes extends OhlcSeriesBaseTypes,
 > extends _ModuleSupport.AbstractBarSeries<TTypes> {
-    protected override createNodeParams(datum: OhlcNodeDatum) {
+    override createNodeParams(datum: OhlcNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radar/radarSeries.ts
@@ -110,7 +110,7 @@ export abstract class RadarSeries<
 > extends _ModuleSupport.PolarSeries<RadarNodeDatum, TOpts, TProps, _ModuleSupport.Marker<RadarNodeDatum>> {
     static override readonly className: string = 'RadarSeries';
 
-    protected override createNodeParams(datum: RadarNodeDatum) {
+    override createNodeParams(datum: RadarNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             angleKey: this.properties.angleKey,

--- a/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-bar/radialBarSeries.ts
@@ -95,7 +95,7 @@ export class RadialBarSeries extends _ModuleSupport.PolarSeries<
 
     override properties = new RadialBarSeriesProperties();
 
-    protected override createNodeParams(datum: RadialBarNodeDatum) {
+    override createNodeParams(datum: RadialBarNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             angleKey: this.properties.angleKey,

--- a/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
+++ b/packages/ag-charts-enterprise/src/series/radial-column/radialColumnSeriesBase.ts
@@ -95,7 +95,7 @@ export abstract class RadialColumnSeriesBase<
     RadialColumnNodeDatum,
     RadialColumnSeriesNodeDataContext
 > {
-    protected override createNodeParams(datum: RadialColumnNodeDatum) {
+    override createNodeParams(datum: RadialColumnNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             angleKey: this.properties.angleKey,

--- a/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
+++ b/packages/ag-charts-enterprise/src/series/range-area/rangeArea.ts
@@ -276,7 +276,7 @@ export class RangeAreaSeries extends _ModuleSupport.CartesianSeries<RangeAreaSer
 
     override properties = new RangeAreaProperties();
 
-    protected override createNodeParams(datum: RangeAreaMarkerDatum) {
+    override createNodeParams(datum: RangeAreaMarkerDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -297,7 +297,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
 
     private readonly aggregationManager = new AggregationManager<RangeBarSeriesDataAggregationFilter>();
 
-    protected override createNodeParams(datum: RangeBarNodeDatum) {
+    override createNodeParams(datum: RangeBarNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -1552,8 +1552,8 @@ describe('WaterfallSeries', () => {
 
             const total = nodeData.find((n) => n.itemType === 'total')!;
             const real = nodeData.find((n) => n.itemType === 'positive')!;
-            series.fireNodeClickEvent(new Event('click'), total, undefined);
-            series.fireNodeClickEvent(new Event('click'), real, undefined);
+            series.fireNodeClickEvent(new Event('click'), [total], undefined);
+            series.fireNodeClickEvent(new Event('click'), [real], undefined);
 
             // The total bar's itemId falls back to its axisLabel; the real bar resolves via datumIndex.
             expect(events[0].itemType).toBe('total');

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -36,7 +36,8 @@ import {
 } from 'ag-charts-community-test';
 
 import { createEnterpriseChart, prepareEnterpriseTestOptions, renderEnterpriseChartImage } from '../../test/utils';
-import type { WaterfallSeries } from './waterfallSeries';
+import type { WaterfallNodeDatum, WaterfallSeries } from './waterfallSeries';
+import { WaterfallSeriesTotal } from './waterfallSeriesProperties';
 
 describe('WaterfallSeries', () => {
     setupMockConsole();
@@ -142,6 +143,10 @@ describe('WaterfallSeries', () => {
                 direction,
             })),
         };
+    }
+
+    function fireNodeClick(series: WaterfallSeries, datum: WaterfallNodeDatum): void {
+        series.fireNodeClickEvent(new Event('click'), [datum], undefined);
     }
 
     it('preserves bigint value precision in the data label and formatter callback (AG-16608)', async () => {
@@ -260,8 +265,8 @@ describe('WaterfallSeries', () => {
             await waitForChartStability(chart);
 
             const series = seriesOf(chart);
-            series.fireNodeClickEvent(new Event('click'), nodeOfType(chart, 'subtotal'));
-            series.fireNodeClickEvent(new Event('click'), nodeOfType(chart, 'positive'));
+            fireNodeClick(series, nodeOfType(chart, 'subtotal'));
+            fireNodeClick(series, nodeOfType(chart, 'positive'));
 
             expect(seriesNodeClick).toHaveBeenCalledTimes(2);
             expect(seriesNodeClick.mock.calls[0][0].totalValue).toBe(SUBTOTAL_VALUE);
@@ -1552,8 +1557,8 @@ describe('WaterfallSeries', () => {
 
             const total = nodeData.find((n) => n.itemType === 'total')!;
             const real = nodeData.find((n) => n.itemType === 'positive')!;
-            series.fireNodeClickEvent(new Event('click'), [total], undefined);
-            series.fireNodeClickEvent(new Event('click'), [real], undefined);
+            fireNodeClick(series, total);
+            fireNodeClick(series, real);
 
             // The total bar's itemId falls back to its axisLabel; the real bar resolves via datumIndex.
             expect(events[0].itemType).toBe('total');

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -37,7 +37,6 @@ import {
 
 import { createEnterpriseChart, prepareEnterpriseTestOptions, renderEnterpriseChartImage } from '../../test/utils';
 import type { WaterfallNodeDatum, WaterfallSeries } from './waterfallSeries';
-import { WaterfallSeriesTotal } from './waterfallSeriesProperties';
 
 describe('WaterfallSeries', () => {
     setupMockConsole();

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -120,7 +120,7 @@ type WaterfallNodePointDatum = _ModuleSupport.DataModelSeriesNodeDatum['point'] 
     readonly y2: number;
 };
 
-interface WaterfallNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum, Readonly<Point> {
+export interface WaterfallNodeDatum extends _ModuleSupport.CartesianSeriesNodeDatum, Readonly<Point> {
     readonly index: number;
     // Set for synthetic total/subtotal bars to their `totals.itemId`, falling back to their `axisLabel`.
     // Real bars leave it unset so `getItemId` resolves via `dataIdKey`, then `datumIndex`.

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -205,7 +205,7 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
 
     override properties = new WaterfallSeriesProperties();
 
-    protected override createNodeParams(datum: WaterfallNodeDatum) {
+    override createNodeParams(datum: WaterfallNodeDatum) {
         return {
             ...super.createNodeParams(datum),
             xKey: this.properties.xKey,

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -208,7 +208,7 @@ export interface AgContextMenuShowOnParamsSeriesArea<_TDatumReserved = never, TC
 }
 
 export interface AgContextMenuShowOnParamsSeriesNode<TDatum = DatumDefault, TContext = ContextDefault> extends Omit<
-    AgNodeContextMenuActionEvent<TDatum, TContext>,
+    Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, 'allNodeParams'>,
     GetItemsParamsOmissions
 > {
     /** Which clicked element this menu item should be shown for. */

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -31,7 +31,11 @@ export interface AgBaseNodeClickEvent<TEvent extends string, TDatum, TContext = 
     type: TEvent;
 }
 
-export interface AgNodeClickEvent<TEvent extends string, TDatum, TContext = ContextDefault> extends AgBaseNodeClickEvent<TEvent, TContext> {
+export interface AgNodeClickEvent<
+    TEvent extends string,
+    TDatum,
+    TContext = ContextDefault,
+> extends AgBaseNodeClickEvent<TEvent, TContext> {
     /** TODO: writeme */
     allNodeParams: AgNodeParams<TDatum>[];
 }
@@ -80,9 +84,9 @@ export interface AgNodeParams<TDatum> {
     /** Histogram series only: zero-based positional index of the bin within the series. */
     binIndex?: number;
     /** Histogram series only: the bin's start and end bounds on the x-axis. */
-    binRange?: [number, number];
+    binRange?: [AgNumericValue, AgNumericValue];
     /** Histogram series only: the aggregated `yKey` value for the bin. */
-    aggregatedValue?: number;
+    aggregatedValue?: AgNumericValue;
     /** Histogram series only: the number of source rows within the bin. */
     frequency?: number;
 }
@@ -305,8 +309,7 @@ export interface AgCaptionListeners<TContext = ContextDefault> {
 export interface AgNodeContextMenuActionEvent<
     TDatum = DatumDefault,
     TContext = ContextDefault,
-> extends AgBaseNodeClickEvent<'nodeContextMenuAction', TDatum, TContext> {
-}
+> extends AgBaseNodeClickEvent<'nodeContextMenuAction', TDatum, TContext> {}
 
 export interface AgBaseChartListeners<TDatum, TContext = ContextDefault> {
     /** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is clicked.

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -25,10 +25,13 @@ interface AgCoordinatedEvent {
     coordinates?: AgCoordinates;
 }
 
-export interface AgNodeClickEvent<TEvent extends string, TDatum, TContext = ContextDefault>
+export interface AgBaseNodeClickEvent<TEvent extends string, TDatum, TContext = ContextDefault>
     extends AgChartEvent<TEvent, TContext>, AgCoordinatedEvent, AgNodeParams<TDatum> {
     /** Event type. */
     type: TEvent;
+}
+
+export interface AgNodeClickEvent<TEvent extends string, TDatum, TContext = ContextDefault> extends AgBaseNodeClickEvent<TEvent, TContext> {
     /** TODO: writeme */
     allNodeParams: AgNodeParams<TDatum>[];
 }
@@ -74,6 +77,14 @@ export interface AgNodeParams<TDatum> {
     sectorLabelKey?: ResolvedDatumKey<TDatum>;
     /** radiusKey as specified on series options */
     radiusKey?: ResolvedDatumKey<TDatum>;
+    /** Histogram series only: zero-based positional index of the bin within the series. */
+    binIndex?: number;
+    /** Histogram series only: the bin's start and end bounds on the x-axis. */
+    binRange?: [number, number];
+    /** Histogram series only: the aggregated `yKey` value for the bin. */
+    aggregatedValue?: number;
+    /** Histogram series only: the number of source rows within the bin. */
+    frequency?: number;
 }
 
 export interface AgSeriesVisibilityChange<TContext = ContextDefault> {
@@ -294,15 +305,7 @@ export interface AgCaptionListeners<TContext = ContextDefault> {
 export interface AgNodeContextMenuActionEvent<
     TDatum = DatumDefault,
     TContext = ContextDefault,
-> extends AgNodeClickEvent<'nodeContextMenuAction', TDatum, TContext> {
-    /** Histogram series only: zero-based positional index of the bin within the series. */
-    binIndex?: number;
-    /** Histogram series only: the bin's start and end bounds on the x-axis. */
-    binRange?: [number, number];
-    /** Histogram series only: the aggregated `yKey` value for the bin. */
-    aggregatedValue?: number;
-    /** Histogram series only: the number of source rows within the bin. */
-    frequency?: number;
+> extends AgBaseNodeClickEvent<'nodeContextMenuAction', TDatum, TContext> {
 }
 
 export interface AgBaseChartListeners<TDatum, TContext = ContextDefault> {

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -35,7 +35,7 @@ export interface AgNodeClickEvent<
     TEvent extends string,
     TDatum,
     TContext = ContextDefault,
-> extends AgBaseNodeClickEvent<TEvent, TContext> {
+> extends AgBaseNodeClickEvent<TEvent, TDatum, TContext> {
     /** TODO: writeme */
     allNodeParams: AgNodeParams<TDatum>[];
 }

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -29,6 +29,8 @@ export interface AgNodeClickEvent<TEvent extends string, TDatum, TContext = Cont
     extends AgChartEvent<TEvent, TContext>, AgCoordinatedEvent, AgNodeParams<TDatum> {
     /** Event type. */
     type: TEvent;
+    /** TODO: writeme */
+    allNodeParams: AgNodeParams<TDatum>[];
 }
 
 /**

--- a/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
+++ b/packages/ag-charts-types/src/series/cartesian/histogramOptions.ts
@@ -164,16 +164,21 @@ export interface AgHistogramSeriesOptionsNames {
     yName?: string;
 }
 
-/** Node click/double-click event fired for a histogram bin. */
-export interface AgHistogramSeriesNodeClickEvent<TDatum = DatumDefault, TContext = ContextDefault>
+interface AgBaseHistogramClickEvent<TType extends string, TDatum, TContext>
     extends
-        Omit<AgNodeClickEvent<'seriesNodeClick', TDatum, TContext>, 'datum' | 'datums'>,
+        Omit<AgNodeClickEvent<TType, TDatum, TContext>, keyof AgHistogramSeriesBinParams<TDatum>>,
         AgHistogramSeriesBinParams<TDatum> {}
 
-export interface AgHistogramSeriesNodeDoubleClickEvent<TDatum = DatumDefault, TContext = ContextDefault>
-    extends
-        Omit<AgNodeClickEvent<'seriesNodeDoubleClick', TDatum, TContext>, 'datum' | 'datums'>,
-        AgHistogramSeriesBinParams<TDatum> {}
+/** Node click/double-click event fired for a histogram bin. */
+export interface AgHistogramSeriesNodeClickEvent<
+    TDatum = DatumDefault,
+    TContext = ContextDefault,
+> extends AgBaseHistogramClickEvent<'seriesNodeClick', TDatum, TContext> {}
+
+export interface AgHistogramSeriesNodeDoubleClickEvent<
+    TDatum = DatumDefault,
+    TContext = ContextDefault,
+> extends AgBaseHistogramClickEvent<'seriesNodeDoubleClick', TDatum, TContext> {}
 
 export interface AgHistogramSeriesListeners<TDatum = DatumDefault, TContext = ContextDefault> {
     /** The listener to call when a histogram bin is clicked. */


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14332

**Known issue / follow-up:**
*  `Series.createNodeEvent` uses `datums[0]` as the "winner" - this is inconsistent with the tooltip candidacy feature. We need to add a `winner: number` index to this method which can be set to the current tooltip candidacy index.