### PR TITLE
Fix negative-value currency formatting in series-labels examples

### DIFF
--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-fitting/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-fitting/main.ts
@@ -6,11 +6,6 @@ import { DataType, data } from './data';
 
 ModuleRegistry.registerModules([BarSeriesModule, LegendModule, CategoryAxisModule, NumberAxisModule]);
 
-function formatCurrency(value: number) {
-    const sign = value < 0 ? '-' : '';
-    return `${sign}$${Math.abs(value)}m`;
-}
-
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),
     title: { text: 'Quarterly Revenue by Leading Division' },
@@ -23,7 +18,7 @@ const options: AgCartesianChartOptions<DataType> = {
             label: {
                 enabled: true,
                 placement: 'inside-end',
-                formatter: (params) => `${formatCurrency(params.value)} ${params.datum.division}`,
+                formatter: (params) => `$${params.value}m ${params.datum.division}`,
                 maxWidth: 70,
                 maxHeight: 54,
                 wrapping: 'on-space',
@@ -31,7 +26,7 @@ const options: AgCartesianChartOptions<DataType> = {
             },
             tooltip: {
                 renderer: ({ datum }) => ({
-                    data: [{ label: 'Revenue', value: formatCurrency(datum.revenue) }],
+                    data: [{ label: 'Revenue', value: `$${datum.revenue}m` }],
                 }),
             },
         },

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-fitting/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-fitting/main.ts
@@ -6,6 +6,11 @@ import { DataType, data } from './data';
 
 ModuleRegistry.registerModules([BarSeriesModule, LegendModule, CategoryAxisModule, NumberAxisModule]);
 
+function formatCurrency(value: number) {
+    const sign = value < 0 ? '-' : '';
+    return `${sign}$${Math.abs(value)}m`;
+}
+
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),
     title: { text: 'Quarterly Revenue by Leading Division' },
@@ -18,11 +23,16 @@ const options: AgCartesianChartOptions<DataType> = {
             label: {
                 enabled: true,
                 placement: 'inside-end',
-                formatter: (params) => `$${params.value}m ${params.datum.division}`,
+                formatter: (params) => `${formatCurrency(params.value)} ${params.datum.division}`,
                 maxWidth: 70,
                 maxHeight: 54,
                 wrapping: 'on-space',
                 truncate: true,
+            },
+            tooltip: {
+                renderer: ({ datum }) => ({
+                    data: [{ label: 'Revenue', value: formatCurrency(datum.revenue) }],
+                }),
             },
         },
     ],

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
@@ -6,11 +6,6 @@ import { DataType, data } from './data';
 
 ModuleRegistry.registerModules([BarSeriesModule, LegendModule, CategoryAxisModule, NumberAxisModule]);
 
-function formatCurrency(value: number) {
-    const sign = value < 0 ? '-' : '';
-    return `${sign}$${Math.abs(value)}m`;
-}
-
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),
     title: { text: 'Quarterly Profit Change ($m)' },
@@ -25,14 +20,11 @@ const options: AgCartesianChartOptions<DataType> = {
                 placement: 'inside-end',
                 orientation: 'horizontal',
                 wrapping: 'never',
-                formatter: (params) => {
-                    const note = params.datum.note ? ` (${params.datum.note})` : '';
-                    return `${formatCurrency(params.value)} profit${note}`;
-                },
+                formatter: (params) => `$${params.value}m profit${params.datum.note ? ` (${params.datum.note})` : ''}`,
             },
             tooltip: {
                 renderer: ({ datum }) => ({
-                    data: [{ label: 'Profit Change', value: formatCurrency(datum.profitChange) }],
+                    data: [{ label: 'Profit Change', value: `$${datum.profitChange}m` }],
                 }),
             },
         },

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
@@ -20,7 +20,11 @@ const options: AgCartesianChartOptions<DataType> = {
                 placement: 'inside-end',
                 orientation: 'horizontal',
                 wrapping: 'never',
-                formatter: (params) => `$${params.value}m profit${params.datum.note ? ` (${params.datum.note})` : ''}`,
+                formatter: (params) => {
+                    const sign = params.value < 0 ? '-' : '';
+                    const note = params.datum.note ? ` (${params.datum.note})` : '';
+                    return `${sign}$${Math.abs(params.value)}m profit${note}`;
+                },
             },
         },
     ],

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
@@ -32,7 +32,6 @@ const options: AgCartesianChartOptions<DataType> = {
             },
             tooltip: {
                 renderer: ({ datum }) => ({
-                    title: datum.quarter,
                     data: [{ label: 'Profit Change', value: formatCurrency(datum.profitChange) }],
                 }),
             },

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
@@ -6,6 +6,11 @@ import { DataType, data } from './data';
 
 ModuleRegistry.registerModules([BarSeriesModule, LegendModule, CategoryAxisModule, NumberAxisModule]);
 
