### PR TITLE
Handle invalid version strings in changelog transformVersion

### DIFF
--- a/external/ag-website-shared/src/components/changelog/Pipeline.tsx
+++ b/external/ag-website-shared/src/components/changelog/Pipeline.tsx
@@ -39,11 +39,11 @@ const getColDefs = (library: Library) => [
             if (hasFixVersion) {
                 const latestFixVersion = fixVersionsArr.length - 1;
                 const fixVersion = fixVersionsArr[latestFixVersion];
-                if (fixVersion.toUpperCase() === 'NEXT') {
+                if (!fixVersion || fixVersion.toUpperCase() === 'NEXT') {
                     return 'Scheduled';
                 } else {
                     const version = library in transformVersion ? transformVersion[library](fixVersion) : fixVersion;
-                    return `Scheduled for ${version}`;
+                    return version ? `Scheduled for ${version}` : 'Scheduled';
                 }
             }
             return 'Backlog';

--- a/external/ag-website-shared/src/components/changelog/transformVersion.test.ts
+++ b/external/ag-website-shared/src/components/changelog/transformVersion.test.ts
@@ -1,0 +1,14 @@
+import { transformVersion } from './transformVersion';
+
+describe.each([
+    { gridVersion: '34.0.2', chartVersion: '12.0.2' },
+    { gridVersion: '22.0.0', chartVersion: '0.0.0' },
+    { gridVersion: 'Next', chartVersion: null },
+    { gridVersion: '', chartVersion: null },
+    { gridVersion: '34.0', chartVersion: null },
+    { gridVersion: '34.0.x', chartVersion: null },
+])('transformVersion.charts', ({ gridVersion, chartVersion }) => {
+    it(`grid version: "${gridVersion}" transforms to ${JSON.stringify(chartVersion)}`, () => {
+        expect(transformVersion.charts(gridVersion)).toEqual(chartVersion);
+    });
+});

--- a/external/ag-website-shared/src/components/changelog/transformVersion.ts
+++ b/external/ag-website-shared/src/components/changelog/transformVersion.ts
@@ -1,13 +1,17 @@
 import type { Library } from '@ag-grid-types';
 
-const gridToChartVersion = (gridVersion: string) => {
+const gridToChartVersion = (gridVersion: string): string | null => {
     const versionParts = gridVersion.split('.');
+    if (versionParts.length !== 3 || versionParts.some((part) => !/^\d+$/.test(part))) {
+        // Not a real grid release version (e.g. a placeholder like "Future" or "TBD") - nothing to transform.
+        return null;
+    }
 
     // The first charts release was on grid version 22 - we'll keep in lock step release wise going forward so this works
-    const chartMajorVersion = parseInt(versionParts[0]) - 22;
+    const chartMajorVersion = parseInt(versionParts[0], 10) - 22;
     return `${chartMajorVersion}.${versionParts[1]}.${versionParts[2]}`;
 };
 
-export const transformVersion: Record<Library, (version: string) => string> = {
+export const transformVersion: Record<Library, (version: string) => string | null> = {
     charts: gridToChartVersion,
 };


### PR DESCRIPTION
## Summary
Add validation to the `transformVersion.charts()` function to safely handle invalid or placeholder version strings (e.g. "Next", "TBD", empty strings, or malformed versions) by returning `null` instead of attempting transformation. Update the Pipeline component to gracefully handle `null` return values.

## Key Changes
- **transformVersion.ts**: Added validation to check that grid versions have exactly 3 numeric parts before transformation; returns `null` for invalid versions
- **transformVersion.ts**: Updated return type annotation from `string` to `string | null` to reflect the new behaviour
- **Pipeline.tsx**: Updated the scheduled version display logic to handle `null` return values, falling back to "Scheduled" when transformation fails
- **transformVersion.test.ts**: Added comprehensive test suite covering valid versions and edge cases (placeholder versions, empty strings, malformed versions)

## Implementation Details
The validation uses a regex check (`/^\d+$/`) to ensure each version part is numeric, preventing errors when processing non-release versions. The Pipeline component now checks for both `null` returns and the "NEXT" placeholder before deciding whether to append the version number to the "Scheduled" message.

https://claude.ai/code/session_014t3L58eBLX25TsrwvoeJwE