### PR TITLE
AG-9809 TC6 Gate the tick-skipping optimisation on whether an axis can be picked

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1142,6 +1142,16 @@ export abstract class Axis<
         return { domain: [...d.domain], clipped: false };
     }
 
+    private pickComputationEnabled = true;
+
+    setPickComputationEnabled(enabled: boolean): void {
+        this.pickComputationEnabled = enabled;
+    }
+
+    protected isPickComputationEnabled(): boolean {
+        return this.pickComputationEnabled;
+    }
+
     protected getLayoutTranslation(): { x: number; y: number } {
         return this.translation;
     }

--- a/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
+++ b/packages/ag-charts-community/src/chart/axis/cartesianAxis.ts
@@ -350,7 +350,8 @@ export abstract class CartesianAxis<
             !(this.primaryLabel?.enabled ?? false) &&
             this.options.tick.enabled === false &&
             !(this.primaryTick?.enabled ?? false) &&
-            this.options.gridLine.enabled === false
+            this.options.gridLine.enabled === false &&
+            !this.isPickComputationEnabled()
         ) {
             const { bbox, spacing } = this.measureAxisLayout(domain, [], [], scrollbar, scrollbarThickness);
             // Performance optimization: if ticks have no effect, don't generate them

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -2252,9 +2252,13 @@ export abstract class Chart implements ModuleInstance, ChartService {
         // Axes the user never named — the implicit primary axes created for a direction no `axes` entry
         // covers — have no unmapped key. Fall back to the canonical id ('x', 'y', ...) so `userKey` is
         // always a usable identifier, matching how option key paths resolve axis keys.
-        const { unmappedAxisKeys } = this.chartOptions;
+        const { unmappedAxisKeys, optionMetadata } = this.chartOptions;
+        // Optimization: try (if possible) to disable the expensive tick-calculation.
+        // This is ignored if the Axis thinks tick-calculation is still required.
+        const pickComputationEnabled = optionMetadata.presetType !== 'sparkline';
         for (const axis of chart.axes) {
             axis.userKey = unmappedAxisKeys.get(axis.id) ?? axis.id;
+            axis.setPickComputationEnabled(pickComputationEnabled);
         }
         return true;
     }

--- a/packages/ag-charts-community/src/chart/chartAxis.ts
+++ b/packages/ag-charts-community/src/chart/chartAxis.ts
@@ -69,6 +69,7 @@ export interface ChartLayout {
 
 export interface ChartAxis<TOptions extends NormalisedBaseAxisOptions = NormalisedBaseAxisOptions> {
     userKey: string;
+    setPickComputationEnabled(enabled: boolean): void;
     attachAxis(opts: AxisGroups): void;
     calculateLayout(
         primaryTickCount?: AxisPrimaryTickCount,

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -312,8 +312,7 @@ describe('AxisDOMProxy', () => {
         });
     });
 
-    // FIXME: See AG-9809 TC6
-    describe.skip('axis with labels, ticks and grid lines disabled', () => {
+    describe('axis with labels, ticks and grid lines disabled - category', () => {
         beforeEach(async () => {
             chart = await createEnterpriseChart({
                 data: [
@@ -349,6 +348,83 @@ describe('AxisDOMProxy', () => {
                 [expect.objectContaining({ value: 'B', index: 1 })],
                 [expect.objectContaining({ value: 'C', index: 2 })],
             ]);
+        });
+    });
+
+    describe('axis with labels, ticks and grid lines disabled - number', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: Array.from({ length: 6 }, (_, i) => ({ x: i * 100, y: i })),
+                axes: {
+                    x: {
+                        type: 'number',
+                        label: { enabled: false },
+                        tick: { enabled: false },
+                        gridLine: { enabled: false },
+                        // A title keeps the axis region non-empty, so it stays clickable.
+                        title: { enabled: true, text: 'Number' },
+                        listeners: { click },
+                    },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true, buttons: { enabled: false } },
+                series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+            });
+        });
+
+        // The axis line spans canvas x 38..780 over a 0..500 domain, with a tick every 100.
+        test('index still resolves to the clicked tick', async () => {
+            await clickAction(38, 545)(chart);
+            await clickAction(186, 545)(chart);
+            await clickAction(335, 545)(chart);
+            await clickAction(483, 545)(chart);
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ value: expect.closeTo(0), index: 0 })],
+                [expect.objectContaining({ value: expect.closeTo(99.73), index: 1 })],
+                [expect.objectContaining({ value: expect.closeTo(200.13), index: 2 })],
+                [expect.objectContaining({ value: expect.closeTo(299.87), index: 3 })],
+            ]);
+        });
+    });
+
+    // `nice: false` used to be one of the conditions that sent the axis down the tick-skipping fast path.
+    // That path is now reserved for chart types where nothing can pick at all, so a clickable axis keeps its
+    // ticks whatever `nice` is set to.
+    describe('axis with labels, ticks and grid lines disabled - number, nice: false', () => {
+        beforeEach(async () => {
+            chart = await createEnterpriseChart({
+                data: Array.from({ length: 6 }, (_, i) => ({ x: i * 100, y: i })),
+                axes: {
+                    x: {
+                        type: 'number',
+                        nice: false,
+                        label: { enabled: false },
+                        tick: { enabled: false },
+                        gridLine: { enabled: false },
+                        title: { enabled: true, text: 'Number' },
+                        listeners: { click },
+                    },
+                    y: { type: 'number' },
+                },
+                zoom: { enabled: true, buttons: { enabled: false } },
+                series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
+            });
+        });
+
+        test('index still resolves to the clicked tick', async () => {
+            await clickAction(38, 545)(chart);
+            await clickAction(483, 545)(chart);
+            await waitForChartStability(chart);
+
+            expect(click.mock.calls).toMatchObject([
+                [expect.objectContaining({ index: 0 })],
+                [expect.objectContaining({ index: expect.any(Number) })],
+            ]);
+            for (const [event] of click.mock.calls) {
+                expect(event.index).toBeGreaterThanOrEqual(0);
+            }
         });
     });
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-9809

