### PR TITLE
AG-17613 Fix `coordinates` on context menu click

### DIFF
--- a/libraries/ag-charts-test/src/caster.ts
+++ b/libraries/ag-charts-test/src/caster.ts
@@ -152,7 +152,7 @@ export class Caster<T> {
     // so unlike accessProperty() this does not assert that the property exists.
     accessNullableProperty<K extends string>(propertyName: K): Caster<unknown> {
         if (this.value == null) {
-            return this as Caster<unknown>;
+            return this;
         }
         return new Caster((this.value as Record<K, unknown>)[propertyName]);
     }

--- a/libraries/ag-charts-test/src/caster.ts
+++ b/libraries/ag-charts-test/src/caster.ts
@@ -78,6 +78,13 @@ export class Caster<T> {
         return convert<CtorReturnType<C>>(this);
     }
 
+    castNullable<C extends AnyCtor>(ctor: C) {
+        if (this.value != null) {
+            expect(this.value).toBeInstanceOf(ctor);
+        }
+        return convert<CtorReturnType<C> | undefined>(this);
+    }
+
     findProperty<K extends string>(propertyName: K) {
         type NewT = Omit<T, K> & { [P in K]: unknown };
         expect(this.value).toHaveProperty(propertyName);
@@ -139,6 +146,15 @@ export class Caster<T> {
     accessProperty<K extends string>(propertyName: K): Caster<unknown> {
         const property = this.findProperty(propertyName).value[propertyName];
         return new Caster(property);
+    }
+
+    // Like foo?.myProp?.myNestedProp — a nullish receiver and an absent property both yield undefined,
+    // so unlike accessProperty() this does not assert that the property exists.
+    accessNullableProperty<K extends string>(propertyName: K): Caster<unknown> {
+        if (this.value == null) {
+            return this as Caster<unknown>;
+        }
+        return new Caster((this.value as Record<K, unknown>)[propertyName]);
     }
 
     assertNonNullish() {

--- a/libraries/ag-charts-test/src/caster.ts
+++ b/libraries/ag-charts-test/src/caster.ts
@@ -146,6 +146,11 @@ export class Caster<T> {
         expect(this.value).not.toBeNull();
         return convert<NonNullable<T>>(this);
     }
+
+    callProperty<K extends keyof T>(propertyName: K) {
+        expect(this.value[propertyName]).toEqual(expect.any(Function));
+        return new Caster<unknown>((this.value[propertyName] as () => void)());
+    }
 }
 
 export function classCast<C extends AnyCtor>(value: unknown, ctor: C) {

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1236,7 +1236,14 @@ export abstract class Axis<
     }
 
     pickValue(point: CurrentPoint): AxisValuePick | undefined {
-        const position = this.isVertical() ? point.currentY : point.currentX;
+        // `point` is relative to the axis proxy region, which is sized to the whole axis group — line,
+        // ticks, labels and title — so its origin sits before the axis origin by the label overhang.
+        // Shift into axis-local space before consulting the scale or the rendered ticks.
+        const region = this.getCanvasBounds();
+        const origin = this.getLayoutTranslation();
+        const position = this.isVertical()
+            ? point.currentY + region.y - origin.y
+            : point.currentX + region.x - origin.x;
 
         const value = unsafeInvert(this.scale, position);
         const domain = unsafeDomain(this.scale);

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -78,6 +78,21 @@ import type { TickInterval } from './axisTick';
 import { type AxisGroupDatumTranslation, NiceMode } from './axisUtil';
 import type { AnyTimeInterval } from './generateTicksUtils';
 
+/**
+ * One tick's pickable extent, in axis-local coordinates, paired with the `value` and `index` the axis
+ * handed the label formatter for it.
+ *
+ * `along` is the extent in scale space. `cross` is the distance range from the axis line, and is only
+ * needed by axes that stack ticks into rows outwards from it (see `GroupedCategoryAxis`); leaving it
+ * undefined means the tick spans the axis perpendicular to its direction, which is the single-row case.
+ */
+export interface AxisPickDatum {
+    readonly index: number;
+    readonly value: AgAxisValue;
+    readonly along: readonly [number, number];
+    readonly cross?: readonly [number, number];
+}
+
 export interface LabelNodeDatum extends TextSizeProperties, TextBoxingProperties {
     color?: CssColor;
     tickId: string;
@@ -235,12 +250,14 @@ export abstract class Axis<
     private allowNull = false;
 
     /**
-     * Rendered-tick positions captured by the tick-layout pass, used by {@link pickValue}
-     * to resolve a click position to a tick index. Populated by subclasses that generate
-     * ticks (see `CartesianAxis`); left empty by axes that do not, in which case no tick
-     * index can be resolved.
+     * The pickable extent of every tick the axis generated, captured at the point where the axis hands
+     * that tick to the label formatter — so a pick and the formatter report the same `value` and `index`
+     * by construction rather than by two computations agreeing.
+     *
+     * Populated by subclasses that generate ticks (see `CartesianAxis` and `GroupedCategoryAxis`); left
+     * empty by axes that do not, in which case no index can be resolved.
      */
-    private pickTickData: { readonly index: number; readonly translation: number }[] = [];
+    private pickTickData: AxisPickDatum[] = [];
 
     readonly caption = new Caption();
 
@@ -1130,6 +1147,11 @@ export abstract class Axis<
         return this.translation;
     }
 
+    /** Whether the scale interpolates between ticks, rather than mapping each tick to a discrete band. */
+    protected get continuous(): boolean {
+        return ContinuousScale.is(this.scale) || DiscreteTimeScale.is(this.scale);
+    }
+
     getLayoutState(): AxisLayout {
         return {
             id: this.id,
@@ -1175,7 +1197,7 @@ export abstract class Axis<
             axisType: this.type,
             scale: this.scale,
             direction: this.direction,
-            continuous: ContinuousScale.is(scale) || DiscreteTimeScale.is(scale),
+            continuous: this.continuous,
             // A getter, not a snapshot: `applyOptions` swaps the options reference on update, so
             // listeners added or removed by a later `chart.update()` must be picked up.
             get listeners() {
@@ -1241,17 +1263,25 @@ export abstract class Axis<
         // Shift into axis-local space before consulting the scale or the rendered ticks.
         const region = this.getCanvasBounds();
         const origin = this.getLayoutTranslation();
-        const position = this.isVertical()
-            ? point.currentY + region.y - origin.y
-            : point.currentX + region.x - origin.x;
+        const localX = point.currentX + region.x - origin.x;
+        const localY = point.currentY + region.y - origin.y;
+        const vertical = this.isVertical();
+        const position = vertical ? localY : localX;
+        // Ticks stack outwards from the axis line, so only the distance from it selects a row.
+        const crossPosition = Math.abs(vertical ? localX : localY);
 
-        const value = unsafeInvert(this.scale, position);
+        const scaleValue = unsafeInvert(this.scale, position);
         const domain = unsafeDomain(this.scale);
-        if (value == null || domain == null) {
+        if (scaleValue == null || domain == null) {
             return undefined;
         }
 
-        const index = this.resolveTickIndex(position);
+        const picked = this.resolvePickDatum(position, crossPosition);
+        const index = picked?.index ?? -1;
+        // On a continuous axis `value` is the position under the pointer, so it is read from the scale
+        // rather than the tick. On a discrete axis the two agree, and taking it from the tick is what
+        // keeps `value` and `index` describing the same thing.
+        const value = this.continuous || picked == null ? scaleValue : picked.value;
 
         // Dynamically extract properties of `AgContextMenuGetItemsParamsAxis` that are not present in the base
         // `AgContextMenuGetItemsParamsAlways` (and also add `caller` so that we can run the context-menu callbacks
@@ -1272,34 +1302,51 @@ export abstract class Axis<
     }
 
     protected setPickTickData(
-        ticks: readonly { readonly index: number; readonly translation: number }[],
+        ticks: readonly { readonly index: number; readonly translation: number; readonly tick?: unknown }[],
         firstTickIndex = 0
     ): void {
         // A picked value's index must match what the axis label formatter reports for the same tick. The
         // formatter numbers ticks by their 0-based position among the generated ticks, whereas TickDatum.index
         // is the absolute index (offset by firstTickIndex on reversed/zoomed axes), so subtract it here.
-        this.pickTickData = ticks.map(({ index, translation }) => ({ index: index - firstTickIndex, translation }));
+        // These ticks occupy a single row, so they span the axis in the perpendicular direction.
+        this.pickTickData = ticks.map(({ index, translation, tick }) => ({
+            index: index - firstTickIndex,
+            value: tick as AgAxisValue,
+            along: [translation, translation] as const,
+        }));
+    }
+
+    protected setPickData(data: AxisPickDatum[]): void {
+        this.pickTickData = data;
     }
 
     /**
-     * Resolve a click position to the index of the nearest rendered tick, clamping
-     * out-of-range positions to the closest end tick. Returns -1 when no ticks are
-     * available (e.g. an axis with labels, ticks and grid lines all disabled).
+     * Resolve a pick position to the tick occupying it. `along` is the axis-local coordinate in scale
+     * space; `cross` is the distance from the axis line, which selects between rows on axes that stack
+     * ticks outwards (see `GroupedCategoryAxis`). Within the candidate row the containing tick wins,
+     * falling back to the nearest one so out-of-range positions clamp to an end tick.
+     *
+     * Returns undefined when the axis generated no ticks, e.g. one with labels, ticks and grid lines
+     * all disabled.
      */
-    private resolveTickIndex(position: number): number {
-        const ticks = this.pickTickData;
-        if (ticks.length === 0) return -1;
+    private resolvePickDatum(along: number, cross: number): AxisPickDatum | undefined {
+        let nearest: AxisPickDatum | undefined;
+        let nearestDistance = Infinity;
 
-        let nearestIndex = ticks[0].index;
-        let nearestDistance = Math.abs(ticks[0].translation - position);
-        for (let i = 1; i < ticks.length; i++) {
-            const distance = Math.abs(ticks[i].translation - position);
+        for (const datum of this.pickTickData) {
+            if (datum.cross != null && (cross < datum.cross[0] || cross > datum.cross[1])) continue;
+
+            const [start, end] = datum.along;
+            if (along >= start && along <= end) return datum;
+
+            const distance = along < start ? start - along : along - end;
             if (distance < nearestDistance) {
                 nearestDistance = distance;
-                nearestIndex = ticks[i].index;
+                nearest = datum;
             }
         }
-        return nearestIndex;
+
+        return nearest;
     }
 
     pickBand(point: Point): AxisBandDatum | undefined {

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -3,8 +3,8 @@ import type {
     AxisPluginModuleInstance,
     Callback,
     CallbackParam,
+    CanvasPoint,
     ChartAnimationPhase,
-    CurrentPoint,
     DomainWithMetadata,
     DynamicContext,
     Normalised,
@@ -1248,14 +1248,13 @@ export abstract class Axis<
         };
     }
 
-    pickValue(point: CurrentPoint): AxisValuePick | undefined {
-        // `point` is relative to the axis proxy region, which is sized to the whole axis group — line,
-        // ticks, labels and title — so its origin sits before the axis origin by the label overhang.
-        // Shift into axis-local space before consulting the scale or the rendered ticks.
-        const region = this.getCanvasBounds();
+    pickValue(point: CanvasPoint): AxisValuePick | undefined {
+        // Canvas space is the only frame every caller shares: the axis proxy region, the series area and
+        // the series rect each sit at their own offset within it. Taking canvas coordinates means the
+        // conversion to axis-local space happens here, once, instead of each caller guessing at it.
         const origin = this.getLayoutTranslation();
-        const localX = point.currentX + region.x - origin.x;
-        const localY = point.currentY + region.y - origin.y;
+        const localX = point.canvasX - origin.x;
+        const localY = point.canvasY - origin.y;
         const vertical = this.isVertical();
         const position = vertical ? localY : localX;
         // Ticks stack outwards from the axis line, so only the distance from it selects a row.

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -78,14 +78,6 @@ import type { TickInterval } from './axisTick';
 import { type AxisGroupDatumTranslation, NiceMode } from './axisUtil';
 import type { AnyTimeInterval } from './generateTicksUtils';
 
-/**
- * One tick's pickable extent, in axis-local coordinates, paired with the `value` and `index` the axis
- * handed the label formatter for it.
- *
- * `along` is the extent in scale space. `cross` is the distance range from the axis line, and is only
- * needed by axes that stack ticks into rows outwards from it (see `GroupedCategoryAxis`); leaving it
- * undefined means the tick spans the axis perpendicular to its direction, which is the single-row case.
- */
 export interface AxisPickDatum {
     readonly index: number;
     readonly value: AgAxisValue;
@@ -249,14 +241,13 @@ export abstract class Axis<
     dataDomain: { domain: D[]; clipped: boolean } = { domain: [], clipped: false };
     private allowNull = false;
 
-    /**
-     * The pickable extent of every tick the axis generated, captured at the point where the axis hands
-     * that tick to the label formatter — so a pick and the formatter report the same `value` and `index`
-     * by construction rather than by two computations agreeing.
-     *
-     * Populated by subclasses that generate ticks (see `CartesianAxis` and `GroupedCategoryAxis`); left
-     * empty by axes that do not, in which case no index can be resolved.
-     */
+    // This is the meta-data about the screen-positioning of the ticks on our axis. It's usually a 1-dimensional scale
+    // value (`along`), but can optionally be 2-dimensional (`cross`, e.g. the "Depth" in grouped category axes). This
+    // is the single-source-of-truth for callbacks that need to broadcast information about the axis and its ticks
+    // (e.g. label.formatter or axis click handlers).
+    //
+    // This must live separately from the scene-graph LabelNodeDatum. This is because label-less axes can still be
+    // interacted with, but they do not include any text nodes in the scene-graph.
     private pickTickData: AxisPickDatum[] = [];
 
     readonly caption = new Caption();

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.test.ts
@@ -1524,8 +1524,9 @@ describe('CartesianAxis', () => {
             expect(yAxis).toBeDefined();
             expect(formatterIndexByValue.size).toBeGreaterThan(0);
 
+            const { x, y } = yAxis.getLayoutTranslation();
             for (const [value, formatterIndex] of formatterIndexByValue) {
-                const pick = yAxis.pickValue({ currentX: 0, currentY: yAxis.scale.convert(value) });
+                const pick = yAxis.pickValue({ canvasX: x, canvasY: y + yAxis.scale.convert(value) });
                 expect(pick).toBeDefined();
                 expect(pick.index).toBe(formatterIndex);
             }

--- a/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/groupedCategoryAxis.ts
@@ -27,7 +27,7 @@ import { Transformable } from '../../scene/transformable';
 import type { AxisPrimaryTickCount } from '../../util/secondaryAxisTicks';
 import type { ChartLayout } from '../chartAxis';
 import { createDatumId } from '../data/processors';
-import type { LabelNodeDatum } from './axis';
+import type { AxisPickDatum, LabelNodeDatum } from './axis';
 import { getAxisLabelSideFlag } from './axisLabelUtil';
 import type { GridLineStyleTickDatum } from './cartesianAxis';
 import { CategoryAxis } from './categoryAxis';
@@ -157,6 +157,7 @@ export class GroupedCategoryAxis extends CategoryAxis<
         this.tickTreeLayout?.resize(this.scale.range, this.scale.step, this.scale.inset, this.scale.bandwidth);
 
         if (!this.tickTreeLayout?.depth) {
+            this.setPickData([]);
             return { bbox: BBox.zero, spacing: 0, tickSizeAtDepth: [], tickLabelLayout: [] };
         }
 
@@ -177,6 +178,7 @@ export class GroupedCategoryAxis extends CategoryAxis<
         type LabelCacheEntry = { text: any; styles: any; truncatedText: string | undefined };
         const labelDataCache = new Map<number, LabelCacheEntry>();
         const depthLabelMaxSize: Record<number, number> = {};
+        const pickIdentities: (Omit<AxisPickDatum, 'cross'> & { depth: number })[] = [];
         for (const [index, datum] of treeLabels.entries()) {
             const depth = maxDepth - datum.depth;
             depthLabelMaxSize[depth] ??= 0;
@@ -189,6 +191,16 @@ export class GroupedCategoryAxis extends CategoryAxis<
             if (maxWidth < MIN_CATEGORY_SPACING) continue;
 
             const inputText = tickFormatter(datum.label, index - 1);
+            // Capture the pick identity here, at the one place this axis decides what `value` and `index`
+            // a tick has, so a click cannot disagree with the formatter. The perpendicular extent is not
+            // known until the row sizes below have been summed, so it is filled in afterwards.
+            const alongHalfWidth = ((datum.leafCount || 1) * step) / 2;
+            pickIdentities.push({
+                index: index - 1,
+                value: datum.label ?? '',
+                along: [datum.screen - alongHalfWidth, datum.screen + alongHalfWidth],
+                depth,
+            });
             let text = inputText;
             const labelStyles = this.getLabelStyles(
                 { value: datum.index, formattedValue: text, depth },
@@ -252,6 +264,19 @@ export class GroupedCategoryAxis extends CategoryAxis<
             spacingSum += optionsMap[d]?.spacing ?? 0;
             tickSizeAtDepth[d] = labelSum + spacingSum;
         }
+
+        // Each depth occupies one row stacked outwards from the axis line, bounded by the cumulative
+        // sizes above. The outermost row runs to infinity so that clicks beyond the labels — on the axis
+        // title, say — still resolve to the group they sit under rather than to no tick at all.
+        this.setPickData(
+            pickIdentities.map(({ depth, ...identity }) => ({
+                ...identity,
+                cross: [
+                    depth === 0 ? 0 : tickSizeAtDepth[depth - 1],
+                    depth === maxDepth - 1 ? Infinity : tickSizeAtDepth[depth],
+                ] as const,
+            }))
+        );
 
         // Second pass: position labels using cached data
         const idGenerator = createIdsGenerator();

--- a/packages/ag-charts-community/src/chart/cartesianChart.ts
+++ b/packages/ag-charts-community/src/chart/cartesianChart.ts
@@ -1,13 +1,5 @@
-import type { CanvasPoint, CurrentPoint, ModuleInstance, RequireOptional, Size } from 'ag-charts-core';
-import {
-    ActionOnSet,
-    ChartAxisDirection,
-    clampArray,
-    entries,
-    fromPairs,
-    groupBy,
-    toCurrentPoint,
-} from 'ag-charts-core';
+import type { CanvasPoint, ModuleInstance, RequireOptional, Size } from 'ag-charts-core';
+import { ActionOnSet, ChartAxisDirection, clampArray, entries, fromPairs, groupBy } from 'ag-charts-core';
 import type { AgCartesianAxisPosition, AgCoordinates } from 'ag-charts-types';
 
 import type { ChartOptions } from '../module/optionsModule';
@@ -90,9 +82,8 @@ export class CartesianChart extends Chart {
 
     override toAgCoordinates(point: CanvasPoint): AgCoordinates {
         const result: AgCoordinates = {};
-        const seriesPoint: CurrentPoint = toCurrentPoint(point, this.seriesRect);
         for (const axis of this.axes) {
-            const pick = axis.pickValue(seriesPoint);
+            const pick = axis.pickValue(point);
             if (pick) {
                 // `Rules` serves as a compile-time check to ensure that we're correctly broadcasting objects that match
                 // the AgAxisCoordinates shape in the API:

--- a/packages/ag-charts-community/src/chart/test/findTarget.ts
+++ b/packages/ag-charts-community/src/chart/test/findTarget.ts
@@ -1,4 +1,4 @@
-import type { CanvasPoint } from 'ag-charts-core';
+import type { BoxBounds, CanvasPoint } from 'ag-charts-core';
 import { boxContains } from 'ag-charts-core';
 import { CANVAS_HEIGHT, CANVAS_WIDTH, Caster, type MockEvent, makeMockEvent } from 'ag-charts-test';
 
@@ -7,6 +7,7 @@ import { TranslatableGroup } from '../../scene/group';
 import { Node } from '../../scene/node';
 import { Selection } from '../../scene/selection';
 import { Transformable } from '../../scene/transformable';
+import { AxisWidget } from '../../widget/axisWidget';
 import { ListWidget } from '../../widget/listWidget';
 import { NativeWidget } from '../../widget/nativeWidget';
 import { SliderWidget } from '../../widget/sliderWidget';
@@ -19,45 +20,56 @@ import { LegendDOMProxy } from '../legend/legendDOMProxy';
 import { LegendMarkerLabel } from '../legend/legendMarkerLabel';
 import { SeriesAreaManager } from '../series/seriesAreaManager';
 
-function initBoundingClientRect(widgets: WidgetSet) {
-    // getBoundingClientRect doesn't work correctly in node.js, but it's used in some parts of ag-charts.
-    const canvasBounds = (): DOMRect => {
+/**
+ * getBoundingClientRect doesn't work correctly in node.js, but it's used in some parts of ag-charts.
+ * `bounds` is read on every call so the stub tracks re-layouts the way the real DOM would.
+ */
+function stubBoundingClientRect(element: HTMLElement, bounds: () => BoxBounds) {
+    (element as any)['getBoundingClientRect'] = (): DOMRect => {
+        const { x, y, width, height } = bounds();
         return {
-            bottom: 0,
-            left: 0,
-            right: 0,
-            top: 0,
-            x: 0,
-            y: 0,
-            height: CANVAS_HEIGHT,
-            width: CANVAS_WIDTH,
-            toJSON() {
-                return `{bottom:0,left:0,right:0,top:0,x:0,y:0,height:${CANVAS_HEIGHT},width:${CANVAS_WIDTH}}`;
-            },
-        };
-    };
-    const seriesBounds = (): DOMRect => {
-        const left = widgets.seriesWidget.cssLeft();
-        const top = widgets.seriesWidget.cssTop();
-        const height = widgets.seriesWidget.cssHeight();
-        const width = widgets.seriesWidget.cssWidth();
-        return {
-            bottom: 0,
-            left,
-            right: 0,
-            top,
-            x: left,
-            y: top,
-            height,
+            x,
+            y,
             width,
+            height,
+            left: x,
+            top: y,
+            right: x + width,
+            bottom: y + height,
             toJSON() {
-                return `{bottom:0,left:${left},right:0,top:${top},x:${left},y:${top},height:${height},width:${width}}`;
+                return `{x:${x},y:${y},width:${width},height:${height}}`;
             },
         };
     };
-    (widgets.chartWidget.getElement() as any)['getBoundingClientRect'] = canvasBounds;
-    (widgets.containerWidget.getElement() as any)['getBoundingClientRect'] = canvasBounds;
-    (widgets.seriesWidget.getElement() as any)['getBoundingClientRect'] = seriesBounds;
+}
+
+function axisRegionWidgets(widgetSet: WidgetSet): AxisWidget[] {
+    const entries = new Caster(widgetSet.axisWidgets).accessProperty('entries').cast(Map).value;
+    const result: AxisWidget[] = [];
+    for (const entry of entries.values()) {
+        const widget = new Caster(entry).accessNullableProperty('region').castNullable(AxisWidget).value;
+        if (widget != null) {
+            result.push(widget);
+        }
+    }
+    return result;
+}
+
+function initBoundingClientRect(widgets: WidgetSet) {
+    const canvasBounds = () => ({ x: 0, y: 0, width: CANVAS_WIDTH, height: CANVAS_HEIGHT });
+    const cssBounds = (widget: Widget) => () => ({
+        x: widget.cssLeft(),
+        y: widget.cssTop(),
+        width: widget.cssWidth(),
+        height: widget.cssHeight(),
+    });
+
+    stubBoundingClientRect(widgets.chartWidget.getElement(), canvasBounds);
+    stubBoundingClientRect(widgets.containerWidget.getElement(), canvasBounds);
+    stubBoundingClientRect(widgets.seriesWidget.getElement(), cssBounds(widgets.seriesWidget));
+    for (const axisWidget of axisRegionWidgets(widgets)) {
+        stubBoundingClientRect(axisWidget.getElement(), () => axisWidget.getBounds());
+    }
 }
 
 function isClickable(widget: Widget | undefined): widget is Widget {

--- a/packages/ag-charts-community/src/chart/test/findTarget.ts
+++ b/packages/ag-charts-community/src/chart/test/findTarget.ts
@@ -141,12 +141,16 @@ function findZoomTarget(
 ): MockEvent | undefined {
     if (zoomModule === undefined) return undefined;
 
-    const caster = new Caster(zoomModule);
-    const zoom = caster.accessProperty('opts').findBoolean('enabled').findBoolean('enableAxisDragging').value;
+    const zoomCaster = new Caster(zoomModule);
+    const zoom = zoomCaster.accessProperty('opts').findBoolean('enabled').findBoolean('enableAxisDragging').value;
+    const hasZooming: boolean = zoom.enabled && zoom.enableAxisDragging;
 
     const axisDOMProxyCaster = new Caster(axisDOMProxyModule);
+    const hasClickListeners: boolean = !!axisDOMProxyCaster
+        .findProperty('hasClickListeners')
+        .callProperty('hasClickListeners').value;
 
-    if (zoom.enabled && zoom.enableAxisDragging) {
+    if (hasZooming || hasClickListeners) {
         const domProxy = axisDOMProxyCaster
             .findProperty('axes')
             .castProperty('axes', Array)

--- a/packages/ag-charts-community/src/module/axisContext.ts
+++ b/packages/ag-charts-community/src/module/axisContext.ts
@@ -1,8 +1,8 @@
 import type {
     AxisID,
     BoxBounds,
+    CanvasPoint,
     ChartAxisDirection,
-    CurrentPoint,
     NormalisedTextOrSegments,
     Point,
     Scale,
@@ -107,8 +107,8 @@ export interface AxisContext {
     attachAxisOverlay(group: Group, slot: 'low' | 'mid' | 'high'): void;
     inRange(value: number, tolerance?: number): boolean;
     getRangeOverflow(value: number): number;
-    /** Pick the scale value at a current-point (click/contextmenu events), relative to axis-dom-proxy HTML element */
-    pickValue(point: CurrentPoint): AxisValuePick | undefined;
+    /** Pick the scale value at a canvas point (click/contextmenu events). */
+    pickValue(point: CanvasPoint): AxisValuePick | undefined;
     pickBand(point: Point): AxisBandDatum | undefined;
     measureBand(value: string): AxisBandMeasurement | undefined;
     /** Defined only on polar axes; cartesian axes leave it undefined. */

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -24,8 +24,7 @@ describe('AxisDOMProxy', () => {
         chart?.destroy();
     });
 
-    // FIXME: See AG-9808 TC1
-    describe.skip('horizontal grouped-category clicks', () => {
+    describe('horizontal grouped-category clicks', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: [
@@ -117,8 +116,7 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    // FIXME: See AG-9808 TC1
-    describe.skip('vertical grouped-category clicks', () => {
+    describe('vertical grouped-category clicks', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: [
@@ -314,8 +312,7 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    // FIXME: See AG-9809 TC6
-    describe.skip('axis with labels, ticks and grid lines disabled', () => {
+    describe('axis with labels, ticks and grid lines disabled', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: [

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest';
 
-import type { AgCartesianChartOptions } from 'ag-charts-community';
 import { Chart, clickAction, setupMockCanvas, waitForChartStability } from 'ag-charts-community-test';
 import { setupMockConsole } from 'ag-charts-test';
 
@@ -9,14 +8,21 @@ import { createEnterpriseChart } from '../../test/utils';
 describe('AxisDOMProxy', () => {
     setupMockCanvas();
     setupMockConsole();
+    let formatter: ReturnType<typeof vi.fn>;
+    let click: ReturnType<typeof vi.fn>;
+    let chart: Chart;
+
+    beforeEach(() => {
+        formatter = vi.fn();
+        click = vi.fn();
+    });
+    afterEach(() => {
+        chart?.destroy();
+    });
 
     describe('horizontal grouped-category clicks', () => {
-        const formatter = vi.fn();
-        const click = vi.fn();
-        let chart: Chart;
-
         beforeEach(async () => {
-            const opts: AgCartesianChartOptions = {
+            chart = await createEnterpriseChart({
                 data: [
                     { y: 10, x: ['Food', 'Meat', 'Fish'] },
                     { y: 10, x: ['Food', 'Meat', 'Chicken'] },
@@ -36,12 +42,7 @@ describe('AxisDOMProxy', () => {
                 },
                 zoom: { enabled: true },
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
-            };
-            chart = await createEnterpriseChart(opts);
-        });
-
-        afterEach(() => {
-            chart?.destroy();
+            });
         });
 
         // Check that label formatter's indices match the DFS ordering of the x-grouping.
@@ -112,11 +113,8 @@ describe('AxisDOMProxy', () => {
     });
 
     describe('vertical grouped-category clicks', () => {
-        const click = vi.fn();
-        let chart: Chart;
-
         beforeEach(async () => {
-            const opts: AgCartesianChartOptions = {
+            chart = await createEnterpriseChart({
                 data: [
                     { x: 10, y: ['Food', 'Meat', 'Fish'] },
                     { x: 10, y: ['Food', 'Meat', 'Chicken'] },
@@ -132,12 +130,7 @@ describe('AxisDOMProxy', () => {
                 },
                 zoom: { enabled: true },
                 series: [{ type: 'bar', direction: 'horizontal', xKey: 'y', yKey: 'x' }],
-            };
-            chart = await createEnterpriseChart(opts);
-        });
-
-        afterEach(() => {
-            chart?.destroy();
+            });
         });
 
         test('click - value/index match', async () => {
@@ -162,6 +155,129 @@ describe('AxisDOMProxy', () => {
                 [expect.objectContaining({ value: 'Soda', index: 7 })],
                 [expect.objectContaining({ value: 'Drink', index: 6 })],
             ]);
+        });
+    });
+
+    describe('continuous axis clicks', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: Array.from({ length: 11 }, (_, i) => ({ x: i * 100, y: i })),
+                axes: {
+                    x: { type: 'number', listeners: { click } },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+            });
+        });
+
+        // On a continuous axis `value` and `index` deliberately describe different things: `value` is interpolated from
+        // the pointer position, `index` is the nearest tick.
+        test('value is interpolated and index tracks the nearest tick', async () => {
+            await clickAction(57, 560)(chart);
+            await clickAction(418, 560)(chart);
+            await clickAction(756, 560)(chart);
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: expect.closeTo(20.86), index: 0 })],
+                [expect.objectContaining({ value: expect.closeTo(512.02), index: 3 })],
+                [expect.objectContaining({ value: expect.closeTo(971.88), index: 5 })],
+            ]);
+        });
+    });
+
+    describe('suppressed overflow labels', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                // Zero right padding removes the slack that normally absorbs the overflowing label.
+                padding: { right: 0, left: 0 },
+                data: Array.from({ length: 11 }, (_, i) => ({ x: i * 100, y: i })),
+                axes: {
+                    x: { type: 'number', listeners: { click } },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+            });
+        });
+
+        // Labels 0 and 1000 render as empty text, leaving 200/400/600/800 (indices 1..4) visible.
+        test('clicking an end reports a visible label, not a suppressed one', async () => {
+            await clickAction(800, 560)(chart); // far right, where '1000' was suppressed
+            await clickAction(25, 560)(chart); // far left, where '0' was suppressed
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ index: 4 })], // nearest visible label is '800'
+                [expect.objectContaining({ index: 1 })], // nearest visible label is '200'
+            ]);
+        });
+    });
+
+    describe('axis with labels, ticks and grid lines disabled', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: [
+                    { x: 'A', y: 1 },
+                    { x: 'B', y: 2 },
+                    { x: 'C', y: 3 },
+                ],
+                axes: {
+                    x: {
+                        type: 'category',
+                        label: { enabled: false },
+                        tick: { enabled: false },
+                        gridLine: { enabled: false },
+                        // A title keeps the axis region non-empty, so it stays clickable.
+                        title: { enabled: true, text: 'Category' },
+                        listeners: { click },
+                    },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+            });
+        });
+
+        test('index still resolves to the clicked category', async () => {
+            await clickAction(194, 545)(chart);
+            await clickAction(414, 545)(chart);
+            await clickAction(634, 545)(chart);
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: 'A', index: 0 })],
+                [expect.objectContaining({ value: 'B', index: 1 })],
+                [expect.objectContaining({ value: 'C', index: 2 })],
+            ]);
+        });
+    });
+
+    describe('band interior clicks', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: Array.from({ length: 12 }, (_, i) => `Category-Name-${i}`).map((x, i) => ({ x, y: i })),
+                axes: {
+                    x: { type: 'category', label: { rotation: 0, avoidCollisions: false }, listeners: { click } },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+            });
+
+            // Band 5 spans canvas 360..403. Both clicks are inside it, so both must report the same
+            // category; today only the one nearer the band's start does.
+            test('every point inside a band reports that band', async () => {
+                await clickAction(378, 560)(chart); // comfortably inside band 5
+                await clickAction(398, 560)(chart); // still inside band 5, 5px from its right edge
+                await waitForChartStability(chart);
+
+                expect(click.mock.calls).toMatchObject([
+                    [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
+                    [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
+                ]);
+            });
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -187,6 +187,76 @@ describe('AxisDOMProxy', () => {
         });
     });
 
+    describe('discrete axis with labels disabled and ticks enabled', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: [
+                    { x: 'A', y: 1 },
+                    { x: 'B', y: 2 },
+                    { x: 'C', y: 3 },
+                ],
+                axes: {
+                    x: {
+                        type: 'category',
+                        label: { enabled: false },
+                        tick: { enabled: true, size: 30 },
+                        listeners: { click },
+                    },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+            });
+        });
+
+        // Clicks land on each band centre, which is also where the tick sits.
+        test('click - value/index match', async () => {
+            await clickAction(170, 565)(chart); // 'A'
+            await clickAction(414, 565)(chart); // 'B'
+            await clickAction(658, 565)(chart); // 'C'
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: 'A', index: 0 })],
+                [expect.objectContaining({ value: 'B', index: 1 })],
+                [expect.objectContaining({ value: 'C', index: 2 })],
+            ]);
+        });
+    });
+
+    describe('continuous axis with labels disabled and ticks enabled', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: Array.from({ length: 11 }, (_, i) => ({ x: i * 100, y: i })),
+                axes: {
+                    x: {
+                        type: 'number',
+                        label: { enabled: false },
+                        tick: { enabled: true, size: 30 },
+                        listeners: { click },
+                    },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+            });
+        });
+
+        // Ticks sit every 200 across a 0..1000 domain; each click is nearest an unambiguous one.
+        test('value is interpolated and index tracks the nearest tick', async () => {
+            await clickAction(200, 565)(chart);
+            await clickAction(480, 565)(chart);
+            await clickAction(640, 565)(chart);
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: expect.closeTo(210.88), index: 1 })],
+                [expect.objectContaining({ value: expect.closeTo(591.84), index: 3 })],
+                [expect.objectContaining({ value: expect.closeTo(809.52), index: 4 })],
+            ]);
+        });
+    });
+
     describe('suppressed overflow labels', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -355,6 +355,21 @@ describe('AxisDOMProxy', () => {
     // to the left of the x-axis origin. This test is there to ensure that this padding does not interfere with the
     // computation of the axis click `value`.
     describe('continuous band interior clicks', () => {
+        let Xs: [number, number, number, number];
+
+        function measureXGridLines(): [number, number, number, number] | undefined {
+            const elem = document.querySelector('.ag-charts-series-area');
+            if (elem instanceof HTMLElement) {
+                const left = Number.parseInt(elem.style.height);
+                const width = Number.parseInt(elem.style.widows);
+                if (!Number.isNaN(left) && !Number.isNaN(width)) {
+                    const step = width / 3;
+                    return [left, left + step, left + step * 2, left + width];
+                }
+            }
+            return undefined;
+        }
+
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: Array.from({ length: 4 }, (_, i) => ({ x: i / 5, y: i * 2 })),
@@ -369,15 +384,16 @@ describe('AxisDOMProxy', () => {
                 zoom: { enabled: true },
                 series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
             });
-            // expect element .ag-charts-series-area to have bounds "width: 733px; height: 534px; left: 47px; top: 20px;"
-            // -> this assumption is required for the hardcoded x/y click coords to be valid.
+
+            Xs = measureXGridLines()!;
+            expect(Xs).toBeDefined();
         });
 
         test('axis click values in the center of X-labels is close to data X-values', async () => {
-            await clickAction(39.5, 572)(chart);
-            await clickAction(286.5, 572)(chart);
-            await clickAction(533.5, 571)(chart);
-            await clickAction(779.5, 572)(chart);
+            await clickAction(Xs[0], 572)(chart);
+            await clickAction(Xs[1], 572)(chart);
+            await clickAction(Xs[2], 571)(chart);
+            await clickAction(Xs[3], 572)(chart);
             await waitForChartStability(chart);
 
             expect(click.mock.calls).toMatchObject([

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -1,0 +1,113 @@
+import { vi } from 'vitest';
+
+import type { AgCartesianChartOptions } from 'ag-charts-community';
+import { Chart, clickAction, setupMockCanvas, waitForChartStability } from 'ag-charts-community-test';
+import { setupMockConsole } from 'ag-charts-test';
+
+import { createEnterpriseChart } from '../../test/utils';
+
+describe('AxisDOMProxy', () => {
+    setupMockCanvas();
+    setupMockConsole();
+
+    describe('grouped-category clicks', () => {
+        const formatter = vi.fn();
+        const click = vi.fn();
+        let chart: Chart;
+
+        beforeEach(async () => {
+            const opts: AgCartesianChartOptions = {
+                data: [
+                    { y: 10, x: ['Food', 'Meat', 'Fish'] },
+                    { y: 10, x: ['Food', 'Meat', 'Chicken'] },
+                    { y: 10, x: ['Food', 'Fruit', 'Banana'] },
+                    { y: 10, x: ['Food', 'Fruit', 'Apple'] },
+                    { y: 10, x: ['Drink', 'Soda', 'Coke'] },
+                    { y: 10, x: ['Drink', 'Soda', 'Pepsi'] },
+                    { y: 10, x: ['Drink', 'Tea', 'Green'] },
+                ],
+                axes: {
+                    x: {
+                        type: 'grouped-category',
+                        depthOptions: [{}, {}, {}],
+                        label: { formatter },
+                        listeners: { click },
+                    },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+            };
+            chart = await createEnterpriseChart(opts);
+        });
+
+        afterEach(() => {
+            chart?.destroy();
+        });
+
+        // Check that label formatter's indices match the DFS ordering of the x-grouping.
+        // Note: axes[].label.formatter is called twice on start up for some reason.
+        test('formatter - value/index match', async () => {
+            expect(formatter.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: 'Food', index: 0 })],
+                [expect.objectContaining({ value: 'Meat', index: 1 })],
+                [expect.objectContaining({ value: 'Fish', index: 2 })],
+                [expect.objectContaining({ value: 'Chicken', index: 3 })],
+                [expect.objectContaining({ value: 'Fruit', index: 4 })],
+                [expect.objectContaining({ value: 'Banana', index: 5 })],
+                [expect.objectContaining({ value: 'Apple', index: 6 })],
+                [expect.objectContaining({ value: 'Drink', index: 7 })],
+                [expect.objectContaining({ value: 'Soda', index: 8 })],
+                [expect.objectContaining({ value: 'Coke', index: 9 })],
+                [expect.objectContaining({ value: 'Pepsi', index: 10 })],
+                [expect.objectContaining({ value: 'Tea', index: 11 })],
+                [expect.objectContaining({ value: 'Green', index: 12 })],
+                [expect.objectContaining({ value: 'Food', index: 0 })],
+                [expect.objectContaining({ value: 'Meat', index: 1 })],
+                [expect.objectContaining({ value: 'Fish', index: 2 })],
+                [expect.objectContaining({ value: 'Chicken', index: 3 })],
+                [expect.objectContaining({ value: 'Fruit', index: 4 })],
+                [expect.objectContaining({ value: 'Banana', index: 5 })],
+                [expect.objectContaining({ value: 'Apple', index: 6 })],
+                [expect.objectContaining({ value: 'Drink', index: 7 })],
+                [expect.objectContaining({ value: 'Soda', index: 8 })],
+                [expect.objectContaining({ value: 'Coke', index: 9 })],
+                [expect.objectContaining({ value: 'Pepsi', index: 10 })],
+                [expect.objectContaining({ value: 'Tea', index: 11 })],
+                [expect.objectContaining({ value: 'Green', index: 12 })],
+            ]);
+        });
+
+        // Check that click's indices match the DFS ordering of the x-grouping.
+        test('click - value/index match', async () => {
+            await clickAction(257, 572)(chart); // 'Food'
+            await clickAction(150, 545)(chart); // 'Meat'
+            await clickAction(100, 493)(chart); // 'Fish'
+            await clickAction(205, 495)(chart); // 'Chicken'
+            await clickAction(364, 548)(chart); // 'Fruit'
+            await clickAction(309, 500)(chart); // 'Banana'
+            await clickAction(412, 499)(chart); // 'Apple'
+            await clickAction(621, 571)(chart); // 'Drink'
+            await clickAction(569, 545)(chart); // 'Soda'
+            await clickAction(519, 499)(chart); // 'Coke'
+            await clickAction(624, 494)(chart); // 'Pepsi'
+            await clickAction(729, 549)(chart); // 'Tea'
+            await clickAction(727, 502)(chart); // 'Green'
+            await waitForChartStability(chart);
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: 'Food', index: 0 })],
+                [expect.objectContaining({ value: 'Meat', index: 1 })],
+                [expect.objectContaining({ value: 'Fish', index: 2 })],
+                [expect.objectContaining({ value: 'Chicken', index: 3 })],
+                [expect.objectContaining({ value: 'Fruit', index: 4 })],
+                [expect.objectContaining({ value: 'Banana', index: 5 })],
+                [expect.objectContaining({ value: 'Apple', index: 6 })],
+                [expect.objectContaining({ value: 'Drink', index: 7 })],
+                [expect.objectContaining({ value: 'Soda', index: 8 })],
+                [expect.objectContaining({ value: 'Coke', index: 9 })],
+                [expect.objectContaining({ value: 'Pepsi', index: 10 })],
+                [expect.objectContaining({ value: 'Tea', index: 11 })],
+                [expect.objectContaining({ value: 'Green', index: 12 })],
+            ]);
+        });
+    });
+});

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -10,7 +10,7 @@ describe('AxisDOMProxy', () => {
     setupMockCanvas();
     setupMockConsole();
 
-    describe('grouped-category clicks', () => {
+    describe('horizontal grouped-category clicks', () => {
         const formatter = vi.fn();
         const click = vi.fn();
         let chart: Chart;
@@ -46,7 +46,7 @@ describe('AxisDOMProxy', () => {
 
         // Check that label formatter's indices match the DFS ordering of the x-grouping.
         // Note: axes[].label.formatter is called twice on start up for some reason.
-        test('formatter - value/index match', async () => {
+        test('formatter - value/index match', () => {
             expect(formatter.mock.calls).toMatchObject([
                 [expect.objectContaining({ value: 'Food', index: 0 })],
                 [expect.objectContaining({ value: 'Meat', index: 1 })],
@@ -107,6 +107,60 @@ describe('AxisDOMProxy', () => {
                 [expect.objectContaining({ value: 'Pepsi', index: 10 })],
                 [expect.objectContaining({ value: 'Tea', index: 11 })],
                 [expect.objectContaining({ value: 'Green', index: 12 })],
+            ]);
+        });
+    });
+
+    describe('vertical grouped-category clicks', () => {
+        const click = vi.fn();
+        let chart: Chart;
+
+        beforeEach(async () => {
+            const opts: AgCartesianChartOptions = {
+                data: [
+                    { x: 10, y: ['Food', 'Meat', 'Fish'] },
+                    { x: 10, y: ['Food', 'Meat', 'Chicken'] },
+                    { x: 10, y: ['Food', 'Fruit', 'Banana'] },
+                    { x: 10, y: ['Drink', 'Soda', 'Coke'] },
+                ],
+                axes: {
+                    y: {
+                        type: 'grouped-category',
+                        depthOptions: [{}, {}, {}],
+                        listeners: { click },
+                    },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'bar', direction: 'horizontal', xKey: 'y', yKey: 'x' }],
+            };
+            chart = await createEnterpriseChart(opts);
+        });
+
+        afterEach(() => {
+            chart?.destroy();
+        });
+
+        test('click - value/index match', async () => {
+            await clickAction(83, 74)(chart); // 'Fish'
+            await clickAction(54, 74)(chart); // 'Meat'
+            await clickAction(26, 74)(chart); // 'Food'
+            await clickAction(83, 234)(chart); // 'Chicken'
+            await clickAction(83, 341)(chart); // 'Banana'
+            await clickAction(54, 341)(chart); // 'Fruit'
+            await clickAction(83, 502)(chart); // 'Coke'
+            await clickAction(54, 502)(chart); // 'Soda'
+            await clickAction(26, 502)(chart); // 'Drink'
+            await waitForChartStability(chart);
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: 'Fish', index: 2 })],
+                [expect.objectContaining({ value: 'Meat', index: 1 })],
+                [expect.objectContaining({ value: 'Food', index: 0 })],
+                [expect.objectContaining({ value: 'Chicken', index: 3 })],
+                [expect.objectContaining({ value: 'Banana', index: 5 })],
+                [expect.objectContaining({ value: 'Fruit', index: 4 })],
+                [expect.objectContaining({ value: 'Coke', index: 8 })],
+                [expect.objectContaining({ value: 'Soda', index: 7 })],
+                [expect.objectContaining({ value: 'Drink', index: 6 })],
             ]);
         });
     });

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -324,7 +324,7 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    describe('band interior clicks', () => {
+    describe('category band interior clicks', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: Array.from({ length: 12 }, (_, i) => `Category-Name-${i}`).map((x, i) => ({ x, y: i })),
@@ -347,6 +347,44 @@ describe('AxisDOMProxy', () => {
             expect(click.mock.calls).toMatchObject([
                 [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
                 [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
+            ]);
+        });
+    });
+
+    // In this example, the X-origin label is a long text "0.000000000", which adds a lot of mouse-interaction padding
+    // to the left of the x-axis origin. This test is there to ensure that this padding does not interfere with the
+    // computation of the axis click `value`.
+    describe('continuous band interior clicks', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: Array.from({ length: 4 }, (_, i) => ({ x: i / 5, y: i * 2 })),
+                axes: {
+                    x: {
+                        type: 'number',
+                        label: { rotation: 0, avoidCollisions: false, format: '#{0.9f}' },
+                        listeners: { click },
+                    },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true },
+                series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+            });
+            // expect element .ag-charts-series-area to have bounds "width: 733px; height: 534px; left: 47px; top: 20px;"
+            // -> this assumption is required for the hardcoded x/y click coords to be valid.
+        });
+
+        test('axis click values in the center of X-labels is close to data X-values', async () => {
+            await clickAction(39.5, 572)(chart);
+            await clickAction(286.5, 572)(chart);
+            await clickAction(533.5, 571)(chart);
+            await clickAction(779.5, 572)(chart);
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: expect.closeTo(0), index: 0 })],
+                [expect.objectContaining({ value: expect.closeTo(0.2), index: 1 })],
+                [expect.objectContaining({ value: expect.closeTo(0.4), index: 2 })],
+                [expect.objectContaining({ value: expect.closeTo(0.6), index: 3 })],
             ]);
         });
     });

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -264,7 +264,7 @@ describe('AxisDOMProxy', () => {
                 padding: { right: 0, left: 0 },
                 data: Array.from({ length: 11 }, (_, i) => ({ x: i * 100, y: i })),
                 axes: {
-                    x: { type: 'number', listeners: { click } },
+                    x: { type: 'number', label: { formatter }, listeners: { click } },
                     y: { type: 'number' },
                 },
                 zoom: { enabled: true },
@@ -272,15 +272,38 @@ describe('AxisDOMProxy', () => {
             });
         });
 
