### PR TITLE
Prototype a raw.githubusercontent.com viewer for snapshot reports

### DIFF
--- a/.github/workflows/gh-pages-snapshot-viewer.yml
+++ b/.github/workflows/gh-pages-snapshot-viewer.yml
@@ -1,0 +1,73 @@
+name: gh-pages snapshot viewer
+
+# Publishes the two-file snapshot-report viewer to gh-pages under snapshot-viewer/.
+#
+# Prototype support, deliberately manual: nothing in CI links to the viewer yet, so there is no
+# reason to pay a Pages rebuild on every push. Run it by hand after changing either file.
+#
+# See external/ag-shared/github/actions/pr-preview-lib/VIEWER-PROTOTYPE.md for what the viewer is
+# for and what is still unanswered about it.
+
+on:
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    # Shares the publish branch with the per-PR publishers and the janitor. Conflicts between them
+    # are resolved by the push-retry loop in gh-pages-commit.sh, not by a lock, so this only
+    # serialises viewer publishes against each other.
+    group: gh-pages-snapshot-viewer
+    cancel-in-progress: false
+
+jobs:
+    publish:
+        runs-on: ubuntu-24.04
+        name: Publish snapshot viewer
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+
+            - name: Stage viewer files
+              shell: bash
+              env:
+                  LIB: external/ag-shared/github/actions/pr-preview-lib
+              run: |
+                  set -euo pipefail
+                  # Staged into a directory of their own because gh-pages-commit.sh copies the whole
+                  # of SOURCE_DIR, and the lib directory also holds the commit script and the
+                  # prototype write-up, which have no business on a public site.
+                  mkdir -p "${RUNNER_TEMP}/viewer"
+                  cp "${LIB}/viewer.html" "${LIB}/report-frame.html" "${RUNNER_TEMP}/viewer/"
+                  ls -l "${RUNNER_TEMP}/viewer"
+
+            - name: Publish to gh-pages
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  MODE: sync
+                  TARGET_PREFIX: snapshot-viewer
+                  COMMIT_MESSAGE: 'pr-preview: publish snapshot report viewer'
+                  PUBLISH_BRANCH: gh-pages
+              run: |
+                  set -euo pipefail
+                  export SOURCE_DIR="${RUNNER_TEMP}/viewer"
+                  bash external/ag-shared/github/actions/pr-preview-lib/gh-pages-commit.sh
+
+            - name: Summary
+              if: always()
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  {
+                      echo "### Snapshot viewer"
+                      echo
+                      echo "<https://ag-grid.github.io/ag-charts/snapshot-viewer/viewer.html>"
+                      echo
+                      echo 'Needs `?repo=owner/name&sha=<40-hex>&path=<file>` to load a report.'
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/external/ag-shared/github/actions/pr-preview-lib/VIEWER-PROTOTYPE.md
+++ b/external/ag-shared/github/actions/pr-preview-lib/VIEWER-PROTOTYPE.md
@@ -1,0 +1,111 @@
+# Raw-artefact viewer — prototype findings
+
+Status: **prototype, not wired into CI.** `viewer.html` and `report-frame.html` are referenced by
+nothing. The snapshot-review publishing path is unchanged.
+
+## The problem this attacks
+
+A snapshot-review report becomes visible to a reviewer only after GitHub Pages rebuilds and
+redeploys the **whole** site. On this repo that was measured at 163–706s, and Pages branch builds
+are single-flight — a later push cancels the in-flight build, so a report can be delayed well past
+that or miss its CI run entirely. That is what produced the false "Report publish failed" comments.
+
+Pages latency is a function of total site size, which is why the prune and the janitor were worth
+doing on their own. But even a small site pays a whole-site rebuild per push.
+
+## The idea
+
+Push report payloads to a **plain git branch** — no Pages build at all — and serve one tiny static
+page from Pages that fetches a payload and renders it.
+
+## What was measured
+
+Against a live artefact already on `gh-pages`
+(`pr-7764/snapshot-regenerated.html`, 788,439 bytes, at gh-pages commit `7695c942`).
+
+### The fetch works, with no proxy and no credential
+
+`raw.githubusercontent.com` answers cross-origin requests with `access-control-allow-origin: *`.
+It also sends `content-type: text/plain` with `x-content-type-options: nosniff`, which is precisely
+why a viewer page is needed: linking a reviewer straight at a report shows them HTML source.
+
+GitHub Actions **artifacts** were ruled out for this earlier — anonymous download returns 401 even
+on a public repo, so a static page would need a credential.
+
+### Push → visible: under half a second
+
+Three runs, pushing a realistic 788 KB payload to a scratch branch and polling raw by commit SHA:
+
+| run | push | push → raw 200 | total |
+| --- | ---- | -------------- | ----- |
+| 1   | 2.90s | 0.32s | 3.22s |
+| 2   | 2.89s | 0.42s | 3.31s |
+| 3   | 3.42s | 0.45s | 3.87s |
+
+Against 163–706s for the Pages path, and with no cancellation failure mode.
+
+### The payload cannot be passed into the frame from outside
+
+This forced the architecture. At 788 KB, on Chrome 141:
+
+| Route | Result |
+| ----- | ------ |
+| `srcdoc` | Silently loads nothing — no parse, no error, blank frame. Small payloads work, so the failure is size, not content |
+| `blob:` URL | Blocked — a sandbox without `allow-same-origin` gives the frame an opaque origin, and an opaque origin may not read a blob owned by ours |
+| `data:` URL | Renders only on a **second** identical assignment. Reproducible, and far too fragile to ship |
+
+So `report-frame.html` performs the fetch from **inside** its own sandbox and `document.write`s the
+result into itself. The payload never travels through a URL or an attribute, and the size ceiling
+disappears. Fetching still works from the opaque origin: the request carries `Origin: null`, which
+`access-control-allow-origin: *` allows.
+
+### The report is sandbox-compatible
+
+`sandbox="allow-scripts"` **without** `allow-same-origin` — the report's scripts run, but the
+document cannot touch the viewer's DOM, storage or cookies. Granting `allow-same-origin` would hand
+fetched HTML the `ag-grid.github.io` origin, which is shared with every PR preview; that is not an
+acceptable trade and the prototype should be abandoned before it is made.
+
+The report needs nothing an opaque origin denies: no `localStorage`, no `sessionStorage`, no
+cookies, no `indexedDB`. The one exception is the Export-decisions **Copy** button, which uses
+`navigator.clipboard` with an `execCommand` fallback; clipboard write may be denied by permissions
+policy in the sandbox. Both paths are already wrapped and fail soft — the "copied" tick simply does
+not appear. **Not yet verified either way.**
+
+Rendering and the onion / swipe / side-by-side panes were confirmed by hand in a real browser.
+Automated verification was not possible: synthetic input does not cross into a cross-origin frame,
+confirmed with a control (the same report at top level takes clicks and scrolls normally).
+
+## Design notes
+
+- **Address by commit SHA, never a branch name.** raw serves `cache-control: max-age=300`, so a
+  branch URL can be five minutes stale, and its content can change under a link already shared. A
+  SHA names one immutable blob. `viewer.html` rejects anything that is not 40 hex characters.
+- **Validate hard, fail closed.** An unvalidated viewer renders arbitrary HTML from any repo under
+  our own origin's URL bar, which is a convincing place to host a phishing page. The owner is
+  allowlisted and every parameter is pattern-checked, in both files — `report-frame.html` is
+  directly fetchable and cannot assume a caller.
+- **The frame posts its content height out** so the outer page owns a single scrollbar; otherwise
+  the report scrolls inside a viewport-height frame and its own sticky header hides behind the
+  viewer's.
+
+## Open questions before adopting
+
+1. **Unauthenticated raw rate limits.** Still unverified, and a viewer that 429s under review load
+   is worse than a slow Pages deploy. Needs a burst test.
+2. **Non-Chrome browsers.** Everything above is Chrome 141 only.
+3. **Export-decisions Copy** in the sandbox (see above).
+4. **Retention.** Payloads on a data branch need their own janitor; the existing sweep only knows
+   about `gh-pages`.
+
+## If adopted
+
+Publish `viewer.html` + `report-frame.html` to `gh-pages` once, at a stable path, and have CI push
+report payloads to a separate data branch and link
+`.../viewer.html?repo=…&sha=…&path=…`. The `Wait for published reports` and
+`Check for in-flight Pages deploys` steps in `ci.yml`, and the three-state pending/live/failed link
+logic they feed, all become unnecessary.
+
+Worth deferring the `gh-pages` publish until the prune in #7764 merges: adding a file to `gh-pages`
+today triggers a rebuild of the full ~1.1 GB site and can cancel an in-flight preview deploy for
+somebody else's PR.

--- a/external/ag-shared/github/actions/pr-preview-lib/report-frame.html
+++ b/external/ag-shared/github/actions/pr-preview-lib/report-frame.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>Report frame</title>
+<!--
+    Inner half of the viewer. Never open this directly — viewer.html embeds it in a sandboxed
+    iframe, which is what puts this document in an opaque origin.
+
+    Why the fetch happens HERE rather than in viewer.html: handing a fetched 800 KB document to a
+    sandboxed frame from outside means encoding it into srcdoc or a data: URL, and both fail at this
+    size on Chrome 141 (srcdoc silently loads nothing; a data: URL renders blank on first navigation
+    and only paints if the identical URL is assigned a second time). Fetching from inside the frame
+    sidesteps the size ceiling entirely — the payload never has to travel through a URL or an
+    attribute.
+
+    Fetching cross-origin still works from here despite the opaque origin: the request carries
+    `Origin: null`, and raw.githubusercontent.com answers with `access-control-allow-origin: *`.
+-->
+<script>
+    (() => {
+        'use strict';
+        // Params arrive on our own URL, put there by viewer.html, which has already validated them.
+        // Re-validated here anyway: this file is fetchable directly, so it cannot assume a caller.
+        const q = new URLSearchParams(location.search);
+        const repo = q.get('repo') || '';
+        const sha = q.get('sha') || '';
+        const path = q.get('path') || '';
+
+        const bad =
+            !/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repo) ||
+            !/^[0-9a-f]{40}$/.test(sha) ||
+            !/^[A-Za-z0-9._\-/]+$/.test(path) ||
+            path.includes('..') ||
+            path.startsWith('/');
+
+        function report(kind, detail) {
+            // The parent cannot read into this opaque-origin document, so outcomes are posted out.
+            parent.postMessage({ source: 'report-frame', kind, detail }, '*');
+        }
+
+        if (bad) {
+            report('error', 'Malformed parameters.');
+            return;
+        }
+
+        fetch(`https://raw.githubusercontent.com/${repo}/${sha}/${path}`, {
+            credentials: 'omit',
+            referrerPolicy: 'no-referrer',
+        })
+            .then((res) => {
+                if (!res.ok) throw Object.assign(new Error(`HTTP ${res.status}`), { status: res.status });
+                return res.text();
+            })
+            .then((html) => {
+                // document.write, not innerHTML: the report is a whole document whose inline
+                // scripts must execute, and innerHTML never runs injected <script> elements.
+                // Rewriting the document does not disturb this script — document.open() replaces
+                // the document, not the global object, so the closure below keeps running.
+                document.open();
+                document.write(html);
+                document.close();
+                report('ready', html.length);
+
+                // The frame reports its own height so the parent can size it to its content and
+                // let the OUTER page own the scrollbar. Without this the report scrolls inside a
+                // viewport-height frame, which gives two nested scrollbars and hides the report's
+                // own sticky header behind the viewer's.
+                let last = 0;
+                const publishHeight = () => {
+                    const h = Math.max(
+                        document.documentElement.scrollHeight,
+                        document.body ? document.body.scrollHeight : 0
+                    );
+                    if (h && h !== last) {
+                        last = h;
+                        report('height', h);
+                    }
+                };
+                publishHeight();
+                // Expanding a case changes the height long after load, so watch rather than
+                // measure once.
+                new ResizeObserver(publishHeight).observe(document.documentElement);
+            })
+            .catch((e) => report('error', e && e.status ? `HTTP ${e.status}` : String(e && e.message)));
+    })();
+</script>

