### PR TITLE
AG-3390 Keep the Salesforce captcha timestamp through React re-renders

### DIFF
--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -86,6 +86,8 @@ export const ContactForm: FunctionComponent<Props> = ({
     submitLabel,
 }: Props) => {
     const formRef = useRef<HTMLFormElement>(null);
+    const captchaTimestamp = useRef('');
+    const reapplyCaptchaTimestamp = useRef<(() => void) | null>(null);
     const [isDebug, setIsDebug] = useState(isDev);
     const [returnUrl, setReturnUrl] = useState(RETURN_URLS.success);
     const [isDisabled, setIsDisabled] = useState(false);
@@ -139,7 +141,9 @@ export const ContactForm: FunctionComponent<Props> = ({
         }
 
         loadRecaptchaScript().then(() => {
-            initCaptcha();
+            reapplyCaptchaTimestamp.current = initCaptcha((ts) => {
+                captchaTimestamp.current = ts;
+            });
         });
     }, []);
 
@@ -149,6 +153,7 @@ export const ContactForm: FunctionComponent<Props> = ({
 
         const captchaPassed = (globalThis as any).grecaptcha.getResponse();
         if (captchaPassed) {
+            reapplyCaptchaTimestamp.current?.();
             formRef.current?.submit();
         } else {
             setCaptchaError(true);
@@ -169,7 +174,7 @@ export const ContactForm: FunctionComponent<Props> = ({
             <input
                 type="hidden"
                 name="captcha_settings"
-                value={`{"keyname":"${captchaSettingsKeyName}","fallback":"true","orgId":"${orgId}","ts":""}`}
+                value={`{"keyname":"${captchaSettingsKeyName}","fallback":"true","orgId":"${orgId}","ts":"${captchaTimestamp.current}"}`}
             />
             <input type="hidden" name="oid" value={orgId} />
             <input type="hidden" name="retURL" value={returnUrl} />

--- a/external/ag-website-shared/src/components/contact-form/initCaptcha.ts
+++ b/external/ag-website-shared/src/components/contact-form/initCaptcha.ts
@@ -1,12 +1,37 @@
-export function initCaptcha() {
+/**
+ * Starts Salesforce's captcha timestamp ticker.
+ *
+ * `onTimestamp` receives every value written, so the caller can render it back into the
+ * hidden input: React resets a controlled input on re-render, and `form.submit()` only
+ * schedules a navigation — the body is serialised in a later task, after any pending
+ * re-render has flushed. Rendering the live timestamp means a re-render at any point
+ * writes the correct value rather than blanking it.
+ *
+ * The ticker stops once the captcha is solved, freezing `ts` at solve time, which is the
+ * elapsed-time signal Salesforce validates.
+ */
+export function initCaptcha(onTimestamp?: (ts: string) => void): () => void {
+    let latest = '';
+
+    function write(ts: string) {
+        const captchaSettings = document.getElementsByName('captcha_settings')[0] as HTMLInputElement | undefined;
+        if (captchaSettings == null || ts === '') {
+            return;
+        }
+        const elems = JSON.parse(captchaSettings.value);
+        elems['ts'] = ts;
+        captchaSettings.value = JSON.stringify(elems);
+    }
+
     function timestamp() {
         const response = document.getElementById('g-recaptcha-response') as HTMLInputElement;
         if (response == null || response.value.trim() == '') {
-            const captchaSettings = document.getElementsByName('captcha_settings')[0] as HTMLInputElement;
-            const elems = JSON.parse(captchaSettings.value);
-            elems['ts'] = JSON.stringify(new Date().getTime());
-            captchaSettings.value = JSON.stringify(elems);
+            latest = JSON.stringify(new Date().getTime());
+            write(latest);
+            onTimestamp?.(latest);
         }
     }
     setInterval(timestamp, 500);
+
+    return () => write(latest);
 }


### PR DESCRIPTION
Ports ag-grid#14852 (`5f7ea32`) to charts. The contact form is shared code and charts' copy was byte-identical to grid's pre-fix version, so this is a verbatim port.

## The bug

`captcha_settings` is Salesforce's Web-to-Lead hidden field. Its `ts` value is maintained by Salesforce's generated 500ms ticker, which writes straight to the DOM and stops writing once the captcha is solved — leaving `ts` frozen at solve time, which is the elapsed-time signal Salesforce validates.

React re-syncs host inputs on every commit, so **any** re-render resets that field back to the JSX value, `"ts":""`. This form re-renders often: `setReturnUrl` on mount, react-hook-form (`mode: 'onTouched'`) whenever an error appears or clears, and `setIsDisabled`/`setCaptchaError` in the submit handler. Because the ticker has stopped by then, a single re-render after the captcha is solved leaves `ts` blank permanently.

Verified against React 18 in jsdom — mutate a hidden input's value from outside React, then trigger an unrelated re-render:

```
after direct DOM write  : {"ts":"1750000000000"}
after unrelated rerender: {"ts":""}
```

Swapping `value` for `defaultValue` does **not** help: `input type="hidden"` uses value-mode *default*, so `.value` is just the content attribute and React's `defaultValue` re-sync clobbers it identically (also verified).

## The fix

`initCaptcha` now reports every timestamp back to the component, which renders it into the hidden input — so a re-render at any point writes the correct value rather than blanking it. It also returns a reapply function, called immediately before `form.submit()`.

## Notes

- The original commit's third hunk (`archiveCurrentRelease.sh`) is deliberately **not** ported. Grid changed `-f` to `-d` because it `rsync`s into a directory; charts `zip`s into a file, so `-f` is correct here.
- One inaccuracy is carried over verbatim, for parity: the new JSDoc claims `form.submit()` "only schedules a navigation — the body is serialised in a later task". Per the HTML spec the entry list is constructed synchronously. The fix is still necessary, but because of the pre-submit re-renders described above. Better corrected in ag-grid and re-synced than diverged here.

## Verification

Both files are byte-identical to ag-grid `latest` after `5f7ea32` (which is also already live on grid's `b36.1.0`). Nothing in this repo tests the contact form, and I did not run the full check suite — the change was made in a throwaway worktree without `node_modules`, so CI is the gate.
