### PR TITLE
AG-18112 Restore the left indent on docs pages without a left menu

### DIFF
--- a/external/ag-website-shared/src/components/page-styles/docs.module.scss
+++ b/external/ag-website-shared/src/components/page-styles/docs.module.scss
@@ -9,10 +9,25 @@
         flex-direction: row;
     }
 
-    // .docPage caps its width to leave room for the 3-12 menu column, which isn't there.
     &.noLeftMenu .docPage {
         width: 100%;
-        max-width: 100%;
+    }
+
+    @media (min-width: $breakpoint-docs-nav-large) {
+        &.noLeftMenu .docPage {
+            width: var(--layout-width-9-12);
+            margin-left: calc(var(--layout-width-3-12) + var(--layout-gap));
+        }
+    }
+
+    @media (max-width: $breakpoint-docs-nav-extra-large) {
+        &.noLeftMenu .docPage {
+            width: var(--layout-width-6-12);
+        }
+    }
+
+    &.noLeftMenu .docPage {
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18112

Fix #AG-18112