--- a/external/ag-shared/github/actions/pr-preview-lib/report-frame.html
+++ b/external/ag-shared/github/actions/pr-preview-lib/report-frame.html
@@ -30,13 +30,22 @@
             parent.postMessage({ source: 'report-frame', kind, detail }, '*');
         }
 
-        // Refuse to run outside the viewer. Sandboxing is applied by the embedding page, so opened
-        // directly this document would render third-party HTML top-level, unsandboxed, on our
-        // origin. Nothing below should be reachable that way.
-        if (window === window.parent) {
+        // Refuse to run anywhere but an opaque origin. This document executes HTML it fetched, so
+        // the isolation is not a nicety — it is the only thing standing between fetched content
+        // and ag-grid.github.io's storage and same-origin resources.
+        //
+        // The check is on the origin itself rather than on being framed. Sandboxing is applied by
+        // the EMBEDDING page, so this file cannot infer it: opened directly it runs top-level and
+        // unsandboxed, and a `window !== parent` test is no better, since anyone may frame this URL
+        // from their own site without a sandbox and get the same unsandboxed execution. A sandbox
+        // without allow-same-origin is exactly what makes `self.origin` the string 'null', so
+        // testing for that is testing for the property actually being relied on.
+        //
+        // Fails closed if origin is unavailable.
+        if (self.origin !== 'null') {
             // document.write, not document.body: this script runs while the document is still
             // parsing, so there is no body element to write into yet. The string is a literal.
-            document.write('This page is only usable inside viewer.html.');
+            document.write('This page only runs inside the sandboxed frame in viewer.html.');
             return;
         }
 
@@ -83,10 +92,13 @@
                 // own sticky header behind the viewer's.
                 let last = 0;
                 const publishHeight = () => {
-                    const h = Math.max(
-                        document.documentElement.scrollHeight,
-                        document.body ? document.body.scrollHeight : 0
-                    );
+                    // getBoundingClientRect, NOT scrollHeight. scrollHeight on the root is at least
+                    // the viewport height, and the parent sets the frame's viewport to whatever we
+                    // report — so a measurement taken that way can never come back smaller than the
+                    // last one. Expanding a case would grow the frame permanently and collapsing it
+                    // would leave the blank space behind. The root element's layout box is sized to
+                    // its content and is not clamped to the viewport, so it can shrink again.
+                    const h = Math.ceil(document.documentElement.getBoundingClientRect().height);
                     if (h && h !== last) {
                         last = h;
                         report('height', h);

--- a/external/ag-shared/github/actions/pr-preview-lib/report-frame.html
+++ b/external/ag-shared/github/actions/pr-preview-lib/report-frame.html
@@ -18,6 +18,28 @@
 <script>
     (() => {
         'use strict';
+        // Exact owner/repo values, never a pattern. This page renders fetched HTML, and it is
+        // served from a domain that also hosts our PR previews, so an attacker who can choose the
+        // repo can put their own page under our name — the sandbox stops it touching our storage
+        // but does nothing about what the address bar says. Keep this list in step with the copy
+        // in viewer.html.
+        const ALLOWED_REPOS = ['ag-grid/ag-charts'];
+
+        function report(kind, detail) {
+            // The parent cannot read into this opaque-origin document, so outcomes are posted out.
+            parent.postMessage({ source: 'report-frame', kind, detail }, '*');
+        }
+
+        // Refuse to run outside the viewer. Sandboxing is applied by the embedding page, so opened
+        // directly this document would render third-party HTML top-level, unsandboxed, on our
+        // origin. Nothing below should be reachable that way.
+        if (window === window.parent) {
+            // document.write, not document.body: this script runs while the document is still
+            // parsing, so there is no body element to write into yet. The string is a literal.
+            document.write('This page is only usable inside viewer.html.');
+            return;
+        }
+
         // Params arrive on our own URL, put there by viewer.html, which has already validated them.
         // Re-validated here anyway: this file is fetchable directly, so it cannot assume a caller.
         const q = new URLSearchParams(location.search);
@@ -26,19 +48,14 @@
         const path = q.get('path') || '';
 
         const bad =
-            !/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repo) ||
+            !ALLOWED_REPOS.includes(repo) ||
             !/^[0-9a-f]{40}$/.test(sha) ||
             !/^[A-Za-z0-9._\-/]+$/.test(path) ||
             path.includes('..') ||
             path.startsWith('/');
 
-        function report(kind, detail) {
-            // The parent cannot read into this opaque-origin document, so outcomes are posted out.
-            parent.postMessage({ source: 'report-frame', kind, detail }, '*');
-        }
-
         if (bad) {
-            report('error', 'Malformed parameters.');
+            report('error', 'Malformed or disallowed parameters.');
             return;
         }
 

--- a/external/ag-shared/github/actions/pr-preview-lib/viewer.html
+++ b/external/ag-shared/github/actions/pr-preview-lib/viewer.html
@@ -125,7 +125,16 @@
             (() => {
                 'use strict';
 
-                const OWNER_ALLOWLIST = ['ag-grid'];
+                // Exact owner/repo values, not an owner prefix: an owner-level allowlist still
+                // admits every repo that owner has, including ones anybody can get content into.
+                // This page renders fetched HTML under a domain that also serves our PR previews,
+                // so whoever chooses the repo chooses what appears under our name. The sandbox
+                // keeps that content away from our storage; it does nothing about what the address
+                // bar says, which is the whole of a phishing page's value.
+                //
+                // Keep in step with the copy in report-frame.html, which enforces the same list —
+                // that file is directly fetchable and cannot rely on this one having run.
+                const ALLOWED_REPOS = ['ag-grid/ag-charts'];
 
                 const el = (id) => document.getElementById(id);
 
@@ -160,8 +169,16 @@
                     if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repo)) {
                         return { error: ['Malformed repo: ', code(repo)] };
                     }
-                    if (!OWNER_ALLOWLIST.includes(repo.split('/')[0])) {
-                        return { error: ['Refusing to load from outside ', code(OWNER_ALLOWLIST.join(', ')), ': ', code(repo)] };
+                    if (!ALLOWED_REPOS.includes(repo)) {
+                        return {
+                            error: [
+                                'Refusing to load from ',
+                                code(repo),
+                                '. This viewer only serves: ',
+                                code(ALLOWED_REPOS.join(', ')),
+                                '.',
+                            ],
+                        };
                     }
                     // Commit SHA only, never a branch name. A branch URL is served with
                     // `cache-control: max-age=300`, so it can be up to 5 minutes stale — and its

--- a/external/ag-shared/github/actions/pr-preview-lib/viewer.html
+++ b/external/ag-shared/github/actions/pr-preview-lib/viewer.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Snapshot report viewer</title>
+        <!--
+            PROTOTYPE — see the plan on at/snapshot-report-raw-viewer.
+
+            Why this page exists at all: raw.githubusercontent.com serves every file as
+            `text/plain` with `x-content-type-options: nosniff`, so linking a reviewer straight at a
+            report shows them HTML source, not a rendered page. It does however send
+            `access-control-allow-origin: *`, so a page on another origin may fetch it and render it
+            itself. That is the whole trick.
+
+            The point of the exercise: report payloads could then live on a plain git branch with no
+            GitHub Pages build at all, removing the whole-site rebuild (and its single-flight
+            cancellation) from the path between CI finishing and a reviewer seeing the report.
+        -->
+        <style>
+            :root {
+                color-scheme: light dark;
+                --fg: #1b1f23;
+                --bg: #ffffff;
+                --muted: #57606a;
+                --line: #d0d7de;
+                --warn-bg: #fff8c5;
+                --warn-line: #d4a72c;
+            }
+            @media (prefers-color-scheme: dark) {
+                :root {
+                    --fg: #e6edf3;
+                    --bg: #0d1117;
+                    --muted: #8b949e;
+                    --line: #30363d;
+                    --warn-bg: #272115;
+                    --warn-line: #9e6a03;
+                }
+            }
+            * {
+                box-sizing: border-box;
+            }
+            body {
+                margin: 0;
+                background: var(--bg);
+                color: var(--fg);
+                font:
+                    14px/1.5 -apple-system,
+                    BlinkMacSystemFont,
+                    'Segoe UI',
+                    Helvetica,
+                    Arial,
+                    sans-serif;
+            }
+            header {
+                display: flex;
+                gap: 12px;
+                align-items: baseline;
+                flex-wrap: wrap;
+                padding: 8px 14px;
+                border-bottom: 1px solid var(--line);
+                /* Sticky, because the frame below is sized to its full content and the page owns
+                   the scrollbar — a static header would scroll away immediately. */
+                position: sticky;
+                top: 0;
+                z-index: 1;
+                background: var(--bg);
+            }
+            header strong {
+                font-weight: 600;
+            }
+            header code {
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                font-size: 12px;
+                color: var(--muted);
+            }
+            #frame {
+                display: block;
+                width: 100%;
+                /* Starting height only; report-frame.html posts its content height and the script
+                   replaces this. */
+                height: 90vh;
+                border: 0;
+            }
+            #status {
+                padding: 24px;
+                max-width: 60rem;
+            }
+            #status h1 {
+                font-size: 18px;
+                margin: 0 0 8px;
+            }
+            #status p {
+                margin: 0 0 12px;
+                color: var(--muted);
+            }
+            #status code {
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                background: var(--warn-bg);
+                border: 1px solid var(--warn-line);
+                border-radius: 4px;
+                padding: 1px 5px;
+                word-break: break-all;
+            }
+            .hidden {
+                display: none;
+            }
+        </style>
+    </head>
+    <body>
+        <header id="header" class="hidden">
+            <strong id="header-title"></strong>
+            <code id="header-source"></code>
+        </header>
+
+        <div id="status">
+            <h1 id="status-title">Loading report…</h1>
+            <p id="status-detail">Fetching from raw.githubusercontent.com.</p>
+        </div>
+
+        <!-- Placeholder only; the real frame is built in script and swapped in here. -->
+        <div id="frame" class="hidden"></div>
+
+        <script>
+            (() => {
+                'use strict';
+
+                const OWNER_ALLOWLIST = ['ag-grid'];
+
+                const el = (id) => document.getElementById(id);
+
+                function fail(title, detail) {
+                    el('status-title').textContent = title;
+                    // textContent throughout: every value here is attacker-controllable via the
+                    // query string, so nothing from it is ever parsed as markup.
+                    el('status-detail').textContent = '';
+                    el('status-detail').append(...detail);
+                    el('status').classList.remove('hidden');
+                    el('frame').classList.add('hidden');
+                }
+
+                function code(text) {
+                    const c = document.createElement('code');
+                    c.textContent = text;
+                    return c;
+                }
+
+                // An unvalidated viewer is a content-injection surface: it would happily render any
+                // HTML from any repo under our origin's URL bar, which is a convincing place to put
+                // a phishing page. Validate hard, fail closed.
+                function readParams() {
+                    const q = new URLSearchParams(location.search);
+                    const repo = q.get('repo') || '';
+                    const sha = q.get('sha') || '';
+                    const path = q.get('path') || '';
+
+                    if (!repo || !sha || !path) {
+                        return { error: ['Expected ', code('?repo=owner/name&sha=<40-hex>&path=<file>'), '.'] };
+                    }
+                    if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(repo)) {
+                        return { error: ['Malformed repo: ', code(repo)] };
+                    }
+                    if (!OWNER_ALLOWLIST.includes(repo.split('/')[0])) {
+                        return { error: ['Refusing to load from outside ', code(OWNER_ALLOWLIST.join(', ')), ': ', code(repo)] };
+                    }
+                    // Commit SHA only, never a branch name. A branch URL is served with
+                    // `cache-control: max-age=300`, so it can be up to 5 minutes stale — and its
+                    // content can change under a link that has already been shared. A SHA URL names
+                    // one immutable blob.
+                    if (!/^[0-9a-f]{40}$/.test(sha)) {
+                        return { error: ['Expected a full 40-character commit SHA, got ', code(sha)] };
+                    }
+                    if (!/^[A-Za-z0-9._\-/]+$/.test(path) || path.includes('..') || path.startsWith('/')) {
+                        return { error: ['Malformed path: ', code(path)] };
+                    }
+                    return { repo, sha, path };
+                }
+
+                function main() {
+                    const params = readParams();
+                    if (params.error) {
+                        fail('Cannot load this report', params.error);
+                        return;
+                    }
+                    const { repo, sha, path } = params;
+
+                    // This page never touches the payload. It points a sandboxed frame at
+                    // report-frame.html, which fetches raw.githubusercontent.com from inside its own
+                    // opaque origin and writes the result into itself. See report-frame.html for why
+                    // the payload is not passed inwards.
+                    //
+                    // sandbox="allow-scripts" WITHOUT allow-same-origin: the report's own scripts
+                    // (onion-skin, swipe, side-by-side) run, but the document cannot read this
+                    // page's DOM, storage or cookies. Adding allow-same-origin would hand fetched
+                    // third-party HTML our origin, which defeats the point of framing it at all.
+                    const inner = new URLSearchParams({ repo, sha, path });
+                    const frame = document.createElement('iframe');
+                    frame.id = 'frame';
+                    frame.title = 'Snapshot report';
+                    frame.referrerPolicy = 'no-referrer';
+                    frame.setAttribute('sandbox', 'allow-scripts');
+                    frame.src = `report-frame.html?${inner}`;
+
+                    // Outcome arrives by postMessage — an opaque-origin frame cannot be inspected
+                    // from here, so a failed fetch inside it is otherwise indistinguishable from a
+                    // slow one.
+                    window.addEventListener('message', (ev) => {
+                        if (ev.source !== frame.contentWindow) return;
+                        const msg = ev.data;
+                        if (!msg || msg.source !== 'report-frame') return;
+                        if (msg.kind === 'height') {
+                            frame.style.height = `${msg.detail}px`;
+                            return;
+                        }
+                        if (msg.kind === 'error') {
+                            const hint =
+                                msg.detail === 'HTTP 404'
+                                    ? ' The commit or path may not exist, or it may have been swept by the janitor.'
+                                    : msg.detail === 'HTTP 403' || msg.detail === 'HTTP 429'
+                                      ? ' raw.githubusercontent.com rate-limits unauthenticated requests; wait a minute and reload.'
+                                      : '';
+                            fail('Report unavailable', [
+                                `${msg.detail} fetching `,
+                                code(`${repo}@${sha.slice(0, 7)}/${path}`),
+                                hint,
+                            ]);
+                            return;
+                        }
+                        el('status').classList.add('hidden');
+                        el('header-source').textContent =
+                            `${repo}@${sha.slice(0, 7)}/${path} · ${msg.detail} bytes`;
+                        el('header').classList.remove('hidden');
+                    });
+
+                    el('frame').replaceWith(frame);
+                    el('header-title').textContent = path.split('/').pop();
+                    document.title = `${path.split('/').pop()} · snapshot report`;
+                }
+
+                main();
+            })();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Exploration, not a switchover. Nothing in CI references the viewer and the snapshot-review publishing path is untouched — this only adds two static files, a write-up, and a manual workflow to publish them so the idea can be tried against real reports.

