### PR TITLE
AG-3390 Stop a navigating click from failing the e2e chart stability wait

### DIFF
--- a/packages/ag-charts-website/e2e/fixture.spec.ts
+++ b/packages/ag-charts-website/e2e/fixture.spec.ts
@@ -1,0 +1,50 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from './fixture';
+
+// Covers the navigation-safety contract of the stability waits this fixture wraps around every
+// locator action. Both pages are served from route handlers, so nothing here depends on the dev
+// server or on a real chart.
+
+const linkPage = ({ navigates }: { navigates: boolean }) => `<html><body>
+<a href="/next" id="link">Next</a>
+<div class="ag-charts-wrapper" data-update-pending="false" data-animating="false"></div>
+<script>
+  const link = document.getElementById('link');
+  // The chart starts an update as the click lands, so the post-click stability wait is still
+  // polling the wrapper when the click's own consequences play out.
+  link.addEventListener('mousedown', () => {
+    document.querySelector('.ag-charts-wrapper').setAttribute('data-update-pending', 'true');
+  });
+  link.addEventListener('click', (e) => {
+    e.preventDefault();
+    ${navigates ? "setTimeout(() => { location.href = '/next'; }, 300);" : ''}
+  });
+</script>
+</body></html>`;
+
+const NEXT_PAGE = `<html><body><h1>A page with no charts</h1></body></html>`;
+
+async function gotoLinkPage(page: Page, { navigates }: { navigates: boolean }) {
+    await page.route('**/link', (route) => route.fulfill({ contentType: 'text/html', body: linkPage({ navigates }) }));
+    await page.route('**/next', (route) => route.fulfill({ contentType: 'text/html', body: NEXT_PAGE }));
+    await page.goto('http://charts-fixture.test/link');
+}
+
+test('a chart detached by navigation does not fail the wait', async ({ page }) => {
+    await gotoLinkPage(page, { navigates: true });
+
+    // The wrapper is counted on this document and gone from the next one. Waiting for a chart
+    // that no longer exists to settle is not a failure — there is nothing left to settle.
+    await page.getByRole('link', { name: 'Next' }).click();
+
+    await expect(page).toHaveURL(/\/next/);
+});
+
+test('a chart that never settles still fails the wait', async ({ page }) => {
+    await gotoLinkPage(page, { navigates: false });
+
+    // The counterpart: the page stays put, so the unsettled wrapper is a real timeout and must
+    // not be swallowed by the tolerance for charts detached by a navigation.
+    await expect(page.getByRole('link', { name: 'Next' }).click()).rejects.toThrow(/toHaveAttribute/);
+});

--- a/packages/ag-charts-website/e2e/fixture.ts
+++ b/packages/ag-charts-website/e2e/fixture.ts
@@ -38,6 +38,9 @@ const LOCATOR_FACTORIES = new Set([
 ]);
 
 async function waitForCharts(page: Page) {
+    // Let an in-flight navigation commit before inspecting the page, so the wrappers we find
+    // belong to the document we are about to assert against.
+    await page.waitForLoadState('domcontentloaded');
     // Wait for a rAF-then-setTimeout chain so that:
     // 1. rAF-scheduled chart updates (zoom animations, scene renders) begin
     // 2. Deferred DOM flushes (setTimeout(0) in DOMElementProxy) execute
@@ -46,7 +49,15 @@ async function waitForCharts(page: Page) {
     // has even been scheduled.
     await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0))));
     for (const locator of await page.locator('.ag-charts-wrapper').all()) {
-        await waitForChartUpdate(locator);
+        try {
+            await waitForChartUpdate(locator);
+        } catch (error) {
+            // A click that navigates away detaches the chart we were waiting on partway
+            // through the wait: the wrapper was counted on the old document and is gone from
+            // the new one. Nothing is left to stabilise, so that is not a failure — but a
+            // wrapper still present in the DOM has genuinely timed out.
+            if ((await locator.count()) > 0) throw error;
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

The post-deploy page verification job fails intermittently on `header nav Community link navigates to community` ([example run](https://github.com/ag-grid/ag-charts/actions/runs/31584813121/job/94076070991)), with an error that names a selector the test never mentions:

```
Locator: locator('.ag-charts-wrapper').first()
Expected: "false"
Error: element(s) not found
```

The assertion comes from the e2e fixture, not the spec. `stableLocator` wraps every locator action in `waitForCharts`, which waits for each `.ag-charts-wrapper` to report a settled chart.

When the click navigates away, that wait snapshots the wrappers on the outgoing document and then polls them against the incoming one:

1. the homepage hero chart is still updating when the click lands, so the wait starts polling it;
2. `/community` commits during those 5s and has no chart at all;
3. the locator re-resolves against the new document, finds nothing, and burns the timeout.

Any nav test can hit this; Community fails most because its destination has no chart to re-resolve against.

## Fix

- Wait for an in-flight navigation to commit before looking for wrappers, so the ones we find belong to the document we assert against.
- Treat a wrapper that disappears partway through its wait as nothing left to stabilise. A wrapper still present in the DOM is a real timeout and still fails.

## Testing

- Added `e2e/fixture.spec.ts`, covering both directions: a chart detached by navigation must not fail the wait, and a chart that never settles must still fail it. Route-mocked, so it needs neither the dev server nor a real chart. The first case reproduces the CI error exactly on `latest` and passes with this change.
- `page-verification.spec.ts` against staging: 127/127 pass.
- `yarn nx format`, `yarn nx lint ag-charts-website` clean. (`nx build:types` has no target for this package; `tsconfig.lint.json` does not type-check under the workspace's TS 5.8 on `latest` either, so the changed files were checked directly instead — no errors from them.)