+function formatCurrency(value: number) {
+    const sign = value < 0 ? '-' : '';
+    return `${sign}$${Math.abs(value)}m`;
+}
+
 const options: AgCartesianChartOptions<DataType> = {
     container: document.getElementById('myChart'),
     title: { text: 'Quarterly Profit Change ($m)' },
@@ -21,10 +26,15 @@ const options: AgCartesianChartOptions<DataType> = {
                 orientation: 'horizontal',
                 wrapping: 'never',
                 formatter: (params) => {
-                    const sign = params.value < 0 ? '-' : '';
                     const note = params.datum.note ? ` (${params.datum.note})` : '';
-                    return `${sign}$${Math.abs(params.value)}m profit${note}`;
+                    return `${formatCurrency(params.value)} profit${note}`;
                 },
+            },
+            tooltip: {
+                renderer: ({ datum }) => ({
+                    title: datum.quarter,
+                    data: [{ label: 'Profit Change', value: formatCurrency(datum.profitChange) }],
+                }),
             },
         },
     ],

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
@@ -130,7 +130,6 @@ function setSeriesType(seriesType: SeriesType) {
                 },
                 tooltip: {
                     renderer: ({ datum }) => ({
-                        title: (datum as BarDataType).quarter,
                         data: [{ label: 'Profit Change', value: formatCurrency((datum as BarDataType).profitChange) }],
                     }),
                 },

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
@@ -126,7 +126,7 @@ function setSeriesType(seriesType: SeriesType) {
                         | AgBarSeriesLabelPlacement[],
                     spacing,
                     truncate: false,
-                    formatter: (params) => formatCurrency(params.value),
+                    format: '$',
                 },
                 tooltip: {
                     renderer: ({ datum }) => ({

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
@@ -28,6 +28,11 @@ type SeriesType = 'bubble' | 'bar' | 'bar-horizontal';
 
 let spacing = 6;
 
+function formatCurrency(value: number) {
+    const sign = value < 0 ? '-' : '';
+    return `${sign}$${Math.abs(value)}m`;
+}
+
 const options: AgCartesianChartOptions<BubbleDataType | BarDataType> = {
     container: document.getElementById('myChart'),
     title: { text: 'Weather Station Readings' },
@@ -121,7 +126,13 @@ function setSeriesType(seriesType: SeriesType) {
                         | AgBarSeriesLabelPlacement[],
                     spacing,
                     truncate: false,
-                    formatter: (params) => `$${params.value}m`,
+                    formatter: (params) => formatCurrency(params.value),
+                },
+                tooltip: {
+                    renderer: ({ datum }) => ({
+                        title: (datum as BarDataType).quarter,
+                        data: [{ label: 'Profit Change', value: formatCurrency((datum as BarDataType).profitChange) }],
+                    }),
                 },
             },
         ];


### PR DESCRIPTION
Three series-labels docs examples format negative bar values incorrectly, and none had a tooltip matching the label's `$` formatting:

- `label-orientation`: label formatter interpolated `params.value` after a leading `$`, so a negative value's own minus sign landed after the dollar sign (`$-5m profit` instead of `-$5m profit`).
- `label-position`: same bug in its bar-series label formatter (`$-5m` instead of `-$5m`), visible when switching to the Bar/Horizontal Bar series (Q3/Q5 have negative `profitChange` values).
- `label-fitting` (the "Collision Avoidance" section example): same formatter pattern; fixed for consistency even though its current dataset has no negative values.

Fixed all three formatters to place the sign before the `$`, and added a `tooltip.renderer` to each bar series so the tooltip matches the label's `$`/sign formatting instead of showing the raw unformatted value. The tooltip renderers omit `title` since the chart already supplies the category heading automatically.

Verified in the browser (dev server) that labels and tooltips both correctly show `-$5m` for negative bars, and that the `label-fitting` tooltip reads cleanly without a redundant title row.