### PR TITLE
AG-14332 Phase 3: Add `winner` parameter to series event allocation

### DIFF
--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -40,7 +40,6 @@ import {
 import type {
     AgActiveItemState,
     AgChartLabelFormatterParams,
-    AgCoordinates,
     AgDrawingMode,
     AgInitialStateLegendOptions,
     AgNodeParams,
@@ -88,6 +87,7 @@ import type { SeriesTooltip } from './seriesTooltip';
 import {
     type BucketLookupFeature,
     type DatumIndex,
+    type FireNodeEventParams,
     HighlightState,
     type INodeEvent,
     type ISeries,
@@ -1202,47 +1202,35 @@ export abstract class Series<
         callWithContext([this.properties, this.ctx.chartService], this.fireEventWrapper, event);
     }
 
-    fireNodeClickEvent(event: Event, datums: TDatum[], coordinates: AgCoordinates | undefined): boolean {
-        return this.fireNodeEvent('seriesNodeClick', event, datums, coordinates);
+    fireNodeClickEvent(opts: FireNodeEventParams): boolean {
+        return this.fireNodeEvent('seriesNodeClick', opts);
     }
 
-    fireNodeDoubleClickEvent(event: Event, datums: TDatum[], coordinates: AgCoordinates | undefined): boolean {
-        return this.fireNodeEvent('seriesNodeDoubleClick', event, datums, coordinates);
+    fireNodeDoubleClickEvent(opts: FireNodeEventParams): boolean {
+        return this.fireNodeEvent('seriesNodeDoubleClick', opts);
     }
 
-    private fireNodeEvent<T extends 'seriesNodeClick' | 'seriesNodeDoubleClick'>(
-        type: T,
-        event: Event,
-        datums: TDatum[],
-        coordinates: AgCoordinates | undefined
-    ) {
-        const clickEvent = this.createNodeEvent(type, event, datums, coordinates);
+    private fireNodeEvent<T extends 'seriesNodeClick' | 'seriesNodeDoubleClick'>(type: T, opts: FireNodeEventParams) {
+        const clickEvent = this.createNodeEvent(type, opts);
         this.fireEvent(clickEvent);
         return !clickEvent.defaultPrevented;
     }
 
-    createNodeContextMenuActionEvent(
-        event: Event,
-        datums: TDatum[],
-        coordinates: AgCoordinates | undefined
-    ): INodeEvent<'nodeContextMenuAction'> {
-        return this.createNodeEvent('nodeContextMenuAction', event, datums, coordinates);
+    createNodeContextMenuActionEvent(opts: FireNodeEventParams): INodeEvent<'nodeContextMenuAction'> {
+        return this.createNodeEvent('nodeContextMenuAction', opts);
     }
 
     // Do not override. Override createNodeParams instead.
-    private createNodeEvent<T extends 'seriesNodeClick' | 'seriesNodeDoubleClick' | 'nodeContextMenuAction'>(
+    createNodeEvent<T extends 'seriesNodeClick' | 'seriesNodeDoubleClick' | 'nodeContextMenuAction'>(
         type: T,
-        event: Event,
-        datums: TDatum[],
-        coordinates: AgCoordinates | undefined
+        opts: FireNodeEventParams
     ) {
+        const { event, datums, winner, coordinates } = opts;
         const allNodeParams: AgNodeParams<unknown>[] = datums.map((d) => d.series.createNodeParams(d));
 
-        // datums[0] is the "winner" for backward compatibility.
-        const datum = datums[0];
         let defaultPrevented = false;
         return {
-            ...this.createNodeParams(datum),
+            ...allNodeParams[winner],
             type,
             event,
             coordinates,

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -65,7 +65,8 @@ import {
     type SeriesNodePickIntent,
     type UnknownSeries,
 } from './series';
-import { type DatumIndex, SelectionState, type SeriesNodeDatum } from './seriesTypes';
+import type { DatumIndex, FireNodeEventParams, SeriesNodeDatum } from './seriesTypes';
+import { SelectionState } from './seriesTypes';
 import { getDatumRefPoint } from './util';
 
 type FocusAnnounceMode = 'always' | 'never' | 'when-changed';
@@ -841,7 +842,13 @@ export class SeriesAreaManager extends BaseManager {
                 this.chart.ctx.chartService,
                 datum
             );
-            const defaultBehavior = series.fireNodeClickEvent(sourceEvent, [datum], coordinates);
+            // Keyboard nav activates exactly one datum: single-entry list, winner is index 0.
+            const defaultBehavior = series.fireNodeClickEvent({
+                event: sourceEvent,
+                datums: [datum],
+                winner: 0,
+                coordinates,
+            });
             if (defaultBehavior) {
                 const syntheticEvent: KeyboardSyntheticMouseWidgetEvent = {
                     type: 'click',
@@ -886,9 +893,20 @@ export class SeriesAreaManager extends BaseManager {
         // interaction via the `series-area:click` event emitted by the caller, but must not also
         // reach the user's node click / double-click listeners (AG-17947).
         const firesUserClickListeners = updated.active.series.firesUserClickListeners(pickedNodes.target);
+
+        // `matches` is the flat, hit-test-ordered pick, spanning every series that overlapped the point.
+        // `updated.active` is pickManager's chosen candidate, which is not necessarily matches[0].
+        const { matches } = pickedNodes;
+        const nodeEventOpts: FireNodeEventParams = {
+            event: event.sourceEvent,
+            datums: matches,
+            winner: matches.indexOf(updated.active),
+            coordinates,
+        };
+
         if (event.type === 'click') {
             const defaultBehavior = firesUserClickListeners
-                ? updated.active.series.fireNodeClickEvent(event.sourceEvent, [updated.active], coordinates)
+                ? updated.active.series.fireNodeClickEvent(nodeEventOpts)
                 : true;
             if (defaultBehavior) {
                 const next = this.pickManager.nextCandidate();
@@ -917,7 +935,7 @@ export class SeriesAreaManager extends BaseManager {
             event.preventZoomDblClick = distance === 0;
 
             if (firesUserClickListeners) {
-                updated.active.series.fireNodeDoubleClickEvent(event.sourceEvent, [updated.active], coordinates);
+                updated.active.series.fireNodeDoubleClickEvent(nodeEventOpts);
             }
             return { node: updated.active, target: pickedNodes.target };
         } else {

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -110,6 +110,20 @@ export interface INodeEvent<TEvent extends string = SeriesNodeEventTypes>
     preventDefault(): void;
 }
 
+export type FireNodeEventParams = {
+    event: Event;
+    /** Every node picked at this point, flat and in hit-test order; may span several series. */
+    datums: SeriesNodeDatum[];
+    /**
+     * Index into `datums` of the node whose params are flattened onto the event root. Historically, click events only
+     * ever reported 1 series-node at most. Nowadays, left/right click events report all series-nodes that overlap at
+     * this click-point (`allNodesParams` / `allShowOnParams` ). The `winner` is that series-node for backward
+     * compatibility.
+     */
+    winner: number;
+    coordinates: AgCoordinates | undefined;
+};
+
 export interface ISeriesProperties {
     cursor: string;
     xKey?: string;
@@ -136,13 +150,9 @@ export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesP
     hasData: boolean;
     update(opts: { seriesRect?: BBox }): Promise<void> | void;
     updatePlacedLabelData?(labels: PlacedLabel<TLabel>[]): void;
-    fireNodeClickEvent(event: Event, datums: SeriesNodeDatum[], coordinates: AgCoordinates | undefined): boolean;
-    fireNodeDoubleClickEvent(event: Event, datums: SeriesNodeDatum[], coordinates: AgCoordinates | undefined): void;
-    createNodeContextMenuActionEvent(
-        event: Event,
-        datums: TDatum[],
-        coordinates: AgCoordinates | undefined
-    ): INodeEvent<'nodeContextMenuAction'>;
+    fireNodeClickEvent(opts: FireNodeEventParams): boolean;
+    fireNodeDoubleClickEvent(opts: FireNodeEventParams): void;
+    createNodeContextMenuActionEvent(opts: FireNodeEventParams): INodeEvent<'nodeContextMenuAction'>;
     createNodeParams(datum: TDatum): AgNodeParams<unknown>;
     getLegendData<T extends ChartLegendType>(legendType: T): ChartLegendDatum<T>[];
     getLegendData(legendType: ChartLegendType): ChartLegendDatum<ChartLegendType>[];

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.ts
@@ -596,7 +596,12 @@ export class ContextMenu extends AbstractModuleInstance {
                 const callers: (Caller | undefined)[] = [pickedNodes[0].series.properties, chart];
                 // FIXME: apiEvent should be of type CallbackParamRules<AgNodeContextMenuActionEvent>
                 const apiEvent: AgNodeContextMenuActionEvent | undefined =
-                    pickedNodes[0]?.series.createNodeContextMenuActionEvent(showEvent, pickedNodes, coordinates);
+                    pickedNodes[0]?.series.createNodeContextMenuActionEvent({
+                        event: showEvent,
+                        datums: pickedNodes,
+                        winner: 0,
+                        coordinates,
+                    });
                 if (apiEvent) {
                     callWithContext(callers, callback, apiEvent);
                 } else {

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfall.test.ts
@@ -145,7 +145,7 @@ describe('WaterfallSeries', () => {
     }
 
     function fireNodeClick(series: WaterfallSeries, datum: WaterfallNodeDatum): void {
-        series.fireNodeClickEvent(new Event('click'), [datum], undefined);
+        series.fireNodeClickEvent({ event: new Event('click'), datums: [datum], winner: 0, coordinates: undefined });
     }
 
     it('preserves bigint value precision in the data label and formatter callback (AG-16608)', async () => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14332

Set `winner` to the current tooltip candidate when applicable.