### PR TITLE
Sync ag-shared across ag-charts, ag-grid and ag-studio

### DIFF
--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = 31a1ca6ea1be7077f82798999d3c875a7974f60a
-	parent = b6a430003cfa2c5b28baa041ad935e9ed685eed6
+	commit = 9767c5b59052be7d6738faf161b1fa6e947de389
+	parent = 47055fbcfc584fec782c2852d7809864ae3be36d
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.gitrepo
+++ b/external/ag-shared/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/ag-grid/ag-shared.git
 	branch = latest
-	commit = da2465b839eb21860a7897c78bf811a894533ad6
-	parent = 4e164a2c77d6f57a26de827a8e8cf43dde24afb5
+	commit = 31a1ca6ea1be7077f82798999d3c875a7974f60a
+	parent = b6a430003cfa2c5b28baa041ad935e9ed685eed6
 	method = rebase
 	cmdver = 0.4.9

--- a/external/ag-shared/.snyk
+++ b/external/ag-shared/.snyk
@@ -102,15 +102,15 @@ ignore:
         created: 2026-05-28T00:00:00.000Z
   SNYK-JS-BRACEEXPANSION-17706650:
     - '@nx/devkit@20.8.4 > minimatch@9.0.3 > brace-expansion@2.0.2':
-        reason: Build/dev/test tooling dependency - not shipped in AG Charts runtime bundles (which have zero third-party runtime dependencies)
+        reason: Build/dev/test tooling dependency - not shipped in AG product runtime bundles (which have zero third-party runtime dependencies)
         expires: '2026-10-23T00:00:00.000Z'
         created: '2026-07-23T00:00:00.000Z'
     - '@nx/devkit@20.8.4 > ejs@3.1.10 > jake@10.9.4 > filelist@1.0.4 > minimatch@5.1.6 > brace-expansion@2.0.2':
-        reason: Build/dev/test tooling dependency - not shipped in AG Charts runtime bundles (which have zero third-party runtime dependencies)
+        reason: Build/dev/test tooling dependency - not shipped in AG product runtime bundles (which have zero third-party runtime dependencies)
         expires: '2026-10-23T00:00:00.000Z'
         created: '2026-07-23T00:00:00.000Z'
     - '@nx/devkit@20.8.4 > tmp@0.2.1 > rimraf@3.0.2 > glob@7.2.3 > minimatch@3.1.2 > brace-expansion@2.0.2':
-        reason: Build/dev/test tooling dependency - not shipped in AG Charts runtime bundles (which have zero third-party runtime dependencies)
+        reason: Build/dev/test tooling dependency - not shipped in AG product runtime bundles (which have zero third-party runtime dependencies)
         expires: '2026-10-23T00:00:00.000Z'
         created: '2026-07-23T00:00:00.000Z'
 patch: {}