The fast path in `CartesianAxis.calculateTickLayout()` skips tick generation when nothing renders from the ticks. Picking needs them too, so `pickValue()` returned `index: -1` on any axis that took it — which is why `coordinates` and the axis click listeners report no index there.

Predicting picking from the options does not scale. Deriving it means enumerating every feature that might click — chart and axis listeners, the context menu, cross lines next, plausibly the navigator after that — and every addition has to remember to extend the condition, with a silently broken callback as the penalty for forgetting. The condition has already grown from four clauses to eight under five unrelated commits since it was added for sparkline performance.

Invert it. Rather than asking which features might pick, ask whether the chart has any surface capable of picking at all, and default to yes:

- `ChartAxis.setPickComputationEnabled()`, defaulting to enabled on `Axis`. A new pick consumer is therefore correct without touching the condition; the cost of forgetting to opt a chart type out is a little wasted work on that type, not a broken callback.
- `Chart.applyAxes()` sets it from `optionMetadata.presetType`, in the loop that already visits every axis so it survives axis reuse as well as recreation. A sparkline registers no axis proxy regions, forces the context menu off and cannot express axis listeners, so nothing can ask its axes what is under the pointer. `AgCharts.__createSparkline()` already supplies the marker, so this needs no preset plumbing and no change in AG Grid.
- `CartesianAxis` gains one clause. The eight existing clauses stay: they ask whether a *renderer* needs the ticks, which is genuinely per-axis — a bar sparkline draws grid lines and must keep them.

The effect is that the fast path is now reserved for chart types that cannot pick, so `-1` is unreachable on any axis a user can interact with, whatever its label, tick, grid-line or `nice` settings.

Tests in axisDomProxy.test.ts: the existing decorations-disabled case is split into `- category` and `- number`, and a `- number, nice: false` case is added. `nice: false` used to be one of the conditions that sent a clickable axis down the fast path.