### PR TITLE
AG-3390 Send an identifying User-Agent on the build-time sitemap fetch

### DIFF
--- a/external/ag-website-shared/src/constants.ts
+++ b/external/ag-website-shared/src/constants.ts
@@ -78,6 +78,12 @@ export const STUDIO_FORM_DATA = {
 // Relative to website folder
 export const SITEMAP_CACHE_DIR = '.astro/cache/sitemap';
 
+/**
+ * `User-Agent` identifying build-time fetches against the live AG sites (sitemaps, robots disallow
+ * lists), which are not served to the default agent.
+ */
+export const BUILD_USER_AGENT = 'Mozilla/5.0 (compatible; ag-website-build)';
+
 export const PRIVACY_POLICY_URL = 'https://www.ag-grid.com/privacy';
 
 // Figma

--- a/external/ag-website-shared/src/utils/getSitemapXml.test.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.test.ts
@@ -1,0 +1,44 @@
+import { vi } from 'vitest';
+
+import { BUILD_USER_AGENT } from '../constants';
+import { getSitemapXml } from './getSitemapXml';
+
+const SITEMAP_URL = 'https://www.ag-grid.com/sitemap-0.xml';
+const SITEMAP_XML = '<urlset><url><loc>https://www.ag-grid.com/</loc></url></urlset>';
+// A cache folder that does not exist, so every case here takes the "fetch from the live site" path
+// — the one a production build hits after `--clean-cache=true`.
+const MISSING_CACHE_DIR = '.astro/cache/sitemap-does-not-exist';
+
+const logger = { info: vi.fn(), warn: vi.fn(), log: vi.fn() };
+
+const fetchSitemap = () =>
+    getSitemapXml({ cacheDir: MISSING_CACHE_DIR, sitemapUrl: SITEMAP_URL, logger, gitHash: 'test-hash' });
+
+describe('getSitemapXml', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('identifies the build in the User-Agent', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => SITEMAP_XML });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchSitemap()).resolves.toBe(SITEMAP_XML);
+
+        expect(fetchMock).toHaveBeenCalledWith(SITEMAP_URL, { headers: { 'User-Agent': BUILD_USER_AGENT } });
+    });
+
+    test('throws on a failed request rather than using the error page as the sitemap', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                status: 503,
+                statusText: 'Service Unavailable',
+                text: async () => '<html><h1>ERROR</h1></html>',
+            })
+        );
+
+        await expect(fetchSitemap()).rejects.toThrow(`Failed to fetch sitemap ${SITEMAP_URL}: 503 Service Unavailable`);
+    });
+});

--- a/external/ag-website-shared/src/utils/getSitemapXml.ts
+++ b/external/ag-website-shared/src/utils/getSitemapXml.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { BUILD_USER_AGENT } from '../constants';
 import { getGitHash } from './gitUtils';
 
 type Logger = Pick<Console, 'info' | 'warn' | 'log'>;
@@ -55,7 +56,12 @@ export const getSitemapXml = async ({
     }
 
     if (xmlSitemap == null) {
-        const response = await fetch(sitemapUrl);
+        const response = await fetch(sitemapUrl, { headers: { 'User-Agent': BUILD_USER_AGENT } });
+        if (!response.ok) {
+            // Without this the error response body is used as the sitemap, silently producing a
+            // broken `/sitemap` page instead of failing the build.
+            throw new Error(`Failed to fetch sitemap ${sitemapUrl}: ${response.status} ${response.statusText}`);
+        }
         xmlSitemap = await response.text();
         logger.log(`⚠️ No cached sitemap found, fetched from live site: ${sitemapUrl}`);
     }


### PR DESCRIPTION
## Problem

`getSitemapXml()` fetches the live sitemap when the cache is cold, and `https://www.ag-grid.com/charts/sitemap-0.xml` answers **403** to the default agent:

```
https://www.ag-grid.com/charts/sitemap-0.xml   default    403 Forbidden  (919-byte error page)
https://www.ag-grid.com/charts/sitemap-0.xml   build UA   200 OK         (91,460 bytes)
```

There was no `response.ok` check, so that 403 error page was used as the sitemap and written into `/sitemap` and `/sitemap.md`. Both `production` and `archive` builds pass `--clean-cache=true --run-second-build=true`, so the first build always hit this and only the second build's cache hid it — it failed silently rather than loudly.

## Changes

- **`BUILD_USER_AGENT`** added to `@ag-website-shared/constants`, naming the caller.
- **`getSitemapXml`** sends it, and now **throws on a non-ok response** so a blocked fetch fails the build instead of shipping an error page as the sitemap.

## Testing

- `getSitemapXml.test.ts` — new suite covering the cache-miss path: the header is sent, and a failed response throws instead of returning the error page as the sitemap. Both cases confirmed red against the unpatched source in this repo before the fix, green after.
- `nx run ag-website-shared:test` — 196 tests pass.
- `nx run ag-website-shared:lint` — 0 errors; the 11 warnings are unchanged from `origin/latest` (verified against the unpatched tree).
- `prettier --check` clean on all three files.

## Notes

- **Staging is unaffected.** `charts-staging.ag-grid.com/sitemap-0.xml` returns 200 to either agent — the WAF only guards `www.ag-grid.com` — so the new `throw` does not change staging, preview or dev builds. Only the production and archive URLs were blocked.
- Ported from the AG Grid change in ag-grid#14876. The `robots.txt` half of that change does **not** apply here: this site's `robots.txt` is a static disallow-all with no fetches.
- These three files live in the `ag-website-shared` subrepo and are now byte-identical across grid, charts and studio, so the next subrepo sync converges rather than conflicting.
- Note for later: all three repos already carry a `BROWSER_USER_AGENT` for this same WAF in `scripts/versions-data/updateVersionsData.ts`. That is a separate, locally-duplicated constant; consolidating the two is worth doing but is out of scope here.