--- a/external/ag-shared/docs/SYNC-LOG.md
+++ b/external/ag-shared/docs/SYNC-LOG.md
@@ -182,6 +182,24 @@ Independent of this fix, the cache key still hashes every workspace `package.jso
 
 ---
 
+## 2026-06-18 -- Ignore ag-website-shared in the Studio watch loop
+
+**Branch:** `fix-watch-ag-website-shared-build`
+
+### Changes
+
+- **[scripts]** `studioWatch.config.js`: added `ag-website-shared` to `BASE_IGNORED_PROJECTS`. The catch-all branch in `getProjectBuildTargets` fires `<project>:build` for any non-package project, but `ag-website-shared` has no `build` target (it is consumed by the docs site as source via Astro/Vite HMR), so saving a file under it logged `NX Cannot find configuration for task ag-website-shared:build` on every save.
+
+### Migration Actions
+
+- [ ] Restart `yarn nx dev` so the watch loop picks up the updated ignore list
+
+### Notes
+
+Studio-only config; charts/grid watch configs are unaffected. The same catch-all assumption exists in their configs — only relevant if either repo gains a build-less website library project.
+
+---
+
 ## 2026-06-17 -- Shared l10n translation-review script
 
 **Branch:** `at/add-l10n-maintenance-rules`

--- a/external/ag-shared/github/actions/setup-nx-core/action.yml
+++ b/external/ag-shared/github/actions/setup-nx-core/action.yml
@@ -237,6 +237,43 @@ runs:
           with:
               branch_type: ${{ steps.nx_config.outputs.type }}
 
+        - name: Resolve yarn cache dir
+          # Ask yarn where its download cache lives rather than hard-coding the default
+          # location, so a relocated cache folder (YARN_CACHE_FOLDER, or a .yarnrc
+          # cache-folder) cannot silently point restore/save at the wrong (empty) path.
+          # Gated to the cases where the yarn cache restore/save can run. Runners are
+          # Linux-only, so no cross-OS path handling is needed.
+          if: inputs.cache_mode != 'off' && inputs.yarn_postinstall != 'no-install'
+          id: yarn_cache_dir
+          shell: bash
+          run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+
+        - name: Restore yarn cache
+          # Persist the yarn v1 download cache so `yarn install --prefer-offline` serves
+          # tarballs from here instead of cold-downloading the dependency closure from the
+          # internal registry — this is the core fix (node_modules was cached but this dir
+          # was not, leaving --prefer-offline ineffective). The cache is content-addressed
+          # by package version, so a restore-keys fallback is safe: stale entries are inert
+          # and simply ignored.
+          #
+          # Only restored when a tarball-fetching `yarn install` will actually run — i.e.
+          # NOT on `no-install` jobs (integrity check only) and NOT when node_modules was an
+          # exact hit (the common warm path: only `yarn postinstall` runs, no tarballs). This
+          # avoids downloading/extracting a large cache on the majority of jobs that never
+          # install. (The rare exact-hit-but-integrity-fails recovery path installs cold — an
+          # accepted trade-off vs restoring on every warm job.) Saved only in rw (below).
+          #
+          # Also skipped for `yarn_postinstall: false` in ro mode: the only install step for
+          # `false` is gated on rw, so an ro+false job never installs and a restore would be
+          # wasted (matters only on an inexact node_modules restore — a degraded path).
+          if: inputs.cache_mode != 'off' && inputs.yarn_postinstall != 'no-install' && (inputs.yarn_postinstall != 'false' || inputs.cache_mode == 'rw') && steps.cache_rw.outputs.cache-hit != 'true' && steps.cache_ro.outputs.cache-hit != 'true'
+          id: yarn_cache
+          uses: actions/cache/restore@v4
+          with:
+              path: ${{ steps.yarn_cache_dir.outputs.dir }}
+              key: yarn-cache-${{ runner.os }}-${{ inputs.node_modules_hash }}
+              restore-keys: yarn-cache-${{ runner.os }}-
+
         - name: yarn install
           if: inputs.yarn_postinstall == 'true'
           id: yarn_install_slow
@@ -315,3 +352,19 @@ runs:
           with:
               path: ${{ inputs.node_modules_paths }}
               key: node_modules-${{ runner.os }}-${{ steps.nx_config.outputs.release_branch && format('release-{0}-{1}', steps.nx_config.outputs.release_branch, inputs.node_modules_hash) || inputs.node_modules_hash }}
+
+        - name: Save yarn cache
+          # Save the download cache warmed by yarn install (see "Restore yarn cache").
+          # rw writers (e.g. the init job) warm it; ro readers (matrix jobs) only restore.
+          # Warmed on the default branch (latest), whose caches GitHub makes readable by all
+          # branches, so a single warm propagates.
+          #
+          # Gated to mirror the restore: only when a real install ran (not `no-install`, and
+          # node_modules was not an exact hit) and the yarn cache itself was not an exact hit
+          # (nothing new to save otherwise). Without this, an exact-node_modules-hit job would
+          # skip the restore yet still attempt a save of an unpopulated/stale cache dir.
+          if: inputs.cache_mode == 'rw' && inputs.yarn_postinstall != 'no-install' && steps.cache_rw.outputs.cache-hit != 'true' && steps.yarn_cache.outputs.cache-hit != 'true'
+          uses: actions/cache/save@v4
+          with:
+              path: ${{ steps.yarn_cache_dir.outputs.dir }}
+              key: yarn-cache-${{ runner.os }}-${{ inputs.node_modules_hash }}

--- a/external/ag-shared/scripts/rulesync-fetch/stage.py
+++ b/external/ag-shared/scripts/rulesync-fetch/stage.py
@@ -16,7 +16,10 @@ checkout should not see ag-charts-specific skills/commands/agents (and vice
 versa). Content from other products' plugins that was staged by a previous
 run (pre-filter manifest, or product changed) is cleaned up at the end of
 ``stage()`` based on the diff between the full manifest and what was staged
-this run.
+this run, unioned with the record of what the previous run staged (see
+``_read_prior_staged``). The manifest diff alone cannot see an item that was
+*dropped* from the manifest between releases — such a path is absent from the
+candidate set, so it would be orphaned in the checkout forever.
 
 Part of AG-17085 Phase 3 (rulesync fetch design); product filtering added
 under AG-17098.
@@ -41,6 +44,13 @@ RULESYNC = REPO_ROOT / ".rulesync"
 MARKER = RULESYNC / ".fetched-from-ag-dev-prompts"
 
 NON_CLAUDE_TARGETS = ["cursor", "codexcli", "geminicli", "copilot", "agentsmd"]
+
+MARKER_HEADER = (
+    "# Managed by external/ag-shared/scripts/rulesync-fetch/stage.py\n"
+    "# Do not edit — regenerated on each setup-prompts run.\n"
+    "# Lines below record what this run staged, so the next run can prune items\n"
+    "# that have since been dropped from the plugin manifest.\n"
+)
 
 # Product plugins — only the current repo's product plugin is staged. Keep in
 # sync with .claude-plugin/marketplace.json. Other plugins (ag-core, ag-prodeng)
@@ -332,10 +342,12 @@ def stage(dry_run: bool = False) -> set[Path]:
         # authoritative source for whichever product tracks it; staging should
         # never clobber it. The `tracked` snapshot is reused from the write
         # guard above.
-        all_possible = _stageable_paths(manifest["plugins"])
+        # The prior-run record covers items dropped from the manifest, which the
+        # manifest diff alone cannot see.
+        all_possible = _stageable_paths(manifest["plugins"]) | _read_prior_staged()
         for stale in sorted(all_possible - staged):
             rel = stale.relative_to(REPO_ROOT) if stale.is_absolute() else stale
-            if rel in tracked:
+            if rel in tracked or _has_tracked_descendant(rel, tracked):
                 print(f"  keeping tracked {rel} (not a stage-leftover)", file=sys.stderr)
                 continue
             if stale.is_symlink() or stale.is_file():
@@ -345,10 +357,7 @@ def stage(dry_run: bool = False) -> set[Path]:
                 shutil.rmtree(stale)
                 print(f"  removed stale {rel}/", file=sys.stderr)
 
-        MARKER.write_text(
-            "# Managed by external/ag-shared/scripts/rulesync-fetch/stage.py\n"
-            "# Do not edit — regenerated on each setup-prompts run.\n"
-        )
+        _write_marker(staged)
 
     print(f"Staged {len(staged)} items into .rulesync/", file=sys.stderr)
     return staged
@@ -373,6 +382,47 @@ def _tracked_files() -> set[Path]:
     except (subprocess.CalledProcessError, FileNotFoundError):
         return set()
     return {Path(line) for line in result.stdout.splitlines() if line}
+
+
+def _has_tracked_descendant(rel: Path, tracked: set[Path]) -> bool:
+    """Whether any tracked file lives under ``rel``.
+
+    Skills stage as directories, and git tracks files rather than directories, so
+    a membership test against ``tracked`` alone never matches a skill directory.
+    Without this, dropping a plugin skill whose name collides with a tracked
+    local skill (e.g. .rulesync/skills/testing/) would rmtree the local one."""
+    return any(rel in candidate.parents for candidate in tracked)
+
+
+def _read_prior_staged() -> set[Path]:
+    """Return the absolute paths recorded by the previous run's marker file.
+
+    The manifest-diff candidate set only covers items the manifest still
+    declares, so an item removed from a plugin's entry would otherwise never be
+    considered for cleanup. Empty for a first run, or for a marker predating
+    this record — both carry no path lines.
+
+    These paths feed the deletion pass, so anything that does not resolve inside
+    .rulesync/ is discarded rather than trusted."""
+    if not MARKER.is_file():
+        return set()
+    out: set[Path] = set()
+    for line in MARKER.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        candidate = (REPO_ROOT / line).resolve()
+        if candidate == RULESYNC.resolve() or RULESYNC.resolve() not in candidate.parents:
+            print(f"  WARN: ignoring out-of-tree marker entry: {line}", file=sys.stderr)
+            continue
+        out.add(REPO_ROOT / line)
+    return out
+
+
+def _write_marker(staged: set[Path]) -> None:
+    """Record the header plus this run's staged paths, repo-relative and sorted."""
+    rels = sorted(str(p.relative_to(REPO_ROOT) if p.is_absolute() else p) for p in staged)
+    MARKER.write_text(MARKER_HEADER + "".join(f"{rel}\n" for rel in rels))
 
 
 def _stageable_paths(plugins: dict) -> set[Path]:

--- a/external/ag-shared/scripts/watch/studioWatch.config.js
+++ b/external/ag-shared/scripts/watch/studioWatch.config.js
@@ -1,5 +1,11 @@
 // Projects whose file changes are never processed by the watch loop.
-const BASE_IGNORED_PROJECTS = ['all'];
+// ag-website-shared is consumed by the docs site as source (Astro plugins + src
+// imported by relative path), so Vite/Astro HMR serves its changes directly — it has
+// no nx `build` target, and the catch-all branch in getProjectBuildTargets would
+// otherwise fire a non-existent `ag-website-shared:build`.
+// ag-studio-docs is the dev server itself, so Astro HMR serves its src/ changes
+// directly; only its generated per-example child projects need a watch-triggered build.
+const BASE_IGNORED_PROJECTS = ['all', 'ag-website-shared', 'ag-studio-docs'];
 const PACKAGE_PROJECTS = ['ag-studio'];
 const EXAMPLE_GENERATOR_PROJECTS = ['ag-studio-generate-example-files'];
 
@@ -17,7 +23,7 @@ function getIgnoredProjects() {
 function getProjectBuildTargets(project) {
     const buildTargets = [];
 
-    if (project.startsWith('ag-studio-docs')) {
+    if (project.startsWith('ag-studio-docs-')) {
         buildTargets.push([project, ['generate'], 'watch']);
     } else if (EXAMPLE_GENERATOR_PROJECTS.includes(project)) {
         buildTargets.push(['ag-studio-docs', ['generate-examples']]);


### PR DESCRIPTION
Cross-repo sync of the `external/ag-shared/` subrepo. This is bidirectional: three repos each had unpushed ag-shared work that had been stranded, so this converges all three onto one upstream commit.

## What ag-charts pushed up

Everything committed to `external/ag-shared/` since the last sync (parent `4e164a2c`, 9 July), including the gh-pages preview work from #7764, the Claude Code cloud-session bootstrap, the e2e shard planner and the SECURITY.md version script.

## What ag-charts receives back

- **`setup-nx-core`**: a yarn download-cache restore/save layer from ag-grid's unpushed work, so `yarn install --prefer-offline` serves tarballs from cache instead of cold-downloading the dependency closure. ag-charts never had this.
- **`studioWatch.config.js`** and a SYNC-LOG entry from ag-studio's unpushed work.
- **`rulesync-fetch/stage.py`** updates.

## Conflict resolutions worth reviewing

- **`docs/SYNC-LOG.md`** is append-only, so both sides were kept at every conflict; ag-studio's 2026-06-18 entry was moved into correct newest-first date position rather than left stranded at the top.
- **`.snyk`** took the upstream superset each time, but only after verifying mechanically that the losing side contributed no unique Snyk keys or dependency paths. One side would also have produced a duplicate `SNYK-JS-TMP-17315641` YAML key.
- **One deliberate content change**: the `SNYK-JS-BRACEEXPANSION-17706650` ignore reasons said "not shipped in AG Charts runtime bundles" in a file all three repos consume (ag-grid's copy said "AG Grid"). Made repo-neutral: "AG product runtime bundles". Substance unchanged.

## Verification

All three repos now carry byte-identical tracked `external/ag-shared/` content (upstream `9767c5b590`), confirmed by comparing tracked file trees excluding the repo-specific `.gitrepo`. `verify-rulesync.sh` passes in all three, no broken symlinks, and the `.claude/settings.json` render is idempotent in each.

## Cross-repo PRs

- ag-grid: https://github.com/ag-grid/ag-grid/pull/14787
- ag-studio: https://github.com/ag-grid/ag-studio/pull/2344
