### PR TITLE
AG-17912, SE-62 Port markdown twins and API reference SSR to b14.1.0

### DIFF
--- a/external/ag-website-shared/src/components/contact-us/ContactPage.astro
+++ b/external/ag-website-shared/src/components/contact-us/ContactPage.astro
@@ -6,30 +6,32 @@ import PageHero from '@ag-website-shared/components/page-hero/PageHero.astro';
 import { getEntry, type CollectionEntry } from 'astro:content';
 import { buildContactPage } from '@ag-website-shared/utils/structuredData';
 import { LIBRARY } from '@constants';
+import { CONTACT_CONTENT, contactSocialLinks } from './contactContent';
 import styles from './ContactPage.module.scss';
 
-const githubUrl = LIBRARY === 'charts' ? 'https://github.com/ag-grid/ag-charts' : 'https://github.com/ag-grid/ag-grid';
+// Copy and links are shared with the /contact.md twin so the two cannot drift.
+const socialLinks = contactSocialLinks(LIBRARY);
 
 const { data: metadata } = (await getEntry('metadata', 'metadata')) as CollectionEntry<'metadata'>;
 const contactPageStructuredData = buildContactPage({
     canonicalUrlBase: metadata.canonicalUrlBase,
     pageUrl: new URL(Astro.url.pathname, metadata.canonicalUrlBase).href,
-    name: 'Contact AG Grid',
+    name: CONTACT_CONTENT.structuredDataName,
 });
 ---
 
 <Layout
-    title="Contact AG Grid: Get in Touch with Our Team"
-    description="Have questions or need assistance? Contact the AG Grid team for support, licensing, or any other inquiries."
+    title={CONTACT_CONTENT.title}
+    description={CONTACT_CONTENT.description}
     showSearchBar={true}
     showDocsNav={false}
     pageStructuredData={[contactPageStructuredData]}
 >
     <div class={styles.contactPage}>
         <PageHero
-            eyebrow="Get in touch"
-            headline="Contact Us"
-            subhead="Get help with pricing, explore use cases, understand how our products can help you, and more."
+            eyebrow={CONTACT_CONTENT.eyebrow}
+            headline={CONTACT_CONTENT.headline}
+            subhead={CONTACT_CONTENT.subhead}
         />
         <div class="layout-max-width-small">
             <section id="contact-section" class={styles.contactSection}>
