### PR TITLE
Scope the CI "Regenerated by CI" snapshot report to the files CI rewrote

### DIFF
--- a/.github/actions/snapshot-review-run/action.yml
+++ b/.github/actions/snapshot-review-run/action.yml
@@ -156,19 +156,30 @@ runs:
               fi
 
               # Report B — regenerated snapshots (when CI pushed to gha/snapshots-<head-ref>).
-              # The two refs must stay distinct: the file set comes from where the snapshot branch
-              # forks off the PR head, because the branch is cut from the stale branch tip and a
-              # HEAD-vs-branch diff would also list every baseline the base branch moved since the
-              # fork point; the pixels come from HEAD, the merge commit the tests actually ran against.
+              # The two refs must stay distinct: the file set comes from the snapshot branch's own
+              # commits, because the branch is cut from the stale branch tip and a HEAD-vs-branch diff
+              # would also list every baseline the base branch moved since the fork point; the pixels
+              # come from HEAD, the merge commit the tests actually ran against.
               if [[ -n "${SNAPSHOT_BRANCH}" ]] && git ls-remote --exit-code --heads origin "${SNAPSHOT_BRANCH}" >/dev/null 2>&1; then
                   git fetch --no-tags --force --quiet origin "${SNAPSHOT_BRANCH}:refs/snap/review" || true
                   if git rev-parse --verify --quiet refs/snap/review >/dev/null; then
-                      # merge-base, not head_sha itself: a re-run rebases the regeneration commits
-                      # back onto the branch as it stood at an earlier run, so the fork point is the
-                      # only ref guaranteed to have just CI's own commits after it.
-                      BRANCH_BASE=''
+                      # Where CI's own commits start. Not head_sha itself and not the merge-base: a
+                      # re-run rebases onto the branch as it stood at an earlier run, and a force-push
+                      # abandons the head it was cut from, either of which drops the merge-base below
+                      # commits the developer wrote. What CI pushed is always the run of
+                      # github-actions[bot] commits at the tip, so walk those off — floored at the
+                      # merge-base, so a bot-authored PR head cannot be stepped past.
+                      FLOOR=''
                       if [[ -n "${HEAD_SHA}" ]]; then
-                          BRANCH_BASE="$(git merge-base "$HEAD_SHA" refs/snap/review 2>/dev/null || true)"
+                          FLOOR="$(git merge-base "$HEAD_SHA" refs/snap/review 2>/dev/null || true)"
+                      fi
+
+                      BRANCH_BASE=''
+                      if [[ -n "$FLOOR" ]]; then
+                          BRANCH_BASE="$(git rev-parse refs/snap/review)"
+                          while [[ "$BRANCH_BASE" != "$FLOOR" && "$(git log -1 --format=%an "$BRANCH_BASE")" == 'github-actions[bot]' ]]; do
+                              BRANCH_BASE="$(git rev-parse "${BRANCH_BASE}^")"
+                          done
                       fi
 
                       if [[ -n "$BRANCH_BASE" ]]; then

--- a/.github/actions/snapshot-review-run/action.yml
+++ b/.github/actions/snapshot-review-run/action.yml
@@ -3,7 +3,8 @@ description: >-
     Generate the asynchronous /snapshot-review reports for a PR and write the `snapshot-review`
     section fragment for the consolidated PR comment. Produces up to two reports: "current PR
     state" (committed baselines vs the merge-base with the base branch) and, when CI regenerated
-    baselines onto the snapshot branch, "regenerated" (committed baselines vs the snapshot branch).
+    baselines onto the snapshot branch, "regenerated" — the files the snapshot branch's own commits
+    rewrote, compared against the baselines as they exist in the checked-out (merged) tree.
     Pixel review is the backbone; scene-graph review is attempted best-effort and skipped cleanly
     when the CI scene captures are unavailable. Never fails the caller — this is advisory only.
 
@@ -15,6 +16,12 @@ inputs:
         description: 'Base branch to diff the current PR state against.'
         required: false
         default: latest