## Why

A snapshot-review report is visible to a reviewer only after GitHub Pages rebuilds and redeploys the whole site: 163–706s here, and cancellable by the next push, which is what produced the false "Report publish failed" comments #7764 worked around.

Pushing report payloads to a plain git branch and fetching them from a static page skips the Pages build entirely. Measured against a live 788 KB artefact, three runs:

| | push | push → visible | total |
| --- | --- | --- | --- |
| 1 | 2.90s | **0.32s** | 3.22s |
| 2 | 2.89s | **0.42s** | 3.31s |
| 3 | 3.42s | **0.45s** | 3.87s |

`raw.githubusercontent.com` serves `access-control-allow-origin: *`, so no proxy and no credential are needed. (GitHub Actions artifacts were ruled out earlier: anonymous download returns 401 even on a public repo.)

## Shape

`viewer.html` validates `?repo/&sha/&path` and frames `report-frame.html`, sandboxed with `allow-scripts` but **not** `allow-same-origin`. The inner frame fetches from raw inside its own opaque origin and writes the payload into itself, then posts its content height back out so the outer page owns a single scrollbar.

The fetch is inside the frame because at this size the payload cannot be passed in from outside: `srcdoc` silently loads nothing, `blob:` is blocked by the opaque origin, and a `data:` URL renders only on a *second* identical assignment. Details in `VIEWER-PROTOTYPE.md`.

Addressed by commit SHA, never a branch name — raw sends `cache-control: max-age=300`, so a branch URL can be stale and can change under a link already shared.

## Keeping it ours

The page renders HTML it fetches, on a domain that also serves our PR previews, so whoever chooses the repo chooses what appears under our name. The sandbox keeps that content away from our storage but does nothing about what the address bar says.

Both files enforce an exact `owner/repo` allowlist — not an owner prefix, which would admit any ag-grid repo a third party can get content into. `report-frame.html` additionally refuses to run unless it is framed: sandboxing is applied by the embedding page, so opened directly it would otherwise render third-party HTML top-level and unsandboxed on our origin.

## Verified

Renders and the onion / swipe / side-by-side panes work, checked by hand in Chrome against a live report. The report uses no API an opaque origin denies (no storage, no cookies). A disallowed repo is refused by name; `report-frame.html` opened directly renders only a refusal.

## Still open

Unauthenticated raw rate limits; non-Chrome browsers; the Export-decisions Copy button under the sandbox; and retention for the payload branch. All listed in the write-up. These want answering before anything is migrated.

## To try it

Merge, then dispatch **gh-pages snapshot viewer**, which publishes to `snapshot-viewer/` on gh-pages.