### PR TITLE
Fix nav entry for Development Validation docs page

### DIFF
--- a/packages/ag-charts-website/src/content/docs-nav/nav.json
+++ b/packages/ag-charts-website/src/content/docs-nav/nav.json
@@ -39,6 +39,11 @@
                         },
                         {
                             "type": "item",
+                            "title": "Development Validation",
+                            "path": "dev-validation"
+                        },
+                        {
+                            "type": "item",
                             "title": "Migration",
                             "path": "migration"
                         },
@@ -376,11 +381,6 @@
                             "type": "item",
                             "title": "Overlays",
                             "path": "overlays"
-                        },
-                        {
-                            "type": "item",
-                            "title": "Dev-Time Validation",
-                            "path": "dev-validation"
                         },
                         {
                             "type": "item",


### PR DESCRIPTION
Fixes the docs nav entry left over from moving the dev-time validation overlay docs to their own page: the item was pointing at the old Overlays location and duplicated, instead of sitting under Development Validation's new location.