### PR TITLE
AG-3390 Keep the Salesforce captcha timestamp through React re-renders (b14.1.0)

### DIFF
--- a/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
+++ b/external/ag-website-shared/src/components/contact-form/ContactForm.tsx
@@ -86,6 +86,8 @@ export const ContactForm: FunctionComponent<Props> = ({
     submitLabel,
 }: Props) => {
     const formRef = useRef<HTMLFormElement>(null);
+    const captchaTimestamp = useRef('');
+    const reapplyCaptchaTimestamp = useRef<(() => void) | null>(null);
     const [isDebug, setIsDebug] = useState(isDev);
     const [returnUrl, setReturnUrl] = useState(RETURN_URLS.success);
     const [isDisabled, setIsDisabled] = useState(false);
@@ -139,7 +141,9 @@ export const ContactForm: FunctionComponent<Props> = ({
         }
 
         loadRecaptchaScript().then(() => {
-            initCaptcha();
+            reapplyCaptchaTimestamp.current = initCaptcha((ts) => {
+                captchaTimestamp.current = ts;
+            });
         });
     }, []);
 
@@ -149,6 +153,7 @@ export const ContactForm: FunctionComponent<Props> = ({
 
         const captchaPassed = (globalThis as any).grecaptcha.getResponse();
         if (captchaPassed) {
+            reapplyCaptchaTimestamp.current?.();
             formRef.current?.submit();
         } else {
             setCaptchaError(true);
@@ -169,7 +174,7 @@ export const ContactForm: FunctionComponent<Props> = ({
             <input
                 type="hidden"
                 name="captcha_settings"
-                value={`{"keyname":"${captchaSettingsKeyName}","fallback":"true","orgId":"${orgId}","ts":""}`}
+                value={`{"keyname":"${captchaSettingsKeyName}","fallback":"true","orgId":"${orgId}","ts":"${captchaTimestamp.current}"}`}
             />
             <input type="hidden" name="oid" value={orgId} />
             <input type="hidden" name="retURL" value={returnUrl} />

--- a/external/ag-website-shared/src/components/contact-form/initCaptcha.ts
+++ b/external/ag-website-shared/src/components/contact-form/initCaptcha.ts
@@ -1,12 +1,37 @@
-export function initCaptcha() {
+/**
+ * Starts Salesforce's captcha timestamp ticker.
+ *
+ * `onTimestamp` receives every value written, so the caller can render it back into the
+ * hidden input: React resets a controlled input on re-render, and `form.submit()` only
+ * schedules a navigation — the body is serialised in a later task, after any pending
+ * re-render has flushed. Rendering the live timestamp means a re-render at any point
+ * writes the correct value rather than blanking it.
+ *
+ * The ticker stops once the captcha is solved, freezing `ts` at solve time, which is the
+ * elapsed-time signal Salesforce validates.
+ */
+export function initCaptcha(onTimestamp?: (ts: string) => void): () => void {
+    let latest = '';
+
+    function write(ts: string) {
+        const captchaSettings = document.getElementsByName('captcha_settings')[0] as HTMLInputElement | undefined;
+        if (captchaSettings == null || ts === '') {
+            return;
+        }
+        const elems = JSON.parse(captchaSettings.value);
+        elems['ts'] = ts;
+        captchaSettings.value = JSON.stringify(elems);
+    }
+
     function timestamp() {
         const response = document.getElementById('g-recaptcha-response') as HTMLInputElement;
         if (response == null || response.value.trim() == '') {
-            const captchaSettings = document.getElementsByName('captcha_settings')[0] as HTMLInputElement;
-            const elems = JSON.parse(captchaSettings.value);
-            elems['ts'] = JSON.stringify(new Date().getTime());
-            captchaSettings.value = JSON.stringify(elems);
+            latest = JSON.stringify(new Date().getTime());
+            write(latest);
+            onTimestamp?.(latest);
         }
     }
     setInterval(timestamp, 500);
+
+    return () => write(latest);
 }


### PR DESCRIPTION
Release-branch cherry-pick of #7833 onto `b14.1.0`, itself a port of ag-grid#14852 (`5f7ea32`).

Salesforce's `captcha_settings` hidden field carries a `ts` timestamp maintained by Salesforce's generated 500ms ticker. React re-syncs host inputs on every commit, so any re-render blanks it back to `"ts":""` — and because the ticker stops writing once the captcha is solved, a single re-render after solving leaves it blank permanently. The fix renders the live timestamp through React and reapplies it immediately before `form.submit()`.

See #7833 (and ag-grid#14852) for the full rationale, including the jsdom verification and why `defaultValue` is not a workaround.

This matters on the release branch because the deployed site is built from it — grid hit the same thing and fixed `b36.1.0` first (ag-grid#14844/#14845/#14850) before forward-porting to `latest`.

## Cherry-pick notes

- Applied **cleanly**, no conflicts — `b14.1.0`'s copies of both files were byte-identical to grid's pre-fix version.
- Resulting files are byte-identical to ag-grid `latest` after `5f7ea32`.
- The commit's `archiveCurrentRelease.sh` hunk is deliberately **not** ported: grid changed `-f` to `-d` because it `rsync`s into a directory, whereas charts `zip`s into a file, so `-f` is correct here.
- Nothing in this repo tests the contact form, and the full check suite was not run locally (throwaway worktree, no `node_modules`) — CI is the gate.
