### PR TITLE
AG-3390 Add staging and report-only configurations to the website preview:csp target

### DIFF
--- a/packages/ag-charts-website/project.json
+++ b/packages/ag-charts-website/project.json
@@ -88,6 +88,12 @@
       "command": "tsx scripts/csp/preview-csp.ts --port=${PORT}",
       "options": {
         "cwd": "packages/ag-charts-website"
+      },
+      "configurations": {
+        "staging": { "args": "--env staging" },
+        "production": { "args": "--env production" },
+        "report-only": { "args": "--mode report-only" },
+        "staging-report-only": { "args": "--env staging --mode report-only" }
       }
     },
     "lint:eslint": {},

--- a/packages/ag-charts-website/scripts/csp/preview-csp.ts
+++ b/packages/ag-charts-website/scripts/csp/preview-csp.ts
@@ -33,7 +33,25 @@ import { EXAMPLES_PATH_REGEXP, getCspHeaderName, getCspValue } from '../../src/u
  *
  * Usage (run after a build; defaults to the enforced production policy):
  *   nx run ag-charts-website:preview:csp
+ *   nx run ag-charts-website:preview:csp:staging              (staging policy, enforced)
+ *   nx run ag-charts-website:preview:csp:report-only          (production policy, report-only)
+ *   nx run ag-charts-website:preview:csp:staging-report-only
  *   tsx packages/ag-charts-website/scripts/csp/preview-csp.ts [--env=...] [--mode=...] [--port=...] [--base=...] [--no-https]
+ *
+ * Those configurations select the POLICY only (which CspEnv getCspValue is built for — the
+ * envs differ in their trial-licence and Salesforce form origins). They deliberately do NOT
+ * change which build is served: `dependsOn` builds the default config, so PUBLIC_SITE_URL
+ * stays https://localhost:4601 and PUBLIC_BASE_URL stays /charts, and the example runner
+ * keeps working.
+ *
+ * A staging/production BUILD is a separate axis and cannot be served faithfully from
+ * localhost — those configurations bake their remote origin into the output and flip
+ * PUBLIC_BASE_URL to / (see .env.build.staging), so absolute-URL fetches leave localhost and
+ * the examples-scope connect-src 'self' blocks them. If you need one regardless, build it
+ * explicitly and then invoke this script directly rather than through the target, so
+ * `dependsOn` does not rebuild the default variant over it — and pass the matching --base:
+ *   nx build ag-charts-website --configuration=staging
+ *   cd packages/ag-charts-website && tsx scripts/csp/preview-csp.ts --env staging --base=/
  *
  * Port: defaults to 4601 to match PUBLIC_SITE_URL baked into a local build
  * (.env.build → https://localhost:4601). The example runner fetches its modules


### PR DESCRIPTION
Port of ag-grid#14821 to Charts.

## What

`preview:csp` only ever served the **enforced production** policy, so validating the staging policy — or serving either policy in report-only form — meant invoking the script by hand.

`preview-csp.ts` already parsed `--env` and `--mode`; this just exposes them as nx configurations, following the same `{"args": ...}` shape `generate-csp` already uses in the same file.

```bash
yarn nx run ag-charts-website:preview:csp                      # production, enforce (unchanged default)
yarn nx run ag-charts-website:preview:csp:staging              # staging policy, enforced
yarn nx run ag-charts-website:preview:csp:report-only          # production policy, report-only
yarn nx run ag-charts-website:preview:csp:staging-report-only
```

The environments genuinely differ — staging resolves to `us-central1-stripe-testing-19784.cloudfunctions.net` and `test.salesforce.com`, production to the live equivalents.

This is arguably worth more on Charts than on Grid: Charts **staging enforces** the `site` scope (`PRODUCTION_CSP_PHASE`/`htaccessRules.ts`), so there is no report-only grace period and a stale hash or stray inline script breaks staging immediately. Being able to serve the staging policy locally is the only way to catch that first.

## Policy only, not the build

The configurations select the **policy**, deliberately not the build. `dependsOn` still builds the default config, so `PUBLIC_SITE_URL` stays `https://localhost:4601`, `PUBLIC_BASE_URL` stays `/charts`, and the example runner keeps working.

A staging/production *build* served from localhost would be self-defeating: those configurations bake their remote origin into the output **and flip `PUBLIC_BASE_URL` to `/`**, so absolute-URL fetches leave localhost and the examples-scope `connect-src 'self'` blocks them — violations that are artefacts of the origin mismatch rather than of the policy. That stays an explicit two-step, documented in the usage comment along with the matching `--base`.

## Testing

- `yarn nx run ag-charts-website:generate-csp --configuration=staging|production` confirms the two envs emit different origins, so `--env` is meaningful.
- `nx show project ag-charts-website` lists all four configurations.
- `yarn nx lint ag-charts-website` passes; no behaviour change to the default target.