-        // Labels 0 and 1000 render as empty text, leaving 200/400/600/800 (indices 1..4) visible.
-        test('clicking an end reports a visible label, not a suppressed one', async () => {
-            await clickAction(800, 560)(chart); // far right, where '1000' was suppressed
-            await clickAction(25, 560)(chart); // far left, where '0' was suppressed
+        // The end labels '0' and '1000' hide themselves to avoid overflowing the chart, rendering as
+        // empty text. Their ticks, grid lines and label data all still exist, so they keep their place
+        // in the numbering: a click at either end reports the hidden label rather than skipping to the
+        // nearest visible one.
+        test('click - value/index match', async () => {
+            await clickAction(800, 560)(chart); // far right, where '1000' hid itself
+            await clickAction(25, 560)(chart); // far left, where '0' hid itself
             await waitForChartStability(chart);
 
             expect(click.mock.calls).toMatchObject([
-                [expect.objectContaining({ index: 4 })], // nearest visible label is '800'
-                [expect.objectContaining({ index: 1 })], // nearest visible label is '200'
+                [expect.objectContaining({ value: 1000, index: 5 })],
+                [expect.objectContaining({ value: 0, index: 0 })],
+            ]);
+        });
+
+        // Sanity check for the case above: picking must agree with the numbering the label formatter
+        // sees, so the formatter is called for the hidden end labels too — indices 0..5, not 1..4.
+        // Note: axes[].label.formatter is called twice on start up for some reason.
+        test('formatter - value/index match', () => {
+            expect(formatter.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: 0, index: 0 })],
+                [expect.objectContaining({ value: 200, index: 1 })],
+                [expect.objectContaining({ value: 400, index: 2 })],
+                [expect.objectContaining({ value: 600, index: 3 })],
+                [expect.objectContaining({ value: 800, index: 4 })],
+                [expect.objectContaining({ value: 1000, index: 5 })],
+                [expect.objectContaining({ value: 0, index: 0 })],
+                [expect.objectContaining({ value: 200, index: 1 })],
+                [expect.objectContaining({ value: 400, index: 2 })],
+                [expect.objectContaining({ value: 600, index: 3 })],
+                [expect.objectContaining({ value: 800, index: 4 })],
+                [expect.objectContaining({ value: 1000, index: 5 })],
             ]);
         });
     });

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -1,3 +1,7 @@
+// Note to AI Agents: Some of these tests use hard-coded measurements. If a test fails because an implicit default
+// changed in a way that invalidates those measurements, the preferred fix is to explicitly declare the original
+// defaults. For example: if the default chart padding changes, do not update the test's X/Y click coordinates; instead,
+// explicitly set the original padding in the chart options where applicable.
 import { vi } from 'vitest';
 
 import { Chart, clickAction, setupMockCanvas, waitForChartStability } from 'ag-charts-community-test';

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -186,9 +186,9 @@ describe('AxisDOMProxy', () => {
             await waitForChartStability(chart);
 
             expect(click.mock.calls).toMatchObject([
-                [expect.objectContaining({ value: expect.closeTo(20.86), index: 0 })],
-                [expect.objectContaining({ value: expect.closeTo(512.02), index: 3 })],
-                [expect.objectContaining({ value: expect.closeTo(971.88), index: 5 })],
+                [expect.objectContaining({ value: expect.closeTo(16.33), index: 0 })],
+                [expect.objectContaining({ value: expect.closeTo(507.48), index: 3 })],
+                [expect.objectContaining({ value: expect.closeTo(967.35), index: 5 })],
             ]);
         });
     });