@@ -38,46 +40,20 @@ const contactPageStructuredData = buildContactPage({
                 </div>
 
                 <div class={styles.socialLinks}>
-                    <a
-                        href={githubUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="GitHub"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="github" />
-                        <span>GitHub</span>
-                    </a>
-                    <a
-                        href="https://x.com/ag_grid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="X (Twitter)"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="xLogo" />
-                        <span>X</span>
-                    </a>
-                    <a
-                        href="https://youtube.com/c/aggrid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="YouTube"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="youtube" />
-                        <span>YouTube</span>
-                    </a>
-                    <a
-                        href="https://linkedin.com/company/ag-grid"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="LinkedIn"
-                        class={styles.socialLinkRow}
-                    >
-                        <Icon name="linkedin" />
-                        <span>LinkedIn</span>
-                    </a>
+                    {
+                        socialLinks.map(({ label, ariaLabel, icon, url }) => (
+                            <a
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label={ariaLabel ?? label}
+                                class={styles.socialLinkRow}
+                            >
+                                <Icon name={icon} />
+                                <span>{label}</span>
+                            </a>
+                        ))
+                    }
                 </div>
             </section>
         </div>

--- a/external/ag-website-shared/src/components/contact-us/contactContent.ts
+++ b/external/ag-website-shared/src/components/contact-us/contactContent.ts
@@ -1,0 +1,44 @@
+import type { IconName } from '@ag-website-shared/components/icon/Icon';
+
+/**
+ * Copy and links for the contact page, shared between `ContactPage.astro` and its markdown twin
+ * (`@ag-website-shared/markdown-pages/buildContactMarkdown`) so the two cannot drift.
+ */
+export const CONTACT_CONTENT = {
+    title: 'Contact AG Grid: Get in Touch with Our Team',
+    description:
+        'Have questions or need assistance? Contact the AG Grid team for support, licensing, or any other inquiries.',
+    eyebrow: 'Get in touch',
+    headline: 'Contact Us',
+    subhead: 'Get help with pricing, explore use cases, understand how our products can help you, and more.',
+    /** Structured-data name for the page. */
+    structuredDataName: 'Contact AG Grid',
+} as const;
+
+export interface ContactSocialLink {
+    label: string;
+    /** Falls back to the label; only needed where the label alone is not self-describing. */
+    ariaLabel?: string;
+    icon: IconName;
+    url: string;
+}
+
+const CONTACT_SOCIAL_LINKS: ContactSocialLink[] = [
+    { label: 'X', ariaLabel: 'X (Twitter)', icon: 'xLogo', url: 'https://x.com/ag_grid' },
+    { label: 'YouTube', icon: 'youtube', url: 'https://youtube.com/c/aggrid' },
+    { label: 'LinkedIn', icon: 'linkedin', url: 'https://linkedin.com/company/ag-grid' },
+];
+
+export const GITHUB_URL_BY_LIBRARY = {
+    charts: 'https://github.com/ag-grid/ag-charts',
+    grid: 'https://github.com/ag-grid/ag-grid',
+} as const;
+
+export function contactGithubUrl(library: string): string {
+    return library === 'charts' ? GITHUB_URL_BY_LIBRARY.charts : GITHUB_URL_BY_LIBRARY.grid;
+}
+
+/** Social links shown beside the contact form, in display order. GitHub differs per product. */
+export function contactSocialLinks(library: string): ContactSocialLink[] {
+    return [{ label: 'GitHub', icon: 'github', url: contactGithubUrl(library) }, ...CONTACT_SOCIAL_LINKS];
+}

--- a/external/ag-website-shared/src/components/link-icon/LinkIcon.tsx
+++ b/external/ag-website-shared/src/components/link-icon/LinkIcon.tsx
@@ -27,7 +27,9 @@ export function LinkIcon({
 
         navigator.clipboard.writeText(redirectUrl ?? href);
 
-        history.replaceState({}, '', hash);
+        // Preserve the existing entry's state: Astro's ClientRouter keeps its scroll and history
+        // index in there, and replacing it wholesale breaks its back/forward handling.
+        history.replaceState(history.state, '', hash);
 
         setLinkCopied(true);
         setlinkActive(true);

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { htmlBlockToMarkdown, htmlInlineToMarkdown } from './htmlInlineToMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+describe('htmlInlineToMarkdown', () => {
+    it('converts anchors, resolving site-relative hrefs against the site root', () => {
+        expect(htmlInlineToMarkdown('See <a href="/about/">about us</a>.', SITE_ROOT)).toBe(
+            'See [about us](https://www.ag-grid.com/about/).'
+        );
+    });
+
+    it('leaves external, mailto and anchor hrefs untouched', () => {
+        expect(htmlInlineToMarkdown('<a href="https://x.com/ag_grid">X</a>', SITE_ROOT)).toBe(
+            '[X](https://x.com/ag_grid)'
+        );
+        expect(htmlInlineToMarkdown('<a href="mailto:a@b.com">mail</a>', SITE_ROOT)).toBe('[mail](mailto:a@b.com)');
+        expect(htmlInlineToMarkdown('<a href="#top">top</a>', SITE_ROOT)).toBe('[top](#top)');
+    });
+
+    it('keeps emphasis rather than flattening it', () => {
+        expect(htmlInlineToMarkdown('Add <b>fast</b> and <strong>rich</strong> grids')).toBe(
+            'Add **fast** and **rich** grids'
+        );
+        expect(htmlInlineToMarkdown('an <em>idea</em> and an <i>aside</i>')).toBe('an *idea* and an *aside*');
+        expect(htmlInlineToMarkdown('call <code>setGridOption()</code>')).toBe('call `setGridOption()`');
+    });
+
+    it('moves whitespace outside the emphasis delimiters, which CommonMark requires', () => {
+        // `** foo **` is not emphasis; the spaces have to sit outside the markers.
+        expect(htmlInlineToMarkdown('over<b> 90% </b>of the Fortune 500')).toBe('over **90%** of the Fortune 500');
+    });
+
+    it('drops empty emphasis rather than emitting stray markers', () => {
+        expect(htmlInlineToMarkdown('a<b></b>b')).toBe('ab');
+    });
+
+    it('strips remaining tags and collapses whitespace', () => {
+        expect(htmlInlineToMarkdown('one<br />two   <span>three</span>')).toBe('onetwo three');
+    });
+});
+
+describe('htmlBlockToMarkdown', () => {
+    it('separates paragraphs into markdown blocks', () => {
+        expect(htmlBlockToMarkdown('<p>First para.</p><p>Second para.</p>')).toBe('First para.\n\nSecond para.');
+    });
+
+    it('renders a list as a single markdown list, not one block per item', () => {
+        expect(htmlBlockToMarkdown('<ul><li>One</li><li>Two</li><li>Three</li></ul>')).toBe('- One\n- Two\n- Three');
+    });
+
+    it('numbers an ordered list, so the sequence the copy relies on survives', () => {
+        expect(htmlBlockToMarkdown('<ol><li>One</li><li>Two</li><li>Three</li></ol>')).toBe('1. One\n2. Two\n3. Three');
+    });
+
+    it('numbers each ordered list from 1, independently of the ones before it', () => {
+        const html = '<ol><li>A</li><li>B</li></ol><ol><li>C</li></ol>';
+        expect(htmlBlockToMarkdown(html)).toBe('1. A\n2. B\n\n1. C');
+    });
+
+    it('keeps ordered and unordered markers apart in the same fragment', () => {
+        const html = '<ol><li>First</li></ol><ul><li>Bullet</li></ul>';
+        expect(htmlBlockToMarkdown(html)).toBe('1. First\n\n- Bullet');
+    });
+
+    it('converts links and emphasis inside ordered list items', () => {
+        const html = '<ol><li><a href="/about/">about</a></li><li><b>bold</b></li></ol>';
+        expect(htmlBlockToMarkdown(html, SITE_ROOT)).toBe('1. [about](https://www.ag-grid.com/about/)\n2. **bold**');
+    });
+
+    it('keeps a paragraph, a list and a heading as separate blocks in source order', () => {
+        const html = '<p>Intro.</p><h6>Section</h6><ul><li>A</li><li>B</li></ul><p>Outro.</p>';
+        expect(htmlBlockToMarkdown(html)).toBe('Intro.\n\n###### Section\n\n- A\n- B\n\nOutro.');
+    });
+
+    it('converts links and emphasis inside blocks', () => {
+        const html = '<p>Read the <a href="https://bryntum.com/docs">docs</a> for <b>Gantt</b>.</p>';
+        expect(htmlBlockToMarkdown(html)).toBe('Read the [docs](https://bryntum.com/docs) for **Gantt**.');
+    });
+
+    it('converts links inside list items', () => {
+        const html = '<ul><li><a href="https://bryntum.com/a">A</a></li><li>plain</li></ul>';
+        expect(htmlBlockToMarkdown(html)).toBe('- [A](https://bryntum.com/a)\n- plain');
+    });
+
+    it('handles bare text outside any block', () => {
+        expect(htmlBlockToMarkdown('Just text, no tags.')).toBe('Just text, no tags.');
+    });
+
+    it('returns an empty string for markup with no text content', () => {
+        expect(htmlBlockToMarkdown('<p></p><ul></ul>')).toBe('');
+    });
+
+    it('leaves no sentinel characters in the output', () => {
+        // Checked with includes() rather than a regex: control characters in a regex literal
+        // trip eslint's no-control-regex.
+        const output = htmlBlockToMarkdown('<p>a</p><ul><li>b</li></ul><p>c</p>');
+        expect(output.includes(String.fromCharCode(0)), 'block sentinel leaked').toBe(false);
+        expect(output.includes(String.fromCharCode(1)), 'line sentinel leaked').toBe(false);
+    });
+});

--- a/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
+++ b/external/ag-website-shared/src/markdoc/htmlInlineToMarkdown.ts
@@ -13,17 +13,106 @@ export function resolveContentLink(href: string, siteRoot?: string): string {
 }
 
 /**
- * Convert an inline HTML fragment (as stored in landing-page/about content) to markdown:
- * `<a>` links become markdown links with their href resolved, and any remaining tags are
+ * Convert an inline HTML fragment (as stored in landing-page/about/policy content) to markdown:
+ * `<a>` links become markdown links with their href resolved, `<strong>`/`<b>` and `<em>`/`<i>`
+ * become their markdown emphasis, `<code>` becomes a code span, and any remaining tags are
  * dropped. Handles single- or double-quoted attributes and extra attributes on the anchor.
  */
 export function htmlInlineToMarkdown(html: string, siteRoot?: string): string {
-    return html
+    return (
+        html
+            .replace(
+                /<a\s+[^>]*?href=['"]([^'"]+)['"][^>]*>([\s\S]*?)<\/a>/gi,
+                (_match, href, text) =>
+                    `[${text.replace(/<[^>]+>/g, '').trim()}](${resolveContentLink(href, siteRoot)})`
+            )
+            // Emphasis carries meaning in the source copy, so keep it rather than flattening it.
+            .replace(/<(strong|b)>([\s\S]*?)<\/\1>/gi, (_match, _tag, text) => emphasise(text, '**'))
+            .replace(/<(em|i)>([\s\S]*?)<\/\1>/gi, (_match, _tag, text) => emphasise(text, '*'))
+            .replace(/<code>([\s\S]*?)<\/code>/gi, (_match, text) => `\`${text.replace(/<[^>]+>/g, '').trim()}\``)
+            .replace(/<[^>]+>/g, '')
+            .replace(/\s+/g, ' ')
+            .trim()
+    );
+}
+
+/**
+ * Whitespace inside an emphasis tag is moved outside the delimiters, since `** foo **` is not
+ * emphasis in CommonMark. An empty tag collapses to nothing rather than to a stray `**`.
+ */
+function emphasise(text: string, delimiter: string): string {
+    const inner = text.replace(/<[^>]+>/g, '');
+    const trimmed = inner.trim();
+    if (!trimmed) {
+        return '';
+    }
+    const leading = inner.startsWith(' ') ? ' ' : '';
+    const trailing = inner.endsWith(' ') ? ' ' : '';
+    return `${leading}${delimiter}${trimmed}${delimiter}${trailing}`;
+}
+
+// Sentinels marking block and line boundaries, so they survive the inline pass (which collapses
+// runs of whitespace). Control characters, so they cannot occur in the source copy.
+const BLOCK_SEPARATOR = '\u0000';
+const LINE_SEPARATOR = '\u0001';
+
+/** Markers emitted for list items, so an already-converted item is not re-run as inline copy. */
+const LIST_MARKER = /^(?:- |\d+\. )/;
+
+/**
+ * Convert a block-level HTML fragment (paragraphs, lists and headings, as stored in the Bryntum
+ * campaign content) to markdown. Block structure becomes markdown blocks; the text inside each is
+ * converted with {@link htmlInlineToMarkdown}, so links and emphasis survive.
+ *
+ * Anchors are expected to be absolute already — resolve product-relative hrefs before calling
+ * (the campaign pages do this with `decorateBryntumHtml`).
+ */
+export function htmlBlockToMarkdown(html: string, siteRoot?: string): string {
+    // Innermost blocks first, so a list item's own markup is consumed before its <ul> wrapper.
+    // List items are line-joined into a single markdown list; other blocks are block-separated.
+    const marked = html
+        // <ol> is consumed whole so its items can be numbered; what reaches the <li> pass below is
+        // therefore unordered, and takes the bullet marker.
         .replace(
-            /<a\s+[^>]*?href=['"]([^'"]+)['"][^>]*>([\s\S]*?)<\/a>/gi,
-            (_match, href, text) => `[${text.replace(/<[^>]+>/g, '').trim()}](${resolveContentLink(href, siteRoot)})`
+            /<ol\b[^>]*>([\s\S]*?)<\/ol>/gi,
+            (_match, items) => `${numberedListItems(items, siteRoot)}${BLOCK_SEPARATOR}`
         )
-        .replace(/<[^>]+>/g, '')
-        .replace(/\s+/g, ' ')
+        .replace(
+            /<li\b[^>]*>([\s\S]*?)<\/li>/gi,
+            (_match, text) => `${LINE_SEPARATOR}- ${htmlInlineToMarkdown(text, siteRoot)}`
+        )
+        .replace(/<\/ul>/gi, BLOCK_SEPARATOR)
+        .replace(
+            /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
+            (_match, level: string, text) =>
+                `${BLOCK_SEPARATOR}${'#'.repeat(Number(level))} ${htmlInlineToMarkdown(text, siteRoot)}${BLOCK_SEPARATOR}`
+        )
+        .replace(
+            /<p\b[^>]*>([\s\S]*?)<\/p>/gi,
+            (_match, text) => `${BLOCK_SEPARATOR}${htmlInlineToMarkdown(text, siteRoot)}${BLOCK_SEPARATOR}`
+        );
+
+    return marked
+        .split(BLOCK_SEPARATOR)
+        .map((block) =>
+            block
+                .split(LINE_SEPARATOR)
+                // List items are already converted; anything left outside a block (bare text,
+                // stray <span>s) is inline copy and still needs converting.
+                .map((line) => (LIST_MARKER.test(line) ? line.trim() : htmlInlineToMarkdown(line, siteRoot)))
+                .filter(Boolean)
+                .join('\n')
+        )
+        .filter(Boolean)
+        .join('\n\n')
         .trim();
+}
+
+/** Numbered from 1: `<ol start>` does not appear in the source copy. */
+function numberedListItems(items: string, siteRoot?: string): string {
+    let position = 0;
+    return items.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_match, text) => {
+        position += 1;
+        return `${LINE_SEPARATOR}${position}. ${htmlInlineToMarkdown(text, siteRoot)}`;
+    });
 }

--- a/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildContactMarkdown.ts
@@ -1,0 +1,30 @@
+import { CONTACT_CONTENT, contactSocialLinks } from '@ag-website-shared/components/contact-us/contactContent';
+
+/**
+ * Build the markdown twin of the contact page. The page's substance is an interactive form, which
+ * markdown cannot carry — so the twin renders the same headline and standfirst, then points at the
+ * form and the support channels that ARE reachable without a browser.
+ *
+ * Product-agnostic: AG Grid, AG Charts and AG Studio share this module and differ only in the
+ * `library` they pass (which selects the GitHub repository).
+ */
+export function buildContactMarkdown({ library, contactUrl }: { library: string; contactUrl: string }): string {
+    const document = [
+        [
+            '---',
+            `title: ${JSON.stringify(CONTACT_CONTENT.title)}`,
+            `description: ${JSON.stringify(CONTACT_CONTENT.description)}`,
+            '---',
+        ].join('\n'),
+        `# ${CONTACT_CONTENT.headline}`,
+        `*${CONTACT_CONTENT.eyebrow}*`,
+        CONTACT_CONTENT.subhead,
+        `The contact form is on the page itself: [${CONTACT_CONTENT.headline}](${contactUrl}).`,
+        '## Elsewhere',
+        contactSocialLinks(library)
+            .map(({ label, url }) => `- [${label}](${url})`)
+            .join('\n'),
+    ];
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildRoadmapMarkdown.ts
@@ -1,0 +1,96 @@
+import type { RoadmapItem } from '@ag-website-shared/components/roadmap/types';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+
+/**
+ * A roadmap item as this builder needs it. `status` is widened from `RoadmapItem`'s union to
+ * `string` so the raw JSON import type-checks — the twin only prints the status as a label,
+ * whereas the page's filter buttons depend on the exact values.
+ */
+type RoadmapMarkdownItem = Omit<RoadmapItem, 'status'> & { status: string };
+
+export interface RoadmapData {
+    introTitle?: string;
+    introText?: string;
+    items: RoadmapMarkdownItem[];
+    lastUpdated: string;
+}
+
+export interface BuildRoadmapMarkdownOptions {
+    roadmapData: RoadmapData;
+    /** Product display name for the page metadata, e.g. `AG Charts`. */
+    productName: string;
+    siteRoot?: string;
+    /** Resolve an item's `./`-prefixed docs link — the site's `urlWithPrefix` bound to a framework. */
+    resolveUrl: (url: string) => string;
+    /**
+     * Year the quarter headings are labelled with. The page uses the current year via
+     * `new Date()`; passed in here so the generated markdown is deterministic for the build.
+     */
+    year: number;
+}
+
+/** Matches the page's `formatLastUpdated`, so both render the date identically. */
+function formatLastUpdated(dateStr: string): string {
+    return new Intl.DateTimeFormat('en', { year: 'numeric', month: 'long', day: 'numeric' }).format(new Date(dateStr));
+}
+
+/**
+ * Build the markdown twin of the roadmap page. Reads the same `roadmap.json` the page renders and
+ * groups items by quarter exactly as `RoadmapBoard` does. The page's status filter is interactive;
+ * here each item carries its status inline instead.
+ *
+ * Product-agnostic: the caller injects `productName`, `resolveUrl` and the year, so AG Grid,
+ * AG Charts and AG Studio share this module.
+ */
+export function buildRoadmapMarkdown({
+    roadmapData,
+    productName,
+    siteRoot,
+    resolveUrl,
+    year,
+}: BuildRoadmapMarkdownOptions): string {
+    const document: string[] = [
+        [
+            '---',
+            `title: ${JSON.stringify(`Roadmap | ${productName}`)}`,
+            `description: ${JSON.stringify(`${productName} Roadmap - see what we are building next, including planned features, items in progress, and recently shipped work.`)}`,
+            '---',
+        ].join('\n'),
+        "# What we're building next",
+    ];
+
+    if (roadmapData.lastUpdated) {
+        document.push(`Last updated: ${formatLastUpdated(roadmapData.lastUpdated)}`);
+    }
+    if (roadmapData.introTitle) {
+        document.push(`## ${roadmapData.introTitle}`);
+    }
+    if (roadmapData.introText) {
+        document.push(roadmapData.introText);
+    }
+
+    // Same grouping as RoadmapBoard: one section per quarter, in the order the items appear.
+    const byQuarter = new Map<number, RoadmapMarkdownItem[]>();
+    for (const item of roadmapData.items) {
+        const quarterItems = byQuarter.get(item.q) ?? [];
+        quarterItems.push(item);
+        byQuarter.set(item.q, quarterItems);
+    }
+
+    for (const [quarter, items] of byQuarter) {
+        document.push(`## Q${quarter} ${year}`);
+        for (const item of items) {
+            const title = item.link ? `[${item.title}](${toAbsoluteUrl(resolveUrl(item.link), siteRoot)})` : item.title;
+            // Status reads as a label because the page conveys it with a coloured pill.
+            document.push(`### ${title} (${item.status.replace(/-/g, ' ')})`);
+            if (item.desc) {
+                document.push(item.desc);
+            }
+            if (item.why) {
+                document.push(`**Why:** ${item.why}`);
+            }
+        }
+    }
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/buildWhatsNewMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/buildWhatsNewMarkdown.ts
@@ -1,0 +1,112 @@
+import whatsNewData from '@ag-website-shared/content/whats-new/data.json';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { parseVersion } from '@ag-website-shared/utils/parseVersion';
+
+/** How many versions the page lists; the twin matches it so the two show the same releases. */
+const MAX_VERSIONS = 12;
+
+export interface WhatsNewVersion {
+    version: string;
+    date?: string;
+    /** Mirrors the page's `Highlight` component: an absolute `url`, a product-docs `path`, or a charts-docs `chartsPath`. */
+    highlights?: Array<{ text: string; url?: string; path?: string; chartsPath?: string }>;
+    notesPath?: string;
+    hideBlogPostLink?: boolean;
+}
+
+export interface BuildWhatsNewMarkdownOptions {
+    /** Product key into the shared whats-new data (`grid`, `charts`, `studio`). */
+    site: keyof typeof whatsNewData;
+    /** The `versions` collection, as the page receives it. */
+    versionsData: WhatsNewVersion[];
+    siteRoot?: string;
+    /**
+     * Resolve a highlight's `./`-prefixed docs path — the site's `urlWithPrefix` bound to a
+     * framework. Highlights link into framework docs, so a product without a framework dimension
+     * can pass its plain base-URL helper instead.
+     */
+    resolveUrl: (url: string) => string;
+    /** Resolve a highlight's `chartsPath` into the charts docs, as the page's `Highlight` does. */
+    resolveChartsUrl?: (url: string) => string;
+}
+
+/** The page title and description, shared so the twin's frontmatter matches the page's meta. */
+export function whatsNewMeta(site: BuildWhatsNewMarkdownOptions['site']) {
+    const { name } = whatsNewData[site];
+    return {
+        title: `${name} What's new`,
+        description: `See what's new in recent ${name} versions. View feature highlights, browse release notes or read our release blogs. Includes major and minor releases.`,
+    };
+}
+
+/**
+ * Build the markdown twin of the What's New page. Reads the same `versions` data and shared
+ * product metadata the page renders, applies the same "has highlights" filter and the same
+ * 12-version cap, and derives blog URLs the same way — so the two cannot drift.
+ *
+ * Product-agnostic: AG Grid, AG Charts and AG Studio share this module.
+ */
+export function buildWhatsNewMarkdown({
+    site,
+    versionsData,
+    siteRoot,
+    resolveUrl,
+    resolveChartsUrl,
+}: BuildWhatsNewMarkdownOptions): string {
+    const { name, blogPrefix } = whatsNewData[site];
+    const { title, description } = whatsNewMeta(site);
+
+    const versions = versionsData.filter((version) => version.highlights).slice(0, MAX_VERSIONS);
+
+    const document: string[] = [
+        ['---', `title: ${JSON.stringify(title)}`, `description: ${JSON.stringify(description)}`, '---'].join('\n'),
+        `# What's New in ${name}`,
+        `See what's new in recent ${name} versions.`,
+    ];
+
+    for (const [index, versionInfo] of versions.entries()) {
+        const { major, minor, isMajor } = parseVersion(versionInfo.version);
+        const blogUrl = `${minor ? `${blogPrefix}${major}-${minor}` : `${blogPrefix}${major}`}/`;
+
+        const heading = [
+            `## ${versionInfo.version}`,
+            index === 0 ? '(latest)' : '',
+            versionInfo.date ? `— ${versionInfo.date}` : '',
+        ]
+            .filter(Boolean)
+            .join(' ');
+        document.push(heading);
+        document.push('Feature Highlights');
+
+        // Same precedence as the page's `Highlight` component: absolute url, then product docs
+        // path, then charts docs path, else plain text.
+        const highlights = (versionInfo.highlights ?? []).map(({ text, url, path, chartsPath }) => {
+            if (url) {
+                return `- [${text}](${url})`;
+            }
+            if (path) {
+                return `- [${text}](${toAbsoluteUrl(resolveUrl(path), siteRoot)})`;
+            }
+            if (chartsPath && resolveChartsUrl) {
+                return `- [${text}](${toAbsoluteUrl(resolveChartsUrl(chartsPath), siteRoot)})`;
+            }
+            return `- ${text}`;
+        });
+        if (highlights.length) {
+            document.push(highlights.join('\n'));
+        }
+
+        const links = [
+            // The page labels this button by release kind; keep the same wording.
+            versionInfo.notesPath
+                ? `[${isMajor ? 'See migration guide' : 'See release notes'}](${toAbsoluteUrl(resolveUrl(versionInfo.notesPath), siteRoot)})`
+                : undefined,
+            versionInfo.hideBlogPostLink ? undefined : `[Read more](${blogUrl})`,
+        ].filter(Boolean);
+        if (links.length) {
+            document.push(links.join(' | '));
+        }
+    }
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
+++ b/external/ag-website-shared/src/markdown-pages/landing-pages/buildLandingPageMarkdown.ts
@@ -1,0 +1,200 @@
+import type {
+    ExtractSection,
+    LandingPageContent,
+    LandingPageSectionType,
+} from '@ag-website-shared/components/landing-pages/types';
+import { htmlInlineToMarkdown } from '@ag-website-shared/markdoc/htmlInlineToMarkdown';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+
+export interface LandingPageVersion {
+    version: string;
+    landingPageHighlight?: string;
+}
+
+export interface BuildLandingPageMarkdownOptions {
+    /** The same `landingPages` collection entry `LandingPage.astro` renders. */
+    content: LandingPageContent;
+    /** The `versions` collection, for the hero's version badge. */
+    versions?: LandingPageVersion[];
+    /** Canonical origin, so links survive being read out of context. */
+    siteRoot?: string;
+    /**
+     * Resolve a content URL to a site-relative path — the site's `urlWithBaseUrl`. Section CTAs,
+     * feature links and example links store `./`-prefixed paths that ALREADY include the framework
+     * segment (`./react-data-grid/getting-started`), so this must be the base-URL helper.
+     */
+    resolveUrl: (url: string) => string;
+    /**
+     * Resolve a link inside an FAQ answer — the site's `urlWithPrefix` bound to the page's
+     * framework. FAQ answers are Markdoc, rendered by `renderFAQAnswers` with the page framework,
+     * so their `./` links are framework-RELATIVE (`./getting-started/`) and need the prefixing
+     * helper instead. Defaults to `resolveUrl` for sites without a framework dimension.
+     */
+    resolveFaqUrl?: (url: string) => string;
+}
+
+export type Resolve = (url: string) => string;
+
+export function link(text: string, url: string, resolve: Resolve, siteRoot?: string): string {
+    return `[${text}](${url.startsWith('http') ? url : toAbsoluteUrl(resolve(url), siteRoot)})`;
+}
+
+/**
+ * Rewrite the targets of markdown links already present in authored copy (FAQ answers are
+ * Markdoc, so they arrive as markdown rather than as a URL field to resolve).
+ */
+export function resolveMarkdownLinks(markdown: string, resolve: Resolve, siteRoot?: string): string {
+    return markdown.replace(/\[([^\]]*)\]\(([^)\s]+)\)/g, (match, text: string, target: string) => {
+        if (target.startsWith('http') || target.startsWith('mailto') || target.startsWith('#')) {
+            return match;
+        }
+        return `[${text}](${toAbsoluteUrl(resolve(target), siteRoot)})`;
+    });
+}
+
+/**
+ * The eyebrow headline that labels a section above its heading on the page. Kept as an
+ * emphasised kicker so it holds that reading order without adding a heading level —
+ * matching how the homepage twin renders its section tags.
+ */
+export function sectionHeader(
+    section: { tag?: string; heading?: string; headingHtml?: string; subHeading?: string; subHeadingHtml?: string },
+    siteRoot?: string
+): string[] {
+    const heading = section.headingHtml ? htmlInlineToMarkdown(section.headingHtml, siteRoot) : section.heading;
+    const subHeading = section.subHeadingHtml
+        ? htmlInlineToMarkdown(section.subHeadingHtml, siteRoot)
+        : section.subHeading;
+
+    const parts: string[] = [];
+    if (section.tag) {
+        parts.push(`*${section.tag}*`);
+    }
+    if (heading) {
+        parts.push(`## ${heading}`);
+    }
+    if (subHeading) {
+        parts.push(subHeading);
+    }
+    return parts;
+}
+
+function featuresBody(section: ExtractSection<'features'>, resolve: Resolve, siteRoot?: string): string[] {
+    return section.items.map((item) => {
+        const title = item.isEnterprise ? `### ${item.title} (Enterprise)` : `### ${item.title}`;
+        const bullets = item.features.map((feature) => {
+            const heading = feature.link
+                ? `**${link(feature.heading, feature.link, resolve, siteRoot)}**`
+                : `**${feature.heading}**`;
+            return `- ${heading} — ${feature.detail}`;
+        });
+        const more = item.docsLink ? `\n\n${link(`More on ${item.title}`, item.docsLink, resolve, siteRoot)}` : '';
+        return `${title}\n\n${bullets.join('\n')}${more}`;
+    });
+}
+
+function examplesBody(section: ExtractSection<'examples'>, resolve: Resolve, siteRoot?: string): string[] {
+    const items = section.items.map((item) => {
+        const demo = item.demo ? ` (${link('live demo', item.demo, resolve, siteRoot)})` : '';
+        return `- **${link(item.title, item.docs, resolve, siteRoot)}** — ${item.content}${demo}`;
+    });
+    return [items.join('\n')];
+}
+
+function pricingBody(section: ExtractSection<'pricing'>, resolve: Resolve, siteRoot?: string): string[] {
+    return section.cards.map((card) => {
+        const features = card.features.map((feature) => `- ${feature}`).join('\n');
+        return [
+            `### ${card.title} — ${card.price}`,
+            `*${card.priceNote}*`,
+            features,
+            link(card.ctaText, card.ctaUrl, resolve, siteRoot),
+        ].join('\n\n');
+    });
+}
+
+/** Section body beyond the shared tag/heading/subheading header. */
+export function sectionBody(
+    section: LandingPageSectionType,
+    resolve: Resolve,
+    resolveFaq: Resolve,
+    siteRoot?: string
+): string[] {
+    switch (section.type) {
+        case 'features':
+            return featuresBody(section, resolve, siteRoot);
+        case 'examples':
+            return examplesBody(section, resolve, siteRoot);
+        case 'faq':
+            return section.items.map(
+                (item) => `### ${item.question}\n\n${resolveMarkdownLinks(item.answer, resolveFaq, siteRoot)}`
+            );
+        case 'contact':
+            return [section.features.map((feature) => `- ${feature}`).join('\n')];
+        case 'pricing':
+            return pricingBody(section, resolve, siteRoot);
+        // The remaining sections are interactive on the page (a showcase carousel, the customer
+        // logo wall, the automated integrated-charts demo, the comparison table, the theme
+        // builder video). They carry no further prose, so their heading and subheading are the
+        // whole of their content here.
+        case 'hero':
+        case 'showcase':
+        case 'customers':
+        case 'integrated-charts':
+        case 'theme-builder':
+        case 'comparison':
+            return [];
+    }
+}
+
+/**
+ * Build the markdown twin of a content-driven landing page. Reads the same `landingPages`
+ * collection entry `LandingPage.astro` renders and walks the same `sections` discriminated
+ * union in the same order, so the two cannot drift.
+ *
+ * Product-agnostic: the caller injects `resolveUrl` (its site's `urlWithBaseUrl`), so AG Grid,
+ * AG Charts and AG Studio share this module and differ only in how they resolve content URLs.
+ */
+export function buildLandingPageMarkdown({
+    content,
+    versions,
+    siteRoot,
+    resolveUrl,
+    resolveFaqUrl = resolveUrl,
+}: BuildLandingPageMarkdownOptions): string {
+    const hero = content.sections.find((section) => section.type === 'hero');
+    const latestVersion = versions?.find((version) => version.landingPageHighlight);
+
+    const frontmatter = [
+        '---',
+        `title: ${JSON.stringify(content.meta.title)}`,
+        `description: ${JSON.stringify(content.meta.description)}`,
+        '---',
+    ].join('\n');
+
+    const intro: string[] = [];
+    if (hero) {
+        const heading = hero.headingHtml ? htmlInlineToMarkdown(hero.headingHtml, siteRoot) : hero.heading;
+        intro.push(`# ${heading}`);
+        intro.push(hero.subHeadingHtml ? htmlInlineToMarkdown(hero.subHeadingHtml, siteRoot) : hero.subHeading);
+        if (hero.showVersionBadge && latestVersion) {
+            intro.push(`**Latest version:** v${latestVersion.version} — ${latestVersion.landingPageHighlight}`);
+        }
+        if (content.packageName) {
+            intro.push(`Install: \`npm install ${content.packageName}\``);
+        }
+        if (hero.secondaryCta?.url) {
+            intro.push(link(hero.secondaryCta.text, hero.secondaryCta.url, resolveUrl, siteRoot));
+        }
+    }
+
+    // The hero is rendered above as the page title; every other section keeps page order.
+    const body = content.sections
+        .filter((section) => section.type !== 'hero')
+        .flatMap((section) => [
+            ...sectionHeader(section, siteRoot),
+            ...sectionBody(section, resolveUrl, resolveFaqUrl, siteRoot),
+        ]);
+
+    return `${[frontmatter, ...intro, ...body].join('\n\n').trimEnd()}\n`;
+}

--- a/external/ag-website-shared/src/markdown-pages/markdownPageRegistry.ts
+++ b/external/ag-website-shared/src/markdown-pages/markdownPageRegistry.ts
@@ -1,0 +1,35 @@
+/**
+ * SE-80: the contract for declaring which pages ship a markdown (`.md`) twin.
+ *
+ * The set of twinned pages is consumed in three places that must agree exactly — the dev-server
+ * negotiation plugin, the Apache rewrite rule, and the Apache `Vary: Accept` scope. Previously
+ * each held its own hand-maintained copy of the list, so adding a twin was a multi-file edit with
+ * nothing to catch an omission. Each product now declares its pages once as `MarkdownPageGroup`s
+ * and derives all three from that single list.
+ *
+ * Only the type lives here. The derivation (see AG Grid's `markdownPages.ts`) is three lines, and
+ * keeping it product-side avoids a runtime import across this package boundary: this subrepo has
+ * no `"type": "module"`, so a consumer running under plain node — as the htaccess test harness does
+ * via `tsx` — would load it as CJS and see no named exports.
+ */
+export interface MarkdownPageGroup {
+    /**
+     * URL path pattern with no leading or trailing slash, e.g. `license-pricing` or
+     * `session/[^/.]+`. Consumers anchor it as `^/(<pattern>)/?$`.
+     *
+     * Must be valid in BOTH the JavaScript RegExp engine (dev-server plugin) and Apache's PCRE
+     * (`RewriteCond`, and `<If>` expressions using `m#...#` delimiters). Keep to the common subset:
+     * `(?:…)`, `|`, `?`, and negated character classes. No named groups, no lookbehind, no `#`.
+     *
+     * Match final path segments with `[^/.]+` rather than `[^/]+` so a request for the twin itself
+     * (`/react-data-grid/cell-editing.md`) never matches and re-negotiates into `….md.md`. No page
+     * slug on any of the sites contains a dot.
+     *
+     * Omit for a page negotiated by a dedicated rule rather than the shared alternation — currently
+     * only the site root, whose twin is `index.md` because it has no path segment to suffix. Such a
+     * group documents the page without contributing to the patterns.
+     */
+    pattern?: string;
+    /** What this group covers, for readers of the registry. Not emitted anywhere. */
+    describes: string;
+}

--- a/packages/ag-charts-website/e2e/api-ref-page.spec.ts
+++ b/packages/ag-charts-website/e2e/api-ref-page.spec.ts
@@ -183,9 +183,9 @@ test.describe('api-ref-page', () => {
         await selectSearchOption(page, 'series type bar');
         await page.keyboard.press('Enter');
 
-        const url = page.url();
-        expect(url).toContain('/options/series/bar/');
-        expect(url).toContain('#reference-AgBarSeriesOptions-type');
+        // Selecting a result hands off to Astro's router, which swaps in the target document, so
+        // the address bar catches up a tick after the keypress rather than during it.
+        await page.waitForURL(/\/options\/series\/bar\/#reference-AgBarSeriesOptions-type$/);
         await expect(page.locator('header h1')).toContainText("type = 'bar'");
     });
 

--- a/packages/ag-charts-website/plugins/agDevMarkdownNegotiation.ts
+++ b/packages/ag-charts-website/plugins/agDevMarkdownNegotiation.ts
@@ -1,32 +1,21 @@
 import type { Plugin } from 'vite';
 
 import agDevMarkdownNegotiation from '../../../external/ag-website-shared/plugins/agDevMarkdownNegotiation';
-import { DISABLE_MARKDOWN_DOCS, FRAMEWORKS, SITE_BASE_URL } from '../src/constants';
+import { DISABLE_MARKDOWN_DOCS, SITE_BASE_URL } from '../src/constants';
+import { markdownPathPatterns } from '../src/utils/markdownPages';
 
-// A single docs page path, e.g. `/charts/react/axes`. The framework segment is matched
-// wherever it appears so the rule holds regardless of the configured base (`/charts`).
-// The final segment excludes dots so the `.md` variant itself never matches (no rewrite
-// loop) and the framework landing page (`/charts/react/`, which has no `.md`) is left alone.
-const DOCS_PAGE_PATH = new RegExp(`/(?:${FRAMEWORKS.join('|')})/[^/.]+/?$`);
-
-// Top-level (non-docs) pages that also ship a `.md` twin. Kept in sync with the same page
-// list in the htaccess negotiation rule (see htaccessRules.ts).
-const TOP_LEVEL_MD_PATH = /\/(?:license-pricing|documentation-archive|gallery)\/?$/;
-
-// The /community landing page and its subpages, each with a `.md` twin.
-const COMMUNITY_MD_PATH = /\/community(?:\/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?\/?$/;
-
+// Content-negotiate charts pages to their markdown variant in the dev server. Charts supplies its
+// URL shapes and base; the shared factory holds the mechanism (see
+// external/ag-website-shared/plugins/agDevMarkdownNegotiation for the full rationale). The page
+// list comes from CHARTS_MARKDOWN_PAGE_GROUPS, the same registry the production htaccess rules
+// derive from, so dev and prod cannot disagree about what is negotiable.
+//
 // Charts is served under a base (`/charts`), so the homepage request is `/charts/`; the shared
 // factory maps that base root to `<base>/index.md`.
-const BASE_PATH = (SITE_BASE_URL ?? '').replace(/\/$/, '');
-
-// Content-negotiate charts docs pages to their markdown variant in the dev server. Charts
-// supplies its URL shapes and base; the shared factory holds the mechanism (see
-// external/ag-website-shared/plugins/agDevMarkdownNegotiation for the full rationale).
 export default function agDevChartsMarkdownNegotiation(): Plugin {
     return agDevMarkdownNegotiation({
-        pathPatterns: [DOCS_PAGE_PATH, TOP_LEVEL_MD_PATH, COMMUNITY_MD_PATH],
+        pathPatterns: markdownPathPatterns(),
         disabled: DISABLE_MARKDOWN_DOCS,
-        basePath: BASE_PATH,
+        basePath: (SITE_BASE_URL ?? '').replace(/\/$/, ''),
     });
 }

--- a/packages/ag-charts-website/src/components/api-documentation/apiReferenceRouting.ts
+++ b/packages/ag-charts-website/src/components/api-documentation/apiReferenceRouting.ts
@@ -1,0 +1,77 @@
+import { navigate } from 'astro:transitions/client';
+import { useEffect, useState } from 'react';
+
+import type { NavigationData } from './apiReferenceHelpers';
+
+/*
+    Astro's ClientRouter owns `history.state` — it reads `index` to work out popstate direction and
+    `scrollX`/`scrollY` to restore scroll. It spreads any `state` passed to `navigate()` alongside
+    those keys, so nesting the reference selection under a single key lets both live in one entry
+    without either overwriting the other.
+*/
+const SELECTION_STATE_KEY = 'apiReferenceSelection';
+
+interface ApiReferenceLocation {
+    pathname: string;
+    /** Includes the leading `#`, matching `window.location.hash`. */
+    hash: string;
+}
+
+const inBrowser = () => typeof window !== 'undefined';
+
+function currentLocation(): ApiReferenceLocation | null {
+    return inBrowser() ? { pathname: window.location.pathname, hash: window.location.hash } : null;
+}
+
+function hrefFor({ pathname, hash }: NavigationData) {
+    return hash ? `${pathname}#${hash}` : pathname;
+}
+
+export function readSelection(): NavigationData | undefined {
+    if (!inBrowser()) return undefined;
+    return (history.state as Record<string, unknown> | null)?.[SELECTION_STATE_KEY] as NavigationData | undefined;
+}
+
+/**
+ * Attach a selection to the current entry. Entries created by a full page load or by arriving from
+ * a non-reference page carry no selection of their own, so a later back/forward has nothing to
+ * restore without this.
+ */
+export function seedSelection(selection: NavigationData) {
+    // Astro's router seeds `index`/`scrollX`/`scrollY` when its module loads; merging onto a state
+    // it has not written yet would produce an entry it can no longer track.
+    if (!inBrowser() || !history.state || readSelection()) return;
+    history.replaceState({ ...history.state, [SELECTION_STATE_KEY]: selection }, '');
+}
+
+export function navigateToSelection(selection: NavigationData) {
+    return navigate(hrefFor(selection), { state: { [SELECTION_STATE_KEY]: selection } });
+}
+
+/**
+ * Current location, tracked through every route Astro can change it by: `astro:page-load` after a
+ * document swap or full load, `popstate` for back/forward, and `hashchange` for the hash-only path
+ * (which Astro handles by assigning `location.href`, so no swap event fires).
+ */
+export function useApiReferenceLocation(): ApiReferenceLocation | null {
+    const [location, setLocation] = useState(currentLocation);
+
+    useEffect(() => {
+        const update = () => {
+            const next = { pathname: window.location.pathname, hash: window.location.hash };
+            setLocation((prev) => (prev?.pathname === next.pathname && prev?.hash === next.hash ? prev : next));
+        };
+
+        document.addEventListener('astro:page-load', update);
+        window.addEventListener('popstate', update);
+        window.addEventListener('hashchange', update);
+
+        return () => {
+            document.removeEventListener('astro:page-load', update);
+            window.removeEventListener('popstate', update);
+            window.removeEventListener('hashchange', update);
+        };
+    }, []);
+
+    return location;
+}

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReference.tsx
@@ -1,7 +1,7 @@
 import Code from '@ag-website-shared/components/code/Code';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import styles from '@ag-website-shared/components/reference-documentation/ApiReference.module.scss';
-import { navigate, scrollIntoViewById, useLocation } from '@ag-website-shared/utils/navigation';
+import { scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import type {
     InterfaceNode,
     MemberNode,
@@ -47,6 +47,7 @@ import {
     resolveAliasedUnion,
     resolveReferenceType,
 } from '../apiReferenceHelpers';
+import { navigateToSelection, useApiReferenceLocation } from '../apiReferenceRouting';
 import { SelectionContext } from './OptionsNavigation';
 import { type CollapsibleType, PropertyTitle, PropertyType } from './Properties';
 
@@ -190,7 +191,7 @@ function UnionVariantNode({
 }) {
     const [isExpanded, toggleExpanded, setExpanded] = useToggle();
     const config = useContext(ApiReferenceConfigContext);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
     const docs = parseJsDocs(variant.node.docs);
     const { discriminator } = variant;
     const displayName = discriminator ? `[${discriminator.key}='${discriminator.value}']` : variant.anchorSegment;
@@ -278,7 +279,7 @@ export function ApiReference({
     const reference = useContext(ApiReferenceContext);
     const config = useContext(ApiReferenceConfigContext);
     const interfaceRef = reference?.get(id);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     // include / exclude / prioritise scope the top-level interface only; nested interfaces
     // and union variants must render their full member set.
@@ -334,7 +335,7 @@ function NodeFactory({ member, anchorId, genericsMap, prefixPath = [], ...props 
     const [isSignatureExpanded, toggleSignature, setSignatureExpanded] = useToggle();
     const interfaceRef = useMemberAdditionalDetails(member);
     const config = useContext(ApiReferenceConfigContext);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     const hasMembers = hasMembersNode(interfaceRef);
     const hasNestedPages = config.specialTypes?.[getMemberType(member)] === 'NestedPage';
@@ -496,7 +497,7 @@ function ApiReferenceRow({
                                     pageTitle: { name: memberName },
                                 };
                                 selection?.setSelection(selectionState);
-                                navigate(selectionState, { state: selectionState });
+                                navigateToSelection(selectionState);
                             }}
                         >
                             See property details <Icon name="arrowRight" />

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.astro
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.astro
@@ -1,0 +1,87 @@
+---
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import {
+    cleanupName,
+    normalizeType,
+    parseJsDocs,
+    processMembers,
+} from '@components/api-documentation/apiReferenceHelpers';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+import styles from './ApiReferenceFallback.module.scss';
+
+interface Props {
+    rootInterface: string;
+    pageInterface?: string;
+    pageTitle?: PageTitle;
+}
+
+const { rootInterface, pageInterface, pageTitle } = Astro.props;
+
+const reference = getInterfacesReference();
+const id = pageInterface ?? rootInterface;
+const pageRef = reference.get(id);
+const interfaceRef = pageRef?.kind === 'interface' ? pageRef : undefined;
+
+const title = pageTitle ?? { name: id };
+const description = interfaceRef && parseJsDocs(interfaceRef.docs);
+const members = interfaceRef ? processMembers(interfaceRef, {}) : [];
+---
+
+{
+    /*
+    Server-rendered reference content for crawlers that don't execute JavaScript. Astro shows this
+    until the interactive <ApiReferencePage> island hydrates and replaces it. Deliberately flat:
+    top-level properties only, so the served HTML stays small (SE-53). Nested children and deep type
+    signatures remain client-rendered.
+*/
+}
+<div class="api-reference-fallback layout-grid">
+    {
+        /* Empty column reserving the left-nav width, so the property content lands at the same
+        x-position as the hydrated layout and the navigation tree fills into reserved space
+        without shifting the page horizontally on hydration. */
+    }
+    <div class={styles.navPlaceholder} aria-hidden="true"></div>
+
+    <div class={styles.referenceContent}>
+        <header>
+            <h1 class="text-3xl">
+                {
+                    title.type ? (
+                        <>
+                            {title.name}
+                            {title.name === 'axes' && <span class={styles.recordAlias}>.key</span>}[type='
+                            <span class={styles.unionDiscriminator}>{title.type}</span>']
+                        </>
+                    ) : (
+                        title.name
+                    )
+                }
+            </h1>
+            {description && <p class="text-secondary">{description}</p>}
+        </header>
+
+        <dl class={styles.referenceList}>
+            {
+                members.map((member) => {
+                    const memberDocs = parseJsDocs(member.docs);
+                    return (
+                        <div class={styles.referenceRow} id={`reference-${id}-${member.name}`}>
+                            <dt>
+                                <span class={styles.propertyName}>{cleanupName(member.name)}</span>
+                                {!member.optional && <span class={styles.required}>required</span>}
+                                <code class={styles.propertyType}>{normalizeType(member.type)}</code>
+                                {member.defaultValue != null && (
+                                    <span class={styles.propertyDefault}>default: {member.defaultValue}</span>
+                                )}
+                            </dt>
+                            {/* Always render the <dd> so every definition-list group has both a
+                                term and a description, even for undocumented members. */}
+                            <dd class="text-secondary">{memberDocs}</dd>
+                        </div>
+                    );
+                })
+            }
+        </dl>
+    </div>
+</div>

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.module.scss
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferenceFallback.module.scss
@@ -1,0 +1,107 @@
+@use 'design-system' as *;
+
+/*
+    Mirror the two-column geometry the hydrated <ApiReferencePage> produces (its
+    `.container.layout-grid` + `.objectViewOuter` + `.referenceOuter`) so the swap from the
+    fallback to the React app does not shift the page horizontally.
+*/
+
+.navPlaceholder {
+    width: calc(100% + var(--layout-horizontal-margins) * 2);
+    margin-left: calc(var(--layout-horizontal-margins) * -1);
+
+    @media screen and (max-width: $breakpoint-options-medium) {
+        /*
+            Below this breakpoint the navigation tree is hidden and the nav stacks above the
+            content as a single search box. Reserve its height so the content does not drop on
+            hydration: the nav's top padding ($spacing-size-5) plus the search box (its text
+            line-box + vertical padding of $spacing-size-3 + 1px border top and bottom).
+        */
+        min-height: calc(#{$spacing-size-5} + var(--text-fs-base) * var(--text-lh-base) + #{$spacing-size-3} + 2px);
+    }
+
+    @media screen and (min-width: $breakpoint-options-medium) {
+        width: calc(var(--layout-width-4-12) + var(--layout-horizontal-margins));
+        box-shadow: -1px 0 0 0 var(--color-border-primary);
+        border-right: 1px solid var(--color-border-primary);
+    }
+
+    @media screen and (min-width: $breakpoint-options-large) {
+        width: calc(var(--layout-width-3-12) + var(--layout-horizontal-margins));
+    }
+}
+
+.referenceContent {
+    width: calc(100% + var(--layout-gap) * 2);
+    margin-left: calc(var(--layout-gap) * -1);
+
+    @media screen and (max-width: $breakpoint-options-medium) {
+        /* Below this breakpoint the content spans full width with no negative bleed, matching
+           the hydrated `.referenceOuter`; without this the body sits ~32px too far left (and
+           off-screen) until hydration snaps it back. */
+        margin-left: 0;
+    }
+
+    @media screen and (min-width: $breakpoint-options-medium) {
+        width: var(--layout-width-8-12);
+        margin-left: 0;
+    }
+
+    @media screen and (min-width: $breakpoint-options-large) {
+        width: var(--layout-width-9-12);
+    }
+
+    header {
+        padding-top: $spacing-size-8;
+        padding-bottom: $spacing-size-6;
+        margin-bottom: $spacing-size-4;
+        border-bottom: 1px solid var(--color-border-secondary);
+    }
+}
+
+.referenceList {
+    margin: 0;
+}
+
+.referenceRow {
+    padding: $spacing-size-4 0;
+    border-top: 1px solid var(--color-border-secondary);
+
+    dt {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: $spacing-size-2;
+    }
+
+    dd {
+        margin: $spacing-size-2 0 0;
+
+        &:empty {
+            margin: 0;
+        }
+    }
+}
+
+.propertyName {
+    font-weight: var(--text-bold);
+}
+
+.propertyType {
+    color: var(--color-fg-code);
+}
+
+.propertyDefault {
+    color: var(--color-fg-secondary);
+    font-size: var(--text-fs-sm);
+}
+
+.required {
+    color: red;
+    font-size: var(--text-fs-sm);
+}
+
+.recordAlias,
+.unionDiscriminator {
+    color: var(--color-fg-code);
+}

--- a/packages/ag-charts-website/src/components/api-documentation/components/ApiReferencePage.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/ApiReferencePage.tsx
@@ -1,15 +1,14 @@
-import { navigate, useHistory, useLocation } from '@ag-website-shared/utils/navigation';
 import type { InterfaceNode } from '@generate-code-reference-plugin/doc-interfaces/types';
 import { fetchInterfacesReference } from '@utils/client/fetchInterfacesReference';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 import classNames from 'classnames';
-import { Action } from 'history';
 import { type CSSProperties, useContext, useEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 import { QueryClientProvider, useQuery } from 'react-query';
 import remarkBreaks from 'remark-breaks';
 
 import { type NavigationData, type PageTitle, type SpecialTypesMap, parseJsDocs } from '../apiReferenceHelpers';
+import { readSelection, seedSelection, useApiReferenceLocation } from '../apiReferenceRouting';
 import {
     ApiReference,
     ApiReferenceConfigContext,
@@ -51,23 +50,32 @@ function ApiReferencePageInner({
     noExpand,
 }: ApiReferencePageOptions) {
     const { data: reference } = useQuery(['resolved-interfaces'], fetchInterfacesReference, queryOptions);
-    const location = useLocation();
-    const [selection, setSelection] = useState<NavigationData>({
-        pageInterface: pageInterface ?? rootInterface,
-        pathname: location?.pathname ?? basePath,
-        hash: location?.hash.substring(1) ?? '',
-        pageTitle: pageTitle ?? { name: rootInterface },
-    });
+    const location = useApiReferenceLocation();
+    const [selection, setSelection] = useState<NavigationData>(
+        () =>
+            readSelection() ?? {
+                pageInterface: pageInterface ?? rootInterface,
+                pathname: location?.pathname ?? basePath,
+                hash: location?.hash.substring(1) ?? '',
+                pageTitle: pageTitle ?? { name: rootInterface },
+            }
+    );
 
     useEffect(() => {
-        navigate({ pathname: location?.pathname, hash: location?.hash }, { state: selection, replace: true });
+        seedSelection(selection);
     }, []);
 
-    useHistory(({ location: historyLocation, action }) => {
-        if (action === Action.Pop && historyLocation.state) {
-            setSelection(historyLocation.state as NavigationData);
+    /*
+        The island is persisted across Astro navigations, so props stay at whatever the first-loaded
+        page supplied. Every entry this app creates carries its selection in Astro's history state,
+        which makes that state — not props — the thing to follow on back/forward.
+    */
+    useEffect(() => {
+        const restored = readSelection();
+        if (restored) {
+            setSelection(restored);
         }
-    });
+    }, [location]);
 
     if (!reference) return null;
 

--- a/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/OptionsNavigation.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { navigate, scrollIntoView, scrollIntoViewById, useLocation } from '@ag-website-shared/utils/navigation';
+import { scrollIntoView, scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import type {
     ApiReferenceNode,
     ApiReferenceType,
@@ -40,6 +40,7 @@ import {
     normalizeType,
     processMembers,
 } from '../apiReferenceHelpers';
+import { navigateToSelection, useApiReferenceLocation } from '../apiReferenceRouting';
 import { ApiReferenceConfigContext, ApiReferenceContext } from './ApiReference';
 import styles from './OptionsNavigation.module.scss';
 import { SearchBox } from './SearchBox';
@@ -60,7 +61,7 @@ export function OptionsNavigation({
     breadcrumbs: string[];
     rootInterface: string;
 }) {
-    const location = useLocation();
+    const location = useApiReferenceLocation();
     const elementRef = useRef<HTMLDivElement>(null);
     const selection = useContext(SelectionContext);
     const reference = useContext(ApiReferenceContext);
@@ -97,7 +98,7 @@ export function OptionsNavigation({
             selection?.setSelection(navData); // trigger change for highlighting selection
         } else {
             selection?.setSelection(navData);
-            navigate(navData, { state: navData });
+            navigateToSelection(navData);
         }
     };
 
@@ -118,7 +119,7 @@ export function OptionsNavigation({
                     onItemClick={(data) => {
                         const navData = getNavigationDataFromPath(data.navPath, config.specialTypes);
                         selection?.setSelection(navData);
-                        navigate(navData, { state: navData });
+                        navigateToSelection(navData);
                     }}
                 />
             </header>
@@ -176,7 +177,7 @@ function NavProperty({
     const selection = useContext(SelectionContext);
     const reference = useContext(ApiReferenceContext);
     const config = useContext(ApiReferenceConfigContext);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     const memberType = getMemberType(member);
     const interfaceRef = reference?.get(memberType);
@@ -517,7 +518,7 @@ function NavBreadcrumb({
         };
         selection?.setSelection(navData);
         window.scrollTo({ behavior: 'smooth', top: 0 });
-        navigate(navData, { state: navData });
+        navigateToSelection(navData);
     };
 
     return (
@@ -619,7 +620,7 @@ function PropertyExpander({ isExpanded, onClick }: { isExpanded?: boolean; onCli
 
 function useAutoExpand(shouldExpand: () => boolean): [boolean, () => void] {
     const [isExpanded, toggleExpanded, setExpanded] = useToggle(shouldExpand);
-    const location = useLocation();
+    const location = useApiReferenceLocation();
 
     useEffect(() => {
         if (!isExpanded) {

--- a/packages/ag-charts-website/src/components/landing-pages/types.ts
+++ b/packages/ag-charts-website/src/components/landing-pages/types.ts
@@ -1,3 +1,5 @@
+import type { LandingPageSectionType } from '@ag-website-shared/components/landing-pages/types';
+
 // ============================================================================
 // AG Charts Specific Section Types
 // ============================================================================
@@ -179,6 +181,8 @@ export interface ChartTypesShowcaseItem {
     title: string;
     /** Short description */
     description: string;
+    /** Link the whole card points at */
+    link?: string;
     /** Example name to embed (optional if using icon) */
     exampleName?: string;
     /** Optional: docs page name if this is a docs example (not gallery) */
@@ -205,3 +209,27 @@ export interface ChartTypesShowcaseSection {
         url: string;
     };
 }
+
+// ============================================================================
+// Landing Page Content
+// ============================================================================
+
+/**
+ * Every section an AG Charts landing page can hold: the charts-specific ones above plus the
+ * sections shared with the other products. The `landingPages` collection schema types `sections`
+ * as `any[]` (it has to cover all three products), so this union is what narrows it — both
+ * `LandingPage.astro` and the `.md` twins walk it.
+ */
+export type ChartsLandingPageSection =
+    | GalleryShowcaseSection
+    | ChartTypesGridSection
+    | InteractiveDemoSection
+    | ChartExplorerSection
+    | FinancialChartsSection
+    | MapChartsSection
+    | WhatsNewSection
+    | PerformanceDemoSection
+    | CodeExampleSection
+    | FeatureGridSection
+    | ChartTypesShowcaseSection
+    | LandingPageSectionType;

--- a/packages/ag-charts-website/src/pages/angular-charts.md.ts
+++ b/packages/ag-charts-website/src/pages/angular-charts.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /angular-charts.md — the markdown twin of the page, built from the same
+// landing-pages/angular-charts.json the page renders. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('angular-charts');

--- a/packages/ag-charts-website/src/pages/contact.md.ts
+++ b/packages/ag-charts-website/src/pages/contact.md.ts
@@ -1,0 +1,23 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { buildContactMarkdown } from '@ag-website-shared/markdown-pages/buildContactMarkdown';
+import { DISABLE_MARKDOWN_DOCS, LIBRARY, SITE_URL } from '@constants';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+// Served at /contact.md — the markdown twin of the /contact page, built from the same shared copy
+// and links the page renders. Content-negotiates from the HTML URL on Accept: text/markdown (see
+// getMarkdownNegotiationRules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildContactMarkdown({
+        library: LIBRARY,
+        contactUrl: toAbsoluteUrl(urlWithBaseUrl('/contact/'), SITE_URL),
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/enterprise-charts.md.ts
+++ b/packages/ag-charts-website/src/pages/enterprise-charts.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /enterprise-charts.md — the markdown twin of the page, built from the same
+// landing-pages/enterprise-charts.json the page renders. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('enterprise-charts');

--- a/packages/ag-charts-website/src/pages/gallery/[pageName].astro
+++ b/packages/ag-charts-website/src/pages/gallery/[pageName].astro
@@ -6,7 +6,7 @@ import GalleryExampleRunner from '@components/gallery/components/GalleryExampleR
 import { getGalleryPages } from '@components/gallery/utils/pageData';
 import { GalleryExampleLink } from '@components/gallery/components/GalleryExampleLink';
 import { GallerySeriesLink } from '@components/gallery/components/GallerySeriesLink';
-import { toTitle } from '@utils/toTitle';
+import { galleryExampleDescription } from '@utils/markdown-pages/buildGalleryExampleMarkdown';
 
 export async function getStaticPaths() {
     const galleryEntry = (await getEntry('gallery', 'data')) as CollectionEntry<'gallery'>;
@@ -18,7 +18,8 @@ export async function getStaticPaths() {
 const { page, prevExample, nextExampleOne, nextExampleTwo } = Astro.props;
 const exampleName = Astro.params.pageName;
 
-const metaDescription = `Example of a ${page.title} Chart built with AG Charts JavaScript Charting Library. Edit source code with CodeSandbox & Plunker. View JavaScript ${toTitle(page.seriesTitle)} Charts documentation for more info.`;
+// Shared with the page's `.md` twin so the two describe the example identically.
+const metaDescription = galleryExampleDescription(page);
 ---
 
 <Layout title={`AG Charts Gallery: ${page.title}`} description={metaDescription} showSearchBar={true}>

--- a/packages/ag-charts-website/src/pages/gallery/[pageName].md.ts
+++ b/packages/ag-charts-website/src/pages/gallery/[pageName].md.ts
@@ -1,0 +1,44 @@
+import { getGalleryPages } from '@components/gallery/utils/pageData';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import type { GalleryExampleNeighbour, GalleryExamplePage } from '@utils/markdown-pages/buildGalleryExampleMarkdown';
+import { buildGalleryExampleMarkdown } from '@utils/markdown-pages/buildGalleryExampleMarkdown';
+import { type CollectionEntry, getEntry } from 'astro:content';
+
+// Served at /gallery/<example>.md — the markdown twin of each gallery example page, built from the
+// same gallery entry and generated example the page renders. Mirrors the page's own getStaticPaths
+// so the two URL sets line up 1:1. Content-negotiates from the HTML URL on Accept: text/markdown
+// (see getMarkdownNegotiationRules in htaccessRules.ts).
+export async function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    const galleryEntry = (await getEntry('gallery', 'data')) as CollectionEntry<'gallery'>;
+    return getGalleryPages({ galleryData: galleryEntry.data });
+}
+
+export async function GET({
+    props,
+    params,
+}: {
+    props: {
+        page: GalleryExamplePage;
+        prevExample: GalleryExampleNeighbour;
+        nextExampleOne: GalleryExampleNeighbour;
+        nextExampleTwo: GalleryExampleNeighbour;
+    };
+    params: Record<string, string>;
+}) {
+    const { page, prevExample, nextExampleOne, nextExampleTwo } = props;
+
+    const output = await buildGalleryExampleMarkdown({
+        page,
+        exampleName: params.pageName,
+        neighbours: [prevExample, nextExampleOne, nextExampleTwo],
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/javascript-charts.md.ts
+++ b/packages/ag-charts-website/src/pages/javascript-charts.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /javascript-charts.md — the markdown twin of the page, built from the same
+// landing-pages/javascript-charts.json the page renders. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('javascript-charts');

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -1,4 +1,5 @@
 ---
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 ---
@@ -9,6 +10,8 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
 >
     <ApiReferencePage
         client:only="react"
+        transition:persist="options-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartOptions"
         breadcrumbs={['options']}
@@ -20,5 +23,7 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
             AgMiniChartSeriesOptions: 'InterfaceArray',
         }}
         noExpand={['theme']}
-    />
+    >
+        <ApiReferenceFallback slot="fallback" rootInterface="AgChartOptions" />
+    </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/options.astro
+++ b/packages/ag-charts-website/src/pages/options.astro
@@ -2,12 +2,10 @@
 import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
+import { OPTIONS_API_PAGE_CONTENT } from '@utils/markdown-pages/apiReferencePageContent';
 ---
 
-<APIViewLayout
-    title="Options API"
-    description="Options API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties."
->
+<APIViewLayout title={OPTIONS_API_PAGE_CONTENT.title} description={OPTIONS_API_PAGE_CONTENT.description}>
     <ApiReferencePage
         client:only="react"
         transition:persist="options-api-reference"

--- a/packages/ag-charts-website/src/pages/options.md.ts
+++ b/packages/ag-charts-website/src/pages/options.md.ts
@@ -1,0 +1,19 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildOptionsApiMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /options.md — the markdown twin of the Options API reference page, built from the same
+// generated interface reference the page renders client-side. Content-negotiates from the HTML URL
+// on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildOptionsApiMarkdown({ reference: getInterfacesReference(), siteRoot: SITE_URL });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
@@ -1,5 +1,6 @@
 ---
 import { getOptionsStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
@@ -23,6 +24,8 @@ const name = capitalizeFirstLetter(Astro.props?.pageTitle?.name);
 >
     <ApiReferencePage
         client:only="react"
+        transition:persist="options-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartOptions"
         breadcrumbs={['options']}
@@ -33,5 +36,12 @@ const name = capitalizeFirstLetter(Astro.props?.pageTitle?.name);
             AgChartSeriesOptions: 'InterfaceArray',
             AgMiniChartSeriesOptions: 'InterfaceArray',
         }}
-    />
+    >
+        <ApiReferenceFallback
+            slot="fallback"
+            rootInterface="AgChartOptions"
+            pageInterface={Astro.props.pageInterface}
+            pageTitle={Astro.props.pageTitle}
+        />
+    </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].astro
@@ -3,6 +3,7 @@ import { getOptionsStaticPaths } from '@components/api-documentation/apiReferenc
 import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
+import { optionsVariantPageContent } from '@utils/markdown-pages/apiReferencePageContent';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
 
 export async function getStaticPaths() {
@@ -10,18 +11,10 @@ export async function getStaticPaths() {
     return getOptionsStaticPaths(reference);
 }
 
-function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-const type = capitalizeFirstLetter(Astro.props?.pageTitle?.type);
-const name = capitalizeFirstLetter(Astro.props?.pageTitle?.name);
+const { title, description } = optionsVariantPageContent(Astro.props.pageTitle);
 ---
 
-<APIViewLayout
-    title=`Options API (${type} ${name})`
-    description=`${type} ${name} API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties.`
->
+<APIViewLayout title={title} description={description}>
     <ApiReferencePage
         client:only="react"
         transition:persist="options-api-reference"

--- a/packages/ag-charts-website/src/pages/options/[...memberName]/[type].md.ts
+++ b/packages/ag-charts-website/src/pages/options/[...memberName]/[type].md.ts
@@ -1,0 +1,33 @@
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import { getOptionsStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { optionsVariantPageContent } from '@utils/markdown-pages/apiReferencePageContent';
+import { buildOptionsVariantMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /options/<member>/<type>.md — the markdown twin of each options union-variant page.
+// Mirrors the page's own getStaticPaths so the two URL sets line up 1:1. Content-negotiates from
+// the HTML URL on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    return getOptionsStaticPaths(getInterfacesReference());
+}
+
+export function GET({ props }: { props: { pageInterface: string; pageTitle: PageTitle } }) {
+    const { pageInterface, pageTitle } = props;
+
+    const output = buildOptionsVariantMarkdown({
+        reference: getInterfacesReference(),
+        pageInterface,
+        pageTitle,
+        ...optionsVariantPageContent(pageTitle),
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/react-charts.md.ts
+++ b/packages/ag-charts-website/src/pages/react-charts.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /react-charts.md — the markdown twin of the page, built from the same
+// landing-pages/react-charts.json the page renders. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('react-charts');

--- a/packages/ag-charts-website/src/pages/roadmap.md.ts
+++ b/packages/ag-charts-website/src/pages/roadmap.md.ts
@@ -1,0 +1,32 @@
+import { buildRoadmapMarkdown } from '@ag-website-shared/markdown-pages/buildRoadmapMarkdown';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+import roadmapData from '../../public/roadmap/roadmap.json';
+
+// Served at /roadmap.md — the markdown twin of the /roadmap page, built from the same roadmap.json
+// the page renders. Content-negotiates from the HTML URL on Accept: text/markdown (see
+// getMarkdownNegotiationRules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildRoadmapMarkdown({
+        roadmapData,
+        productName: 'AG Charts',
+        siteRoot: SITE_URL,
+        // Item links are framework-relative, resolved per-framework by RoadmapCard. The page is
+        // framework-agnostic, so the twin picks the framework-agnostic core — matching the other
+        // markdown twins (homepage, license-pricing).
+        resolveUrl: (url) => urlWithPrefix({ framework: 'javascript', url }),
+        // The page labels quarters with the current year; the build stamps it here so the generated
+        // markdown is deterministic within a build.
+        year: new Date().getFullYear(),
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/session/[slug].md.ts
+++ b/packages/ag-charts-website/src/pages/session/[slug].md.ts
@@ -1,0 +1,24 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { SESSIONS, type Session, sessionSlug } from '@utils/beyondThePromptSessions';
+import { buildSessionMarkdown } from '@utils/markdown-pages/buildSessionMarkdown';
+
+// Served at /session/<slug>.md — the markdown twin of each recorded session page, built from the
+// same SESSIONS entry the page renders. Mirrors the page's own getStaticPaths so the two URL sets
+// line up 1:1. Content-negotiates from the HTML URL on Accept: text/markdown (see
+// getMarkdownNegotiationRules in htaccessRules.ts).
+export function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    return SESSIONS.filter((session) => session.youtubeUrl).map((session) => ({
+        params: { slug: sessionSlug(session.title) },
+        props: { session },
+    }));
+}
+
+export function GET({ props }: { props: { session: Session } }) {
+    return new Response(buildSessionMarkdown({ session: props.session, siteRoot: SITE_URL }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/sitemap.astro
+++ b/packages/ag-charts-website/src/pages/sitemap.astro
@@ -6,6 +6,7 @@ import Layout from '../layouts/Layout.astro';
 import { PRODUCTION_CHARTS_SITE_URL, LIVE_SITEMAP_URL } from '../constants';
 import { getSitemapXml } from '@ag-website-shared/utils/getSitemapXml';
 import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
+import { SITEMAP_PAGE_CONTENT } from '@utils/markdown-pages/sitemapPageContent';
 
 const sitemapUrl = LIVE_SITEMAP_URL || `${PRODUCTION_CHARTS_SITE_URL}/sitemap-0.xml`;
 const xmlSitemap = await getSitemapXml({
@@ -16,8 +17,8 @@ const parsedSitemap = parseSitemap(xmlSitemap);
 ---
 
 <Layout
-    title={'Sitemap | AG Charts'}
-    description={'The AG Charts sitemap. Contains links to every page on the site, including docs.'}
+    title={SITEMAP_PAGE_CONTENT.title}
+    description={SITEMAP_PAGE_CONTENT.description}
     showDocsNav={false}
     showSearchBar={true}
 >

--- a/packages/ag-charts-website/src/pages/sitemap.md.ts
+++ b/packages/ag-charts-website/src/pages/sitemap.md.ts
@@ -1,0 +1,42 @@
+import parseSitemap from '@ag-website-shared/components/sitemap/utils/sitemaputils';
+import { SITEMAP_CACHE_DIR } from '@ag-website-shared/constants';
+import { getSitemapXml } from '@ag-website-shared/utils/getSitemapXml';
+import { DISABLE_MARKDOWN_DOCS, LIVE_SITEMAP_URL, PRODUCTION_CHARTS_SITE_URL } from '@constants';
+import { SITEMAP_PAGE_CONTENT } from '@utils/markdown-pages/sitemapPageContent';
+
+// Served at /sitemap.md — the markdown twin of the HTML sitemap page, built from the same parsed
+// sitemap XML the page renders, so the two list the same pages under the same categories.
+// Content-negotiates from the HTML URL on Accept: text/markdown (see htaccessRules.ts).
+export async function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const sitemapUrl = LIVE_SITEMAP_URL ?? `${PRODUCTION_CHARTS_SITE_URL}/sitemap-0.xml`;
+    const xmlSitemap = await getSitemapXml({ cacheDir: SITEMAP_CACHE_DIR, sitemapUrl });
+    const parsedSitemap = parseSitemap(xmlSitemap);
+
+    const sections = Object.keys(parsedSitemap).map((category) => {
+        const links = parsedSitemap[category].map(({ url, pageName }) => `- [${pageName}](${url})`).join('\n');
+        return `## ${category}\n\n${links}`;
+    });
+
+    const output =
+        [
+            [
+                '---',
+                `title: ${JSON.stringify(SITEMAP_PAGE_CONTENT.title)}`,
+                `description: ${JSON.stringify(SITEMAP_PAGE_CONTENT.description)}`,
+                '---',
+            ].join('\n'),
+            `# ${SITEMAP_PAGE_CONTENT.heading}`,
+            SITEMAP_PAGE_CONTENT.description,
+            `Most pages listed here also have a markdown version: append \`.md\` to the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${PRODUCTION_CHARTS_SITE_URL}/index.md. The Options and Themes API reference pages have no markdown version.`,
+            ...sections,
+        ].join('\n\n') + '\n';
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/sitemap.md.ts
+++ b/packages/ag-charts-website/src/pages/sitemap.md.ts
@@ -31,7 +31,7 @@ export async function GET() {
             ].join('\n'),
             `# ${SITEMAP_PAGE_CONTENT.heading}`,
             SITEMAP_PAGE_CONTENT.description,
-            `Most pages listed here also have a markdown version: append \`.md\` to the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${PRODUCTION_CHARTS_SITE_URL}/index.md. The Options and Themes API reference pages have no markdown version.`,
+            `Every page listed here also has a markdown version: append \`.md\` to the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${PRODUCTION_CHARTS_SITE_URL}/index.md.`,
             ...sections,
         ].join('\n\n') + '\n';
 

--- a/packages/ag-charts-website/src/pages/themes-api.astro
+++ b/packages/ag-charts-website/src/pages/themes-api.astro
@@ -2,12 +2,10 @@
 import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
+import { THEMES_API_PAGE_CONTENT } from '@utils/markdown-pages/apiReferencePageContent';
 ---
 
-<APIViewLayout
-    title="Themes API"
-    description="Themes API reference for AG Charts JavaScript Charting Library. Search for properties or browse our tree-data explorer; access types, defaults, and child properties."
->
+<APIViewLayout title={THEMES_API_PAGE_CONTENT.title} description={THEMES_API_PAGE_CONTENT.description}>
     <ApiReferencePage
         client:only="react"
         transition:persist="themes-api-reference"

--- a/packages/ag-charts-website/src/pages/themes-api.astro
+++ b/packages/ag-charts-website/src/pages/themes-api.astro
@@ -1,4 +1,5 @@
 ---
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 ---
@@ -9,6 +10,8 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
 >
     <ApiReferencePage
         client:only="react"
+        transition:persist="themes-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartTheme"
         breadcrumbs={['options', 'theme']}
@@ -17,5 +20,7 @@ import APIViewLayout from '@layouts/APIViewLayout.astro';
         specialTypes={{
             AgBaseChartThemeOverrides: 'NestedPage',
         }}
-    />
+    >
+        <ApiReferenceFallback slot="fallback" rootInterface="AgChartTheme" />
+    </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/themes-api.md.ts
+++ b/packages/ag-charts-website/src/pages/themes-api.md.ts
@@ -1,0 +1,19 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { buildThemesApiMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /themes-api.md — the markdown twin of the Themes API reference page, built from the
+// same generated interface reference the page renders client-side. Content-negotiates from the
+// HTML URL on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const output = buildThemesApiMarkdown({ reference: getInterfacesReference(), siteRoot: SITE_URL });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].astro
+++ b/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].astro
@@ -1,5 +1,6 @@
 ---
 import { getThemesApiStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import ApiReferenceFallback from '@components/api-documentation/components/ApiReferenceFallback.astro';
 import { ApiReferencePage } from '@components/api-documentation/components/ApiReferencePage';
 import APIViewLayout from '@layouts/APIViewLayout.astro';
 import { getInterfacesReference } from '@utils/server/getInterfacesReference';
@@ -13,6 +14,8 @@ export async function getStaticPaths() {
 <APIViewLayout title="Themes API">
     <ApiReferencePage
         client:only="react"
+        transition:persist="themes-api-reference"
+        transition:persist-props
         {...Astro.props}
         rootInterface="AgChartTheme"
         breadcrumbs={['options', 'theme']}
@@ -21,5 +24,12 @@ export async function getStaticPaths() {
         specialTypes={{
             AgBaseChartThemeOverrides: 'NestedPage',
         }}
-    />
+    >
+        <ApiReferenceFallback
+            slot="fallback"
+            rootInterface="AgChartTheme"
+            pageInterface={Astro.props.pageInterface}
+            pageTitle={Astro.props.pageTitle}
+        />
+    </ApiReferencePage>
 </APIViewLayout>

--- a/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].md.ts
+++ b/packages/ag-charts-website/src/pages/themes-api/overrides/[memberName].md.ts
@@ -1,0 +1,33 @@
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import { getThemesApiStaticPaths } from '@components/api-documentation/apiReferenceHelpers';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { THEMES_API_PAGE_CONTENT } from '@utils/markdown-pages/apiReferencePageContent';
+import { buildThemesApiOverrideMarkdown } from '@utils/markdown-pages/buildApiReferenceMarkdown';
+import { getInterfacesReference } from '@utils/server/getInterfacesReference';
+
+// Served at /themes-api/overrides/<member>.md — the markdown twin of each theme-override page.
+// Mirrors the page's own getStaticPaths so the two URL sets line up 1:1. Content-negotiates from
+// the HTML URL on Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export function getStaticPaths() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return [];
+    }
+    return getThemesApiStaticPaths(getInterfacesReference());
+}
+
+export function GET({ props }: { props: { pageInterface: string; pageTitle: PageTitle } }) {
+    const { pageInterface, pageTitle } = props;
+
+    const output = buildThemesApiOverrideMarkdown({
+        reference: getInterfacesReference(),
+        pageInterface,
+        pageTitle,
+        title: THEMES_API_PAGE_CONTENT.title,
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/pages/vue-charts.md.ts
+++ b/packages/ag-charts-website/src/pages/vue-charts.md.ts
@@ -1,0 +1,6 @@
+import { landingPageMarkdownResponse } from '@utils/markdown-pages/landingPageMarkdownResponse';
+
+// Served at /vue-charts.md — the markdown twin of the page, built from the same
+// landing-pages/vue-charts.json the page renders. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export const GET = () => landingPageMarkdownResponse('vue-charts');

--- a/packages/ag-charts-website/src/pages/whats-new.md.ts
+++ b/packages/ag-charts-website/src/pages/whats-new.md.ts
@@ -1,0 +1,30 @@
+// cspell:ignore whats
+import { buildWhatsNewMarkdown } from '@ag-website-shared/markdown-pages/buildWhatsNewMarkdown';
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+import { type CollectionEntry, getEntry } from 'astro:content';
+
+// Served at /whats-new.md — the markdown twin of the /whats-new page, built from the same versions
+// collection and shared product metadata the page renders. Content-negotiates from the HTML URL on
+// Accept: text/markdown (see getMarkdownNegotiationRules in htaccessRules.ts).
+export async function GET() {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const { data: versionsData } = (await getEntry('versions', 'ag-charts-versions')) as CollectionEntry<'versions'>;
+
+    const output = buildWhatsNewMarkdown({
+        site: 'charts',
+        versionsData,
+        siteRoot: SITE_URL,
+        // Highlight and release-note paths are framework-relative; the page resolves them against
+        // the reader's remembered framework, so the twin picks the framework-agnostic core.
+        resolveUrl: (url) => urlWithPrefix({ framework: 'javascript', url }),
+    });
+
+    return new Response(output, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/utils/agentReadinessFiles.test.ts
+++ b/packages/ag-charts-website/src/utils/agentReadinessFiles.test.ts
@@ -24,12 +24,21 @@ describe('buildLlmsTxt', () => {
         expect(txt).toContain('(https://www.ag-grid.com/charts/sitemap-index.xml)');
     });
 
-    test('advertises the per-page markdown (.md) convention and the extra .md twins', () => {
+    test('advertises the markdown (.md) convention as a site-wide rule, not a page list', () => {
         expect(txt).toContain('.md');
         expect(txt).toContain('https://www.ag-grid.com/charts/javascript/quick-start.md');
-        expect(txt).toContain(
-            'Home, Gallery, Community, Documentation Archive and Pricing pages also have `.md` versions'
-        );
+        // Nearly every page in the sitemap has a twin, so llms.txt states the rule. Enumerating
+        // pages here would drift the moment one is added (see markdownPages.test.ts).
+        expect(txt).toContain('append `.md` to any page URL listed in the sitemap');
+        expect(txt).toContain('Accept: text/markdown');
+    });
+
+    test('names the API reference pages as the one gap, so an agent does not chase 404s', () => {
+        expect(txt).toContain('Options and Themes API reference pages are the exception');
+    });
+
+    test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
+        expect(txt).toContain('https://www.ag-grid.com/charts/index.md');
     });
 
     test('omits the markdown convention when markdown docs are disabled', () => {
@@ -55,11 +64,18 @@ describe('buildAgentsMd', () => {
         expect(md).toContain('https://www.ag-grid.com/charts/llms.txt');
     });
 
-    test('advertises the markdown (.md) versions', () => {
+    test('advertises the markdown (.md) versions as a site-wide rule', () => {
         expect(md).toContain('Markdown for LLMs');
         expect(md).toContain('https://www.ag-grid.com/charts/javascript/quick-start.md');
-        expect(md).toContain('[Community](https://www.ag-grid.com/charts/community/)');
-        expect(md).toContain('[Documentation Archive](https://www.ag-grid.com/charts/documentation-archive/)');
+        // Nearly every page in the sitemap has a twin, so point at the sitemap rather than
+        // listing pages that would drift (see markdownPages.test.ts for the guarantee).
+        expect(md).toContain('append `.md` to any page URL listed in the');
+        expect(md).toContain('[sitemap](https://www.ag-grid.com/charts/sitemap-index.xml)');
+        expect(md).toContain('Options and Themes API reference pages are the exception');
+    });
+
+    test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
+        expect(md).toContain('https://www.ag-grid.com/charts/index.md');
     });
 
     test('omits the markdown affordance when markdown docs are disabled', () => {

--- a/packages/ag-charts-website/src/utils/agentReadinessFiles.test.ts
+++ b/packages/ag-charts-website/src/utils/agentReadinessFiles.test.ts
@@ -27,14 +27,14 @@ describe('buildLlmsTxt', () => {
     test('advertises the markdown (.md) convention as a site-wide rule, not a page list', () => {
         expect(txt).toContain('.md');
         expect(txt).toContain('https://www.ag-grid.com/charts/javascript/quick-start.md');
-        // Nearly every page in the sitemap has a twin, so llms.txt states the rule. Enumerating
-        // pages here would drift the moment one is added (see markdownPages.test.ts).
+        // Every page in the sitemap has a twin, so llms.txt states the rule. Enumerating pages
+        // here would drift the moment one is added (see markdownPages.test.ts).
         expect(txt).toContain('append `.md` to any page URL listed in the sitemap');
         expect(txt).toContain('Accept: text/markdown');
     });
 
-    test('names the API reference pages as the one gap, so an agent does not chase 404s', () => {
-        expect(txt).toContain('Options and Themes API reference pages are the exception');
+    test('claims no exceptions to the rule, so an agent does not skip a page that has a twin', () => {
+        expect(txt).not.toContain('exception');
     });
 
     test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {
@@ -67,11 +67,11 @@ describe('buildAgentsMd', () => {
     test('advertises the markdown (.md) versions as a site-wide rule', () => {
         expect(md).toContain('Markdown for LLMs');
         expect(md).toContain('https://www.ag-grid.com/charts/javascript/quick-start.md');
-        // Nearly every page in the sitemap has a twin, so point at the sitemap rather than
-        // listing pages that would drift (see markdownPages.test.ts for the guarantee).
+        // Every page in the sitemap has a twin, so point at the sitemap rather than listing
+        // pages that would drift (see markdownPages.test.ts for the guarantee).
         expect(md).toContain('append `.md` to any page URL listed in the');
         expect(md).toContain('[sitemap](https://www.ag-grid.com/charts/sitemap-index.xml)');
-        expect(md).toContain('Options and Themes API reference pages are the exception');
+        expect(md).not.toContain('exception');
     });
 
     test('points at index.md for the homepage, whose twin is not a `.md` suffix', () => {

--- a/packages/ag-charts-website/src/utils/agentReadinessFiles.ts
+++ b/packages/ag-charts-website/src/utils/agentReadinessFiles.ts
@@ -27,7 +27,6 @@ interface AgentReadinessInput {
 }
 
 interface AgentReadinessLinks {
-    home: string;
     quickStart: string;
     options: string;
     gallery: string;
@@ -38,12 +37,13 @@ interface AgentReadinessLinks {
     pipeline: string;
     sitemap: string;
     llmsTxt: string;
+    /** The homepage twin, which is `index.md` rather than a `.md` suffix on the site root. */
+    homepageMarkdown: string;
 }
 
 function buildLinks({ siteRoot, chartsDocsPrefix }: AgentReadinessInput): AgentReadinessLinks {
     const docs = `${siteRoot}${chartsDocsPrefix}/`;
     return {
-        home: siteRoot,
         quickStart: `${docs}quick-start/`,
         options: `${docs}options/`,
         gallery: `${siteRoot}gallery/`,
@@ -54,6 +54,7 @@ function buildLinks({ siteRoot, chartsDocsPrefix }: AgentReadinessInput): AgentR
         pipeline: `${siteRoot}pipeline/`,
         sitemap: `${siteRoot}sitemap-index.xml`,
         llmsTxt: `${siteRoot}llms.txt`,
+        homepageMarkdown: `${siteRoot}index.md`,
     };
 }
 
@@ -63,11 +64,13 @@ function buildLinks({ siteRoot, chartsDocsPrefix }: AgentReadinessInput): AgentR
  */
 export function buildLlmsTxt(input: AgentReadinessInput): string {
     const l = buildLinks(input);
-    // Only advertise the `.md` convention when those routes are actually built.
+    // Only advertise the `.md` convention when those routes are actually built. Nearly every page
+    // in the sitemap has a twin (enforced by the post-build check in markdownPages.test.ts), so
+    // this states the rule rather than enumerating pages that would drift out of date.
     const markdownLine =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- Markdown versions: append \`.md\` to any Charts docs page URL for a clean, framework-specific Markdown copy (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. The Home, Gallery, Community, Documentation Archive and Pricing pages also have \`.md\` versions.`;
+            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}. The Options and Themes API reference pages are the exception and have no Markdown version.`;
     return `# AG Charts
 > High-performance JavaScript Charting library, framework-agnostic with React, Angular and Vue support. Free Community and paid Enterprise editions. Current major version: v${input.majorVersion}.
 
@@ -92,11 +95,12 @@ export function buildLlmsTxt(input: AgentReadinessInput): string {
  */
 export function buildAgentsMd(input: AgentReadinessInput): string {
     const l = buildLinks(input);
-    // Advertise the markdown twins only when they are built (see includeMarkdownDocs).
+    // Advertise the markdown twins only when they are built (see includeMarkdownDocs). Nearly
+    // every page in the sitemap has one, so state the rule rather than listing pages.
     const markdownBullet =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- **Markdown for LLMs:** append \`.md\` to any Charts docs page URL (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. The [Home](${l.home}), [Gallery](${l.gallery}), [Community](${l.community}), [Documentation Archive](${l.documentationArchive}) and [Pricing](${l.pricing}) pages also have \`.md\` versions.`;
+            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}. The Options and Themes API reference pages are the exception and have no Markdown version.`;
     return `# AG Charts - guide for AI coding assistants
 
 - **What it is:** high-performance JavaScript Charting library. Framework-agnostic, with React, Angular and Vue wrappers. Community (free) and Enterprise (licensed) editions.

--- a/packages/ag-charts-website/src/utils/agentReadinessFiles.ts
+++ b/packages/ag-charts-website/src/utils/agentReadinessFiles.ts
@@ -70,7 +70,7 @@ export function buildLlmsTxt(input: AgentReadinessInput): string {
     const markdownLine =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}. The Options and Themes API reference pages are the exception and have no Markdown version.`;
+            : `\n- Markdown versions: append \`.md\` to any page URL listed in the sitemap for a clean Markdown copy (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or send \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Charts
 > High-performance JavaScript Charting library, framework-agnostic with React, Angular and Vue support. Free Community and paid Enterprise editions. Current major version: v${input.majorVersion}.
 
@@ -100,7 +100,7 @@ export function buildAgentsMd(input: AgentReadinessInput): string {
     const markdownBullet =
         input.includeMarkdownDocs === false
             ? ''
-            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}. The Options and Themes API reference pages are the exception and have no Markdown version.`;
+            : `\n- **Markdown for LLMs:** append \`.md\` to any page URL listed in the [sitemap](${l.sitemap}) (e.g. ${l.quickStart.replace(/\/$/, '')}.md), or request the page with \`Accept: text/markdown\`. Docs pages are resolved for the framework in the URL. The homepage is the one URL with no \`.md\` suffix - its copy is ${l.homepageMarkdown}.`;
     return `# AG Charts - guide for AI coding assistants
 
 - **What it is:** high-performance JavaScript Charting library. Framework-agnostic, with React, Angular and Vue wrappers. Community (free) and Enterprise (licensed) editions.

--- a/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -36,7 +36,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
     RewriteEngine On
 
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/]+?|license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery))/?$
+    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts))/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -51,7 +51,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 # Docs pages content-negotiate on Accept (see the markdown rewrite), so shared caches must
 # key on it. Scoped to the negotiated paths (incl. the homepage) so the rest of the site keeps
 # its default.
-<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/]+|license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
+<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
     Header append Vary Accept
 </If>
 
@@ -159,7 +159,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
     RewriteEngine On
 
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/]+?|license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery))/?$
+    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts))/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -174,7 +174,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 # Docs pages content-negotiate on Accept (see the markdown rewrite), so shared caches must
 # key on it. Scoped to the negotiated paths (incl. the homepage) so the rest of the site keeps
 # its default.
-<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/]+|license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
+<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
     Header append Vary Accept
 </If>
 

--- a/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -36,7 +36,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
     RewriteEngine On
 
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts))/?$
+    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?))/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -51,7 +51,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 # Docs pages content-negotiate on Accept (see the markdown rewrite), so shared caches must
 # key on it. Scoped to the negotiated paths (incl. the homepage) so the rest of the site keeps
 # its default.
-<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
+<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
     Header append Vary Accept
 </If>
 
@@ -159,7 +159,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
     RewriteEngine On
 
     RewriteCond %{HTTP_ACCEPT} text/markdown
-    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts))/?$
+    RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?))/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f
     RewriteRule ^ /%1.md [L]
 
@@ -174,7 +174,7 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 # Docs pages content-negotiate on Accept (see the markdown rewrite), so shared caches must
 # key on it. Scoped to the negotiated paths (incl. the homepage) so the rest of the site keeps
 # its default.
-<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
+<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?)/?$# || %{REQUEST_URI} =~ m#^/charts/?$#">
     Header append Vary Accept
 </If>
 

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
@@ -231,6 +231,13 @@ describe('htaccessRules markdown content negotiation', () => {
         '/charts/angular-charts/',
         '/charts/vue-charts/',
         '/charts/enterprise-charts/',
+        '/charts/options/',
+        '/charts/options/axes/number/',
+        '/charts/options/series/bar/',
+        '/charts/options/initialState/annotations/callout/',
+        '/charts/options/navigator/miniChart/series/line/',
+        '/charts/themes-api/',
+        '/charts/themes-api/overrides/bar/',
     ];
 
     // Paths that must NOT negotiate: they have no `.md` twin, and rewriting them would either
@@ -243,9 +250,9 @@ describe('htaccessRules markdown content negotiation', () => {
         '/charts/style-guide/', // non-public, sitemap-excluded
         '/charts/contact/success/', // form result, sitemap-excluded
         '/charts/contact/failure/',
-        '/charts/options/', // API reference, deliberately untwinned
-        '/charts/options/series/bar/',
-        '/charts/themes-api/',
+        '/charts/options/series/bar.md', // the twin itself
+        '/charts/options/series/', // the member path alone is not a page
+        '/charts/themes-api/overrides/', // likewise
         '/charts/gallery-test/',
         '/charts/javascript/quick-start/examples/create-a-chart/',
         '/charts/debug/versions.json',

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
@@ -190,43 +190,119 @@ describe('htaccessRules redirects (SE-60/SE-61)', () => {
 describe('htaccessRules markdown content negotiation', () => {
     const production = getHtaccessContent({ env: 'production' });
     const staging = getHtaccessContent({ env: 'staging' });
-    // Rendered under the pinned `/charts` base (see vi.mock above), so the negotiated paths carry
-    // the deployed prefix. %1 (base included, leading slash excluded) is the document-root-relative
-    // path reused in the -f test and the rewrite target.
-    const negotiationRules = [
-        'RewriteCond %{HTTP_ACCEPT} text/markdown',
-        'RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/]+?|license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery))/?$',
-        'RewriteCond %{DOCUMENT_ROOT}/%1.md -f',
-        'RewriteRule ^ /%1.md [L]',
+    // The negotiated path list is derived from CHARTS_MARKDOWN_PAGE_GROUPS, so asserting the
+    // literal regex here would just restate the registry. Instead, pull the generated pattern
+    // back out and check which URLs it actually matches — that catches a broken pattern, which a
+    // string comparison against a hand-copied regex never would. Rendered under the pinned
+    // `/charts` base (see vi.mock above), so the negotiated paths carry the deployed prefix.
+    const extractNegotiationPattern = (content: string) => {
+        const match = content.match(/RewriteCond %\{REQUEST_URI\} \^\/\((.+)\)\/\?\$/);
+        expect(match).not.toBeNull();
+        return new RegExp(`^/(${match![1]})/?$`);
+    };
+
+    const extractVaryPattern = (content: string) => {
+        const match = content.match(/<If "%\{REQUEST_URI\} =~ m#\^\/charts\/\(\?:(.+)\)\/\?\$#/);
+        expect(match).not.toBeNull();
+        return new RegExp(`^/charts/(?:${match![1]})/?$`);
+    };
+
+    // One representative URL per group in the registry. Nearly every URL in the sitemap must
+    // negotiate, so a group added without a matching pattern shows up here.
+    const negotiablePaths = [
+        '/charts/react/axes-types/',
+        '/charts/javascript/quick-start/',
+        '/charts/changelog/',
+        '/charts/contact/',
+        '/charts/documentation-archive/',
+        '/charts/license-pricing/',
+        '/charts/pipeline/',
+        '/charts/roadmap/',
+        '/charts/sitemap/',
+        '/charts/whats-new/',
+        '/charts/community/',
+        '/charts/community/events/',
+        '/charts/community/beyond-the-prompt/',
+        '/charts/session/opening-keynote/',
+        '/charts/gallery/',
+        '/charts/gallery/simple-bar/',
+        '/charts/javascript-charts/',
+        '/charts/react-charts/',
+        '/charts/angular-charts/',
+        '/charts/vue-charts/',
+        '/charts/enterprise-charts/',
+    ];
+
+    // Paths that must NOT negotiate: they have no `.md` twin, and rewriting them would either
+    // 404 or (for the `.md` itself) loop into `.md.md`.
+    const nonNegotiablePaths = [
+        '/charts/react/axes-types.md', // the twin itself — final segments exclude dots
+        '/charts/react/', // framework landing page, a redirect stub
+        '/charts/documentation/', // redirect stub, sitemap-excluded
+        '/charts/licensing/', // redirect stub, sitemap-excluded
+        '/charts/style-guide/', // non-public, sitemap-excluded
+        '/charts/contact/success/', // form result, sitemap-excluded
+        '/charts/contact/failure/',
+        '/charts/options/', // API reference, deliberately untwinned
+        '/charts/options/series/bar/',
+        '/charts/themes-api/',
+        '/charts/gallery-test/',
+        '/charts/javascript/quick-start/examples/create-a-chart/',
+        '/charts/debug/versions.json',
+        '/charts/sitemap-0.xml',
+        '/charts/sitemap-index.xml',
     ];
 
     it('serves the per-page .md variant when Accept: text/markdown, gated by an on-disk check', () => {
         for (const content of [production, staging]) {
             expect(content).toContain('<IfModule mod_rewrite.c>');
             expect(content).toContain('RewriteEngine On');
-            for (const rule of negotiationRules) {
-                expect(content).toContain(rule);
-            }
+            expect(content).toContain('RewriteCond %{HTTP_ACCEPT} text/markdown');
+            expect(content).toContain('RewriteCond %{DOCUMENT_ROOT}/%1.md -f');
+            expect(content).toContain('RewriteRule ^ /%1.md [L]');
         }
     });
 
-    it('negotiates the top-level twins (license-pricing, community + subpages, documentation-archive) alongside framework docs pages', () => {
-        for (const content of [production, staging]) {
-            expect(content).toContain(
-                '|license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery))/?$'
-            );
-            // changelog/pipeline are out of scope for this branch — they must not be negotiated.
-            expect(content).not.toContain('changelog');
-            expect(content).not.toContain('pipeline');
+    it('negotiates exactly the same set of paths in both environments', () => {
+        expect(extractNegotiationPattern(staging).source).toBe(extractNegotiationPattern(production).source);
+    });
+
+    it('negotiates every page group in the registry, with and without a trailing slash', () => {
+        const pattern = extractNegotiationPattern(production);
+        for (const path of negotiablePaths) {
+            expect(pattern.test(path), `${path} should negotiate`).toBe(true);
+            expect(pattern.test(path.replace(/\/$/, '')), `${path} (no trailing slash)`).toBe(true);
         }
     });
 
-    it('adds Vary: Accept for negotiated paths (both envs) so shared caches key on the negotiated representation', () => {
+    it('leaves pages without a .md twin untouched', () => {
+        const pattern = extractNegotiationPattern(production);
+        for (const path of nonNegotiablePaths) {
+            expect(pattern.test(path), `${path} should not negotiate`).toBe(false);
+        }
+    });
+
+    it('captures the base-relative page path in %1 so the -f guard and rewrite target resolve under /charts', () => {
+        const pattern = extractNegotiationPattern(production);
+        // %1 is the first capture group, reused as `%1.md` in both the guard and the target, so it
+        // must carry the base with the leading slash excluded.
+        expect('/charts/community/events/'.match(pattern)?.[1]).toBe('charts/community/events');
+        expect('/charts/react/axes-types/'.match(pattern)?.[1]).toBe('charts/react/axes-types');
+        expect('/charts/gallery/simple-bar'.match(pattern)?.[1]).toBe('charts/gallery/simple-bar');
+    });
+
+    it('adds Vary: Accept for exactly the negotiated paths (both envs) so shared caches key on the negotiated representation', () => {
         for (const content of [production, staging]) {
-            expect(content).toContain(
-                '<If "%{REQUEST_URI} =~ m#^/charts/(?:(?:react|angular|vue|javascript)/[^/]+|license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery)/?$#'
-            );
             expect(content).toContain('Header append Vary Accept');
+            // The Vary scope must cover the negotiated set exactly — narrower and a cache could
+            // serve markdown to a browser; wider and unrelated pages lose cache keying.
+            const varyPattern = extractVaryPattern(content);
+            for (const path of negotiablePaths) {
+                expect(varyPattern.test(path), `${path} should carry Vary: Accept`).toBe(true);
+            }
+            for (const path of nonNegotiablePaths) {
+                expect(varyPattern.test(path), `${path} should not carry Vary: Accept`).toBe(false);
+            }
         }
     });
 

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
@@ -1,6 +1,7 @@
 import type { AstroUserConfig } from 'astro';
 
 import { SITE_BASE_URL } from '../../constants';
+import { markdownPathAlternation } from '../markdownPages';
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
 import { getCspHtaccessBlock, getScopedCspHtaccessBlock } from './cspRules';
@@ -98,19 +99,17 @@ export function getMarkdownNegotiationRules() {
     // (as with the mod_alias redirects above — Apache does not strip it here either). %1 must be
     // the document-root-relative path so both the on-disk `-f` test and the rewrite target resolve
     // to the real .md under /charts, so the base is captured inside %1 (leading slash excluded),
-    // not matched outside it. Charts docs pages live at /<base>/<framework>/<pageName>; the
-    // top-level .md twins in scope are license-pricing, the community landing + subpages,
-    // documentation-archive and gallery.
+    // not matched outside it. The set of negotiable pages comes from CHARTS_MARKDOWN_PAGE_GROUPS,
+    // the same registry the dev-server plugin uses.
     const basePath = (SITE_BASE_URL ?? '').replace(/\/$/, '');
     const baseRelative = basePath.replace(/^\//, '');
     const capturePrefix = baseRelative ? `${baseRelative}/` : '';
-    const topLevel =
-        'license-pricing|community(?:/(?:events|showcase|tools-extensions|media|beyond-the-prompt))?|documentation-archive|gallery';
-    const negotiatedPath = `^/(${capturePrefix}(?:(?:react|angular|vue|javascript)/[^/]+?|${topLevel}))/?$`;
+    const pages = markdownPathAlternation();
+    const negotiatedPath = `^/(${capturePrefix}(?:${pages}))/?$`;
     // Match the same single-page shape as negotiatedPath so Vary: Accept is only appended to the
     // pages that actually content-negotiate — not every nested URL under /<base>/<framework>/
     // (framework landing pages, example routes, assets), which would fragment shared caches.
-    const varyScope = `^${basePath}/(?:(?:react|angular|vue|javascript)/[^/]+|${topLevel})/?$`;
+    const varyScope = `^${basePath}/(?:${pages})/?$`;
 
     // Content-negotiate docs pages to their per-page markdown variant when a client asks
     // for it via Accept: text/markdown (typically an AI agent — browsers never send this, so HTML

--- a/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.ts
+++ b/packages/ag-charts-website/src/utils/markdoc/renderApiReferenceTable.ts
@@ -26,6 +26,18 @@ import { getInterfacesReference } from '@utils/server/getInterfacesReference';
 const MAX_DEPTH = 8;
 const MAX_ROWS = 1500;
 
+export interface ApiReferenceTableLimits {
+    /**
+     * Stop expanding nested members below this depth. Set it where the reference branches
+     * combinatorially — `AgChartTheme.overrides` repeats the whole chart tree once per chart type,
+     * so a full expansion runs to tens of thousands of rows — and say so on the page, since a
+     * caller-set depth truncates silently.
+     */
+    maxDepth?: number;
+    /** Stop after this many rows. Raise alongside a `maxDepth` wide enough to exceed the default. */
+    maxRows?: number;
+}
+
 // A union alias with dozens of variants (e.g. AgIconName, 53 string literals) makes an unreadable
 // cell; past this budget the alias name is left in place, still resolvable from the docs site.
 const MAX_UNION_SIGNATURE_CHARS = 120;
@@ -94,7 +106,13 @@ function formatMemberType(reference: ApiReferenceType, member: MemberNode): stri
  *
  * Pure (no filesystem access) so it is unit-testable; the entry point loads the reference.
  */
-export function buildApiReferenceTable(reference: ApiReferenceType, attributes: Record<string, unknown>): string {
+export function buildApiReferenceTable(
+    reference: ApiReferenceType,
+    attributes: Record<string, unknown>,
+    limits: ApiReferenceTableLimits = {}
+): string {
+    const maxDepth = limits.maxDepth ?? MAX_DEPTH;
+    const maxRows = limits.maxRows ?? MAX_ROWS;
     const id = interfaceId(attributes);
     if (!id) {
         return '';
@@ -121,7 +139,8 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
 
     const hideRequired = attributes.hideRequired === true;
     const rows: string[][] = [];
-    let capped = false;
+    let depthCapped = false;
+    let rowsCapped = false;
 
     function collectRows(
         node: InterfaceNode | TypeLiteralNode,
@@ -135,8 +154,8 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
         typeArguments?: string[]
     ): void {
         for (const member of processMembers(node, memberConfig, typeArguments)) {
-            if (rows.length >= MAX_ROWS) {
-                capped = true;
+            if (rows.length >= maxRows) {
+                rowsCapped = true;
                 return;
             }
 
@@ -155,8 +174,8 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
             if (!nested || ancestors.has(nested.typeName)) {
                 continue;
             }
-            if (depth >= MAX_DEPTH) {
-                capped = true;
+            if (depth >= maxDepth) {
+                depthCapped = true;
                 continue;
             }
 
@@ -175,10 +194,12 @@ export function buildApiReferenceTable(reference: ApiReferenceType, attributes: 
 
     collectRows(interfaceRef, config, '', 1, new Set([id]));
 
-    if (capped) {
+    // A caller-set depth is a deliberate policy the page states for itself, so only the default
+    // guard warns. The row cap is always a runaway backstop.
+    if (rowsCapped || (depthCapped && limits.maxDepth == null)) {
         // eslint-disable-next-line no-console
         console.warn(
-            `apiReference "${id}": nested expansion hit the ${MAX_ROWS}-row/${MAX_DEPTH}-level cap; table truncated.`
+            `apiReference "${id}": nested expansion hit the ${maxRows}-row/${maxDepth}-level cap; table truncated.`
         );
     }
 

--- a/packages/ag-charts-website/src/utils/markdown-pages/apiReferencePageContent.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/apiReferencePageContent.ts
@@ -1,0 +1,42 @@
+import type { PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+
+/**
+ * Titles and meta descriptions for the Options and Themes API reference pages, read by both the
+ * `.astro` pages and their markdown twins so the two cannot describe the same page differently.
+ */
+export const OPTIONS_API_PAGE_CONTENT = {
+    title: 'Options API',
+    description:
+        'Options API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties.',
+};
+
+export const THEMES_API_PAGE_CONTENT = {
+    title: 'Themes API',
+    description:
+        'Themes API reference for AG Charts JavaScript Charting Library. Search for properties or browse our tree-data explorer; access types, defaults, and child properties.',
+};
+
+function capitaliseFirstLetter(value: string) {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/** Metadata for one union variant of the options reference, e.g. `series[type='bar']`. */
+export function optionsVariantPageContent({ name, type }: PageTitle) {
+    const variant = `${capitaliseFirstLetter(type ?? '')} ${capitaliseFirstLetter(name)}`;
+    return {
+        title: `${OPTIONS_API_PAGE_CONTENT.title} (${variant})`,
+        description: `${variant} API reference for AG Charts JavaScript Charting Library. Search for any property or browse our tree-data explorer; access types, defaults, and child properties.`,
+    };
+}
+
+/**
+ * The page heading for a reference page, mirroring the `<h1>` the page renders: a union variant
+ * reads as an indexed access (`series[type='bar']`), and the axes record is keyed
+ * (`axes.key[type='number']`).
+ */
+export function apiReferencePageHeading({ name, type }: PageTitle) {
+    if (!type) {
+        return name;
+    }
+    return `${name}${name === 'axes' ? '.key' : ''}[type='${type}']`;
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import { optionsVariantPageContent } from './apiReferencePageContent';
+import {
+    buildOptionsApiMarkdown,
+    buildOptionsVariantMarkdown,
+    buildThemesApiMarkdown,
+} from './buildApiReferenceMarkdown';
+
+// The ambient test env has no site base, so the URLs below carry no `/charts` prefix.
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+const member = (name: string, type: any, extra: Record<string, unknown> = {}) => ({
+    kind: 'member' as const,
+    name,
+    type,
+    optional: true,
+    ...extra,
+});
+const iface = (name: string, members: any[], extra: Record<string, unknown> = {}) => ({
+    kind: 'interface' as const,
+    name,
+    members,
+    ...extra,
+});
+const alias = (name: string, type: any) => ({ kind: 'typeAlias' as const, name, type });
+const union = (...types: any[]) => ({ kind: 'union' as const, type: types });
+const typeRef = (type: string) => ({ kind: 'typeRef' as const, type });
+const variant = (name: string, discriminator: string, members: any[] = []) =>
+    iface(name, [member('type', `'${discriminator}'`, { optional: false }), ...members]);
+
+const makeReference = (nodes: Record<string, unknown>) => new Map<string, any>(Object.entries(nodes)) as any;
+
+/**
+ * The shape `getOptionsStaticPaths` fans out over: four discriminated unions, each variant carrying
+ * the string literal that names its page. Real interface names, since the builders look them up.
+ */
+const optionsReference = makeReference({
+    AgChartOptions: iface(
+        'AgChartOptions',
+        [
+            member('series', { kind: 'array', type: typeRef('AgChartSeriesOptions') }),
+            member('legend', typeRef('AgChartLegendOptions')),
+        ],
+        { docs: ['Configuration for the chart.'] }
+    ),
+    AgChartLegendOptions: iface('AgChartLegendOptions', [
+        member('enabled', 'boolean', { docs: ['Whether to show the legend.'] }),
+    ]),
+    AgChartSeriesOptions: alias('AgChartSeriesOptions', union('AgBarSeriesOptions', 'AgLineSeriesOptions')),
+    AgBarSeriesOptions: variant('AgBarSeriesOptions', 'bar', [
+        member('xKey', 'string', { optional: false }),
+        member('label', typeRef('AgBarSeriesLabelOptions')),
+    ]),
+    AgBarSeriesLabelOptions: iface('AgBarSeriesLabelOptions', [member('enabled', 'boolean')]),
+    AgLineSeriesOptions: variant('AgLineSeriesOptions', 'line'),
+    AgChartAxesOptions: alias('AgChartAxesOptions', union('AgNumberAxisOptions')),
+    AgNumberAxisOptions: variant('AgNumberAxisOptions', 'number'),
+    AgAnnotation: alias('AgAnnotation', union('AgLineAnnotation')),
+    AgLineAnnotation: variant('AgLineAnnotation', 'line'),
+    AgMiniChartSeriesOptions: alias('AgMiniChartSeriesOptions', union('AgMiniChartLineSeriesOptions')),
+    AgMiniChartLineSeriesOptions: variant('AgMiniChartLineSeriesOptions', 'line'),
+});
+
+/**
+ * `overrides` nests one entry per chart type, each holding a further group of options — the branch
+ * the themes twin caps, since the real reference repeats the whole chart tree under every type.
+ */
+const themesReference = makeReference({
+    AgChartTheme: iface(
+        'AgChartTheme',
+        [
+            member('baseTheme', 'AgChartThemeName'),
+            member('palette', typeRef('AgChartThemePalette')),
+            member('overrides', typeRef('AgThemeOverrides')),
+        ],
+        { docs: ['This object is used to define the configuration for a custom chart theme.'] }
+    ),
+    AgChartThemePalette: iface('AgChartThemePalette', [member('fills', 'string[]')]),
+    AgThemeOverrides: iface('AgThemeOverrides', [
+        member('bar', typeRef('AgBarThemeOverrides')),
+        member('line', typeRef('AgLineThemeOverrides')),
+    ]),
+    AgBarThemeOverrides: iface('AgBarThemeOverrides', [
+        member('series', typeRef('AgBarSeriesThemeableOptions')),
+        member('axes', typeRef('AgCartesianAxesTheme')),
+    ]),
+    AgBarSeriesThemeableOptions: iface('AgBarSeriesThemeableOptions', [member('cornerRadius', 'number')]),
+    AgCartesianAxesTheme: iface('AgCartesianAxesTheme', [member('number', 'AgNumberAxisTheme')]),
+    AgLineThemeOverrides: iface('AgLineThemeOverrides', [member('series', typeRef('AgBarSeriesThemeableOptions'))]),
+});
+
+/** The `Property` column of each table row, which is what carries the nesting. */
+function propertyPaths(output: string): string[] {
+    return output
+        .split('\n')
+        .filter((line) => line.startsWith('| ') && !line.startsWith('| --- '))
+        .slice(1)
+        .map((line) => line.split('|')[1].trim());
+}
+
+describe('buildOptionsApiMarkdown', () => {
+    const output = buildOptionsApiMarkdown({ reference: optionsReference, siteRoot: SITE_ROOT });
+
+    it("emits frontmatter matching the page's title and description", () => {
+        expect(output.startsWith('---\ntitle: "Options API"\n')).toBe(true);
+        expect(output).toContain('description: "Options API reference for AG Charts');
+        expect(output).toContain('\n# AgChartOptions\n');
+        expect(output).toContain('Configuration for the chart.');
+        expect(output).toContain('Interface: `AgChartOptions`');
+    });
+
+    it('flattens the property tree the page expands on click into dotted-path rows', () => {
+        expect(propertyPaths(output)).toEqual(['series', 'legend', 'legend.enabled']);
+    });
+
+    it('links every variant page, so an agent can reach the per-type reference', () => {
+        expect(output).toContain("- [series[type='bar']](https://www.ag-grid.com/options/series/bar/)");
+        // The axes record is keyed, which the heading has to show.
+        expect(output).toContain("- [axes.key[type='number']](https://www.ag-grid.com/options/axes/number/)");
+        expect(output).toContain(
+            "- [initialState.annotations[type='line']](https://www.ag-grid.com/options/initialState/annotations/line/)"
+        );
+        expect(output).toContain(
+            "- [navigator.miniChart.series[type='line']](https://www.ag-grid.com/options/navigator/miniChart/series/line/)"
+        );
+    });
+});
+
+describe('buildOptionsVariantMarkdown', () => {
+    const pageTitle = { name: 'series', type: 'bar' };
+    const output = buildOptionsVariantMarkdown({
+        reference: optionsReference,
+        pageInterface: 'AgBarSeriesOptions',
+        pageTitle,
+        ...optionsVariantPageContent(pageTitle),
+        siteRoot: SITE_ROOT,
+    });
+
+    it("titles the page as the variant, matching the HTML page's own metadata", () => {
+        expect(output).toContain('title: "Options API (Bar Series)"');
+        expect(output).toContain("\n# series[type='bar']\n");
+        expect(output).toContain('Interface: `AgBarSeriesOptions`');
+    });
+
+    it('documents the variant interface, not the root options', () => {
+        expect(propertyPaths(output)).toEqual(['type (required)', 'xKey (required)', 'label', 'label.enabled']);
+    });
+
+    it('links back to the options reference it is part of', () => {
+        expect(output).toContain('[AG Charts Options API reference](https://www.ag-grid.com/options/)');
+    });
+});
+
+describe('buildThemesApiMarkdown', () => {
+    const output = buildThemesApiMarkdown({ reference: themesReference, siteRoot: SITE_ROOT });
+
+    it("emits frontmatter matching the page's title and description", () => {
+        expect(output.startsWith('---\ntitle: "Themes API"\n')).toBe(true);
+        expect(output).toContain('\n# AgChartTheme\n');
+        expect(output).toContain('Interface: `AgChartTheme`');
+    });
+
+    it('lists every chart type that can be themed, and the option groups each one takes', () => {
+        const paths = propertyPaths(output);
+
+        expect(paths).toContain('overrides');
+        expect(paths).toContain('overrides.bar');
+        expect(paths).toContain('overrides.bar.series');
+        expect(paths).toContain('overrides.bar.axes');
+        expect(paths).toContain('overrides.line');
+    });
+
+    it('stops before the combinatorial part of the tree, and says so', () => {
+        // Every chart type repeats the whole chart options tree, so expanding a fourth level runs
+        // to tens of thousands of rows. The reader is told where the table stops instead.
+        expect(propertyPaths(output)).not.toContain('overrides.bar.series.cornerRadius');
+        expect(output).toContain('Only the first three levels of `overrides` are listed');
+        expect(output).toContain('[Options API reference](https://www.ag-grid.com/options/)');
+    });
+
+    it('expands the rest of the theme in full', () => {
+        const paths = propertyPaths(output);
+
+        expect(paths).toContain('baseTheme');
+        expect(paths).toContain('palette');
+        expect(paths).toContain('palette.fills');
+    });
+});

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildApiReferenceMarkdown.ts
@@ -1,0 +1,166 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import type { ApiReferenceType, PageTitle } from '@components/api-documentation/apiReferenceHelpers';
+import { getOptionsStaticPaths, parseJsDocs } from '@components/api-documentation/apiReferenceHelpers';
+import type { ApiReferenceTableLimits } from '@utils/markdoc/renderApiReferenceTable';
+import { buildApiReferenceTable } from '@utils/markdoc/renderApiReferenceTable';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+import { OPTIONS_API_PAGE_CONTENT, THEMES_API_PAGE_CONTENT, apiReferencePageHeading } from './apiReferencePageContent';
+
+/**
+ * `AgChartTheme.overrides` holds one entry per chart type, each repeating the whole chart options
+ * tree, so a full expansion is combinatorial — ~97k rows and 15MB. Three levels reach every chart
+ * type and the option groups it themes, which is the structure the page is actually about; the
+ * properties inside those groups are documented under `/options/`.
+ */
+const THEMES_API_TABLE_LIMITS: ApiReferenceTableLimits = { maxDepth: 3, maxRows: 5000 };
+
+interface ApiReferenceMarkdownParams {
+    reference: ApiReferenceType;
+    /** Interface the page documents; its members become the property table. */
+    pageInterface: string;
+    /** Page heading, mirroring the page's `<h1>`. */
+    heading: string;
+    title: string;
+    description: string;
+    /** Markdown blocks appended after the table — related pages, and any caveat about the table. */
+    sections?: string[];
+    tableLimits?: ApiReferenceTableLimits;
+}
+
+function frontmatter(title: string, description: string) {
+    return ['---', `title: ${JSON.stringify(title)}`, `description: ${JSON.stringify(description)}`, '---'].join('\n');
+}
+
+/**
+ * Build the markdown twin of an API reference page. The page renders its property tree client-side
+ * from the generated interface reference, so the twin reads that same reference and flattens the
+ * tree the reader would expand into dotted-path rows — the same table the docs pages' `apiReference`
+ * tag produces, so the two surfaces describe a property identically.
+ */
+function buildApiReferenceMarkdown({
+    reference,
+    pageInterface,
+    heading,
+    title,
+    description,
+    sections = [],
+    tableLimits,
+}: ApiReferenceMarkdownParams): string {
+    const interfaceRef = reference.get(pageInterface);
+    const docs = interfaceRef?.kind === 'interface' ? parseJsDocs(interfaceRef.docs) : undefined;
+
+    const document = [
+        frontmatter(title, description),
+        `# ${heading}`,
+        docs,
+        `Interface: \`${pageInterface}\``,
+        buildApiReferenceTable(reference, { id: pageInterface }, tableLimits),
+        ...sections,
+    ];
+
+    return `${document.filter(Boolean).join('\n\n').trimEnd()}\n`;
+}
+
+/** The `/options/` page, whose union variants each have a reference page of their own. */
+export function buildOptionsApiMarkdown({
+    reference,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    siteRoot?: string;
+}): string {
+    const variants = getOptionsStaticPaths(reference).map(({ params, props }) => {
+        const href = toAbsoluteUrl(urlWithBaseUrl(`/options/${params.memberName}/${params.type}/`), siteRoot);
+        return `- [${apiReferencePageHeading(props.pageTitle)}](${href})`;
+    });
+
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface: 'AgChartOptions',
+        heading: 'AgChartOptions',
+        ...OPTIONS_API_PAGE_CONTENT,
+        sections: variants.length
+            ? [
+                  '## Options with a reference page per type',
+                  'Each of these properties is a union whose variants are documented separately.',
+                  variants.join('\n'),
+              ]
+            : [],
+    });
+}
+
+/** One union variant of the options reference, e.g. `series[type='bar']`. */
+export function buildOptionsVariantMarkdown({
+    reference,
+    pageInterface,
+    pageTitle,
+    title,
+    description,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    pageInterface: string;
+    pageTitle: PageTitle;
+    title: string;
+    description: string;
+    siteRoot?: string;
+}): string {
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface,
+        heading: apiReferencePageHeading(pageTitle),
+        title,
+        description,
+        sections: [
+            `Part of the [AG Charts Options API reference](${toAbsoluteUrl(urlWithBaseUrl('/options/'), siteRoot)}).`,
+        ],
+    });
+}
+
+/** The `/themes-api/` page. */
+export function buildThemesApiMarkdown({
+    reference,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    siteRoot?: string;
+}): string {
+    const optionsUrl = toAbsoluteUrl(urlWithBaseUrl('/options/'), siteRoot);
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface: 'AgChartTheme',
+        heading: 'AgChartTheme',
+        ...THEMES_API_PAGE_CONTENT,
+        tableLimits: THEMES_API_TABLE_LIMITS,
+        sections: [
+            `Only the first three levels of \`overrides\` are listed: every chart type it accepts, and the option groups each one themes. Those groups take the themeable subset of the corresponding chart options — see the [Options API reference](${optionsUrl}).`,
+        ],
+    });
+}
+
+/** One `AgChartTheme.overrides` entry with a reference page of its own. */
+export function buildThemesApiOverrideMarkdown({
+    reference,
+    pageInterface,
+    pageTitle,
+    title,
+    siteRoot,
+}: {
+    reference: ApiReferenceType;
+    pageInterface: string;
+    pageTitle: PageTitle;
+    title: string;
+    siteRoot?: string;
+}): string {
+    return buildApiReferenceMarkdown({
+        reference,
+        pageInterface,
+        heading: apiReferencePageHeading(pageTitle),
+        title,
+        description: THEMES_API_PAGE_CONTENT.description,
+        sections: [
+            `Part of the [AG Charts Themes API reference](${toAbsoluteUrl(urlWithBaseUrl('/themes-api/'), siteRoot)}).`,
+        ],
+    });
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildChartsLandingPageMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildChartsLandingPageMarkdown.test.ts
@@ -1,0 +1,126 @@
+// cspell:ignore whats
+import { describe, expect, it } from 'vitest';
+
+import angularCharts from '../../content/landing-pages/angular-charts.json';
+import enterpriseCharts from '../../content/landing-pages/enterprise-charts.json';
+import javascriptCharts from '../../content/landing-pages/javascript-charts.json';
+import reactCharts from '../../content/landing-pages/react-charts.json';
+import vueCharts from '../../content/landing-pages/vue-charts.json';
+import versionsData from '../../content/versions/ag-charts-versions.json';
+import type { ChartsLandingPageContent } from './buildChartsLandingPageMarkdown';
+import { buildChartsLandingPageMarkdown } from './buildChartsLandingPageMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+// The real content the pages render, so a section type added to a landing page without a matching
+// branch in the builder shows up as missing output rather than as a silent gap.
+const PAGES: Array<[string, ChartsLandingPageContent]> = [
+    ['javascript-charts', javascriptCharts as ChartsLandingPageContent],
+    ['react-charts', reactCharts as ChartsLandingPageContent],
+    ['angular-charts', angularCharts as ChartsLandingPageContent],
+    ['vue-charts', vueCharts as ChartsLandingPageContent],
+    ['enterprise-charts', enterpriseCharts as ChartsLandingPageContent],
+];
+
+const build = (content: ChartsLandingPageContent) =>
+    buildChartsLandingPageMarkdown({ content, versions: versionsData, siteRoot: SITE_ROOT });
+
+describe.each(PAGES)('buildChartsLandingPageMarkdown (%s)', (_slug, content) => {
+    const output = build(content);
+
+    it("emits frontmatter from the page's own meta, then the hero as H1", () => {
+        expect(output.startsWith('---\n')).toBe(true);
+        expect(output).toContain(`title: ${JSON.stringify(content.meta.title)}`);
+        expect(output).toContain(`description: ${JSON.stringify(content.meta.description)}`);
+        const hero = content.sections.find((section) => section.type === 'hero');
+        expect(hero).toBeDefined();
+        expect(output).toContain(`\n# `);
+    });
+
+    it('renders every non-hero section heading, in page order', () => {
+        const headings = content.sections
+            .filter((section) => section.type !== 'hero')
+            .map((section) => ('heading' in section ? section.heading : undefined))
+            .filter((heading): heading is string => heading != null);
+
+        expect(headings.length).toBeGreaterThan(0);
+        let cursor = 0;
+        for (const heading of headings) {
+            const index = output.indexOf(`## ${heading}`, cursor);
+            expect(index, `"${heading}" should appear after the preceding section`).toBeGreaterThan(-1);
+            cursor = index;
+        }
+    });
+
+    it('gives the install command for the page package', () => {
+        expect(output).toContain(`Install: \`npm install ${content.packageName}\``);
+    });
+
+    it('resolves every relative link to an absolute URL', () => {
+        const targets = [...output.matchAll(/\]\(([^)]+)\)/g)].map((match) => match[1]);
+        expect(targets.length).toBeGreaterThan(0);
+        for (const target of targets) {
+            expect(target, `${target} should be absolute`).toMatch(/^https?:\/\//);
+        }
+    });
+
+    it('ends with a single trailing newline', () => {
+        expect(output.endsWith('\n')).toBe(true);
+        expect(output.endsWith('\n\n')).toBe(false);
+    });
+});
+
+describe('buildChartsLandingPageMarkdown section rendering', () => {
+    const output = build(javascriptCharts as ChartsLandingPageContent);
+
+    it('lists feature-grid cards with their links and descriptions', () => {
+        expect(output).toContain(
+            '- **[Canvas-based Performance](https://www.ag-grid.com/javascript/large-dataset-interactivity/)** —'
+        );
+    });
+
+    it('lists chart types with the link each card points at', () => {
+        expect(output).toContain('- **[Area Charts](https://www.ag-grid.com/javascript/area-series/)** —');
+    });
+
+    it('fences the code example in its declared language, under its filename', () => {
+        expect(output).toContain('`revenueChart.js`');
+        expect(output).toContain("```js\nimport { AgCharts } from 'ag-charts-community';");
+    });
+
+    it("lists the same releases as the page's What's New section", () => {
+        const [latest] = versionsData.filter((version) => version.version.endsWith('.0'));
+        expect(output).toContain(`### [${latest.version}`);
+    });
+
+    it('links the hero gallery examples to their gallery pages', () => {
+        expect(output).toContain('- [Line](https://www.ag-grid.com/gallery/line-with-time-axis/)');
+    });
+
+    it('resolves FAQ answer links, which are framework-relative Markdoc', () => {
+        expect(output).toContain('## Frequently Asked Questions');
+        expect(output).toContain('[AG Charts Enterprise](https://www.ag-grid.com/license-pricing/)');
+    });
+});
+
+describe('buildChartsLandingPageMarkdown enterprise page', () => {
+    const output = build(enterpriseCharts as ChartsLandingPageContent);
+
+    it('renders the pricing cards with their features and CTA', () => {
+        const pricing = (enterpriseCharts as ChartsLandingPageContent).sections.find(
+            (section) => section.type === 'pricing'
+        );
+        expect(pricing).toBeDefined();
+        const [card] = pricing!.cards;
+        expect(output).toContain(`### ${card.title} — ${card.price}`);
+        expect(output).toContain(`- ${card.features[0]}`);
+    });
+
+    it('lists the map chart cards', () => {
+        const maps = (enterpriseCharts as ChartsLandingPageContent).sections.find(
+            (section) => section.type === 'map-charts'
+        );
+        expect(maps).toBeDefined();
+        expect(output).toContain(`- **${maps!.cards[0].title}** —`);
+    });
+});

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildChartsLandingPageMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildChartsLandingPageMarkdown.ts
@@ -1,0 +1,211 @@
+// cspell:ignore whats
+import type { HeroSection, LandingPageContent } from '@ag-website-shared/components/landing-pages/types';
+import { htmlInlineToMarkdown } from '@ag-website-shared/markdoc/htmlInlineToMarkdown';
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import type {
+    LandingPageVersion,
+    Resolve,
+} from '@ag-website-shared/markdown-pages/landing-pages/buildLandingPageMarkdown';
+import {
+    link,
+    sectionBody,
+    sectionHeader,
+} from '@ag-website-shared/markdown-pages/landing-pages/buildLandingPageMarkdown';
+import type {
+    ChartTypesShowcaseSection,
+    ChartsLandingPageSection,
+    CodeExampleSection,
+    FeatureGridSection,
+    MapChartsSection,
+    WhatsNewSection,
+} from '@components/landing-pages/types';
+import { getFrameworkFromInternalFramework } from '@utils/framework';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+
+import { type ReleaseVersion, latestReleasesMarkdown } from './latestReleasesMarkdown';
+
+/** The `landingPages` entry as this builder needs it: the shared shape, narrowed to charts sections. */
+export type ChartsLandingPageContent = Omit<LandingPageContent, 'sections'> & {
+    sections: ChartsLandingPageSection[];
+};
+
+export interface BuildChartsLandingPageMarkdownOptions {
+    content: ChartsLandingPageContent;
+    /** The `versions` collection, for the hero's version badge and the What's New section. */
+    versions?: Array<LandingPageVersion & ReleaseVersion>;
+    siteRoot?: string;
+}
+
+/** Default number of releases the What's New section lists, matching WhatsNewSection.astro. */
+const DEFAULT_VERSIONS_TO_SHOW = 3;
+
+/** A section's own call to action, as `LandingPageSection` renders it beneath the heading. */
+function ctaBlock(cta: { text: string; url: string } | undefined, resolve: Resolve, siteRoot?: string): string[] {
+    return cta ? [link(cta.text, cta.url, resolve, siteRoot)] : [];
+}
+
+function featureGridBody(section: FeatureGridSection, resolve: Resolve, siteRoot?: string): string[] {
+    // Each card is a link, so the title carries it; the section's own cta is not rendered by
+    // FeatureGridSection.astro, so it is not rendered here either.
+    return [
+        section.items
+            .map((item) => `- **${link(item.title, item.link, resolve, siteRoot)}** — ${item.description}`)
+            .join('\n'),
+    ];
+}
+
+function chartTypesShowcaseBody(section: ChartTypesShowcaseSection, resolve: Resolve, siteRoot?: string): string[] {
+    const items = section.items
+        .map((item) => {
+            // Not every card carries a link — the "And More..." card and the docs-example cards on
+            // the enterprise page have none, and the page renders those as unlinked cards.
+            const title = item.link ? link(item.title, item.link, resolve, siteRoot) : item.title;
+            return `- **${title}** — ${item.description}`;
+        })
+        .join('\n');
+    return [items, ...ctaBlock(section.cta, resolve, siteRoot)];
+}
+
+function codeExampleBody(section: CodeExampleSection): string[] {
+    const fileName = section.fileName ? `\`${section.fileName}\`` : undefined;
+    const fence = `\`\`\`${section.language ?? 'ts'}\n${section.code}\n\`\`\``;
+    return [fileName, fence].filter((part): part is string => part != null);
+}
+
+function mapChartsBody(section: MapChartsSection, resolve: Resolve, siteRoot?: string): string[] {
+    const cards = section.cards.map((card) => `- **${card.title}** — ${card.description}`).join('\n');
+    return [cards, ...ctaBlock(section.cta, resolve, siteRoot)];
+}
+
+function whatsNewBody(
+    section: WhatsNewSection,
+    versions: BuildChartsLandingPageMarkdownOptions['versions'],
+    resolve: Resolve,
+    siteRoot?: string
+): string[] {
+    const releases = versions
+        ? latestReleasesMarkdown({
+              versionsData: versions,
+              count: section.versionsToShow ?? DEFAULT_VERSIONS_TO_SHOW,
+          })
+        : '';
+    return [releases, ...ctaBlock(section.cta, resolve, siteRoot)].filter(Boolean);
+}
+
+/**
+ * Body of a charts-specific section. The sections shared with the other products fall through to
+ * the shared builder's own handling, so the two stay in step.
+ */
+function chartsSectionBody(
+    section: ChartsLandingPageSection,
+    versions: BuildChartsLandingPageMarkdownOptions['versions'],
+    resolve: Resolve,
+    resolveFaq: Resolve,
+    siteRoot?: string
+): string[] {
+    switch (section.type) {
+        case 'feature-grid':
+            return featureGridBody(section, resolve, siteRoot);
+        case 'chart-types-showcase':
+            return chartTypesShowcaseBody(section, resolve, siteRoot);
+        case 'code-example':
+            return codeExampleBody(section);
+        case 'map-charts':
+            return mapChartsBody(section, resolve, siteRoot);
+        case 'whats-new':
+            return whatsNewBody(section, versions, resolve, siteRoot);
+        // A live demo or a chart explorer on the page: no further prose, so the heading,
+        // subheading and CTA are the whole of their content here.
+        case 'performance-demo':
+        case 'financial-charts':
+        case 'chart-explorer':
+            return ctaBlock(section.cta, resolve, siteRoot);
+        // A chart grid or a carousel, with no CTA of its own — the heading and subheading the
+        // shared header already emitted are all they carry.
+        case 'interactive-demo':
+        case 'gallery-showcase':
+        case 'chart-types':
+            return [];
+        default:
+            return sectionBody(section, resolve, resolveFaq, siteRoot);
+    }
+}
+
+/**
+ * The hero, rendered as the document title. The page's auto-scrolling gallery becomes a list of the
+ * examples it cycles, each linked to its gallery page where one exists (a hero example with a
+ * `pageName` is a docs example and has no gallery URL).
+ */
+function heroBlock(
+    hero: HeroSection,
+    content: ChartsLandingPageContent,
+    versions: BuildChartsLandingPageMarkdownOptions['versions'],
+    siteRoot?: string
+): string[] {
+    const heading = hero.headingHtml ? htmlInlineToMarkdown(hero.headingHtml, siteRoot) : hero.heading;
+    const latestVersion = versions?.find((version) => version.landingPageHighlight);
+
+    const parts = [
+        `# ${heading}`,
+        hero.subHeadingHtml ? htmlInlineToMarkdown(hero.subHeadingHtml, siteRoot) : hero.subHeading,
+    ];
+    if (hero.showVersionBadge && latestVersion) {
+        parts.push(`**Latest version:** v${latestVersion.version} — ${latestVersion.landingPageHighlight}`);
+    }
+    if (content.packageName) {
+        parts.push(`Install: \`npm install ${content.packageName}\``);
+    }
+    if (hero.secondaryCta?.url) {
+        parts.push(link(hero.secondaryCta.text, hero.secondaryCta.url, urlWithBaseUrl, siteRoot));
+    }
+    if (hero.galleryExamples?.length) {
+        const examples = hero.galleryExamples.map(({ title, exampleName, pageName }) =>
+            pageName
+                ? `- ${title}`
+                : `- [${title}](${toAbsoluteUrl(urlWithBaseUrl(`/gallery/${exampleName}/`), siteRoot)})`
+        );
+        parts.push(examples.join('\n'));
+    }
+    return parts;
+}
+
+/**
+ * Build the markdown twin of an AG Charts landing page. Reads the same `landingPages` collection
+ * entry `LandingPage.astro` renders and walks the same `sections` union in the same order, so the
+ * two cannot drift. The interactive sections — live demos, the chart-type grid, the comparison
+ * table — reduce to their heading, subheading and CTA, which is all the prose they carry.
+ */
+export function buildChartsLandingPageMarkdown({
+    content,
+    versions,
+    siteRoot,
+}: BuildChartsLandingPageMarkdownOptions): string {
+    const framework = getFrameworkFromInternalFramework(content.internalFramework);
+    // Section CTAs, feature links and card links store './'-prefixed paths that ALREADY carry the
+    // framework segment, so they resolve the way the page resolves them — with the base-URL helper.
+    const resolveUrl: Resolve = urlWithBaseUrl;
+    // FAQ answers are Markdoc, rendered per-framework by renderFAQAnswers, so their links are
+    // framework-relative and need the prefixing helper to land on the right docs page.
+    const resolveFaqUrl: Resolve = (url) => urlWithPrefix({ framework, url });
+
+    const frontmatter = [
+        '---',
+        `title: ${JSON.stringify(content.meta.title)}`,
+        `description: ${JSON.stringify(content.meta.description)}`,
+        '---',
+    ].join('\n');
+
+    const hero = content.sections.find((section) => section.type === 'hero');
+    const intro = hero ? heroBlock(hero, content, versions, siteRoot) : [];
+
+    // The hero is rendered above as the page title; every other section keeps page order.
+    const body = content.sections
+        .filter((section) => section.type !== 'hero')
+        .flatMap((section) => [
+            ...sectionHeader(section, siteRoot),
+            ...chartsSectionBody(section, versions, resolveUrl, resolveFaqUrl, siteRoot),
+        ]);
+
+    return `${[frontmatter, ...intro, ...body].join('\n\n').trimEnd()}\n`;
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryExampleMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryExampleMarkdown.test.ts
@@ -1,0 +1,112 @@
+import { getGalleryExamples } from '@components/gallery/utils/filesData';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import galleryData from '../../content/gallery/data.json';
+import { buildGalleryExampleMarkdown, galleryExampleDescription } from './buildGalleryExampleMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+const DIST = join(__dirname, '../../../../../dist/packages/ag-charts-website');
+
+// The real gallery entries the pages render, so a chart type added without a docs page or a
+// mis-shaped entry shows up here rather than in a broken twin.
+const EXAMPLES = getGalleryExamples({ galleryData });
+
+const buildFor = (exampleName: string) => {
+    const entry = EXAMPLES.find((example) => example.exampleName === exampleName);
+    expect(entry, `${exampleName} should be in the gallery data`).toBeDefined();
+    const { page, prevExample, nextExampleOne, nextExampleTwo } = entry!;
+    return buildGalleryExampleMarkdown({
+        page,
+        exampleName,
+        neighbours: [prevExample, nextExampleOne, nextExampleTwo],
+        siteRoot: SITE_ROOT,
+    });
+};
+
+describe('buildGalleryExampleMarkdown', () => {
+    it('covers every gallery example the page fans out to', () => {
+        expect(EXAMPLES.length).toBeGreaterThan(100);
+        expect(new Set(EXAMPLES.map((example) => example.exampleName)).size).toBe(EXAMPLES.length);
+    });
+
+    it("emits frontmatter matching the page's title and description", async () => {
+        const output = await buildFor('simple-bar');
+        expect(output.startsWith('---\n')).toBe(true);
+        expect(output).toContain('title: "AG Charts Gallery: Bar Chart"');
+        expect(output).toContain(
+            `description: ${JSON.stringify(
+                galleryExampleDescription({
+                    title: 'Bar Chart',
+                    name: 'simple-bar',
+                    seriesTitle: 'Bar',
+                })
+            )}`
+        );
+        expect(output).toContain('\n# Bar Chart');
+    });
+
+    it('names the chart type and links its documentation page', async () => {
+        const output = await buildFor('simple-bar');
+        expect(output).toContain('Chart type: Bar');
+        expect(output).toContain('[View Bar Charts Documentation](https://www.ag-grid.com/javascript/bar-series/)');
+    });
+
+    it('flags an enterprise chart type, as the page does with its enterprise icon', async () => {
+        const output = await buildFor('simple-sunburst');
+        expect(output).toContain('Chart type: Sunburst (Enterprise)');
+    });
+
+    it('links the runnable example', async () => {
+        const output = await buildFor('simple-bar');
+        expect(output).toContain('[Run this example](https://www.ag-grid.com/gallery/examples/simple-bar/)');
+    });
+
+    it('links the three neighbouring examples the page links to', async () => {
+        const entry = EXAMPLES.find((example) => example.exampleName === 'simple-bar')!;
+        const output = await buildFor('simple-bar');
+        for (const neighbour of [entry.prevExample, entry.nextExampleOne, entry.nextExampleTwo]) {
+            expect(output).toContain(`- [${neighbour.title}](https://www.ag-grid.com/gallery/${neighbour.name}/)`);
+        }
+    });
+
+    it('ends with a single trailing newline', async () => {
+        const output = await buildFor('simple-bar');
+        expect(output.endsWith('\n')).toBe(true);
+        expect(output.endsWith('\n\n')).toBe(false);
+    });
+});
+
+// The example source is read from the `generate-examples` output, which the unit-test target does
+// not build — so it is asserted against the twins a real build emitted instead. Requires
+// `nx build ag-charts-website`; skipped otherwise so unit runs stay fast.
+describe.runIf(existsSync(join(DIST, 'gallery/simple-bar.md')))('the built gallery twins', () => {
+    const builtTwin = (exampleName: string) => readFileSync(join(DIST, `gallery/${exampleName}.md`), 'utf8');
+
+    it('inlines the example source with the generator harness stripped', () => {
+        const output = builtTwin('simple-bar');
+        expect(output).toContain('## Source');
+        expect(output).toContain('```js\n');
+        expect(output).toContain('AgCharts.create(options)');
+        // The dark-mode and e2e-theme harness the generator injects must not leak through.
+        expect(output).not.toContain('DARK MODE START');
+        expect(output).not.toContain('E2E THEME START');
+    });
+
+    it('links the data module the source reads rather than inlining it', () => {
+        expect(builtTwin('simple-bar')).toContain('/gallery/examples/simple-bar/data.js)');
+    });
+
+    it('leaves the bulky data out of the twin itself', () => {
+        // This example's data module alone is ~60KB of coordinates; the twin must not carry it.
+        expect(builtTwin('scatter-with-large-data').length).toBeLessThan(20_000);
+    });
+
+    it('emits a twin for every gallery example the page fans out to', () => {
+        const missing = EXAMPLES.filter(({ exampleName }) => !existsSync(join(DIST, `gallery/${exampleName}.md`))).map(
+            ({ exampleName }) => exampleName
+        );
+        expect(missing).toEqual([]);
+    });
+});

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryExampleMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryExampleMarkdown.ts
@@ -1,0 +1,112 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { getGeneratedContents } from '@components/example-generator';
+import { stripOutExampleGeneratorCode } from '@components/example-runner/components/stripOutExampleGeneratorCode';
+import { getExampleFileUrl, getExampleUrl, getPageUrl } from '@components/gallery/utils/urlPaths';
+import { toTitle } from '@utils/toTitle';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
+import GithubSlugger from 'github-slugger';
+
+/** A gallery example as `getGalleryExamples` hands it to the page (and to this builder). */
+export interface GalleryExamplePage {
+    title: string;
+    name: string;
+    seriesTitle: string;
+    /** Docs page for the chart type. Absent for series whose docs page follows the default slug. */
+    seriesLink?: string;
+    enterprise?: boolean;
+}
+
+/** A neighbouring example, as the page's "More from the charts gallery" links render it. */
+export interface GalleryExampleNeighbour {
+    title: string;
+    name: string;
+}
+
+export interface BuildGalleryExampleMarkdownOptions {
+    page: GalleryExamplePage;
+    exampleName: string;
+    /** The three neighbours the page links to, in page order. */
+    neighbours: GalleryExampleNeighbour[];
+    siteRoot?: string;
+}
+
+/**
+ * The page's meta description, shared with `gallery/[pageName].astro` so the twin's frontmatter
+ * matches the page's own metadata.
+ */
+export function galleryExampleDescription(page: GalleryExamplePage): string {
+    return `Example of a ${page.title} Chart built with AG Charts JavaScript Charting Library. Edit source code with CodeSandbox & Plunker. View JavaScript ${toTitle(page.seriesTitle)} Charts documentation for more info.`;
+}
+
+/** Matches GallerySeriesLink: an explicit `seriesLink`, else the chart type's default docs slug. */
+function seriesDocsUrl(page: GalleryExamplePage): string {
+    const slugger = new GithubSlugger();
+    const url = page.seriesLink ?? `./${slugger.slug(page.seriesTitle)}-series`;
+    return urlWithPrefix({ url, framework: 'javascript' });
+}
+
+/**
+ * Build the markdown twin of a `/gallery/<example>` page. Reads the same gallery entry the page
+ * renders and the same generated example the page's code viewer shows — the vanilla build, with the
+ * generator's dark-mode and e2e harness stripped, as on the page.
+ *
+ * The chart itself is a live iframe on the page; here it is the example's own source, which is what
+ * a reader without a browser needs. Data and topology files are linked rather than inlined: several
+ * run to tens of kilobytes of raw coordinates and say nothing about how the chart is configured.
+ */
+export async function buildGalleryExampleMarkdown({
+    page,
+    exampleName,
+    neighbours,
+    siteRoot,
+}: BuildGalleryExampleMarkdownOptions): Promise<string> {
+    const contents = await getGeneratedContents({ type: 'gallery', exampleName });
+
+    const document: string[] = [
+        [
+            '---',
+            `title: ${JSON.stringify(`AG Charts Gallery: ${page.title}`)}`,
+            `description: ${JSON.stringify(galleryExampleDescription(page))}`,
+            '---',
+        ].join('\n'),
+        `# ${page.title}`,
+    ];
+
+    const chartType = page.enterprise ? `${page.seriesTitle} (Enterprise)` : page.seriesTitle;
+    document.push(`Chart type: ${chartType}`);
+    document.push(
+        `[View ${toTitle(page.seriesTitle)} Charts Documentation](${toAbsoluteUrl(seriesDocsUrl(page), siteRoot)})`
+    );
+    // `getExampleUrl` omits the trailing slash the site serves the page on.
+    document.push(`[Run this example](${toAbsoluteUrl(`${getExampleUrl({ exampleName })}/`, siteRoot)})`);
+
+    const entryFileName = contents?.entryFileName;
+    if (entryFileName && contents?.files?.[entryFileName]) {
+        const files = { ...contents.files };
+        stripOutExampleGeneratorCode(files);
+        document.push('## Source', `\`\`\`js\n${files[entryFileName].trim()}\n\`\`\``);
+
+        // Data and topology modules the source imports, linked to the files the example serves.
+        const dataFiles = Object.keys(contents.files).filter(
+            (fileName) => fileName !== entryFileName && fileName.endsWith('.js')
+        );
+        if (dataFiles.length) {
+            const links = dataFiles
+                .map(
+                    (fileName) =>
+                        `- [${fileName}](${toAbsoluteUrl(getExampleFileUrl({ exampleName, fileName }), siteRoot)})`
+                )
+                .join('\n');
+            document.push('The source above reads its data from:', links);
+        }
+    }
+
+    if (neighbours.length) {
+        const links = neighbours
+            .map(({ title, name }) => `- [${title}](${toAbsoluteUrl(getPageUrl(name), siteRoot)})`)
+            .join('\n');
+        document.push('## More from the charts gallery', links);
+    }
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.ts
@@ -1,14 +1,12 @@
-import whatsNewData from '@ag-website-shared/content/whats-new/data.json';
 import { htmlInlineToMarkdown } from '@ag-website-shared/markdoc/htmlInlineToMarkdown';
 import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
-import { parseVersion } from '@ag-website-shared/utils/parseVersion';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 import faqData from '../../content/faqs/homepage.json';
 import homepage from '../../content/homepage/homepage.json';
 import versionsData from '../../content/versions/ag-charts-versions.json';
+import { latestReleasesMarkdown } from './latestReleasesMarkdown';
 
-const { blogPrefix } = whatsNewData['charts'];
 const NUM_LATEST_RELEASES = 3;
 
 interface HomepageCta {
@@ -50,15 +48,6 @@ interface FaqItem {
     question: string;
     answer: string;
 }
-interface VersionHighlight {
-    text: string;
-}
-interface VersionEntry {
-    version: string;
-    date?: string;
-    highlights?: VersionHighlight[];
-}
-
 function ctaLink(title: string, url: string, siteRoot?: string): string {
     return `[${title}](${toAbsoluteUrl(urlWithBaseUrl(url), siteRoot)})`;
 }
@@ -89,27 +78,9 @@ function integratedBlock(section: HomepageSections['integrated'], siteRoot?: str
     return [`## ${section.heading}`, htmlInlineToMarkdown(section.subHeadingHtml, siteRoot)].join('\n\n');
 }
 
-// Mirror index.astro: keep the `.0` releases, take the three most recent that have
-// highlights, and build each blog URL from the parsed version and the charts blog prefix.
-function latestReleasesBlock(): string {
-    const releases = (versionsData as VersionEntry[])
-        .filter((version) => version.version.endsWith('.0'))
-        .slice(0, NUM_LATEST_RELEASES)
-        .filter((version) => version.highlights);
-
-    return releases
-        .map((version) => {
-            const { major, minor } = parseVersion(version.version);
-            const blogUrl = `${minor ? `${blogPrefix}${major}-${minor}` : `${blogPrefix}${major}`}/`;
-            const date = version.date ? ` — ${version.date}` : '';
-            const highlights = version.highlights!.map((highlight) => `- ${highlight.text}`).join('\n');
-            return `### [${version.version}${date}](${blogUrl})\n\n${highlights}`;
-        })
-        .join('\n\n');
-}
-
 function releasesBlock(section: HomepageSections['releases'], siteRoot?: string): string {
-    return [ctaSectionBlock(section, siteRoot), latestReleasesBlock()].join('\n\n');
+    const releases = latestReleasesMarkdown({ versionsData, count: NUM_LATEST_RELEASES });
+    return [ctaSectionBlock(section, siteRoot), releases].join('\n\n');
 }
 
 function faqsBlock(section: HomepageSections['faqs']): string {

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildSessionMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildSessionMarkdown.test.ts
@@ -1,0 +1,50 @@
+import { SESSIONS, sessionSlug } from '@utils/beyondThePromptSessions';
+import { describe, expect, it } from 'vitest';
+
+import { buildSessionMarkdown, sessionDescription } from './buildSessionMarkdown';
+
+const SITE_ROOT = 'https://www.ag-grid.com/';
+
+// The same filter the page's getStaticPaths applies: only recorded sessions get a page.
+const RECORDED = SESSIONS.filter((session) => session.youtubeUrl);
+
+describe('buildSessionMarkdown', () => {
+    it('covers every recorded session', () => {
+        expect(RECORDED.length).toBeGreaterThan(0);
+        expect(new Set(RECORDED.map((session) => sessionSlug(session.title))).size).toBe(RECORDED.length);
+    });
+
+    describe.each(RECORDED.map((session) => [sessionSlug(session.title), session] as const))('%s', (_slug, session) => {
+        const output = buildSessionMarkdown({ session, siteRoot: SITE_ROOT });
+
+        it('emits frontmatter matching the page title and description, then the session as H1', () => {
+            expect(output).toContain(`title: ${JSON.stringify(`${session.title} | Beyond the Prompt`)}`);
+            expect(output).toContain(`description: ${JSON.stringify(sessionDescription(session))}`);
+            expect(output).toContain(`# ${session.title}`);
+        });
+
+        it('links the recording and the parent Beyond the Prompt page', () => {
+            expect(output).toContain(`[Watch the recording](${session.youtubeUrl})`);
+            expect(output).toContain('https://www.ag-grid.com/community/beyond-the-prompt/');
+        });
+
+        it('ends with a single trailing newline', () => {
+            expect(output.endsWith('\n')).toBe(true);
+            expect(output.endsWith('\n\n')).toBe(false);
+        });
+    });
+
+    it('lists the speakers with their roles, as the page does', () => {
+        const withSpeakers = RECORDED.find((session) => session.speakers?.length);
+        expect(withSpeakers).toBeDefined();
+        const output = buildSessionMarkdown({ session: withSpeakers!, siteRoot: SITE_ROOT });
+        const speaker = withSpeakers!.speakers![0];
+        expect(output).toContain(`${speaker.name} (${speaker.role})`);
+    });
+
+    it('falls back to a generated description when the session has none', () => {
+        expect(sessionDescription({ title: 'A Talk' })).toBe(
+            'Watch "A Talk" from Beyond the Prompt, the AG Grid and Bryntum conference.'
+        );
+    });
+});

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildSessionMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildSessionMarkdown.ts
@@ -1,0 +1,49 @@
+import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import type { Session } from '@utils/beyondThePromptSessions';
+import { sessionDurationMins } from '@utils/beyondThePromptSessions';
+import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
+
+/** The page's description fallback, shared so the twin's frontmatter matches the page's meta. */
+export function sessionDescription(session: Session): string {
+    return (
+        session.description ?? `Watch "${session.title}" from Beyond the Prompt, the AG Grid and Bryntum conference.`
+    );
+}
+
+/**
+ * Build the markdown twin of a `/session/<slug>` recording page. Reads the same `SESSIONS` entry
+ * the page renders, so title, speakers, description and recording link cannot drift. The page's
+ * embedded YouTube player becomes a plain link to the recording — the closest markdown can get.
+ */
+export function buildSessionMarkdown({ session, siteRoot }: { session: Session; siteRoot?: string }): string {
+    const description = sessionDescription(session);
+    const durationMins = sessionDurationMins(session);
+
+    const document: string[] = [
+        [
+            '---',
+            `title: ${JSON.stringify(`${session.title} | Beyond the Prompt`)}`,
+            `description: ${JSON.stringify(description)}`,
+            '---',
+        ].join('\n'),
+        `# ${session.title}`,
+    ];
+
+    if (session.speakers?.length) {
+        document.push(session.speakers.map((speaker) => `${speaker.name} (${speaker.role})`).join(', '));
+    }
+    if (durationMins != null) {
+        document.push(`Duration: ${durationMins} minutes`);
+    }
+    if (session.youtubeUrl) {
+        document.push(`[Watch the recording](${session.youtubeUrl})`);
+    }
+    if (session.description) {
+        document.push(session.description);
+    }
+    document.push(
+        `[← Back to Beyond the Prompt](${toAbsoluteUrl(urlWithBaseUrl('/community/beyond-the-prompt/'), siteRoot)})`
+    );
+
+    return `${document.join('\n\n').trimEnd()}\n`;
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/landingPageMarkdownResponse.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/landingPageMarkdownResponse.ts
@@ -1,0 +1,32 @@
+import { DISABLE_MARKDOWN_DOCS, SITE_URL } from '@constants';
+import { getEntry } from 'astro:content';
+
+import { buildChartsLandingPageMarkdown } from './buildChartsLandingPageMarkdown';
+
+/**
+ * Shared body of the landing-page `.md` endpoints. Every landing page renders through the same
+ * `LandingPage.astro` template from its `landingPages` collection entry, so its markdown twin is
+ * the same builder over the same entry — only the slug differs.
+ */
+export async function landingPageMarkdownResponse(slug: string): Promise<Response> {
+    if (DISABLE_MARKDOWN_DOCS) {
+        return new Response(null, { status: 404 });
+    }
+
+    const contentEntry = await getEntry('landingPages', slug);
+    if (!contentEntry) {
+        return new Response(null, { status: 404 });
+    }
+    const versionsEntry = await getEntry('versions', 'ag-charts-versions');
+
+    const markdown = buildChartsLandingPageMarkdown({
+        content: contentEntry.data,
+        versions: versionsEntry?.data,
+        siteRoot: SITE_URL,
+    });
+
+    return new Response(markdown, {
+        status: 200,
+        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/latestReleasesMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/latestReleasesMarkdown.ts
@@ -1,0 +1,40 @@
+import whatsNewData from '@ag-website-shared/content/whats-new/data.json';
+import { parseVersion } from '@ag-website-shared/utils/parseVersion';
+
+const { blogPrefix } = whatsNewData['charts'];
+
+export interface ReleaseVersion {
+    version: string;
+    date?: string;
+    highlights?: Array<{ text: string }>;
+}
+
+export interface LatestReleasesOptions {
+    /** The `versions` collection, newest first, as the pages receive it. */
+    versionsData: ReleaseVersion[];
+    /** How many feature releases to list — the page's own cap. */
+    count: number;
+}
+
+/**
+ * The latest feature releases as markdown: a heading per version linking its release blog, then its
+ * highlights as bullets.
+ *
+ * Mirrors how both the homepage and the landing pages' What's New section pick versions — `.0`
+ * releases only, newest first, capped, and only those carrying highlights — and how they derive the
+ * blog URL from the parsed version, so the twins show the same releases as the pages.
+ */
+export function latestReleasesMarkdown({ versionsData, count }: LatestReleasesOptions): string {
+    return versionsData
+        .filter((version) => version.version.endsWith('.0'))
+        .slice(0, count)
+        .filter((version) => version.highlights)
+        .map((version) => {
+            const { major, minor } = parseVersion(version.version);
+            const blogUrl = `${minor ? `${blogPrefix}${major}-${minor}` : `${blogPrefix}${major}`}/`;
+            const date = version.date ? ` — ${version.date}` : '';
+            const highlights = version.highlights!.map((highlight) => `- ${highlight.text}`).join('\n');
+            return `### [${version.version}${date}](${blogUrl})\n\n${highlights}`;
+        })
+        .join('\n\n');
+}

--- a/packages/ag-charts-website/src/utils/markdown-pages/sitemapPageContent.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/sitemapPageContent.ts
@@ -1,0 +1,9 @@
+/**
+ * Metadata for the HTML sitemap page, shared between `sitemap.astro` and its markdown twin
+ * (`/sitemap.md`) so the title, description and heading cannot drift between the two renderings.
+ */
+export const SITEMAP_PAGE_CONTENT = {
+    title: 'Sitemap | AG Charts',
+    description: 'The AG Charts sitemap. Contains links to every page on the site, including docs.',
+    heading: 'Sitemap',
+} as const;

--- a/packages/ag-charts-website/src/utils/markdownPages.test.ts
+++ b/packages/ag-charts-website/src/utils/markdownPages.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { CHARTS_MARKDOWN_PAGE_GROUPS, markdownPathAlternation, markdownPathPatterns } from './markdownPages';
+
+const DIST = join(__dirname, '../../../../dist/packages/ag-charts-website');
+const SITEMAP = join(DIST, 'sitemap-0.xml');
+
+// The ambient test env has no site base, so the patterns anchor at `/` and are matched below
+// against base-relative paths.
+const patterns = markdownPathPatterns();
+const isNegotiable = (pathname: string) => patterns.some((pattern) => pattern.test(pathname));
+
+describe('CHARTS_MARKDOWN_PAGE_GROUPS', () => {
+    it('produces patterns valid in both JavaScript and Apache PCRE', () => {
+        // The alternation is embedded in a RewriteCond and an <If> expression, so it must avoid
+        // constructs PCRE lacks or that would break the `m#...#` delimiters.
+        const alternation = markdownPathAlternation();
+        expect(() => new RegExp(`^/(${alternation})/?$`)).not.toThrow();
+        expect(alternation).not.toContain('#');
+        expect(alternation).not.toMatch(/\(\?<[=!]/); // lookbehind
+        expect(alternation).not.toMatch(/\(\?<[A-Za-z]/); // named groups
+    });
+
+    it('never matches a .md URL, so negotiation cannot loop into .md.md', () => {
+        expect(isNegotiable('/react/axes-types.md')).toBe(false);
+        expect(isNegotiable('/roadmap.md')).toBe(false);
+        expect(isNegotiable('/gallery/simple-bar.md')).toBe(false);
+        expect(isNegotiable('/session/opening-keynote.md')).toBe(false);
+    });
+
+    it('documents every group, so the registry reads as the list it is', () => {
+        for (const group of CHARTS_MARKDOWN_PAGE_GROUPS) {
+            expect(group.describes, JSON.stringify(group)).toBeTruthy();
+        }
+    });
+});
+
+/**
+ * The Options and Themes API reference. Both render client-side from the generated interface
+ * reference, so a twin would need a markdown rendering of that whole tree — a separate piece of
+ * work, and the one documented gap in the "every sitemap URL has a twin" rule (`llms.txt` and
+ * `AGENTS.md` say so explicitly).
+ */
+const isApiReferencePage = (pathname: string) => /\/(?:options|themes-api)(?:\/|$)/.test(pathname);
+
+/**
+ * Twins generated on production by grid's Jira cron (`scripts/jira/production/getCharts*` in the
+ * ag-grid repo) rather than by this build, so they are absent from a local `dist` by design. Their
+ * pages advertise the `.md` only in production for the same reason.
+ */
+const CRON_GENERATED_TWINS = ['/changelog/', '/pipeline/'];
+
+function builtSitemapPaths(): string[] {
+    if (!existsSync(SITEMAP)) {
+        return [];
+    }
+    return [...readFileSync(SITEMAP, 'utf8').matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+        (match) => new URL(match[1]).pathname
+    );
+}
+
+// Gate on a *complete* build: an absent dist (a plain unit run) or a half-written one (a build in
+// flight) skips rather than fails, since neither says anything about page coverage. The site has
+// ~750 pages, so this threshold cannot be met by a partial build of the non-docs pages alone.
+const sitemapPaths = builtSitemapPaths();
+const hasCompleteBuild = sitemapPaths.length > 500;
+
+// The site is served under a base (`/charts`), which the sitemap carries but `dist` does not — the
+// dist root *is* that base. The site root is the shortest path in any sitemap, so it gives the base
+// without depending on the env the build ran under.
+const sitemapBase = hasCompleteBuild
+    ? sitemapPaths.reduce((shortest, path) => (path.length < shortest.length ? path : shortest)).replace(/\/$/, '')
+    : '';
+const baseRelative = (pathname: string) => pathname.slice(sitemapBase.length) || '/';
+
+// The invariant this whole feature rests on: an agent can append `.md` to any URL in the sitemap.
+// Requires a build (`nx build ag-charts-website`); skipped otherwise so unit runs stay fast.
+describe.runIf(hasCompleteBuild)('every sitemap URL has a .md twin in dist', () => {
+    const missing = sitemapPaths.filter((pathname) => {
+        const trimmed = baseRelative(pathname).replace(/\/$/, '');
+        // The homepage twin is index.md — the site root has no segment to suffix.
+        const twin = trimmed === '' ? 'index.md' : `${trimmed.slice(1)}.md`;
+        return !existsSync(join(DIST, twin));
+    });
+
+    // Guard against a vacuous pass: if filtering ever empties the set, the assertions below would
+    // hold trivially and the check would silently stop protecting anything.
+    it('checks a full sitemap', () => {
+        expect(sitemapPaths.length).toBeGreaterThan(500);
+        expect(sitemapBase).toBe('/charts');
+    });
+
+    it('emits a .md file next to every page, bar the documented exceptions', () => {
+        const unexplained = missing.filter(
+            (pathname) => !isApiReferencePage(pathname) && !CRON_GENERATED_TWINS.includes(baseRelative(pathname))
+        );
+        expect(unexplained, `${unexplained.length} sitemap URLs have no .md twin`).toEqual([]);
+    });
+
+    it('routes every page with a twin through the negotiation patterns', () => {
+        // A twin that exists on disk but is not in the registry would never be served on
+        // `Accept: text/markdown`, so the two must agree.
+        const unroutable = sitemapPaths
+            .map(baseRelative)
+            .filter((pathname) => pathname !== '/' && !isApiReferencePage(pathname) && !isNegotiable(pathname));
+        expect(unroutable, `${unroutable.length} pages have a twin but no negotiation rule`).toEqual([]);
+    });
+
+    it('keeps the API reference exclusion honest — it is still in the sitemap and still untwinned', () => {
+        // If the reference gains twins, this fails and `isApiReferencePage` must go, rather than
+        // quietly staying as a place real gaps could hide.
+        const apiPages = sitemapPaths.filter(isApiReferencePage);
+        expect(apiPages.length).toBeGreaterThan(50);
+        expect(missing.filter(isApiReferencePage)).toEqual(apiPages);
+    });
+
+    it('keeps the cron-generated exclusion free of stale entries', () => {
+        for (const pathname of CRON_GENERATED_TWINS) {
+            expect(sitemapPaths.map(baseRelative), `${pathname} is no longer in the sitemap`).toContain(pathname);
+        }
+    });
+
+    it('leaves the contact result pages out of the sitemap entirely', () => {
+        // Post-submission confirmations: robots-disallowed, so listing them would contradict
+        // robots.txt. They have no twin by design (see sitemap.ts).
+        const relative = sitemapPaths.map(baseRelative);
+        expect(relative).not.toContain('/contact/success/');
+        expect(relative).not.toContain('/contact/failure/');
+        expect(relative).toContain('/contact/');
+    });
+});

--- a/packages/ag-charts-website/src/utils/markdownPages.test.ts
+++ b/packages/ag-charts-website/src/utils/markdownPages.test.ts
@@ -38,14 +38,6 @@ describe('CHARTS_MARKDOWN_PAGE_GROUPS', () => {
 });
 
 /**
- * The Options and Themes API reference. Both render client-side from the generated interface
- * reference, so a twin would need a markdown rendering of that whole tree — a separate piece of
- * work, and the one documented gap in the "every sitemap URL has a twin" rule (`llms.txt` and
- * `AGENTS.md` say so explicitly).
- */
-const isApiReferencePage = (pathname: string) => /\/(?:options|themes-api)(?:\/|$)/.test(pathname);
-
-/**
  * Twins generated on production by grid's Jira cron (`scripts/jira/production/getCharts*` in the
  * ag-grid repo) rather than by this build, so they are absent from a local `dist` by design. Their
  * pages advertise the `.md` only in production for the same reason.
@@ -92,10 +84,8 @@ describe.runIf(hasCompleteBuild)('every sitemap URL has a .md twin in dist', () 
         expect(sitemapBase).toBe('/charts');
     });
 
-    it('emits a .md file next to every page, bar the documented exceptions', () => {
-        const unexplained = missing.filter(
-            (pathname) => !isApiReferencePage(pathname) && !CRON_GENERATED_TWINS.includes(baseRelative(pathname))
-        );
+    it('emits a .md file next to every page, bar the documented exception', () => {
+        const unexplained = missing.filter((pathname) => !CRON_GENERATED_TWINS.includes(baseRelative(pathname)));
         expect(unexplained, `${unexplained.length} sitemap URLs have no .md twin`).toEqual([]);
     });
 
@@ -104,16 +94,35 @@ describe.runIf(hasCompleteBuild)('every sitemap URL has a .md twin in dist', () 
         // `Accept: text/markdown`, so the two must agree.
         const unroutable = sitemapPaths
             .map(baseRelative)
-            .filter((pathname) => pathname !== '/' && !isApiReferencePage(pathname) && !isNegotiable(pathname));
+            .filter((pathname) => pathname !== '/' && !isNegotiable(pathname));
         expect(unroutable, `${unroutable.length} pages have a twin but no negotiation rule`).toEqual([]);
     });
 
-    it('keeps the API reference exclusion honest — it is still in the sitemap and still untwinned', () => {
-        // If the reference gains twins, this fails and `isApiReferencePage` must go, rather than
-        // quietly staying as a place real gaps could hide.
-        const apiPages = sitemapPaths.filter(isApiReferencePage);
-        expect(apiPages.length).toBeGreaterThan(50);
-        expect(missing.filter(isApiReferencePage)).toEqual(apiPages);
+    describe('the API reference twins', () => {
+        // These fan out from the generated interface reference rather than from a content
+        // collection, so a change to the generator can drop them from the build — or, since the
+        // builders degrade to an empty table rather than throwing, reduce them to a stub with
+        // frontmatter and no properties. Only a built twin can show either.
+        const apiPages = sitemapPaths.filter((pathname) => /\/(?:options|themes-api)(?:\/|$)/.test(pathname));
+        const twinBody = (path: string) =>
+            readFileSync(join(DIST, `${baseRelative(path).replace(/^\/|\/$/g, '')}.md`), 'utf8');
+        const propertyRows = (body: string) =>
+            body.split('\n').filter((line) => line.startsWith('| ') && !line.startsWith('| --- ')).length - 1;
+
+        it('covers every reference page in the sitemap', () => {
+            expect(apiPages.length).toBeGreaterThan(50);
+            expect(missing.filter((pathname) => apiPages.includes(pathname))).toEqual([]);
+        });
+
+        it('carries a populated property table on every one, not an empty shell', () => {
+            const empty = apiPages.filter((pathname) => propertyRows(twinBody(pathname)) < 1);
+            expect(empty, `${empty.length} reference twins have no properties`).toEqual([]);
+        });
+
+        it('resolves the root interfaces the two references hang off', () => {
+            expect(twinBody('/charts/options/')).toContain('Interface: `AgChartOptions`');
+            expect(twinBody('/charts/themes-api/')).toContain('Interface: `AgChartTheme`');
+        });
     });
 
     it('keeps the cron-generated exclusion free of stale entries', () => {

--- a/packages/ag-charts-website/src/utils/markdownPages.ts
+++ b/packages/ag-charts-website/src/utils/markdownPages.ts
@@ -1,0 +1,75 @@
+// Type-only import: erased at runtime, so this module stays loadable under plain node (the
+// htaccess test harness runs it through `tsx`, where the shared subrepo resolves as CJS).
+import type { MarkdownPageGroup } from '../../../../external/ag-website-shared/src/markdown-pages/markdownPageRegistry';
+import { FRAMEWORKS, SITE_BASE_URL } from '../constants';
+
+/**
+ * Every AG Charts page that ships a markdown (`.md`) twin, declared once.
+ *
+ * Derives the dev-server negotiation patterns, the Apache rewrite rule and the Apache
+ * `Vary: Accept` scope — see `@ag-website-shared/markdown-pages/markdownPageRegistry` for the
+ * pattern-syntax constraints (the patterns are compiled by both JavaScript and PCRE).
+ *
+ * The invariant this list serves: **every URL in the sitemap has a `.md` twin**. It is enforced
+ * by the post-build check in `markdownPages.test.ts`, so a new page added without a twin fails
+ * rather than silently 404ing for agents. Pages excluded from the sitemap (example runners,
+ * `debug/*`, redirect stubs, the contact result pages) are correspondingly absent here.
+ *
+ * Imported by the dev-server Vite plugin, which is bundled with `astro.config.mjs` and so
+ * resolves without tsconfig path aliases — hence the relative import above.
+ */
+export const CHARTS_MARKDOWN_PAGE_GROUPS: MarkdownPageGroup[] = [
+    {
+        describes: 'The homepage. Negotiated by a dedicated rule: its twin is index.md, not <path>.md.',
+    },
+    {
+        describes: 'Every docs page, once per framework — the bulk of the twins.',
+        pattern: `(?:${FRAMEWORKS.join('|')})/[^/.]+`,
+    },
+    {
+        describes: 'Top-level content pages.',
+        pattern: 'changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new',
+    },
+    {
+        describes: 'The community landing page and its subpages.',
+        pattern: 'community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?',
+    },
+    {
+        describes: 'Beyond the Prompt conference session recordings.',
+        pattern: 'session/[^/.]+',
+    },
+    {
+        describes: 'The gallery landing page and every gallery example.',
+        pattern: 'gallery(?:/[^/.]+)?',
+    },
+    {
+        describes: 'SEO landing pages, all rendered from the landingPages collection.',
+        pattern: '(?:angular|enterprise|javascript|react|vue)-charts',
+    },
+];
+
+function patternedGroups(): string[] {
+    return CHARTS_MARKDOWN_PAGE_GROUPS.map((group) => group.pattern).filter(
+        (pattern): pattern is string => pattern != null && pattern.length > 0
+    );
+}
+
+/**
+ * Alternation fragment for embedding in an anchored Apache regex, e.g. `^/(<alternation>)/?$`.
+ * Base-free: charts is served under `SITE_BASE_URL`, and the htaccess rules splice that in
+ * themselves because the rewrite has to capture it (see `getMarkdownNegotiationRules`).
+ */
+export function markdownPathAlternation(): string {
+    return patternedGroups().join('|');
+}
+
+/**
+ * Anchored JavaScript regexes, one per group, for the dev-server negotiation plugin and the
+ * coverage check. Matched against a full request pathname, which carries the base, so the base
+ * is anchored in. A trailing slash is optional so both `/charts/gallery` and `/charts/gallery/`
+ * negotiate.
+ */
+export function markdownPathPatterns(): RegExp[] {
+    const basePath = (SITE_BASE_URL ?? '').replace(/\/$/, '');
+    return patternedGroups().map((pattern) => new RegExp(`^${basePath}/(?:${pattern})/?$`));
+}

--- a/packages/ag-charts-website/src/utils/markdownPages.ts
+++ b/packages/ag-charts-website/src/utils/markdownPages.ts
@@ -46,6 +46,16 @@ export const CHARTS_MARKDOWN_PAGE_GROUPS: MarkdownPageGroup[] = [
         describes: 'SEO landing pages, all rendered from the landingPages collection.',
         pattern: '(?:angular|enterprise|javascript|react|vue)-charts',
     },
+    {
+        // The member paths mirror the ones getOptionsStaticPaths fans out over; a fifth added there
+        // without a pattern here fails the coverage check rather than silently losing negotiation.
+        describes: 'The Options API reference and the union variants with a page of their own.',
+        pattern: 'options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?',
+    },
+    {
+        describes: 'The Themes API reference and its per-override pages.',
+        pattern: 'themes-api(?:/overrides/[^/.]+)?',
+    },
 ];
 
 function patternedGroups(): string[] {

--- a/packages/ag-charts-website/src/utils/sitemap.ts
+++ b/packages/ag-charts-website/src/utils/sitemap.ts
@@ -41,7 +41,14 @@ const isRedirectPage = (page: string) => {
  * Exclude specific pages
  */
 const isNonPublicContent = (page: string) => {
-    return page.endsWith('/style-guide/');
+    return (
+        page.endsWith('/style-guide/') ||
+        // Post-submission confirmation pages. They carry no content a searcher or an agent can use,
+        // and they are disallowed in robots.txt (see getSitemapIgnorePaths), so listing them in the
+        // sitemap contradicts it and Search Console reports "submitted URL blocked by robots.txt".
+        page.endsWith('/contact/failure/') ||
+        page.endsWith('/contact/success/')
+    );
 };
 
 /*

--- a/packages/ag-charts-website/src/utils/sitemapPages.ts
+++ b/packages/ag-charts-website/src/utils/sitemapPages.ts
@@ -48,6 +48,9 @@ const getIgnoredPages = () => {
         addTrailingSlash(urlWithBaseUrl(`/${FRAMEWORK_REDIRECT_PATH}`)),
         // Release note stubs — minimal content, crawl waste
         addTrailingSlash(urlWithBaseUrl('/changelog/releases')),
+        // Contact form result pages — post-submission confirmations, nothing to index
+        addTrailingSlash(urlWithBaseUrl('/contact/failure')),
+        addTrailingSlash(urlWithBaseUrl('/contact/success')),
     ];
 };
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17912
https://ag-grid.atlassian.net/browse/SE-62

Ports three merged `latest` PRs to the release branch, cherry-picked in their original order:

| | | |
| --- | --- | --- |
| #7761 | `AG-17912` | Markdown twins for the remaining 132 sitemap pages |
| #7469 | `SE-62` | Server-rendered top-level content on the `/options/` API reference pages |
| #7783 | `AG-17912` | Markdown twins for the 77 API reference pages |

Together they make the "every sitemap URL has a `.md` twin" invariant hold on this branch.

## Port fidelity

All three are squash commits on `latest`, so each cherry-picked as a single commit — **no conflicts, no manual resolution**. Diffing every file the three PRs touched against `origin/latest` leaves five, and each difference is pre-existing divergence between `b14.1.0` and `latest` rather than anything the port dropped:

- `htaccessRules.test.ts.snap` — CSP only (`esm.sh`, script hashes, the SystemJS comment). The markdown negotiation rules merged in correctly.
- `LinkIcon.tsx` — a `tabIndex` added on `latest`.
- `ApiReference.tsx` — `getVariantDiscriminator` was hoisted into `apiReferenceHelpers` on `latest`; it is still file-local here.
- `OptionsNavigation.tsx`, `e2e/api-ref-page.spec.ts` — unrelated `latest` work.

One thing worth knowing for review: `getOptionsStaticPaths` on this branch inlines its own `extractTypeValue` rather than calling `getVariantDiscriminator`, but returns the same `{ params, props }` shape, so the new `.md.ts` routes and the markdown builder work against it unchanged.

## Verification on this branch

Not assumed from `latest` — rebuilt and re-run here, after deleting the website `dist` so no artefact from the other branch could mask a gap.

- `nx build ag-charts-website` — **exit 0**, 1027 tasks
- **757 sitemap URLs, 1017 `.md` files; probing every sitemap URL for a `.md` sibling leaves exactly `/changelog/` and `/pipeline/`** — the two whose twins production's Jira cron generates rather than this build
- `nx test ag-charts-website` — **643 pass, 0 fail** (fewer tests than `latest` because the intervening feature work is not on this branch)
- `nx lint ag-charts-website` — clean (9 pre-existing warnings) · `nx format` clean
- API reference twins built as expected: 75 variant pages, `options.md` 88 KB / 646 rows, `themes-api.md` 160 KB / 1409 rows, `options/series/bar.md` 218 rows
- `llms.txt` and `AGENTS.md` carry no "exception" wording

`nx test:e2e ag-charts-website` has not been run — no Docker in this environment.