### PR TITLE
AG-17912 Add markdown twins for the API reference pages

### DIFF
--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -2,12 +2,10 @@
 import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
+import { OPTIONS_API_PAGE_CONTENT } from '@utils/markdown-pages/apiReferencePageContent';
 ---
 
-<APIViewLayout
-    title="Options API"
-    description="Options API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties."
->
+<APIViewLayout title={OPTIONS_API_PAGE_CONTENT.title} description={OPTIONS_API_PAGE_CONTENT.description}>
     <ApiReferencePage
         client:only="react"
         transition:persist="options-api-reference"

--- a/packages/ag-charts-website/src/pages/options.md.ts
+++ b/packages/ag-charts-website/src/pages/options.md.ts
@@ -1,0 +1,19 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildOptionsApiMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /options.md — the markdown twin of the Options API reference page, built from the same
+// generated interface reference the page renders client-side. Content-negotiates from the HTML URL
+// on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildOptionsApiMarkdown({ reference: getInterfacesReference(), siteRoot: SITE_URL });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
@@ -3,6 +3,7 @@ import { getOptionsStaticPaths } from '@components/api-documentation/apiReferenc
 import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
+import { optionsVariantPageContent } from '@utils/markdown-pages/apiReferencePageContent';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
 
 export async function getStaticPaths() {
@@ -10,18 +11,10 @@ export async function getStaticPaths() {
     return getOptionsStaticPaths(reference);
 }
 
-function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-const type = capitalizeFirstLetter(Astro.props?.pageTitle?.type);
-const name = capitalizeFirstLetter(Astro.props?.pageTitle?.name);
+const { title, description } = optionsVariantPageContent(Astro.props.pageTitle);
 ---
 
-<APIViewLayout
-    title=`Options API (${type} ${name})`
-    description=`${type} ${name} API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties.`
->
+<APIViewLayout title={title} description={description}>
     <ApiReferencePage
         client:only="react"
         transition:persist="options-api-reference"

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].md.ts
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].md.ts
@@ -1,0 +1,33 @@
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import { getOptionsStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { optionsVariantPageContent } from '@utils/markdown-pages/apiReferencePageContent';
+import { buildOptionsVariantMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /options/<member>/<type>.md — the markdown twin of each options union-variant page.
+// Mirrors the page's own getStaticPaths so the two URL sets line up 1:1. Content-negotiates from
+// the HTML URL on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    return getOptionsStaticPaths(getInterfacesReference());
+}
+
+export function GET({ props }: { props: { pageInterface: string; pageTitle: PageTitle } }) {
+    const { pageInterface, pageTitle } = props;
+
+    const output = buildOptionsVariantMarkdown({
+        reference: getInterfacesReference(),
+        pageInterface,
+        pageTitle,
+        ...optionsVariantPageContent(pageTitle),
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/sitemap.md.ts
+++ b/packages/ag-charts-website/src/pages/sitemap.md.ts
@@ -31,7 +31,7 @@ export async function GET() {
             ].join('\n'),
             `# ${SITEMAP_PAGE_CONTENT.heading}`,
             SITEMAP_PAGE_CONTENT.description,
-            `Most pages listed here also have a markdown version: append \`.md\` to the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${PRODUCTION_CHARTS_SITE_URL}/index.md. The Options and Themes API reference pages have no markdown version.`,
+            `Every page listed here also has a markdown version: append \`.md\` to the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${PRODUCTION_CHARTS_SITE_URL}/index.md.`,
             ...sections,
         ].join('\n\n') + '\n';
 

--- a/packages/ag-charts-website/src/pages/themes-api.astro
+++ b/packages/ag-charts-website/src/pages/themes-api.astro
@@ -2,12 +2,10 @@
 import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
+import { THEMES_API_PAGE_CONTENT } from '@utils/markdown-pages/apiReferencePageContent';
 ---
 
-<APIViewLayout
-    title="Themes API"
-    description="Themes API reference for AG Charts JavaScript Charting Library. Search for properties or browse our tree-data explorer; access types, defaults, and child properties."
->
+<APIViewLayout title={THEMES_API_PAGE_CONTENT.title} description={THEMES_API_PAGE_CONTENT.description}>
     <ApiReferencePage
         client:only="react"
         transition:persist="themes-api-reference"

--- a/packages/ag-charts-website/src/pages/themes-api.md.ts
+++ b/packages/ag-charts-website/src/pages/themes-api.md.ts
@@ -1,0 +1,19 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildThemesApiMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /themes-api.md — the markdown twin of the Themes API reference page, built from the
+// same generated interface reference the page renders client-side. Content-negotiates from the
+// HTML URL on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildThemesApiMarkdown({ reference: getInterfacesReference(), siteRoot: SITE_URL });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].md.ts
+++ b/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].md.ts
@@ -1,0 +1,33 @@
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import { getThemesApiStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { THEMES_API_PAGE_CONTENT } from '@utils/markdown-pages/apiReferencePageContent';
+import { buildThemesApiOverrideMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /themes-api/overrides/<member>.md — the markdown twin of each theme-override page.
+// Mirrors the page's own getStaticPaths so the two URL sets line up 1:1. Content-negotiates from
+// the HTML URL on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    return getThemesApiStaticPaths(getInterfacesReference());
+}
+
+export function GET({ props }: { props: { pageInterface: string; pageTitle: PageTitle } }) {
+    const { pageInterface, pageTitle } = props;
+
+    const output = buildThemesApiOverrideMarkdown({
+        reference: getInterfacesReference(),
+        pageInterface,
+        pageTitle,
+        title: THEMES_API_PAGE_CONTENT.title,
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/utils/agentReadinessFiles.test.ts
+++ b/packages/ag-charts-website/src/utils/agentReadinessFiles.test.ts
@@ -27,14 +27,14 @@ describe('buildLlmsTxt', () => {
     test('advertises the markdown (.md) convention as a site-wide rule, not a page list', () => {
         expect(txt).toContain('.md');
         expect(txt).toContain('https://www.ag-grid.com/charts/javascript/quick-start.md');
-        // Nearly every page in the sitemap has a twin, so llms.txt states the rule. Enumerating
-        // pages here would drift the moment one is added (see markdownPages.test.ts).
+        // Every page in the sitemap has a twin, so llms.txt states the rule. Enumerating pages
+        // here would drift the moment one is added (see markdownPages.test.ts).
         expect(txt).toContain('append `.md` to any page URL listed in the sitemap');
         expect(txt).toContain('Accept: text/markdown');
     });
 
-    test('names the API reference pages as the one gap, so an agent does not chase 404s', () => {
-        expect(txt).toContain('Options and Themes API reference pages are the exception');
+    test('claims no exceptions to the rule, so an agent does not skip a page that has a twin', () => {
+        expect(txt).not.toContain('exception');
     });
 
     test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
@@ -67,11 +67,11 @@ describe('buildAgentsMd', () => {
     test('advertises the markdown (.md) versions as a site-wide rule', () => {
         expect(md).toContain('Markdown for LLMs');
         expect(md).toContain('https://www.ag-grid.com/charts/javascript/quick-start.md');
-        // Nearly every page in the sitemap has a twin, so point at the sitemap rather than
-        // listing pages that would drift (see markdownPages.test.ts for the guarantee).
+        // Every page in the sitemap has a twin, so point at the sitemap rather than listing
+        // pages that would drift (see markdownPages.test.ts for the guarantee).
         expect(md).toContain('append `.md` to any page URL listed in the');
         expect(md).toContain('[sitemap](https://www.ag-grid.com/charts/sitemap-index.xml)');
-        expect(md).toContain('Options and Themes API reference pages are the exception');
+        expect(md).not.toContain('exception');
     });
 
     test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {

--- a/packages/ag-charts-website/src/utils/agentReadinessFiles.ts
+++ b/packages/ag-charts-website/src/utils/agentReadinessFiles.ts
@@ -70,7 +70,7 @@ export function buildLlmsTxt(input: AgentReadinessInput): string {
     const markdownLine =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}. The Options and Themes API reference pages are the exception and have no Markdown version.`;
+            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Charts
 > High-performance JavaScript Charting library, framework-agnostic with React, Angular and Vue support. Free Community and paid Enterprise editions. Current major version: v${input.majorVersion}.
 
@@ -100,7 +100,7 @@ export function buildAgentsMd(input: AgentReadinessInput): string {
     const markdownBullet =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}. The Options and Themes API reference pages are the exception and have no Markdown version.`;
+            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Charts - guide for AI coding assistants
 
 - **What it is:** high-performance JavaScript Charting library. Framework-agnostic, with React, Angular and Vue wrappers. Community (free) and Enterprise (licensed) editions.

--- a/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -37,7 +37,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
     RewriteEngine On
 
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts))/?$
+    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?))/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -52,7 +52,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 # Docs pages content-negotiate on Accept (see the markdown rewrite), so shared caches must
 # key on it. Scoped to the negotiated paths (incl. the homepage) so the rest of the site keeps
 # its default.
-<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
+<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
     Header append Vary Accept
 </If>
 
@@ -161,7 +161,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
     RewriteEngine On
 
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts))/?$
+    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?))/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -176,7 +176,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 # Docs pages content-negotiate on Accept (see the markdown rewrite), so shared caches must
 # key on it. Scoped to the negotiated paths (incl. the homepage) so the rest of the site keeps
 # its default.
-<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
+<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
     Header append Vary Accept
 </If>
 

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
@@ -231,6 +231,13 @@ describe('htaccessRules markdown content negotiation', () => {
         '/charts/angular-charts/',
         '/charts/vue-charts/',
         '/charts/enterprise-charts/',
+        '/charts/options/',
+        '/charts/options/axes/number/',
+        '/charts/options/series/bar/',
+        '/charts/options/initialState/annotations/callout/',
+        '/charts/options/navigator/miniChart/series/line/',
+        '/charts/themes-api/',
+        '/charts/themes-api/overrides/bar/',
     ];
 
     // Paths that must NOT negotiate: they have no `.md` twin, and rewriting them would either
@@ -243,9 +250,9 @@ describe('htaccessRules markdown content negotiation', () => {
         '/charts/style-guide/', // non-public, sitemap-excluded
         '/charts/contact/success/', // form result, sitemap-excluded
         '/charts/contact/failure/',
-        '/charts/options/', // API reference, deliberately untwinned
-        '/charts/options/series/bar/',
-        '/charts/themes-api/',
+        '/charts/options/series/bar.md', // the twin itself
+        '/charts/options/series/', // the member path alone is not a page
+        '/charts/themes-api/overrides/', // likewise
         '/charts/gallery-test/',
         '/charts/javascript/quick-start/examples/create-a-chart/',
         '/charts/debug/versions.json',

--- a/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.ts
@@ -26,6 +26,18 @@ import { getInterfacesReference } from '@utils/server/getInterfacesReference';
 const MAX_DEPTH = 8;
 const MAX_ROWS = 1500;
 
+export interface ApiReferenceTableLimits {
+    /**
+     * Stop expanding nested members below this depth. Set it where the reference branches
+     * combinatorially — `AgChartTheme.overrides` repeats the whole chart tree once per chart type,
+     * so a full expansion runs to tens of thousands of rows — and say so on the page, since a
+     * caller-set depth truncates silently.
+     */
+    maxDepth?: number;
+    /** Stop after this many rows. Raise alongside a `maxDepth` wide enough to exceed the default. */
+    maxRows?: number;
+}
+
 // A union alias with dozens of variants (e.g. AgIconName, 53 string literals) makes an unreadable
 // cell; past this budget the alias name is left in place, still resolvable from the docs site.
 const MAX_UNION_SIGNATURE_CHARS = 120;
@@ -94,7 +106,13 @@ function formatMemberType(reference: ApiReferenceType, member: MemberNode): stri
  *
  * Pure (no filesystem access) so it is unit-testable; the entry point loads the reference.
  */
-export function buildApiReferenceTable(reference: ApiReferenceType, attributes: Record<string, unknown>): string {
+export function buildApiReferenceTable(
+    reference: ApiReferenceType,
+    attributes: Record<string, unknown>,
+    limits: ApiReferenceTableLimits = {}
+): string {
+    const maxDepth = limits.maxDepth ?? MAX_DEPTH;
+    const maxRows = limits.maxRows ?? MAX_ROWS;
     const id = interfaceId(attributes);
     if (!id) {
         return '';
@@ -121,7 +139,8 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
 
     const hideRequired = attributes.hideRequired === true;
     const rows: string[][] = [];
-    let capped = false;
+    let depthCapped = false;
+    let rowsCapped = false;
 
     function collectRows(
         node: InterfaceNode | TypeLiteralNode,
@@ -135,8 +154,8 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
         typeArguments?: string[]
     ): void {
         for (const member of processMembers(node, memberConfig, typeArguments)) {
-            if (rows.length >= MAX_ROWS) {
-                capped = true;
+            if (rows.length >= maxRows) {
+                rowsCapped = true;
                 return;
             }
 
@@ -155,8 +174,8 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
             if (!nested || ancestors.has(nested.typeName)) {
                 continue;
             }
-            if (depth >= MAX_DEPTH) {
-                capped = true;
+            if (depth >= maxDepth) {
+                depthCapped = true;
                 continue;
             }
 
@@ -175,10 +194,12 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
 
     collectRows(interfaceRef, config, '', 1, new Set([id]));
 
-    if (capped) {
+    // A caller-set depth is a deliberate policy the page states for itself, so only the default
+    // guard warns. The row cap is always a runaway backstop.
+    if (rowsCapped || (depthCapped && limits.maxDepth == null)) {
         // eslint-disable-next-line no-console
         console.warn(
-            `apiReference "${id}": nested expansion hit the ${MAX_ROWS}-row/${MAX_DEPTH}-level cap; table truncated.`
+            `apiReference "${id}": nested expansion hit the ${maxRows}-row/${maxDepth}-level cap; table truncated.`
         );
     }
 

--- a/packages/ag-charts-website/src/utils/markdown-pages/apiReferencePageContent.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/apiReferencePageContent.ts
@@ -1,0 +1,42 @@
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+
+/**
+ * Titles and meta descriptions for the Options and Themes API reference pages, read by both the
+ * `.astro` pages and their markdown twins so the two cannot describe the same page differently.
+ */
+export const OPTIONS_API_PAGE_CONTENT = {
+    title: 'Options API',
+    description:
+        'Options API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties.',
+};
+
+export const THEMES_API_PAGE_CONTENT = {
+    title: 'Themes API',
+    description:
+        'Themes API reference for AG Charts JavaScript Charting Library. Search for properties or browse our tree-data explorer; access types, defaults, and child properties.',
+};
+
+function capitaliseFirstLetter(value: string) {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/** Metadata for one union variant of the options reference, e.g. `series[type='bar']`. */
+export function optionsVariantPageContent({ name, type }: PageTitle) {
+    const variant = `${capitaliseFirstLetter(type ?? '')} ${capitaliseFirstLetter(name)}`;
+    return {
+        title: `${OPTIONS_API_PAGE_CONTENT.title} (${variant})`,
+        description: `${variant} API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties.`,
+    };
+}
+
+/**
+ * The page heading for a reference page, mirroring the `<h1>` the page renders: a union variant
+ * reads as an indexed access (`series[type='bar']`), and the axes record is keyed
+ * (`axes.key[type='number']`).
+ */
+export function apiReferencePageHeading({ name, type }: PageTitle) {
+    if (!type) {
+        return name;
+    }
+    return `${name}${name === 'axes' ? '.key' : ''}[type='${type}']`;
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.test.ts
@@ -1,0 +1,144 @@
+import type { ApiReferenceType } from '@components/api-documentation/apiReferenceHelpers';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { optionsVariantPageContent } from './apiReferencePageContent';
+import {
+    buildOptionsApiMarkdown,
+    buildOptionsVariantMarkdown,
+    buildThemesApiMarkdown,
+} from './buildApiReferenceMarkdown';
+
+// The ambient test env has no site base, so the URLs below carry no `/charts` prefix.
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+// The generated reference the pages themselves render, so a renamed or dropped interface shows up
+// here rather than in a silently empty twin. Produced by `nx build ag-charts-types`, which
+// `nx test ag-charts-website` depends on.
+const reference: ApiReferenceType = new Map(
+    Object.entries(
+        JSON.parse(
+            readFileSync(
+                join(__dirname, '../../../../../dist/packages/ag-charts-types/resolved-interfaces.AUTO.json'),
+                'utf8'
+            )
+        )
+    )
+);
+
+/** Body rows of the first markdown table, as `[property, type, default, description]`. */
+function tableRows(output: string): string[][] {
+    return output
+        .split('\n')
+        .filter((line) => line.startsWith('| ') && !line.startsWith('| --- '))
+        .slice(1)
+        .map((line) =>
+            line
+                .split(/(?<!\\)\|/)
+                .slice(1, -1)
+                .map((cell) => cell.trim())
+        );
+}
+
+const propertyPaths = (output: string) => tableRows(output).map(([property]) => property);
+
+describe('buildOptionsApiMarkdown', () => {
+    const output = buildOptionsApiMarkdown({ reference, siteRoot: SITE_ROOT });
+
+    it("emits frontmatter matching the page's title and description", () => {
+        expect(output.startsWith('---\ntitle: "Options API"\n')).toBe(true);
+        expect(output).toContain('description: "Options API reference for AG Charts');
+        expect(output).toContain('\n# AgChartOptions\n');
+        expect(output).toContain('Interface: `AgChartOptions`');
+    });
+
+    it('flattens the property tree the page expands on click into dotted-path rows', () => {
+        const paths = propertyPaths(output);
+
+        expect(paths).toContain('series');
+        expect(paths).toContain('legend');
+        expect(paths).toContain('legend.enabled');
+        expect(paths.length).toBeGreaterThan(500);
+    });
+
+    it('links every variant page, so an agent can reach the per-type reference', () => {
+        expect(output).toContain("- [series[type='bar']](https://www.ag-grid.com/options/series/bar/)");
+        // The axes record is keyed, which the heading has to show.
+        expect(output).toContain("- [axes.key[type='number']](https://www.ag-grid.com/options/axes/number/)");
+        expect(output).toContain(
+            "- [initialState.annotations[type='line']](https://www.ag-grid.com/options/initialState/annotations/line/)"
+        );
+        expect(output).toContain(
+            "- [navigator.miniChart.series[type='line']](https://www.ag-grid.com/options/navigator/miniChart/series/line/)"
+        );
+    });
+});
+
+describe('buildOptionsVariantMarkdown', () => {
+    const pageTitle = { name: 'series', type: 'bar' };
+    const output = buildOptionsVariantMarkdown({
+        reference,
+        pageInterface: 'AgBarSeriesOptions',
+        pageTitle,
+        ...optionsVariantPageContent(pageTitle),
+        siteRoot: SITE_ROOT,
+    });
+
+    it("titles the page as the variant, matching the HTML page's own metadata", () => {
+        expect(output).toContain('title: "Options API (Bar Series)"');
+        expect(output).toContain("\n# series[type='bar']\n");
+        expect(output).toContain('Interface: `AgBarSeriesOptions`');
+    });
+
+    it('documents the variant interface, not the root options', () => {
+        const paths = propertyPaths(output);
+
+        expect(paths).toContain('type (required)');
+        expect(paths).toContain('xKey (required)');
+        expect(paths).toContain('label');
+        expect(paths).toContain('label.enabled');
+        expect(paths).not.toContain('legend');
+    });
+
+    it('links back to the options reference it is part of', () => {
+        expect(output).toContain('[AG Charts Options API reference](https://www.ag-grid.com/options/)');
+    });
+});
+
+describe('buildThemesApiMarkdown', () => {
+    const output = buildThemesApiMarkdown({ reference, siteRoot: SITE_ROOT });
+
+    it("emits frontmatter matching the page's title and description", () => {
+        expect(output.startsWith('---\ntitle: "Themes API"\n')).toBe(true);
+        expect(output).toContain('\n# AgChartTheme\n');
+        expect(output).toContain('Interface: `AgChartTheme`');
+    });
+
+    it('lists every chart type that can be themed, and the option groups each one takes', () => {
+        const paths = propertyPaths(output);
+
+        expect(paths).toContain('overrides');
+        expect(paths).toContain('overrides.bar');
+        expect(paths).toContain('overrides.bar.series');
+        expect(paths).toContain('overrides.bar.axes');
+        expect(paths).toContain('overrides.treemap');
+    });
+
+    it('stops before the combinatorial part of the tree, and says so', () => {
+        // Every chart type repeats the whole chart options tree, so expanding a fourth level runs
+        // to tens of thousands of rows. The reader is told where the table stops instead.
+        expect(propertyPaths(output)).not.toContain('overrides.bar.series.cornerRadius');
+        expect(output).toContain('Only the first three levels of `overrides` are listed');
+        expect(output).toContain('[Options API reference](https://www.ag-grid.com/options/)');
+    });
+
+    it('expands the rest of the theme in full', () => {
+        const paths = propertyPaths(output);
+
+        expect(paths).toContain('baseTheme');
+        expect(paths).toContain('palette');
+        expect(paths).toContain('palette.fills');
+        expect(paths).toContain('params');
+    });
+});

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.test.ts
@@ -1,6 +1,3 @@
-import type { ApiReferenceType } from '@components/api-documentation/apiReferenceHelpers';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { optionsVariantPageContent } from './apiReferencePageContent';
@@ -13,53 +10,108 @@ import {
 // The ambient test env has no site base, so the URLs below carry no `/charts` prefix.
 const SITE_ROOT = 'https://www.ag-grid.com/';
 
-// The generated reference the pages themselves render, so a renamed or dropped interface shows up
-// here rather than in a silently empty twin. Produced by `nx build ag-charts-types`, which
-// `nx test ag-charts-website` depends on.
-const reference: ApiReferenceType = new Map(
-    Object.entries(
-        JSON.parse(
-            readFileSync(
-                join(__dirname, '../../../../../dist/packages/ag-charts-types/resolved-interfaces.AUTO.json'),
-                'utf8'
-            )
-        )
-    )
-);
+const member = (name: string, type: any, extra: Record<string, unknown> = {}) => ({
+    kind: 'member' as const,
+    name,
+    type,
+    optional: true,
+    ...extra,
+});
+const iface = (name: string, members: any[], extra: Record<string, unknown> = {}) => ({
+    kind: 'interface' as const,
+    name,
+    members,
+    ...extra,
+});
+const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
+const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
+const typeRef = (type: string) => ({ kind: 'typeRef' as const, type });
+const variant = (name: string, discriminator: string, members: any[] = []) =>
+    iface(name, [member('type', `'${discriminator}'`, { optional: false }), ...members]);
 
-/** Body rows of the first markdown table, as `[property, type, default, description]`. */
-function tableRows(output: string): string[][] {
+const makeReference = (nodes: Record<string, unknown>) => new Map<string, any>(Object.entries(nodes)) as any;
+
+/**
+ * The shape `getOptionsStaticPaths` fans out over: four discriminated unions, each variant carrying
+ * the string literal that names its page. Real interface names, since the builders look them up.
+ */
+const optionsReference = makeReference({
+    AgChartOptions: iface(
+        'AgChartOptions',
+        [
+            member('series', { kind: 'array', type: typeRef('AgChartSeriesOptions') }),
+            member('legend', typeRef('AgChartLegendOptions')),
+        ],
+        { docs: ['Configuration for the chart.'] }
+    ),
+    AgChartLegendOptions: iface('AgChartLegendOptions', [
+        member('enabled', 'boolean', { docs: ['Whether to show the legend.'] }),
+    ]),
+    AgChartSeriesOptions: alias('AgChartSeriesOptions', union('AgBarSeriesOptions', 'AgLineSeriesOptions')),
+    AgBarSeriesOptions: variant('AgBarSeriesOptions', 'bar', [
+        member('xKey', 'string', { optional: false }),
+        member('label', typeRef('AgBarSeriesLabelOptions')),
+    ]),
+    AgBarSeriesLabelOptions: iface('AgBarSeriesLabelOptions', [member('enabled', 'boolean')]),
+    AgLineSeriesOptions: variant('AgLineSeriesOptions', 'line'),
+    AgChartAxesOptions: alias('AgChartAxesOptions', union('AgNumberAxisOptions')),
+    AgNumberAxisOptions: variant('AgNumberAxisOptions', 'number'),
+    AgAnnotation: alias('AgAnnotation', union('AgLineAnnotation')),
+    AgLineAnnotation: variant('AgLineAnnotation', 'line'),
+    AgMiniChartSeriesOptions: alias('AgMiniChartSeriesOptions', union('AgMiniChartLineSeriesOptions')),
+    AgMiniChartLineSeriesOptions: variant('AgMiniChartLineSeriesOptions', 'line'),
+});
+
+/**
+ * `overrides` nests one entry per chart type, each holding a further group of options — the branch
+ * the themes twin caps, since the real reference repeats the whole chart tree under every type.
+ */
+const themesReference = makeReference({
+    AgChartTheme: iface(
+        'AgChartTheme',
+        [
+            member('baseTheme', 'AgChartThemeName'),
+            member('palette', typeRef('AgChartThemePalette')),
+            member('overrides', typeRef('AgThemeOverrides')),
+        ],
+        { docs: ['This object is used to define the configuration for a custom chart theme.'] }
+    ),
+    AgChartThemePalette: iface('AgChartThemePalette', [member('fills', 'string[]')]),
+    AgThemeOverrides: iface('AgThemeOverrides', [
+        member('bar', typeRef('AgBarThemeOverrides')),
+        member('line', typeRef('AgLineThemeOverrides')),
+    ]),
+    AgBarThemeOverrides: iface('AgBarThemeOverrides', [
+        member('series', typeRef('AgBarSeriesThemeableOptions')),
+        member('axes', typeRef('AgCartesianAxesTheme')),
+    ]),
+    AgBarSeriesThemeableOptions: iface('AgBarSeriesThemeableOptions', [member('cornerRadius', 'number')]),
+    AgCartesianAxesTheme: iface('AgCartesianAxesTheme', [member('number', 'AgNumberAxisTheme')]),
+    AgLineThemeOverrides: iface('AgLineThemeOverrides', [member('series', typeRef('AgBarSeriesThemeableOptions'))]),
+});
+
+/** The `Property` column of each table row, which is what carries the nesting. */
+function propertyPaths(output: string): string[] {
     return output
         .split('\n')
         .filter((line) => line.startsWith('| ') && !line.startsWith('| --- '))
         .slice(1)
-        .map((line) =>
-            line
-                .split(/(?<!\\)\|/)
-                .slice(1, -1)
-                .map((cell) => cell.trim())
-        );
+        .map((line) => line.split('|')[1].trim());
 }
 
-const propertyPaths = (output: string) => tableRows(output).map(([property]) => property);
-
 describe('buildOptionsApiMarkdown', () => {
-    const output = buildOptionsApiMarkdown({ reference, siteRoot: SITE_ROOT });
+    const output = buildOptionsApiMarkdown({ reference: optionsReference, siteRoot: SITE_ROOT });
 
     it("emits frontmatter matching the page's title and description", () => {
         expect(output.startsWith('---\ntitle: "Options API"\n')).toBe(true);
         expect(output).toContain('description: "Options API reference for AG Charts');
         expect(output).toContain('\n# AgChartOptions\n');
+        expect(output).toContain('Configuration for the chart.');
         expect(output).toContain('Interface: `AgChartOptions`');
     });
 
     it('flattens the property tree the page expands on click into dotted-path rows', () => {
-        const paths = propertyPaths(output);
-
-        expect(paths).toContain('series');
-        expect(paths).toContain('legend');
-        expect(paths).toContain('legend.enabled');
-        expect(paths.length).toBeGreaterThan(500);
+        expect(propertyPaths(output)).toEqual(['series', 'legend', 'legend.enabled']);
     });
 
     it('links every variant page, so an agent can reach the per-type reference', () => {
@@ -78,7 +130,7 @@ describe('buildOptionsApiMarkdown', () => {
 describe('buildOptionsVariantMarkdown', () => {
     const pageTitle = { name: 'series', type: 'bar' };
     const output = buildOptionsVariantMarkdown({
-        reference,
+        reference: optionsReference,
         pageInterface: 'AgBarSeriesOptions',
         pageTitle,
         ...optionsVariantPageContent(pageTitle),
@@ -92,13 +144,7 @@ describe('buildOptionsVariantMarkdown', () => {
     });
 
     it('documents the variant interface, not the root options', () => {
-        const paths = propertyPaths(output);
-
-        expect(paths).toContain('type (required)');
-        expect(paths).toContain('xKey (required)');
-        expect(paths).toContain('label');
-        expect(paths).toContain('label.enabled');
-        expect(paths).not.toContain('legend');
+        expect(propertyPaths(output)).toEqual(['type (required)', 'xKey (required)', 'label', 'label.enabled']);
     });
 
     it('links back to the options reference it is part of', () => {
@@ -107,7 +153,7 @@ describe('buildOptionsVariantMarkdown', () => {
 });
 
 describe('buildThemesApiMarkdown', () => {
-    const output = buildThemesApiMarkdown({ reference, siteRoot: SITE_ROOT });
+    const output = buildThemesApiMarkdown({ reference: themesReference, siteRoot: SITE_ROOT });
 
     it("emits frontmatter matching the page's title and description", () => {
         expect(output.startsWith('---\ntitle: "Themes API"\n')).toBe(true);
@@ -122,7 +168,7 @@ describe('buildThemesApiMarkdown', () => {
         expect(paths).toContain('overrides.bar');
         expect(paths).toContain('overrides.bar.series');
         expect(paths).toContain('overrides.bar.axes');
-        expect(paths).toContain('overrides.treemap');
+        expect(paths).toContain('overrides.line');
     });
 
     it('stops before the combinatorial part of the tree, and says so', () => {
@@ -139,6 +185,5 @@ describe('buildThemesApiMarkdown', () => {
         expect(paths).toContain('baseTheme');
         expect(paths).toContain('palette');
         expect(paths).toContain('palette.fills');
-        expect(paths).toContain('params');
     });
 });

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.ts
@@ -1,0 +1,166 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import type { ApiReferenceType, PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import { getOptionsStaticPaths, parseJsDocs } from '@components/api-documentation/apiReferenceHelpers';
+import type { ApiReferenceTableLimits } from '@utils/markdoc/renderApiReferenceTable';
+import { buildApiReferenceTable } from '@utils/markdoc/renderApiReferenceTable';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+import { OPTIONS_API_PAGE_CONTENT, THEMES_API_PAGE_CONTENT, apiReferencePageHeading } from './apiReferencePageContent';
+
+/**
+ * `AgChartTheme.overrides` holds one entry per chart type, each repeating the whole chart options
+ * tree, so a full expansion is combinatorial — ~97k rows and 15MB. Three levels reach every chart
+ * type and the option groups it themes, which is the structure the page is actually about; the
+ * properties inside those groups are documented under `/options/`.
+ */
+const THEMES_API_TABLE_LIMITS: ApiReferenceTableLimits = { maxDepth: 3, maxRows: 5000 };
+
+interface ApiReferenceMarkdownParams {
+    reference: ApiReferenceType;
+    /** Interface the page documents; its members become the property table. */
+    pageInterface: string;
+    /** Page heading, mirroring the page's `<h1>`. */
+    heading: string;
+    title: string;
+    description: string;
+    /** Markdown blocks appended after the table — related pages, and any caveat about the table. */
+    sections?: string[];
+    tableLimits?: ApiReferenceTableLimits;
+}
+
+function frontmatter(title: string, description: string) {
+    return ['---', `title: ${JSON.stringify(title)}`, `description: ${JSON.stringify(description)}`, '---'].join('\n');
+}
+
+/**
+ * Build the markdown twin of an API reference page. The page renders its property tree client-side
+ * from the generated interface reference, so the twin reads that same reference and flattens the
+ * tree the reader would expand into dotted-path rows — the same table the docs pages' `apiReference`
+ * tag produces, so the two surfaces describe a property identically.
+ */
+function buildApiReferenceMarkdown({
+    reference,
+    pageInterface,
+    heading,
+    title,
+    description,
+    sections = [],
+    tableLimits,
+}: ApiReferenceMarkdownParams): string {
+    const interfaceRef = reference.get(pageInterface);
+    const docs = interfaceRef?.kind === 'interface' ? parseJsDocs(interfaceRef.docs) : undefined;
+
+    const document = [
+        frontmatter(title, description),
+        `# ${heading}`,
+        docs,
+        `Interface: \`${pageInterface}\``,
+        buildApiReferenceTable(reference, { id: pageInterface }, tableLimits),
+        ...sections,
+    ];
+
+    return `${document.filter(Boolean).join('\n\n').trimEnd()}\n`;
+}
+
+/** The `/options/` page, whose union variants each have a reference page of their own. */
+export function buildOptionsApiMarkdown({
+    reference,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    siteRoot?: string;
+}): string {
+    const variants = getOptionsStaticPaths(reference).map(({ params, props }) => {
+        const href = toAbsoluteUrl(urlWithBaseUrl(`/options/${params.memberName}/${params.type}/`), siteRoot);
+        return `- [${apiReferencePageHeading(props.pageTitle)}](${href})`;
+    });
+
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface: 'AgChartOptions',
+        heading: 'AgChartOptions',
+        ...OPTIONS_API_PAGE_CONTENT,
+        sections: variants.length
+            ? [
+                  '## Options with a reference page per type',
+                  'Each of these properties is a union whose variants are documented separately.',
+                  variants.join('\n'),
+              ]
+            : [],
+    });
+}
+
+/** One union variant of the options reference, e.g. `series[type='bar']`. */
+export function buildOptionsVariantMarkdown({
+    reference,
+    pageInterface,
+    pageTitle,
+    title,
+    description,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    pageInterface: string;
+    pageTitle: PageTitle;
+    title: string;
+    description: string;
+    siteRoot?: string;
+}): string {
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface,
+        heading: apiReferencePageHeading(pageTitle),
+        title,
+        description,
+        sections: [
+            `Part of the [AG Charts Options API reference](${toAbsoluteUrl(urlWithBaseUrl('/options/'), siteRoot)}).`,
+        ],
+    });
+}
+
+/** The `/themes-api/` page. */
+export function buildThemesApiMarkdown({
+    reference,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    siteRoot?: string;
+}): string {
+    const optionsUrl = toAbsoluteUrl(urlWithBaseUrl('/options/'), siteRoot);
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface: 'AgChartTheme',
+        heading: 'AgChartTheme',
+        ...THEMES_API_PAGE_CONTENT,
+        tableLimits: THEMES_API_TABLE_LIMITS,
+        sections: [
+            `Only the first three levels of \`overrides\` are listed: every chart type it accepts, and the option groups each one themes. Those groups take the themeable subset of the corresponding chart options — see the [Options API reference](${optionsUrl}).`,
+        ],
+    });
+}
+
+/** One `AgChartTheme.overrides` entry with a reference page of its own. */
+export function buildThemesApiOverrideMarkdown({
+    reference,
+    pageInterface,
+    pageTitle,
+    title,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    pageInterface: string;
+    pageTitle: PageTitle;
+    title: string;
+    siteRoot?: string;
+}): string {
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface,
+        heading: apiReferencePageHeading(pageTitle),
+        title,
+        description: THEMES_API_PAGE_CONTENT.description,
+        sections: [
+            `Part of the [AG Charts Themes API reference](${toAbsoluteUrl(urlWithBaseUrl('/themes-api/'), siteRoot)}).`,
+        ],
+    });
+}

--- a/packages/ag-charts-website/src/utils/markdownPages.test.ts
+++ b/packages/ag-charts-website/src/utils/markdownPages.test.ts
@@ -38,14 +38,6 @@ describe('CHARTS_MARKDOWN_PAGE_GROUPS', () => {
 });
 
 /**
- * The Options and Themes API reference. Both render client-side from the generated interface
- * reference, so a twin would need a markdown rendering of that whole tree — a separate piece of
- * work, and the one documented gap in the "every sitemap URL has a twin" rule (`llms.txt` and
- * `AGENTS.md` say so explicitly).
- */
-const isApiReferencePage = (pathname: string) => /\/(?:options|themes-api)(?:\/|$)/.test(pathname);
-
-/**
  * Twins generated on production by grid's Jira cron (`scripts/jira/production/getCharts*` in the
  * ag-grid repo) rather than by this build, so they are absent from a local `dist` by design. Their
  * pages advertise the `.md` only in production for the same reason.
@@ -92,10 +84,8 @@ describe.runIf(hasCompleteBuild)('every sitemap URL has a .md twin in dist', () 
         expect(sitemapBase).toBe('/charts');
     });
 
-    it('emits a .md file next to every page, bar the documented exceptions', () => {
-        const unexplained = missing.filter(
-            (pathname) => !isApiReferencePage(pathname) && !CRON_GENERATED_TWINS.includes(baseRelative(pathname))
-        );
+    it('emits a .md file next to every page, bar the documented exception', () => {
+        const unexplained = missing.filter((pathname) => !CRON_GENERATED_TWINS.includes(baseRelative(pathname)));
         expect(unexplained, `${unexplained.length} sitemap URLs have no .md twin`).toEqual([]);
     });
 
@@ -104,16 +94,16 @@ describe.runIf(hasCompleteBuild)('every sitemap URL has a .md twin in dist', () 
         // `Accept: text/markdown`, so the two must agree.
         const unroutable = sitemapPaths
             .map(baseRelative)
-            .filter((pathname) => pathname !== '/' && !isApiReferencePage(pathname) && !isNegotiable(pathname));
+            .filter((pathname) => pathname !== '/' && !isNegotiable(pathname));
         expect(unroutable, `${unroutable.length} pages have a twin but no negotiation rule`).toEqual([]);
     });
 
-    it('keeps the API reference exclusion honest — it is still in the sitemap and still untwinned', () => {
-        // If the reference gains twins, this fails and `isApiReferencePage` must go, rather than
-        // quietly staying as a place real gaps could hide.
-        const apiPages = sitemapPaths.filter(isApiReferencePage);
+    it('covers the API reference, whose pages are the deepest URLs in the sitemap', () => {
+        // These fan out from the generated interface reference rather than from a content
+        // collection, so a change to the generator can drop them from the build entirely.
+        const apiPages = sitemapPaths.filter((pathname) => /\/(?:options|themes-api)(?:\/|$)/.test(pathname));
         expect(apiPages.length).toBeGreaterThan(50);
-        expect(missing.filter(isApiReferencePage)).toEqual(apiPages);
+        expect(missing.filter((pathname) => apiPages.includes(pathname))).toEqual([]);
     });
 
     it('keeps the cron-generated exclusion free of stale entries', () => {

--- a/packages/ag-charts-website/src/utils/markdownPages.test.ts
+++ b/packages/ag-charts-website/src/utils/markdownPages.test.ts
@@ -98,12 +98,31 @@ describe.runIf(hasCompleteBuild)('every sitemap URL has a .md twin in dist', () 
         expect(unroutable, `${unroutable.length} pages have a twin but no negotiation rule`).toEqual([]);
     });
 
-    it('covers the API reference, whose pages are the deepest URLs in the sitemap', () => {
+    describe('the API reference twins', () => {
         // These fan out from the generated interface reference rather than from a content
-        // collection, so a change to the generator can drop them from the build entirely.
+        // collection, so a change to the generator can drop them from the build — or, since the
+        // builders degrade to an empty table rather than throwing, reduce them to a stub with
+        // frontmatter and no properties. Only a built twin can show either.
         const apiPages = sitemapPaths.filter((pathname) => /\/(?:options|themes-api)(?:\/|$)/.test(pathname));
-        expect(apiPages.length).toBeGreaterThan(50);
-        expect(missing.filter((pathname) => apiPages.includes(pathname))).toEqual([]);
+        const twinBody = (path: string) =>
+            readFileSync(join(DIST, `${baseRelative(path).replace(/^\/|\/$/g, '')}.md`), 'utf8');
+        const propertyRows = (body: string) =>
+            body.split('\n').filter((line) => line.startsWith('| ') && !line.startsWith('| --- ')).length - 1;
+
+        it('covers every reference page in the sitemap', () => {
+            expect(apiPages.length).toBeGreaterThan(50);
+            expect(missing.filter((pathname) => apiPages.includes(pathname))).toEqual([]);
+        });
+
+        it('carries a populated property table on every one, not an empty shell', () => {
+            const empty = apiPages.filter((pathname) => propertyRows(twinBody(pathname)) < 1);
+            expect(empty, `${empty.length} reference twins have no properties`).toEqual([]);
+        });
+
+        it('resolves the root interfaces the two references hang off', () => {
+            expect(twinBody('/charts/options/')).toContain('Interface: `AgChartOptions`');
+            expect(twinBody('/charts/themes-api/')).toContain('Interface: `AgChartTheme`');
+        });
     });
 
     it('keeps the cron-generated exclusion free of stale entries', () => {

--- a/packages/ag-charts-website/src/utils/markdownPages.ts
+++ b/packages/ag-charts-website/src/utils/markdownPages.ts
@@ -46,6 +46,16 @@ export const CHARTS_MARKDOWN_PAGE_GROUPS: MarkdownPageGroup[] = [
         describes: 'SEO landing pages, all rendered from the landingPages collection.',
         pattern: '(?:angular|enterprise|javascript|react|vue)-charts',
     },
+    {
+        // The member paths mirror the ones getOptionsStaticPaths fans out over; a fifth added there
+        // without a pattern here fails the coverage check rather than silently losing negotiation.
+        describes: 'The Options API reference and the union variants with a page of their own.',
+        pattern: 'options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?',
+    },
+    {
+        describes: 'The Themes API reference and its per-override pages.',
+        pattern: 'themes-api(?:/overrides/[^/.]+)?',
+    },
 ];
 
 function patternedGroups(): string[] {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17912

Follow-up to #7761 and #7469. Closes the last gap in the "every sitemap URL has a `.md` twin" invariant: the **77 Options and Themes API reference pages**, which #7761 named as its one documented exception.

After this, the only sitemap URLs without a twin in a local `dist` are `/changelog/` and `/pipeline/`, whose twins production's Jira cron generates rather than this build.

## What the twins contain

Both page families render their property tree client-side from the generated interface reference, so the twins read that same reference and flatten the tree the reader would expand into dotted-path rows — the **same table the docs pages' `apiReference` tag already produces**, so a property reads identically on both surfaces.

| Page | Twin | Size |
| --- | --- | ---: |
| `/options/` | `AgChartOptions`, plus a link to each of the 75 variant pages | 92 KB |
| `/options/<member>/<type>/` (75) | the variant interface, e.g. `AgBarSeriesOptions` | 12–28 KB |
| `/themes-api/` | `AgChartTheme` | 160 KB |

Frontmatter, `<h1>` and the `Interface:` line mirror what the page itself renders — including the keyed axes heading (`axes.key[type='number']`).

## The one place the tree had to be capped

`AgChartTheme.overrides` holds one entry per chart type, each repeating the entire chart options tree. Expanding it fully is combinatorial: **96,702 rows / 15.6 MB**, and still depth-capped. It is capped at three levels instead — every chart type, and the option groups each one themes — which is the structure that page is actually about; the properties inside those groups are documented under `/options/`. The page states where the table stops and links there, rather than truncating silently.

`buildApiReferenceTable` gained an optional `limits` parameter for this. The warning it already emitted now fires only when the **default** guard is hit — a caller-set depth is a deliberate policy the page explains itself — and the row cap warns either way, so a genuine runaway is still loud.

## Page metadata extracted first

The titles and meta descriptions were inline in the four `.astro` pages, including a local `capitalizeFirstLetter` for the variant titles. They move to `apiReferencePageContent.ts` and the pages are repointed at it, so a twin's frontmatter cannot drift from the page's own `<title>`/`<meta>`. Verified unchanged on a dev server: `AG Charts: Options API (Bar Series)` and its description render exactly as before.

## Honesty of the invariant

- `markdownPages.test.ts` loses `isApiReferencePage` entirely, as its own comment required ("if the reference gains twins, this fails and `isApiReferencePage` must go"). In its place is a check that the reference **is** covered — these pages fan out from the generated reference rather than a content collection, so a generator change can drop them from the build.
- `llms.txt`, `AGENTS.md` and the sitemap twin stop naming these pages as the exception; their tests now assert the word *exception* is absent, so re-introducing a carve-out has to be deliberate.

## `themes-api/overrides/` builds zero pages (pre-existing)

`getThemesApiStaticPaths` looks up `AgBaseChartThemeOverrides`, which is **absent from the generated reference** — the interface is now `AgThemeOverrides`. So `/themes-api/overrides/<name>/` has produced no pages for some time, and the `specialTypes={{ AgBaseChartThemeOverrides: 'NestedPage' }}` on the themes page is dead with it. Not fixed here — it would add 36 pages to the sitemap and belongs in its own change. The `.md.ts` route mirrors the `.astro` page's `getStaticPaths` anyway, so the two URL sets stay 1:1 whenever that is fixed.

## Verification

- `nx test ag-charts-website` — **682 pass, 0 fail** (the 3 failures on `latest` were the coverage check reading a stale `dist`; green after a rebuild)
- `nx lint ag-charts-website` — clean (9 pre-existing warnings) · `nx format` clean
- `nx build ag-charts-website` — **exit 0**, 1035 tasks; probing all 761 sitemap URLs for a `.md` sibling leaves exactly `/changelog/` and `/pipeline/`
- **`Accept: text/markdown` negotiation exercised against a live dev server** — the gap #7761 listed as untested. All six URL shapes negotiate `200 text/markdown` from their HTML URL, the `.md` URLs serve directly, and `Accept: text/html` still returns HTML.

## Note for the reviewer

The htaccess snapshot was regenerated. The diff is 4 lines: the two new groups appended to the negotiation alternation and to the `Vary: Accept` scope, in both environments. Nothing else in the generated `.htaccess` moved.