+    head_sha:
+        description: >-
+            The PR head commit the snapshot branch was cut from, used to scope the regenerated
+            report to the files CI rewrote. Without it that report also lists upstream baseline drift.
+        required: false
+        default: ''
     scripts_root:
         description: 'Directory containing the installed snapshot-review scripts.'
         required: false
@@ -50,6 +57,7 @@ runs:
           env:
               SNAPSHOT_BRANCH: ${{ inputs.snapshot_branch }}
               BASE_BRANCH: ${{ inputs.base_branch }}
+              HEAD_SHA: ${{ inputs.head_sha }}
               SCRIPTS: ${{ inputs.scripts_root }}
               GH_TOKEN: ${{ inputs.github_token }}
               # Point the run's artifacts page from inside the section text (fallback link).
@@ -75,19 +83,27 @@ runs:
 
               # PNG families: unit image snapshots (__image_snapshots__) and e2e/package (*-snapshots).
               # These are git pathspecs — '*' matches '/', so they scope to the two snapshot dir shapes.
-              INCLUDES=(--include '*__image_snapshots__/*.png' --include '*-snapshots/*.png')
+              PATHSPECS=('*__image_snapshots__/*.png' '*-snapshots/*.png')
+              INCLUDES=(); for p in "${PATHSPECS[@]}"; do INCLUDES+=(--include "$p"); done
 
               # Build one report; append its summary to the section body. Args: <label> <before> <after> <slug>
+              # Callers may set REPORT_INCLUDES to override the pathspecs for a single report.
               SECTION="${SECTIONS}/25-snapshot-review.md"
               : > "${WORK}/section-body.md"
               ANY=0
