### PR TITLE
AG-18050 Add pipeline fixture entry to verify fix on staging

### DIFF
--- a/packages/ag-charts-website/public/pipeline/pipeline.json
+++ b/packages/ag-charts-website/public/pipeline/pipeline.json
@@ -2798,5 +2798,19 @@
         "deprecationNotes": null,
         "breakingChangesNotes": null,
         "documentationUrl": null
+    },
+    {
+        "key": "AG-18050",
+        "issueType": "Bug",
+        "componentsByName": ["Charts"],
+        "summary": "[Charts] Website pipeline shows \"NaN.Undefined\" for tickets without a version",
+        "versions": [""],
+        "status": "Needs Review",
+        "resolution": null,
+        "features": [],
+        "moreInformation": null,
+        "deprecationNotes": null,
+        "breakingChangesNotes": null,
+        "documentationUrl": null
     }
 ]


### PR DESCRIPTION
## Summary

- The AG-18050 fix (#7868) is already merged into `latest`.
- This PR adds a fixture entry to `packages/ag-charts-website/public/pipeline/pipeline.json` with an empty-string fix version (`"versions": [""]`), reproducing the shape of data that previously rendered as `"Scheduled for NaN.undefined.undefined"` on the [pipeline page](https://www.ag-grid.com/charts/pipeline/).

## Purpose

This lets the fix be verified visually on this PR's staging preview: the new `AG-18050` row's Status column should show `Scheduled` rather than a `NaN.undefined...` string.

**Not intended to be merged** — this fixture data is only for staging verification. Please close/discard this PR once verified.

Claude-Session: https://claude.ai/code/session_014t3L58eBLX25TsrwvoeJwE

---
_Generated by [Claude Code](https://claude.ai/code/session_014t3L58eBLX25TsrwvoeJwE)_