### PR TITLE
Fix negative-value currency formatting in series-labels examples (#7779)

### DIFF
--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-fitting/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-fitting/main.ts
@@ -24,6 +24,11 @@ const options: AgCartesianChartOptions<DataType> = {
                 wrapping: 'on-space',
                 truncate: true,
             },
+            tooltip: {
+                renderer: ({ datum }) => ({
+                    data: [{ label: 'Revenue', value: `$${datum.revenue}m` }],
+                }),
+            },
         },
     ],
     axes: {

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-orientation/main.ts
@@ -22,6 +22,11 @@ const options: AgCartesianChartOptions<DataType> = {
                 wrapping: 'never',
                 formatter: (params) => `$${params.value}m profit${params.datum.note ? ` (${params.datum.note})` : ''}`,
             },
+            tooltip: {
+                renderer: ({ datum }) => ({
+                    data: [{ label: 'Profit Change', value: `$${datum.profitChange}m` }],
+                }),
+            },
         },
     ],
     axes: {

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
@@ -126,7 +126,7 @@ function setSeriesType(seriesType: SeriesType) {
                         | AgBarSeriesLabelPlacement[],
                     spacing,
                     truncate: false,
-                    format: '$',
+                    formatter: ({ value }) => formatCurrency(value),
                 },
                 tooltip: {
                     renderer: ({ datum }) => ({

--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
@@ -28,6 +28,11 @@ type SeriesType = 'bubble' | 'bar' | 'bar-horizontal';
 
 let spacing = 6;
 
+function formatCurrency(value: number) {
+    const sign = value < 0 ? '-' : '';
+    return `${sign}$${Math.abs(value)}m`;
+}
+
 const options: AgCartesianChartOptions<BubbleDataType | BarDataType> = {
     container: document.getElementById('myChart'),
     title: { text: 'Weather Station Readings' },
@@ -121,7 +126,12 @@ function setSeriesType(seriesType: SeriesType) {
                         | AgBarSeriesLabelPlacement[],
                     spacing,
                     truncate: false,
-                    formatter: (params) => `$${params.value}m`,
+                    format: '$',
+                },
+                tooltip: {
+                    renderer: ({ datum }) => ({
+                        data: [{ label: 'Profit Change', value: formatCurrency((datum as BarDataType).profitChange) }],
+                    }),
                 },
             },
         ];


### PR DESCRIPTION
## Summary
Cherry-pick of #7779 onto `b14.1.0`.

- Fixes negative-value currency sign placement in the `label-orientation`, `label-position`, and `label-fitting` series-labels examples (sign was landing after the `$` instead of before it).
- Adds matching `$`-formatted tooltips to the bar series in those examples.

## Test plan
- [x] Clean cherry-pick, no conflicts