+              REPORT_INCLUDES=()
+              REPORT_LABELS=()
 
               build_report() {
                   local label="$1" before="$2" after="$3" slug="$4"
                   local dir="${WORK}/${slug}"
+                  local includes=("${INCLUDES[@]}")
+                  if [[ ${#REPORT_INCLUDES[@]} -gt 0 ]]; then
+                      includes=("${REPORT_INCLUDES[@]}")
+                  fi
                   mkdir -p "$dir"
                   echo "--- ${label}: collecting ${before}...${after}" >&2
-                  bash "$COLLECT" --before "$before" --after "$after" --out "$dir" "${INCLUDES[@]}" >&2 || {
+                  bash "$COLLECT" --before "$before" --after "$after" --out "$dir" "${includes[@]}" >&2 || {
                       echo "::warning::collect failed for ${label}; skipping."; return 1; }
 
                   # Skip a report with no changed images (keeps the section relevant, not noisy).
@@ -98,8 +114,11 @@ runs:
 
                   local html="${HTML_DIR}/snapshot-${slug}.html"
                   local md="${dir}/summary.md"
-                  if ! python3 "$REPORT" --in "$dir" --out "$html" --summary-md "$md" \
-                        --title "Snapshot review — ${label}" >&2; then
+                  local args=(--in "$dir" --out "$html" --summary-md "$md" --title "Snapshot review — ${label}")
+                  if [[ ${#REPORT_LABELS[@]} -gt 0 ]]; then
+                      args+=("${REPORT_LABELS[@]}")
+                  fi
+                  if ! python3 "$REPORT" "${args[@]}" >&2; then
                       echo "::warning::report builder failed for ${label} (needs --summary-md support); skipping."
                       return 1
                   fi
@@ -136,11 +155,37 @@ runs:
                   echo "::warning::could not resolve merge-base with ${BASE_BRANCH}; skipping current-state report."
               fi
 
-              # Report B — regenerated snapshots: HEAD .. gha/snapshots-<head-ref> (when CI pushed to it).
+              # Report B — regenerated snapshots (when CI pushed to gha/snapshots-<head-ref>).
+              # The two refs must stay distinct: the file set comes from where the snapshot branch
+              # forks off the PR head, because the branch is cut from the stale branch tip and a
+              # HEAD-vs-branch diff would also list every baseline the base branch moved since the
+              # fork point; the pixels come from HEAD, the merge commit the tests actually ran against.
               if [[ -n "${SNAPSHOT_BRANCH}" ]] && git ls-remote --exit-code --heads origin "${SNAPSHOT_BRANCH}" >/dev/null 2>&1; then
                   git fetch --no-tags --force --quiet origin "${SNAPSHOT_BRANCH}:refs/snap/review" || true
                   if git rev-parse --verify --quiet refs/snap/review >/dev/null; then
-                      build_report "Regenerated by CI" "HEAD" "refs/snap/review" "regenerated" || true
+                      # merge-base, not head_sha itself: a re-run rebases the regeneration commits
+                      # back onto the branch as it stood at an earlier run, so the fork point is the
+                      # only ref guaranteed to have just CI's own commits after it.
+                      BRANCH_BASE=''
+                      if [[ -n "${HEAD_SHA}" ]]; then
+                          BRANCH_BASE="$(git merge-base "$HEAD_SHA" refs/snap/review 2>/dev/null || true)"
+                      fi
+
+                      if [[ -n "$BRANCH_BASE" ]]; then
+                          while IFS= read -r p; do
+                              REPORT_INCLUDES+=(--include ":(literal)${p}")
+                          done < <(git -c core.quotepath=false diff --name-only "$BRANCH_BASE" refs/snap/review -- "${PATHSPECS[@]}")
+                      else
+                          echo "::warning::head_sha '${HEAD_SHA}' missing or unrelated to ${SNAPSHOT_BRANCH}; the regenerated report will also list upstream baseline drift."
+                      fi
+
+                      # Nothing rewritten (the branch exists from an earlier run): no report to build.
+                      if [[ -n "$BRANCH_BASE" && ${#REPORT_INCLUDES[@]} -eq 0 ]]; then
+                          echo "--- Regenerated by CI: snapshot branch rewrote no baselines" >&2
+                      else
+                          REPORT_LABELS=(--before-label "Committed (merged with \`${BASE_BRANCH}\`)" --after-label "Regenerated by CI")
+                          build_report "Regenerated by CI" "HEAD" "refs/snap/review" "regenerated" || true
+                      fi
                   fi
               fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1921,6 +1921,7 @@ jobs:
               with:
                   snapshot_branch: ${{ needs.init.outputs.snapshot_branch }}
                   base_branch: ${{ github.base_ref }}
+                  head_sha: ${{ github.event.pull_request.head.sha }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   # Reports are pushed to the `snapshot-review` branch below and read from
                   # raw.githubusercontent.com by the static viewer on gh-pages, so the link is a


### PR DESCRIPTION
The "Regenerated by CI" report (Report B) listed snapshots the branch never touched — on #7786 it showed 19 changes, of which 18 were noise. It was a plain `HEAD..gha/snapshots-<branch>` diff, and those two refs disagree about more than the regenerations:

- On a `pull_request` event the checkout has no `ref:`, so `HEAD` is `refs/pull/N/merge` — the PR head **merged with the base tip**, carrying the newest upstream baselines.
- `snapshot-branch` cuts `gha/snapshots-<head_ref>` from `github.head_ref`, the **stale branch tip**.

So every baseline that moved on `latest` since the fork point appeared in the report *inverted*, as though the snapshot branch were reverting it. On #7786 (69 commits behind) that was the sankey node-corner-radius family, the scatter-quadrant preset family and the two axis label-text-alignment baselines — exactly the 18 spurious entries.

Report A ("Current PR state") was never affected; it already goes through `git merge-base`.

## What changed

Report-side only — the snapshot branch is still cut from `github.head_ref`, so nothing changes for anyone pulling `gha/snapshots-<branch>` into their branch.

Report B's two concerns are now separated:

- **Which files to review** — `git diff --name-only <start of CI's commits> refs/snap/review`, passed to `snapshot-collect.sh` as `:(literal)` pathspecs that replace the directory globs. This is precisely the set CI's own commits rewrote.
- **What to compare against** — still `before = HEAD`, so the "before" image is the baseline as it exists *merged*, i.e. the one the tests actually ran against.

Report B also now passes `--before-label` / `--after-label` so the page states which two things are being compared.

## Worth knowing

- **Finding the start of CI's commits is the fiddly part**, and neither obvious answer works. `head_sha` alone is wrong because `snapshot-branch` pushes with `while ! git push …; do git pull --rebase; done`: a re-run rebases the new regeneration commit onto the *existing* snapshot branch, whose root stays at the head SHA from the earlier run, so any baseline the developer pushed in between reappears as drift (measured: 2 entries where 1 is correct). `git merge-base` alone is wrong too — after a force-push the branch is rooted on an abandoned head, so the merge-base drops below commits the developer wrote (measured on a rebased #7786: **23** entries where 1 is correct; thanks to the Codex review for catching this one). What is stable in every case is that CI's commits are the run of `github-actions[bot]` commits at the branch tip, so those are walked off directly — floored at the merge-base, so a bot-authored PR head can't be stepped past.
- **How stale branches arise at all.** `snapshot-prepare` deletes `gha/snapshots-<head_ref>` at the start of every run, so a fresh run always rebuilds it from the current head. What it does not cover is a *job-level* re-run — which the E2E job explicitly invites by failing itself "so it can be retried individually". `init` does not re-run, so the branch is rebuilt from whatever the branch tip is *now* while `head_sha` still comes from the old run's event payload. Push a commit, then re-run the old run's failed jobs, and the merge-base sits below it. The bot-commit walk stops at the right place regardless of which of the two is stale.
- **Fallbacks are non-fatal.** No `head_sha`, or one unrelated to the snapshot branch, emits a `::warning::` and falls back to today's behaviour rather than dropping the report. An empty file set (branch left over from an earlier run, nothing rewritten now) skips Report B; Report A is unaffected either way.
- **`:(literal)` is deliberate.** Baseline filenames are derived from test names and can contain `[` or `*`, which would otherwise be read as glob metacharacters.
- **Rename detection.** Restricting a pathspec to the new path can defeat git's rename detection. CI never renames a baseline it regenerates, so this is inert here — flagged rather than coded around.
- **Label flags need a recent `snapshot-report.py`.** `--before-label` / `--after-label` come from `@ag-grid/dev-prompts`, installed unpinned at the `canary` dist-tag; current canary supports them. If an older build were ever installed, argparse would reject the flags and Report B would be skipped with a warning — the job would not fail.

## Verification

**This PR is its own live test.** The E2E Cross-Browser job regenerated 5 baselines onto `gha/snapshots-imoses/snapshot-report-fix`, and the branch is 20 commits behind `latest` with **24 baselines** having moved upstream in between — all of them present in the merge ref CI checked out (`d3a72dfc`). The report listed **5 cases, exactly the ones CI rewrote**. On the old code it would have listed 29. (Those 5 turned out to be flaky `annotation-text-*-webkit` renders — they matched on the next run, so the snapshot branch has since been cleaned up and later runs produce no snapshot section at all.)

Also verified locally against the #7786 refs:

1. **Repro, 19 → 1.** Rebuilt the three commits with plumbing (`merge-tree` / `commit-tree`, no checkouts): the merge ref, PR head `9643e24f3d`, and a stand-in snapshot-branch commit. Old file set = 19 paths (the 18 upstream ones plus `gallery-customised-waterfall`); new file set = 1, just the waterfall baseline.
2. **Step body executed** against a scratch `origin` + clone with `snapshot-collect.sh` / `snapshot-report.py` stubbed to record their arguments. Confirmed across all five paths: the linear case (one `:(literal)` include, correct labels, both reports written), the re-run case (1 include where the naive head-SHA diff gives 2), the force-push case (1 where the merge-base gives 23), the empty-set case (Report B skipped, section still written), and the fallbacks (absent and unresolvable `head_sha`).
3. `prettier --check` clean on both files. `actionlint` was not available locally. The pixel-diff half of `snapshot-collect.sh` was not exercised — no `magick` on this machine — but the change only alters which pathspecs and labels it receives.
