### PR TITLE
Preserve millions suffix in label-position bar labels

### DIFF
--- a/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-labels/_examples/label-position/main.ts
@@ -126,7 +126,7 @@ function setSeriesType(seriesType: SeriesType) {
                         | AgBarSeriesLabelPlacement[],
                     spacing,
                     truncate: false,
-                    format: '$',
+                    formatter: ({ value }) => formatCurrency(value),
                 },
                 tooltip: {
                     renderer: ({ datum }) => ({


### PR DESCRIPTION
## Summary
- The `label-position` series-labels example (bar series) used `format: '$'` for its labels, which dropped the previous `m` (millions) suffix, making the bar labels inconsistent with the axis titles and tooltip that both describe values in millions.
- Replaces `format: '$'` with a `formatter` that reuses the existing `formatCurrency` helper, restoring the `$Xm` / `-$Xm` label text while keeping the correct sign placement fixed in #7779.
- Same fix also applied to the b14.1.0 cherry-pick, see #7787.

## Test plan
- [x] `yarn nx lint ag-charts-website`