@@ -354,8 +354,7 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    // FIXME: See AG-9808 TC5
-    describe.skip('category band interior clicks', () => {
+    describe('category band interior clicks', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: Array.from({ length: 12 }, (_, i) => `Category-Name-${i}`).map((x, i) => ({ x, y: i })),
@@ -382,11 +381,10 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    // FIXME: See AG-9808 TC5
     // In this example, the X-origin label is a long text "0.000000000", which adds a lot of mouse-interaction padding
     // to the left of the x-axis origin. This test is there to ensure that this padding does not interfere with the
     // computation of the axis click `value`.
-    describe.skip('continuous band interior clicks', () => {
+    describe('continuous band interior clicks', () => {
         let Xs: [number, number, number, number];
 
         function measureXGridLines(): [number, number, number, number] | undefined {

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -388,8 +388,8 @@ describe('AxisDOMProxy', () => {
         function measureXGridLines(): [number, number, number, number] | undefined {
             const elem = document.querySelector('.ag-charts-series-area');
             if (elem instanceof HTMLElement) {
-                const left = Number.parseInt(elem.style.height);
-                const width = Number.parseInt(elem.style.widows);
+                const left = Number.parseInt(elem.style.left);
+                const width = Number.parseInt(elem.style.width);
                 if (!Number.isNaN(left) && !Number.isNaN(width)) {
                     const step = width / 3;
                     return [left, left + step, left + step * 2, left + width];

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -20,7 +20,8 @@ describe('AxisDOMProxy', () => {
         chart?.destroy();
     });
 
-    describe('horizontal grouped-category clicks', () => {
+    // FIXME: See AG-9808 TC1
+    describe.skip('horizontal grouped-category clicks', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: [
@@ -112,7 +113,8 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    describe('vertical grouped-category clicks', () => {
+    // FIXME: See AG-9808 TC1
+    describe.skip('vertical grouped-category clicks', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: [
@@ -308,7 +310,8 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    describe('axis with labels, ticks and grid lines disabled', () => {
+    // FIXME: See AG-9809 TC6
+    describe.skip('axis with labels, ticks and grid lines disabled', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: [
@@ -347,7 +350,8 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    describe('category band interior clicks', () => {
+    // FIXME: See AG-9808 TC5
+    describe.skip('category band interior clicks', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: Array.from({ length: 12 }, (_, i) => `Category-Name-${i}`).map((x, i) => ({ x, y: i })),
@@ -374,10 +378,11 @@ describe('AxisDOMProxy', () => {
         });
     });
 
+    // FIXME: See AG-9808 TC5
     // In this example, the X-origin label is a long text "0.000000000", which adds a lot of mouse-interaction padding
     // to the left of the x-axis origin. This test is there to ensure that this padding does not interfere with the
     // computation of the axis click `value`.
-    describe('continuous band interior clicks', () => {
+    describe.skip('continuous band interior clicks', () => {
         let Xs: [number, number, number, number];
 
         function measureXGridLines(): [number, number, number, number] | undefined {

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -265,19 +265,19 @@ describe('AxisDOMProxy', () => {
                 zoom: { enabled: true },
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
             });
+        });
 
-            // Band 5 spans canvas 360..403. Both clicks are inside it, so both must report the same
-            // category; today only the one nearer the band's start does.
-            test('every point inside a band reports that band', async () => {
-                await clickAction(378, 560)(chart); // comfortably inside band 5
-                await clickAction(398, 560)(chart); // still inside band 5, 5px from its right edge
-                await waitForChartStability(chart);
+        // Band 5 spans canvas 360..403. Both clicks are inside it, so both must report the same
+        // category; today only the one nearer the band's start does.
+        test('every point inside a band reports that band', async () => {
+            await clickAction(378, 560)(chart); // comfortably inside band 5
+            await clickAction(398, 560)(chart); // still inside band 5, 5px from its right edge
+            await waitForChartStability(chart);
 
-                expect(click.mock.calls).toMatchObject([
-                    [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
-                    [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
-                ]);
-            });
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
+                [expect.objectContaining({ value: 'Category-Name-5', index: 5 })],
+            ]);
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -1,6 +1,6 @@
 import type { AgAxisClickEvent } from 'ag-charts-community';
 import { _ModuleSupport, _Widget } from 'ag-charts-community';
-import type { AxisID, CanvasPoint, DynamicContext } from 'ag-charts-core';
+import type { AxisID, CanvasPoint, CurrentPoint, DynamicContext } from 'ag-charts-core';
 import { AbstractModuleInstance, ChartAxisDirection, boxEmpty, callWithContext } from 'ag-charts-core';
 
 type AxisHit = { axisId: AxisID; direction: ChartAxisDirection };
@@ -217,7 +217,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
 
         // Annotate the overlapping axis so the series-area dispatch offers it as an additional region,
         // rather than dispatching a competing axis-only menu. This lets a node and an axis co-exist.
-        event.axis = this.pickAxisValue(axis.axisId, event.widgetEvent);
+        event.axis = this.pickAxisValue(axis.axisId, event);
     }
 
     private onSeriesAreaDoubleClick(event: _ModuleSupport.DragInterpreterDblClickEvent) {
@@ -297,8 +297,12 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         });
     }
 
-    private pickAxisValue(axisId: AxisID, widgetEvent: _Widget.MouseWidgetEvent<'contextmenu'>) {
-        return this.ctx.axisManager.getAxisIdContext(axisId)?.pickValue(widgetEvent);
+    private pickAxisValue(axisId: AxisID, point: Readonly<CanvasPoint>) {
+        return this.ctx.axisManager.getAxisIdContext(axisId)?.pickValue(point);
+    }
+
+    private toCanvasPoint(div: _Widget.AxisWidget, point: Readonly<CurrentPoint>): CanvasPoint {
+        return { canvasX: point.currentX + div.cssLeft(), canvasY: point.currentY + div.cssTop() };
     }
 
     /**
@@ -310,8 +314,11 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         // Keyboard activation is out of scope for this feature (AG-9809).
         if (widgetEvent.device === 'keyboard') return;
 
+        const div = this.axes.find((axis) => axis.axisId === axisId)?.div;
+        if (!div) return;
+
         const axisCtx = this.ctx.axisManager.getAxisIdContext(axisId);
-        const pick = axisCtx?.pickValue(widgetEvent);
+        const pick = axisCtx?.pickValue(this.toCanvasPoint(div, widgetEvent));
         if (!axisCtx || !pick) return;
 
         const isDoubleClick = widgetEvent.type === 'dblclick';
@@ -347,7 +354,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         canvasX: number,
         canvasY: number
     ) {
-        const pick = this.pickAxisValue(axisId, widgetEvent);
+        const pick = this.pickAxisValue(axisId, { canvasX, canvasY });
         if (!pick) return;
 
         this.ctx.contextMenuRegistry?.dispatchContext('axis', { widgetEvent, canvasX, canvasY }, pick);

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
@@ -267,4 +267,48 @@ describe('Context Menu', () => {
         chart = AgCharts.create(prepareEnterpriseTestOptions({ ...EXAMPLE_OPTIONS, contextMenu }));
         expectWarningsCalls().toMatchSnapshot();
     });
+
+    describe('coordinates param', () => {
+        let getItems: ReturnType<typeof vi.fn>;
+
+        async function contextMenuAtPlotCentre() {
+            const seriesRect = deproxy(chart).seriesRect;
+            expect(seriesRect).toBeDefined();
+            const { x, y, width, height } = seriesRect!;
+            await contextMenuAction(x + width / 2, y + height / 2)(chart);
+            await waitForChartStability(chart);
+        }
+
+        beforeEach(async () => {
+            getItems = vi.fn(({ defaultItems }) => defaultItems);
+            await prepareChart(
+                { enabled: true, getItems },
+                {
+                    data: Array.from({ length: 4 }, (_, i) => ({ x: i / 5, y: i * 2 })),
+                    // `contextMenu.getItems()` receives the axis values under the pointer via its `coordinates` param.
+                    // Nine-decimal x labels are used so that the axis labels overhang the plot area by a wide margin.
+                    axes: {
+                        x: { type: 'number', label: { avoidCollisions: false, rotation: 0, format: '#{0.9f}' } },
+                        y: { type: 'number' },
+                    },
+                    series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+                    contextMenu: { enabled: true },
+                }
+            );
+        });
+
+        // Domains are 0..0.6 on x and 0..6 on y.
+        test('reports the axis values under the pointer', async () => {
+            await contextMenuAtPlotCentre();
+
+            expect(getItems).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    coordinates: expect.objectContaining({
+                        x: expect.objectContaining({ value: expect.closeTo(0.3) }),
+                        y: expect.objectContaining({ value: expect.closeTo(3) }),
+                    }),
+                })
+            );
+        });
+    });
 });

--- a/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
+++ b/packages/ag-charts-enterprise/src/features/context-menu/contextMenu.test.ts
@@ -14,6 +14,7 @@ import {
     setupMockConsole,
     waitForChartStability,
 } from 'ag-charts-community-test';
+import { Caster } from 'ag-charts-test';
 
 import { prepareEnterpriseTestOptions } from '../../test/utils';
 import { DEFAULT_CONTEXT_MENU_CLASS } from './contextMenuStyles';
@@ -307,6 +308,62 @@ describe('Context Menu', () => {
                         x: expect.objectContaining({ value: expect.closeTo(0.3) }),
                         y: expect.objectContaining({ value: expect.closeTo(3) }),
                     }),
+                })
+            );
+        });
+    });
+
+    describe('overlapping axis region', () => {
+        let getItems: ReturnType<typeof vi.fn>;
+
+        // Aims at the horizontal centre of the plot area, on the band occupied by the crossing axis. Both are
+        // read from internals purely to place the pointer.
+        async function contextMenuAtCrossingAxisCentre() {
+            const inner = deproxy(chart);
+            const seriesRect = inner.seriesRect!;
+            const xAxis = new Caster(inner.axes.find((axis) => axis.direction === 'x'))
+                .cast(_ModuleSupport.Axis)
+                .findProperty('getCanvasBounds')
+                .castProperty('getCanvasBounds', Function).value;
+            expect(seriesRect).toBeDefined();
+
+            const { x, width } = seriesRect;
+            await contextMenuAction(x + width / 2, xAxis.getCanvasBounds().y + 5)(chart);
+            await waitForChartStability(chart);
+        }
+
+        beforeEach(async () => {
+            getItems = vi.fn(({ defaultItems }) => defaultItems);
+            // An axis placed inside the plot area with `crossAt` is not dispatched through its own proxy region —
+            // the series area picks it up and annotates it onto the menu as an extra region. That is a separate
+            // code path from `coordinates`, and the only one where the axis origin picks up `crossAxisTranslation`.
+            await prepareChart(
+                { enabled: true, getItems },
+                {
+                    data: Array.from({ length: 4 }, (_, i) => ({ x: i / 5, y: i * 2 - 3 })),
+                    axes: {
+                        x: {
+                            type: 'number',
+                            crossAt: { value: 0 },
+                            label: { format: '#{0.9f}', avoidCollisions: false, rotation: 0 },
+                        },
+                        y: { type: 'number' },
+                    },
+                    series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+                    contextMenu: { enabled: true },
+                }
+            );
+        });
+
+        // The x domain is 0..0.6, so its centre is 0.3.
+        test('reports the axis value under the pointer', async () => {
+            await contextMenuAtCrossingAxisCentre();
+
+            expect(getItems).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    allShowOnParams: expect.arrayContaining([
+                        expect.objectContaining({ showOn: 'axis', value: expect.closeTo(0.3) }),
+                    ]),
                 })
             );
         });


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17613

This was more noticeable when the X-label of the origin tick is very long, causing the bounds of the axis-dom-proxy to extend well beyond the left of the origin 0.

Depends on:
* https://github.com/ag-grid/ag-charts/pull/7803
* I will rebase once that PR stack in merged in.